### PR TITLE
feat: new firmware channel for early access program

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -72,19 +72,19 @@ export class DataManager {
     }
 
     private static async loadFirmwareReleaseConfig(onlyLocal: boolean): Promise<void> {
-        let firmwareRelaseConfig;
+        let firmwareReleaseConfig;
         if (onlyLocal) {
-            firmwareRelaseConfig = {
+            firmwareReleaseConfig = {
                 config: this.getLocalFirmwareReleaseConfig(),
                 isRemote: false,
             };
         } else {
-            firmwareRelaseConfig = await getFirmwareReleaseConfig();
+            firmwareReleaseConfig = await getFirmwareReleaseConfig();
         }
-        const { config, isRemote } = firmwareRelaseConfig;
-        const firmwareconfig = await initializeFirmwareConfig(config, isRemote);
-        this.setFirmwareReleaseConfig(firmwareconfig.releases);
-        this.setFirmwareIntermediaryReleaseConfig(firmwareconfig.intermediaries);
+        const { config, isRemote } = firmwareReleaseConfig;
+        const firmwareConfig = await initializeFirmwareConfig(config, isRemote);
+        this.setFirmwareReleaseConfig(firmwareConfig.releases);
+        this.setFirmwareIntermediaryReleaseConfig(firmwareConfig.intermediaries);
     }
 
     public static getProtobufMessages() {

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -58,6 +58,7 @@ const UNSIGNED_LOCALHOST = {
 };
 const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
     production: RELEASES_URL_REMOTE_BASE,
+    'production-early-access': RELEASES_URL_REMOTE_BASE,
     'test-unsigned': UNSIGNED_URL_REMOTE_BASE,
     'test-unsigned-stable': UNSIGNED_STABLE_URL_REMOTE_BASE,
     'test-signed': SIGNED_URL_REMOTE_BASE,
@@ -65,14 +66,15 @@ const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
     'localhost-signed': SIGNED_LOCALHOST,
 };
 
-type OnlineFirmwareBaseUrl = RemoteBaseInfo & { env: FirmwareChannel };
+type OnlineFirmwareBaseUrl = RemoteBaseInfo & { firmwareChannel: FirmwareChannel };
 
 /**
  * Obtains the base URL and middle path where to find firmware releases, based on the current settings.
  * Examples:
- *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', env: 'production' }
- *   { BASE_URL: 'https://suite.corp.sldev.cz', MIDDLE_PATH: 'firmware/signed', env: 'test-signed' }
- *   { BASE_URL: 'http://localhost:3000', MIDDLE_PATH: 'firmware/unsigned', env: 'localhost-unsigned' }
+ *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production' }
+ *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production-early-access' }
+ *   { BASE_URL: 'https://suite.corp.sldev.cz', MIDDLE_PATH: 'firmware/signed', firmwareChannel: 'test-signed' }
+ *   { BASE_URL: 'http://localhost:3000', MIDDLE_PATH: 'firmware/unsigned', firmwareChannel: 'localhost-unsigned' }
  */
 export const getOnlineFirmwareBaseUrl = (): OnlineFirmwareBaseUrl => {
     const firmwareChannel = DataManager.getSettings('firmwareChannel');
@@ -81,13 +83,13 @@ export const getOnlineFirmwareBaseUrl = (): OnlineFirmwareBaseUrl => {
         // If for some reason `firmwareChannel` settings is not set we return production one.
         return {
             ...FIRMWARE_REMOTE_BASE_URLS['production'],
-            env: 'production' as FirmwareChannel,
+            firmwareChannel: 'production' as FirmwareChannel,
         };
     }
 
     return {
         ...FIRMWARE_REMOTE_BASE_URLS[firmwareChannel],
-        env: firmwareChannel,
+        firmwareChannel,
     };
 };
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -50,6 +50,7 @@ export type FirmwareUpdateFlowType =
 
 export type FirmwareChannel =
     | 'production'
+    | 'production-early-access'
     | 'test-unsigned'
     | 'test-unsigned-stable'
     | 'test-signed'

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -16,12 +16,18 @@ const JWS_CONFIG = {
 
 type JwsInfo = {
     jws: string;
-    env: FirmwareChannel;
+    firmwareChannel: FirmwareChannel;
+};
+
+const CONFIG_PATH_BY_CHANNEL: Partial<Record<FirmwareChannel, string>> = {
+    production: 'config/',
+    'production-early-access': 'config-early-access/',
 };
 
 const fetchRemoteJws = async (): Promise<JwsInfo> => {
-    const { BASE_URL, MIDDLE_PATH, env } = getOnlineFirmwareBaseUrl();
-    const path = `${MIDDLE_PATH}/${env === 'production' ? 'config/' : ''}${JWS_CONFIG.REMOTE_FILENAME}`;
+    const { BASE_URL, MIDDLE_PATH, firmwareChannel } = getOnlineFirmwareBaseUrl();
+    const configPath = CONFIG_PATH_BY_CHANNEL[firmwareChannel] ?? '';
+    const path = `${MIDDLE_PATH}/${configPath}${JWS_CONFIG.REMOTE_FILENAME}`;
     const remoteReleasesUrl = new URL(path, BASE_URL);
 
     try {
@@ -44,7 +50,7 @@ const fetchRemoteJws = async (): Promise<JwsInfo> => {
             throw new Error('Invalid response format: "jws" property missing or not a string.');
         }
 
-        return { jws: data.jws, env };
+        return { jws: data.jws, firmwareChannel };
     } catch (error) {
         throw new Error(
             `Failed to fetch remote JWS: ${error instanceof Error ? error.message : String(error)}`,
@@ -78,9 +84,11 @@ const verifyAndDecodeJws = (jws: string, publicKey: string): FirmwareReleaseConf
 
 export const getFirmwareReleaseConfig = async () => {
     try {
-        const { jws, env } = await fetchRemoteJws();
+        const { jws, firmwareChannel } = await fetchRemoteJws();
 
-        const useProductionKey = ['test-signed', 'production'].includes(env);
+        const useProductionKey = ['test-signed', 'production-early-access', 'production'].includes(
+            firmwareChannel,
+        );
         const publicKey = getFirmwareReleaseJwsPublicKey(useProductionKey);
         const remoteConfig = verifyAndDecodeJws(jws, publicKey);
 

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -9,6 +9,7 @@ import { init } from 'src/actions/suite/initAction';
 import { useGuideKeyboard } from 'src/hooks/guide';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useWindowVisibility } from 'src/hooks/suite/useWindowVisibility';
+import { selectDesktopUpdateAllowPrerelease } from 'src/reducers/suite/desktopUpdateReducer';
 import {
     selectIsTransportInitialized,
     selectPrerequisite,
@@ -54,7 +55,10 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
     const { device } = useDevice();
-    useReportDeviceCompromised({ device });
+    useReportDeviceCompromised({
+        device,
+        selectAllowPrerelease: selectDesktopUpdateAllowPrerelease,
+    });
     useDeviceCompromisedNotification();
 
     const dispatch = useDispatch();

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -186,6 +186,7 @@ export const extraDependencies: ExtraDependenciesStatic = {
             pairingMethods: ['CodeEntry'],
             knownCredentials: state.thp?.credentials,
         }),
+        selectAllowPrerelease: (state: AppState) => state.desktopUpdate?.allowPrerelease ?? false,
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -1,30 +1,34 @@
 import styled from 'styled-components';
 
-import { firmwareActions, selectFirmwareChannel } from '@suite-common/firmware';
+import { firmwareActions, selectEffectiveFirmwareChannel } from '@suite-common/firmware';
 import { Column, Text } from '@trezor/components';
 import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectDesktopUpdateAllowPrerelease } from 'src/reducers/suite/desktopUpdateReducer';
 
 const StyledActionSelect = styled(ActionSelect)`
     min-width: 256px;
 `;
 
+const effectiveFirmwareChannel = selectEffectiveFirmwareChannel(selectDesktopUpdateAllowPrerelease);
+
 export const FirmwareUpdateEnvironmentSelect = () => {
-    const firmwareChannel = useSelector(selectFirmwareChannel);
+    const firmwareChannel = useSelector(effectiveFirmwareChannel);
+    const isAllowPrerelease = useSelector(selectDesktopUpdateAllowPrerelease);
     const dispatch = useDispatch();
 
     const options: { label: string; value: FirmwareChannel }[] = [
         { label: 'Production', value: 'production' },
+        { label: 'Production Early Access', value: 'production-early-access' },
         { label: 'Test Unsigned', value: 'test-unsigned' },
         { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
         { label: 'Test Signed', value: 'test-signed' },
         { label: 'Localhost Signed', value: 'localhost-signed' },
         { label: 'Localhost Unsigned', value: 'localhost-unsigned' },
     ];
-    const selectedOption = options.find(option => option.value === firmwareChannel) || options[0];
-
+    const selectedOption = options.find(o => o.value === firmwareChannel) ?? options[0];
     const handleChange = (item: { value: FirmwareChannel }) => {
         dispatch(firmwareActions.setFirmwareChannel(item.value));
     };
@@ -42,6 +46,12 @@ export const FirmwareUpdateEnvironmentSelect = () => {
                         <Text intent="info">
                             If you select production, the binaries will be cached.
                         </Text>
+                        {isAllowPrerelease && (
+                            <Text intent="warning">
+                                Early Access program is enabled. Firmware channel is fixed to
+                                Production Early Access.
+                            </Text>
+                        )}
                     </Column>
                 }
             />
@@ -50,6 +60,7 @@ export const FirmwareUpdateEnvironmentSelect = () => {
                     onChange={handleChange}
                     value={selectedOption}
                     options={options}
+                    isDisabled={isAllowPrerelease}
                 />
             </ActionColumn>
         </SectionItem>

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -5,7 +5,7 @@ import {
     selectIsPendingTransportEvent,
     selectSelectedDevice,
 } from '@suite-common/device';
-import { selectFirmwareChannel } from '@suite-common/firmware';
+import { selectEffectiveFirmwareChannel } from '@suite-common/firmware';
 import {
     Feature,
     parseTimeoutThresholdsPerModel,
@@ -55,7 +55,9 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
         } = extra;
 
         const getEnabledNetworks = () => selectEnabledNetworks(getState());
-        const getFirmwareChannel = () => selectFirmwareChannel(getState());
+        const getEffectiveFirmwareChannel = selectEffectiveFirmwareChannel(
+            extra.selectors.selectAllowPrerelease,
+        );
 
         // set event listeners and dispatch as
         TrezorConnect.on(DEVICE_EVENT, ({ event: _, ...eventData }) => {
@@ -205,7 +207,7 @@ export const connectInitThunk = createThunk<void, ConnectInitHooks | void, void>
                 thp,
                 debug: showConnectLogs,
                 firmwareHashCheckTimeouts,
-                firmwareChannel: getFirmwareChannel(),
+                firmwareChannel: getEffectiveFirmwareChannel(getState()),
             });
         } catch (error) {
             let formattedError: string;

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -7,7 +7,7 @@ import {
     getIsDeviceIdValid,
     selectPersistentDeviceDataById,
 } from '@suite-common/device';
-import { selectFirmwareChannel } from '@suite-common/firmware';
+import { selectIsProductionFirmwareChannel } from '@suite-common/firmware';
 import { TrezorDevice } from '@suite-common/suite-types';
 import { isDeviceKnown as getIsDeviceKnown, isDeviceAcquired } from '@suite-common/suite-utils';
 import { FIRMWARE } from '@trezor/connect';
@@ -18,9 +18,12 @@ import { reportSecurityCheckThunk } from './reportSecurityCheckThunk';
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenariosConfig';
 
 // to avoid unnecessary wallet-core import
-type CommonProps = { device: TrezorDevice | undefined };
+type CommonProps = {
+    device: TrezorDevice | undefined;
+    selectAllowPrerelease: (state: any) => boolean;
+};
 
-const useCommonData = ({ device }: CommonProps) => {
+const useCommonData = ({ device }: Pick<CommonProps, 'device'>) => {
     const model = device?.features?.internal_model;
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
@@ -32,10 +35,12 @@ const useCommonData = ({ device }: CommonProps) => {
     );
 };
 
-const useReportRevisionCheck = ({ device }: CommonProps) => {
+const useReportRevisionCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const firmwareSource = useSelector(selectFirmwareChannel);
+    const isProductionFirmwareChannel = useSelector(
+        selectIsProductionFirmwareChannel(selectAllowPrerelease),
+    );
 
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
@@ -45,7 +50,7 @@ const useReportRevisionCheck = ({ device }: CommonProps) => {
     const errorPayload = isError ? revisionCheck.errorPayload : null;
 
     const shouldReport =
-        firmwareSource === 'production' &&
+        isProductionFirmwareChannel &&
         device?.connected === true &&
         errorType !== null &&
         revisionCheckErrorScenarios[errorType].shouldReport;
@@ -64,10 +69,12 @@ const useReportRevisionCheck = ({ device }: CommonProps) => {
     }, [dispatch, commonData, errorType, errorPayload, shouldReport]);
 };
 
-const useReportHashCheck = ({ device }: CommonProps) => {
+const useReportHashCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const firmwareSource = useSelector(selectFirmwareChannel);
+    const isProductionFirmwareChannel = useSelector(
+        selectIsProductionFirmwareChannel(selectAllowPrerelease),
+    );
 
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks.firmwareHash : null;
     const isError = hashCheck && !hashCheck.success;
@@ -76,7 +83,7 @@ const useReportHashCheck = ({ device }: CommonProps) => {
     const attemptCount = isError ? hashCheck.attemptCount : null;
 
     const shouldReport =
-        firmwareSource === 'production' &&
+        isProductionFirmwareChannel &&
         device?.connected === true &&
         errorType !== null &&
         hashCheckErrorScenarios[errorType].shouldReport;
@@ -184,8 +191,8 @@ const useReportDeviceMetaChecks = ({ device }: CommonProps) => {
  * Optionally report both FW authenticity checks (revision and hash) to Sentry and/or show toast notifications,
  * based on behavior scenarios definitions. This may happen even when no UI is displayed for the checks.
  */
-export const useReportDeviceCompromised = ({ device }: CommonProps) => {
-    useReportRevisionCheck({ device });
-    useReportHashCheck({ device });
-    useReportDeviceMetaChecks({ device });
+export const useReportDeviceCompromised = ({ device, selectAllowPrerelease }: CommonProps) => {
+    useReportRevisionCheck({ device, selectAllowPrerelease });
+    useReportHashCheck({ device, selectAllowPrerelease });
+    useReportDeviceMetaChecks({ device, selectAllowPrerelease });
 };

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,4 +1,4 @@
-import { PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction, createSelector } from '@reduxjs/toolkit';
 
 import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { FirmwareStatus, TrezorDevice } from '@suite-common/suite-types';
@@ -134,3 +134,20 @@ export const selectSwitchFirmwareType = (state: RootState) => state.firmware.swi
 
 export const selectIsFirmwareInstallationRunning = (state: RootState) =>
     state.firmware.status === 'started';
+
+export const selectEffectiveFirmwareChannel = (selectAllowPrerelease: (state: any) => boolean) =>
+    createSelector(
+        selectFirmwareChannel,
+        selectAllowPrerelease,
+        (firmwareChannel, allowPrerelease): FirmwareChannel =>
+            // When a user is in the Early Access Program, the firmware channel is forced to `production-early-access`.
+            // This factory accepts `selectAllowPrerelease` as a parameter because it is a platform-specific extra dependency.
+            allowPrerelease ? 'production-early-access' : firmwareChannel,
+    );
+
+export const selectIsProductionFirmwareChannel = (selectAllowPrerelease: (state: any) => boolean) =>
+    createSelector(
+        selectEffectiveFirmwareChannel(selectAllowPrerelease),
+        (firmwareChannel): boolean =>
+            ['production', 'production-early-access'].includes(firmwareChannel),
+    );

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -84,6 +84,7 @@ export type ExtraDependenciesStatic = {
         >;
         selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
         selectThpSettings: SuiteCompatibleSelector<NonNullable<ConnectSettings['thp']>>;
+        selectAllowPrerelease: SuiteCompatibleSelector<boolean>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -138,6 +138,7 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         selectThpSettings: notImplementedSelector('selectThpSettings', {
             pairingMethods: ['CodeEntry'],
         }),
+        selectAllowPrerelease: notImplementedSelector('selectAllowPrerelease', false),
     },
     actions: {
         setAccountAddMetadata: notImplementedAction('setAccountAddMetadata'),

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -25,7 +25,7 @@ export const useGlobalHooks = () => {
 
     useDetectDeviceError();
     useHandleDeviceAuthorization();
-    useReportDeviceCompromised({ device });
+    useReportDeviceCompromised({ device, selectAllowPrerelease: () => false });
     useRenderDeviceDangerBanner();
     useDeviceCompromisedNotification();
 

--- a/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
@@ -10,6 +10,7 @@ import { FirmwareChannel } from '@trezor/connect/src/types/firmware';
 
 const options: SelectItemType<FirmwareChannel>[] = [
     { label: 'Production', value: 'production' },
+    { label: 'Production Early Access', value: 'production-early-access' },
     { label: 'Test Unsigned', value: 'test-unsigned' },
     { label: 'Test Unsigned Stable', value: 'test-unsigned-stable' },
     { label: 'Test Signed', value: 'test-signed' },

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -126,6 +126,7 @@ export const extraDependencies: ExtraDependenciesStatic = {
             pairingMethods: ['CodeEntry', 'NFC'],
             knownCredentials: state.thp?.credentials,
         }),
+        selectAllowPrerelease: () => false,
         selectIsSuiteSyncEnabled,
 
         // Not implemented. We assume those are NEVER called on Native


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding new production Firmware channel `production-early-access` that will be used when user opts-in for Early Access Program.

The current debug configuration for Firmware Channel will be disable when Early Access Program is selected and `production-early-access` will be the one selected.

## Notes for QA

1. Test that there is new Firmware Channel in debug to select.
2. Test that when user opts-in for Early Access Program the Firmware is taken from channel `production-early-access`.

<img width="932" height="196" alt="image" src="https://github.com/user-attachments/assets/7f52d85b-df0b-4809-bf55-3351a0837418" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/early-access-firmware-channel&lookback=7)


