### PR TITLE
refactor(product-components): extract notification subcomponents and fix Storybook fonts

### DIFF
--- a/packages/product-components/.storybook/manager-head.html
+++ b/packages/product-components/.storybook/manager-head.html
@@ -1,2 +1,2 @@
-<link media="all" rel="stylesheet" href="./fonts/fonts.css" />
+<link media="all" rel="stylesheet" href="/static/fonts/fonts.css" />
 <link media="all" rel="stylesheet" href="./fonts/style.css" />

--- a/packages/product-components/.storybook/preview-head.html
+++ b/packages/product-components/.storybook/preview-head.html
@@ -1,2 +1,2 @@
-<link media="all" rel="stylesheet" href="./fonts/fonts.css" />
+<link media="all" rel="stylesheet" href="/static/fonts/fonts.css" />
 <link media="all" rel="stylesheet" href="./fonts/style.css" />

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:^",

--- a/packages/product-components/src/components/Notifications/ExchangeAmountWithSymbol.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeAmountWithSymbol.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { Row, Text } from '@trezor/components';
+
+import { type ExchangeInfoAsset } from './notificationsTypes';
+
+type ExchangeAmountWithSymbolProps = {
+    amount: ReactNode;
+    asset: ExchangeInfoAsset;
+};
+
+export const ExchangeAmountWithSymbol = ({ amount, asset }: ExchangeAmountWithSymbolProps) => {
+    const resolvedDisplaySymbol = asset.displaySymbol ?? getDisplaySymbol(asset.symbol);
+
+    return (
+        <Row gap={4} alignItems="baseline">
+            {amount}
+            <Text>{resolvedDisplaySymbol}</Text>
+        </Row>
+    );
+};

--- a/packages/product-components/src/components/Notifications/ExchangeAssetWithFallback.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeAssetWithFallback.tsx
@@ -1,0 +1,25 @@
+import { getCoingeckoId, getDisplaySymbol } from '@suite-common/wallet-config';
+
+import { type ExchangeInfoAsset } from './notificationsTypes';
+import { AssetLogo } from '../AssetLogo/AssetLogo';
+
+type ExchangeAssetWithFallbackProps = {
+    asset: ExchangeInfoAsset;
+};
+
+export const ExchangeAssetWithFallback = ({ asset }: ExchangeAssetWithFallbackProps) => {
+    const resolvedDisplaySymbol = asset.displaySymbol ?? getDisplaySymbol(asset.symbol);
+    const resolvedCoingeckoId = asset.coingeckoId ?? getCoingeckoId(asset.symbol) ?? '';
+
+    return (
+        asset.icon ?? (
+            <AssetLogo
+                size={20}
+                coingeckoId={resolvedCoingeckoId}
+                contractAddress={asset.contractAddress}
+                symbol={asset.symbol}
+                placeholder={resolvedDisplaySymbol}
+            />
+        )
+    );
+};

