### PR TITLE
fix(suite-native): Browser should be not killed when put to background

### DIFF
--- a/suite-native/module-trading/src/hooks/general/providerConfirmation/useBrowserAuth.ts
+++ b/suite-native/module-trading/src/hooks/general/providerConfirmation/useBrowserAuth.ts
@@ -111,6 +111,10 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
                     presentationStyle: WebBrowserPresentationStyle.OVER_FULL_SCREEN,
                     dismissButtonStyle: 'close',
                     enableBarCollapsing: false,
+                    // this allows to keep the browser open in the background on android, so user can switch
+                    // from and back to it (e.g. to copy the 2FA code from authenticator app)
+                    // without it being killed by the system
+                    showInRecents: true,
                 });
 
                 switch (type) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Browser should not be killed anymore when it loses focus.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24695


## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/do-not-close-android-browser&lookback=7)