### PR TITLE
fix(suite): ethereum staking time in progress bar

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
@@ -1,20 +1,25 @@
 import { useEffect, useMemo } from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
+import { commonQueryKeys } from '@suite-common/react-query';
 import { getDaysToAddToPool, getDaysToUnstake } from '@suite-common/staking';
 import {
     fetchAllTransactionsForAccountThunk,
+    fetchEverstakeDataApi,
     selectAccountIsStakingActive,
     selectAccountStakeTransactions,
     selectAccountUnstakeTransactions,
     selectHasRunningDiscovery,
     selectPoolStatsApyData,
     selectPoolStatsNextRewardPayout,
-    selectValidatorsQueue,
 } from '@suite-common/wallet-core';
-import { SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
+import { EverstakeEndpointType, SelectedAccountLoaded } from '@suite-common/wallet-types';
+import {
+    getStakingDataForNetwork,
+    hasStakeInPendingDepositedState,
+} from '@suite-common/wallet-utils';
 import { Column, Flex, Grid } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
@@ -40,9 +45,6 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
     const { isBelowLaptop } = useLayoutSize();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    const { data, isLoading } =
-        useSelector(state => selectValidatorsQueue(state, account?.symbol)) || {};
-
     const apy = useSelector(state => selectPoolStatsApyData(state, account));
     const nextRewardPayout = useSelector(state =>
         selectPoolStatsNextRewardPayout(state, account?.symbol),
@@ -52,6 +54,31 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
     const unstakeTxs = useSelector(state => selectAccountUnstakeTransactions(state, accountKey));
 
     const dispatch = useDispatch();
+
+    const lastTxBlockTime = useMemo(() => {
+        if (!stakeTxs?.length) return undefined;
+
+        return stakeTxs[0]?.blockTime;
+    }, [stakeTxs]);
+
+    const { data: validatorQueueData, isLoading: isValidatorQueueLoading } = useQuery({
+        enabled: !!account,
+        queryKey: commonQueryKeys.validatorsQueue(accountKey, lastTxBlockTime),
+        staleTime: 60 * 1000, // 1 minute
+        queryFn: () => {
+            if (!account) return;
+
+            const timestamp = hasStakeInPendingDepositedState(account)
+                ? lastTxBlockTime
+                : undefined;
+
+            return fetchEverstakeDataApi({
+                symbol: 'eth',
+                endpointType: EverstakeEndpointType.ValidatorsQueue,
+                timestamp,
+            });
+        },
+    });
 
     useEffect(() => {
         if (accountKey) {
@@ -66,8 +93,8 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
 
     const txs = useMemo(() => [...stakeTxs, ...unstakeTxs], [stakeTxs, unstakeTxs]);
 
-    const daysToAddToPool = getDaysToAddToPool(stakeTxs, data);
-    const daysToUnstake = getDaysToUnstake(unstakeTxs, data);
+    const daysToAddToPool = getDaysToAddToPool(stakeTxs, validatorQueueData);
+    const daysToUnstake = getDaysToUnstake(unstakeTxs, validatorQueueData);
 
     const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
 
@@ -77,10 +104,10 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
         <StakingDashboard
             selectedAccount={selectedAccount}
             dashboard={
-                <Column gap={spacings.xxxxl}>
+                <Column gap={48}>
                     {isStakingActive ? (
                         <DashboardSection>
-                            <Column gap={spacings.sm}>
+                            <Column gap={12}>
                                 {isDiscoveryRunning && <DiscoveryWarning />}
 
                                 <InstantStakeBanner
@@ -88,23 +115,22 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
                                     daysToAddToPool={daysToAddToPool}
                                     daysToUnstake={daysToUnstake}
                                 />
-                                <Grid
-                                    columns={isBelowLaptop || !canClaim ? 1 : 2}
-                                    gap={spacings.sm}
-                                >
+                                <Grid columns={isBelowLaptop || !canClaim ? 1 : 2} gap={12}>
                                     <ClaimCard />
-                                    <Flex direction={canClaim ? 'column' : 'row'} gap={spacings.sm}>
+                                    <Flex direction={canClaim ? 'column' : 'row'} gap={12}>
                                         <ApyCard apy={apy} />
                                         <PayoutCardNextRewards
                                             nextRewardPayout={nextRewardPayout}
                                             daysToAddToPool={daysToAddToPool}
-                                            validatorWithdrawTime={data?.validatorWithdrawTime}
+                                            validatorWithdrawTime={
+                                                validatorQueueData?.validatorWithdrawTime
+                                            }
                                         />
                                     </Flex>
                                 </Grid>
                                 <StakingCard
                                     account={account}
-                                    isValidatorsQueueLoading={isLoading}
+                                    isValidatorsQueueLoading={isValidatorQueueLoading}
                                     daysToAddToPool={daysToAddToPool}
                                     daysToUnstake={daysToUnstake}
                                 />

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -3,6 +3,12 @@ import type { AllowedQueryKey } from '../types';
 export const commonQueryKeys = {
     txSimulationEVM: (input?: any) => ['tx-simulation-evm', input],
     dappScan: (url?: string) => ['dapp-scan', url],
+    validatorsQueue: (accountKey: string, timestamp?: number) => [
+        'everstake',
+        'validatorsQueue',
+        accountKey,
+        timestamp ?? 'no-ts',
+    ],
 } as const satisfies Record<string, AllowedQueryKey>;
 
 export const desktopQueryKeys = {

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -6,6 +6,7 @@ import {
     EVERSTAKE_ASSET_ENDPOINT_TYPES,
     EVERSTAKE_ENDPOINT_TYPES,
     EverstakeAssetEndpointType,
+    EverstakeDataParams,
     EverstakeEndpointType,
     EverstakeRewardsEndpointType,
     EverstakeStakingInfo,
@@ -27,48 +28,53 @@ import { selectEverstakeData } from './stakeSelectors';
 
 const STAKE_MODULE = '@common/wallet-core/stake';
 
-export const fetchEverstakeData = createThunk<
-    ValidatorsQueue | { ethApy: number; nextRewardPayout: number },
-    {
-        symbol: 'eth';
-        endpointType: EverstakeEndpointType;
-    },
-    { rejectValue: string }
->(`${STAKE_MODULE}/fetchEverstakeData`, async (params, { fulfillWithValue, rejectWithValue }) => {
-    const { symbol, endpointType } = params;
+export async function fetchEverstakeDataApi(params: EverstakeDataParams) {
+    const { symbol, endpointType, timestamp } = params;
+
+    if (symbol !== 'eth') {
+        throw new Error('Only Ethereum is supported for this endpoint');
+    }
 
     const endpointSuffix = EVERSTAKE_ENDPOINT_TYPES[endpointType];
     const endpointPrefix = EVERSTAKE_ENDPOINT_PREFIX[symbol];
 
+    const response = await fetch(
+        `${endpointPrefix}/${endpointSuffix}${timestamp ? `?timestamp=${timestamp}` : ''}`,
+    );
+
+    if (!response.ok) throw new Error(response.statusText);
+
+    const data = await response.json();
+
+    if (endpointType === EverstakeEndpointType.PoolStats) {
+        return {
+            ethApy: Number(new BigNumber(data.apr).times(100).toPrecision(3, BigNumber.ROUND_DOWN)),
+            nextRewardPayout: Math.ceil(data.next_reward_payout_in / 60 / 60 / 24),
+        };
+    }
+
+    return {
+        validatorsEnteringNum: data.validators_entering_num,
+        validatorsExitingNum: data.validators_exiting_num,
+        validatorsTotalCount: data.validators_total_count,
+        validatorsPerEpoch: data.validators_per_epoch,
+        validatorActivationTime: data.validator_activation_time,
+        validatorExitTime: data.validator_exit_time,
+        validatorWithdrawTime: data.validator_withdraw_time,
+        validatorAddingDelay: data.validator_adding_delay,
+        updatedAt: data.updated_at,
+    };
+}
+
+export const fetchEverstakeData = createThunk<
+    ValidatorsQueue | { ethApy: number; nextRewardPayout: number },
+    EverstakeDataParams,
+    { rejectValue: string }
+>(`${STAKE_MODULE}/fetchEverstakeData`, async (params, { fulfillWithValue, rejectWithValue }) => {
     try {
-        const response = await fetch(`${endpointPrefix}/${endpointSuffix}`);
+        const data = await fetchEverstakeDataApi(params);
 
-        if (!response.ok) {
-            throw Error(response.statusText);
-        }
-
-        const data = await response.json();
-
-        if (endpointType === EverstakeEndpointType.PoolStats) {
-            return fulfillWithValue({
-                ethApy: Number(
-                    new BigNumber(data.apr).times(100).toPrecision(3, BigNumber.ROUND_DOWN),
-                ),
-                nextRewardPayout: Math.ceil(data.next_reward_payout_in / 60 / 60 / 24),
-            });
-        }
-
-        return fulfillWithValue({
-            validatorsEnteringNum: data.validators_entering_num,
-            validatorsExitingNum: data.validators_exiting_num,
-            validatorsTotalCount: data.validators_total_count,
-            validatorsPerEpoch: data.validators_per_epoch,
-            validatorActivationTime: data.validator_activation_time,
-            validatorExitTime: data.validator_exit_time,
-            validatorWithdrawTime: data.validator_withdraw_time,
-            validatorAddingDelay: data.validator_adding_delay,
-            updatedAt: data.updated_at,
-        } as ValidatorsQueue);
+        return fulfillWithValue(data);
     } catch (error) {
         return rejectWithValue(error.toString());
     }

--- a/suite-common/wallet-types/src/stakeTypes.ts
+++ b/suite-common/wallet-types/src/stakeTypes.ts
@@ -1,4 +1,4 @@
-import type { Network } from '@suite-common/wallet-config';
+import type { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import type { FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
@@ -41,6 +41,12 @@ export const EVERSTAKE_ASSET_ENDPOINT_TYPES = {
         dsol: 'chain',
         ada: 'blockchain/summary',
     },
+};
+
+export type EverstakeDataParams = {
+    symbol: NetworkSymbol;
+    endpointType: EverstakeEndpointType;
+    timestamp?: number;
 };
 
 export interface ValidatorsQueue {

--- a/suite-common/wallet-utils/src/ethereumStakingUtils.ts
+++ b/suite-common/wallet-utils/src/ethereumStakingUtils.ts
@@ -146,3 +146,18 @@ export const getStakeType = (precomposedForm: FormState, outputs: ReviewOutput[]
               .filter(output => output.type === 'data')
               .map(output => getTxStakeNameByDataHex(output?.value))
               .find(type => type) || null;
+
+export const hasStakeInPendingDepositedState = (account: Account) => {
+    if (account?.networkType !== 'ethereum') return false;
+
+    const pool = getAccountEverstakeStakingPool(account);
+    if (!pool) return false;
+
+    const { pendingDepositedBalance, pendingBalance } = pool;
+
+    if (new BigNumber(pendingDepositedBalance).gt(0) && new BigNumber(pendingBalance).lte(0)) {
+        return true;
+    }
+
+    return false;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an issue where the staking progress bar showed increasing activation time.
Now activation estimates account for the current epoch timestamp.

## QA

Progress time of staking should now decrease by elapsed days. It should not copy ethereum staking queue

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24929