--- a/packages/product-components/src/components/Notifications/ExchangeInfoNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeInfoNotification.stories.tsx
@@ -1,0 +1,94 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { IconName, Toast, ToastProps, variables } from '@trezor/components';
+
+import { ExchangeInfoNotification } from './ExchangeInfoNotification';
+
+const meta: Meta<typeof ExchangeInfoNotification> = {
+    title: 'Notifications/ExchangeInfoNotification',
+    component: ExchangeInfoNotification,
+    parameters: {
+        controls: {
+            exclude: ['message', 'send', 'receive', 'renderAmount'],
+        },
+    },
+};
+
+export default meta;
+
+type NotificationVariant = 'success' | 'info' | 'warning' | 'error' | 'transparent';
+
+type ExchangeInfoToastStoryArgs = {
+    variant: NotificationVariant;
+    icon?: IconName;
+    dismissible: boolean;
+};
+
+const mapNotificationVariantToIntent = (variant: NotificationVariant): ToastProps['intent'] => {
+    const variantMap: Record<NotificationVariant, ToastProps['intent']> = {
+        success: 'brand',
+        info: 'info',
+        warning: 'warning',
+        error: 'critical',
+        transparent: 'neutral',
+    };
+
+    return variantMap[variant];
+};
+
+const exchangeInfoContent = (
+    <ExchangeInfoNotification
+        message="Swap transaction from Solana #1 to Ethereum #1 was broadcast"
+        send={{
+            symbol: 'sol',
+            amount: 3,
+            displaySymbol: 'SOL',
+            coingeckoId: 'solana',
+        }}
+        receive={{
+            symbol: 'eth',
+            amount: 0.0051663,
+            displaySymbol: 'ETH',
+            coingeckoId: 'ethereum',
+        }}
+    />
+);
+
+export const Default: StoryObj<typeof ExchangeInfoNotification> = {
+    render: () => exchangeInfoContent,
+};
+
+export const InToast: StoryObj<ExchangeInfoToastStoryArgs> = {
+    args: {
+        variant: 'success',
+        icon: 'arrowUp',
+        dismissible: true,
+    },
+    argTypes: {
+        variant: {
+            control: {
+                type: 'select',
+            },
+            options: ['success', 'info', 'warning', 'error', 'transparent'],
+        },
+        icon: {
+            options: [undefined, ...variables.ICONS],
+            control: {
+                type: 'select',
+            },
+        },
+        dismissible: {
+            control: {
+                type: 'boolean',
+            },
+        },
+    },
+    render: ({ variant, icon, dismissible }) => (
+        <Toast
+            intent={mapNotificationVariantToIntent(variant)}
+            icon={icon}
+            dismissible={dismissible}
+            content={exchangeInfoContent}
+        />
+    ),
+};

--- a/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeInfoNotification.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+
+import { Column, Icon, Row, Text } from '@trezor/components';
+
+import { ExchangeAmountWithSymbol } from './ExchangeAmountWithSymbol';
+import { ExchangeAssetWithFallback } from './ExchangeAssetWithFallback';
+import { type ExchangeInfoAmountSide, type ExchangeInfoAsset } from './notificationsTypes';
+
+export type { ExchangeInfoAmountSide, ExchangeInfoAsset } from './notificationsTypes';
+
+export type ExchangeInfoNotificationProps = {
+    message: ReactNode;
+    send: ExchangeInfoAsset;
+    receive: ExchangeInfoAsset;
+    renderAmount?: (amount: ReactNode, side: ExchangeInfoAmountSide) => ReactNode;
+};
+
+export const ExchangeInfoNotification = ({
+    message,
+    send,
+    receive,
+    renderAmount,
+}: ExchangeInfoNotificationProps) => {
+    const sendAmount = renderAmount ? renderAmount(send.amount, 'send') : send.amount;
+    const receiveAmount = renderAmount ? renderAmount(receive.amount, 'receive') : receive.amount;
+
+    return (
+        <Column gap={4}>
+            <Text typographyStyle="highlight">{message}</Text>
+            <Row gap={8} alignItems="center">
+                <ExchangeAssetWithFallback asset={send} />
+                <ExchangeAmountWithSymbol amount={sendAmount} asset={send} />
+                <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />
+                <ExchangeAssetWithFallback asset={receive} />
+                <ExchangeAmountWithSymbol amount={receiveAmount} asset={receive} />
+            </Row>
+        </Column>
+    );
+};

