### PR TITLE
refactor(e2e-suite): refactor relay server wipe

### DIFF
--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -16,8 +16,7 @@
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
-        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up -d --force-recreate quota-db suite-sync -d && docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml logs -f suite-sync",
-        "docker:suite-sync:stop": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml down"
+        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up quota-db suite-sync"
     },
     "devDependencies": {
         "@currents/playwright": "^1.19.0",

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -1,6 +1,6 @@
 import { Evolu, SimpleName, getOrThrow } from '@evolu/common';
 import { Upsertable, createEvolu, createOwnerWebSocketTransport } from '@evolu/common/local-first';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { execSync } from 'child_process';
 import { diff } from 'jest-diff';
 import { isEqual, omit, orderBy } from 'lodash';
@@ -62,16 +62,6 @@ export class EvoluClient {
         }
 
         return this._evolu;
-    }
-
-    @step()
-    wipeAndRestartServer() {
-        execSync(
-            'docker compose -f docker/docker-compose.suite-ci-e2e.yml up --force-recreate -d quota-db suite-sync',
-            {
-                cwd: '../../',
-            },
-        );
     }
 
     @step()
@@ -151,3 +141,23 @@ export class EvoluClient {
         }).toPass({ timeout });
     }
 }
+
+export const wipeAndRestartEvoluServer = async () => {
+    await test.step('Wipe Evolu Relay data', () => {
+        execSync(
+            'docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T suite-sync rm -rf /app/data',
+            {
+                cwd: '../../',
+            },
+        );
+    });
+
+    await test.step('Restart Evolu Relay server', () => {
+        execSync(
+            'docker compose -f docker/docker-compose.suite-ci-e2e.yml restart quota-db suite-sync',
+            {
+                cwd: '../../',
+            },
+        );
+    });
+};

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -4,39 +4,27 @@ import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
 import { execSync } from 'child_process';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
