### PR TITLE
Feat: device meta checks Suite UI

### DIFF
--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -239,19 +239,17 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unacquired device', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                transportSessionOwner: 'foo',
-                type: 'unacquired',
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        transportSessionOwner: 'foo',
+                        type: 'unacquired',
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -268,20 +266,18 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unreadable device: webusb HID', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'unable to open device',
-                hid: true,
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'WebUsbTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        type: 'unreadable',
+                        error: 'unable to open device',
+                        hid: true,
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -299,19 +295,17 @@ describe(`${Preloader.name} component`, () => {
     it('Unreadable device: missing udev on Linux', () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => true);
 
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'LIBUSB_ERROR_ACCESS',
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        type: 'unreadable',
+                        error: 'LIBUSB_ERROR_ACCESS',
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -330,19 +324,17 @@ describe(`${Preloader.name} component`, () => {
     it('Unreadable device: missing udev on non-Linux os (should never happen)', () => {
         jest.spyOn(envUtils, 'isLinux').mockImplementation(() => false);
 
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'LIBUSB_ERROR_ACCESS',
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        type: 'unreadable',
+                        error: 'LIBUSB_ERROR_ACCESS',
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -358,19 +350,17 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unreadable device: unknown error', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                type: 'unreadable',
-                error: 'Unexpected error',
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        type: 'unreadable',
+                        error: 'Unexpected error',
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -386,19 +376,17 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unknown device (should never happen)', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                transportSessionOwner: 'foo',
-                features: undefined,
-            },
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice({
+                        transportSessionOwner: 'foo',
+                        features: undefined,
+                    }),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -415,16 +403,12 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Seedless device', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice({ mode: 'seedless' }),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: { selectedDevice: mockSuiteDevice({ mode: 'seedless' }) },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -441,16 +425,12 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Recovery mode device', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice({}, { recovery_status: 'Recovery' }),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: { selectedDevice: mockSuiteDevice({}, { recovery_status: 'Recovery' }) },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -467,16 +447,12 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Not initialized device', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice({ mode: 'initialize' }),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: { selectedDevice: mockSuiteDevice({ mode: 'initialize' }) },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -493,19 +469,17 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Bootloader device with installed firmware', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice(
-                { mode: 'bootloader' },
-                { firmware_present: true, bootloader_mode: true },
-            ),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice(
+                        { mode: 'bootloader' },
+                        { firmware_present: true, bootloader_mode: true },
+                    ),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -523,19 +497,17 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Bootloader device without firmware', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice(
-                { mode: 'bootloader' },
-                { firmware_present: false, bootloader_mode: true },
-            ),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: {
+                    selectedDevice: mockSuiteDevice(
+                        { mode: 'bootloader' },
+                        { firmware_present: false, bootloader_mode: true },
+                    ),
+                },
             }),
         );
         const { unmount } = renderWithProviders(
@@ -572,16 +544,12 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Required FW update device', () => {
-        const device: DeepPartial<AppState['device']> = {
-            selectedDevice: mockSuiteDevice({ firmware: 'required' }),
-        };
-
         const store = initStore(
             getInitialState({
                 suite: {
                     transport: { transports: [createTransportInfo({ type: 'BridgeTransport' })] },
                 },
-                device,
+                device: { selectedDevice: mockSuiteDevice({ firmware: 'required' }) },
             }),
         );
         const { unmount } = renderWithProviders(

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -3,6 +3,7 @@ import '@suite-common/test-utils/src/globalOverrides';
 import { fireEvent } from '@testing-library/react';
 
 import { AnalyticsState } from '@suite-common/analytics-redux';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { TransportInfo } from '@trezor/connect';
 import * as envUtils from '@trezor/env-utils';
 import { DeepPartial } from '@trezor/type-utils';
@@ -415,11 +416,7 @@ describe(`${Preloader.name} component`, () => {
 
     it('Seedless device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'seedless',
-                features: {},
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice({ mode: 'seedless' }),
         };
 
         const store = initStore(
@@ -445,10 +442,7 @@ describe(`${Preloader.name} component`, () => {
 
     it('Recovery mode device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                features: { recovery_status: 'Recovery' },
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice({}, { recovery_status: 'Recovery' }),
         };
 
         const store = initStore(
@@ -474,11 +468,7 @@ describe(`${Preloader.name} component`, () => {
 
     it('Not initialized device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'initialize',
-                features: {},
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice({ mode: 'initialize' }),
         };
 
         const store = initStore(
@@ -504,11 +494,10 @@ describe(`${Preloader.name} component`, () => {
 
     it('Bootloader device with installed firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'bootloader',
-                features: { firmware_present: true },
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice(
+                { mode: 'bootloader' },
+                { firmware_present: true, bootloader_mode: true },
+            ),
         };
 
         const store = initStore(
@@ -535,11 +524,10 @@ describe(`${Preloader.name} component`, () => {
 
     it('Bootloader device without firmware', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                mode: 'bootloader',
-                features: { firmware_present: false },
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice(
+                { mode: 'bootloader' },
+                { firmware_present: false, bootloader_mode: true },
+            ),
         };
 
         const store = initStore(
@@ -585,11 +573,7 @@ describe(`${Preloader.name} component`, () => {
 
     it('Required FW update device', () => {
         const device: DeepPartial<AppState['device']> = {
-            selectedDevice: {
-                firmware: 'required',
-                features: {},
-                authenticityChecks: {},
-            },
+            selectedDevice: mockSuiteDevice({ firmware: 'required' }),
         };
 
         const store = initStore(

--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -1,7 +1,7 @@
-import { messageSystemInitialState } from '@suite-common/message-system';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { AcquiredDevice, AppState } from 'src/types/suite';
@@ -26,15 +26,21 @@ const authenticityChecksFail: AcquiredDevice['authenticityChecks'] = {
 
 const defaultDevice = mockSuiteDevice();
 if (!deviceUtils.isDeviceAcquired(defaultDevice)) {
-    throw 'mockSuiteDevice() must return an AcquiredDevice here.';
+    throw `${mockSuiteDevice.name}() must return an AcquiredDevice here.`;
 }
+// derived from this device
+const matchingDevicePersistentData = {
+    ...defaultDevicePersistentData,
+    device_id: defaultDevice.features.device_id,
+    unit_color: defaultDevice.features.unit_color,
+    internal_model: defaultDevice.features.internal_model,
+};
 
 const fixtures: Fixture[] = [
     {
         description: 'returns false if all checks pass',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 selectedDevice: {
@@ -58,7 +64,6 @@ const fixtures: Fixture[] = [
                     app: 'settings',
                 },
             },
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 selectedDevice: {
@@ -73,7 +78,6 @@ const fixtures: Fixture[] = [
         description: 'returns true if firmware check errored and not dismissed',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 selectedDevice: {
@@ -88,7 +92,6 @@ const fixtures: Fixture[] = [
         description: 'returns false if firmware check errored and dismissed',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 dismissedSecurityChecks: { firmwareAuthenticity: ['device-id'] },
@@ -104,7 +107,6 @@ const fixtures: Fixture[] = [
         description: 'returns false if a firmware check errored but is disabled',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 selectedDevice: {
@@ -132,12 +134,11 @@ const fixtures: Fixture[] = [
         description: 'returns true if entropy check errored',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 persistentDeviceData: [
                     {
-                        ...defaultDevicePersistentData,
+                        ...matchingDevicePersistentData,
                         lastEntropyCheckResult: { success: false },
                     },
                 ],
@@ -153,12 +154,11 @@ const fixtures: Fixture[] = [
         description: 'returns false if entropy check errored but is disabled',
         state: {
             ...initialAppState,
-            messageSystem: messageSystemInitialState,
             device: {
                 ...initialAppState.device,
                 persistentDeviceData: [
                     {
-                        ...defaultDevicePersistentData,
+                        ...matchingDevicePersistentData,
                         lastEntropyCheckResult: { success: false },
                     },
                 ],
@@ -179,6 +179,33 @@ const fixtures: Fixture[] = [
             },
         },
         result: false,
+    },
+    {
+        description: 'returns true for a device with an invalid id',
+        state: {
+            ...initialAppState,
+            device: { ...initialAppState.device, selectedDevice: { ...defaultDevice, id: null } },
+        },
+        result: true,
+    },
+    {
+        description: 'returns true for a device with mismatch against its persistent data',
+        state: {
+            ...initialAppState,
+            device: {
+                ...initialAppState.device,
+                persistentDeviceData: [matchingDevicePersistentData],
+                selectedDevice: {
+                    ...defaultDevice,
+                    features: {
+                        ...defaultDevice.features,
+                        internal_model: DeviceModelInternal.T1B1,
+                        unit_color: 333,
+                    },
+                },
+            },
+        },
+        result: true,
     },
 ];
 

--- a/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/__tests__/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -1,6 +1,5 @@
-import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { defaultDevicePersistentData, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import * as deviceUtils from '@suite-common/suite-utils';
-import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -2,6 +2,7 @@ import { TranslationKey } from '@suite/intl';
 import { SkippedHashCheckError } from '@suite-common/firmware-authenticity';
 import {
     getIsDeviceIdValid,
+    selectIsDeviceInvariabilityCheckSuccess,
     selectSelectedDevice,
     selectWasFwHashCheckOtherErrorLastTime,
 } from '@suite-common/wallet-core';
@@ -36,6 +37,7 @@ const hashCheckSubtitleMap: Record<
 
 const DeviceCompromisedContent = () => {
     const isValidId = getIsDeviceIdValid(useSelector(selectSelectedDevice));
+    const isDeviceInvariabilityCheckSuccess = useSelector(selectIsDeviceInvariabilityCheckSuccess);
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
     const isEntropyCheckFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
@@ -48,6 +50,17 @@ const DeviceCompromisedContent = () => {
                 ctaSection={<FwAuthenticityCheckSupportButton />}
                 heading="TR_DEVICE_COMPROMISED_HEADING"
                 text="TR_DEVICE_COMPROMISED_INVALID_ID_TEXT"
+                checklistItems={hardFailureChecklistItems}
+            />
+        );
+    }
+    // this check is only a precaution, not expected to be seen often
+    if (!isDeviceInvariabilityCheckSuccess) {
+        return (
+            <SecurityCheckFail
+                ctaSection={<FwAuthenticityCheckSupportButton />}
+                heading="TR_DEVICE_COMPROMISED_HEADING"
+                text="TR_DEVICE_COMPROMISED_INVARIABILITY_CHECK_FAILED_TEXT"
                 checklistItems={hardFailureChecklistItems}
             />
         );

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,6 +1,10 @@
 import { TranslationKey } from '@suite/intl';
 import { SkippedHashCheckError } from '@suite-common/firmware-authenticity';
-import { selectWasFwHashCheckOtherErrorLastTime } from '@suite-common/wallet-core';
+import {
+    getIsDeviceIdValid,
+    selectSelectedDevice,
+    selectWasFwHashCheckOtherErrorLastTime,
+} from '@suite-common/wallet-core';
 import { Card } from '@trezor/components';
 import { FirmwareHashCheckError } from '@trezor/connect';
 
@@ -17,6 +21,7 @@ import {
     DismissFwAuthenticityCheckButton,
     EntropyCheckSupportButton,
     FwAuthencityChecksCtas,
+    FwAuthenticityCheckSupportButton,
 } from './deviceCompromisedCtas';
 import { WelcomeLayout } from '../layouts/WelcomeLayout/WelcomeLayout';
 
@@ -30,11 +35,23 @@ const hashCheckSubtitleMap: Record<
 };
 
 const DeviceCompromisedContent = () => {
+    const isValidId = getIsDeviceIdValid(useSelector(selectSelectedDevice));
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
     const isEntropyCheckFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
     const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
 
+    // this check is only a precaution, not expected to be seen often
+    if (!isValidId) {
+        return (
+            <SecurityCheckFail
+                ctaSection={<FwAuthenticityCheckSupportButton />}
+                heading="TR_DEVICE_COMPROMISED_HEADING"
+                text="TR_DEVICE_COMPROMISED_INVALID_ID_TEXT"
+                checklistItems={hardFailureChecklistItems}
+            />
+        );
+    }
     if (isEntropyCheckFailed) {
         return (
             <SecurityCheckFail

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -5,6 +5,7 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { DeviceReducerState, deviceInitialState } from '@suite-common/wallet-core';
 import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { AppState } from 'src/reducers/store';
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
@@ -50,6 +51,13 @@ const defaultDevice = mockSuiteDevice();
 if (!deviceUtils.isDeviceAcquired(defaultDevice)) {
     throw 'mockSuiteDevice() must return an AcquiredDevice here.';
 }
+// derived from this device
+const matchingDevicePersistentData = {
+    ...defaultDevicePersistentData,
+    device_id: defaultDevice.features.device_id,
+    unit_color: defaultDevice.features.unit_color,
+    internal_model: defaultDevice.features.internal_model,
+};
 
 const deviceCompromisedFixtures: Array<{
     description: string;
@@ -57,12 +65,12 @@ const deviceCompromisedFixtures: Array<{
     result: TranslationKey;
 }> = [
     {
-        description: 'Errored entropy check',
+        description: 'Entropy check error',
         device: {
             ...deviceInitialState,
             persistentDeviceData: [
                 {
-                    ...defaultDevicePersistentData,
+                    ...matchingDevicePersistentData,
                     lastEntropyCheckResult: { success: false },
                 },
             ],
@@ -71,7 +79,7 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
     },
     {
-        description: 'Errored firmware hash check',
+        description: 'Firmware hash check error',
         device: {
             ...deviceInitialState,
             selectedDevice: {
@@ -131,7 +139,7 @@ const deviceCompromisedFixtures: Array<{
         result: 'TR_FAILED_VERIFY_DEVICE_AGAIN_TEXT',
     },
     {
-        description: 'Errored firmware revision check',
+        description: 'Firmware revision check error',
         device: {
             ...deviceInitialState,
             selectedDevice: {
@@ -146,6 +154,27 @@ const deviceCompromisedFixtures: Array<{
             },
         },
         result: 'TR_DEVICE_COMPROMISED_FW_REVISION_CHECK_TEXT',
+    },
+    {
+        description: 'Device Id check error',
+        device: { ...initialAppState.device, selectedDevice: { ...defaultDevice, id: null } },
+        result: 'TR_DEVICE_COMPROMISED_INVALID_ID_TEXT',
+    },
+    {
+        description: 'Device invariability check error',
+        device: {
+            ...initialAppState.device,
+            persistentDeviceData: [matchingDevicePersistentData],
+            selectedDevice: {
+                ...defaultDevice,
+                features: {
+                    ...defaultDevice.features,
+                    internal_model: DeviceModelInternal.T1B1,
+                    unit_color: 333,
+                },
+            },
+        },
+        result: 'TR_DEVICE_COMPROMISED_INVARIABILITY_CHECK_FAILED_TEXT',
     },
 ];
 

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -1,10 +1,9 @@
 import '@suite-common/test-utils/src/globalOverrides';
 
 import { TranslationKey } from '@suite/intl';
-import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { defaultDevicePersistentData, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { DeviceReducerState, deviceInitialState } from '@suite-common/wallet-core';
-import { defaultDevicePersistentData } from '@suite-common/wallet-core/src/support/deviceMocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { AppState } from 'src/reducers/store';

--- a/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
@@ -31,7 +31,7 @@ export const AuthenticateDeviceSupportButton = () => (
     <ContactSupport supportUrl={TREZOR_SUPPORT_DEVICE_AUTHENTICATION_FAILED_URL} />
 );
 
-const FwAuthenticityCheckSupportButton = () => (
+export const FwAuthenticityCheckSupportButton = () => (
     <ContactSupport supportUrl={TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_URL} />
 );
 

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -9,6 +9,7 @@ import {
     getIsDeviceIdValid,
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
+    selectIsDeviceInvariabilityCheckSuccess,
     selectIsEntropyCheckFailed,
     selectIsFirmwareAuthenticityCheckDismissed,
     selectSelectedDevice,
@@ -97,6 +98,8 @@ export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
 
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
     const isDeviceIdValid = getIsDeviceIdValid(selectSelectedDevice(state));
+    const deviceInvariabilitySuccess = selectIsDeviceInvariabilityCheckSuccess(state);
+
     const isFirmwareCheckEnabledAndFailed =
         selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
     const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
@@ -106,6 +109,7 @@ export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean =
 
     return (
         !isDeviceIdValid ||
+        !deviceInvariabilitySuccess ||
         (!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
         isEntropyCheckEnabledAndFailed
     );

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -6,13 +6,12 @@ import {
 } from '@suite-common/firmware-authenticity';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import {
-    getIsDeviceIdValid,
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
+    selectIsDeviceIdCheckSuccess,
     selectIsDeviceInvariabilityCheckSuccess,
     selectIsEntropyCheckFailed,
     selectIsFirmwareAuthenticityCheckDismissed,
-    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 
 import { AppState } from 'src/types/suite';
@@ -96,9 +95,23 @@ export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
     return isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem && isEntropyCheckFailed;
 };
 
+export const selectIsDeviceIdCheckEnabledAndFailed = (state: AppState) => {
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.idCheck);
+    const isDeviceIdValid = selectIsDeviceIdCheckSuccess(state);
+
+    return !isDisabledByMessageSystem && !isDeviceIdValid;
+};
+
+export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AppState) => {
+    const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.invariabilityCheck);
+    const isDeviceInvariabilityCheckSuccess = selectIsDeviceInvariabilityCheckSuccess(state);
+
+    return !isDisabledByMessageSystem && !isDeviceInvariabilityCheckSuccess;
+};
+
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
-    const isDeviceIdValid = getIsDeviceIdValid(selectSelectedDevice(state));
-    const deviceInvariabilitySuccess = selectIsDeviceInvariabilityCheckSuccess(state);
+    const isDeviceIdCheckFailed = selectIsDeviceIdCheckEnabledAndFailed(state);
+    const isDeviceInvariabilityCheckFailed = selectIsDeviceInvariabilityEnabledAndFailed(state);
 
     const isFirmwareCheckEnabledAndFailed =
         selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
@@ -108,8 +121,8 @@ export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean =
     const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);
 
     return (
-        !isDeviceIdValid ||
-        !deviceInvariabilitySuccess ||
+        isDeviceIdCheckFailed ||
+        isDeviceInvariabilityCheckFailed ||
         (!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
         isEntropyCheckEnabledAndFailed
     );

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -6,10 +6,12 @@ import {
 } from '@suite-common/firmware-authenticity';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import {
+    getIsDeviceIdValid,
     selectFirmwareHashCheckError,
     selectFirmwareRevisionCheckError,
     selectIsEntropyCheckFailed,
     selectIsFirmwareAuthenticityCheckDismissed,
+    selectSelectedDevice,
 } from '@suite-common/wallet-core';
 
 import { AppState } from 'src/types/suite';
@@ -94,6 +96,7 @@ export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
 };
 
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
+    const isDeviceIdValid = getIsDeviceIdValid(selectSelectedDevice(state));
     const isFirmwareCheckEnabledAndFailed =
         selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
     const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
@@ -102,6 +105,7 @@ export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean =
     const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);
 
     return (
+        !isDeviceIdValid ||
         (!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
         isEntropyCheckEnabledAndFailed
     );

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFirmwareChannel } from '@suite-common/firmware';
 import { TrezorDevice } from '@suite-common/suite-types';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
+import { isDeviceKnown as getIsDeviceKnown, isDeviceAcquired } from '@suite-common/suite-utils';
 import {
     type DeviceRootState,
     deviceInvariabilityCheck,
@@ -124,9 +124,35 @@ const useReportDeviceMetaChecks = ({ device }: CommonProps) => {
         selectPersistentDeviceDataById(state, device?.id),
     );
     const idCheckSuccess = getIsDeviceIdValid(device);
+
+    const isDeviceKnown = getIsDeviceKnown(device);
+    const isBootloaderMode = device?.features?.bootloader_mode === true;
+    const currentModel = device?.features?.internal_model;
+    const currentColor = device?.features?.unit_color;
+    const hasPreviousRecord = previousData !== undefined;
+    const previousModel = previousData?.internal_model;
+    const previousColor = previousData?.unit_color;
+
     const invariabilityCheckResult = useMemo(
-        () => deviceInvariabilityCheck({ device, previousData }),
-        [device, previousData],
+        () =>
+            deviceInvariabilityCheck({
+                isDeviceKnown,
+                isBootloaderMode,
+                currentModel,
+                currentColor,
+                hasPreviousRecord,
+                previousModel,
+                previousColor,
+            }),
+        [
+            isDeviceKnown,
+            isBootloaderMode,
+            currentModel,
+            currentColor,
+            hasPreviousRecord,
+            previousModel,
+            previousColor,
+        ],
     );
 
     useEffect(() => {

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -74,6 +74,9 @@ export const Feature = {
     deviceAuthenticityCheckOptiga: 'security.deviceAuthenticityCheck.optiga',
     deviceAuthenticityCheckTropic: 'security.deviceAuthenticityCheck.tropic',
 
+    idCheck: 'security.deviceMetaChecks.id',
+    invariabilityCheck: 'security.deviceMetaChecks.invariability',
+
     trading: {
         buy: 'trading.buy',
         sell: 'trading.sell',

--- a/suite-common/suite-types/mocks/index.ts
+++ b/suite-common/suite-types/mocks/index.ts
@@ -3,3 +3,4 @@ export {
     mockSuiteDevice,
     mockGetFirmwareReleaseConfigInfo,
 } from './mockSuiteDevice';
+export { defaultDevicePersistentData } from './mockDevicePersistentData';

--- a/suite-common/suite-types/mocks/mockDevicePersistentData.ts
+++ b/suite-common/suite-types/mocks/mockDevicePersistentData.ts
@@ -1,9 +1,6 @@
-import { PersistentDeviceData } from '@suite-common/suite-types';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-// This file is intentionally not reexported in index.ts, so that bundler won't have to import.
-
-// TODO some mocks from @suite-common/test-utils should be moved to this file
+import type { PersistentDeviceData } from '../src';
 
 export const defaultDevicePersistentData: PersistentDeviceData = {
     device_id: 'device-id',

--- a/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
+++ b/suite-common/wallet-core/src/device/__fixtures__/forgetPersistentDataPreloadedState.ts
@@ -1,12 +1,11 @@
 import { BluetoothState, prepareInitialState } from '@suite-common/bluetooth';
 import { createBluetoothDeviceCommon } from '@suite-common/bluetooth/src/support/mocks';
 import { BluetoothDeviceCommon } from '@suite-common/bluetooth/src/types';
-import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { defaultDevicePersistentData, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { ThpState, initialThpState } from '@suite-common/thp';
 import { createCredential, createDeviceThp } from '@suite-common/thp/src/support/mocks';
 import { asBluetoothDeviceId } from '@trezor/connect';
 
-import { defaultDevicePersistentData } from '../../support/deviceMocks';
 import { DeviceReducerState, deviceInitialState } from '../deviceReducer';
 
 type ForgetPersistentDataPreloadedState = {

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -39,6 +39,7 @@ import {
 } from './deviceConstants';
 import { DeviceRootState } from './deviceReducer';
 import { deviceInvariabilityCheck } from './services/deviceInvariabilityCheck';
+import { getIsDeviceIdValid } from './services/getIsDeviceIdValid';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
@@ -401,9 +402,23 @@ export const selectWasFwHashCheckOtherErrorLastTime = createMemoizedSelector(
     },
 );
 
+export const selectIsDeviceIdCheckSuccess = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => getIsDeviceIdValid(device) === true,
+);
+
 export const selectIsDeviceInvariabilityCheckSuccess = createMemoizedSelector(
     [selectSelectedDevice, selectSelectedPersistentDeviceData],
-    (device, previousData) => deviceInvariabilityCheck({ device, previousData }).success,
+    (device, previousData) => {
+        // just a failsafe in case memoization returned wrong results
+        if (device && previousData && device.id !== previousData.device_id) {
+            console.error('Device invariability check ID mismatch');
+
+            return true;
+        }
+
+        return deviceInvariabilityCheck({ device, previousData }).success;
+    },
 );
 
 export const selectIsPortfolioTrackerDevice = createMemoizedSelector(

--- a/suite-common/wallet-core/src/device/deviceSelectors.ts
+++ b/suite-common/wallet-core/src/device/deviceSelectors.ts
@@ -38,7 +38,10 @@ import {
     PORTFOLIO_TRACKER_DEVICE_ID,
 } from './deviceConstants';
 import { DeviceRootState } from './deviceReducer';
-import { deviceInvariabilityCheck } from './services/deviceInvariabilityCheck';
+import {
+    deviceInvariabilityCheck,
+    rawDataToDeviceInvariabilityCheckDTO,
+} from './services/deviceInvariabilityCheck';
 import { getIsDeviceIdValid } from './services/getIsDeviceIdValid';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
@@ -416,8 +419,9 @@ export const selectIsDeviceInvariabilityCheckSuccess = createMemoizedSelector(
 
             return true;
         }
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
 
-        return deviceInvariabilityCheck({ device, previousData }).success;
+        return deviceInvariabilityCheck(dto).success;
     },
 );
 

--- a/suite-common/wallet-core/src/device/services/__tests__/deviceInvariabilityCheck.test.ts
+++ b/suite-common/wallet-core/src/device/services/__tests__/deviceInvariabilityCheck.test.ts
@@ -1,7 +1,10 @@
 import { defaultDevicePersistentData, mockConnectDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { deviceInvariabilityCheck } from '../deviceInvariabilityCheck';
+import {
+    deviceInvariabilityCheck,
+    rawDataToDeviceInvariabilityCheckDTO,
+} from '../deviceInvariabilityCheck';
 
 const deviceId = 'asdf1234';
 const defaultFeatures = { internal_model: DeviceModelInternal.T3B1, unit_color: 1 } as const;
@@ -14,13 +17,15 @@ describe(deviceInvariabilityCheck.name, () => {
             ...defaultFeatures,
             device_id: deviceId,
         };
-        const result = deviceInvariabilityCheck({ device, previousData });
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
+        const result = deviceInvariabilityCheck(dto);
         expect(result).toEqual({ success: true, payload: undefined });
     });
 
     it('returns success when there is no previous record', () => {
         const device = mockConnectDevice({ id: deviceId }, defaultFeatures);
-        const result = deviceInvariabilityCheck({ device, previousData: undefined });
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData: undefined });
+        const result = deviceInvariabilityCheck(dto);
         expect(result).toEqual({ success: true, payload: undefined });
     });
 
@@ -34,7 +39,8 @@ describe(deviceInvariabilityCheck.name, () => {
             ...defaultFeatures,
             device_id: deviceId,
         };
-        const result = deviceInvariabilityCheck({ device, previousData });
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
+        const result = deviceInvariabilityCheck(dto);
         expect(result).toEqual({
             success: false,
             error: {
@@ -51,7 +57,8 @@ describe(deviceInvariabilityCheck.name, () => {
             ...defaultFeatures,
             device_id: deviceId,
         };
-        const result = deviceInvariabilityCheck({ device, previousData });
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
+        const result = deviceInvariabilityCheck(dto);
         expect(result).toEqual({
             success: false,
             error: {
@@ -71,7 +78,8 @@ describe(deviceInvariabilityCheck.name, () => {
             ...defaultFeatures,
             device_id: deviceId,
         };
-        const result = deviceInvariabilityCheck({ device, previousData });
+        const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
+        const result = deviceInvariabilityCheck(dto);
         expect(result).toEqual({
             success: false,
             error: {

--- a/suite-common/wallet-core/src/device/services/__tests__/deviceInvariabilityCheck.test.ts
+++ b/suite-common/wallet-core/src/device/services/__tests__/deviceInvariabilityCheck.test.ts
@@ -1,7 +1,6 @@
-import { mockConnectDevice } from '@suite-common/suite-types/mocks';
+import { defaultDevicePersistentData, mockConnectDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { defaultDevicePersistentData } from '../../../support/deviceMocks';
 import { deviceInvariabilityCheck } from '../deviceInvariabilityCheck';
 
 const deviceId = 'asdf1234';

--- a/suite-common/wallet-core/src/device/services/deviceInvariabilityCheck.ts
+++ b/suite-common/wallet-core/src/device/services/deviceInvariabilityCheck.ts
@@ -1,5 +1,5 @@
 import type { PersistentDeviceData } from '@suite-common/suite-types';
-import { isDeviceKnown } from '@suite-common/suite-utils';
+import { isDeviceKnown as getIsDeviceKnown } from '@suite-common/suite-utils';
 import type { Device, Features } from '@trezor/connect';
 import { type Result, err, ok } from '@trezor/type-utils';
 
@@ -10,32 +10,36 @@ type DeviceInvariabilityCheckError = {
     previousColor?: Features['unit_color'];
 };
 
-type DeviceInvariabilityCheckParams = {
-    device?: Device;
-    previousData?: PersistentDeviceData;
+type DeviceInvariabilityCheckDTO = {
+    isDeviceKnown: boolean;
+    isBootloaderMode: boolean;
+    currentModel?: Features['internal_model'];
+    currentColor?: Features['unit_color'];
+    hasPreviousRecord?: boolean;
+    previousModel?: PersistentDeviceData['internal_model'];
+    previousColor?: PersistentDeviceData['unit_color'];
 };
 
 // Compares an incoming device with its previous data to check invariability of certain properties.
 export const deviceInvariabilityCheck = ({
-    device,
-    previousData,
-}: DeviceInvariabilityCheckParams): Result<void, DeviceInvariabilityCheckError> => {
+    isDeviceKnown,
+    isBootloaderMode,
+    currentModel,
+    currentColor,
+    hasPreviousRecord,
+    previousModel,
+    previousColor,
+}: DeviceInvariabilityCheckDTO): Result<void, DeviceInvariabilityCheckError> => {
     if (
-        // no device, no problem
-        !device ||
         // no previous data to compare against (first time occurrence of this device id)
-        !previousData ||
+        !hasPreviousRecord ||
         // skip when unacquired or bootloader mode (device will become acquired & normal mode later)
-        !isDeviceKnown(device) ||
-        device.features.bootloader_mode === true
+        !isDeviceKnown ||
+        isBootloaderMode
     ) {
         return ok();
     }
 
-    const currentModel = device.features.internal_model;
-    const previousModel = previousData.internal_model;
-    const currentColor = device.features.unit_color;
-    const previousColor = previousData.unit_color;
     const isModelMismatch = currentModel !== previousModel;
     const isColorMismatch = currentColor !== previousColor;
 
@@ -50,3 +54,21 @@ export const deviceInvariabilityCheck = ({
 
     return ok();
 };
+
+type RawData = {
+    device?: Device;
+    previousData?: PersistentDeviceData;
+};
+
+export const rawDataToDeviceInvariabilityCheckDTO = ({
+    device,
+    previousData,
+}: RawData): DeviceInvariabilityCheckDTO => ({
+    isDeviceKnown: getIsDeviceKnown(device),
+    isBootloaderMode: device?.features?.bootloader_mode === true,
+    currentModel: device?.features?.internal_model,
+    currentColor: device?.features?.unit_color,
+    hasPreviousRecord: previousData !== undefined,
+    previousModel: previousData?.internal_model,
+    previousColor: previousData?.unit_color,
+});

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7255,6 +7255,10 @@ export const messages = defineMessages({
         id: 'TR_DEVICE_COMPROMISED_INVALID_ID_TEXT',
         defaultMessage: 'Security check (id validity check) has failed.',
     },
+    TR_DEVICE_COMPROMISED_INVARIABILITY_CHECK_FAILED_TEXT: {
+        id: 'TR_DEVICE_COMPROMISED_INVARIABILITY_CHECK_FAILED_TEXT',
+        defaultMessage: 'Your device manipulates its model or color.',
+    },
     TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT: {
         id: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
         defaultMessage: 'Your device firmware hash check has failed.',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7251,6 +7251,10 @@ export const messages = defineMessages({
         id: 'TR_DEVICE_COMPROMISED_ENTROPY_CHECK_TEXT',
         defaultMessage: 'Security check (entropy verification) has failed.',
     },
+    TR_DEVICE_COMPROMISED_INVALID_ID_TEXT: {
+        id: 'TR_DEVICE_COMPROMISED_INVALID_ID_TEXT',
+        defaultMessage: 'Security check (id validity check) has failed.',
+    },
     TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT: {
         id: 'TR_DEVICE_COMPROMISED_FW_HASH_CHECK_TEXT',
         defaultMessage: 'Your device firmware hash check has failed.',


### PR DESCRIPTION
## Description

Commits extracted originally from https://github.com/trezor/trezor-suite-private/pull/191 + some new:

- implement Id check UI in Suite
- implement device invariability check UI in Suite 
- small code cosmetics in test :lipstick: :nail_care:
- **new:** implement message system to turn off both checks
- **new:** move a test fixture to proper location as per new guide

## Notes for QA


This can be tested on [the testing branch](https://github.com/trezor/trezor-suite/tree/feat/device-meta-checks-suite-UI-TESTING) which is deployed on [sldev Web](https://dev.suite.sldev.cz/suite-web/feat/device-meta-checks-suite-UI-TESTING/web/).

#### Id check

- Open Suite Web without a device
- In devtools, use the following:
```
device_id = null;
```
- Connect a device
- See Device Compromised (id check) :ghost: 
- Go to Settings > Debug > Message system manager, and add following message:
```
{"conditions": [{"environment": {"desktop": "*", "mobile": "*", "web": "*" } } ], "message": {"id": "4687cc45-1e79-4ee3-8647-326dbe200074", "priority": 1, "dismissible": false, "variant": "info", "category": "feature", "content": {"en": "Placeholder", "es": "Placeholder", "cs": "Placeholder", "de": "Placeholder", "fr": "Placeholder", "it": "Placeholder", "pt": "Placeholder", "tr": "Placeholder", "ru": "Placeholder", "ja": "Placeholder", "uk": "Placeholder", "hu": "Placeholder" }, "feature": [{"domain": "security.deviceMetaChecks.id", "flag": false } ] } }
```
- Go to Dashboard, and there should be _FW authenticity_ Device Compromised (because the testing branch is a primitive tool), but no id check
  - Ofc if you have FW auth checks on. If they're off, there shall be no Device Compromised screen

#### Invariability check

- Reload page to clear the mock
- In devtools, use **either** of the following:
```
internal_model = 'T1B1'; // a different one than you use
unit_color = 333;
``` 
- Connect a device
- See Device Compromised (invariability check) :ghost: 
- Go to Settings > Debug > Message system manager, and add following message:
```
{"conditions": [{"environment": {"desktop": "*", "mobile": "*", "web": "*" } } ], "message": {"id": "b47170d9-2f0b-4639-bbdb-3c592bd685c8", "priority": 1, "dismissible": false, "variant": "info", "category": "feature", "content": {"en": "Placeholder", "es": "Placeholder", "cs": "Placeholder", "de": "Placeholder", "fr": "Placeholder", "it": "Placeholder", "pt": "Placeholder", "tr": "Placeholder", "ru": "Placeholder", "ja": "Placeholder", "uk": "Placeholder", "hu": "Placeholder" }, "feature": [{"domain": "security.deviceMetaChecks.invariability", "flag": false } ] } }
```
- Go to Dashboard, similarly there should now be either FW auth check Device Compromised, or none 

#### Further monitoring

The instructions above just describe how the test & message system should work as intended.

I don't know if there will be any false positives, so please test what comes to your mind, and be on the lookout if these screens pop up during other QA (you can't miss it, it blocks the Suite :smile: )

Also notes that if Id is invalid, the invariability check won't happen (can't match past data if there's no Id)

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/192

## Screenshots:

Device compromised (Id check fail)

<img width="886" height="507" alt="ID check fail" src="https://github.com/user-attachments/assets/9d775652-7fd2-4c20-a69b-513748ed9229" />

Device compromised (device invariability check fail)

<img width="886" height="507" alt="invariability check fail" src="https://github.com/user-attachments/assets/b4613ea5-79f5-4e96-ae33-298ee13393be" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/device-meta-checks-suite-UI&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/device-meta-checks-suite-UI&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/device-meta-checks-suite-UI&lookback=7)