### PR TITLE
Suite sync test: Create new label and verify sync to Relay

### DIFF
--- a/suite/e2e/fixtures/metadata/default-metadata-ids.ts
+++ b/suite/e2e/fixtures/metadata/default-metadata-ids.ts
@@ -1,0 +1,15 @@
+import { OwnerId, getOrThrow } from '@evolu/common';
+
+import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
+import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+
+// Ids for default mnemonic_12: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
+export const ownerId = getOrThrow(OwnerId.from('0Fco3XDgKR59zX5VBvyyGQ'));
+export const ownerSecret = asSuiteSyncOwnerSecretHex(
+    'd5cafbfc837fcdba7fd54025ce352fac369db9383d41d73dbd4f3353b63bc4644585f41195021419707ccdf76bbdf0b1cb0e11f07ff19a41b5f22602dfee3b63',
+);
+export const walletDescriptor = asWalletDescriptor('mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer');
+export const WALLET_INDEX = 0;
+export const accountDescriptor = asAccountDescriptor(
+    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
+);

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -16,7 +16,8 @@
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
-        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up --force-recreate quota-db suite-sync"
+        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up -d --force-recreate quota-db suite-sync -d && docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml logs -f suite-sync",
+        "docker:suite-sync:stop": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml down"
     },
     "devDependencies": {
         "@currents/playwright": "^1.19.0",
@@ -25,7 +26,6 @@
         "@playwright/browser-firefox": "^1.57.0",
         "@playwright/browser-webkit": "^1.57.0",
         "@playwright/test": "^1.57.0",
-        "@scure/bip39": "^1.5.1",
         "@solana-program/stake": "^0.5.0",
         "@solana/addresses": "^2.3.0",
         "@solana/kit": "^2.3.0",

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,6 +1,9 @@
 import { Evolu, SimpleName, getOrThrow } from '@evolu/common';
 import { Upsertable, createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
 import { expect } from '@playwright/test';
+import { execSync } from 'child_process';
+import { diff } from 'jest-diff';
+import { isEqual, omit, orderBy } from 'lodash';
 
 import { Schema, createEvoluAppOwnerFromTrezorData } from '@suite-common/suite-sync-evolu';
 import { SuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
@@ -9,6 +12,7 @@ import { createNodeEvoluDeps } from './createEvoluNodeDeps';
 import { step } from '../common';
 
 type TableName = keyof typeof Schema;
+const allTables = Object.keys(Schema) as TableName[];
 
 export class EvoluClient {
     private _evolu?: Evolu<typeof Schema>;
@@ -61,6 +65,16 @@ export class EvoluClient {
     }
 
     @step()
+    wipeAndRestartServer() {
+        execSync(
+            'docker compose -f docker/docker-compose.suite-ci-e2e.yml up --force-recreate -d quota-db suite-sync',
+            {
+                cwd: '../../',
+            },
+        );
+    }
+
+    @step()
     writeTo<T extends TableName>(table: T, object: Upsertable<(typeof Schema)[T]>) {
         const upsertResult = this.evolu.upsert(table, object as any);
         if (!upsertResult.ok) {
@@ -94,7 +108,6 @@ export class EvoluClient {
 
     @step()
     async debugReadAllTablesAndThrow() {
-        const allTables = Object.keys(Schema) as TableName[];
         const allDataPromise = allTables.map(async table => await this.readFrom(table));
         await expect(async () => {
             const allData = await Promise.all(allDataPromise);
@@ -107,5 +120,34 @@ export class EvoluClient {
             // we have collected all data, throw it for debugging purposes
             throw new Error(`Evolu Data: ${JSON.stringify(allData, null, 2)}`);
         }).toPass({ timeout: 3_000, intervals: [1000, 2000, 2500] });
+    }
+
+    @step()
+    async expectInTable<T extends TableName>(
+        table: T,
+        expectedData: object[],
+        options?: {
+            softExpect?: boolean;
+            omit?: string[];
+            timeout?: number;
+        },
+    ) {
+        const omitFields = options?.omit ?? ['id', 'createdAt'];
+        const timeout = options?.timeout ?? 5_000;
+        const expectFn = options?.softExpect ? expect.soft : expect;
+
+        await expectFn(async () => {
+            const actualData = await this.readFrom(table);
+            const actualOmitted = actualData.map(item => omit(item, omitFields));
+            // Unfortunately label is the only guaranteed property for ordering
+            // might not be sufficient for more advance test scenarios. YAGNI for now.
+            const actualOrdered = orderBy(actualOmitted, ['label']);
+            const expectedOrdered = orderBy(expectedData, ['label']);
+            if (!isEqual(expectedOrdered, actualOrdered)) {
+                throw new Error(
+                    `Table "${table}" data does not match.\nDiff:\n${diff(expectedOrdered, actualOrdered)}`,
+                );
+            }
+        }).toPass({ timeout });
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
@@ -16,18 +16,17 @@ export class AccountMetadata extends MetadataBase {
     }
 
     @step()
-    async changeLabel(accountId: string, newLabel: string) {
-        await this.page.resetMousePosition();
-        // ensure account label is loaded - test can be too fast
-        await expect(this.accountLabel(accountId)).toHaveText(/[A-Za-z]+/);
-        await this.accountLabel(accountId).hover();
-        await this.editLabelButton(accountId).click();
-        await this.fillLabelInput(newLabel, { useButton: true });
+    async changeLabel({ accountId, label }: { accountId: string; label: string }) {
+        await this.clickEditLabelButton(accountId);
+        await this.fillLabelInput(label, { useButton: true });
+        await this.successIconIsVisible(accountId);
     }
 
     @step()
     async clickEditLabelButton(accountId: string) {
         await this.page.resetMousePosition();
+        // ensure account label is loaded - test can be too fast
+        await expect(this.accountLabel(accountId)).toHaveText(/[A-Za-z]+/);
         await this.accountLabel(accountId).hover();
         await this.editLabelButton(accountId).click();
     }

--- a/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
@@ -26,4 +26,11 @@ export class AddressMetadata extends MetadataBase {
         await expect(this.successLabel(accountId)).toBeVisible();
         await expect(this.successLabel(accountId)).toBeHidden();
     }
+
+    @step()
+    async changeLabel({ address, label }: { address: string; label: string }) {
+        await this.clickEditLabel(address);
+        await this.fillLabelInput(label);
+        await this.successIconIsVisible(address);
+    }
 }

--- a/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
@@ -23,7 +23,15 @@ export class OutputMetadata extends MetadataBase {
     }
 
     @step()
-    async editLabel(outputId: string, txNumber: number, label: string) {
+    async changeLabel({
+        outputId,
+        txNumber,
+        label,
+    }: {
+        outputId: string;
+        txNumber: number;
+        label: string;
+    }) {
         await this.clickAddLabelButton(outputId, txNumber);
         await this.outputMetadataInput(outputId, txNumber).fill(label);
         await this.page.keyboard.press('Enter');

--- a/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
@@ -9,6 +9,7 @@ export class WalletMetadata extends MetadataBase {
         this.page.getByTestId(`@switch-device/wallet-on-index/${index}`);
     readonly labelChangeSuccessIcon = (index: number) =>
         this.walletOnIndex(index).getByTestId(this.successId);
+
     @step()
     async clickEditLabel(index: number) {
         await this.page.resetMousePosition();
@@ -22,5 +23,12 @@ export class WalletMetadata extends MetadataBase {
     async successIconIsVisible(standardWalletIndex: number) {
         await expect(this.labelChangeSuccessIcon(standardWalletIndex)).toBeVisible();
         await expect(this.labelChangeSuccessIcon(standardWalletIndex)).toBeHidden();
+    }
+
+    @step()
+    async changeLabel({ index, label }: { index: number; label: string }) {
+        await this.clickEditLabel(index);
+        await this.fillLabelInput(label);
+        await this.successIconIsVisible(index);
     }
 }

--- a/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
+++ b/suite/e2e/tests/metadata/legacy/account-metadata.test.ts
@@ -42,11 +42,13 @@ test.describe('Account metadata', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
         });
 
         await test.step('Edit label with button submit', async () => {
-            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'even cooler');
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: 'even cooler',
+            });
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText('even cooler');
-            await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
         await test.step('Discard label changes via Escape', async () => {
@@ -97,11 +99,10 @@ test.describe('Account metadata', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
             await walletPage.addAccountButton.click();
             await settingsPage.coinsTab.networkButton('btc').click();
             await page.getByTestId('@add-account').click();
-            await metadataPage.account.changeLabel(
-                newAccountLabelId,
-                'adding label to a newly added account. does it work?',
-            );
-            await metadataPage.account.successIconIsVisible(newAccountLabelId);
+            await metadataPage.account.changeLabel({
+                accountId: newAccountLabelId,
+                label: 'adding label to a newly added account. does it work?',
+            });
             await expect(
                 walletPage.accountLabel({
                     symbol: 'btc',

--- a/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
+++ b/suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts
@@ -120,7 +120,10 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
             });
 
             await walletPage.openAccount();
-            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: 'Kvooo',
+            });
             await expect(
                 metadataPage.account.accountLabel(AccountLabelId.BitcoinDefault1),
             ).toContainText('Kvooo');
@@ -160,7 +163,10 @@ test.describe('Dropbox API errors', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
 
             await walletPage.openAccount();
             // just enter some label, this indicates that app did not crash
-            await metadataPage.account.changeLabel(AccountLabelId.BitcoinDefault1, 'Kvooo');
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: 'Kvooo',
+            });
         },
     );
 

--- a/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
+++ b/suite/e2e/tests/metadata/legacy/output-labeling.test.ts
@@ -38,7 +38,11 @@ test.describe('Metadata - Output labeling', { tag: ['@webOnly', '@T3W1', '@T3T1'
             });
 
             await test.step('Add label to output 3 and verify', async () => {
-                await metadataPage.output.editLabel(OutputLabelId.BitcoinLegacy6, 2, 'output 3');
+                await metadataPage.output.changeLabel({
+                    outputId: OutputLabelId.BitcoinLegacy6,
+                    txNumber: 2,
+                    label: 'output 3',
+                });
                 await expect(
                     metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy6, 2),
                 ).toContainText('output 3');
@@ -46,18 +50,22 @@ test.describe('Metadata - Output labeling', { tag: ['@webOnly', '@T3W1', '@T3T1'
 
             await test.step('Label "send to myself tx"', async () => {
                 await walletPage.openAccount({ symbol: 'btc', type: 'legacy', atIndex: 9 });
-                await metadataPage.output.editLabel(
-                    OutputLabelId.BitcoinLegacy10,
-                    0,
-                    'really to myself',
-                );
+                await metadataPage.output.changeLabel({
+                    outputId: OutputLabelId.BitcoinLegacy10,
+                    txNumber: 0,
+                    label: 'really to myself',
+                });
                 await expect(
                     metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
                 ).toContainText('really to myself');
             });
 
             await test.step('Test that label can be edited and submitted by enter', async () => {
-                await metadataPage.output.editLabel(OutputLabelId.BitcoinLegacy10, 0, 'edited');
+                await metadataPage.output.changeLabel({
+                    outputId: OutputLabelId.BitcoinLegacy10,
+                    txNumber: 0,
+                    label: 'edited',
+                });
                 await expect(
                     metadataPage.output.outputLabel(OutputLabelId.BitcoinLegacy10, 0),
                 ).toContainText('edited');

--- a/suite/e2e/tests/metadata/legacy/remembered-device.test.ts
+++ b/suite/e2e/tests/metadata/legacy/remembered-device.test.ts
@@ -98,10 +98,10 @@ test.describe('Remembered device', { tag: ['@webOnly', '@T2T1'] }, () => {
             await device.powerOff();
 
             // Device is saved, when disconnected, user still can edit labels
-            await metadataPage.account.changeLabel(
-                AccountLabelId.BitcoinDefault1,
-                'edited for remembered',
-            );
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: 'edited for remembered',
+            });
             await expect(page.getByTestId('@account-menu/btc/normal/0/label')).toContainText(
                 'edited for remembered',
             );

--- a/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
@@ -1,69 +1,129 @@
-import { generateMnemonic } from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
-
-import { skipFixture } from '../../../support/common';
+import {
+    WALLET_INDEX,
+    accountDescriptor,
+    ownerId,
+    ownerSecret,
+    walletDescriptor,
+} from '../../../fixtures/metadata/default-metadata-ids';
 import { AccountLabelId } from '../../../support/enums/accountLabelId';
 import { expect, test } from '../../../support/fixtures';
+
+const expectedWallet = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    walletDescriptor,
+    label: 'Evolu write wallet',
+};
+
+const expectedAccount = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    accountDescriptor,
+    networkSymbol: 'btc',
+    label: 'Evolu write BTC account',
+};
+
+const expectedAddress = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    accountDescriptor,
+    label: 'Evolu write BTC address',
+    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+    networkSymbol: 'btc',
+};
+
+const expectedOutput = {
+    isDeleted: null,
+    updatedAt: null,
+    ownerId,
+    accountDescriptor,
+    label: 'Evolu write output',
+    networkSymbol: 'btc',
+    outputIndex: '0',
+    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
+};
 
 test.describe(
     'Suite Sync - Labelling',
     { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
     () => {
         test.use({
-            exceptionLogger: skipFixture,
             firmwareVersion: '2-main',
-            deviceSetup: {
-                mnemonic: generateMnemonic(wordlist),
-                passphrase_protection: true,
-            },
+            deviceSetup: { passphrase_protection: true },
         });
 
-        test('Sync account label across sessions', async ({
-            page,
-            onboardingPage,
-            settingsPage,
+        test.beforeEach(async ({ evoluClient, onboardingPage, metadataPage }) => {
+            evoluClient.wipeAndRestartServer();
+            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+            await metadataPage.setupQuotaManager();
+            await metadataPage.enableSuiteSync();
+        });
+
+        test('Create new labels', async ({
+            evoluClient,
+            dashboardPage,
             walletPage,
             metadataPage,
         }) => {
-            await test.step('Onboarding and enable Suite Sync', async () => {
-                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-                await metadataPage.setupQuotaManager();
-                await metadataPage.enableSuiteSync();
+            await test.step('Verify BTC account label is synced', async () => {
+                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+                await metadataPage.account.changeLabel({
+                    accountId: AccountLabelId.BitcoinDefault1,
+                    label: expectedAccount.label,
+                });
+                await expect
+                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                    .toHaveText(expectedAccount.label, { timeout: 30_000 });
             });
 
-            const newLabel = 'my synced btc account label';
-            await test.step('Change BTC account label in first session', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
-                await metadataPage.account.metadataInput.fill(newLabel);
-                await page.keyboard.press('Enter');
+            await test.step('Change wallet label', async () => {
+                await dashboardPage.openDeviceSwitcher();
+                await metadataPage.wallet.changeLabel({
+                    index: WALLET_INDEX,
+                    label: expectedWallet.label,
+                });
+                await expect
+                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                    .toHaveText(expectedWallet.label);
+                await dashboardPage.deviceSwitchingCloseButton.click();
+            });
+
+            await test.step('Change address label', async () => {
+                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+                await walletPage.receiveButton.click();
+                await metadataPage.address.changeLabel({
+                    address: expectedAddress.address,
+                    label: expectedAddress.label,
+                });
+                await expect
+                    .soft(metadataPage.address.label(expectedAddress.address))
+                    .toHaveText(expectedAddress.label);
+            });
+
+            await test.step('Change output label', async () => {
+                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+                await metadataPage.output.changeLabel({
+                    outputId: expectedOutput.txId,
+                    txNumber: Number(expectedOutput.outputIndex),
+                    label: expectedOutput.label,
+                });
                 await expect(
-                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-                ).toHaveText(newLabel);
-
-                await page.waitForTimeout(5_000); // wait for sync to complete
+                    metadataPage.output.outputLabel(
+                        expectedOutput.txId,
+                        Number(expectedOutput.outputIndex),
+                    ),
+                ).toHaveText(expectedOutput.label);
             });
 
-            await test.step('Wipe Suite to simulate new session', async () => {
-                await settingsPage.navigateTo('application');
-                await settingsPage.resetAppButton.click();
-            });
-
-            await test.step('Onboarding and enable Suite Sync', async () => {
-                await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-                await metadataPage.setupQuotaManager();
-                await metadataPage.enableSuiteSync();
-            });
-
-            await test.step('Verify BTC account label is synced in second session', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await expect(
-                    walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-                ).toHaveText(newLabel, { timeout: 30_000 });
+            await test.step('Verify data are sync to Relay', async () => {
+                await evoluClient.init({ ownerSecret });
+                await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
+                await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
+                await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
+                await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
             });
         });
     },

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -1,21 +1,15 @@
-import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
-import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
-
-import { isWebProject, skipFixture } from '../../../support/common';
+import {
+    WALLET_INDEX,
+    accountDescriptor,
+    ownerSecret,
+    walletDescriptor,
+} from '../../../fixtures/metadata/default-metadata-ids';
+import { isWebProject } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 
-// const ownerId = getOrThrow(OwnerId.from('0Fco3XDgKR59zX5VBvyyGQ'));
-const ownerSecret = asSuiteSyncOwnerSecretHex(
-    'd5cafbfc837fcdba7fd54025ce352fac369db9383d41d73dbd4f3353b63bc4644585f41195021419707ccdf76bbdf0b1cb0e11f07ff19a41b5f22602dfee3b63',
-);
-
-const WALLET_SEED_INDEX = 0;
-const accountDescriptor = asAccountDescriptor(
-    'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
-);
 const walletSeed = {
     id: 'ya1CCDTCVPyRa6egTac7yg',
-    walletDescriptor: asWalletDescriptor('mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer'),
+    walletDescriptor,
     label: 'Evolu synced wallet',
 };
 
@@ -39,21 +33,19 @@ test.describe(
     { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
     () => {
         test.use({
-            exceptionLogger: skipFixture,
             firmwareVersion: '2-main',
             deviceSetup: { passphrase_protection: true },
         });
 
         test.beforeEach(async ({ evoluClient, onboardingPage }) => {
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
             await test.step('Seed Evolu relay server', async () => {
-                await evoluClient.init({
-                    ownerSecret,
-                });
+                evoluClient.wipeAndRestartServer();
+                await evoluClient.init({ ownerSecret });
                 evoluClient.writeTo('wallet', walletSeed);
                 evoluClient.writeTo('account', accountSeed);
                 evoluClient.writeTo('address', addressSeed);
             });
+            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
         });
 
         test('Sync labels from server', async ({
@@ -112,7 +104,7 @@ test.describe(
             await test.step('Verify wallet label is synced', async () => {
                 await dashboardPage.openDeviceSwitcher();
                 await expect
-                    .soft(metadataPage.wallet.walletLabel(WALLET_SEED_INDEX))
+                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
                     .toHaveText(walletSeed.label);
                 await dashboardPage.deviceSwitchingCloseButton.click();
             });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15602,7 +15602,6 @@ __metadata:
     "@playwright/browser-firefox": "npm:^1.57.0"
     "@playwright/browser-webkit": "npm:^1.57.0"
     "@playwright/test": "npm:^1.57.0"
-    "@scure/bip39": "npm:^1.5.1"
     "@solana-program/stake": "npm:^0.5.0"
     "@solana/addresses": "npm:^2.3.0"
     "@solana/kit": "npm:^2.3.0"


### PR DESCRIPTION
Reworks original test to focus solely on label creation and propagating to Relay server.

- DRY tests data to fixture -> this will probably continue as add more tests
- new mechanism for wiping Ralay server. By force-recreating it. I will later revisit it for improvements. ATM it takes ~16s every test
- new verification method expectInTable
- refactored all metadata classes to provide changeLabel method with verification of status icon


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-write-2&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-write-2&lookback=7)