### PR TITLE
refactor(components): add isClean prop to Input and Select components

### DIFF
--- a/packages/components/src/components/form/Input/Input.stories.tsx
+++ b/packages/components/src/components/form/Input/Input.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof InputComponent> = {
         hasError: false,
         showClearButton: false,
         isMasked: false,
+        isClean: false,
         ...getFramePropsStory(allowedInputFrameProps).args,
     },
     argTypes: {
@@ -38,6 +39,9 @@ const meta: Meta<typeof InputComponent> = {
             control: { type: 'boolean' },
         },
         isMasked: {
+            control: { type: 'boolean' },
+        },
+        isClean: {
             control: { type: 'boolean' },
         },
         ...getFramePropsStory(allowedInputFrameProps).argTypes,

--- a/packages/components/src/components/form/Input/Input.tsx
+++ b/packages/components/src/components/form/Input/Input.tsx
@@ -23,11 +23,12 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedInputFrameProps)[number
 const StyledInput = styled.input<{
     $hasLabel?: boolean;
     $isMasked?: boolean;
+    $isClean?: boolean;
     $size: InputSize;
 }>`
     ${commonInputStyles}
 
-    padding: 0 ${INPUT_PADDING}px;
+    padding: 0 ${({ $isClean }) => ($isClean ? 0 : INPUT_PADDING)}px;
     padding-top: ${({ $hasLabel, $size }) => ($hasLabel ? mapSizeToPaddingTop($size) : 0)}px;
 
     ${({ $isMasked }) => $isMasked && `-webkit-text-security: disc;`}
@@ -48,6 +49,7 @@ export type InputProps = InputHTMLProps &
         showClearButton?: boolean;
         onClear?: () => void;
         isMasked?: boolean;
+        isClean?: boolean;
     };
 
 export const Input = ({
@@ -62,6 +64,7 @@ export const Input = ({
     placeholder,
     onClear,
     isMasked,
+    isClean,
     ...rest
 }: InputProps) => {
     const formCellProps = pickFormCellProps(rest);
@@ -79,12 +82,17 @@ export const Input = ({
 
     return (
         <FormCell {...formCellProps} data-testid={dataTest}>
-            <InputWrapper hasError={hasError} isDisabled={isDisabled ?? false} size={size}>
-                <Row height={mapSizeToHeight(size)}>
+            <InputWrapper
+                hasError={hasError}
+                isDisabled={isDisabled ?? false}
+                size={size}
+                isClean={isClean}
+            >
+                <Row height={isClean ? undefined : mapSizeToHeight(size)}>
                     {leftContent && (
                         <Row
                             flex="0 0 auto"
-                            padding={{ left: INPUT_PADDING }}
+                            padding={isClean ? undefined : { left: INPUT_PADDING }}
                             data-testid={`${dataTest}/input-addon`}
                         >
                             {leftContent}
@@ -99,16 +107,17 @@ export const Input = ({
                             autoCapitalize="off"
                             spellCheck={false}
                             disabled={isDisabled ?? false}
-                            $hasLabel={!!label}
+                            $hasLabel={!!label && !isClean}
                             ref={innerRef}
                             data-lpignore="true"
                             $isMasked={isMasked}
+                            $isClean={isClean}
                             $size={size}
                             placeholder={placeholder}
                             data-testid={dataTest}
                             {...inputProps}
                         />
-                        {label && (
+                        {label && !isClean && (
                             <FloatingLabel
                                 $isDisabled={isDisabled}
                                 $isActive={!!value || !!placeholder}
@@ -121,7 +130,7 @@ export const Input = ({
                     {(rightContent || hasShowClearButton) && (
                         <Row
                             flex="0 0 auto"
-                            padding={{ right: INPUT_PADDING }}
+                            padding={isClean ? undefined : { right: INPUT_PADDING }}
                             data-testid={`${dataTest}/input-addon`}
                             gap={12}
                         >

--- a/packages/components/src/components/form/Select/Select.stories.tsx
+++ b/packages/components/src/components/form/Select/Select.stories.tsx
@@ -5,17 +5,45 @@ import { Option, Select as SelectComponent, SelectProps, allowedSelectFrameProps
 import { getFramePropsStory } from '../../../utils/frameProps';
 import { inputSizes } from '../types';
 
-const values: any = {
-    'None (default)': null,
-    Low: { label: 'low', value: 'low' },
-    Medium: { label: 'medium', value: 'medium' },
-    High: { label: 'high', value: 'high' },
-    Custom: { label: 'custom', value: 'custom' },
+const groupedValues: Record<string, Record<string, Option>> = {
+    Common: {
+        Low: { label: 'Low', value: 'low' },
+        Medium: { label: 'Medium', value: 'medium' },
+        High: { label: 'High', value: 'high' },
+        Custom: { label: 'Custom', value: 'custom' },
+        Auto: { label: 'Auto', value: 'auto' },
+        Default: { label: 'Default', value: 'default' },
+    },
+    Performance: {
+        Eco: { label: 'Eco', value: 'eco' },
+        Balanced: { label: 'Balanced', value: 'balanced' },
+        Turbo: { label: 'Turbo', value: 'turbo' },
+        Extreme: { label: 'Extreme', value: 'extreme' },
+        Burst: { label: 'Burst', value: 'burst' },
+        Sustained: { label: 'Sustained', value: 'sustained' },
+    },
+    Security: {
+        Standard: { label: 'Standard', value: 'standard' },
+        Strict: { label: 'Strict', value: 'strict' },
+        Hardened: { label: 'Hardened', value: 'hardened' },
+        Maximum: { label: 'Maximum', value: 'maximum' },
+        Paranoid: { label: 'Paranoid', value: 'paranoid' },
+        Lockdown: { label: 'Lockdown', value: 'lockdown' },
+    },
+    Network: {
+        Offline: { label: 'Offline', value: 'offline' },
+        Limited: { label: 'Limited', value: 'limited' },
+        Normal: { label: 'Normal', value: 'normal' },
+        Preferred: { label: 'Preferred', value: 'preferred' },
+        Priority: { label: 'Priority', value: 'priority' },
+        Realtime: { label: 'Realtime', value: 'realtime' },
+    },
 };
 
-const options = Object.keys(values)
-    .filter((k: string) => values[k])
-    .map((k: string) => values[k]);
+const groupedOptions = Object.entries(groupedValues).map(([label, values]) => ({
+    label,
+    options: Object.values(values),
+}));
 
 const meta: Meta<typeof SelectComponent> = {
     title: '✏️ Form',
@@ -29,7 +57,14 @@ export const Select: StoryObj<SelectProps> = {
         const [{ option }, updateArgs] = useArgs();
         const setOption = (option2: Option) => updateArgs({ option: option2 });
 
-        return <SelectComponent {...args} value={option} onChange={setOption} options={options} />;
+        return (
+            <SelectComponent
+                {...args}
+                value={option}
+                onChange={setOption}
+                options={groupedOptions}
+            />
+        );
     },
     args: {
         label: 'Label',

--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -7,8 +7,6 @@ import ReactSelect, {
     ValueContainerProps,
 } from 'react-select';
 
-import { useTheme } from 'styled-components';
-
 import {
     FormCell,
     FormCellProps,
@@ -19,8 +17,12 @@ import { InputSize } from '../types';
 import {
     Control,
     DropdownIndicator,
+    Group,
+    GroupHeading,
     IndicatorsContainer,
     LoadingIndicator,
+    Menu,
+    MenuList,
     Option,
     Placeholder,
     SingleValue,
@@ -65,7 +67,6 @@ export const Select = ({
     ...rest
 }: SelectProps) => {
     const selectRef = useRef<SelectInstance<OptionType, boolean>>(null);
-    const theme = useTheme();
 
     const formCellProps = pickFormCellProps(rest);
     const { isDisabled, hasError } = formCellProps;
@@ -112,15 +113,19 @@ export const Select = ({
                 />
             ),
             Option: (optionProps: OptionProps) => (
-                <Option {...optionProps} data-testid={dataTest} />
+                <Option {...optionProps} size={size} data-testid={dataTest} />
             ),
+            Menu,
+            MenuList,
+            GroupHeading,
+            Group,
             IndicatorsContainer,
             DropdownIndicator,
             ValueContainer: (valueContainerProps: ValueContainerProps) => (
                 <ValueContainer
                     {...valueContainerProps}
                     minValueWidth={minValueWidth}
-                    hasLabel={!!label}
+                    hasLabel={!!label && !isClean}
                     size={size}
                 />
             ),
@@ -147,7 +152,7 @@ export const Select = ({
                 menuPlacement="auto"
                 placeholder={placeholder ?? ''}
                 unstyled
-                styles={createSharedMenuStyles<OptionType>(theme)}
+                styles={createSharedMenuStyles<OptionType>()}
                 components={memoizedComponents}
                 {...reactSelectProps}
             />

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -2,7 +2,11 @@ import { ReactNode, useEffect, useRef } from 'react';
 import {
     ControlProps,
     DropdownIndicatorProps,
+    GroupHeadingProps,
+    GroupProps,
     IndicatorsContainerProps,
+    MenuListProps,
+    MenuProps,
     OptionProps,
     PlaceholderProps,
     SingleValueProps,
@@ -10,17 +14,23 @@ import {
     components,
 } from 'react-select';
 
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import type { Option as OptionType } from './types';
-import { Row } from '../../Flex/Flex';
+import { Box } from '../../Box/Box';
+import { Column, Row } from '../../Flex/Flex';
 import { Icon } from '../../Icon/Icon';
 import { Spinner } from '../../loaders/Spinner/Spinner';
 import { Text } from '../../typography/Text/Text';
 import { FloatingLabel } from '../FloatingLabel';
 import { InputWrapper } from '../InputWrapper';
 import { InputSize } from '../types';
-import { INPUT_PADDING, mapSizeToHeight, mapSizeToPaddingTop } from '../utils';
+import {
+    INPUT_PADDING,
+    mapSizeToHeight,
+    mapSizeToPaddingTop,
+    mapSizeToTypographyStyle,
+} from '../utils';
 
 const DropdownWrapper = styled.div<{ $isOpen: boolean }>`
     transform: ${({ $isOpen }) => ($isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
@@ -58,7 +68,7 @@ export const Control = ({
                 size={size}
                 isClean={isClean}
             >
-                {label && !isLoading && (
+                {label && !isLoading && !isClean && (
                     <FloatingLabel
                         $isActive={hasValue || !!placeholder || !!isSearchable}
                         $isDisabled={isDisabled}
@@ -81,11 +91,78 @@ export const Control = ({
     );
 };
 
-type OptionComponentProps = OptionProps<OptionType, boolean> & {
-    'data-testid'?: string;
+export const Menu = ({ children, ...props }: MenuProps<OptionType, boolean>) => {
+    const theme = useTheme();
+
+    return (
+        <components.Menu {...props}>
+            <Box
+                flex="1"
+                minWidth={140}
+                borderRadius={16}
+                backgroundColor="baseFillSurfaceModeless"
+                borderColor="baseBorderSurfaceModeless"
+                borderWidth={1}
+                shadow={theme.boxShadowElevated}
+                overflow="auto"
+                width="fit-content"
+            >
+                {children}
+            </Box>
+        </components.Menu>
+    );
 };
 
-export const Option = ({ 'data-testid': dataTest, ...props }: OptionComponentProps) => {
+export const MenuList = ({ children, ...props }: MenuListProps<OptionType, boolean>) => {
+    const isGrouped = props.selectProps.options.some(option => option.options);
+
+    return (
+        <components.MenuList
+            {...props}
+            innerProps={{
+                ...props.innerProps,
+                style: {
+                    ...props.innerProps.style,
+                    padding: 8,
+                },
+            }}
+        >
+            <Column gap={isGrouped ? 12 : 0}>{children}</Column>
+        </components.MenuList>
+    );
+};
+
+export const GroupHeading = ({ children, ...props }: GroupHeadingProps<OptionType, boolean>) =>
+    children ? (
+        <components.GroupHeading {...props}>
+            <Text
+                as="div"
+                variant="tertiary"
+                typographyStyle="label"
+                padding={{ horizontal: 8, vertical: 4 }}
+            >
+                {children}
+            </Text>
+        </components.GroupHeading>
+    ) : null;
+
+export const Group = ({ children, ...props }: GroupProps<OptionType, boolean>) => (
+    <components.Group {...props}>
+        <Column>{children}</Column>
+    </components.Group>
+);
+
+type OptionComponentProps = OptionProps<OptionType, boolean> & {
+    'data-testid'?: string;
+    size: InputSize;
+};
+
+export const Option = ({
+    'data-testid': dataTest,
+    size,
+    children,
+    ...props
+}: OptionComponentProps) => {
     const ref = useRef<HTMLDivElement>(undefined);
 
     useEffect(() => {
@@ -105,9 +182,24 @@ export const Option = ({ 'data-testid': dataTest, ...props }: OptionComponentPro
                     'data-testid': `${dataTest}/option/${
                         typeof props.data.value === 'string' ? props.data.value : props.label
                     }`,
+                    style: {
+                        ...props.innerProps.style,
+                        scrollMarginTop: 8,
+                    },
                 } as OptionProps<OptionType, boolean>['innerProps']
             }
-        />
+        >
+            <Box
+                borderRadius={8}
+                backgroundColor={props.isFocused ? 'stateFillElementGhostHovered' : undefined}
+                cursor="pointer"
+                padding={{ vertical: 6, horizontal: 8 }}
+            >
+                <Text as="div" typographyStyle={mapSizeToTypographyStyle(size)}>
+                    {children}
+                </Text>
+            </Box>
+        </components.Option>
     );
 };
 

--- a/packages/components/src/components/form/Select/utils.ts
+++ b/packages/components/src/components/form/Select/utils.ts
@@ -1,69 +1,12 @@
 import { StylesConfig } from 'react-select';
 
-import { CSSObject, DefaultTheme } from 'styled-components';
+import { CSSObject } from 'styled-components';
 
-import { borders, spacings, spacingsPx, typographyStylesBase, zIndices } from '@trezor/theme';
+import { zIndices } from '@trezor/theme';
 
-export const createSharedMenuStyles = <OptionType>(
-    theme: DefaultTheme,
-): StylesConfig<OptionType, boolean> => ({
+export const createSharedMenuStyles = <OptionType>(): StylesConfig<OptionType, boolean> => ({
     menuPortal: base => ({
         ...(base as Record<string, CSSObject>),
         zIndex: zIndices.selectMenu,
-    }),
-    menu: base => ({
-        ...(base as Record<string, CSSObject>),
-        display: 'flex',
-        flexDirection: 'column',
-        flex: 1,
-        padding: spacings.sm,
-        minWidth: 180,
-        borderRadius: borders.radii.md,
-        background: theme.backgroundSurfaceElevation1,
-        outline: `1px solid ${theme.baseBorderSurfaceAction}`,
-        boxShadow: theme.boxShadowElevated,
-        listStyleType: 'none',
-        overflow: 'hidden',
-        transition: 'background 0.3s',
-        border: 'none',
-        width: 'fit-content',
-    }),
-    menuList: (base, { maxHeight }) => ({
-        ...(base as Record<string, CSSObject>),
-        maxHeight,
-        overflowY: 'auto',
-    }),
-    groupHeading: base => ({
-        ...(base as Record<string, CSSObject>),
-        margin: 0,
-        padding: spacings.xs,
-        ...{
-            ...typographyStylesBase.label,
-            lineHeight: `${typographyStylesBase.label.lineHeight}px`,
-        },
-        textTransform: 'initial',
-    }),
-    group: base => ({
-        ...(base as Record<string, CSSObject>),
-        padding: 0,
-        '& + &': {
-            paddingTop: spacingsPx.xxs,
-            marginTop: spacingsPx.xxs,
-        },
-    }),
-    option: (base, { isFocused }) => ({
-        ...(base as Record<string, CSSObject>),
-        padding: `${spacingsPx.xs} ${spacingsPx.sm}`,
-        borderRadius: borders.radii.xxs,
-        background: isFocused ? theme.backgroundSurfaceElevation2 : 'transparent',
-        color: theme.textDefault,
-        ...{
-            ...typographyStylesBase.body,
-            lineHeight: `${typographyStylesBase.body.lineHeight}px`,
-        },
-        cursor: 'pointer',
-        '&:active': {
-            background: theme.backgroundSurfaceElevation0,
-        },
     }),
 });

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeSelect.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
@@ -29,7 +31,7 @@ interface AccountTypeSelectProps {
     selectedAccountType?: NetworkAccount;
 }
 
-export const AccountTypeSelect = ({
+const AccountTypeSelectComponent = ({
     selectedAccountType,
     accountTypes,
     networkType,
@@ -63,6 +65,7 @@ export const AccountTypeSelect = ({
     const options = accountTypes.map(buildAccountTypeOption);
     // the default, 'normal' account type is expected to be the first one
     const defaultAccountType = accountTypes[0];
+    const value = buildAccountTypeOption(selectedAccountType ?? defaultAccountType);
 
     const bip43PathToDescribe = selectedAccountType?.bip43Path ?? defaultAccountType.bip43Path;
 
@@ -73,7 +76,7 @@ export const AccountTypeSelect = ({
                 label={<Translation id="TR_ACCOUNT_TYPE" />}
                 isSearchable={false}
                 isClearable={false}
-                value={buildAccountTypeOption(selectedAccountType ?? defaultAccountType)}
+                value={value}
                 options={options}
                 formatOptionLabel={formatLabel}
                 onChange={(option: Option) => onSelectAccountType(option.value)}
@@ -90,3 +93,5 @@ export const AccountTypeSelect = ({
         </Column>
     );
 };
+
+export const AccountTypeSelect = memo(AccountTypeSelectComponent);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -140,12 +140,16 @@ export const AddAccountModal = ({
 
     const isCoinjoinVisible = (isCoinjoinPublic || isDebug) && !isCoinjoinDisabled;
 
-    const getAvailableAccountTypes = (network: Network) => {
+    const accountTypes = useMemo(() => {
+        if (!isSelectedNetworkEnabled || !selectedNetwork) {
+            return undefined;
+        }
+
         const defaultAccount: NetworkAccount = {
-            bip43Path: network.bip43Path,
+            bip43Path: selectedNetwork.bip43Path,
             accountType: 'normal',
         };
-        const otherAccounts = Object.values(network.accountTypes)
+        const otherAccounts = Object.values(selectedNetwork.accountTypes)
             /**
              * Filter out coinjoin account type if it is not visible.
              * Visibility of coinjoin account type depends on coinjoin feature config in message system.
@@ -156,11 +160,7 @@ export const AddAccountModal = ({
 
         // the default account is expected to be the first one
         return [defaultAccount, ...otherAccounts];
-    };
-
-    const accountTypes = isSelectedNetworkEnabled
-        ? getAvailableAccountTypes(selectedNetwork)
-        : undefined;
+    }, [isCoinjoinVisible, isDebug, isSelectedNetworkEnabled, selectedNetwork]);
 
     const selectedNetworks = selectedNetwork ? [selectedNetwork.symbol] : [];
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSearchBox.tsx
@@ -18,12 +18,14 @@ export const AccountSearchBox = () => {
     return (
         <Input
             value={searchString ?? ''}
+            isClean
             onChange={e => {
                 setSearchString(e.target.value);
             }}
             leftContent={
                 <Icon
                     name="magnifyingGlass"
+                    margin={{ left: 12, right: 20 }}
                     size={16}
                     variant="default"
                     onClick={() => {


### PR DESCRIPTION
## Notes for QA
- updated Select list so that the items align with the text in Select itself
- list text now reflects the size prop of the Select
- fixed Select re-rendering in add account modal
- added isClean prop to Input component

## Screenshots:

### Before
<img width="484" height="237" alt="image" src="https://github.com/user-attachments/assets/fe0017c1-ffde-4a4f-aa5f-58158850ef3d" />

### After
<img width="490" height="255" alt="image" src="https://github.com/user-attachments/assets/37a78b20-9013-4bd8-ae62-5f89c2186572" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/select&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/select&lookback=7)