### PR TITLE
Make the native backup flow work the same

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
         );
 
         commonShellHook = ''
-          export NODE_OPTIONS=--max_old_space_size=4096
+          export NODE_OPTIONS=--max_old_space_size=8192
           export CURDIR="$(pwd)"
           export PATH="$PATH:$CURDIR/node_modules/.bin"
           export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"

--- a/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/__fixtures__/onboardingActions.ts
@@ -26,24 +26,6 @@ export default [
         },
     },
     {
-        description:
-            'goToNextStep: from backup step skip set-pin when pin is already set, no more steps → goToSuite resets to initial state',
-        initialState: {
-            onboarding: {
-                activeStepId: STEP.ID_BACKUP_STEP,
-            },
-            device: {
-                selectedDevice: mockSuiteDevice(undefined, {
-                    pin_protection: true,
-                }),
-            },
-        },
-        action: () => onboardingActions.goToNextStep(),
-        expect: {
-            toMatchObject: { activeStepId: STEP.ID_FIRMWARE_STEP },
-        },
-    },
-    {
         description: 'goToPreviousStep',
         initialState: {
             onboarding: {

--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -31,31 +31,28 @@ export const BackupSeedCards = () => {
 
     return (
         <Column gap={16}>
-            <Paragraph
-                typographyStyle="body-sm"
-                intent="neutral"
-                priority="secondary"
-                align="center"
-            >
+            <Paragraph typographyStyle="body-sm" align="center">
                 <Translation id="TR_ONBOARDING_CLICK_TO_CONFIRM" />
             </Paragraph>
             <Grid gap={16} columns={isBelowTablet ? 1 : 3}>
                 {items.map(item => (
                     <Card
-                        paddingType="large"
+                        paddingType="normal"
+                        height="100%"
+                        minHeight="140px"
                         key={item.key}
                         onClick={() => dispatch(backupActions.toggleCheckboxByKey(item.key))}
                         data-testid={`@backup/check-item/${item.key}`}
                     >
-                        <Column gap={16}>
-                            <Row gap={16} alignItems="flex-start" justifyContent="space-between">
-                                <Icon name={item.icon} intent="neutral" priority="secondary" />
+                        <Column height="100%" justifyContent="space-between">
+                            <Row gap={16} alignItems="center" justifyContent="space-between">
                                 <Checkbox
                                     isChecked={isChecked(item.key)}
                                     onChange={event => {
                                         event.preventDefault();
                                     }}
                                 />
+                                <Icon name={item.icon} size={24} />
                             </Row>
                             <Paragraph typographyStyle="body-sm">{item.label}</Paragraph>
                         </Column>

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -9,6 +9,7 @@ import { type AnyStepId } from 'src/types/onboarding';
 
 type SkipStepConfirmationProps = {
     onCancel: () => void;
+    onConfirm?: () => void;
 };
 
 type SkipModalContent = {
@@ -47,7 +48,7 @@ const getModalContent = (
     }
 };
 
-export const SkipStepConfirmation = ({ onCancel }: SkipStepConfirmationProps) => {
+export const SkipStepConfirmation = ({ onCancel, onConfirm }: SkipStepConfirmationProps) => {
     const { activeStepId, goToNextStep, resolveNextAfterSkipped } = useOnboarding();
     const { heading, secondaryButtonText, body, nextStep } = getModalContent(
         activeStepId,
@@ -57,7 +58,11 @@ export const SkipStepConfirmation = ({ onCancel }: SkipStepConfirmationProps) =>
     if (!heading) return;
 
     const handleSkipStepConfirm = () => {
-        goToNextStep(nextStep);
+        if (onConfirm) {
+            onConfirm();
+        } else {
+            goToNextStep(nextStep);
+        }
     };
 
     return (

--- a/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
+++ b/packages/suite/src/components/onboarding/SkipStepConfirmation.tsx
@@ -30,7 +30,6 @@ const getModalContent = (
                 body: <Translation id="TR_SKIP_UPDATE_DESCRIPTION" />,
             };
         case STEP.ID_SECURITY_STEP:
-        case STEP.ID_BACKUP_STEP:
             return {
                 heading: <Translation id="TR_SKIP_BACKUP" />,
                 secondaryButtonText: <Translation id="TR_SKIP_BACKUP" />,

--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -86,12 +86,7 @@ export const stepCategories: StepCategory[] = [
             {
                 id: STEP.ID_SECURITY_STEP,
                 path: [STEP.PATH_RECOVERY, STEP.PATH_CREATE],
-                prerequisites: [...commonPrerequisites, ...afterInitializePrerequisites],
-            },
-            {
-                id: STEP.ID_BACKUP_STEP,
-                path: [STEP.PATH_CREATE],
-                prerequisites: [...commonPrerequisites, ...afterInitializePrerequisites],
+                prerequisites: [...commonPrerequisites, 'device-recovery-mode', 'device-different'],
             },
         ],
     },

--- a/packages/suite/src/constants/onboarding/steps.ts
+++ b/packages/suite/src/constants/onboarding/steps.ts
@@ -1,5 +1,4 @@
 export const ID_CREATE_OR_RECOVER = 'create-or-recover';
-export const ID_BACKUP_STEP = 'backup';
 export const ID_FINAL_STEP = 'final';
 export const ID_FIRMWARE_STEP = 'firmware';
 export const ID_RESET_DEVICE_STEP = 'reset-device';

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -29,7 +29,6 @@ export type Step = {
 // todo: remove, improve typing
 export type AnyStepId =
     | typeof STEP.ID_CREATE_OR_RECOVER
-    | typeof STEP.ID_BACKUP_STEP
     | typeof STEP.ID_FIRMWARE_STEP
     | typeof STEP.ID_AUTHENTICATE_DEVICE_STEP
     | typeof STEP.ID_TUTORIAL_STEP

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -1,8 +1,8 @@
-import { type AcquiredDevice } from '@suite-common/suite-types';
-import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
+import type { AcquiredDevice } from '@suite-common/suite-types';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
+import { stepCategories } from 'src/config/onboarding/steps';
 import * as STEP from 'src/constants/onboarding/steps';
-import { type Step, type StepCategory } from 'src/types/onboarding';
 
 import {
     type IsStepUsedProps,
@@ -13,247 +13,240 @@ import {
     resolveNextAvailableStep,
 } from '../steps';
 
-const firmwareStep: Step = {
-    id: STEP.ID_FIRMWARE_STEP,
-    path: [],
-};
+const allSteps = stepCategories.flatMap(category => category.steps);
 
-const backupStep: Step = {
-    id: STEP.ID_BACKUP_STEP,
-    path: [],
-    supportedModels: [
-        DeviceModelInternal.T3B1,
-        { model: DeviceModelInternal.T3T1, minFwVersion: '2.8.0' },
-    ],
-};
+const createDevice = (overrides: Partial<AcquiredDevice['features']>) =>
+    ({
+        features: {
+            internal_model: DeviceModelInternal.T2T1,
+            ...overrides,
+        },
+    }) as AcquiredDevice;
 
-const stepCategory: StepCategory = {
-    id: 'device',
-    labelTranslationId: 'TR_DEVICE',
-    steps: [firmwareStep],
-};
+const defaultDevice = createDevice({ internal_model: DeviceModelInternal.T2T1 });
 
-const defaultDevice = {
-    features: { internal_model: DeviceModelInternal.T1B1 },
-    firmwareType: FirmwareType.Universal,
-} as AcquiredDevice;
-
-const propsMock: IsStepUsedProps = {
+const createProps = (overrides?: Partial<IsStepUsedProps>): IsStepUsedProps => ({
     onboardingPath: [],
     device: defaultDevice,
     isDeviceAuthenticityCheckEnabled: true,
     isUnlockedBootloaderAllowed: false,
-};
+    ...overrides,
+});
 
-const stepsMock = [firmwareStep, backupStep];
+const getStepsForPath = (path: typeof STEP.PATH_CREATE | typeof STEP.PATH_RECOVERY) =>
+    allSteps.filter(step =>
+        isStepUsed(step, createProps({ onboardingPath: [path], device: defaultDevice })),
+    );
 
 describe('steps', () => {
-    describe(findNextStep.name, () => {
-        it('should find next step', () => {
-            const device = {
-                ...defaultDevice,
-                features: {
-                    internal_model: DeviceModelInternal.T2T1,
-                    backup_availability: 'Required',
-                },
-            } as AcquiredDevice;
+    describe('real onboarding flow - create wallet (T2T1)', () => {
+        const createSteps = getStepsForPath(STEP.PATH_CREATE);
 
-            expect(findNextStep(firmwareStep.id, stepsMock, device)).toEqual(backupStep);
+        it('should contain the expected steps for T2T1 create flow', () => {
+            const stepIds = createSteps.map(s => s.id);
+            expect(stepIds).toEqual([
+                STEP.ID_FIRMWARE_STEP,
+                STEP.ID_CREATE_OR_RECOVER,
+                STEP.ID_RESET_DEVICE_STEP,
+                STEP.ID_SECURITY_STEP,
+                STEP.ID_SET_PIN_STEP,
+            ]);
         });
 
-        it('should return null in no next step exists', () => {
-            expect(findNextStep(backupStep.id, stepsMock, defaultDevice)).toBe(null);
-        });
-    });
-
-    describe(findPrevStep.name, () => {
-        it('should find previous step', () => {
-            expect(findPrevStep(backupStep.id, stepsMock)).toEqual(firmwareStep);
-        });
-
-        it('should throw on improper use (no more step exists)', () => {
-            expect(() => findPrevStep(firmwareStep.id, stepsMock)).toThrow('no prev step exists');
-        });
-    });
-
-    describe(isStepUsed.name, () => {
-        it('empty path means no restriction', () => {
-            expect(isStepUsed(firmwareStep, propsMock)).toEqual(true);
+        it('should navigate through the full create flow', () => {
+            expect(findNextStep(STEP.ID_FIRMWARE_STEP, createSteps, defaultDevice)?.id).toBe(
+                STEP.ID_CREATE_OR_RECOVER,
+            );
+            expect(findNextStep(STEP.ID_CREATE_OR_RECOVER, createSteps, defaultDevice)?.id).toBe(
+                STEP.ID_RESET_DEVICE_STEP,
+            );
+            expect(findNextStep(STEP.ID_RESET_DEVICE_STEP, createSteps, defaultDevice)?.id).toBe(
+                STEP.ID_SECURITY_STEP,
+            );
+            expect(findNextStep(STEP.ID_SECURITY_STEP, createSteps, defaultDevice)?.id).toBe(
+                STEP.ID_SET_PIN_STEP,
+            );
+            expect(findNextStep(STEP.ID_SET_PIN_STEP, createSteps, defaultDevice)).toBe(null);
         });
 
-        it('should return false for no overlap', () => {
-            const stepWithPath: Step = { ...firmwareStep, path: ['create'] };
-            const propsWithPath: IsStepUsedProps = { ...propsMock, onboardingPath: ['recovery'] };
-            expect(isStepUsed(stepWithPath, propsWithPath)).toEqual(false);
-        });
+        it('should skip PIN step when device already has pin protection', () => {
+            const deviceWithPin = createDevice({
+                internal_model: DeviceModelInternal.T2T1,
+                pin_protection: true,
+            });
 
-        it('should return true for full overlap', () => {
-            const stepWithPath: Step = { ...firmwareStep, path: ['create'] };
-            const propsWithPath: IsStepUsedProps = { ...propsMock, onboardingPath: ['create'] };
-            expect(isStepUsed(stepWithPath, propsWithPath)).toEqual(true);
-        });
-
-        it('should exclude steps not supported by device', () => {
-            const deviceT3B1 = {
-                features: {
-                    internal_model: DeviceModelInternal.T3B1,
-                    backup_availability: 'Required',
-                },
-            } as AcquiredDevice;
-            const propsWithT3B1 = { ...propsMock, device: deviceT3B1 };
-            expect(isStepUsed(backupStep, propsWithT3B1)).toEqual(true);
-
-            const deviceT1B1 = {
-                features: { internal_model: DeviceModelInternal.T1B1 },
-            } as AcquiredDevice;
-            const propsWithT1B1 = { ...propsMock, device: deviceT1B1 };
-            expect(isStepUsed(backupStep, propsWithT1B1)).toEqual(false);
-        });
-
-        it('should exclude steps not supported by firmware', () => {
-            const deviceT3T1newer = {
-                features: {
-                    internal_model: DeviceModelInternal.T3T1,
-                    major_version: 2,
-                    minor_version: 8,
-                    patch_version: 0,
-                    backup_availability: 'Required',
-                },
-            } as AcquiredDevice;
-            const propsNewerT3T1 = { ...propsMock, device: deviceT3T1newer };
-            expect(isStepUsed(backupStep, propsNewerT3T1)).toEqual(true);
-
-            const deviceT3T1older = {
-                features: {
-                    internal_model: DeviceModelInternal.T3T1,
-                    major_version: 2,
-                    minor_version: 7,
-                    patch_version: 2,
-                },
-            } as AcquiredDevice;
-            const propsOlderT3T1 = { ...propsMock, device: deviceT3T1older };
-            expect(isStepUsed(backupStep, propsOlderT3T1)).toEqual(false);
-        });
-
-        it('should exclude steps as per firmware type', () => {
-            const btcOnlyDevice = { ...defaultDevice, firmwareType: FirmwareType.BitcoinOnly };
-            const universalStep: Step = {
-                id: STEP.ID_SET_PIN_STEP,
-                supportedFirmwareTypes: [FirmwareType.Universal],
-            };
-            const btcOnlyStep: Step = {
-                id: STEP.ID_SET_PIN_STEP,
-                supportedFirmwareTypes: [FirmwareType.BitcoinOnly],
-            };
-            const propsBtcOnly = { ...propsMock, device: btcOnlyDevice };
-
-            expect(isStepUsed(universalStep, propsMock)).toEqual(true);
-            expect(isStepUsed(btcOnlyStep, propsMock)).toEqual(false);
-            expect(isStepUsed(universalStep, propsBtcOnly)).toEqual(false);
-            expect(isStepUsed(btcOnlyStep, propsBtcOnly)).toEqual(true);
+            expect(findNextStep(STEP.ID_SECURITY_STEP, createSteps, deviceWithPin)).toBe(null);
         });
     });
 
-    describe(isStepCategoryUsed.name, () => {
-        it('should return true for category with at least one valid step', () => {
-            expect(isStepCategoryUsed(stepCategory, propsMock)).toEqual(true);
+    describe('real onboarding flow - create wallet (T3T1)', () => {
+        const deviceT3T1 = createDevice({
+            internal_model: DeviceModelInternal.T3T1,
+            major_version: 2,
+            minor_version: 8,
+            patch_version: 0,
+            backup_availability: 'Required',
+        } as Partial<AcquiredDevice['features']>);
+
+        const createSteps = allSteps.filter(step =>
+            isStepUsed(
+                step,
+                createProps({ onboardingPath: [STEP.PATH_CREATE], device: deviceT3T1 }),
+            ),
+        );
+
+        it('should include authenticate and tutorial steps for T3T1', () => {
+            const stepIds = createSteps.map(s => s.id);
+            expect(stepIds).toContain(STEP.ID_AUTHENTICATE_DEVICE_STEP);
+            expect(stepIds).toContain(STEP.ID_TUTORIAL_STEP);
         });
 
-        it('should return false for category with no steps', () => {
-            const modifiedStepCategory: StepCategory = { ...stepCategory, steps: [] };
-            expect(isStepCategoryUsed(modifiedStepCategory, propsMock)).toEqual(false);
-        });
-
-        it('should return false for category with only irrelevant steps', () => {
-            const deviceBtcOnlyT1B1 = {
-                firmwareType: FirmwareType.BitcoinOnly,
-                features: {
-                    internal_model: DeviceModelInternal.T3T1,
-                    major_version: 1,
-                    minor_version: 12,
-                    patch_version: 1,
-                },
-            } as AcquiredDevice;
-            const propsWithBtcOnlyT1B1 = { ...propsMock, device: deviceBtcOnlyT1B1 };
-
-            const modifiedStepCategory: StepCategory = {
-                ...stepCategory,
-                steps: [backupStep],
-            };
-            expect(isStepCategoryUsed(modifiedStepCategory, propsWithBtcOnlyT1B1)).toEqual(false);
-        });
-    });
-
-    describe(resolveNextAvailableStep.name, () => {
-        const setPinStep: Step = { id: STEP.ID_SET_PIN_STEP, path: [] };
-        const backupStepInSteps: Step = { id: STEP.ID_BACKUP_STEP, path: [] };
-
-        const steps: Step[] = [backupStepInSteps, setPinStep];
-
-        it('should return requested step if it is accessible', () => {
-            const device = {
-                ...defaultDevice,
-                features: {
-                    internal_model: DeviceModelInternal.T2T1,
-                    pin_protection: false,
-                    backup_availability: 'Required',
-                },
-            } as AcquiredDevice;
-
-            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, steps, device)).toEqual(
-                setPinStep,
+        it('should navigate through the full T3T1 create flow', () => {
+            expect(findNextStep(STEP.ID_FIRMWARE_STEP, createSteps, deviceT3T1)?.id).toBe(
+                STEP.ID_AUTHENTICATE_DEVICE_STEP,
+            );
+            expect(
+                findNextStep(STEP.ID_AUTHENTICATE_DEVICE_STEP, createSteps, deviceT3T1)?.id,
+            ).toBe(STEP.ID_TUTORIAL_STEP);
+            expect(findNextStep(STEP.ID_TUTORIAL_STEP, createSteps, deviceT3T1)?.id).toBe(
+                STEP.ID_CREATE_OR_RECOVER,
             );
         });
+    });
 
-        it('should skip PIN step when pin protection is already set', () => {
-            const device = {
-                ...defaultDevice,
-                features: {
-                    internal_model: DeviceModelInternal.T2T1,
-                    pin_protection: true,
-                    backup_availability: 'Required',
-                },
-            } as AcquiredDevice;
+    describe('real onboarding flow - recovery (T2T1)', () => {
+        const recoverySteps = getStepsForPath(STEP.PATH_RECOVERY);
 
-            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, steps, device)).toEqual(null);
+        it('should contain the expected steps for T2T1 recovery flow', () => {
+            const stepIds = recoverySteps.map(s => s.id);
+            expect(stepIds).toEqual([
+                STEP.ID_FIRMWARE_STEP,
+                STEP.ID_CREATE_OR_RECOVER,
+                STEP.ID_RECOVERY_STEP,
+                STEP.ID_SECURITY_STEP,
+                STEP.ID_SET_PIN_STEP,
+            ]);
         });
 
-        it('should NOT skip Backup step when device does not require backup - you cant do backup on the device', () => {
-            const device = {
-                ...defaultDevice,
-                features: {
-                    internal_model: DeviceModelInternal.T2T1,
-                    pin_protection: false,
-                    backup_availability: 'Available',
-                },
-            } as AcquiredDevice;
-
-            expect(resolveNextAvailableStep(STEP.ID_BACKUP_STEP, steps, device)).toEqual(
-                backupStepInSteps,
+        it('should navigate through the full recovery flow', () => {
+            expect(findNextStep(STEP.ID_FIRMWARE_STEP, recoverySteps, defaultDevice)?.id).toBe(
+                STEP.ID_CREATE_OR_RECOVER,
             );
-        });
-
-        it('should return null when requested step is not in steps list', () => {
-            expect(resolveNextAvailableStep(STEP.ID_FIRMWARE_STEP, steps, defaultDevice)).toEqual(
-                null,
+            expect(findNextStep(STEP.ID_CREATE_OR_RECOVER, recoverySteps, defaultDevice)?.id).toBe(
+                STEP.ID_RECOVERY_STEP,
+            );
+            expect(findNextStep(STEP.ID_RECOVERY_STEP, recoverySteps, defaultDevice)?.id).toBe(
+                STEP.ID_SECURITY_STEP,
             );
         });
     });
 
     describe(findNextStep.name, () => {
         it('should return null when current step is not present in the steps list', () => {
-            // This may happen when a step becomes unused right after it is completed (e.g. backup step is removed
-            // from available steps once the device no longer requires backup). In that case returning the first step
-            // (firmware) would incorrectly restart onboarding.
-            const steps: Step[] = [
-                { id: STEP.ID_FIRMWARE_STEP, path: [] },
-                { id: STEP.ID_SECURITY_STEP, path: [] },
-                { id: STEP.ID_SET_PIN_STEP, path: [] },
-            ];
+            const createSteps = getStepsForPath(STEP.PATH_CREATE);
+            expect(findNextStep(STEP.ID_RECOVERY_STEP, createSteps, defaultDevice)).toBe(null);
+        });
+    });
 
-            // Without the `currentIndex === -1` guard this would incorrectly return `steps[0]` (firmware).
-            expect(findNextStep(STEP.ID_BACKUP_STEP, steps, defaultDevice)).toEqual(null);
-            expect(findNextStep(STEP.ID_BACKUP_STEP, steps, defaultDevice)).not.toEqual(steps[0]);
+    describe(findPrevStep.name, () => {
+        it('should find previous step', () => {
+            const createSteps = getStepsForPath(STEP.PATH_CREATE);
+            expect(findPrevStep(STEP.ID_CREATE_OR_RECOVER, createSteps)?.id).toBe(
+                STEP.ID_FIRMWARE_STEP,
+            );
+        });
+
+        it('should throw on improper use (no more step exists)', () => {
+            const createSteps = getStepsForPath(STEP.PATH_CREATE);
+            expect(() => findPrevStep(createSteps[0].id, createSteps)).toThrow(
+                'no prev step exists',
+            );
+        });
+    });
+
+    describe(isStepUsed.name, () => {
+        it('should exclude authenticate step when authenticity check is disabled', () => {
+            const authenticateStep = allSteps.find(s => s.id === STEP.ID_AUTHENTICATE_DEVICE_STEP)!;
+            const deviceT3T1 = createDevice({
+                internal_model: DeviceModelInternal.T3T1,
+                backup_availability: 'Required',
+            } as Partial<AcquiredDevice['features']>);
+
+            expect(
+                isStepUsed(
+                    authenticateStep,
+                    createProps({
+                        device: deviceT3T1,
+                        isDeviceAuthenticityCheckEnabled: true,
+                    }),
+                ),
+            ).toBe(true);
+
+            expect(
+                isStepUsed(
+                    authenticateStep,
+                    createProps({
+                        device: deviceT3T1,
+                        isDeviceAuthenticityCheckEnabled: false,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('should exclude tutorial step for unsupported models', () => {
+            const tutorialStep = allSteps.find(s => s.id === STEP.ID_TUTORIAL_STEP)!;
+            expect(isStepUsed(tutorialStep, createProps({ device: defaultDevice }))).toBe(false);
+
+            const deviceT3B1 = createDevice({
+                internal_model: DeviceModelInternal.T3B1,
+                backup_availability: 'Required',
+            } as Partial<AcquiredDevice['features']>);
+            expect(isStepUsed(tutorialStep, createProps({ device: deviceT3B1 }))).toBe(true);
+        });
+
+        it('should exclude tutorial step for T3T1 with old firmware', () => {
+            const tutorialStep = allSteps.find(s => s.id === STEP.ID_TUTORIAL_STEP)!;
+            const deviceOldFw = createDevice({
+                internal_model: DeviceModelInternal.T3T1,
+                major_version: 2,
+                minor_version: 7,
+                patch_version: 2,
+            } as Partial<AcquiredDevice['features']>);
+            expect(isStepUsed(tutorialStep, createProps({ device: deviceOldFw }))).toBe(false);
+        });
+    });
+
+    describe(isStepCategoryUsed.name, () => {
+        it('should return true for categories with at least one valid step', () => {
+            const deviceCategory = stepCategories.find(c => c.id === 'device')!;
+            expect(isStepCategoryUsed(deviceCategory, createProps())).toBe(true);
+        });
+    });
+
+    describe(resolveNextAvailableStep.name, () => {
+        const createSteps = getStepsForPath(STEP.PATH_CREATE);
+
+        it('should return requested step if it is accessible', () => {
+            expect(
+                resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, createSteps, defaultDevice)?.id,
+            ).toBe(STEP.ID_SET_PIN_STEP);
+        });
+
+        it('should skip PIN step when pin protection is already set', () => {
+            const deviceWithPin = createDevice({
+                internal_model: DeviceModelInternal.T2T1,
+                pin_protection: true,
+            });
+
+            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, createSteps, deviceWithPin)).toBe(
+                null,
+            );
+        });
+
+        it('should return null when requested step is not in steps list', () => {
+            expect(
+                resolveNextAvailableStep(STEP.ID_RECOVERY_STEP, createSteps, defaultDevice),
+            ).toBe(null);
         });
     });
 });

--- a/packages/suite/src/views/backup/BackupStep1Initial.tsx
+++ b/packages/suite/src/views/backup/BackupStep1Initial.tsx
@@ -7,7 +7,7 @@ import {
 import { Translation } from '@suite/intl';
 import { selectIsDeviceLocked } from '@suite/locks';
 import { selectSelectedDevice } from '@suite-common/device';
-import { Modal, Paragraph } from '@trezor/components';
+import { Badge, Column, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { PreBackupCheckboxes } from 'src/components/backup';
@@ -45,7 +45,14 @@ export const BackupStep1Initial = ({
             onCancel={onCancel}
             intent="brand"
             data-testid="@backup"
-            heading={<Translation id="TR_CREATE_BACKUP" />}
+            heading={
+                <Column gap={8} alignItems="center" justifyContent="center">
+                    <Badge intent="neutral" size="medium">
+                        <Translation id="TR_NEW_WALLET" />
+                    </Badge>
+                    <Translation id="TR_CREATE_BACKUP" />
+                </Column>
+            }
             description={<BackupStepDescription />}
             bottomContent={
                 <>

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -9,7 +9,6 @@ import { OnboardingLayout } from 'src/components/onboarding/OnboardingLayout';
 import * as STEP from 'src/constants/onboarding/steps';
 import { useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 import { UnexpectedState } from 'src/views/onboarding/UnexpectedState';
-import { BackupStep } from 'src/views/onboarding/steps/BackupStep';
 import { CreateOrRecoverStep } from 'src/views/onboarding/steps/CreateOrRecoverStep';
 import { DeviceAuthenticityStep } from 'src/views/onboarding/steps/DeviceAuthenticityStep';
 import { DeviceTutorialStep } from 'src/views/onboarding/steps/DeviceTutorialStep';
@@ -56,11 +55,8 @@ export const Onboarding = () => {
                 // b) Seed recovery
                 return RecoveryStep;
             case STEP.ID_SECURITY_STEP:
-                // Security intro (BACKUP, PIN), option to skip them
+                // Wallet creation + backup (resetDevice with skip_backup: false)
                 return SecurityStep;
-            case STEP.ID_BACKUP_STEP:
-                // Seed backup
-                return BackupStep;
             case STEP.ID_SET_PIN_STEP:
                 // Pin setup
                 return PinStep;

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite/recovery';
 import { selectSelectedDevice } from '@suite-common/device';
 import { isDeviceWithButtonOnlyNoTouchscreen } from '@suite-common/suite-utils';
-import { Column } from '@trezor/components';
+import { Badge, Column } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 
@@ -45,7 +45,14 @@ export const RecoveryStep = () => {
         if (deviceModelInternal === DeviceModelInternal.T1B1) {
             return (
                 <RecoveryStepBox
-                    heading={<Translation id="TR_RECOVER_YOUR_WALLET_FROM" />}
+                    heading={
+                        <Column gap={8} alignItems="center" justifyContent="center">
+                            <Badge intent="neutral" size="medium">
+                                <Translation id="TR_RECOVER_WALLET" />
+                            </Badge>
+                            <Translation id="TR_RECOVER_YOUR_WALLET_FROM" />
+                        </Column>
+                    }
                     description={<Translation id="TR_RECOVER_SUBHEADING_COMPUTER" />}
                 >
                     <SelectWordCount
@@ -74,7 +81,14 @@ export const RecoveryStep = () => {
 
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_RECOVER_YOUR_WALLET_FROM" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_RECOVER_YOUR_WALLET_FROM" />
+                    </Column>
+                }
                 description={<Translation id={subheadingKey} />}
                 innerActions={
                     <OnboardingCard.Button
@@ -98,7 +112,14 @@ export const RecoveryStep = () => {
 
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_SELECT_RECOVERY_METHOD" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_SELECT_RECOVERY_METHOD" />
+                    </Column>
+                }
                 description={
                     deviceModelInternal === DeviceModelInternal.T1B1 && wordsCount === 24 ? (
                         <Translation
@@ -125,7 +146,14 @@ export const RecoveryStep = () => {
         // On T1B1 we show confirm bubble only while we wait for confirmation that users wants to start the process
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_RECOVER_YOUR_WALLET_FROM" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_RECOVER_YOUR_WALLET_FROM" />
+                    </Column>
+                }
                 description={
                     deviceModelInternal === DeviceModelInternal.T1B1 ? null : (
                         <Translation id={subheadingKey} />
@@ -156,7 +184,14 @@ export const RecoveryStep = () => {
 
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_RECOVER_YOUR_WALLET_FROM" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_RECOVER_YOUR_WALLET_FROM" />
+                    </Column>
+                }
                 device={device}
                 description={
                     deviceModelInternal === DeviceModelInternal.T1B1 ? (
@@ -183,7 +218,14 @@ export const RecoveryStep = () => {
 
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_WALLET_RECOVERED_FROM_SEED" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_WALLET_RECOVERED_FROM_SEED" />
+                    </Column>
+                }
                 innerActions={
                     <OnboardingCard.Button
                         data-testid="@onboarding/recovery/continue-button"
@@ -198,7 +240,14 @@ export const RecoveryStep = () => {
     if (status === 'finished' && error) {
         return (
             <RecoveryStepBox
-                heading={<Translation id="TR_RECOVERY_FAILED" />}
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_RECOVERY_FAILED" />
+                    </Column>
+                }
                 description={<Translation id="TR_RECOVERY_ERROR" values={{ error }} />}
                 variant="destructive"
                 innerActions={

--- a/packages/suite/src/views/onboarding/steps/ResetDeviceStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDeviceStep.tsx
@@ -2,15 +2,12 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { OnboardingCard } from '@suite/onboarding-components';
-import { goto } from '@suite/router';
-import { selectIsDebugModeActive } from '@suite/settings';
 import { selectDeviceDefaultBackupType, selectSelectedDevice } from '@suite-common/device';
 import { type BackupType } from '@suite-common/suite-types';
 import { Badge, Column, Text } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
-import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+import { useDevice, useOnboarding, useSelector } from 'src/hooks/suite';
 
 import { SelectBackupType } from './SelectBackupType/SelectBackupType';
 import { isShamirBackupType } from './utils';
@@ -27,26 +24,8 @@ export const ResetDeviceStep = () => {
 
     const [backupType, setBackupType] = useState<BackupType>(deviceDefaultBackupType);
     const { goToPreviousStep, goToNextStep, updateAnalytics, updateBackupType } = useOnboarding();
-    const dispatch = useDispatch();
-    const isDebugModeActive = useSelector(selectIsDebugModeActive);
-    const [debugInProgress, setDebugInProgress] = useState(false);
 
     const isDeviceLocked = isLocked();
-
-    const getResetDeviceParams = useCallback((type: BackupType) => {
-        switch (type) {
-            case 'shamir-single':
-            case 'shamir-advanced':
-                // We do not send `_Extendable` versions of the `backup_type` to be compatible
-                // with older firmwares. New firmware creates always extensible Shamir. Even for
-                // original, non-extendable enum values.
-                return { backup_type: 1 as const };
-            case '12-words':
-                return { backup_type: 0 as const, strength: 128 };
-            case '24-words':
-                return { backup_type: 0 as const, strength: 256 };
-        }
-    }, []);
 
     // Only saves the selected backup type and navigates to the security step.
     // The actual resetDevice call (with skip_backup: false) happens in SecurityStep,
@@ -103,52 +82,22 @@ export const ResetDeviceStep = () => {
                 )
             }
             device={device}
-            isConfirmedOnDevice={debugInProgress}
             innerActions={
-                !debugInProgress && (
-                    <OnboardingCard.Button
-                        isDisabled={isDeviceLocked}
-                        onClick={() => handleSubmit(backupType)}
-                        data-testid="@onboarding/select-seed-type-confirm"
-                    >
-                        <Translation id="TR_ONBOARDING_SELECT_SEED_TYPE_CONTINUE" />
-                    </OnboardingCard.Button>
-                )
+                <OnboardingCard.Button
+                    isDisabled={isDeviceLocked}
+                    onClick={() => handleSubmit(backupType)}
+                    data-testid="@onboarding/select-seed-type-confirm"
+                >
+                    <Translation id="TR_ONBOARDING_SELECT_SEED_TYPE_CONTINUE" />
+                </OnboardingCard.Button>
             }
             outerActions={
-                !debugInProgress && (
-                    <>
-                        <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
-                            <Translation id="TR_BACK" />
-                        </OnboardingCard.SecondaryButton>
-                        {isDebugModeActive && (
-                            <OnboardingCard.SecondaryButton
-                                onClick={async () => {
-                                    updateBackupType(backupType);
-                                    setDebugInProgress(true);
-                                    const result = await dispatch(
-                                        resetDevice({
-                                            ...getResetDeviceParams(backupType),
-                                            skip_backup: true,
-                                        }),
-                                    );
-                                    setDebugInProgress(false);
-                                    if (result?.success) {
-                                        goToNextStep('set-pin');
-                                    } else {
-                                        dispatch(goto({ routeName: 'suite-index' }));
-                                    }
-                                }}
-                                data-testid="@onboarding/skip-backup-debug"
-                            >
-                                <Translation id="TR_CREATE_WALLET" /> (debug, no backup)
-                            </OnboardingCard.SecondaryButton>
-                        )}
-                    </>
-                )
+                <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
+                    <Translation id="TR_BACK" />
+                </OnboardingCard.SecondaryButton>
             }
         >
-            {!debugInProgress && canChoseBackupType && (
+            {canChoseBackupType && (
                 <SelectBackupType
                     selected={backupType}
                     onOpen={() => updateAnalytics({ wasSelectTypeOpened: true })}

--- a/packages/suite/src/views/onboarding/steps/ResetDeviceStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/ResetDeviceStep.tsx
@@ -2,13 +2,14 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { OnboardingCard } from '@suite/onboarding-components';
+import { goto } from '@suite/router';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { selectDeviceDefaultBackupType, selectSelectedDevice } from '@suite-common/device';
 import { type BackupType } from '@suite-common/suite-types';
-import { Text } from '@trezor/components';
+import { Badge, Column, Text } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
-import * as STEP from 'src/constants/onboarding/steps';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 
 import { SelectBackupType } from './SelectBackupType/SelectBackupType';
@@ -24,61 +25,39 @@ export const ResetDeviceStep = () => {
     const deviceModel = device?.features?.internal_model;
     const unitPackaging = device?.features?.unit_packaging ?? 0;
 
-    const [submitted, setSubmitted] = useState(false);
     const [backupType, setBackupType] = useState<BackupType>(deviceDefaultBackupType);
     const { goToPreviousStep, goToNextStep, updateAnalytics, updateBackupType } = useOnboarding();
-
     const dispatch = useDispatch();
-
-    const isWaitingForConfirmation =
-        device?.buttonRequests.some(
-            r => r.code === 'ButtonRequest_ResetDevice' || r.code === 'ButtonRequest_ProtectCall',
-        ) && !submitted; // ButtonRequest_ResetDevice is for T2T1, ButtonRequest_ProtectCall for T1B1
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const [debugInProgress, setDebugInProgress] = useState(false);
 
     const isDeviceLocked = isLocked();
 
-    const onResetDevice = useCallback(
-        async (params?: Parameters<typeof resetDevice>[0]) => {
-            setSubmitted(false);
+    const getResetDeviceParams = useCallback((type: BackupType) => {
+        switch (type) {
+            case 'shamir-single':
+            case 'shamir-advanced':
+                // We do not send `_Extendable` versions of the `backup_type` to be compatible
+                // with older firmwares. New firmware creates always extensible Shamir. Even for
+                // original, non-extendable enum values.
+                return { backup_type: 1 as const };
+            case '12-words':
+                return { backup_type: 0 as const, strength: 128 };
+            case '24-words':
+                return { backup_type: 0 as const, strength: 256 };
+        }
+    }, []);
 
-            const result = await dispatch(resetDevice(params));
-
-            setSubmitted(true);
-
-            if (result?.success) {
-                goToNextStep(STEP.ID_SECURITY_STEP);
-            }
-        },
-        [dispatch, goToNextStep],
-    );
-
+    // Only saves the selected backup type and navigates to the security step.
+    // The actual resetDevice call (with skip_backup: false) happens in SecurityStep,
+    // where the backup guide is shown before wallet creation + backup.
     const handleSubmit = useCallback(
-        async (type: BackupType) => {
-            switch (type) {
-                case 'shamir-single':
-                    // We do not send `_Extendable` versions of the `backup_type` to be compatible
-                    // with older firmwares. New firmware creates always extensible Shamir. Even for
-                    // original, non-extendable enum values.
-                    await onResetDevice({ backup_type: 1 });
-                    break;
-                case 'shamir-advanced': // <-- bad naming, this means `multi-share`
-                    // This is for multi-share, but we send simple Slip39_Basic. At this point,
-                    // the device does not care about extendibility, the only info needed is that its Shamir
-                    // and extendability are handled in the `TrezorConnect.backupDevice(...)
-                    await onResetDevice({ backup_type: 1 });
-                    break;
-                case '12-words':
-                    await onResetDevice({ backup_type: 0, strength: 128 });
-                    break;
-                case '24-words':
-                    await onResetDevice({ backup_type: 0, strength: 256 });
-                    break;
-            }
-
+        (type: BackupType) => {
             updateBackupType(type);
             updateAnalytics({ seedType: type });
+            goToNextStep();
         },
-        [updateBackupType, updateAnalytics, onResetDevice],
+        [updateBackupType, updateAnalytics, goToNextStep],
     );
 
     useEffect(() => {
@@ -92,23 +71,24 @@ export const ResetDeviceStep = () => {
         return null;
     }
 
-    const isWaitingOnDevice = isWaitingForConfirmation || isDeviceLocked;
     const canChoseBackupType = deviceModel !== undefined && canChooseBackupType(deviceModel);
 
-    const getChooseBackupTranslationId = () => {
-        if (isWaitingOnDevice) {
-            return 'TR_ONBOARDING_WILL_CREATE_BACKUP_TYPE';
-        }
-
-        return isShamirBackupType(deviceDefaultBackupType)
+    const getChooseBackupTranslationId = () =>
+        isShamirBackupType(deviceDefaultBackupType)
             ? 'TR_ONBOARDING_SELECTED_OPTIMAL_BACKUP_TYPE'
             : 'TR_ONBOARDING_SELECTED_DEFAULT_BACKUP_TYPE';
-    };
 
     return (
         <OnboardingCard
             iconName="wallet"
-            heading={<Translation id="TR_ONBOARDING_CREATE_NEW_WALLET" />}
+            heading={
+                <Column gap={8} alignItems="center" justifyContent="center">
+                    <Badge intent="neutral" size="medium">
+                        <Translation id="TR_NEW_WALLET" />
+                    </Badge>
+                    <Translation id="TR_WALLET_BACKUP_TYPE" />
+                </Column>
+            }
             description={
                 canChoseBackupType ? (
                     <Translation
@@ -123,29 +103,52 @@ export const ResetDeviceStep = () => {
                 )
             }
             device={device}
-            isActionAbortable={true}
-            isConfirmedOnDevice={isWaitingForConfirmation}
+            isConfirmedOnDevice={debugInProgress}
             innerActions={
-                !isWaitingOnDevice && (
+                !debugInProgress && (
                     <OnboardingCard.Button
                         isDisabled={isDeviceLocked}
                         onClick={() => handleSubmit(backupType)}
                         data-testid="@onboarding/select-seed-type-confirm"
                     >
-                        <Translation id="TR_ONBOARDING_SELECT_SEED_TYPE_CONFIRM" />
+                        <Translation id="TR_ONBOARDING_SELECT_SEED_TYPE_CONTINUE" />
                     </OnboardingCard.Button>
                 )
             }
             outerActions={
-                !isWaitingOnDevice && (
-                    // There is no point to show back button if user can't click it because confirmOnDevice bubble is active
-                    <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
-                        <Translation id="TR_BACK" />
-                    </OnboardingCard.SecondaryButton>
+                !debugInProgress && (
+                    <>
+                        <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
+                            <Translation id="TR_BACK" />
+                        </OnboardingCard.SecondaryButton>
+                        {isDebugModeActive && (
+                            <OnboardingCard.SecondaryButton
+                                onClick={async () => {
+                                    updateBackupType(backupType);
+                                    setDebugInProgress(true);
+                                    const result = await dispatch(
+                                        resetDevice({
+                                            ...getResetDeviceParams(backupType),
+                                            skip_backup: true,
+                                        }),
+                                    );
+                                    setDebugInProgress(false);
+                                    if (result?.success) {
+                                        goToNextStep('set-pin');
+                                    } else {
+                                        dispatch(goto({ routeName: 'suite-index' }));
+                                    }
+                                }}
+                                data-testid="@onboarding/skip-backup-debug"
+                            >
+                                <Translation id="TR_CREATE_WALLET" /> (debug, no backup)
+                            </OnboardingCard.SecondaryButton>
+                        )}
+                    </>
                 )
             }
         >
-            {!isWaitingOnDevice && canChoseBackupType && (
+            {!debugInProgress && canChoseBackupType && (
                 <SelectBackupType
                     selected={backupType}
                     onOpen={() => updateAnalytics({ wasSelectTypeOpened: true })}

--- a/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
@@ -10,13 +10,15 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
 import { BackupSeedCards } from 'src/components/backup';
+import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
 import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
 
-type SecurityStepStatus = 'initial' | 'in-progress' | 'finished';
+type SecurityStepStatus = 'initial' | 'in-progress' | 'skipping-backup' | 'finished';
 
 export const SecurityStep = () => {
     const [status, setStatus] = useState<SecurityStepStatus>('initial');
-    const { goToNextStep, goToPreviousStep, updateAnalytics, backupType } = useOnboarding();
+    const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
+    const { goToNextStep, updateAnalytics, backupType } = useOnboarding();
     const { isLocked } = useDevice();
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
@@ -24,24 +26,27 @@ export const SecurityStep = () => {
     const isDeviceLocked = isLocked();
     const isBackupRequired = useSelector(selectIsDeviceBackupRequired);
 
-    const getResetDeviceParams = useCallback(() => {
-        // All types use skip_backup: false — wallet creation + backup is atomic,
-        // matching native device onboarding. If backup fails, device wipes itself.
-        switch (backupType) {
-            case 'shamir-single':
-                // Slip39_Single_Extendable — firmware handles single-share Shamir natively,
-                // shows "20 words" without asking for shares/threshold.
-                return { backup_type: 3 as const, skip_backup: false };
-            case 'shamir-advanced':
-                return { backup_type: 1 as const, skip_backup: false };
-            case '12-words':
-                return { backup_type: 0 as const, strength: 128, skip_backup: false };
-            case '24-words':
-                return { backup_type: 0 as const, strength: 256, skip_backup: false };
-            default:
-                return exhaustive(backupType);
-        }
-    }, [backupType]);
+    const getResetDeviceParams = useCallback(
+        (skipBackup: boolean = false) => {
+            // All types use skip_backup: false — wallet creation + backup is atomic,
+            // matching native device onboarding. If backup fails, device wipes itself.
+            switch (backupType) {
+                case 'shamir-single':
+                    // Slip39_Single_Extendable — firmware handles single-share Shamir natively,
+                    // shows "20 words" without asking for shares/threshold.
+                    return { backup_type: 3 as const, skip_backup: skipBackup };
+                case 'shamir-advanced':
+                    return { backup_type: 1 as const, skip_backup: skipBackup };
+                case '12-words':
+                    return { backup_type: 0 as const, strength: 128, skip_backup: skipBackup };
+                case '24-words':
+                    return { backup_type: 0 as const, strength: 256, skip_backup: skipBackup };
+                default:
+                    return exhaustive(backupType);
+            }
+        },
+        [backupType],
+    );
 
     const handleStart = useCallback(async () => {
         updateAnalytics({ backup: 'create' });
@@ -58,36 +63,59 @@ export const SecurityStep = () => {
         }
     }, [dispatch, getResetDeviceParams, updateAnalytics]);
 
+    const handleSkipBackup = useCallback(async () => {
+        updateAnalytics({ backup: 'skip' });
+        setShowSkipConfirmation(false);
+        setStatus('skipping-backup');
+        const result = await dispatch(resetDevice(getResetDeviceParams(true)));
+        if (result?.success) {
+            goToNextStep('set-pin');
+        } else {
+            dispatch(goto({ routeName: 'suite-index' }));
+        }
+    }, [dispatch, getResetDeviceParams, goToNextStep, updateAnalytics]);
+
     if (status === 'initial') {
         return (
-            <OnboardingCard
-                iconName="trezorBackup"
-                heading={
-                    <Column gap={8} alignItems="center" justifyContent="center">
-                        <Badge intent="neutral" size="medium">
-                            <Translation id="TR_NEW_WALLET" />
-                        </Badge>
-                        <Translation id="TR_CREATE_BACKUP" />
-                    </Column>
-                }
-                description={<Translation id="TR_ONBOARDING_BACKUP_SUBHEADING" />}
-                innerActions={
-                    <OnboardingCard.Button
-                        data-testid="@onboarding/create-backup-button"
-                        onClick={handleStart}
-                        isDisabled={!canContinue(backup.userConfirmed, isDeviceLocked)}
-                    >
-                        <Translation id="TR_START_BACKUP" />
-                    </OnboardingCard.Button>
-                }
-                outerActions={
-                    <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
-                        <Translation id="TR_BACK" />
-                    </OnboardingCard.SecondaryButton>
-                }
-            >
-                <BackupSeedCards />
-            </OnboardingCard>
+            <>
+                {showSkipConfirmation && (
+                    <SkipStepConfirmation
+                        onCancel={() => setShowSkipConfirmation(false)}
+                        onConfirm={handleSkipBackup}
+                    />
+                )}
+                <OnboardingCard
+                    iconName="trezorBackup"
+                    heading={
+                        <Column gap={8} alignItems="center" justifyContent="center">
+                            <Badge intent="neutral" size="medium">
+                                <Translation id="TR_NEW_WALLET" />
+                            </Badge>
+                            <Translation id="TR_CREATE_BACKUP" />
+                        </Column>
+                    }
+                    description={<Translation id="TR_ONBOARDING_BACKUP_SUBHEADING" />}
+                    innerActions={
+                        <OnboardingCard.Button
+                            data-testid="@onboarding/create-backup-button"
+                            onClick={handleStart}
+                            isDisabled={!canContinue(backup.userConfirmed, isDeviceLocked)}
+                        >
+                            <Translation id="TR_START_BACKUP" />
+                        </OnboardingCard.Button>
+                    }
+                    outerActions={
+                        <OnboardingCard.SecondaryButton
+                            onClick={() => setShowSkipConfirmation(true)}
+                            data-testid="@onboarding/skip-backup"
+                        >
+                            <Translation id="TR_SKIP_BACKUP" />
+                        </OnboardingCard.SecondaryButton>
+                    }
+                >
+                    <BackupSeedCards />
+                </OnboardingCard>
+            </>
         );
     }
 
@@ -129,6 +157,24 @@ export const SecurityStep = () => {
     }
 
     // In-progress: wallet creation or backup running on device
+    if (status === 'skipping-backup') {
+        return (
+            <OnboardingCard
+                iconName="wallet"
+                heading={<Translation id="TR_CREATE_WALLET" />}
+                description={
+                    <Translation
+                        id="TR_ONBOARDING_WILL_CREATE_BACKUP_TYPE"
+                        values={{ br: () => <br /> }}
+                    />
+                }
+                device={device}
+                isConfirmedOnDevice
+                isActionAbortable
+            />
+        );
+    }
+
     return (
         <OnboardingCard
             iconName="trezorBackup"

--- a/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
@@ -1,46 +1,142 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
+import { canContinue } from '@suite/backup';
 import { Translation } from '@suite/intl';
 import { OnboardingCard } from '@suite/onboarding-components';
+import { goto } from '@suite/router';
+import { selectIsDeviceBackupRequired, selectSelectedDevice } from '@suite-common/device';
+import { Badge, Column } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
-import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
-import { useOnboarding } from 'src/hooks/suite';
+import { resetDevice } from 'src/actions/settings/deviceSettingsActions';
+import { BackupSeedCards } from 'src/components/backup';
+import { useDevice, useDispatch, useOnboarding, useSelector } from 'src/hooks/suite';
+
+type SecurityStepStatus = 'initial' | 'in-progress' | 'finished';
 
 export const SecurityStep = () => {
-    const [showSkipConfirmation, setShowSkipConfirmation] = useState(false);
-    const { goToNextStep, updateAnalytics } = useOnboarding();
+    const [status, setStatus] = useState<SecurityStepStatus>('initial');
+    const { goToNextStep, goToPreviousStep, updateAnalytics, backupType } = useOnboarding();
+    const { isLocked } = useDevice();
+    const device = useSelector(selectSelectedDevice);
+    const dispatch = useDispatch();
+    const backup = useSelector(state => state.backup);
+    const isDeviceLocked = isLocked();
+    const isBackupRequired = useSelector(selectIsDeviceBackupRequired);
 
-    return (
-        <>
-            {showSkipConfirmation && (
-                <SkipStepConfirmation onCancel={() => setShowSkipConfirmation(false)} />
-            )}
+    const getResetDeviceParams = useCallback(() => {
+        // All types use skip_backup: false — wallet creation + backup is atomic,
+        // matching native device onboarding. If backup fails, device wipes itself.
+        switch (backupType) {
+            case 'shamir-single':
+                // Slip39_Single_Extendable — firmware handles single-share Shamir natively,
+                // shows "20 words" without asking for shares/threshold.
+                return { backup_type: 3 as const, skip_backup: false };
+            case 'shamir-advanced':
+                return { backup_type: 1 as const, skip_backup: false };
+            case '12-words':
+                return { backup_type: 0 as const, strength: 128, skip_backup: false };
+            case '24-words':
+                return { backup_type: 0 as const, strength: 256, skip_backup: false };
+            default:
+                return exhaustive(backupType);
+        }
+    }, [backupType]);
+
+    const handleStart = useCallback(async () => {
+        updateAnalytics({ backup: 'create' });
+        setStatus('in-progress');
+
+        // Wallet creation + backup in one atomic call, same as native device onboarding.
+        // If backup fails, the device wipes itself (skip_backup: false).
+        const result = await dispatch(resetDevice(getResetDeviceParams()));
+
+        if (result?.success) {
+            setStatus('finished');
+        } else {
+            dispatch(goto({ routeName: 'suite-index' }));
+        }
+    }, [dispatch, getResetDeviceParams, updateAnalytics]);
+
+    if (status === 'initial') {
+        return (
             <OnboardingCard
-                iconName="check"
-                heading={<Translation id="TR_YOUR_WALLET_SUCCESSFULLY_CREATED" />}
-                description={<Translation id="TR_YOUR_WALLET_IS_ALMOST_READY_DESCRIPTION" />}
+                iconName="trezorBackup"
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_NEW_WALLET" />
+                        </Badge>
+                        <Translation id="TR_CREATE_BACKUP" />
+                    </Column>
+                }
+                description={<Translation id="TR_ONBOARDING_BACKUP_SUBHEADING" />}
                 innerActions={
                     <OnboardingCard.Button
                         data-testid="@onboarding/create-backup-button"
-                        onClick={() => {
-                            goToNextStep();
-                        }}
+                        onClick={handleStart}
+                        isDisabled={!canContinue(backup.userConfirmed, isDeviceLocked)}
                     >
-                        <Translation id="TR_CONTINUE_TO_BACKUP" />
+                        <Translation id="TR_START_BACKUP" />
                     </OnboardingCard.Button>
                 }
                 outerActions={
-                    <OnboardingCard.SecondaryButton
-                        data-testid="@onboarding/skip-backup"
-                        onClick={() => {
-                            setShowSkipConfirmation(true);
-                            updateAnalytics({ backup: 'skip' });
-                        }}
-                    >
-                        <Translation id="TR_SKIP_BACKUP" />
+                    <OnboardingCard.SecondaryButton onClick={() => goToPreviousStep()}>
+                        <Translation id="TR_BACK" />
                     </OnboardingCard.SecondaryButton>
                 }
+            >
+                <BackupSeedCards />
+            </OnboardingCard>
+        );
+    }
+
+    if (status === 'finished') {
+        if (isBackupRequired) {
+            return (
+                <OnboardingCard
+                    iconName="warning"
+                    heading={<Translation id="TR_WALLET_CREATED_NOT_SECURED" />}
+                    description={<Translation id="TR_WALLET_CREATED_NOT_SECURED_DESCRIPTION" />}
+                    variant="warning"
+                    innerActions={
+                        <OnboardingCard.Button
+                            data-testid="@onboarding/continue-button"
+                            onClick={() => goToNextStep()}
+                        >
+                            <Translation id="TR_CONTINUE_TO_PIN" />
+                        </OnboardingCard.Button>
+                    }
+                />
+            );
+        }
+
+        return (
+            <OnboardingCard
+                iconName="check"
+                heading={<Translation id="TR_BACKUP_CREATED" />}
+                description={<Translation id="TR_BACKUP_FINISHED_TEXT" />}
+                innerActions={
+                    <OnboardingCard.Button
+                        data-testid="@onboarding/continue-button"
+                        onClick={() => goToNextStep()}
+                    >
+                        <Translation id="TR_BACKUP_FINISHED_BUTTON" />
+                    </OnboardingCard.Button>
+                }
             />
-        </>
+        );
+    }
+
+    // In-progress: wallet creation or backup running on device
+    return (
+        <OnboardingCard
+            iconName="trezorBackup"
+            heading={<Translation id="TR_CREATE_BACKUP" />}
+            description={<Translation id="TR_ONBOARDING_TREZOR_WILL_DISPLAY_BACKUP" />}
+            device={device}
+            isConfirmedOnDevice
+            isActionAbortable
+        />
     );
 };

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/SelectBackupType.tsx
@@ -39,12 +39,13 @@ const SELECT_ELEMENT_HEIGHT_MOBILE = 62;
 const Wrapper = styled.div`
     width: 100%;
     display: flex;
+    align-items: center;
     flex-direction: column;
     gap: ${spacingsPx.xl};
 `;
 
 const SelectWrapper = styled.div<{ $elevation: Elevation }>`
-    width: 100%;
+    width: 700px;
     border-radius: ${borders.radii.sm};
     border: 1px solid ${mapElevationToBorder};
     background: ${mapElevationToBackground};

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -77,6 +77,11 @@ export interface ReadAndConfirmShamirMnemonicEmu {
     threshold: number;
 }
 
+export interface ReadAndConfirmAtomicShamirMnemonicEmu {
+    shares: number;
+    threshold: number;
+}
+
 type StartBridgeVersion = '2.0.33' | 'node-bridge';
 
 export const MNEMONICS = {
@@ -297,6 +302,15 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
         await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
         await this.client.send({
             type: 'emulator-read-and-confirm-shamir-mnemonic',
+            ...options,
+        });
+
+        return null;
+    }
+    async readAndConfirmAtomicShamirMnemonicEmu(options: ReadAndConfirmAtomicShamirMnemonicEmu) {
+        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await this.client.send({
+            type: 'emulator-read-and-confirm-atomic-shamir-mnemonic',
             ...options,
         });
 

--- a/shell.nix
+++ b/shell.nix
@@ -67,7 +67,7 @@ in
     NIX_CC="${gcc}";
 
     shellHook = ''
-      export NODE_OPTIONS=--max_old_space_size=4096
+      export NODE_OPTIONS=--max_old_space_size=8192
       export CURDIR="$(pwd)"
       export PATH="$PATH:$CURDIR/node_modules/.bin"
       export ELECTRON_BUILDER_CACHE="$CURDIR/.cache/electron-builder"

--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
 import {
     Model,
+    ReadAndConfirmAtomicShamirMnemonicEmu,
     ReadAndConfirmShamirMnemonicEmu,
     SetupEmu,
     TrezorUserEnvLink,
@@ -97,6 +98,11 @@ export class DeviceFixture {
     @step()
     async readAndConfirmShamirMnemonic(options: ReadAndConfirmShamirMnemonicEmu) {
         await TrezorUserEnvLink.readAndConfirmShamirMnemonicEmu(options);
+    }
+
+    @step()
+    async readAndConfirmAtomicShamirMnemonic(options: ReadAndConfirmAtomicShamirMnemonicEmu) {
+        await TrezorUserEnvLink.readAndConfirmAtomicShamirMnemonicEmu(options);
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/onboarding/backupSection.ts
+++ b/suite/e2e/support/pageObjects/onboarding/backupSection.ts
@@ -54,22 +54,59 @@ export class BackupSection {
     }
 
     @step()
-    async passThroughShamirBackup(shares: number, threshold: number) {
-        // Backup button should be disabled until all checkboxes are checked
-        await expect(this.startButton).toBeDisabled();
+    async passThroughShamirBackup(
+        shares: number,
+        threshold: number,
+        { deviceConfirmations }: { deviceConfirmations: number },
+    ) {
+        const backupButton = this.page.getByTestId('@onboarding/create-backup-button');
+        const closeButton = this.page.getByTestId('@onboarding/continue-button');
+
+        await expect(backupButton).toBeDisabled();
 
         await this.wroteSeedProperlyCheckbox.click();
         await this.madeNoDigitalCopyCheckbox.click();
         await this.willHideSeedCheckbox.click();
 
-        // Create Shamir backup on device
-        await this.startButton.click();
+        await backupButton.click();
+
         await this.devicePrompt.confirmOnDevicePromptIsShown();
+        for (let i = 0; i < deviceConfirmations; i++) {
+            await this.page.waitForTimeout(1000);
+            await this.device.pressYes();
+        }
 
-        // Adding delay to mitigate race condition; avoids hitting the homescreen
         await this.page.waitForTimeout(1000);
-        await this.device.readAndConfirmShamirMnemonic({ shares, threshold });
+        await this.device.readAndConfirmAtomicShamirMnemonic({ shares, threshold });
 
-        await this.closeButton.click();
+        await closeButton.click();
+    }
+
+    @step()
+    async passThroughBip39Backup({ deviceConfirmations }: { deviceConfirmations: number }) {
+        const backupButton = this.page.getByTestId('@onboarding/create-backup-button');
+        const closeButton = this.page.getByTestId('@onboarding/continue-button');
+
+        await expect(backupButton).toBeDisabled();
+
+        await this.wroteSeedProperlyCheckbox.click();
+        await this.madeNoDigitalCopyCheckbox.click();
+        await this.willHideSeedCheckbox.click();
+
+        await backupButton.click();
+
+        await this.devicePrompt.confirmOnDevicePromptIsShown();
+        for (let i = 0; i < deviceConfirmations; i++) {
+            await this.page.waitForTimeout(1000);
+            await this.device.pressYes();
+        }
+
+        // For BIP39, manually confirm all seed words on device (48 presses for 12 words on T1B1)
+        await this.page.waitForTimeout(1000);
+        for (let i = 0; i < 48; i++) {
+            await this.device.pressYes();
+        }
+
+        await closeButton.click();
     }
 }

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -40,34 +40,27 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await onboardingPage.createWalletButton.click();
             });
 
-            await test.step('Confirm on device', async () => {
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressYes();
-            });
-
-            await test.step('Start backup process', async () => {
-                await onboardingPage.createBackupButton.click();
-            });
-
             await test.step('Check backup completion steps', async () => {
                 await onboardingPage.backup.wroteSeedProperlyCheckbox.click();
                 await onboardingPage.backup.madeNoDigitalCopyCheckbox.click();
                 await onboardingPage.backup.willHideSeedCheckbox.click();
-                await devicePrompt.confirmOnDevicePromptIsHidden();
 
-                await onboardingPage.backup.startButton.click();
-                await devicePrompt.confirmOnDevicePromptIsShown();
+                await page.getByTestId('@onboarding/create-backup-button').click();
 
+                await page.waitForTimeout(1_000);
+                await device.pressYes();
+                await page.waitForTimeout(1_000);
+                await device.pressYes();
                 // Emulator needs to initialize the seed first
                 await page.waitForTimeout(1_000);
                 for (let i = 0; i < 48; i++) {
                     await device.pressYes();
                 }
-
-                await onboardingPage.backup.closeButton.click();
+                await page.getByTestId('@onboarding/continue-button').click();
             });
 
             await test.step('Lets set PIN', async () => {
+                await page.waitForTimeout(2_000);
                 const pin = '12345';
 
                 await onboardingPage.pin.setPinButton.click();

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -18,17 +18,17 @@ test.describe('Onboarding - create wallet', { tag: ['@T2T1'] }, () => {
         await analyticsSection.passThroughAnalytics();
         await onboardingPage.firmware.continueThroughFirmware();
 
-        // Will be clicking on Shamir backup button
+        // Select backup type (no device interaction, just navigates to SecurityStep)
         await onboardingPage.createWalletButton.click();
         await onboardingPage.selectSeedType('shamir-advanced');
-        await devicePrompt.confirmOnDevicePromptIsShown();
-        await device.pressYes();
 
-        await onboardingPage.createBackupButton.click();
-
+        // Start backup
         const shares = 3;
         const threshold = 2;
-        await onboardingPage.backup.passThroughShamirBackup(shares, threshold);
+        await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+            deviceConfirmations: 4,
+        });
+
         await onboardingPage.pin.setPinButton.click();
         await devicePrompt.confirmOnDevicePromptIsShown();
 

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts
@@ -37,9 +37,20 @@ test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }
             await test.step('Start creating wallet', async () => {
                 await onboardingPage.firmware.continueThroughFirmware();
                 await onboardingPage.createWalletButton.click();
-                await onboardingPage.selectSeedType('12-words');
+                // Proceed with default backup type (12-words for T2T1)
+                await onboardingPage.selectSeedConfirmButton.click();
+
+                await onboardingPage.backup.wroteSeedProperlyCheckbox.click();
+                await onboardingPage.backup.madeNoDigitalCopyCheckbox.click();
+                await onboardingPage.backup.willHideSeedCheckbox.click();
+                await onboardingPage.createBackupButton.click();
+
+                // Wallet creation begins on device, entropy check runs after seed generation.
+                // Reject backup early so pending resetDevice settles.
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();
+                await device.pressYes();
+                await device.pressNo();
             });
 
             await test.step('Land on entropy check failure', async () => {
@@ -62,6 +73,7 @@ test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }
             // note that this specific string is one of the ignored errors, see getIsIgnoredEntropyCheckError
             const mockedError = 'device disconnected during action';
             await page.ensureStoreOnDesktop();
+
             await page.evaluate(
                 action => window.store.dispatch(action),
                 deviceActions.setSimulatedEntropyCheckFail({
@@ -73,15 +85,23 @@ test.describe('Onboarding - simulated entropy check failure', { tag: ['@T2T1'] }
             await test.step('Start creating wallet', async () => {
                 await onboardingPage.firmware.continueThroughFirmware();
                 await onboardingPage.createWalletButton.click();
-                await onboardingPage.selectSeedType('12-words');
+                await onboardingPage.selectSeedConfirmButton.click();
+
+                await onboardingPage.backup.wroteSeedProperlyCheckbox.click();
+                await onboardingPage.backup.madeNoDigitalCopyCheckbox.click();
+                await onboardingPage.backup.willHideSeedCheckbox.click();
+                await onboardingPage.createBackupButton.click();
+
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();
+                await device.pressYes();
+                await device.pressNo();
             });
 
             await test.step('Display error toast, but stay on the same screen (no device compromised)', async () => {
                 await expect(page.getByTestId('@toast/error')).toContainText(mockedError);
                 await page.waitForTimeout(500); // we do not expect any navigation, so ensure no navigation occurs
-                await expect(onboardingPage.selectSeedConfirmButton).toBeVisible();
+                await expect(page.getByTestId('@button/go-to-onboarding')).toBeVisible();
             });
         },
     );

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -41,26 +41,18 @@ test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1', '@s
                 await onboardingPage.tutorial.skip();
             });
 
-            await test.step('Create wallet with Shamir backup', async () => {
+            await test.step('Select backup type and create wallet with backup', async () => {
+                // Select backup type (no device interaction, just navigates to SecurityStep)
                 await onboardingPage.createWalletButton.click();
                 await onboardingPage.selectSeedType('shamir-advanced');
-            });
 
-            await test.step('Accept ToS and confirm wallet creation', async () => {
-                // Accept ToS
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressYes();
-
-                // Confirm wallet created
-                await devicePrompt.confirmOnDevicePromptIsShown();
-                await device.pressYes();
-                await onboardingPage.createBackupButton.click();
-            });
-
-            await test.step('Create backup with Shamir shares and threshold', async () => {
+                // SecurityStep: check backup seed cards, create wallet + backup on device, continue
+                // In the new atomic flow, wallet creation and backup happen together
                 const shares = 3;
                 const threshold = 2;
-                await onboardingPage.backup.passThroughShamirBackup(shares, threshold);
+                await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+                    deviceConfirmations: 3,
+                });
             });
 
             await test.step('Set PIN', async () => {

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -31,24 +31,17 @@ test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => 
             await page.waitForTimeout(500);
             await onboardingPage.tutorial.skip();
 
-            // Create wallet with Shamir backup
+            // Select backup type (no device interaction, just navigates to SecurityStep)
             await onboardingPage.createWalletButton.click();
             await onboardingPage.selectSeedType('shamir-advanced');
 
-            // Accept ToS
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-
-            // Confirm wallet created
-            await devicePrompt.confirmOnDevicePromptIsShown();
-            await device.pressYes();
-
-            await onboardingPage.createBackupButton.click();
-
-            // Create backup with Shamir shares and threshold
+            // SecurityStep: check backup seed cards, create wallet + backup on device, continue
+            // In the new atomic flow, wallet creation and backup happen together
             const shares = 3;
             const threshold = 2;
-            await onboardingPage.backup.passThroughShamirBackup(shares, threshold);
+            await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+                deviceConfirmations: 3,
+            });
 
             // Set PIN
             await onboardingPage.pin.setPinButton.click();

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -13,6 +13,10 @@ export const messages = defineMessages({
         defaultMessage: 'Error 404: Link not found',
         id: 'TR_404_TITLE',
     },
+    TR_NEW: {
+        defaultMessage: 'New',
+        id: 'TR_NEW',
+    },
     TR_NEW_PASSPHRASE_WALLET: {
         defaultMessage: 'New passphrase',
         id: 'TR_NEW_PASSPHRASE_WALLET',
@@ -4840,6 +4844,19 @@ export const messages = defineMessages({
         id: 'TR_BACKUP_CREATED',
         defaultMessage: 'Wallet backup created successfully',
     },
+    TR_WALLET_CREATED_NOT_SECURED: {
+        id: 'TR_WALLET_CREATED_NOT_SECURED',
+        defaultMessage: 'Wallet created, but not secured',
+    },
+    TR_WALLET_CREATED_NOT_SECURED_DESCRIPTION: {
+        id: 'TR_WALLET_CREATED_NOT_SECURED_DESCRIPTION',
+        defaultMessage:
+            'If your Trezor is lost, damaged, or stolen, you will lose access to your funds without a wallet backup. Finish your Trezor setup first, then create a wallet backup in Device Settings.',
+    },
+    TR_CONTINUE_TO_PIN: {
+        id: 'TR_CONTINUE_TO_PIN',
+        defaultMessage: 'Continue to PIN',
+    },
     TR_REMOVE: {
         id: 'TR_REMOVE',
         defaultMessage: 'Remove',
@@ -5181,6 +5198,18 @@ export const messages = defineMessages({
         defaultMessage:
             "Generates a single set of 12 or 24 words that can fully recover your wallet. A legacy wallet backup can't be upgraded to a Multi-share Backup. <a>Learn more</a>",
     },
+    TR_NEW_WALLET: {
+        id: 'TR_NEW_WALLET',
+        defaultMessage: 'New wallet',
+    },
+    TR_RECOVER_WALLET: {
+        id: 'TR_RECOVER_WALLET',
+        defaultMessage: 'Recover wallet',
+    },
+    TR_WALLET_BACKUP_TYPE: {
+        id: 'TR_WALLET_BACKUP_TYPE',
+        defaultMessage: 'Wallet backup type',
+    },
     TR_CREATE_WALLET_DEFAULT_OPTION_DISABLED_TOOLTIP: {
         id: 'TR_CREATE_WALLET_DEFAULT_OPTION_DISABLED_TOOLTIP',
         defaultMessage: 'Update your device firmware to enable the Single-share Backup feature.',
@@ -5207,9 +5236,9 @@ export const messages = defineMessages({
         id: 'TR_ONBOARDING_CANNOT_SELECT_SEED_TYPE',
         defaultMessage: 'Trezor will create your new wallet.',
     },
-    TR_ONBOARDING_SELECT_SEED_TYPE_CONFIRM: {
-        id: 'TR_ONBOARDING_SELECT_SEED_TYPE_CONFIRM',
-        defaultMessage: 'Create wallet',
+    TR_ONBOARDING_SELECT_SEED_TYPE_CONTINUE: {
+        id: 'TR_ONBOARDING_SELECT_SEED_TYPE_CONTINUE',
+        defaultMessage: 'Continue',
     },
     TR_CREATE_WALLET: {
         id: 'TR_CREATE_WALLET',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are making the desktop wallet creation + backup work the same as the mobile one. (merging the wallet creation + backup together). So when the backup is anyhow interrupted (unplug, BT disconnect) the wallet creation fails and device is wiped. Before, the device stayed in the state like "backup failed, wipe the device"
‼️ @vojtatranta add this https://satoshilabs.slack.com/archives/C07CPLU4SE8/p1773749532622599?thread_ts=1770222748.019379&cid=C07CPLU4SE8

## Notes for QA

This PR aligns the create wallet + backup flow on desktop with native. Meaning, the wallet creation and backup guide is made as a "one step" on the device. Not as in the past, where on the desktop user first created a wallet, then he clicked in the Suite Onboarding to continue to backup.

Reason for change: if backup fails (eg. disconnecting the device, BT connection drops) the device isn't "bricked" in the state state "backup failed".

I am kindly asking you to test **all the devices** and go through the onboarding while trying to disconnect the device. At that case ,device should just appear to be wiped and ready to be set-up.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24511 https://github.com/trezor/trezor-suite/issues/25009

## Screenshots:
Added / Edited screens
<img width="1150" height="662" alt="Screenshot 2026-03-26 at 3 01 38 PM" src="https://github.com/user-attachments/assets/6c8f395c-8e59-4779-9724-4e6e2bbcc2fb" />
<img width="1179" height="880" alt="Screenshot 2026-03-26 at 3 01 03 PM" src="https://github.com/user-attachments/assets/c98a9040-caea-46db-9ac4-da098cb265f2" />
<img width="1137" height="831" alt="Screenshot 2026-03-26 at 3 00 58 PM" src="https://github.com/user-attachments/assets/7f16dee4-e243-4779-943c-07efbea9df2b" />

<img width="1136" height="900" alt="Screenshot 2026-04-01 at 11 04 26 AM" src="https://github.com/user-attachments/assets/7b04cf42-a5f9-4814-8fcb-114db24de969" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25009-backup-create-onboarding-alignment&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25009-backup-create-onboarding-alignment&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25009-backup-create-onboarding-alignment&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25009-backup-create-onboarding-alignment&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T09:08:57.102Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T13:45:27.046Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->