### PR TITLE
fix(suite-native): stucked card animation on ios

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -83,16 +83,20 @@ export const CompactCardWithIconLayout = ({
         cardVariantToColorsMap[variant];
 
     const tap = Gesture.Tap()
+        .maxDuration(5000)
         .onBegin(() => {
             isPressed.value = true;
+        })
+        .onFinalize(() => {
+            isPressed.value = false;
+        })
+        .onTouchesCancelled(() => {
+            isPressed.value = false;
         })
         .onEnd(() => {
             if (onPress) {
                 runOnJS(onPress)();
             }
-        })
-        .onFinalize(() => {
-            isPressed.value = false;
         });
 
     const animatedStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Description
- fix stuck app settings card animation

## Related Issue

Resolve #25104


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ios-card-animation-stuck-25104&lookback=7)