### PR TITLE
feat(suite-native): release xlm tokens to production

### DIFF
--- a/suite-native/tokens/package.json
+++ b/suite-native/tokens/package.json
@@ -18,7 +18,6 @@
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
-        "@suite-native/config": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "react": "19.1.0"
     }

--- a/suite-native/tokens/src/utils.ts
+++ b/suite-native/tokens/src/utils.ts
@@ -1,7 +1,6 @@
 import { G, S } from '@mobily/ts-belt';
 
 import { NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
-import { isDevelopOrDebugEnv } from '@suite-native/config';
 
 export const getTokenName = (tokenName?: string) => {
     if (G.isNullable(tokenName) || S.isEmpty(tokenName)) return 'Unknown token';
@@ -9,10 +8,5 @@ export const getTokenName = (tokenName?: string) => {
     return tokenName;
 };
 
-export const isNetworkWithTokens = (symbol: NetworkSymbol) => {
-    if (symbol === 'xlm' && !isDevelopOrDebugEnv()) {
-        return false;
-    }
-
-    return getNetworkFeatures(symbol).includes('tokens');
-};
+export const isNetworkWithTokens = (symbol: NetworkSymbol) =>
+    getNetworkFeatures(symbol).includes('tokens');

--- a/suite-native/tokens/tsconfig.json
+++ b/suite-native/tokens/tsconfig.json
@@ -20,7 +20,6 @@
         {
             "path": "../../suite-common/wallet-utils"
         },
-        { "path": "../config" },
         {
             "path": "../../packages/blockchain-link"
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14066,7 +14066,6 @@ __metadata:
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
-    "@suite-native/config": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     react: "npm:19.1.0"
   languageName: unknown


### PR DESCRIPTION
Release XLM also for prod app

## Notes for QA

XLM tokens should be visible in RC and production apps




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/release-xlm-tokens-to-prod&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/release-xlm-tokens-to-prod&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/release-xlm-tokens-to-prod&lookback=7)