### PR TITLE
chore(suite-sync): remove redundant dep

### DIFF
--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -133,7 +133,6 @@ export const createSuiteSyncCompositionRoot = (
         dispatch: deps.dispatch,
         ensureWalletSuiteSyncOn: createEnsureWalletSuiteSyncOn({
             getState: deps.getState,
-            refreshSuiteSyncKeys,
             ensureSuiteSyncData: subscribeSuiteSyncData,
             subscriptionStorage,
         }),

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -1,6 +1,5 @@
 import {
     EnsureWalletSuiteSyncOn,
-    RefreshSuiteSyncKeysDep,
     SubscribeSuiteSyncDataDep,
     SubscriptionStorageDep,
 } from '@suite-common/suite-sync-types';
@@ -13,7 +12,6 @@ import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from '../
 export type EnsureWalletSuiteSyncOnDeps = {
     getState: () => any;
 } & SubscribeSuiteSyncDataDep &
-    RefreshSuiteSyncKeysDep &
     SubscriptionStorageDep;
 
 export const createEnsureWalletSuiteSyncOn =

--- a/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
@@ -29,7 +29,6 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             getState: () => createMockState([]),
             ensureSuiteSyncData: null,
             subscriptionStorage: createSubscriptionStorageMock(),
-            refreshSuiteSyncKeys: null,
         });
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
@@ -49,7 +48,6 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([mockSuiteDevice({ unavailableCapabilities })]),
-            refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: null,
             subscriptionStorage: createSubscriptionStorageMock(),
         });
@@ -71,7 +69,6 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([DEVICE_123]),
-            refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: () => Promise.resolve(ensureResult),
             subscriptionStorage: createSubscriptionStorageMock(),
         });
@@ -93,7 +90,6 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([DEVICE_123]),
-            refreshSuiteSyncKeys: null,
             ensureSuiteSyncData: () => Promise.resolve(ensureResult),
             subscriptionStorage: createSubscriptionStorageMock(),
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Super isolated change to remove redundant dependency to one of the suite sync methods. No functional change.

## Notes for QA
Nothing to test.



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-sync/remove-redundant-dep&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-sync/remove-redundant-dep&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-sync/remove-redundant-dep&lookback=7)