### PR TITLE
feat(suite-native): switch Earn and Trade tabs in mobile navigation

### DIFF
--- a/suite-native/app/src/navigation/AppTabNavigator.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.tsx
@@ -45,7 +45,6 @@ export const AppTabNavigator = () => {
         >
             <Tab.Screen name={AppTabsRoutes.HomeStack} component={HomeStackNavigator} />
             <Tab.Screen name={AppTabsRoutes.AccountsStack} component={AccountsStackNavigator} />
-            <Tab.Screen name={AppTabsRoutes.EarnStack} component={EarnStackNavigator} />
             {isTradingEnabled && (
                 <Tab.Screen
                     name={AppTabsRoutes.TradeStack}
@@ -55,6 +54,7 @@ export const AppTabNavigator = () => {
                     }}
                 />
             )}
+            <Tab.Screen name={AppTabsRoutes.EarnStack} component={EarnStackNavigator} />
             <Tab.Screen name={AppTabsRoutes.Settings} component={SettingsScreen} />
         </Tab.Navigator>
     );

--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.comp.test.tsx
@@ -93,4 +93,26 @@ describe('AppTabNavigator', () => {
 
         expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
+
+    it('should not render Earn tab when the Earn flag is disabled', async () => {
+        const { queryByText } = await renderTabs({
+            featureFlags: {
+                ...featureFlagsInitialState,
+                [FeatureFlag.IsEarnEnabled]: false,
+            },
+        });
+
+        expect(queryByText('Earn')).toBe(null);
+    });
+
+    it('should render Earn tab when the Earn flag is enabled', async () => {
+        const { queryByText } = await renderTabs({
+            featureFlags: {
+                ...featureFlagsInitialState,
+                [FeatureFlag.IsEarnEnabled]: true,
+            },
+        });
+
+        expect(queryByText('Earn')).toBeTruthy();
+    });
 });

--- a/suite-native/app/src/navigation/routes.ts
+++ b/suite-native/app/src/navigation/routes.ts
@@ -38,7 +38,7 @@ const settings = enhanceTabOption({
 export const rootTabsOptions = {
     ...homeStack,
     ...accountsStack,
-    ...earnStack,
     ...tradeStack,
+    ...earnStack,
     ...settings,
 };

--- a/suite-native/navigation/src/components/TabBar.tsx
+++ b/suite-native/navigation/src/components/TabBar.tsx
@@ -36,8 +36,8 @@ const tabBarStyle = prepareNativeStyle<{
 const TabBarLabelTxKeys = {
     [AppTabsRoutes.HomeStack]: 'navigation.tabs.home',
     [AppTabsRoutes.AccountsStack]: 'navigation.tabs.accounts',
-    [AppTabsRoutes.EarnStack]: 'navigation.tabs.earn',
     [AppTabsRoutes.TradeStack]: 'navigation.tabs.trade',
+    [AppTabsRoutes.EarnStack]: 'navigation.tabs.earn',
     [AppTabsRoutes.Settings]: 'navigation.tabs.settings',
 } as const satisfies Record<AppTabsRoutes, TxKeyPath>;
 

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -32,8 +32,8 @@ export enum RootStackRoutes {
 export enum AppTabsRoutes {
     HomeStack = 'HomeStack',
     AccountsStack = 'AccountsStack',
-    EarnStack = 'EarnStack',
     TradeStack = 'TradeStack',
+    EarnStack = 'EarnStack',
     Settings = 'Settings',
 }
 


### PR DESCRIPTION
## Description

Switch Earn and Trade tabs in bottom navigation on mobile.

## Related Issue

Resolve #25167 

## Screenshots:

<img width="435" height="208" alt="Screenshot 2026-02-13 at 16 31 09" src="https://github.com/user-attachments/assets/de1f0f79-07d2-468e-9a2b-be92283af7f1" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/mobile-switch-trade-earn-tabs&lookback=7)