--- a/packages/product-components/src/components/Notifications/TransactionAmount.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionAmount.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+
+import { NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { Row } from '@trezor/components';
+
+import {
+    type TransactionNotificationToken,
+    type TransactionNotificationType,
+} from './notificationsTypes';
+
+type TransactionAmountProps = {
+    amount: ReactNode;
+    notificationType: TransactionNotificationType;
+    symbol: NetworkSymbol;
+    token?: TransactionNotificationToken;
+    tokenSymbol?: string;
+    isInfiniteApproval?: boolean;
+    unlimitedApprovalLabel?: ReactNode;
+    renderAmount?: (amount: ReactNode) => ReactNode;
+};
+
+export const TransactionAmount = ({
+    amount,
+    notificationType,
+    symbol,
+    token,
+    tokenSymbol,
+    isInfiniteApproval,
+    unlimitedApprovalLabel,
+    renderAmount,
+}: TransactionAmountProps) => {
+    const shouldRenderApprovalAmountWithSymbol =
+        notificationType === 'tx-approved' || notificationType === 'tx-revoked';
+    const resolvedTokenDisplaySymbol = getDisplaySymbol(tokenSymbol ?? token?.symbol ?? symbol);
+    const resolvedAmountValue =
+        notificationType === 'tx-approved' && isInfiniteApproval
+            ? (unlimitedApprovalLabel ?? amount)
+            : amount;
+
+    const amountContent = shouldRenderApprovalAmountWithSymbol ? (
+        <Row display="inline-flex" gap={4} alignItems="baseline">
+            {resolvedAmountValue}
+            <span>{resolvedTokenDisplaySymbol}</span>
+        </Row>
+    ) : (
+        resolvedAmountValue
+    );
+
+    return renderAmount ? renderAmount(amountContent) : amountContent;
+};

--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -1,0 +1,58 @@
+import { ReactNode } from 'react';
+
+import { NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
+
+import {
+    type TransactionNotificationToken,
+    type TransactionNotificationType,
+} from './notificationsTypes';
+import { AssetLogo } from '../AssetLogo/AssetLogo';
+import { CoinLogo } from '../CoinLogo/CoinLogo';
+
+type TransactionIconProps = {
+    icon?: ReactNode;
+    notificationType: TransactionNotificationType;
+    symbol: NetworkSymbol;
+    accountSymbol: NetworkSymbol;
+    token?: TransactionNotificationToken;
+};
+
+type ShouldDisplayAssetLogoProps = {
+    notificationType: TransactionNotificationType;
+    token?: TransactionNotificationToken;
+};
+
+const shouldDisplayAssetLogo = ({ notificationType, token }: ShouldDisplayAssetLogoProps) => {
+    const isApprovalType = notificationType === 'tx-approved' || notificationType === 'tx-revoked';
+    const isTransferTokenType =
+        notificationType === 'tx-sent' || notificationType === 'tx-received';
+
+    return (isApprovalType || isTransferTokenType) && !!token;
+};
+
+export const TransactionIcon = ({
+    icon,
+    notificationType,
+    symbol,
+    accountSymbol,
+    token,
+}: TransactionIconProps) => {
+    if (icon) {
+        return icon;
+    }
+
+    if (shouldDisplayAssetLogo({ notificationType, token }) && token) {
+        return (
+            <AssetLogo
+                symbol={symbol}
+                coingeckoId={getCoingeckoId(accountSymbol) ?? ''}
+                contractAddress={token.contract ?? null}
+                placeholder={token.symbol ?? token.name ?? symbol}
+                size={20}
+                shouldTryToFetch
+            />
+        );
+    }
+
+    return <CoinLogo symbol={symbol} size={20} />;
+};

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -1,0 +1,195 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { IconName, Toast, ToastProps } from '@trezor/components';
+
+import {
+    TransactionNotification,
+    type TransactionNotificationProps,
+} from './TransactionNotification';
+
+const meta: Meta<typeof TransactionNotification> = {
+    title: 'Notifications/TransactionNotification',
+    component: TransactionNotification,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TransactionNotification>;
+type TransactionNotificationType = TransactionNotificationProps['notificationType'];
+
+type TransactionToastStoryArgs = {
+    notificationType: TransactionNotificationType;
+};
+
+const transactionNotificationConfig: Record<
+    TransactionNotificationType,
+    {
+        toastIcon?: IconName;
+        intent: ToastProps['intent'];
+        message: string;
+        amount: string;
+        transaction: Pick<
+            TransactionNotificationProps,
+            'notificationType' | 'symbol' | 'accountSymbol' | 'token'
+        >;
+    }
+> = {
+    'tx-received': {
+        toastIcon: 'arrowDown',
+        intent: 'info',
+        message: 'Received',
+        amount: '4.6 ETH',
+        transaction: {
+            notificationType: 'tx-received',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+        },
+    },
+    'tx-confirmed': {
+        intent: 'info',
+        message: 'Transaction in Ethereum #1 confirmed',
+        amount: '4.6 ETH',
+        transaction: {
+            notificationType: 'tx-confirmed',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+        },
+    },
+    'tx-revoked': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Revoke transaction was broadcasted',
+        amount: '',
+        transaction: {
+            notificationType: 'tx-revoked',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+            token: {
+                contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+                name: 'LINK',
+                symbol: 'LINK',
+            },
+        },
+    },
+    'tx-claimed': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Claimed',
+        amount: '101.6 SOL',
+        transaction: {
+            notificationType: 'tx-claimed',
+            symbol: 'sol',
+            accountSymbol: 'sol',
+        },
+    },
+    'tx-unstaked': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Unstaked',
+        amount: '4.6 ETH',
+        transaction: {
+            notificationType: 'tx-unstaked',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+        },
+    },
+    'tx-staked': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Staked from Ethereum #1',
+        amount: '4.6 ETH',
+        transaction: {
+            notificationType: 'tx-staked',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+        },
+    },
+    'tx-approved': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Approve transaction was broadcasted',
+        amount: '0.46024759',
+        transaction: {
+            notificationType: 'tx-approved',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+            token: {
+                contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+                name: 'LINK',
+                symbol: 'LINK',
+            },
+        },
+    },
+    'tx-sent': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Sent from Ethereum #1',
+        amount: '0.46024759 LINK',
+        transaction: {
+            notificationType: 'tx-sent',
+            symbol: 'eth',
+            accountSymbol: 'eth',
+            token: {
+                contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+                name: 'LINK',
+                symbol: 'LINK',
+            },
+        },
+    },
+};
+
+export const Default: Story = {
+    args: {
+        message: 'Sent from Ethereum #1',
+        notificationType: 'tx-sent',
+        symbol: 'eth',
+        accountSymbol: 'eth',
+        token: {
+            contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+            name: 'LINK',
+            symbol: 'LINK',
+        },
+        amount: '0.46024759 LINK',
+    },
+};
+
+export const InToast: StoryObj<TransactionToastStoryArgs> = {
+    args: {
+        notificationType: 'tx-sent',
+    },
+    argTypes: {
+        notificationType: {
+            control: {
+                type: 'select',
+            },
+            options: [
+                'tx-sent',
+                'tx-received',
+                'tx-revoked',
+                'tx-claimed',
+                'tx-unstaked',
+                'tx-staked',
+                'tx-approved',
+                'tx-confirmed',
+            ],
+        },
+    },
+    render: ({ notificationType }) => {
+        const config = transactionNotificationConfig[notificationType];
+
+        return (
+            <Toast
+                intent={config.intent}
+                icon={config.toastIcon}
+                dismissible
+                content={
+                    <TransactionNotification
+                        message={config.message}
+                        amount={config.amount}
+                        {...config.transaction}
+                    />
+                }
+            />
+        );
+    },
+};

