### PR TITLE
fix(trading): enhance default asset creation with network symbol support

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import {
+    TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_DEFAULT_PAYMENT_METHOD,
     type TradingBuyInfoSelector,
     TradingCountryCode,
@@ -13,7 +14,7 @@ import {
     selectTradingPrefilledFromAccount,
     useTradingAssets,
 } from '@suite-common/trading';
-import { networks } from '@suite-common/wallet-config';
+import { type NetworkConfigWithoutTestnets, networks } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { isArrayMember, typedObjectValues } from '@trezor/utils';
 
@@ -36,9 +37,16 @@ export const useTradingBuyFormDefaultValues = (
         ? (buyInfo?.buyInfo?.country as TradingCountryCode | undefined)
         : regional.UNKNOWN_COUNTRY;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
+
+    // For testnet accounts, use default currency instead of casting to mainnet-only type
+    const isTestnetAccount = !!networks[accountSymbol]?.testnet;
+    const defaultNetworkSymbol: NetworkConfigWithoutTestnets['symbol'] = isTestnetAccount
+        ? TRADING_DEFAULT_CRYPTO_CURRENCY
+        : (accountSymbol as NetworkConfigWithoutTestnets['symbol']);
+
     const defaultCrypto = useMemo(
-        () => createAssetOptionFromCryptoId(cryptoId as CryptoId | undefined),
-        [createAssetOptionFromCryptoId, cryptoId],
+        () => createAssetOptionFromCryptoId(cryptoId as CryptoId | undefined, defaultNetworkSymbol),
+        [createAssetOptionFromCryptoId, cryptoId, defaultNetworkSymbol],
     );
     const defaultPaymentMethod: TradingPaymentMethodListProps = useMemo(
         () => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix buy default assent on wallet fresh load

## Notes for QA

Try to replicate steps described in the issue

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24381

## Screenshots:



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/buy-default-asset&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/buy-default-asset&lookback=7)