### PR TITLE
refactor(e2e-suite): refactor relay server wipe and base fixture file

### DIFF
--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -16,8 +16,7 @@
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
-        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up -d --force-recreate quota-db suite-sync -d && docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml logs -f suite-sync",
-        "docker:suite-sync:stop": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml down"
+        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up quota-db suite-sync"
     },
     "devDependencies": {
         "@currents/playwright": "^1.19.0",

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,7 +1,6 @@
 import { Evolu, SimpleName, getOrThrow } from '@evolu/common';
 import { Upsertable, createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
 import { expect } from '@playwright/test';
-import { execSync } from 'child_process';
 import { diff } from 'jest-diff';
 import { isEqual, omit, orderBy } from 'lodash';
 
@@ -62,16 +61,6 @@ export class EvoluClient {
         }
 
         return this._evolu;
-    }
-
-    @step()
-    wipeAndRestartServer() {
-        execSync(
-            'docker compose -f docker/docker-compose.suite-ci-e2e.yml up --force-recreate -d quota-db suite-sync',
-            {
-                cwd: '../../',
-            },
-        );
     }
 
     @step()

--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -1,0 +1,155 @@
+import { BrowserContext, TestInfo, test } from '@playwright/test';
+import { execSync } from 'child_process';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import { BRIDGE_VERSION } from './bridge';
+import { getVideoPath, mockRemoteMessageSystem } from './common';
+import { Suite, launchSuite } from './electron';
+import { ElectronConf } from './testExtends/suiteBaseFixture';
+
+export const electronSetup = async (
+    testInfo: TestInfo,
+    locale: string | undefined,
+    colorScheme: any,
+    electronConf: ElectronConf,
+) => {
+    const suite = await launchSuite({
+        locale,
+        colorScheme,
+        artefactFolder: testInfo.outputDir,
+        viewport: testInfo.project.use.viewport!,
+        ...electronConf,
+    });
+
+    // Mocks shell.openExternal to prevent opening real browser windows.
+    await suite.electronApp.evaluate(({ shell }) => {
+        shell.openExternal = (url: string) => {
+            console.warn(`[mock] shell.openExternal called with: ${url}`);
+
+            return Promise.resolve(); // satisfies the 'async' requirement implicitly
+        };
+    });
+
+    await suite.window
+        .context()
+        .tracing.start({ screenshots: true, snapshots: true, sources: true });
+    // this setting only takes effect for the renderer process. To emulate offline mode also in the main process, a custom runtime flag is used.
+    await suite.electronApp.context().setOffline(electronConf.offlineMode ?? false);
+
+    await mockRemoteMessageSystem(suite.window);
+
+    return suite;
+};
+export const electronTeardown = async (
+    suite: Suite,
+    testInfo: TestInfo,
+    electronConf: ElectronConf,
+) => {
+    const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
+    await suite.window.context().tracing.stop({ path: tracePath });
+    testInfo.attachments.push({
+        name: 'electron-logs.txt',
+        path: `${testInfo.outputDir}/electron-logs.txt`,
+        contentType: 'text/plain',
+    });
+    testInfo.attachments.push({
+        name: 'trace',
+        path: tracePath,
+        contentType: 'application/zip',
+    });
+    const videoPath = getVideoPath(testInfo.outputDir);
+    if (videoPath) {
+        testInfo.attachments.push({
+            name: 'video',
+            path: videoPath,
+            contentType: 'video/webm',
+        });
+    }
+    const closePromise = suite.electronApp.close();
+    // Handle modal that asks to enable auto-start
+    if (electronConf.exposeConnectWs) {
+        await suite.window.getByTestId('@auto-start-before-quit/button-quit').click();
+    }
+    await closePromise;
+};
+export const webSetup = async (browserContext: BrowserContext) => {
+    await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
+
+    // Need to allow this to be able to access bridge on localhost
+    // When running tests against suite deployed elsewhere
+    if (browserContext.browser()?.browserType().name() === 'chromium') {
+        await browserContext.grantPermissions(['local-network-access']);
+    }
+
+    const page = await browserContext.newPage();
+
+    // Tells the app to attach Redux Store to window object. packages/suite-web/src/support/usePlaywright.ts
+    // Which is needed for methods manupalating Redux store like onboardingPage.disableFirmwareHashCheck
+    await page.context().addInitScript(() => {
+        window.Playwright = true;
+    });
+    await page.goto('./');
+    await mockRemoteMessageSystem(page);
+
+    return page;
+};
+// Gives trezorUserEnv promise a 30s to complete, else restart tenv to recover from potential hangs
+export const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise(
+        (_, reject) =>
+            (timeoutId = setTimeout(() => {
+                if (process.env.COMPOSE_FILE) {
+                    execSync('docker compose restart trezor-user-env-unix', { cwd: '../../' }); // restart tenv to fix potential hangs
+                }
+                reject(new Error('TrezorUserEnv action timed out'));
+            }, 30000)),
+    );
+
+    const promiseWithClearingTimeout = async () => {
+        await promise;
+        clearTimeout(timeoutId);
+    };
+
+    await Promise.race([promiseWithClearingTimeout(), timeoutPromise]);
+};
+
+export const cleanupTrezorUserEnv = async (testInfo: TestInfo) => {
+    const setupPromise = (async () => {
+        await TrezorUserEnvLink.logTestDetails(
+            ` - - - EXECUTING TENV CLEANUP FOR TEST ${testInfo.titlePath.join(' - ')}`,
+        );
+        await TrezorUserEnvLink.stopBridge();
+        await TrezorUserEnvLink.stopEmu();
+        await TrezorUserEnvLink.connect();
+        await TrezorUserEnvLink.logTestDetails(
+            ` - - - TENV CLEANUP COMPLETED FOR TEST ${testInfo.titlePath.join(' - ')}`,
+        );
+    })();
+
+    await test.step('Device environment cleanup', async () => {
+        await trezorUserEnvStuckProtection(setupPromise);
+    });
+};
+
+export const wipeAndRestartEvoluServer = async () => {
+    await test.step('Wipe Evolu Relay data', () => {
+        execSync(
+            'docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T suite-sync rm -rf /app/data',
+            {
+                cwd: '../../',
+            },
+        );
+    });
+
+    await test.step('Restart Evolu Relay server', () => {
+        execSync(
+            'docker compose -f docker/docker-compose.suite-ci-e2e.yml restart quota-db suite-sync',
+            {
+                cwd: '../../',
+            },
+        );
+    });
+};

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,20 +1,26 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
-import { execSync } from 'child_process';
+import { Page, test as base } from '@playwright/test';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { SetupEmu, TrezorUserEnvLink, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
-import { getUrl, getVideoPath, isDesktopProject, mockRemoteMessageSystem } from '../common';
-import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
+import { getUrl, isDesktopProject } from '../common';
+import { LaunchSuiteParams } from '../electron';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
-import { BRIDGE_VERSION } from '../bridge';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
 import { DeviceFixture } from '../device';
+import {
+    cleanupTrezorUserEnv,
+    electronSetup,
+    electronTeardown,
+    trezorUserEnvStuckProtection,
+    webSetup,
+    wipeAndRestartEvoluServer,
+} from '../setup';
 
-type ElectronConf = Pick<
+export type ElectronConf = Pick<
     LaunchSuiteParams,
     'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
 >;
@@ -31,123 +37,19 @@ type TrezorUserEnv = Pick<
 >;
 
 type SuiteBaseFixture = {
+    wipeEvoluRelay: boolean;
+    wipeEvoluRelayExecution: void;
     startEmulator: boolean;
     setupEmulator: boolean;
     deviceSetup: SetupEmu;
-    device: DeviceFixture;
     electronConf: ElectronConf;
     ignoreJSExceptions: Array<string>;
+
+    device: DeviceFixture;
     url: string;
     trezorUserEnv: TrezorUserEnv;
     page: Page;
     exceptionLogger: void;
-};
-
-const electronSetup = async (
-    testInfo: TestInfo,
-    locale: string | undefined,
-    colorScheme: any,
-    electronConf: ElectronConf,
-) => {
-    const suite = await launchSuite({
-        locale,
-        colorScheme,
-        artefactFolder: testInfo.outputDir,
-        viewport: testInfo.project.use.viewport!,
-        ...electronConf,
-    });
-
-    // Mocks shell.openExternal to prevent opening real browser windows.
-    await suite.electronApp.evaluate(({ shell }) => {
-        shell.openExternal = (url: string) => {
-            console.warn(`[mock] shell.openExternal called with: ${url}`);
-
-            return Promise.resolve(); // satisfies the 'async' requirement implicitly
-        };
-    });
-
-    await suite.window
-        .context()
-        .tracing.start({ screenshots: true, snapshots: true, sources: true });
-    // this setting only takes effect for the renderer process. To emulate offline mode also in the main process, a custom runtime flag is used.
-    await suite.electronApp.context().setOffline(electronConf.offlineMode ?? false);
-
-    await mockRemoteMessageSystem(suite.window);
-
-    return suite;
-};
-
-const electronTeardown = async (suite: Suite, testInfo: TestInfo, electronConf: ElectronConf) => {
-    const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
-    await suite.window.context().tracing.stop({ path: tracePath });
-    testInfo.attachments.push({
-        name: 'electron-logs.txt',
-        path: `${testInfo.outputDir}/electron-logs.txt`,
-        contentType: 'text/plain',
-    });
-    testInfo.attachments.push({
-        name: 'trace',
-        path: tracePath,
-        contentType: 'application/zip',
-    });
-    const videoPath = getVideoPath(testInfo.outputDir);
-    if (videoPath) {
-        testInfo.attachments.push({
-            name: 'video',
-            path: videoPath,
-            contentType: 'video/webm',
-        });
-    }
-    const closePromise = suite.electronApp.close();
-    // Handle modal that asks to enable auto-start
-    if (electronConf.exposeConnectWs) {
-        await suite.window.getByTestId('@auto-start-before-quit/button-quit').click();
-    }
-    await closePromise;
-};
-
-const webSetup = async (browserContext: BrowserContext) => {
-    await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
-
-    // Need to allow this to be able to access bridge on localhost
-    // When running tests against suite deployed elsewhere
-    if (browserContext.browser()?.browserType().name() === 'chromium') {
-        await browserContext.grantPermissions(['local-network-access']);
-    }
-
-    const page = await browserContext.newPage();
-
-    // Tells the app to attach Redux Store to window object. packages/suite-web/src/support/usePlaywright.ts
-    // Which is needed for methods manupalating Redux store like onboardingPage.disableFirmwareHashCheck
-    await page.context().addInitScript(() => {
-        window.Playwright = true;
-    });
-    await page.goto('./');
-    await mockRemoteMessageSystem(page);
-
-    return page;
-};
-
-// Gives trezorUserEnv promise a 30s to complete, else restart tenv to recover from potential hangs
-const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const timeoutPromise = new Promise(
-        (_, reject) =>
-            (timeoutId = setTimeout(() => {
-                if (process.env.COMPOSE_FILE) {
-                    execSync('docker compose restart trezor-user-env-unix', { cwd: '../../' }); // restart tenv to fix potential hangs
-                }
-                reject(new Error('TrezorUserEnv action timed out'));
-            }, 30_000)),
-    );
-
-    const promiseWithClearingTimeout = async () => {
-        await promise;
-        clearTimeout(timeoutId);
-    };
-
-    await Promise.race([promiseWithClearingTimeout(), timeoutPromise]);
 };
 
 // This is the base Suite text fixture containing all the necessary setup and core page object
