### PR TITLE
No renderHookWithStoreProviderAsync in trading-x packages

### DIFF
--- a/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
@@ -2,7 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { EventType } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
-import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { useExchangeAnalyticReportCallback } from '../useExchangeAnalyticReportCallback';
@@ -33,13 +33,12 @@ describe('useExchangeAnalyticReportCallback', () => {
         };
     });
 
-    it('should call analytics on mount', async () => {
+    it('should call analytics on mount', () => {
         preloadedState!.wallet!.trading!.exchange!.selectedQuote = exchangeQuotes[0];
 
-        const { result } = await renderHookWithStoreProviderAsync(
-            () => useExchangeAnalyticReportCallback(),
-            { preloadedState },
-        );
+        const { result } = renderHookWithStoreProvider(() => useExchangeAnalyticReportCallback(), {
+            preloadedState,
+        });
 
         result.current('exchange-form', 'continue');
 
@@ -53,11 +52,10 @@ describe('useExchangeAnalyticReportCallback', () => {
         });
     });
 
-    it('should work without quote', async () => {
-        const { result } = await renderHookWithStoreProviderAsync(
-            () => useExchangeAnalyticReportCallback(),
-            { preloadedState },
-        );
+    it('should work without quote', () => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeAnalyticReportCallback(), {
+            preloadedState,
+        });
 
         result.current('exchange-form', 'continue');
 
@@ -70,10 +68,10 @@ describe('useExchangeAnalyticReportCallback', () => {
         });
     });
 
-    it('should allow to specify quote as parameter', async () => {
+    it('should allow to specify quote as parameter', () => {
         preloadedState!.wallet!.trading!.exchange!.selectedQuote = exchangeQuotes[0];
 
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () => useExchangeAnalyticReportCallback(exchangeQuotes[3]),
             { preloadedState },
         );
@@ -93,8 +91,8 @@ describe('useExchangeAnalyticReportCallback', () => {
     it.each([
         [{ ...exchangeQuotes[0], send: 'unknown_cryptoID' as CryptoId }],
         [{ ...exchangeQuotes[0], receive: 'unknown_cryptoID' as CryptoId }],
-    ])('should work with unknown quote values', async quote => {
-        const { result } = await renderHookWithStoreProviderAsync(
+    ])('should work with unknown quote values', quote => {
+        const { result } = renderHookWithStoreProvider(
             () => useExchangeAnalyticReportCallback(quote),
             { preloadedState },
         );

--- a/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
@@ -6,7 +6,7 @@ import {
     TradingSellStep,
 } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
-import { PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import { useTradingAnalyticReportCallback } from '../useTradingAnalyticReportCallback';
@@ -41,8 +41,8 @@ describe('useTradingAnalyticReportCallback', () => {
             preloadedState.wallet!.trading!.sell!.selectedQuote = sellQuotes[0];
         });
 
-        it('should return sell analytics callback', async () => {
-            const { result } = await renderHookWithStoreProviderAsync(
+        it('should return sell analytics callback', () => {
+            const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('sell'),
                 { preloadedState },
             );
@@ -70,8 +70,8 @@ describe('useTradingAnalyticReportCallback', () => {
             preloadedState.wallet!.trading!.exchange!.selectedQuote = exchangeQuotes[0];
         });
 
-        it('should return exchange analytics callback', async () => {
-            const { result } = await renderHookWithStoreProviderAsync(
+        it('should return exchange analytics callback', () => {
+            const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('exchange'),
                 { preloadedState },
             );
@@ -99,8 +99,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return null action (no analytics)', async () => {
-            const { result } = await renderHookWithStoreProviderAsync(
+        it('should return null action (no analytics)', () => {
+            const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback(undefined),
                 { preloadedState },
             );
@@ -118,8 +118,8 @@ describe('useTradingAnalyticReportCallback', () => {
             };
         });
 
-        it('should return null action (no analytics)', async () => {
-            const { result } = await renderHookWithStoreProviderAsync(
+        it('should return null action (no analytics)', () => {
+            const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('buy'),
                 { preloadedState },
             );

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useDispatchProviderConfirmationStatus.hook.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useDispatchProviderConfirmationStatus.hook.test.ts
@@ -1,9 +1,4 @@
-import {
-    TestStore,
-    act,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { TestStore, act, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { selectTradingProviderConfirmationStatus } from '@suite-native/trading-state';
 
 import { useDispatchProviderConfirmationStatus } from '../useDispatchProviderConfirmationStatus';
@@ -12,14 +7,14 @@ describe('useDispatchProviderConfirmationStatus', () => {
     let store: TestStore;
 
     const renderUseDispatchProviderConfirmationStatus = () =>
-        renderHookWithStoreProviderAsync(() => useDispatchProviderConfirmationStatus(), { store });
+        renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), { store });
 
-    beforeEach(async () => {
-        ({ store } = await initStore());
+    beforeEach(() => {
+        ({ store } = initStore());
     });
 
-    it('should provide callback for dispatching setProviderConfirmationStatus trading action', async () => {
-        const { result } = await renderUseDispatchProviderConfirmationStatus();
+    it('should provide callback for dispatching setProviderConfirmationStatus trading action', () => {
+        const { result } = renderUseDispatchProviderConfirmationStatus();
 
         act(() => {
             result.current('window_opened');

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.hook.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.hook.test.ts
@@ -1,10 +1,5 @@
 import { sendFormActions } from '@suite-common/wallet-core';
-import {
-    TestStore,
-    act,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { TestStore, act, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     selectTradingProviderConfirmationStatus,
     tradingActions,
@@ -16,36 +11,36 @@ describe('useProviderConfirmationStatus', () => {
     let store: TestStore;
 
     const renderUseProviderConfirmationStatus = () =>
-        renderHookWithStoreProviderAsync(() => useProviderConfirmationStatus(), {
+        renderHookWithStoreProvider(() => useProviderConfirmationStatus(), {
             store,
         });
 
-    beforeEach(async () => {
-        ({ store } = await initStore());
+    beforeEach(() => {
+        ({ store } = initStore());
     });
 
     afterEach(() => {
         jest.useRealTimers();
     });
 
-    it('should return current status', async () => {
+    it('should return current status', () => {
         store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
-        const { result } = await renderUseProviderConfirmationStatus();
+        const { result } = renderUseProviderConfirmationStatus();
 
         expect(result.current).toEqual('window_opened');
     });
 
-    it('should clear tradingProviderConfirmationStatus on unmount', async () => {
+    it('should clear tradingProviderConfirmationStatus on unmount', () => {
         store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));
-        const { unmount } = await renderUseProviderConfirmationStatus();
+        const { unmount } = renderUseProviderConfirmationStatus();
 
         unmount();
 
         expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('inactive');
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_incomplete" is set', async () => {
-        await renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_incomplete" is set', () => {
+        renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
         act(() => {
@@ -64,8 +59,8 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_with_success" is set', async () => {
-        await renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_failed" after 30 "window_closed_with_success" is set', () => {
+        renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
         act(() => {
@@ -84,8 +79,8 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should not set tradingProviderConfirmationStatus to "confirmation_failed" when status changes', async () => {
-        await renderUseProviderConfirmationStatus();
+    it('should not set tradingProviderConfirmationStatus to "confirmation_failed" when status changes', () => {
+        renderUseProviderConfirmationStatus();
         jest.useFakeTimers();
 
         act(() => {
@@ -112,8 +107,8 @@ describe('useProviderConfirmationStatus', () => {
         );
     });
 
-    it('should set tradingProviderConfirmationStatus to "confirmation_success" when isTradeFinalized becomes truthy', async () => {
-        await renderUseProviderConfirmationStatus();
+    it('should set tradingProviderConfirmationStatus to "confirmation_success" when isTradeFinalized becomes truthy', () => {
+        renderUseProviderConfirmationStatus();
 
         act(() => {
             store.dispatch(tradingActions.setProviderConfirmationStatus('window_opened'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Removes usage of deprecated `renderHookWithStoreProviderAsync` and uses `renderHookWithStoreProvider` instead.
- Removed awaiting of `initStore` as it is synchronous now.

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=no-provider-async-in-trading-tests&lookback=7)