### PR TITLE
feat(suite): render Earn Yield table from Yield opportunities

### DIFF
--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -11,7 +11,7 @@ export { mapTrezorModelToIcon } from './utils/mapTrezorModelToIcon';
 export { RotateDeviceImage } from './components/RotateDeviceImage/RotateDeviceImage';
 export { TrezorLogo } from './components/TrezorLogo/TrezorLogo';
 export { PasswordStrengthIndicator } from './components/PasswordStrengthIndicator/PasswordStrengthIndicator';
-export { CoinLogo } from './components/CoinLogo/CoinLogo';
+export { CoinLogo, type CoinLogoType } from './components/CoinLogo/CoinLogo';
 export { isCoinSymbol } from './constants/coins';
 export { AssetShareIndicator } from './components/AssetShareIndicator/AssetShareIndicator';
 export * from './components/TokenIconSet/TokenIconSet';

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -29,6 +29,7 @@
         "@suite-common/delegated-identity-key": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/device-authenticity": "workspace:*",
+        "@suite-common/earn-api": "workspace:*",
         "@suite-common/feedback": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/firmware": "workspace:*",

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCell.tsx
@@ -1,61 +1,64 @@
-import styled from 'styled-components';
-
-import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { TokenDto } from '@suite-common/earn-api';
+import { NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { Column } from '@trezor/components';
-import { CoinLogo } from '@trezor/product-components';
-import { spacingsPx, typography } from '@trezor/theme';
+import { Column, Row } from '@trezor/components';
+import { AssetLogo, CoinLogo } from '@trezor/product-components';
 
-import { AccountLabel, CoinBalance } from 'src/components/suite';
-
-const AccountCellContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: ${spacingsPx.md};
-    ${typography['body-sm']};
-    color: ${({ theme }) => theme.textSubdued};
-    cursor: inherit;
-`;
-
-const AccountLabelContainer = styled.div`
-    color: ${({ theme }) => theme.textDefault};
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-`;
+import { EarnAccountCellDetails } from './EarnAccountCellDetails';
+import { EarnTokenBalance } from './types';
 
 type EarnAccountCellProps = {
     account?: Account;
     symbol?: NetworkSymbol;
+    iconToken?: TokenDto;
+    showAssetNetworkIcon?: boolean;
+    tokenBalance?: EarnTokenBalance;
 };
 
-export const EarnAccountCell = ({ account, symbol }: EarnAccountCellProps) => {
+export const EarnAccountCell = ({
+    account,
+    symbol,
+    iconToken,
+    showAssetNetworkIcon = false,
+    tokenBalance,
+}: EarnAccountCellProps) => {
     const networkSymbol = account?.symbol ?? symbol;
+    const assetLogo =
+        iconToken && networkSymbol
+            ? {
+                  coingeckoId: getCoingeckoId(networkSymbol) ?? iconToken.coinGeckoId,
+                  placeholder: iconToken.symbol || iconToken.name || 'token',
+                  contractAddress: iconToken.address ?? null,
+                  showNetworkIcon: showAssetNetworkIcon,
+              }
+            : undefined;
 
     if (!networkSymbol) return null;
 
     return (
-        <AccountCellContainer>
+        <Row gap={16} cursor="inherit">
             <Column alignItems="center">
-                <CoinLogo size={32} symbol={networkSymbol} />
+                {assetLogo?.coingeckoId ? (
+                    <AssetLogo
+                        size={32}
+                        coingeckoId={assetLogo.coingeckoId}
+                        placeholder={assetLogo.placeholder}
+                        symbol={networkSymbol}
+                        contractAddress={assetLogo.contractAddress}
+                        showNetworkIcon={assetLogo.showNetworkIcon}
+                    />
+                ) : (
+                    <CoinLogo size={32} symbol={networkSymbol} type="tokenWithNetwork" />
+                )}
             </Column>
 
             <Column flex="1" overflow="hidden" gap={2}>
-                <AccountLabelContainer>
-                    {account ? (
-                        <AccountLabel
-                            account={account}
-                            showAccountTypeBadge={true}
-                            accountTypeBadgeSize="small"
-                        />
-                    ) : (
-                        symbol && getNetwork(symbol).name
-                    )}
-                </AccountLabelContainer>
-
-                {account && <CoinBalance value={account.formattedBalance} symbol={networkSymbol} />}
+                <EarnAccountCellDetails
+                    account={account}
+                    networkSymbol={networkSymbol}
+                    tokenBalance={tokenBalance}
+                />
             </Column>
-        </AccountCellContainer>
+        </Row>
     );
 };

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCellDetails.tsx
@@ -1,0 +1,63 @@
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+import { Text } from '@trezor/components';
+
+import { AccountLabel, FormattedCryptoAmount } from 'src/components/suite';
+
+import { EarnTokenBalance } from './types';
+
+type EarnAccountCellDetailsProps = {
+    account?: Account;
+    networkSymbol: NetworkSymbol;
+    tokenBalance?: EarnTokenBalance;
+};
+
+export const EarnAccountCellDetails = ({
+    account,
+    networkSymbol,
+    tokenBalance,
+}: EarnAccountCellDetailsProps) => {
+    if (!account) {
+        return (
+            <Text
+                typographyStyle="body-sm"
+                intent="neutral"
+                priority="primary"
+                ellipsisLineCount={1}
+                maxWidth="100%"
+            >
+                {getNetwork(networkSymbol).name}
+            </Text>
+        );
+    }
+
+    return (
+        <>
+            <AccountLabel
+                account={account}
+                showAccountTypeBadge
+                accountTypeBadgeSize="small"
+                intent="neutral"
+                priority="primary"
+                typographyStyle="body-sm"
+            />
+
+            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                {tokenBalance ? (
+                    <FormattedCryptoAmount
+                        value={tokenBalance.value}
+                        symbol={tokenBalance.symbol}
+                        contractAddress={tokenBalance.contractAddress}
+                        isBalance
+                    />
+                ) : (
+                    <FormattedCryptoAmount
+                        value={account.formattedBalance}
+                        symbol={networkSymbol}
+                        isBalance
+                    />
+                )}
+            </Text>
+        </>
+    );
+};

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -1,0 +1,75 @@
+import { ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Button, Paragraph, Table } from '@trezor/components';
+
+import { openModal } from 'src/actions/suite/modalActions';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+
+import { EarnAccountCell } from './EarnAccountCell';
+
+type EarnInactiveNetworkOpportunityProps = {
+    symbol: NetworkSymbol;
+    apy: number | null;
+    note?: ReactNode;
+};
+
+export const EarnInactiveNetworkOpportunity = ({
+    symbol,
+    apy,
+    note,
+}: EarnInactiveNetworkOpportunityProps) => {
+    const dispatch = useDispatch();
+    const { device } = useDevice();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const { name } = getNetwork(symbol);
+
+    const openAddAcountModal = () => {
+        if (!device) {
+            return;
+        }
+
+        dispatch(
+            openModal({
+                type: 'add-account',
+                device,
+                symbol,
+                noRedirect: true,
+                isCoinjoinDisabled: true,
+                isBackClickDisabled: true,
+            }),
+        );
+    };
+
+    return (
+        <Table.Row>
+            <Table.Cell>
+                <EarnAccountCell symbol={symbol} />
+            </Table.Cell>
+
+            <Table.Cell>
+                <ApyValue apy={apy} />
+            </Table.Cell>
+
+            <Table.Cell colSpan={2}>
+                {note && (
+                    <Paragraph typographyStyle="body-md" intent="neutral">
+                        {note}
+                    </Paragraph>
+                )}
+            </Table.Cell>
+
+            <Table.Cell align="end">
+                <Button size="small" onClick={openAddAcountModal} isDisabled={isDiscoveryRunning}>
+                    <Translation
+                        id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
+                        values={{ networkName: name }}
+                    />
+                </Button>
+            </Table.Cell>
+        </Table.Row>
+    );
+};

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnNotAvailableText.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnNotAvailableText.tsx
@@ -1,0 +1,8 @@
+import { Translation } from '@suite/intl';
+import { Paragraph } from '@trezor/components';
+
+export const EarnNotAvailableText = () => (
+    <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+        <Translation id="TR_EARN_NOT_AVAILABLE" />
+    </Paragraph>
+);

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnRewardsAmount.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnRewardsAmount.tsx
@@ -1,10 +1,11 @@
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { TokenSymbol } from '@suite-common/wallet-types';
 import { H4, type TextProps } from '@trezor/components';
 
 type EarnRewardsAmountProps = {
-    symbol: NetworkSymbol;
+    symbol: NetworkSymbol | TokenSymbol;
     rewards: string;
     apy: number | null;
     intent?: TextProps['intent'];

--- a/packages/suite/src/components/earn/EarnDashboard/common/types.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/common/types.ts
@@ -1,0 +1,7 @@
+import { TokenSymbol } from '@suite-common/wallet-types';
+
+export type EarnTokenBalance = {
+    value: string;
+    symbol: TokenSymbol;
+    contractAddress?: string | null;
+};

--- a/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingAccountRow.tsx
@@ -19,7 +19,6 @@ import {
     isCardanoStakedOutsideEverstake,
 } from '@suite-common/wallet-utils';
 import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 import { BigNumber } from '@trezor/utils';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -334,7 +333,7 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
             {state === 'staking-outdated-provider' && (
                 <>
                     <Table.Cell colSpan={2}>
-                        <Row gap={spacings.xxs}>
+                        <Row gap={4}>
                             <Icon name="warning" size={24} variant="warning" />
                             <Paragraph typographyStyle="body-md" intent="warning">
                                 <Translation

--- a/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingActivateRow.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingActivateRow.tsx
@@ -1,74 +1,32 @@
 import { Translation } from '@suite/intl';
 import { NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { selectHasRunningDiscovery, selectPoolStatsApyData } from '@suite-common/wallet-core';
+import { selectPoolStatsApyData } from '@suite-common/wallet-core';
 import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
-import { Button, Paragraph, Table } from '@trezor/components';
 
-import { openModal } from 'src/actions/suite/modalActions';
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
-import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+import { useSelector } from 'src/hooks/suite';
 
-import { EarnAccountCell } from '../common/EarnAccountCell';
+import { EarnInactiveNetworkOpportunity } from '../common/EarnInactiveNetworkOpportunity';
 
 export const EarnStakingActivateRow = ({ symbol }: { symbol: NetworkSymbol }) => {
-    const dispatch = useDispatch();
-    const { device } = useDevice();
     const apy = useSelector(state => selectPoolStatsApyData(state, undefined, symbol));
-    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    const { displaySymbol, name } = getNetwork(symbol);
+    const { displaySymbol } = getNetwork(symbol);
     const minStakingAmount =
         getStakingLimitsByNetworkSymbol(symbol)?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
 
-    const startNetworkDiscovery = () => {
-        if (!device) return;
-
-        dispatch(
-            openModal({
-                type: 'add-account',
-                device,
-                symbol,
-                noRedirect: true,
-                isCoinjoinDisabled: true,
-                isBackClickDisabled: true,
-            }),
-        );
-    };
-
     return (
-        <Table.Row>
-            <Table.Cell>
-                <EarnAccountCell symbol={symbol} />
-            </Table.Cell>
-
-            <Table.Cell>
-                <ApyValue apy={apy} />
-            </Table.Cell>
-
-            <Table.Cell colSpan={2}>
-                <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
-                    <Translation
-                        id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
-                        values={{
-                            amount: minStakingAmount?.toString(),
-                            displaySymbol,
-                        }}
-                    />
-                </Paragraph>
-            </Table.Cell>
-
-            <Table.Cell align="end">
-                <Button
-                    size="small"
-                    onClick={startNetworkDiscovery}
-                    isDisabled={isDiscoveryRunning}
-                >
-                    <Translation
-                        id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
-                        values={{ networkName: name }}
-                    />
-                </Button>
-            </Table.Cell>
-        </Table.Row>
+        <EarnInactiveNetworkOpportunity
+            symbol={symbol}
+            apy={apy}
+            note={
+                <Translation
+                    id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
+                    values={{
+                        amount: minStakingAmount?.toString(),
+                        displaySymbol,
+                    }}
+                />
+            }
+        />
     );
 };

--- a/packages/suite/src/components/earn/EarnDashboard/utils/earnApyUtils.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/utils/earnApyUtils.ts
@@ -1,0 +1,12 @@
+import { BigNumber } from '@trezor/utils';
+
+export const getApyPercent = (apyRate: number): number | null => {
+    if (!Number.isFinite(apyRate)) {
+        return null;
+    }
+
+    return new BigNumber(apyRate).times(100).decimalPlaces(2).toNumber();
+};
+
+export const getApyRate = (apyRate: number): number =>
+    Number.isFinite(apyRate) ? apyRate : Number.NEGATIVE_INFINITY;

--- a/packages/suite/src/components/earn/EarnDashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/utils/earnYieldUtils.ts
@@ -1,0 +1,52 @@
+import { BalanceType, YieldBalancesDto } from '@suite-common/earn-api';
+import { BigNumber } from '@trezor/utils';
+
+export const getYieldAddressKey = (yieldId: string, address: string) =>
+    `${yieldId}:${address.toLowerCase()}`;
+
+const SUPPLIED_BALANCE_TYPES = new Set<BalanceType>([BalanceType.active, BalanceType.entering]);
+
+export const getSuppliedBalancesByYieldAndAddress = (items: YieldBalancesDto[]) =>
+    items.reduce((acc, item) => {
+        item.balances.forEach(balance => {
+            if (!SUPPLIED_BALANCE_TYPES.has(balance.type)) {
+                return;
+            }
+
+            const key = getYieldAddressKey(item.yieldId, balance.address);
+            const previousAmount = acc.get(key) ?? '0';
+            const nextAmount = new BigNumber(previousAmount).plus(balance.amount).toString();
+
+            acc.set(key, nextAmount);
+        });
+
+        return acc;
+    }, new Map<string, string>());
+
+type YieldRowWithAvailableBalance = {
+    additionalSupplyAmount: string;
+    matchedToken: unknown;
+    account?: {
+        formattedBalance: string;
+    };
+};
+
+type YieldRowWithSuppliedBalance = {
+    suppliedAmount: string;
+};
+
+const getYieldAvailableBalanceForSorting = (row: YieldRowWithAvailableBalance) =>
+    row.matchedToken ? row.additionalSupplyAmount : (row.account?.formattedBalance ?? '0');
+
+export const compareYieldRowsBySuppliedAmountDesc = (
+    a: YieldRowWithSuppliedBalance,
+    b: YieldRowWithSuppliedBalance,
+) => new BigNumber(b.suppliedAmount).comparedTo(a.suppliedAmount) ?? 0;
+
+export const compareYieldRowsByAvailableBalanceDesc = (
+    a: YieldRowWithAvailableBalance,
+    b: YieldRowWithAvailableBalance,
+) =>
+    new BigNumber(getYieldAvailableBalanceForSorting(b)).comparedTo(
+        getYieldAvailableBalanceForSorting(a),
+    ) ?? 0;

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -1,0 +1,213 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import {
+    getTradingPrefilledFromAccountData,
+    toTokenCryptoId,
+    tradingActions,
+} from '@suite-common/trading';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { goto } from 'src/actions/suite/routerActions';
+import { useDispatch } from 'src/hooks/suite';
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+
+import { type YieldAccountOpportunity } from './types';
+import { EarnAccountCell } from '../common/EarnAccountCell';
+import { EarnRewardsAmount } from '../common/EarnRewardsAmount';
+
+type EarnYieldAccountOpportunityProps = {
+    opportunity: YieldAccountOpportunity;
+};
+
+export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpportunityProps) => {
+    const dispatch = useDispatch();
+    const { CryptoAmountFormatter } = useFormatters();
+
+    const hasMatchedToken = opportunity.matchedToken !== undefined;
+    const hasSuppliedBalance = new BigNumber(opportunity.suppliedAmount).gt(0);
+    const hasMatchedTokenWithBalance =
+        hasMatchedToken && new BigNumber(opportunity.additionalSupplyAmount).gt(0);
+    const hasRewardsData = hasMatchedTokenWithBalance || hasSuppliedBalance;
+    const hasApy = opportunity.apyPercentage !== null;
+    const yearlyRewards = hasRewardsData
+        ? new BigNumber(opportunity.suppliedAmount)
+              .times(opportunity.vault.rewardRate.total)
+              .toString()
+        : '0';
+    const potentialRewards = hasRewardsData
+        ? new BigNumber(opportunity.suppliedAmount)
+              .plus(opportunity.additionalSupplyAmount)
+              .times(opportunity.vault.rewardRate.total)
+              .toString()
+        : '0';
+    const hasPotentialRewards = new BigNumber(potentialRewards).gt(0);
+    const formattedSuppliedAmount = CryptoAmountFormatter.format(opportunity.suppliedAmount, {
+        symbol: opportunity.suppliedSymbol,
+        withSymbol: false,
+        isBalance: true,
+    });
+    const formattedAdditionalSupplyAmount = CryptoAmountFormatter.format(
+        opportunity.additionalSupplyAmount,
+        {
+            symbol: opportunity.suppliedSymbol,
+            withSymbol: false,
+            isBalance: true,
+        },
+    );
+    const navigateToTradingBuy = () => {
+        const networkSymbol = opportunity.account?.symbol ?? opportunity.networkSymbol;
+        const accountIndex = opportunity.account?.index ?? 0;
+        const accountType = opportunity.account?.accountType ?? 'normal';
+        const tokenAddress = opportunity.vault.token.address;
+
+        if (opportunity.account) {
+            const tokenCryptoId = tokenAddress
+                ? toTokenCryptoId(
+                      networkSymbol,
+                      getContractAddressForNetworkSymbol(networkSymbol, tokenAddress),
+                  )
+                : undefined;
+
+            dispatch(
+                tradingActions.setTradingFromPrefilledAccount(
+                    getTradingPrefilledFromAccountData(opportunity.account, tokenCryptoId),
+                ),
+            );
+        }
+
+        dispatch(
+            goto('wallet-trading-buy', {
+                params: {
+                    symbol: networkSymbol,
+                    accountIndex,
+                    accountType,
+                },
+            }),
+        );
+    };
+
+    return (
+        <Table.Row>
+            <Table.Cell>
+                <EarnAccountCell
+                    account={opportunity.account}
+                    symbol={opportunity.networkSymbol}
+                    iconToken={opportunity.vault.token}
+                    showAssetNetworkIcon
+                    tokenBalance={
+                        hasMatchedToken
+                            ? {
+                                  value: opportunity.additionalSupplyAmount,
+                                  symbol: opportunity.suppliedSymbol,
+                                  contractAddress: opportunity.suppliedContractAddress,
+                              }
+                            : undefined
+                    }
+                />
+            </Table.Cell>
+
+            <Table.Cell>
+                <ApyValue apy={opportunity.apyPercentage} />
+            </Table.Cell>
+
+            {hasRewardsData ? (
+                <>
+                    <Table.Cell>
+                        <Row width="100%" alignItems="center" justifyContent="space-between">
+                            <Column>
+                                <EarnRewardsAmount
+                                    symbol={opportunity.suppliedSymbol}
+                                    rewards={yearlyRewards}
+                                    apy={opportunity.apyPercentage}
+                                />
+
+                                {hasSuppliedBalance && (
+                                    <Paragraph
+                                        typographyStyle="body-sm"
+                                        intent="neutral"
+                                        priority="secondary"
+                                    >
+                                        <Translation
+                                            id="TR_EARN_YIELD_DASHBOARD_SUPPLIED"
+                                            values={{
+                                                amount: formattedSuppliedAmount,
+                                                displaySymbol: opportunity.suppliedSymbol,
+                                            }}
+                                        />
+                                    </Paragraph>
+                                )}
+                            </Column>
+
+                            {hasApy && (
+                                <Icon name="arrowRight" variant="tertiary" size="mediumLarge" />
+                            )}
+                        </Row>
+                    </Table.Cell>
+
+                    <Table.Cell>
+                        {hasPotentialRewards && (
+                            <Column>
+                                <EarnRewardsAmount
+                                    symbol={opportunity.suppliedSymbol}
+                                    rewards={potentialRewards}
+                                    apy={opportunity.apyPercentage}
+                                    intent="brand"
+                                />
+
+                                <Paragraph
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <Translation
+                                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                                        values={{
+                                            amount: formattedAdditionalSupplyAmount,
+                                            displaySymbol: opportunity.suppliedSymbol,
+                                        }}
+                                    />
+                                </Paragraph>
+                            </Column>
+                        )}
+                    </Table.Cell>
+                </>
+            ) : (
+                <Table.Cell colSpan={2} />
+            )}
+
+            <Table.Cell align="end">
+                <Row justifyContent="flex-end" gap={8}>
+                    {hasSuppliedBalance && (
+                        <>
+                            <Button size="small">
+                                <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE" />
+                            </Button>
+                            <Button size="small" intent="brand" priority="secondary">
+                                <Translation id="TR_EARN_YIELD_DASHBOARD_WITHDRAW" />
+                            </Button>
+                        </>
+                    )}
+
+                    {!hasSuppliedBalance && hasMatchedTokenWithBalance && (
+                        <Button size="small" isDisabled={!opportunity.vault.status.enter}>
+                            <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW" />
+                        </Button>
+                    )}
+
+                    {!hasSuppliedBalance && !hasMatchedTokenWithBalance && (
+                        <Button
+                            size="small"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={navigateToTradingBuy}
+                        >
+                            <Translation id="TR_BUY" />
+                        </Button>
+                    )}
+                </Row>
+            </Table.Cell>
+        </Table.Row>
+    );
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTable.tsx
@@ -1,21 +1,56 @@
-import { Translation } from '@suite/intl';
-import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
-import { Button, Card, Paragraph, Row, Table } from '@trezor/components';
-import { BigNumber } from '@trezor/utils';
+import { useMemo } from 'react';
+
+import { YieldDto } from '@suite-common/earn-api';
+import { NORMAL_ACCOUNT_TYPE } from '@suite-common/wallet-config';
+import {
+    selectDeviceSupportedNetworks,
+    selectVisibleDeviceAccounts,
+} from '@suite-common/wallet-core';
+import { Card, Table } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 
-import { EarnAccountCell } from '../common/EarnAccountCell';
+import { EarnYieldTableBody } from './EarnYieldTableBody';
+import { useAllYieldOpportunities } from './hooks/useAllYieldOpportunities';
+import { useBalances } from './hooks/useBalances';
+import { useYieldTableData } from './hooks/useYieldTableData';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
 
+const isYieldOpportunityAvailable = (vault: YieldDto) =>
+    !vault.metadata.underMaintenance && !vault.metadata.deprecated;
+
 export const EarnYieldTable = () => {
     const visibleAccounts = useSelector(selectVisibleDeviceAccounts);
-    const ethereumAccounts = visibleAccounts.filter(account => account.symbol === 'eth');
-    const isYieldActive = ethereumAccounts.some(account =>
-        new BigNumber(account.formattedBalance).gt(0),
+    const normalAccounts = useMemo(
+        () => visibleAccounts.filter(account => account.accountType === NORMAL_ACCOUNT_TYPE),
+        [visibleAccounts],
     );
+    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const { yieldOpportunities, isYieldOpportunitiesLoading } = useAllYieldOpportunities();
+
+    const availableVaults = useMemo(
+        () => yieldOpportunities.filter(isYieldOpportunityAvailable),
+        [yieldOpportunities],
+    );
+
+    const visibleAccountSymbols = useMemo(
+        () => new Set(normalAccounts.map(account => account.symbol)),
+        [normalAccounts],
+    );
+    const { suppliedBalancesByYieldAndAddress } = useBalances({
+        vaults: availableVaults,
+        accounts: normalAccounts,
+    });
+    const { yieldAccountOpportunities, yieldNetworksNotActivated, isYieldActive } =
+        useYieldTableData({
+            availableVaults,
+            deviceSupportedNetworkSymbols,
+            suppliedBalancesByYieldAndAddress,
+            visibleAccounts: normalAccounts,
+            visibleAccountSymbols,
+        });
 
     const badge = getEarnDashboardBadgeState({
         isSectionActive: isYieldActive,
@@ -33,87 +68,11 @@ export const EarnYieldTable = () => {
             <Card paddingType="none">
                 <Table isRowHighlightedOnHover margin={{ top: 8 }}>
                     <EarnDashboardTableHeader />
-
-                    <Table.Body>
-                        {ethereumAccounts.length === 0 ? (
-                            <Table.Row>
-                                <Table.Cell colSpan={5}>
-                                    <Paragraph
-                                        typographyStyle="body-md"
-                                        intent="neutral"
-                                        priority="secondary"
-                                    >
-                                        <Translation id="TR_ACCOUNT_NO_ACCOUNTS" />
-                                    </Paragraph>
-                                </Table.Cell>
-                            </Table.Row>
-                        ) : (
-                            ethereumAccounts.map(account => {
-                                const hasBalance = new BigNumber(account.formattedBalance).gt(0);
-
-                                return (
-                                    <Table.Row key={account.key}>
-                                        <Table.Cell>
-                                            <EarnAccountCell account={account} />
-                                        </Table.Cell>
-
-                                        <Table.Cell>
-                                            <Paragraph
-                                                typographyStyle="body-md"
-                                                intent="neutral"
-                                                priority="secondary"
-                                            >
-                                                <Translation id="TR_EARN_NOT_AVAILABLE" />
-                                            </Paragraph>
-                                        </Table.Cell>
-
-                                        <Table.Cell>
-                                            <Paragraph
-                                                typographyStyle="body-md"
-                                                intent="neutral"
-                                                priority="secondary"
-                                            >
-                                                <Translation id="TR_EARN_NOT_AVAILABLE" />
-                                            </Paragraph>
-                                        </Table.Cell>
-
-                                        <Table.Cell>
-                                            <Paragraph
-                                                typographyStyle="body-md"
-                                                intent="neutral"
-                                                priority="secondary"
-                                            >
-                                                <Translation id="TR_EARN_NOT_AVAILABLE" />
-                                            </Paragraph>
-                                        </Table.Cell>
-
-                                        <Table.Cell align="end">
-                                            <Row justifyContent="flex-end" gap={8}>
-                                                {hasBalance ? (
-                                                    <>
-                                                        <Button size="small">
-                                                            <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE" />
-                                                        </Button>
-                                                        <Button
-                                                            size="small"
-                                                            intent="brand"
-                                                            priority="secondary"
-                                                        >
-                                                            <Translation id="TR_EARN_YIELD_DASHBOARD_WITHDRAW" />
-                                                        </Button>
-                                                    </>
-                                                ) : (
-                                                    <Button size="small">
-                                                        <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW" />
-                                                    </Button>
-                                                )}
-                                            </Row>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                );
-                            })
-                        )}
-                    </Table.Body>
+                    <EarnYieldTableBody
+                        isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                        yieldAccountOpportunities={yieldAccountOpportunities}
+                        yieldNetworksNotActivated={yieldNetworksNotActivated}
+                    />
                 </Table>
             </Card>
         </EarnDashboardSection>

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTableBody.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTableBody.tsx
@@ -1,0 +1,62 @@
+import { Translation } from '@suite/intl';
+import { Paragraph, Row, Spinner, Table } from '@trezor/components';
+
+import { EarnYieldAccountOpportunity } from './EarnYieldAccountOpportunity';
+import { type YieldAccountOpportunity, type YieldNetworkNotActivated } from './types';
+import { EarnInactiveNetworkOpportunity } from '../common/EarnInactiveNetworkOpportunity';
+
+type EarnYieldTableBodyProps = {
+    isYieldOpportunitiesLoading: boolean;
+    yieldAccountOpportunities: YieldAccountOpportunity[];
+    yieldNetworksNotActivated: YieldNetworkNotActivated[];
+};
+
+export const EarnYieldTableBody = ({
+    isYieldOpportunitiesLoading,
+    yieldAccountOpportunities,
+    yieldNetworksNotActivated,
+}: EarnYieldTableBodyProps) => {
+    if (isYieldOpportunitiesLoading) {
+        return (
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell colSpan={5}>
+                        <Row width="100%" justifyContent="center" padding={{ vertical: 16 }}>
+                            <Spinner size={24} />
+                        </Row>
+                    </Table.Cell>
+                </Table.Row>
+            </Table.Body>
+        );
+    }
+
+    if (yieldAccountOpportunities.length === 0 && yieldNetworksNotActivated.length === 0) {
+        return (
+            <Table.Body>
+                <Table.Row>
+                    <Table.Cell colSpan={5}>
+                        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+                            <Translation id="TR_ACCOUNT_NO_ACCOUNTS" />
+                        </Paragraph>
+                    </Table.Cell>
+                </Table.Row>
+            </Table.Body>
+        );
+    }
+
+    return (
+        <Table.Body>
+            {yieldAccountOpportunities.map(opportunity => (
+                <EarnYieldAccountOpportunity key={opportunity.key} opportunity={opportunity} />
+            ))}
+
+            {yieldNetworksNotActivated.map(network => (
+                <EarnInactiveNetworkOpportunity
+                    key={network.symbol}
+                    symbol={network.symbol}
+                    apy={network.apyPercentage}
+                />
+            ))}
+        </Table.Body>
+    );
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useAllYieldOpportunities.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useAllYieldOpportunities.ts
@@ -1,0 +1,55 @@
+import { YieldDto, getYields } from '@suite-common/earn-api';
+import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
+
+const STALE_TIME = 1000 * 60 * 5;
+const YIELD_OPPORTUNITIES_PAGE_SIZE = 20;
+
+const getAllYieldOpportunities = async ({ limit }: { limit: number }) => {
+    let offset = 0;
+    let totalItems = Number.POSITIVE_INFINITY;
+    let fetchedItemsCount = 0;
+    const allItems: YieldDto[] = [];
+
+    while (fetchedItemsCount < totalItems) {
+        const response = await getYields({
+            offset,
+            limit,
+            providers: ['morpho'],
+            types: ['vault'],
+            sort: 'statusEnterDesc',
+        });
+        const items = response.data.items ?? [];
+        const total = response.data.total ?? fetchedItemsCount;
+        const responseLimit = response.data.limit ?? limit;
+        const responseOffset = response.data.offset ?? offset;
+
+        if (items.length === 0) {
+            break;
+        }
+
+        allItems.push(...items);
+        fetchedItemsCount += items.length;
+        totalItems = total;
+        offset = responseOffset + responseLimit;
+    }
+
+    return allItems;
+};
+
+export const useAllYieldOpportunities = () => {
+    const yieldOpportunitiesQuery = useQuery({
+        queryKey: desktopQueryKeys.yieldOpportunities({
+            limit: YIELD_OPPORTUNITIES_PAGE_SIZE,
+        }),
+        queryFn: () =>
+            getAllYieldOpportunities({
+                limit: YIELD_OPPORTUNITIES_PAGE_SIZE,
+            }),
+        staleTime: STALE_TIME,
+    });
+
+    return {
+        yieldOpportunities: yieldOpportunitiesQuery.data ?? [],
+        isYieldOpportunitiesLoading: yieldOpportunitiesQuery.isLoading,
+    };
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useBalances.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useBalances.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+
+import { BalancesQueryDto, YieldDto, getAggregateBalances } from '@suite-common/earn-api';
+import { useQuery } from '@suite-common/react-query';
+import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+
+import { getSuppliedBalancesByYieldAndAddress } from '../../utils/earnYieldUtils';
+
+const STALE_TIME = 1000 * 60 * 5;
+
+type UseBalancesProps = {
+    vaults: YieldDto[];
+    accounts: Account[];
+};
+
+export const useBalances = ({ vaults, accounts }: UseBalancesProps) => {
+    const balanceQueries = useMemo<BalancesQueryDto[]>(() => {
+        const queryMap = new Map<string, BalancesQueryDto>();
+
+        vaults.forEach(vault => {
+            const network = getNetworkByYieldXyzId(vault.network);
+
+            if (!network) {
+                return;
+            }
+
+            accounts
+                .filter(account => account.symbol === network.symbol)
+                .forEach(account => {
+                    const query = {
+                        yieldId: vault.id,
+                        address: account.descriptor,
+                        network: vault.network,
+                    } satisfies BalancesQueryDto;
+
+                    queryMap.set(`${query.yieldId}:${query.address}:${query.network}`, query);
+                });
+        });
+
+        return Array.from(queryMap.values());
+    }, [accounts, vaults]);
+
+    const balancesQuery = useQuery({
+        queryKey: ['yield-balances', balanceQueries],
+        queryFn: async () => {
+            const response = await getAggregateBalances({ queries: balanceQueries });
+
+            return response.data.items;
+        },
+        staleTime: STALE_TIME,
+        enabled: balanceQueries.length > 0,
+    });
+
+    const suppliedBalancesByYieldAndAddress = useMemo(
+        () => getSuppliedBalancesByYieldAndAddress(balancesQuery.data ?? []),
+        [balancesQuery.data],
+    );
+
+    return { suppliedBalancesByYieldAndAddress };
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldTableData.ts
@@ -1,0 +1,186 @@
+import { useMemo } from 'react';
+
+import { YieldDto } from '@suite-common/earn-api';
+import {
+    NORMAL_ACCOUNT_TYPE,
+    type NetworkSymbol,
+    getNetworkByYieldXyzId,
+} from '@suite-common/wallet-config';
+import { Account, TokenInfoBranded, toTokenSymbol } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+import { getApyPercent, getApyRate } from '../../utils/earnApyUtils';
+import {
+    compareYieldRowsByAvailableBalanceDesc,
+    compareYieldRowsBySuppliedAmountDesc,
+    getYieldAddressKey,
+} from '../../utils/earnYieldUtils';
+import { type YieldAccountOpportunity, type YieldNetworkNotActivated } from '../types';
+
+const getMatchedTokenForVault = (
+    account: Account,
+    vault: YieldDto,
+): TokenInfoBranded | undefined => {
+    const accountTokens = account.tokens as TokenInfoBranded[] | undefined;
+
+    if (!accountTokens?.length) {
+        return undefined;
+    }
+
+    const vaultTokenAddress = vault.token.address?.toLowerCase();
+    const vaultTokenSymbol = vault.token.symbol.toLowerCase();
+
+    return accountTokens.find(token => {
+        const tokenAddress = token.contract?.toLowerCase();
+
+        if (vaultTokenAddress && tokenAddress) {
+            return tokenAddress === vaultTokenAddress;
+        }
+
+        return token.symbol.toLowerCase() === vaultTokenSymbol;
+    });
+};
+
+type UseYieldTableDataProps = {
+    availableVaults: YieldDto[];
+    deviceSupportedNetworkSymbols: NetworkSymbol[];
+    suppliedBalancesByYieldAndAddress: Map<string, string>;
+    visibleAccounts: Account[];
+    visibleAccountSymbols: Set<NetworkSymbol>;
+};
+
+export const useYieldTableData = ({
+    availableVaults,
+    deviceSupportedNetworkSymbols,
+    suppliedBalancesByYieldAndAddress,
+    visibleAccounts,
+    visibleAccountSymbols,
+}: UseYieldTableDataProps) => {
+    const yieldAccountOpportunities = useMemo<YieldAccountOpportunity[]>(() => {
+        const allOpportunities = availableVaults.flatMap(vault => {
+            const network = getNetworkByYieldXyzId(vault.network);
+
+            if (!network) {
+                return [];
+            }
+            const isNetworkActivated = visibleAccountSymbols.has(network.symbol);
+
+            if (!isNetworkActivated) {
+                return [];
+            }
+
+            const networkAccounts = visibleAccounts.filter(
+                account =>
+                    account.accountType === NORMAL_ACCOUNT_TYPE &&
+                    account.symbol === network.symbol,
+            );
+
+            return networkAccounts.map(account => {
+                const matchedToken = getMatchedTokenForVault(account, vault);
+                const suppliedAmount =
+                    suppliedBalancesByYieldAndAddress.get(
+                        getYieldAddressKey(vault.id, account.descriptor),
+                    ) ?? '0';
+
+                return {
+                    key: `${vault.id}:${account.key}`,
+                    account,
+                    networkSymbol: network.symbol,
+                    vault,
+                    matchedToken,
+                    suppliedAmount,
+                    additionalSupplyAmount: matchedToken?.balance ?? '0',
+                    suppliedSymbol: matchedToken?.symbol ?? toTokenSymbol(vault.token.symbol),
+                    suppliedContractAddress: matchedToken?.contract ?? vault.token.address ?? null,
+                    apyPercentage: getApyPercent(vault.rewardRate.total),
+                };
+            });
+        });
+
+        const activeOpportunities: YieldAccountOpportunity[] = [];
+        const supplyableOpportunities: YieldAccountOpportunity[] = [];
+        const opportunitiesWithoutSupplyableBalance: YieldAccountOpportunity[] = [];
+
+        allOpportunities.forEach(opportunity => {
+            const hasSuppliedBalance = new BigNumber(opportunity.suppliedAmount).gt(0);
+            const hasMatchedToken = opportunity.matchedToken !== undefined;
+            const hasSupplyableBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
+
+            if (hasSuppliedBalance) {
+                activeOpportunities.push(opportunity);
+
+                return;
+            }
+
+            if (hasMatchedToken && hasSupplyableBalance) {
+                supplyableOpportunities.push(opportunity);
+
+                return;
+            }
+
+            opportunitiesWithoutSupplyableBalance.push(opportunity);
+        });
+
+        return [
+            ...activeOpportunities.toSorted(compareYieldRowsBySuppliedAmountDesc),
+            ...supplyableOpportunities.toSorted(compareYieldRowsByAvailableBalanceDesc),
+            ...opportunitiesWithoutSupplyableBalance.toSorted(
+                compareYieldRowsByAvailableBalanceDesc,
+            ),
+        ];
+    }, [
+        availableVaults,
+        suppliedBalancesByYieldAndAddress,
+        visibleAccounts,
+        visibleAccountSymbols,
+    ]);
+
+    const yieldNetworksNotActivated = useMemo<YieldNetworkNotActivated[]>(() => {
+        const networkRowsBySymbol = availableVaults.reduce((map, vault) => {
+            const network = getNetworkByYieldXyzId(vault.network);
+
+            if (!network) {
+                return map;
+            }
+
+            const isNetworkActivated = visibleAccountSymbols.has(network.symbol);
+            const isNetworkSupported = deviceSupportedNetworkSymbols.includes(network.symbol);
+
+            if (isNetworkActivated || !isNetworkSupported) {
+                return map;
+            }
+
+            const currentApyRate = getApyRate(vault.rewardRate.total);
+            const currentNetworkRow = map.get(network.symbol);
+
+            if (!currentNetworkRow || currentApyRate > currentNetworkRow.apyRate) {
+                map.set(network.symbol, {
+                    symbol: network.symbol,
+                    apyPercentage: getApyPercent(vault.rewardRate.total),
+                    apyRate: currentApyRate,
+                });
+            }
+
+            return map;
+        }, new Map<NetworkSymbol, YieldNetworkNotActivated & { apyRate: number }>());
+
+        return Array.from(networkRowsBySymbol.values()).map(({ symbol, apyPercentage }) => ({
+            symbol,
+            apyPercentage,
+        }));
+    }, [availableVaults, deviceSupportedNetworkSymbols, visibleAccountSymbols]);
+
+    const isYieldActive = useMemo(
+        () =>
+            yieldAccountOpportunities.some(opportunity =>
+                new BigNumber(opportunity.suppliedAmount).gt(0),
+            ),
+        [yieldAccountOpportunities],
+    );
+
+    return {
+        isYieldActive,
+        yieldAccountOpportunities,
+        yieldNetworksNotActivated,
+    };
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/types.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/types.ts
@@ -1,0 +1,21 @@
+import { YieldDto } from '@suite-common/earn-api';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Account, TokenInfoBranded, TokenSymbol } from '@suite-common/wallet-types';
+
+export type YieldAccountOpportunity = {
+    key: string;
+    account?: Account;
+    networkSymbol: NetworkSymbol;
+    vault: YieldDto;
+    matchedToken: TokenInfoBranded | undefined;
+    suppliedAmount: string;
+    additionalSupplyAmount: string;
+    suppliedSymbol: TokenSymbol;
+    suppliedContractAddress: string | null;
+    apyPercentage: number | null;
+};
+
+export type YieldNetworkNotActivated = {
+    symbol: NetworkSymbol;
+    apyPercentage: number | null;
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -88,6 +88,7 @@ export const useTradingReceiveAddress = ({
 }: UseTradingReceiveAddressProps) => {
     const dispatch = useDispatch();
     const accounts = useSelector(state => state.wallet.accounts);
+    const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const device = useSelector(selectSelectedDevice);
     const sendAccountKey = useSelector(selectTradingExchangeAccountKey);
 
@@ -237,6 +238,20 @@ export const useTradingReceiveAddress = ({
             }
         }
 
+        const preferredReceiveAccountKey =
+            persistedReceiveAccountKey ?? selectedAccount.account?.key;
+        if (preferredReceiveAccountKey) {
+            const preferredSuiteOption = selectAccountOptions.find(
+                option => option.account?.key === preferredReceiveAccountKey,
+            );
+
+            if (preferredSuiteOption) {
+                selectAccountOption(preferredSuiteOption);
+
+                return;
+            }
+        }
+
         const sendAccount =
             type === 'exchange'
                 ? accounts.find(account => account.key === sendAccountKey)
@@ -265,6 +280,7 @@ export const useTradingReceiveAddress = ({
         persistedReceiveAccountKey,
         persistedReceiveAddress,
         isPreviousRouteFromTradeSection,
+        selectedAccount.account?.key,
         selectAccountOption,
     ]);
 

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -35,6 +35,7 @@
         {
             "path": "../../suite-common/device-authenticity"
         },
+        { "path": "../../suite-common/earn-api" },
         { "path": "../../suite-common/feedback" },
         {
             "path": "../../suite-common/fiat-services"

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -13,6 +13,8 @@ export type MetadataItem = string;
 export type XpubAddress = string;
 
 export type TokenSymbol = string & Branded<'TokenSymbol'>;
+export const toTokenSymbol = (value: string) => value as TokenSymbol;
+
 export type TokenAddress = string & Branded<'TokenAddress'>;
 export const toTokenAddress = (value: string) => value as TokenAddress;
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8885,6 +8885,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW',
         defaultMessage: 'Supply now',
     },
+    TR_EARN_YIELD_DASHBOARD_SUPPLIED: {
+        id: 'TR_EARN_YIELD_DASHBOARD_SUPPLIED',
+        defaultMessage: '{amount} {displaySymbol} supplied',
+    },
     TR_EARN_DASHBOARD_ACTIVE: {
         id: 'TR_EARN_DASHBOARD_ACTIVE',
         defaultMessage: 'Active',

--- a/yarn.lock
+++ b/yarn.lock
@@ -15875,6 +15875,7 @@ __metadata:
     "@suite-common/delegated-identity-key": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/device-authenticity": "workspace:*"
+    "@suite-common/earn-api": "workspace:*"
     "@suite-common/feedback": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/firmware": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add Stablecoin Yield dashboard table backed by Yield.xyz API data, including account-opportunity rows, inactive network activation rows, supplied balance aggregation, and staking-consistent visual styling.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25021

## Screenshots:

<img width="1228" height="845" alt="image" src="https://github.com/user-attachments/assets/6a3b8bd7-ce56-486e-971c-95978ec77365" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-dashboard-yield&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-dashboard-yield&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-dashboard-yield&lookback=7)