@@ -155,12 +57,26 @@ const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
 // and provide the necessary page object which is either electron window or web page
 // Extending our fixtures from currentsTest ensures Currents fixtures initialize first and quarantine works even for fails in beforeEach section
 const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
+    wipeEvoluRelay: false,
+    wipeEvoluRelayExecution: [
+        async ({ wipeEvoluRelay }, use) => {
+            if (wipeEvoluRelay) {
+                // Needs to happen before initializing browser/electron context
+                await wipeAndRestartEvoluServer();
+            }
+            await use();
+        },
+        { auto: true },
+    ],
     target: [PlaywrightTarget.Web, { option: true }],
     model: [undefined, { option: true }],
     firmwareVersion: [undefined, { option: true }],
     startEmulator: true,
     setupEmulator: true,
     deviceSetup: {},
+    electronConf: {},
+    ignoreJSExceptions: [],
+
     trezorUserEnv: async ({}, use) => {
         // This proxy limits the exposed methods from TrezorUserEnvLink and wraps the calls with test.step
         const TrezorUserEnvLinkProxy = new Proxy<TrezorUserEnv>(
@@ -182,27 +98,14 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         );
         await use(TrezorUserEnvLinkProxy);
     },
+
     device: [
         async (
             { startEmulator, setupEmulator, model, firmwareVersion, deviceSetup },
             use,
             testInfo,
         ) => {
-            const setupPromise = (async () => {
-                await TrezorUserEnvLink.logTestDetails(
-                    ` - - - EXECUTING TENV CLEANUP FOR TEST ${testInfo.titlePath.join(' - ')}`,
-                );
-                await TrezorUserEnvLink.stopBridge();
-                await TrezorUserEnvLink.stopEmu();
-                await TrezorUserEnvLink.connect();
-                await TrezorUserEnvLink.logTestDetails(
-                    ` - - - TENV CLEANUP COMPLETED FOR TEST ${testInfo.titlePath.join(' - ')}`,
-                );
-            })();
-
-            await base.step('Device environment cleanup', async () => {
-                await trezorUserEnvStuckProtection(setupPromise);
-            });
+            await cleanupTrezorUserEnv(testInfo);
 
             if (!model || !firmwareVersion) {
                 await use(undefined as unknown as DeviceFixture);
@@ -246,8 +149,6 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         },
         { auto: true },
     ],
-    electronConf: {},
-    ignoreJSExceptions: [],
 
     url: async ({ target }, use, testInfo) => {
         await use(getUrl(testInfo, target));
@@ -265,6 +166,7 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
             await use(page);
         }
     },