--- a/packages/product-components/src/components/Notifications/TransactionNotification.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.tsx
@@ -1,0 +1,62 @@
+import { ReactNode } from 'react';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Column, Row, Text } from '@trezor/components';
+
+import { TransactionAmount } from './TransactionAmount';
+import { TransactionIcon } from './TransactionIcon';
+import {
+    type TransactionNotificationToken,
+    type TransactionNotificationType,
+} from './notificationsTypes';
+
+export type TransactionNotificationProps = {
+    message: ReactNode;
+    amount: ReactNode;
+    notificationType: TransactionNotificationType;
+    symbol: NetworkSymbol;
+    accountSymbol: NetworkSymbol;
+    token?: TransactionNotificationToken;
+    icon?: ReactNode;
+    tokenSymbol?: string;
+    isInfiniteApproval?: boolean;
+    unlimitedApprovalLabel?: ReactNode;
+    renderAmount?: (amount: ReactNode) => ReactNode;
+};
+
+export const TransactionNotification = ({
+    message,
+    amount,
+    notificationType,
+    symbol,
+    accountSymbol,
+    token,
+    icon,
+    tokenSymbol,
+    isInfiniteApproval,
+    unlimitedApprovalLabel,
+    renderAmount,
+}: TransactionNotificationProps) => (
+    <Column gap={4}>
+        <Text typographyStyle="highlight">{message}</Text>
+        <Row gap={8} alignItems="center">
+            <TransactionIcon
+                icon={icon}
+                notificationType={notificationType}
+                symbol={symbol}
+                accountSymbol={accountSymbol}
+                token={token}
+            />
+            <TransactionAmount
+                amount={amount}
+                notificationType={notificationType}
+                symbol={symbol}
+                token={token}
+                tokenSymbol={tokenSymbol}
+                isInfiniteApproval={isInfiniteApproval}
+                unlimitedApprovalLabel={unlimitedApprovalLabel}
+                renderAmount={renderAmount}
+            />
+        </Row>
+    </Column>
+);

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+
+import type { NotificationEntry } from '@suite-common/toast-notifications';
+
+type ExchangeToastAssetData = Extract<
+    NotificationEntry,
+    { type: 'tx-exchange' }
+>['metadata']['send'];
+
+export type ExchangeInfoAmountSide = 'send' | 'receive';
+
+export type ExchangeInfoAsset = Pick<ExchangeToastAssetData, 'symbol' | 'contractAddress'> & {
+    amount: ReactNode;
+    displaySymbol?: string;
+    coingeckoId?: string;
+    icon?: ReactNode;
+};
+
+export type TransactionNotificationType =
+    | 'tx-sent'
+    | 'tx-received'
+    | 'tx-confirmed'
+    | 'tx-staked'
+    | 'tx-unstaked'
+    | 'tx-claimed'
+    | 'tx-approved'
+    | 'tx-revoked';
+
+type TransactionNotificationWithToken = Extract<
+    NotificationEntry,
+    { type: 'tx-sent' | 'tx-received' | 'tx-confirmed' | 'tx-approved' | 'tx-revoked' }
+>;
+
+export type TransactionNotificationToken = TransactionNotificationWithToken['token'];

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -32,3 +32,7 @@ export { DataAnalytics } from './components/DataAnalytics';
 export * from './components/AssetLogo/AssetLogo';
 export { isNetworkSymbolWithIcon } from './constants/networks';
 export * from './components/TopAssets/TopAssets';
