### PR TITLE
Connect popup tests

### DIFF
--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -67,17 +67,21 @@ export class CoreInSuiteDesktop implements ConnectImpl {
     }
 
     public async init({ manifest, version }: ConnectImplSettings): Promise<void> {
-        const permission = await navigator.permissions
-            .query({
-                // @ts-expect-error outdated type definitions
-                name: 'local-network-access',
-            })
-            .catch(() => undefined);
-        if (permission) {
-            this.localNetworkPermissionState = permission.state;
-            permission.onchange = () => {
+        // navigator should be always present in the runtime
+        // but since in tests we run this code in node.js for convenience, we can make this check optional
+        if (typeof navigator !== 'undefined' && navigator?.permissions?.query) {
+            const permission = await navigator.permissions
+                .query({
+                    // @ts-expect-error outdated type definitions
+                    name: 'local-network-access',
+                })
+                .catch(() => undefined);
+            if (permission) {
                 this.localNetworkPermissionState = permission.state;
-            };
+                permission.onchange = () => {
+                    this.localNetworkPermissionState = permission.state;
+                };
+            }
         }
 
         // manifest is required in all implementations. for core-in-suite-desktop, also manifest.appName is required

--- a/suite/e2e/tests/trezor-connect/error.test.ts
+++ b/suite/e2e/tests/trezor-connect/error.test.ts
@@ -3,7 +3,7 @@ import TrezorConnect from '@trezor/connect-web';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
+++ b/suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe(
     'TrezorConnect.ethereumSignMessage',
-    { tag: ['@group=connect', '@desktopOnly'] },
+    { tag: ['@T3T1', '@T3W1', '@desktopOnly'] },
     () => {
         test.use({ electronConf: { exposeConnectWs: true } });
         test.beforeEach(async ({ onboardingPage }) => {

--- a/suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts
+++ b/suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.describe(
     'TrezorConnect.ethereumSignTransaction',
-    { tag: ['@group=connect', '@desktopOnly'] },
+    { tag: ['@T3T1', '@T3W1', '@desktopOnly'] },
     () => {
         test.use({ electronConf: { exposeConnectWs: true } });
         test.beforeEach(async ({ onboardingPage }) => {

--- a/suite/e2e/tests/trezor-connect/getAccountInfo.test.ts
+++ b/suite/e2e/tests/trezor-connect/getAccountInfo.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.getAccountInfo', { tag: ['@group=connect', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.getAccountInfo', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/suite/e2e/tests/trezor-connect/getAddress.test.ts
+++ b/suite/e2e/tests/trezor-connect/getAddress.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { expect, test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.getAddress', { tag: ['@group=connect', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.getAddress', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();

--- a/suite/e2e/tests/trezor-connect/permissions.test.ts
+++ b/suite/e2e/tests/trezor-connect/permissions.test.ts
@@ -4,7 +4,7 @@ import TrezorConnect from '@trezor/connect-web';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
@@ -39,7 +39,9 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
                 coin: 'btc',
             });
 
-            await expect(connectPermissionsModal.processParagraph).toHaveText('node');
+            await expect(connectPermissionsModal.processParagraph).toHaveText(
+                /^(node|MainThread)$/,
+            );
             await expect(connectPermissionsModal.rememberCheckbox).toHaveTranslation(
                 'TR_CONNECT_MODAL_REMEMBER',
             );
@@ -68,7 +70,9 @@ test.describe('TrezorConnect', { tag: ['@group=connect', '@desktopOnly'] }, () =
                 path: "m/44'/0'/0'/0/0",
                 coin: 'btc',
             });
-            await expect(connectPermissionsModal.processParagraph).toHaveText('node');
+            await expect(connectPermissionsModal.processParagraph).toHaveText(
+                /^(node|MainThread)$/,
+            );
         },
     );
 });

--- a/suite/e2e/tests/trezor-connect/signTransaction.test.ts
+++ b/suite/e2e/tests/trezor-connect/signTransaction.test.ts
@@ -2,7 +2,7 @@ import TrezorConnect from '@trezor/connect-web';
 
 import { test } from '../../support/fixtures';
 
-test.describe('TrezorConnect.signTransaction', { tag: ['@group=connect', '@desktopOnly'] }, () => {
+test.describe('TrezorConnect.signTransaction', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();


### PR DESCRIPTION
It turned out that the connect-popup tests have been turned off for some time. This PR re-enables them. 

the tmp commit should probably be removed before merging

 please halp @HajekOndrej @Vere-Grey 

