### PR TITLE
fix(native): show xpub at correct moment

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsDeviceBackupRequired, selectSelectedDevice } from '@suite-common/device';
-import { AccountsRootState, selectAccountByKey, showXpubOnDevice } from '@suite-common/wallet-core';
+import { AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
 import { useAlert } from '@suite-native/alerts';
@@ -43,7 +43,6 @@ export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: Acco
     const showXpub = useCallback(() => {
         if (!device || !account) return;
 
-        showXpubOnDevice(device, account);
         if (isDeviceBackupRequired) {
             openWalletBackupWarningSheet();
         } else {
@@ -113,6 +112,7 @@ export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: Acco
                 onClose={closeXpubQRSheet}
                 symbol={account.symbol}
                 qrCodeData={accountXpub}
+                accountKey={accountKey}
             />
         </>
     );

--- a/suite-native/qr-code/package.json
+++ b/suite-native/qr-code/package.json
@@ -10,7 +10,9 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@suite-common/device": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
@@ -26,6 +28,7 @@
         "expo-image-picker": "~17.0.10",
         "react": "19.1.0",
         "react-native": "0.81.5",
-        "react-qr-code": "2.0.18"
+        "react-qr-code": "2.0.18",
+        "react-redux": "9.2.0"
     }
 }

--- a/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
+import { selectSelectedDevice } from '@suite-common/device';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { AccountsRootState, selectAccountByKey, showXpubOnDevice } from '@suite-common/wallet-core';
+import { AccountKey } from '@suite-common/wallet-types';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
 import { BottomSheetModal, BottomSheetModalRef, Box, Button, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { Translation, useTranslate } from '@suite-native/intl';
+import TrezorConnect from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { XpubQRCodeCard } from './XpubQRCodeCard';
@@ -14,6 +19,7 @@ type XpubQRCodeBottomSheetProps = {
     qrCodeData?: string;
     symbol: NetworkSymbol;
     ref: BottomSheetModalRef;
+    accountKey: AccountKey;
 };
 
 const buttonStyle = prepareNativeStyle(utils => ({
@@ -25,13 +31,21 @@ export const XpubQRCodeBottomSheet = ({
     qrCodeData,
     symbol,
     ref,
+    accountKey,
 }: XpubQRCodeBottomSheetProps) => {
+    const [confirmationInProgress, setConfirmationInProgress] = useState(false);
     const { translate } = useTranslate();
     const networkType = getNetworkType(symbol);
     const isAddressBased = isAddressBasedNetwork(networkType);
     const { applyStyle } = useNativeStyles();
     const copyToClipboard = useCopyToClipboard();
     const [isXpubShown, setIsXpubShown] = useState(isAddressBased);
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    const device = useSelector(selectSelectedDevice);
 
     if (!qrCodeData) return null;
 
@@ -60,8 +74,26 @@ export const XpubQRCodeBottomSheet = ({
         />
     );
 
-    const handleShowXpub = () => {
-        setIsXpubShown(true);
+    const handleCancelConfirmation = () => {
+        if (!confirmationInProgress) return;
+
+        setConfirmationInProgress(false);
+        TrezorConnect.cancel();
+    };
+
+    const handleShowXpub = async () => {
+        if (!device || !account) return;
+
+        setConfirmationInProgress(true);
+        const xpubResponse = await showXpubOnDevice(device, account);
+
+        if (xpubResponse.success) {
+            setIsXpubShown(true);
+        } else {
+            onClose();
+        }
+
+        setConfirmationInProgress(false);
     };
 
     const handleCopyXpub = async () => {
@@ -70,7 +102,12 @@ export const XpubQRCodeBottomSheet = ({
     };
 
     return (
-        <BottomSheetModal ref={ref} isCloseDisplayed title={sheetTitle}>
+        <BottomSheetModal
+            ref={ref}
+            isCloseDisplayed
+            title={sheetTitle}
+            onClose={handleCancelConfirmation}
+        >
             <VStack spacing="sp24">
                 <XpubQRCodeCard isXpubShown={isXpubShown} qrCodeData={qrCodeData} />
 

--- a/suite-native/qr-code/tsconfig.json
+++ b/suite-native/qr-code/tsconfig.json
@@ -2,8 +2,12 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../../suite-common/device" },
         {
             "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-core"
         },
         {
             "path": "../../suite-common/wallet-types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13778,7 +13778,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/qr-code@workspace:suite-native/qr-code"
   dependencies:
+    "@suite-common/device": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/atoms": "workspace:*"
@@ -13795,6 +13797,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-qr-code: "npm:2.0.18"
+    react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
Xpub prompt was shown at device at incorrect moment.

**changes**:
- call trezor get pub keys when user clicks on the button
- cancel in progress call when user closes the bottom sheet

## Notes for QA

- XPUB should be shown once user clicks `Show public key` button

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/20959

## Screenshots:

https://github.com/user-attachments/assets/2bc39cdf-ccfb-48a1-a5c2-c8c51d9228e1



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/xpub-shown-early&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/xpub-shown-early&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/xpub-shown-early&lookback=7)