+export { ExchangeInfoNotification } from './components/Notifications/ExchangeInfoNotification';
+export { TransactionNotification } from './components/Notifications/TransactionNotification';
+export type { TransactionNotificationProps } from './components/Notifications/TransactionNotification';
+export type { TransactionNotificationType } from './components/Notifications/notificationsTypes';

--- a/packages/product-components/tsconfig.json
+++ b/packages/product-components/tsconfig.json
@@ -20,6 +20,9 @@
             "path": "../../suite-common/suite-types"
         },
         {
+            "path": "../../suite-common/toast-notifications"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/ExchangeInfoRenderer.tsx
@@ -1,9 +1,7 @@
 import { Translation } from '@suite/intl';
 import { selectTradingCoinSymbolByCryptoId } from '@suite-common/trading';
-import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
-import { Column, Icon, Row } from '@trezor/components';
-import { AssetLogo } from '@trezor/product-components';
+import { ExchangeInfoNotification } from '@trezor/product-components';
 
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
@@ -25,9 +23,6 @@ export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRen
         selectTradingCoinSymbolByCryptoId(state, receive.cryptoId),
     );
 
-    const sendNetwork = getNetwork(send.symbol);
-    const receiveNetwork = getNetwork(receive.symbol);
-
     const sendAccount = useSelector(state => selectAccountByKey(state, send.accountKey));
     const receiveAccount = useSelector(state => selectAccountByKey(state, receive.accountKey));
 
