### PR TITLE
Mobile trading: display error message when no URI is provided

### DIFF
--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.hook.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.hook.test.ts
@@ -264,7 +264,7 @@ describe('useBrowserAuth', () => {
             expect(selectTradingProviderConfirmationStatus(store.getState())).toBe('window_opened');
         });
 
-        it('should log error when method is not supported', () => {
+        it('should log error and dispatch error message when method is not supported', () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
             const { result } = renderUseBrowserAuth();
@@ -286,6 +286,9 @@ describe('useBrowserAuth', () => {
                 expect.objectContaining({
                     message: 'Unable to open browser, no URI provided.',
                 }),
+            );
+            expect(selectTradingSellLastErrorMessage(store.getState())).toBe(
+                getTranslation('moduleTrading.browser.noURL'),
             );
         });
     });

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.hook.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.hook.test.ts
@@ -71,6 +71,7 @@ describe('useBrowserAuth', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockLinkingURL = null;
+        mockDismissBrowser.mockResolvedValue({ type: WebBrowserResultType.DISMISS });
         ({ store } = initStore({ wallet: getWalletState() }));
     });
 

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -156,13 +156,14 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
                 const msg = 'Unable to open browser, no URI provided.';
                 console.warn(msg);
                 captureSentryException(new BrowserAuthError(msg));
+                dispatchLastErrorMessage(translate('moduleTrading.browser.noURL'));
 
                 return;
             }
 
             await openBrowser(source.uri, returnUrl);
         },
-        [openBrowser],
+        [openBrowser, dispatchLastErrorMessage, translate],
     );
 
     return { openBrowser, openBrowserForFormData };

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -79,7 +79,10 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
         }
 
         handleBrowserSuccess();
-        dismissBrowser();
+        dismissBrowser().catch(_ => {
+            // Ignore the error, browser might have been already closed.
+            // (And in fact it most probably already is.)
+        });
     }, [
         lastCallbackUrl,
         orderId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display error message to user when no URI is provided by trade response.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=set-last-error-on-no-uri&lookback=7)