+
     exceptionLogger: [
         async ({ page, ignoreJSExceptions }, use, testInfo) => {
             const errors: Error[] = [];

--- a/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
@@ -46,84 +46,72 @@ const expectedOutput = {
     txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
 };
 
-test.describe(
-    'Suite Sync - Labelling',
-    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
-    () => {
-        test.use({
-            deviceSetup: { passphrase_protection: true },
+test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
+
+    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await metadataPage.setupQuotaManager();
+        await metadataPage.enableSuiteSync();
+    });
+
+    test('Create new labels', async ({ evoluClient, dashboardPage, walletPage, metadataPage }) => {
+        await test.step('Change account label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: expectedAccount.label,
+            });
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText(expectedAccount.label, { timeout: 30_000 });
         });
 
-        test.beforeEach(async ({ evoluClient, onboardingPage, metadataPage }) => {
-            evoluClient.wipeAndRestartServer();
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-            await metadataPage.setupQuotaManager();
-            await metadataPage.enableSuiteSync();
+        await test.step('Change wallet label', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: WALLET_INDEX,
+                label: expectedWallet.label,
+            });
+            await expect
+                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .toHaveText(expectedWallet.label);
+            await dashboardPage.deviceSwitchingCloseButton.click();
         });
 
-        test('Create new labels', async ({
-            evoluClient,
-            dashboardPage,
-            walletPage,
-            metadataPage,
-        }) => {
-            await test.step('Verify BTC account label is synced', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await metadataPage.account.changeLabel({
-                    accountId: AccountLabelId.BitcoinDefault1,
-                    label: expectedAccount.label,
-                });
-                await expect
-                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
-                    .toHaveText(expectedAccount.label, { timeout: 30_000 });
+        await test.step('Change address label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await metadataPage.address.changeLabel({
+                address: expectedAddress.address,
+                label: expectedAddress.label,
             });
-
-            await test.step('Change wallet label', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await metadataPage.wallet.changeLabel({
-                    index: WALLET_INDEX,
-                    label: expectedWallet.label,
-                });
-                await expect
-                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
-                    .toHaveText(expectedWallet.label);
-                await dashboardPage.deviceSwitchingCloseButton.click();
-            });
-
-            await test.step('Change address label', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await walletPage.receiveButton.click();
-                await metadataPage.address.changeLabel({
-                    address: expectedAddress.address,
-                    label: expectedAddress.label,
-                });
-                await expect
-                    .soft(metadataPage.address.label(expectedAddress.address))
-                    .toHaveText(expectedAddress.label);
-            });
-
-            await test.step('Change output label', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await metadataPage.output.changeLabel({
-                    outputId: expectedOutput.txId,
-                    txNumber: Number(expectedOutput.outputIndex),
-                    label: expectedOutput.label,
-                });
-                await expect(
-                    metadataPage.output.outputLabel(
-                        expectedOutput.txId,
-                        Number(expectedOutput.outputIndex),
-                    ),
-                ).toHaveText(expectedOutput.label);
-            });
-
-            await test.step('Verify data are sync to Relay', async () => {
-                await evoluClient.init({ ownerSecret });
-                await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
-                await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
-                await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
-                await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
-            });
+            await expect
+                .soft(metadataPage.address.label(expectedAddress.address))
+                .toHaveText(expectedAddress.label);
         });
