### PR TITLE
Fix/connect thp error handling

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -91,6 +91,8 @@ const waitForThpPairingConfirmation = async ({
     }
 };
 
+const WAIT_FOR_RECONNECT_TIME = 2000;
+
 const waitForReconnectedDevice = async (
     { bootloader, method, intermediary }: ReconnectParams,
     {
@@ -131,6 +133,7 @@ const waitForReconnectedDevice = async (
 
     let reconnectedDevice: Device | undefined;
     let thpPairingError = false;
+    let waitTime = WAIT_FOR_RECONNECT_TIME;
     do {
         postMessage(
             createUiMessage(UI.FIRMWARE_RECONNECT, {
@@ -142,7 +145,8 @@ const waitForReconnectedDevice = async (
             }),
         );
 
-        await resolveAfter(2000);
+        await resolveAfter(waitTime);
+
         try {
             reconnectedDevice = deviceList.getOnlyDevice(device.descriptor.apiType);
         } catch {
@@ -196,8 +200,11 @@ const waitForReconnectedDevice = async (
                 uiPromises.rejectAll(error);
 
                 // error in THP pairing
-                if (error.code === 'Device_ThpPairingTagInvalid') {
-                    thpPairingError = true;
+                thpPairingError = error.code === 'Device_ThpPairingTagInvalid';
+                if (thpPairingError || error.code === 'Failure_ActionCancelled') {
+                    waitTime = 0;
+                } else {
+                    waitTime = WAIT_FOR_RECONNECT_TIME;
                 }
             }
         }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -567,7 +567,10 @@ export class Device extends TypedEmitter<DeviceEvents> {
                     this.busy = 'pin-locked';
                 }
 
-                if (error.code === 'Device_ThpPairingTagInvalid') {
+                if (
+                    error.code === 'Device_ThpPairingTagInvalid' ||
+                    error.code === 'Failure_ActionCancelled'
+                ) {
                     // return as TypedError
                     return Promise.reject(error);
                 }

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -4,10 +4,10 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
 import { createDeferred } from '@trezor/utils';
 
+import { abortThpWorkflow, thpCall } from './thpCall';
 import { DataManager } from '../../data/DataManager';
 import { DEVICE, UiResponseThpPairingTag } from '../../events';
 import type { Device } from '../Device';
-import { abortThpWorkflow, thpCall } from './thpCall';
 
 const processQrCodeTag = async (device: Device, value: string) => {
     const thpState = device.getThpState();
@@ -61,9 +61,6 @@ const processNfcTag = async (device: Device, value: string) => {
 };
 
 const processCodeEntry = async (device: Device, value: string) => {
-    if (value.length !== 6) {
-        throw ERRORS.TypedError('Device_ThpPairingTagInvalid');
-    }
     const codeValue = Buffer.from(value, 'ascii');
 
     const thpState = device.getThpState();
@@ -140,21 +137,27 @@ const waitForPairingTag = async (device: Device) => {
         throw ERRORS.TypedError('Device_ThpPairingMethodsException');
     }
 
-    const dfd = createDeferred<UiResponseThpPairingTag['payload'] | { error: string }>();
+    const dfd = createDeferred<
+        UiResponseThpPairingTag['payload'] | { error: ERRORS.TrezorError }
+    >();
 
     // start listening for the Cancel message from Trezor
     const { readAbort, readCancel } = waitForPairingCancel(device);
     const cancelResult = readCancel
         .then(readResult => {
             if (readResult.success) {
-                let error: string;
-                if (readResult.payload.type === 'Failure' && readResult.payload.message.message) {
-                    error = readResult.payload.message.message;
+                let code, message;
+                const { payload } = readResult;
+                if (payload.type === 'Failure') {
+                    code = payload.message.code;
+                    message = payload.message.message;
                 } else {
-                    error = `Pairing tag cancelled (${readResult.payload.type})`;
+                    message = `Unexpected message type: ${readResult.payload.type}`;
                 }
 
-                dfd.resolve({ error });
+                dfd.resolve({
+                    error: ERRORS.TypedError(code || 'ThpUnknownError', message),
+                });
             }
         })
         .catch(() => {
@@ -179,7 +182,9 @@ const waitForPairingTag = async (device: Device) => {
             dfd.resolve(response.payload);
         } else {
             abortThpWorkflow(device).then(() => {
-                dfd.resolve({ error: response.error.message });
+                dfd.resolve({
+                    error: ERRORS.TypedError('ThpUnknownError', response.error.message),
+                });
             });
         }
     });
@@ -193,7 +198,7 @@ const waitForPairingTag = async (device: Device) => {
     thpState.setPairingTagPromise(undefined);
 
     if ('error' in pairingResponse) {
-        throw new Error(pairingResponse.error);
+        throw pairingResponse.error;
     }
 
     // node-bridge + usb: abort received on client side of http request resolves faster than server. result with "device call in progress"
@@ -201,7 +206,8 @@ const waitForPairingTag = async (device: Device) => {
 
     return processThpPairingResponse(device, pairingResponse).catch(e => {
         // catch pairing tag mismatch
-        if (e.code === 'Failure_FirmwareError') {
+        // DataError since 2.10.0 https://github.com/trezor/trezor-firmware/commit/b0c3be9b1d95946471ebdab27918a3f652cf11e9
+        if (e.code === 'Failure_FirmwareError' || e.code === 'Failure_DataError') {
             // 'Unexpected Code Entry Tag'
             throw ERRORS.TypedError('Device_ThpPairingTagInvalid', e.message);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Charrypicked from https://github.com/trezor/trezor-suite/pull/24952
Better error handling in THP pairing.

1. canceling on device while waiting for host to send `CodeEntry`  returns `TrezorError` (with code) instead of just plain `Error`
2. `Failure_ActionCancelled` is returned as TypedError (TrezorError) instead of `Device_InitializeFailed`. The difference is that as result of failed (canceled) THP pairing the message displayed in the toast says "Canceled" instead of `Initialize failed:  Cancelled, code: Failure_ActionCancelled`. There is remaining issue in texting `Cancelled` (from trezor) vs `Canceled` (from host)
3. Fix catching pairing tag error - it was changed recently from `Failure_FirmwareError` to `Failure_DataError` https://github.com/trezor/trezor-firmware/commit/b0c3be9b1d95946471ebdab27918a3f652cf11e9
4. remove premature `CodeEntry` length check - if it throw here workflow will be interrupted on host but Trezor will stay with displayed code. This is not our (suite) case because we have check for  the code input, i just noticed it while testing
5. We dont need to wait 2 seconds after failed THP pairing in firmware update flow

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-thp-error-handling&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-thp-error-handling&lookback=7)