### PR TITLE
refactor(e2e-suite): switches suite sync test off debug mode

### DIFF
--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -65,6 +65,7 @@ export class MetadataPage {
         await this.settingsPage.navigateTo('debug');
         await this.settingsPage.debugTab.suiteSyncUrlInput.fill('http://127.0.0.1:4000');
         await this.settingsPage.debugTab.suiteSyncUrlSaveButton.click();
+        await this.page.disableDebugMode();
 
         // Select Suite Sync as the labeling method
         await this.settingsPage.navigateTo('application');
@@ -94,5 +95,6 @@ export class MetadataPage {
         await this.settingsPage.debugTab.quotaManagerCheckbox.click();
         await this.settingsPage.debugTab.quotaManagerUrlInput.fill('http://127.0.0.1:4001');
         await this.settingsPage.debugTab.quotaManagerUrlSaveButton.click();
+        await this.page.disableDebugMode();
     }
 }

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -125,7 +125,7 @@ export class OnboardingPage {
         // Enabled debug mode is needed for passing firmware checks but it also enables several hidden features
         // that differs from production version, so we disable it again after onboarding is done
         if (!options?.keepDebugModeEnabled) {
-            await this.disableDebugMode();
+            await this.page.disableDebugMode();
         }
         await this.page.discoveryShouldFinish();
     }
@@ -179,15 +179,6 @@ export class OnboardingPage {
                 },
             ],
         );
-    }
-
-    @step()
-    async disableDebugMode() {
-        await this.page.ensureStoreOnDesktop();
-        await this.page.evaluate(action => window.store.dispatch(action), {
-            type: SuiteActions.SET_DEBUG_MODE,
-            payload: { showDebugMenu: false },
-        });
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -158,7 +158,16 @@ export class SettingsPage {
             application: () => this.applicationTabButton.click(),
             coins: () => this.coinsTabButton.click(),
             device: () => this.deviceTabButton.click(),
-            debug: () => this.debugTabButton.click(),
+            debug: async () => {
+                // We cannot rely on the debug tab button being visible in the menu
+                const isDebugEnabled = await this.page.getReduxObject(
+                    'suite.settings.debug.showDebugMenu',
+                );
+                if (!isDebugEnabled) {
+                    await this.toggleDebugModeInSettings();
+                }
+                await this.debugTabButton.click();
+            },
             connect: () => this.connectTabButton.click(),
         };
         await tabNavigation[tab]();

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -3,6 +3,8 @@ import { writeFileSync } from 'fs';
 import { get, isMatch, set } from 'lodash';
 import { join } from 'path';
 
+import { SUITE as SuiteActions } from '@trezor/suite/src/actions/suite/constants';
+
 declare module '@playwright/test' {
     interface Page {
         // Locators
@@ -33,13 +35,14 @@ declare module '@playwright/test' {
             expectedValue: unknown,
             options?: { timeout?: number },
         ): Promise<void>;
-        getReduxObject(objectPath: string): Promise<any>;
+        getReduxObject(objectPath?: string): Promise<any>;
         resetMousePosition(): Promise<void>;
         runWithReduxDump<T>(
             action: () => Promise<T>,
             options?: { slice?: string; filePrefix?: string },
         ): Promise<void>;
         selectDropdownOptionWithRetry(dropdown: Locator, option: Locator): Promise<void>;
+        disableDebugMode(): Promise<void>;
     }
 }
 
@@ -84,8 +87,12 @@ export const enhancePage = (page: Page): Page => {
         }).toPass({ timeout: 5000 });
     };
 
-    page.getReduxObject = async (objectPath: string) => {
+    page.getReduxObject = async (objectPath?: string) => {
         const state = await page.evaluate(() => window.store.getState());
+
+        if (!objectPath) {
+            return state;
+        }
 
         return get(state, objectPath);
     };
@@ -147,17 +154,16 @@ export const enhancePage = (page: Page): Page => {
         action: () => Promise<T>,
         options?: { slice?: string; filePrefix?: string },
     ): Promise<void> {
-        const slice = options?.slice ?? 'wallet';
-        const prefix = options?.filePrefix ?? slice;
+        const prefix = options?.filePrefix ?? options?.slice ?? 'redux_dump';
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
 
-        const beforeRaw = await page.getReduxObject(slice);
+        const beforeRaw = await page.getReduxObject(options?.slice);
         const beforePath = join(process.cwd(), `${prefix}_before_${ts}.json`);
         writeFileSync(beforePath, JSON.stringify(beforeRaw, null, 2), 'utf-8');
 
         await action();
 
-        const afterRaw = await page.getReduxObject(slice);
+        const afterRaw = await page.getReduxObject(options?.slice);
         const afterPath = join(process.cwd(), `${prefix}_after_${ts}.json`);
         writeFileSync(afterPath, JSON.stringify(afterRaw, null, 2), 'utf-8');
 
@@ -170,6 +176,16 @@ You can use a diff tool to compare the state before and after the action.
 
     page.resetMousePosition = async function () {
         await page.mouse.move(0, 0); // reset mouse position to avoid hover issues
+    };
+
+    page.disableDebugMode = async function () {
+        await test.step('Disable Debug mode', async () => {
+            await page.ensureStoreOnDesktop();
+            await page.evaluate(action => window.store.dispatch(action), {
+                type: SuiteActions.SET_DEBUG_MODE,
+                payload: { showDebugMenu: false },
+            });
+        });
     };
 
     return page;

--- a/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/suite-sync.test.ts
@@ -50,7 +50,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
     test.use({ wipeEvoluRelay: true });
 
     test.beforeEach(async ({ onboardingPage, metadataPage }) => {
-        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await onboardingPage.completeOnboarding();
         await metadataPage.setupQuotaManager();
         await metadataPage.enableSuiteSync();
     });

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -38,7 +38,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             evoluClient.writeTo('account', accountSeed);
             evoluClient.writeTo('address', addressSeed);
         });
-        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await onboardingPage.completeOnboarding();
     });
 
     test('Sync labels from server', async ({


### PR DESCRIPTION
We want our automation as close to production. This means running tests out of DEBUG mode.

Suite sync url configuration are atm in debug section. We need to set those to our local RELAY
So I have modify several things:
- settings navigation to debug automatically sets debug mod if not already
- disabling debug mod is on page object
- this way our methods for evolu configuration can at start enter debug mod and then disable it again.

```
    async setupQuotaManager() {
        await this.settingsPage.navigateTo('debug');
        await this.settingsPage.debugTab.quotaManagerCheckbox.click();
        await this.settingsPage.debugTab.quotaManagerUrlInput.fill('http://127.0.0.1:4001');
        await this.settingsPage.debugTab.quotaManagerUrlSaveButton.click();
        await this.page.disableDebugMode();
    }
```

Refactor: our redux dump now can dump whole redux store. Not just parts.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-no-debug&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-no-debug&lookback=7)