-    },
-);
+
+        await test.step('Change output label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.output.changeLabel({
+                outputId: expectedOutput.txId,
+                txNumber: Number(expectedOutput.outputIndex),
+                label: expectedOutput.label,
+            });
+            await expect(
+                metadataPage.output.outputLabel(
+                    expectedOutput.txId,
+                    Number(expectedOutput.outputIndex),
+                ),
+            ).toHaveText(expectedOutput.label);
+        });
+
+        await test.step('Verify data are sync to Relay', async () => {
+            await evoluClient.init({ ownerSecret });
+            await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
+            await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
+            await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
+            await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
+        });
+    });
+});

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -28,93 +28,84 @@ const addressSeed = {
     networkSymbol: 'btc',
 };
 
-test.describe(
-    'Suite Sync - Labelling',
-    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
-    () => {
-        test.use({
-            deviceSetup: { passphrase_protection: true },
-        });
+test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
 
-        test.beforeEach(async ({ evoluClient, onboardingPage }) => {
-            await test.step('Seed Evolu relay server', async () => {
-                evoluClient.wipeAndRestartServer();
-                await evoluClient.init({ ownerSecret });
-                evoluClient.writeTo('wallet', walletSeed);
-                evoluClient.writeTo('account', accountSeed);
-                evoluClient.writeTo('address', addressSeed);
-            });
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    test.beforeEach(async ({ evoluClient, onboardingPage }) => {
+        await test.step('Seed Evolu relay server', async () => {
+            await evoluClient.init({ ownerSecret });
+            evoluClient.writeTo('wallet', walletSeed);
+            evoluClient.writeTo('account', accountSeed);
+            evoluClient.writeTo('address', addressSeed);
         });
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    });
 
-        test('Sync labels from server', async ({
-            target,
-            device,
-            dashboardPage,
-            walletPage,
-            metadataPage,
-        }) => {
-            await test.step('Enable Suite Sync', async () => {
-                await metadataPage.setupQuotaManager();
-                await metadataPage.initiateSuiteSyncSetup();
-                if (isWebProject(target)) {
-                    // eslint-disable-next-line playwright/no-conditional-expect
-                    await expect(device).toShowOnDisplay({
-                        T3W1: {
-                            header: { title: 'Suite Sync' },
-                            body: [
-                                [
-                                    'Allow Trezor Suite',
-                                    '\n',
-                                    'on Chrome to use',
-                                    '\n',
-                                    'Suite Sync with this',
-                                    '\n',
-                                    'Trezor?',
-                                ],
+    test('Sync labels from server', async ({
+        target,
+        device,
+        dashboardPage,
+        walletPage,
+        metadataPage,
+    }) => {
+        await test.step('Enable Suite Sync', async () => {
+            await metadataPage.setupQuotaManager();
+            await metadataPage.initiateSuiteSyncSetup();
+            if (isWebProject(target)) {
+                // eslint-disable-next-line playwright/no-conditional-expect
+                await expect(device).toShowOnDisplay({
+                    T3W1: {
+                        header: { title: 'Suite Sync' },
+                        body: [
+                            [
+                                'Allow Trezor Suite',
+                                '\n',
+                                'on Chrome to use',
+                                '\n',
+                                'Suite Sync with this',
+                                '\n',
+                                'Trezor?',
                             ],
-                            actions: { right_button: 'Confirm' },
-                        },
-                        T3T1: {
-                            body: [
-                                [
-                                    'Allow Trezor Suite to use',
-                                    '\n',
-                                    'Suite Sync with this',
-                                    '\n',
-                                    'Trezor?',
-                                ],
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
+                    T3T1: {
+                        body: [
+                            [
+                                'Allow Trezor Suite to use',
+                                '\n',
+                                'Suite Sync with this',
+                                '\n',
+                                'Trezor?',
                             ],
-                        },
-                    });
-                }
-                await metadataPage.confirmSuiteSyncSetup();
-            });
-
-            await test.step('Verify BTC account label is synced', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await expect
-                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
-                    .toHaveText(accountSeed.label, { timeout: 30_000 });
-            });
-
-            await test.step('Verify wallet label is synced', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await expect
-                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
-                    .toHaveText(walletSeed.label);
-                await dashboardPage.deviceSwitchingCloseButton.click();
-            });
-
-            await test.step('Verify address label is synced', async () => {
-                await walletPage.openAccount();
-                await walletPage.receiveButton.click();
-                await expect
-                    .soft(metadataPage.address.label(addressSeed.address))
-                    .toHaveText(addressSeed.label);
-            });
+                        ],
+                    },
+                });
+            }
+            await metadataPage.confirmSuiteSyncSetup();
         });
-    },
-);
+
+        await test.step('Verify BTC account label is synced', async () => {
+            await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText(accountSeed.label, { timeout: 30_000 });
+        });
+
+        await test.step('Verify wallet label is synced', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await expect
+                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .toHaveText(walletSeed.label);
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
+
+        await test.step('Verify address label is synced', async () => {
+            await walletPage.openAccount();
+            await walletPage.receiveButton.click();
+            await expect
+                .soft(metadataPage.address.label(addressSeed.address))
+                .toHaveText(addressSeed.label);
+        });
+    });
+});


### PR DESCRIPTION
splits off support methods from suiteBaseFixture.ts

Original solution somehow broke web and tests could not continue. 
New solution
```
const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
    wipeEvoluRelay: false,
    wipeEvoluRelayExecution: [
        async ({ wipeEvoluRelay }, use) => {
            if (wipeEvoluRelay) {
                // Needs to happen before initializing browser/electron context
                await wipeAndRestartEvoluServer();
            }
            await use();
        },
        { auto: true },
    ],
```

in test
```
test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
    test.use({ wipeEvoluRelay: true });

    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
        await metadataPage.setupQuotaManager();
        await metadataPage.enableSuiteSync();
    });
```

This is a clean solution but preferable would be to do the restart as part of evoluClient Fixture and not be force to have another two fixtures just for this restart and specifically have to say in tests if we want the restarts or not.

So I suggest using this solution to unblock tests and attempt to rework it later.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-refactor-relay-restart&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-refactor-relay-restart&lookback=7)