### PR TITLE
Fix unwanted line break in trading footer

### DIFF
--- a/suite-native/link/src/components/Link.tsx
+++ b/suite-native/link/src/components/Link.tsx
@@ -1,4 +1,4 @@
-import { GestureResponderEvent } from 'react-native';
+import { GestureResponderEvent, type TextProps } from 'react-native';
 import Animated, {
     interpolateColor,
     useAnimatedStyle,
@@ -6,10 +6,10 @@ import Animated, {
     withTiming,
 } from 'react-native-reanimated';
 
-import { RequireAtLeastOne } from 'type-fest';
+import type { RequireAtLeastOne } from 'type-fest';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import { Color, TypographyStyle } from '@trezor/theme';
+import type { Color, TypographyStyle } from '@trezor/theme';
 
 import { useOpenLink } from '../useOpenLink';
 
@@ -24,7 +24,11 @@ type LinkProps = RequireAtLeastOne<
         textVariant?: TypographyStyle;
     },
     'href' | 'onPress'
->;
+> &
+    Omit<
+        TextProps,
+        'onPress' | 'onPressIn' | 'onPressOut' | 'style' | 'suppressHighlighting' | 'children'
+    >;
 
 const textStyle = prepareNativeStyle<{ isUnderlined: boolean; textVariant: TypographyStyle }>(
     (utils, { isUnderlined, textVariant }) => ({
@@ -42,6 +46,8 @@ const ANIMATION_DURATION = 100;
 const IS_NOT_PRESSED_VALUE = 0;
 const IS_PRESSED_VALUE = 1;
 
+const noop = () => {};
+
 export const Link = ({
     href,
     label,
@@ -50,6 +56,7 @@ export const Link = ({
     textPressedColor = 'textPrimaryPressed',
     textVariant = 'body',
     onPress,
+    ...textProps
 }: LinkProps) => {
     const { utils, applyStyle } = useNativeStyles();
     const openLink = useOpenLink();
@@ -80,8 +87,9 @@ export const Link = ({
 
     return (
         <Animated.Text
+            {...textProps}
             onPressIn={handlePressIn}
-            onPress={() => {}} // If the handling is defined in onPress, the very short taps are sometimes ignored
+            onPress={noop} // If the handling is defined in onPress, the very short taps are sometimes ignored
             onPressOut={handlePressOut}
             style={[applyStyle(textStyle, { isUnderlined, textVariant }), animatedTextColorStyle]}
             suppressHighlighting

--- a/suite-native/module-trading/src/components/general/Footer.tsx
+++ b/suite-native/module-trading/src/components/general/Footer.tsx
@@ -92,6 +92,8 @@ export const Footer = ({ isFormMountedRecently }: FooterProps) => {
                         textPressedColor="textDisabled"
                         href={TREZOR_TRADING_LEARN_MORE_URL}
                         label={<Translation id="moduleTrading.tradingScreen.footer.learnMore" />}
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
                     />
                 </HStack>
             </VStack>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Only CZ footer was affected. Probably because of the "í" character.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25117


## Screenshots:
### Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/59028fe3-6bdc-4432-8804-79374feef203" />

### After
<img width="300" alt="image" src="https://github.com/user-attachments/assets/30ea3047-30ef-4961-a74d-2105fe0fc7fd" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25117-mobile-trading-footer-více-informací-is-not-wholly-visible&lookback=7)