### PR TITLE
test(e2e-suite): new test legacy label to Suite Sync

### DIFF
--- a/suite/e2e/fixtures/metadata/suite-sync-data.ts
+++ b/suite/e2e/fixtures/metadata/suite-sync-data.ts
@@ -1,0 +1,33 @@
+import { accountDescriptor, ownerSecret, walletDescriptor } from './default-metadata-ids';
+
+export const walletSeed = {
+    id: 'ya1CCDTCVPyRa6egTac7yg',
+    walletDescriptor,
+    label: 'Evolu synced wallet',
+};
+
+export const accountSeed = {
+    id: 'RSZ0aKqUcO_e0WoQO32x4w',
+    accountDescriptor,
+    networkSymbol: 'btc',
+    label: 'Evolu synced BTC account',
+};
+
+export const addressSeed = {
+    id: 'DmBRN-GwcRyC-cuTPczSXg',
+    label: 'Evolu synced BTC address',
+    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+    accountDescriptor,
+    networkSymbol: 'btc',
+};
+
+export const outputSeed = {
+    id: 'TR7Axj6suVoVTBJO5saruA',
+    accountDescriptor,
+    label: 'Evolu synced output',
+    networkSymbol: 'btc',
+    outputIndex: '0',
+    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
+};
+
+export { ownerSecret };

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -1,0 +1,49 @@
+import { accountSeed } from './suite-sync/sync-from-relay.test';
+import { ownerSecret } from '../../fixtures/metadata/default-metadata-ids';
+import { AccountLabelId } from '../../support/enums/accountLabelId';
+import { expect, test } from '../../support/fixtures';
+import { MetadataProvider } from '../../support/mocks/metadataMock';
+
+test.describe('Labeling migration', {tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] }, () => {
+    test.use({ firmwareVersion: '2-main' });
+
+    test.beforeEach(async ({ metadataMock, evoluClient, onboardingPage }) => {
+        await metadataMock.start(MetadataProvider.DROPBOX);
+        await test.step('Seed Evolu relay server', async () => {
+            evoluClient.wipeAndRestartServer();
+            await evoluClient.init({ ownerSecret });
+            evoluClient.writeTo('account', accountSeed);
+        });
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    });
+
+    test('Migration from Dropbox', async ({ page, walletPage, metadataPage }) => {
+        await test.step('Set up Dropbox labeling', async () => {
+            await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
+            await expect(
+                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+            ).toHaveText('Bitcoin #1');
+
+            // wait until account page is fully loaded
+            await expect(walletPage.fiatAmount).toBeVisible();
+            await metadataPage.account.clickEditLabelButton(AccountLabelId.BitcoinDefault1);
+            await metadataPage.passThroughInitMetadata(MetadataProvider.DROPBOX);
+        });
+
+        await test.step('Add legacy account label', async () => {
+            await metadataPage.account.metadataInput.fill('new dropbox label');
+            await page.keyboard.press('Enter');
+            await expect(
+                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+            ).toHaveText('new dropbox label');
+            await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
+        });
+
+        await test.step('Switch to Suite Sync labeling and confirm legacy label is retained', async () => {
+            await metadataPage.enableSuiteSync();
+            await expect(
+                walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
+            ).toHaveText(accountSeed.label);
+        });
+    });
+});

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -1,16 +1,14 @@
-import { accountSeed } from './suite-sync/sync-from-relay.test';
-import { ownerSecret } from '../../fixtures/metadata/default-metadata-ids';
+import { accountSeed, ownerSecret } from '../../fixtures/metadata/suite-sync-data';
 import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
 
-test.describe('Labeling migration', {tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] }, () => {
-    test.use({ firmwareVersion: '2-main' });
+test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
 
     test.beforeEach(async ({ metadataMock, evoluClient, onboardingPage }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
         await test.step('Seed Evolu relay server', async () => {
-            evoluClient.wipeAndRestartServer();
             await evoluClient.init({ ownerSecret });
             evoluClient.writeTo('account', accountSeed);
         });

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
@@ -7,20 +7,20 @@ import { isWebProject } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 
 const defaultWalletIndex = 0;
-const walletSeed = {
+export const walletSeed = {
     id: 'ya1CCDTCVPyRa6egTac7yg',
     walletDescriptor,
     label: 'Evolu synced wallet',
 };
 
-const accountSeed = {
+export const accountSeed = {
     id: 'RSZ0aKqUcO_e0WoQO32x4w',
     accountDescriptor,
     networkSymbol: 'btc',
     label: 'Evolu synced BTC account',
 };
 
-const addressSeed = {
+export const addressSeed = {
     id: 'DmBRN-GwcRyC-cuTPczSXg',
     label: 'Evolu synced BTC address',
     address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
@@ -1,41 +1,14 @@
 import {
-    accountDescriptor,
+    accountSeed,
+    addressSeed,
+    outputSeed,
     ownerSecret,
-    walletDescriptor,
-} from '../../../fixtures/metadata/default-metadata-ids';
+    walletSeed,
+} from '../../../fixtures/metadata/suite-sync-data';
 import { isWebProject } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 
 const defaultWalletIndex = 0;
-export const walletSeed = {
-    id: 'ya1CCDTCVPyRa6egTac7yg',
-    walletDescriptor,
-    label: 'Evolu synced wallet',
-};
-
-export const accountSeed = {
-    id: 'RSZ0aKqUcO_e0WoQO32x4w',
-    accountDescriptor,
-    networkSymbol: 'btc',
-    label: 'Evolu synced BTC account',
-};
-
-export const addressSeed = {
-    id: 'DmBRN-GwcRyC-cuTPczSXg',
-    label: 'Evolu synced BTC address',
-    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
-    accountDescriptor,
-    networkSymbol: 'btc',
-};
-
-const outputSeed = {
-    id: 'TR7Axj6suVoVTBJO5saruA',
-    accountDescriptor,
-    label: 'Evolu synced output',
-    networkSymbol: 'btc',
-    outputIndex: '0',
-    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
-};
 
 test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });


### PR DESCRIPTION
Adding new e2e test for future migration testing when migration will be finished.
For now only testing the option to switch between legacy and Suite Sync. 
Migration from Dropbox/Google Drive/Locally saved will be added in the future.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-legacy-label-to-suiteSync&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-legacy-label-to-suiteSync&lookback=7)