### PR TITLE
chore(suite-native): Trading: improve ProviderStatusDevButtons.tsx

### DIFF
--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
@@ -1,14 +1,24 @@
-import { Button, HStack, VStack } from '@suite-native/atoms';
+import { useSelector } from 'react-redux';
+
+import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { DebugModeView } from '@suite-native/trading-debug';
+import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
 
 import { useDispatchProviderConfirmationStatus } from '../hooks/useDispatchProviderConfirmationStatus';
 
 const ProviderStatusDevButtonsContent = () => {
     const dispatchHelper = useDispatchProviderConfirmationStatus();
+    const currentStatus = useSelector(selectTradingProviderConfirmationStatus);
 
     return (
-        <VStack spacing="sp4" alignItems="center">
+        <VStack spacing="sp4" flex={1}>
             <HStack>
+                <Text variant="callout">Current status:</Text>
+                <Text variant="callout" color="textSubdued">
+                    {currentStatus}
+                </Text>
+            </HStack>
+            <HStack justifyContent="center" spacing="sp4">
                 <Button
                     colorScheme="redElevation0"
                     size="tiny"
@@ -45,7 +55,7 @@ const ProviderStatusDevButtonsContent = () => {
                     success
                 </Button>
             </HStack>
-            <HStack>
+            <HStack justifyContent="center">
                 <Button
                     colorScheme="yellowElevation0"
                     size="tiny"

--- a/suite-native/trading-browser-auth/src/components/__tests__/ProviderStatusDevButtons.comp.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ProviderStatusDevButtons.comp.test.tsx
@@ -1,10 +1,5 @@
 import { FeatureFlag, toggleFeatureFlag } from '@suite-native/feature-flags';
-import {
-    TestStore,
-    initStore,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { TestStore, initStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
 
 import { ProviderStatusDevButtons } from '../ProviderStatusDevButtons';
@@ -13,21 +8,29 @@ describe('ProviderStatusDevButtons', () => {
     let store: TestStore;
 
     const renderProviderStatusDevButtons = () =>
-        renderWithStoreProviderAsync(<ProviderStatusDevButtons />, { store });
+        renderWithStoreProvider(<ProviderStatusDevButtons />, { store });
 
-    beforeEach(async () => {
-        ({ store } = await initStore());
+    beforeEach(() => {
+        ({ store } = initStore());
     });
 
-    it('should display nothing without debug mode', async () => {
-        const { toJSON } = await renderProviderStatusDevButtons();
+    it('should display nothing without debug mode', () => {
+        const { toJSON } = renderProviderStatusDevButtons();
 
         expect(toJSON()).toBeNull();
     });
 
+    it('should display current status', () => {
+        store.dispatch(toggleFeatureFlag({ featureFlag: FeatureFlag.IsTradingDebugEnabled }));
+        const { getByText } = renderProviderStatusDevButtons();
+
+        expect(getByText('Current status:')).toBeOnTheScreen();
+        expect(getByText('inactive')).toBeOnTheScreen();
+    });
+
     it('should change state on buttons press', async () => {
         store.dispatch(toggleFeatureFlag({ featureFlag: FeatureFlag.IsTradingDebugEnabled }));
-        const { getByText } = await renderProviderStatusDevButtons();
+        const { getByText } = renderProviderStatusDevButtons();
 
         await userEvent.press(getByText('restart flow'));
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`ProviderStatusDevButtons` now displays current status as well. (when trading debug FF is enabled)

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->


## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-11 at 14 49 47" src="https://github.com/user-attachments/assets/a286c04f-3b29-4b41-8bc6-bd8211732c40" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=improve-status-dev-buttons&lookback=7)