### PR TITLE
fix(suite-native): stop loading inactive tokens when coin definitions fail

### DIFF
--- a/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
@@ -29,7 +29,7 @@ export const useInactiveStellarTokens = (accountKey: AccountKey) => {
         selectCoinDefinitions(state, account?.symbol ?? 'xlm'),
     );
 
-    const isCoinDefinitionsLoading = coinDefinitions?.isLoading ?? true;
+    const isCoinDefinitionsLoading = coinDefinitions?.isLoading ?? false;
 
     useEffect(() => {
         if (!tokenMetadata) {


### PR DESCRIPTION
## Description

This PR aims to fix an issue with infinite loading of XLM inactive tokens.

Important: this is a blind hotfix since I was not able to replicate it. However, when coin definitions fail to load, set `loading` to `false` (might fix the issue).

## Related Issue

Resolve #25140 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/xlm-inactive-tokens&lookback=7)