### PR TITLE
Revert "fix(suite-native): prevent UI glitches when new THP code is requested"

### DIFF
--- a/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
+++ b/suite-native/module-authorize-device/src/hooks/useInitiateThpConnection.ts
@@ -1,27 +1,13 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-
 import { acquireDevice, selectSelectedDevice } from '@suite-common/wallet-core';
-import {
-    AuthorizeDeviceStackParamList,
-    AuthorizeDeviceStackRoutes,
-} from '@suite-native/navigation';
-
-type NavigationProp = NativeStackNavigationProp<AuthorizeDeviceStackParamList>;
 
 export const useInitiateThpConnection = () => {
-    const navigation = useNavigation<NavigationProp>();
     const dispatch = useDispatch();
 
     const device = useSelector(selectSelectedDevice);
 
     const initiateThpConnection = () => {
-        // Navigate as soon as the action is called, do not wait for deviceConnectionMiddleware to
-        // do that. In addition to better UX, this also prevents the current screen from multiplying
-        // in the navigation stack and the invalidCode alert from reappearing once dismissed.
-        navigation.replace(AuthorizeDeviceStackRoutes.ThpConfirmation);
         dispatch(acquireDevice({ requestedDevice: device }));
     };
 


### PR DESCRIPTION


This reverts commit f96ec91d1641f1c5999aa94ac463bdefb671f0dc.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Probably caused bug with T3W1 during device onboarding. Needs to be confirmed.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=revert/native/thp-navigation-glithch-fix&lookback=7)