### PR TITLE
feat(connect): mac field in all address responses

### DIFF
--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -154,6 +154,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
                     batch.address_parameters.address_n_staking,
                 ),
                 address: response.address,
+                mac: response.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -117,6 +117,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
+                mac: response.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -119,6 +119,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 address: message.address,
+                mac: message.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -117,6 +117,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
+                mac: response.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -117,6 +117,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 address: response.address,
+                mac: response.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/api/tron/api/tronGetAddress.ts
+++ b/packages/connect/src/api/tron/api/tronGetAddress.ts
@@ -117,6 +117,7 @@ export default class TronGetAddress extends AbstractMethod<'tronGetAddress', Par
                 path: batch.address_n,
                 serializedPath: getSerializedPath(batch.address_n),
                 address: message.address,
+                mac: message.mac,
             });
 
             if (this.hasBundle) {

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -41,6 +41,7 @@ export interface CardanoAddress {
     serializedPath: string;
     serializedStakingPath: string;
     address: string;
+    mac?: string;
 }
 
 // cardanoGetNativeScriptHash


### PR DESCRIPTION
## Description

Add SLIP-24 mac field for all remaining GetAddress methods - Cardano, Ripple, Solana, Stellar, Tezos, Tron. 
Excluding Monero, where it's not available. 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/getaddress-mac-altcoins&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/getaddress-mac-altcoins&lookback=7)