### PR TITLE
Mobile Trading: do not close keyboard after trading input focus

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.tsx
@@ -39,11 +39,10 @@ export const BuyTradeableAssetPicker = () => {
             setSelectedValue(asset);
             if (shouldFocusInput) {
                 setShouldFocusInput(false);
-                // CryptoAmountInput is rendered disabled allow changes to propagate and
-                // allow bottom-sheet to hide first.
+                // CryptoAmountInput is rendered disabled allow changes to propagate
                 setTimeout(() => {
                     inputRef.current?.focus();
-                }, 300);
+                }, 0);
             }
         },
         [shouldFocusInput, setSelectedValue],
@@ -78,6 +77,7 @@ export const BuyTradeableAssetPicker = () => {
                 isVisible={isSheetVisible}
                 onClose={hideSheet}
                 onAssetSelect={onAssetSelect}
+                hideKeyboardOnAssetSelect={!shouldFocusInput}
             />
         </>
     );

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.tsx
@@ -20,7 +20,7 @@ import { MyAssetsDisabledListItem } from './MyAssetsDisabledListItem';
 export type MyAssetSheetProps = {
     tradingType: TradingType;
     isVisible: boolean;
-    onClose: () => void;
+    onClose: (shouldHideKeyboard?: boolean) => void;
     onAssetSelect: MyAssetListItemProps['onPress'];
 };
 
@@ -42,7 +42,7 @@ export const MyAssetSheet = memo(
     ({ tradingType, isVisible, onClose, onAssetSelect }: MyAssetSheetProps) => {
         const onAssetSelectCallback = (asset: TradeableAsset, account: Account) => {
             onAssetSelect(asset, account);
-            onClose();
+            onClose(false);
         };
 
         const myAssets = useSelector((state: CombinedSelectorsRootState) =>

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.comp.test.tsx
@@ -124,7 +124,7 @@ describe('MyAssetSheet', () => {
         );
 
         expect(onClose).toHaveBeenCalledTimes(1);
-        expect(onClose).toHaveBeenCalledWith();
+        expect(onClose).toHaveBeenCalledWith(false);
     });
 
     it('should render formatted account type badge when defined', async () => {

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetSheet.tsx
@@ -14,8 +14,9 @@ import {
 
 export type TradeableAssetsSheetProps = {
     isVisible: boolean;
-    onClose: () => void;
+    onClose: (shouldHideKeyboard?: boolean) => void;
     onAssetSelect: (symbol: TradeableAsset) => void;
+    hideKeyboardOnAssetSelect?: boolean;
     assets: TradeableAsset[];
     onFilterChange: (value: string) => void;
     onSelectedNetworkFilter: (symbol: NetworkSymbol | undefined) => void;
@@ -36,6 +37,7 @@ export const TradeableAssetSheet = memo(
         isVisible,
         onClose,
         onAssetSelect,
+        hideKeyboardOnAssetSelect,
         assets,
         onFilterChange,
         onSelectedNetworkFilter,
@@ -43,8 +45,8 @@ export const TradeableAssetSheet = memo(
         testID,
     }: TradeableAssetsSheetProps) => {
         const onAssetSelectCallback = (asset: TradeableAsset) => {
-            onClose();
             onAssetSelect(asset);
+            onClose(hideKeyboardOnAssetSelect);
         };
 
         const listData = useFavouriteAssetsSectionList(assets);

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.comp.test.tsx
@@ -38,6 +38,24 @@ describe('TradeableAssetSheet', () => {
 
         expect(selectMock).toHaveBeenCalledTimes(1);
         expect(closeMock).toHaveBeenCalledTimes(1);
+        expect(closeMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should call onAssetSelect with hideKeyboardOnAssetSelect=true when an item is pressed', async () => {
+        const closeMock = jest.fn();
+        const selectMock = jest.fn();
+
+        const { getByText } = await renderTradeableAssetsSheet({
+            onClose: closeMock,
+            onAssetSelect: selectMock,
+            hideKeyboardOnAssetSelect: true,
+        });
+
+        fireEvent.press(getByText('BTC'));
+
+        expect(selectMock).toHaveBeenCalledTimes(1);
+        expect(closeMock).toHaveBeenCalledTimes(1);
+        expect(closeMock).toHaveBeenCalledWith(true);
     });
 
     it('should render correct empty component', async () => {

--- a/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -28,7 +28,7 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(true);
         });
 
-        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called two times', () => {
+        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called two times by default', () => {
             const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
@@ -38,6 +38,32 @@ describe('useBottomSheetControls', () => {
             });
 
             expect(keyboardDismissSpy).toHaveBeenCalledTimes(2);
+            expect(result.current.isSheetVisible).toBe(false);
+        });
+
+        it('should be false after hideTradeableAssetsSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', () => {
+            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
+
+            act(() => {
+                result.current.showSheet();
+                result.current.hideSheet(true);
+            });
+
+            expect(keyboardDismissSpy).toHaveBeenCalledTimes(2);
+            expect(result.current.isSheetVisible).toBe(false);
+        });
+
+        it('should be false after hideTradeableAssetsSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', () => {
+            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
+
+            act(() => {
+                result.current.showSheet();
+                result.current.hideSheet(false);
+            });
+
+            expect(keyboardDismissSpy).toHaveBeenCalledTimes(1);
             expect(result.current.isSheetVisible).toBe(false);
         });
     });

--- a/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -28,7 +28,7 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(true);
         });
 
-        it('should be false after hideTradeableAssetsSheet call and Keyboard.dismiss should be called two times by default', () => {
+        it('should be false after hideSheet call and Keyboard.dismiss should be called two times by default', () => {
             const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
@@ -41,7 +41,7 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be false after hideTradeableAssetsSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', () => {
+        it('should be false after hideSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', () => {
             const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
@@ -54,7 +54,7 @@ describe('useBottomSheetControls', () => {
             expect(result.current.isSheetVisible).toBe(false);
         });
 
-        it('should be false after hideTradeableAssetsSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', () => {
+        it('should be false after hideSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', () => {
             const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 

--- a/suite-native/trading-atoms/src/hooks/useBottomSheetControls.ts
+++ b/suite-native/trading-atoms/src/hooks/useBottomSheetControls.ts
@@ -11,8 +11,10 @@ export const useBottomSheetControls = () => {
         setIsSheetVisible(true);
     }, []);
 
-    const hideSheet = useCallback(() => {
-        Keyboard.dismiss();
+    const hideSheet = useCallback((shouldHideKeyboard: boolean = true) => {
+        if (shouldHideKeyboard) {
+            Keyboard.dismiss();
+        }
         setIsSheetVisible(false);
     }, []);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not close keyboard on bottom sheet close when trading input focus is scheduled.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25179


## Screenshots:
### Before
https://github.com/user-attachments/assets/36345882-e33f-4e3a-bace-064cffc35dcb

### After

https://github.com/user-attachments/assets/5573a3f2-84dc-4b8b-be03-5c2fbeda69be



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25179-on-selecting-asset-keyboard-i-closed&lookback=7)