### PR TITLE
fix(connect-web): support sldev branches with slashes

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -68,11 +68,10 @@ export class CoreInSuiteWeb implements ConnectImpl {
             typeof window !== 'undefined' &&
             window.location.href.startsWith('https://dev.suite.sldev.cz/connect/')
         ) {
-            const branch = window.location.href
-                .replace('https://dev.suite.sldev.cz/connect/', '')
-                .split('/')[0];
-
-            return `https://dev.suite.sldev.cz/suite-web/${branch}/web/connect-popup`;
+            const branch = window.location.href.match(/\/connect\/(.+?)(?:\/methods\/|$)/)?.[1];
+            if (branch) {
+                return `https://dev.suite.sldev.cz/suite-web/${branch}/web/connect-popup`;
+            }
         }
 
         return 'https://suite.trezor.io/web/connect-popup';


### PR DESCRIPTION
## Description

After changes in #25079 it was not possible to test on branches containing a slash such as `feature/xyz`... 


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connectsrc/branch/with/slashes&lookback=7)