### PR TITLE
fix(suite-native): passphrase flow handling for device authorization

### DIFF
--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -43,7 +43,8 @@ export const deviceAuthorizationSlice = createSlice({
             })
             .addCase(UI.REQUEST_PASSPHRASE, (state, action) => {
                 // @ts-expect-error payload not typed
-                if (action.payload?.device?._state?.staticSessionId) {
+                // TODO properly type check with some guard
+                if (action.payload?.device?.state?.staticSessionId) {
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.PassphraseRequested;
                 } else if (state.deviceAuthorizationStep === DeviceAuthorizationStep.PinRequested) {
                     // If pin was requested for new passphrase wallet, we can't wait for close window to reset the state
@@ -71,7 +72,8 @@ export const deviceAuthorizationSlice = createSlice({
             .addMatcher(isPassphraseButtonRequestCode, (state, action) => {
                 if (
                     // @ts-expect-error payload not typed
-                    !action.payload.device._state &&
+                    // TODO properly type check with some guard
+                    !action.payload.device.state &&
                     state.deviceAuthorizationStep === DeviceAuthorizationStep.PinRequested
                 ) {
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.Idle;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After [this PR](https://github.com/trezor/trezor-suite/pull/24573) we need to change the device state that we react to from connect. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25092

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/passphrase-flow-handling-for-authorization&lookback=7)