### PR TITLE
fix(suite-native): fix earn to home navigation for btc-only firmware on android

### DIFF
--- a/suite-native/device-manager/src/components/DeviceManagerContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerContent.tsx
@@ -92,12 +92,7 @@ export const DeviceManagerContent = () => {
 
         // When user selects BTC only device in device switcher, redirect to homescreen out of the earn section.
         if (isOnEarnScreenRoute && isBitcoinOnlyFirmware) {
-            navigation.reset({
-                index: 0,
-                routes: [
-                    { name: AppTabsRoutes.HomeStack, params: { screen: HomeStackRoutes.Home } },
-                ],
-            });
+            navigation.navigate(AppTabsRoutes.HomeStack, { screen: HomeStackRoutes.Home });
         }
 
         dispatch(selectDeviceThunk({ device: selectedDevice }));


### PR DESCRIPTION
## Description

Fix Earn to Home navigation on Android when switching to bitcoin-only firmware.

## Related Issue

Resolve #24704 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/mobile-earn-btc-fw&lookback=7)