### PR TITLE
fix(suite-native): passphrase ui action type guards

### DIFF
--- a/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
+++ b/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
@@ -39,7 +39,7 @@ describe('deviceAuthorizationSlice', () => {
                 payload: {
                     // @ts-expect-error This is how connect sends the payload for device state, but then it's stored differently in redux so this util doesn't recognize
                     // this type of property. For testing purposes however, it's fine.
-                    device: mockSuiteDevice({ _state: { staticSessionId: 'test-session-id' } }),
+                    device: mockSuiteDevice({ state: { staticSessionId: 'test-session-id' } }),
                 },
             });
 
@@ -69,7 +69,7 @@ describe('deviceAuthorizationSlice', () => {
             const state = deviceAuthorizationReducer(undefined, {
                 type: UI.REQUEST_PASSPHRASE,
                 payload: {
-                    device: { ...mockSuiteDevice(), _state: { staticSessionId: undefined } },
+                    device: { ...mockSuiteDevice(), state: { staticSessionId: undefined } },
                 },
             });
 

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -5,6 +5,7 @@ import { UI } from '@trezor/connect';
 import {
     isFlowEndingButtonRequest,
     isPassphraseButtonRequestCode,
+    isPassphraseRequest,
     isPinButtonRequestCode,
     isSuiteSyncButtonRequest,
 } from './utils';
@@ -42,8 +43,7 @@ export const deviceAuthorizationSlice = createSlice({
                 state.deviceAuthorizationStep = DeviceAuthorizationStep.PinRequested;
             })
             .addCase(UI.REQUEST_PASSPHRASE, (state, action) => {
-                // @ts-expect-error payload not typed
-                if (action.payload?.device?._state?.staticSessionId) {
+                if (isPassphraseRequest(action) && action.payload?.device?.state?.staticSessionId) {
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.PassphraseRequested;
                 } else if (state.deviceAuthorizationStep === DeviceAuthorizationStep.PinRequested) {
                     // If pin was requested for new passphrase wallet, we can't wait for close window to reset the state
@@ -70,8 +70,7 @@ export const deviceAuthorizationSlice = createSlice({
             // 3. After pin is succesfully entered, we receive next step passphrase button request so we reset to Idle so passphrase module gets focused.
             .addMatcher(isPassphraseButtonRequestCode, (state, action) => {
                 if (
-                    // @ts-expect-error payload not typed
-                    !action.payload.device._state &&
+                    !action.payload.device.state &&
                     state.deviceAuthorizationStep === DeviceAuthorizationStep.PinRequested
                 ) {
                     state.deviceAuthorizationStep = DeviceAuthorizationStep.Idle;

--- a/suite-native/device-authorization/src/utils.ts
+++ b/suite-native/device-authorization/src/utils.ts
@@ -1,20 +1,22 @@
 import { G } from '@mobily/ts-belt';
 import { UnknownAction } from '@reduxjs/toolkit';
 
-import { UI } from '@trezor/connect';
+import { UI, UiRequestDeviceAction } from '@trezor/connect';
 
 export const pinButtonRequestCodes = [
     'ButtonRequest_PinEntry',
     'PinMatrixRequestType_Current',
 ] as const;
 
-export const isPinButtonRequestCode = (action: UnknownAction) =>
+export const isPinButtonRequestCode = (action: UnknownAction): action is UiRequestDeviceAction =>
     action.type === UI.REQUEST_BUTTON &&
     G.isNotNullable(action.payload) &&
     'code' in action.payload &&
     pinButtonRequestCodes.includes(action.payload.code as (typeof pinButtonRequestCodes)[number]);
 
-export const isPassphraseButtonRequestCode = (action: UnknownAction) =>
+export const isPassphraseButtonRequestCode = (
+    action: UnknownAction,
+): action is UiRequestDeviceAction =>
     action.type === UI.REQUEST_PASSPHRASE_ON_DEVICE ||
     (action.type === UI.REQUEST_BUTTON &&
         G.isNotNullable(action.payload) &&
@@ -22,6 +24,9 @@ export const isPassphraseButtonRequestCode = (action: UnknownAction) =>
         action.payload.code === 'ButtonRequest_Other' &&
         'name' in action.payload &&
         action.payload.name === 'passphrase_host1');
+
+export const isPassphraseRequest = (action: UnknownAction): action is UiRequestDeviceAction =>
+    action.type === UI.REQUEST_PASSPHRASE;
 
 export const flowEndingButtonRequests = [
     'ButtonRequest_ConfirmOutput',


### PR DESCRIPTION
## Description

Based on #25095 but fixes the type

## Related Issue

Resolve #25092


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-device-authorization-passphrase-action-type-guard&lookback=7)