### PR TITLE
chore(suite-desktop-core): better distinguish request-managers

### DIFF
--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -10,6 +10,11 @@ import { interceptTlsConnect } from './interceptor/interceptTlsConnect';
 import { TorIdentities } from './torIdentities';
 import { InterceptorOptions } from './types';
 
+/**
+ * Create an interceptor that can be used to intercept and manage network requests made from a Node.js environment.
+
+ * Note that this DOESN'T apply to requests from the Electron browser, that's done in `create-electron-session-interceptor.ts`
+ */
 export const createInterceptor = (interceptorOptions: InterceptorOptions) => {
     const requestPool = createRequestPool(interceptorOptions);
     const torIdentities = new TorIdentities(interceptorOptions.getTorSettings);

--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -13,12 +13,12 @@ import { createDeferred, resolveAfter } from '@trezor/utils';
 import { handshakeAndHangDetect } from './handshake-and-hang-detect';
 import { processStatePatch, removeElectronAppData, restartApp } from './libs/app-utils';
 import { APP_NAME } from './libs/constants';
+import { createElectronSessionInterceptor } from './libs/create-electron-session-interceptor';
 import { getBuildInfo, getComputerInfo } from './libs/info';
 import { loadIndex } from './libs/loadIndex';
 import { Logger } from './libs/logger';
 import { MainWindowProxy } from './libs/main-window-proxy';
 import { hasSwitch } from './libs/process-switches';
-import { createInterceptor } from './libs/request-interceptor';
 import { MIN_HEIGHT, MIN_WIDTH } from './libs/screen';
 import { initSentry } from './libs/sentry';
 import { Store, WinBoundsCoords } from './libs/store';
@@ -177,7 +177,7 @@ const init = async () => {
     await app.whenReady();
 
     // Load bridge module first, it is required in both UI and daemon mode
-    const interceptor = createInterceptor();
+    const interceptor = createElectronSessionInterceptor();
     const mainWindowProxy = new MainWindowProxy();
     const { loadModules: loadBackgroundModules, quitModules: quitBackgroundModules } =
         initBackgroundModules({

--- a/packages/suite-desktop-core/src/libs/create-electron-session-interceptor.ts
+++ b/packages/suite-desktop-core/src/libs/create-electron-session-interceptor.ts
@@ -3,11 +3,14 @@ import { session } from 'electron';
 import { hasSwitch } from './process-switches';
 
 /**
- * Should be used for all webRequest.on* events as there can be only
- * one listener for each of them, but sometimes we need to bind more
- * of them.
+ * Create an electron Renderer interceptor with API to add/remove custom handlers. In the Renderer process,
+ * network requests are made from the electron binary itself (the browser), so we use the electron api.
+ * Session.webRequest interceptor allows only one onBeforeRequest handler, but sometimes we need to bind more.
+ *
+ * This applies on all Renderer process traffic + also electron-updater traffic (it uses an electron Session too).
+ * Note that this DOESN'T apply to network requests directly from nodejs, that's done in packages/request-manager
  */
-export const createInterceptor = (): RequestInterceptor => {
+export const createElectronSessionInterceptor = (): RequestInterceptor => {
     let beforeRequestListeners: BeforeRequestListener[] = [];
     const filter = { urls: ['*://*/*'] };
 

--- a/packages/suite-desktop-core/src/modules/request-filter.ts
+++ b/packages/suite-desktop-core/src/modules/request-filter.ts
@@ -11,9 +11,11 @@ import type { ModuleInit } from './module';
 export const SERVICE_NAME = 'request-filter';
 
 /**
- * This module handles request interception for the renderer thread. Requests are happening
- * in the Chromium browser, so we have to relay on the apo we get from Electron
+ * This module handles request interception for the Electron Renderer thread. Requests are happening
+ * in the Chromium browser (the Electron binary itself), so we have to relay on the api we get from Electron
  * (it falls down to `session.defaultSession.webRequest.onBeforeRequest`).
+ *
+ * The actual interception is done in `createElectronSessionInterceptor`, injected when loading modules.
  */
 export const init: ModuleInit = ({ interceptor }) => {
     const { logger } = global;

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -1,10 +1,9 @@
 /**
  * Request Interceptor
- * This module intercepts requests from electron nodejs main process and
- * lets request-manager interceptor knows if Tor is enable so it has to use Tor or not.
+ * This module intercepts requests from Electron Main process (direct network requests from nodejs) and
+ * lets request-manager interceptor knows if Tor is enabled (whether it has to use Tor or not).
  *
- *
- * Differences from request-filter module is that it intercepts all requests from electron nodejs main process,
+ * Differences from request-filter module is that it intercepts all requests from Electron Main process (nodejs),
  * whereas request-filter logs and filters allowed requests from electron renderer process.
  */
 import { isDevEnv } from '@suite-common/suite-utils';
@@ -29,7 +28,9 @@ const mainThreadAllowedDomain = {
 };
 
 /**
- * This module handles request interception for the main thread.
+ * This module handles request interception for the electron Main thread.
+ *
+ * Please note that the `interceptor` from ModuleInit api is for the Renderer process, so we don't use it here.
  */
 export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) => {
     const { logger } = global;


### PR DESCRIPTION
## Description

After #25017, where it confused the hell out of me, I'm just doing slight renaming and even more explicit comments.
The comments are good enough already, but I'd like it even more foolproof :sweat_smile: 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-request-interceptors-comments&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/cleanup-request-interceptors-comments&lookback=7)