### PR TITLE
fix(connect): THP loop ackBit check

### DIFF
--- a/packages/transport/src/thp/loop.ts
+++ b/packages/transport/src/thp/loop.ts
@@ -132,7 +132,7 @@ export const thpLoop = async ({
                 switch (ackResult.payload.messageType) {
                     case THP_CONTROL_BYTE.ACK_MESSAGE: {
                         const { ackBit } = protocolThp.readThpHeader(ackResult.payload.header);
-                        if (ackBit === thpState.recvAckBit) {
+                        if (ackBit === thpState.sendAckBit) {
                             phase = ThpLoopState.READ_RESPONSE;
                         } else {
                             debug(`READ_ACK unexpected ThpAck bit`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Thp state is desynchronized after sending `Cancel` - in reported case when you cancel tutorial before recovery

Resolve: https://github.com/trezor/trezor-suite/issues/25086 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-akc-bit&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-akc-bit&lookback=7)