@@ -37,64 +32,54 @@ export const ExchangeInfoRenderer = ({ render: View, ...props }: ExchangeInfoRen
             message="TOAST_TX_COMPOSED"
             messageValues={{
                 content: (
-                    <Column gap={4}>
-                        <Translation
-                            id={props.message}
-                            values={{
-                                sendAccount: sendAccount && (
-                                    <AccountLabeling
-                                        account={sendAccount}
-                                        showAccountTypeBadge
-                                        accountTypeBadgeSize="small"
-                                        accountLabelRowProps={{
-                                            display: 'inline-flex',
-                                            gap: 4,
-                                            padding: { left: 4, right: 4 },
-                                            'data-testid': '@toast/tx-exchange/send-account',
-                                        }}
-                                    />
-                                ),
-                                receiveAccount: receiveAccount && (
-                                    <AccountLabeling
-                                        account={receiveAccount}
-                                        showAccountTypeBadge
-                                        accountTypeBadgeSize="small"
-                                        accountLabelRowProps={{
-                                            display: 'inline-flex',
-                                            gap: 4,
-                                            padding: { left: 4, right: 4 },
-                                            'data-testid': '@toast/tx-exchange/receive-account',
-                                        }}
-                                    />
-                                ),
-                            }}
-                        />
-                        <Row gap={8} alignItems="center">
-                            <AssetLogo
-                                size={20}
-                                coingeckoId={sendNetwork.coingeckoId ?? ''}
-                                contractAddress={send.contractAddress}
-                                symbol={send.symbol}
-                                placeholder={getDisplaySymbol(sendSymbol || send.symbol)}
+                    <ExchangeInfoNotification
+                        message={
+                            <Translation
+                                id={props.message}
+                                values={{
+                                    sendAccount: sendAccount && (
+                                        <AccountLabeling
+                                            account={sendAccount}
+                                            showAccountTypeBadge
+                                            accountTypeBadgeSize="small"
+                                            accountLabelRowProps={{
+                                                display: 'inline-flex',
+                                                gap: 4,
+                                                padding: { left: 4, right: 4 },
+                                                'data-testid': '@toast/tx-exchange/send-account',
+                                            }}
+                                        />
+                                    ),
+                                    receiveAccount: receiveAccount && (
+                                        <AccountLabeling
+                                            account={receiveAccount}
+                                            showAccountTypeBadge
+                                            accountTypeBadgeSize="small"
+                                            accountLabelRowProps={{
+                                                display: 'inline-flex',
+                                                gap: 4,
+                                                padding: { left: 4, right: 4 },
+                                                'data-testid': '@toast/tx-exchange/receive-account',
+                                            }}
+                                        />
+                                    ),
+                                }}
                             />
-                            <HiddenPlaceholder data-testid="@toast/tx-exchange/send-amount">
-                                {send.amount}
+                        }
+                        send={{
+                            ...send,
+                            displaySymbol: sendSymbol || send.symbol,
+                        }}
+                        receive={{
+                            ...receive,
+                            displaySymbol: receiveSymbol || receive.symbol,
+                        }}
+                        renderAmount={(amount, side) => (
+                            <HiddenPlaceholder data-testid={`@toast/tx-exchange/${side}-amount`}>
+                                {amount}
                             </HiddenPlaceholder>
-                            {getDisplaySymbol(sendSymbol || send.symbol)}
-                            <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />
-                            <AssetLogo
-                                size={20}
-                                coingeckoId={receiveNetwork.coingeckoId ?? ''}
-                                contractAddress={receive.contractAddress}
-                                symbol={receive.symbol}
-                                placeholder={getDisplaySymbol(receiveSymbol || receive.symbol)}
-                            />
-                            <HiddenPlaceholder data-testid="@toast/tx-exchange/receive-amount">
-                                {receive.amount}
-                            </HiddenPlaceholder>
-                            {getDisplaySymbol(receiveSymbol || receive.symbol)}
-                        </Row>
-                    </Column>
+                        )}
+                    />
                 ),
             }}
         />

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -1,5 +1,4 @@
 import { Translation } from '@suite/intl';
-import { getCoingeckoId, getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     selectAccounts,
     selectBlockchainState,
@@ -17,8 +16,8 @@ import {
     getConfirmations,
     isStakeTypeTx,
 } from '@suite-common/wallet-utils';
-import { Column, Row } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { Row } from '@trezor/components';
+import { TransactionNotification } from '@trezor/product-components';
 
 import { openModal } from 'src/actions/suite/modalActions';
 import { goto } from 'src/actions/suite/routerActions';
@@ -28,7 +27,6 @@ import type { NotificationRendererProps } from 'src/components/suite/notificatio
 import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectRouteName } from 'src/reducers/suite/routerReducer';
-import { Account } from 'src/types/wallet';
 import { getTxAnchor } from 'src/utils/suite/anchor';
 
 type TransactionRendererProps = NotificationViewProps &
@@ -42,90 +40,6 @@ type TransactionRendererProps = NotificationViewProps &
         | 'tx-approved'
         | 'tx-revoked'
     >;
-
-type TransactionRendererContentProps = {
-    notification: TransactionRendererProps['notification'];
-    account: Account;
-};
-
-const TransactionRendererContent = ({ notification, account }: TransactionRendererContentProps) => {
-    const amountTestId = `@toast/${notification.type}/amount`;
-
-    switch (notification.type) {
-        case 'tx-approved':
-        case 'tx-revoked': {
-            const { token, symbol } = notification;
-            const coingeckoId = getCoingeckoId(account.symbol);
-
-            return (
-                <Row gap={8} alignItems="center">
-                    <AssetLogo
-                        symbol={symbol}
-                        coingeckoId={coingeckoId ?? ''}
-                        contractAddress={token.contract}
-                        placeholder={token.name ?? symbol}
-                        size={20}
-                        shouldTryToFetch
-                    />
-                    <HiddenPlaceholder data-testid={amountTestId}>
-                        <Row display="inline-flex" gap={4} alignItems="baseline">
-                            {notification.type === 'tx-approved' &&
-                            notification.isInfiniteApproval ? (
-                                <Translation id="TR_APPROVE_AMOUNT_UNLIMITED" />
-                            ) : (
-                                notification.formattedAmount
-                            )}
-                            <span>{getDisplaySymbol(token.symbol ?? notification.symbol)}</span>
-                        </Row>
-                    </HiddenPlaceholder>
-                </Row>
-            );
-        }
-        case 'tx-sent':
-        case 'tx-received': {
-            const { token, symbol } = notification;
-            const coingeckoId = getCoingeckoId(account.symbol);
-
-            return (
-                <Row gap={8} alignItems="center">
-                    {token ? (
-                        <AssetLogo
-                            symbol={symbol}
-                            coingeckoId={coingeckoId ?? ''}
-                            contractAddress={token.contract}
-                            placeholder={token.name ?? symbol}
-                            size={20}
-                            shouldTryToFetch
-                        />
-                    ) : (
-                        <CoinLogo symbol={symbol} size={20} />
-                    )}
-
-                    <HiddenPlaceholder data-testid={amountTestId}>
-                        {notification.formattedAmount}
-                    </HiddenPlaceholder>
-                </Row>
-            );
-        }
-        case 'tx-staked':
-        case 'tx-unstaked':
-        case 'tx-claimed':
-        case 'tx-confirmed':
-        default: {
-            const { symbol } = notification;
-
-            return (
-                <Row gap={8} alignItems="center">
-                    <CoinLogo symbol={symbol} size={20} />
-
-                    <HiddenPlaceholder data-testid={amountTestId}>
-                        {notification.formattedAmount}
-                    </HiddenPlaceholder>
-                </Row>
-            );
-        }
-    }
-};
 
 export const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProps) => {
     const { symbol, descriptor, txid, device } = props.notification;
@@ -151,6 +65,8 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
         ? 'wallet-staking'
         : 'wallet-index';
     const isTradingRoute = !!routeName?.includes('wallet-trading');
+    const transactionToken = 'token' in props.notification ? props.notification.token : undefined;
+    const toastTestIdPrefix = `@toast/${props.notification.type}`;
 
     const handleTransactionClick = () => {
         const deviceToSelect = accountDevice || device;
@@ -190,32 +106,45 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
             message="TOAST_TX_COMPOSED"
             messageValues={{
                 content: (
-                    <Column gap={4}>
-                        <Translation
-                            id={props.message}
-                            values={{
-                                ...props.messageValues,
-                                account: (
-                                    <Row
-                                        display="inline-flex"
-                                        alignItems="center"
-                                        data-testid={`@toast/${props.notification.type}/account`}
-                                    >
-                                        <AccountLabeling
-                                            account={account}
-                                            showAccountTypeBadge
-                                            accountTypeBadgeSize="small"
-                                        />
-                                    </Row>
-                                ),
-                                confirmations,
-                            }}
-                        />
-                        <TransactionRendererContent
-                            account={account}
-                            notification={props.notification}
-                        />
-                    </Column>
+                    <TransactionNotification
+                        message={
+                            <Translation
+                                id={props.message}
+                                values={{
+                                    ...props.messageValues,
+                                    account: (
+                                        <Row
+                                            display="inline-flex"
+                                            alignItems="center"
+                                            data-testid={`${toastTestIdPrefix}/account`}
+                                        >
+                                            <AccountLabeling
+                                                account={account}
+                                                showAccountTypeBadge
+                                                accountTypeBadgeSize="small"
+                                            />
+                                        </Row>
+                                    ),
+                                    confirmations,
+                                }}
+                            />
+                        }
+                        notificationType={props.notification.type}
+                        symbol={props.notification.symbol}
+                        accountSymbol={account.symbol}
+                        token={transactionToken}
+                        amount={props.notification.formattedAmount}
+                        isInfiniteApproval={
+                            props.notification.type === 'tx-approved' &&
+                            props.notification.isInfiniteApproval
+                        }
+                        unlimitedApprovalLabel={<Translation id="TR_APPROVE_AMOUNT_UNLIMITED" />}
+                        renderAmount={amount => (
+                            <HiddenPlaceholder data-testid={`${toastTestIdPrefix}/amount`}>
+                                {amount}
+                            </HiddenPlaceholder>
+                        )}
+                    />
                 ),
             }}
             action={

--- a/yarn.lock
+++ b/yarn.lock
@@ -15279,6 +15279,7 @@ __metadata:
     "@storybook/react-webpack5": "npm:^9.0.16"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:^"


### PR DESCRIPTION
## Description

This PR refactors notification rendering so that `@trezor/product-components` owns more UI logic, and fixes font rendering in the' product-components' Storybook.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25129

## Screenshots:

<img width="1095" height="771" alt="image" src="https://github.com/user-attachments/assets/1c977a5b-6e76-4fcc-a64f-ca0bb9d8bc47" />

<img width="1480" height="780" alt="image" src="https://github.com/user-attachments/assets/29525ad7-5232-4faf-8f8e-97573950e903" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/refactor-notification-components&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/refactor-notification-components&lookback=7)