-import { SetupEmu, TrezorUserEnvLink, TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
+import { SetupEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { getUrl, getVideoPath, isDesktopProject, mockRemoteMessageSystem } from '../common';
-import { LaunchSuiteParams, Suite, launchSuite } from '../electron';
+import { Suite, launchSuite } from '../electron';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
 import { BRIDGE_VERSION } from '../bridge';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
 import { DeviceFixture } from '../device';
-
-type ElectronConf = Pick<
-    LaunchSuiteParams,
-    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
->;
-type TrezorUserEnv = Pick<
-    TrezorUserEnvLinkClass,
-    | 'logTestDetails'
-    | 'startBridge'
-    | 'stopBridge'
-    | 'connect'
-    | 'disconnect'
-    | 'generateBlock'
-    | 'mineBlocks'
-    | 'sendToAddressAndMineBlock'
->;
+import { wipeAndRestartEvoluServer } from '../helpers/evoluClient';
+import { ElectronConf, TrezorUserEnv } from '../types';
 
 type SuiteBaseFixture = {
+    wipeEvoluRelay: boolean;
+    wipeEvoluRelayExecution: void;
     startEmulator: boolean;
     setupEmulator: boolean;
     deviceSetup: SetupEmu;
-    device: DeviceFixture;
     electronConf: ElectronConf;
     ignoreJSExceptions: Array<string>;
+    device: DeviceFixture;
     url: string;
     trezorUserEnv: TrezorUserEnv;
     page: Page;
@@ -155,6 +143,17 @@ const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
 // and provide the necessary page object which is either electron window or web page
 // Extending our fixtures from currentsTest ensures Currents fixtures initialize first and quarantine works even for fails in beforeEach section
 const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
+    wipeEvoluRelay: false,
+    wipeEvoluRelayExecution: [
+        async ({ wipeEvoluRelay }, use) => {
+            if (wipeEvoluRelay) {
+                // Needs to happen before initializing browser/electron context
+                await wipeAndRestartEvoluServer();
+            }
+            await use();
+        },
+        { auto: true },
+    ],
     target: [PlaywrightTarget.Web, { option: true }],
     model: [undefined, { option: true }],
     firmwareVersion: [undefined, { option: true }],

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -1,6 +1,9 @@
 import { AnalyticsDesktopEvents } from '@suite/analytics';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { urlSearchParams } from '@trezor/suite/src//utils/suite/metadata';
+import { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
+
+import { LaunchSuiteParams } from '../electron';
 export type Requests = ReturnType<typeof urlSearchParams>[];
 
 /**
@@ -40,3 +43,19 @@ declare global {
         store?: any;
     }
 }
+
+export type ElectronConf = Pick<
+    LaunchSuiteParams,
+    'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
+>;
+export type TrezorUserEnv = Pick<
+    TrezorUserEnvLinkClass,
+    | 'logTestDetails'
+    | 'startBridge'
+    | 'stopBridge'
+    | 'connect'
+    | 'disconnect'
+    | 'generateBlock'
+    | 'mineBlocks'
+    | 'sendToAddressAndMineBlock'
+>;

--- a/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
@@ -46,84 +46,72 @@ const expectedOutput = {
     txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
 };
 
-test.describe(
-    'Suite Sync - Labelling',
-    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
-    () => {
-        test.use({
-            deviceSetup: { passphrase_protection: true },
+test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
+
+    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await metadataPage.setupQuotaManager();
+        await metadataPage.enableSuiteSync();
+    });
+
+    test('Create new labels', async ({ evoluClient, dashboardPage, walletPage, metadataPage }) => {
+        await test.step('Change account label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: expectedAccount.label,
+            });
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText(expectedAccount.label, { timeout: 30_000 });
         });
 
-        test.beforeEach(async ({ evoluClient, onboardingPage, metadataPage }) => {
-            evoluClient.wipeAndRestartServer();
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-            await metadataPage.setupQuotaManager();
-            await metadataPage.enableSuiteSync();
+        await test.step('Change wallet label', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: WALLET_INDEX,
+                label: expectedWallet.label,
+            });
+            await expect
+                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .toHaveText(expectedWallet.label);
+            await dashboardPage.deviceSwitchingCloseButton.click();
         });
 
-        test('Create new labels', async ({
-            evoluClient,
-            dashboardPage,
-            walletPage,
-            metadataPage,
-        }) => {
-            await test.step('Verify BTC account label is synced', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await metadataPage.account.changeLabel({
-                    accountId: AccountLabelId.BitcoinDefault1,
-                    label: expectedAccount.label,
-                });
-                await expect
-                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
-                    .toHaveText(expectedAccount.label, { timeout: 30_000 });
+        await test.step('Change address label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await metadataPage.address.changeLabel({
+                address: expectedAddress.address,
+                label: expectedAddress.label,
             });
-
-            await test.step('Change wallet label', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await metadataPage.wallet.changeLabel({
-                    index: WALLET_INDEX,
-                    label: expectedWallet.label,
-                });
-                await expect
-                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
-                    .toHaveText(expectedWallet.label);
-                await dashboardPage.deviceSwitchingCloseButton.click();
-            });
-
-            await test.step('Change address label', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await walletPage.receiveButton.click();
-                await metadataPage.address.changeLabel({
-                    address: expectedAddress.address,
-                    label: expectedAddress.label,
-                });
-                await expect
-                    .soft(metadataPage.address.label(expectedAddress.address))
-                    .toHaveText(expectedAddress.label);
-            });
-
-            await test.step('Change output label', async () => {
-                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
-                await metadataPage.output.changeLabel({
-                    outputId: expectedOutput.txId,
-                    txNumber: Number(expectedOutput.outputIndex),
-                    label: expectedOutput.label,
-                });
-                await expect(
-                    metadataPage.output.outputLabel(
-                        expectedOutput.txId,
-                        Number(expectedOutput.outputIndex),
-                    ),
-                ).toHaveText(expectedOutput.label);
-            });
-
-            await test.step('Verify data are sync to Relay', async () => {
-                await evoluClient.init({ ownerSecret });
-                await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
-                await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
-                await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
-                await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
-            });
+            await expect
+                .soft(metadataPage.address.label(expectedAddress.address))
+                .toHaveText(expectedAddress.label);
         });
-    },
-);
+
+        await test.step('Change output label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.output.changeLabel({
+                outputId: expectedOutput.txId,
+                txNumber: Number(expectedOutput.outputIndex),
+                label: expectedOutput.label,
+            });
+            await expect(
+                metadataPage.output.outputLabel(
+                    expectedOutput.txId,
+                    Number(expectedOutput.outputIndex),
+                ),
+            ).toHaveText(expectedOutput.label);
+        });
+
+        await test.step('Verify data are sync to Relay', async () => {
+            await evoluClient.init({ ownerSecret });
+            await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
+            await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
+            await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
+            await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
+        });
+    });
+});

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -28,93 +28,84 @@ const addressSeed = {
     networkSymbol: 'btc',
 };
 
-test.describe(
-    'Suite Sync - Labelling',
-    { tag: ['@webOnly', '@specificFirmware', '@T3W1', '@T3T1'] },
-    () => {
-        test.use({
-            deviceSetup: { passphrase_protection: true },
-        });
+test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
 
-        test.beforeEach(async ({ evoluClient, onboardingPage }) => {
-            await test.step('Seed Evolu relay server', async () => {
-                evoluClient.wipeAndRestartServer();
-                await evoluClient.init({ ownerSecret });
-                evoluClient.writeTo('wallet', walletSeed);
-                evoluClient.writeTo('account', accountSeed);
-                evoluClient.writeTo('address', addressSeed);
-            });
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    test.beforeEach(async ({ evoluClient, onboardingPage }) => {
+        await test.step('Seed Evolu relay server', async () => {
+            await evoluClient.init({ ownerSecret });
+            evoluClient.writeTo('wallet', walletSeed);
+            evoluClient.writeTo('account', accountSeed);
+            evoluClient.writeTo('address', addressSeed);
         });
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    });
 
-        test('Sync labels from server', async ({
-            target,
-            device,
-            dashboardPage,
-            walletPage,
-            metadataPage,
-        }) => {
-            await test.step('Enable Suite Sync', async () => {
-                await metadataPage.setupQuotaManager();
-                await metadataPage.initiateSuiteSyncSetup();
-                if (isWebProject(target)) {
-                    // eslint-disable-next-line playwright/no-conditional-expect
-                    await expect(device).toShowOnDisplay({
-                        T3W1: {
-                            header: { title: 'Suite Sync' },
-                            body: [
-                                [
-                                    'Allow Trezor Suite',
-                                    '\n',
-                                    'on Chrome to use',
-                                    '\n',
-                                    'Suite Sync with this',
-                                    '\n',
-                                    'Trezor?',
-                                ],
+    test('Sync labels from server', async ({
+        target,
+        device,
+        dashboardPage,
+        walletPage,
+        metadataPage,
+    }) => {
+        await test.step('Enable Suite Sync', async () => {
+            await metadataPage.setupQuotaManager();
+            await metadataPage.initiateSuiteSyncSetup();
+            if (isWebProject(target)) {
+                // eslint-disable-next-line playwright/no-conditional-expect
+                await expect(device).toShowOnDisplay({
+                    T3W1: {
+                        header: { title: 'Suite Sync' },
+                        body: [
+                            [
+                                'Allow Trezor Suite',
+                                '\n',
+                                'on Chrome to use',
+                                '\n',
+                                'Suite Sync with this',
+                                '\n',
+                                'Trezor?',
                             ],
-                            actions: { right_button: 'Confirm' },
-                        },
-                        T3T1: {
-                            body: [
-                                [
-                                    'Allow Trezor Suite to use',
-                                    '\n',
-                                    'Suite Sync with this',
-                                    '\n',
-                                    'Trezor?',
-                                ],
+                        ],
+                        actions: { right_button: 'Confirm' },
+                    },
+                    T3T1: {
+                        body: [
+                            [
+                                'Allow Trezor Suite to use',
+                                '\n',
+                                'Suite Sync with this',
+                                '\n',
+                                'Trezor?',
                             ],
-                        },
-                    });
-                }
-                await metadataPage.confirmSuiteSyncSetup();
-            });
-
-            await test.step('Verify BTC account label is synced', async () => {
-                await walletPage
-                    .accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 })
-                    .click();
-                await expect
-                    .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
-                    .toHaveText(accountSeed.label, { timeout: 30_000 });
-            });
-
-            await test.step('Verify wallet label is synced', async () => {
-                await dashboardPage.openDeviceSwitcher();
-                await expect
-                    .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
-                    .toHaveText(walletSeed.label);
-                await dashboardPage.deviceSwitchingCloseButton.click();
-            });
-
-            await test.step('Verify address label is synced', async () => {
-                await walletPage.openAccount();
-                await walletPage.receiveButton.click();
-                await expect
-                    .soft(metadataPage.address.label(addressSeed.address))
-                    .toHaveText(addressSeed.label);
-            });
+                        ],
+                    },
+                });
+            }
+            await metadataPage.confirmSuiteSyncSetup();
         });
-    },
-);
+
+        await test.step('Verify BTC account label is synced', async () => {
+            await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText(accountSeed.label, { timeout: 30_000 });
+        });
+
+        await test.step('Verify wallet label is synced', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await expect
+                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .toHaveText(walletSeed.label);
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
+
+        await test.step('Verify address label is synced', async () => {
+            await walletPage.openAccount();
+            await walletPage.receiveButton.click();
+            await expect
+                .soft(metadataPage.address.label(addressSeed.address))
+                .toHaveText(addressSeed.label);
+        });
+    });
+});


### PR DESCRIPTION
Original solution somehow broke web and tests could not continue.
New solution
```
const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
    wipeEvoluRelay: false,
    wipeEvoluRelayExecution: [
        async ({ wipeEvoluRelay }, use) => {
            if (wipeEvoluRelay) {
                // Needs to happen before initializing browser/electron context
                await wipeAndRestartEvoluServer();
            }
            await use();
        },
        { auto: true },
    ],
```
in test
```
test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
    test.use({ wipeEvoluRelay: true });

    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
        await metadataPage.setupQuotaManager();
        await metadataPage.enableSuiteSync();
    });
```
This is a clean solution but preferable would be to do the restart as part of evoluClient Fixture and not be force to have another two fixtures just for this restart and specifically have to say in tests if we want the restarts or not.

So I suggest using this solution to unblock tests and attempt to rework it later.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-refactor-relay-restart-min&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-refactor-relay-restart-min&lookback=7)