### PR TITLE
Add calldata package for type-safe tx encoding

### DIFF
--- a/suite-common/calldata/README.md
+++ b/suite-common/calldata/README.md
@@ -1,0 +1,159 @@
+# @suite-common/calldata
+
+## Overview
+
+Type-safe calldata builder for blockchain transactions. Validates inputs, normalizes values, applies configurable policies (error/warning/ignore), and encodes transaction data.
+
+Built with chain-agnostic core - add validators and encoders for any chain. Currently implements EVM using viem.
+
+## Usage
+
+```typescript
+import { Calldata } from '@suite-common/calldata';
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+const result = Calldata.evm.erc20.approve(
+    {
+        spender: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
+        amount: asAmountSubunit(new BigNumber('1000000')),
+    },
+    { sender: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3' },
+);
+
+if (result.isValid) {
+    console.log(result.data);
+} else {
+    console.log(result.errors);
+}
+```
+
+The second argument is context - additional data for validation (e.g., sender address for self-transfer detection). Required fields depend on the builder.
+
+## Architecture
+
+### Flow
+
+```
+Input → Validate → Normalize → Inspect → Policy → Encode → Calldata
+```
+
+1. **Validate** - check raw input format (e.g., valid address string)
+2. **Normalize** - transform to typed value (e.g., lowercase address)
+3. **Inspect** - check normalized value for issues (e.g., zero address, self-transfer)
+4. **Policy** - categorize issues as `error`, `warning`, or `ignore`
+5. **Encode** - if no errors, encode params to calldata
+
+### Validator
+
+Validators use `createValidator` factory with three stages:
+
+```typescript
+const validateAddress = createValidator({
+    validate: [isValidAddress],
+    normalize: input => input.toLowerCase(),
+    inspect: [isZeroAddress, isSameAsSender],
+});
+```
+
+- `validate` - array of checks, stops at first failure
+- `normalize` - transforms valid input to typed output
+- `inspect` - optional checks on normalized value, collects all issues
+
+### Policy
+
+Policies map issue codes to severities:
+
+```typescript
+const policy = createPolicy({
+    ZERO_ADDRESS: 'error',
+    SELF_ADDRESS: 'warning',
+    ZERO_AMOUNT: 'ignore',
+});
+```
+
+### Param
+
+Combines validator with policy:
+
+```typescript
+const spenderParam = createParam({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'warning' }),
+});
+```
+
+### Encoder
+
+Encoders are chain-specific - implement one per chain.
+
+EVM encoder uses viem's `encodeFunctionData`.
+
+```typescript
+const encode = createEvmEncoder(EVM_ABI.erc20.approve);
+```
+
+### Builder
+
+Combines params with encoder:
+
+```typescript
+const buildApprove = createBuilder({
+    params: {
+        spender: spenderParam,
+        amount: amountParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc20.approve),
+});
+```
+
+Parameter names (`spender`, `amount`) are derived directly from the ABI - TypeScript will error on wrong param names or types.
+
+## Adding New Calls
+
+1. **Add ABI to constants**
+
+```typescript
+// constants/evm.ts
+export const EVM_ABI = {
+    erc20: {
+        approve: parseAbi(['function approve(address spender, uint256 amount)']),
+        transfer: parseAbi(['function transfer(address to, uint256 amount)']),
+    },
+};
+```
+
+2. **Create builder**
+
+```typescript
+// builder/evm/myMethod.ts
+const recipientParam = createParam({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error' }),
+});
+
+const amountParam = createParam({
+    validate: validateUint256,
+});
+
+export const buildMyMethod = createBuilder({
+    params: {
+        recipient: recipientParam,
+        amount: amountParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.myContract.myMethod),
+});
+```
+
+3. **Export from Calldata**
+
+```typescript
+// calldata.ts
+export const Calldata = {
+    evm: {
+        myContract: {
+            myMethod: buildMyMethod,
+        },
+    },
+};
+```

--- a/suite-common/calldata/jest.config.js
+++ b/suite-common/calldata/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for web packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.base` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/calldata/package.json
+++ b/suite-common/calldata/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@suite-common/calldata",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/suite-constants": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
+        "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*",
+        "viem": "^2.39.0"
+    }
+}

--- a/suite-common/calldata/src/builder/createBuilder.ts
+++ b/suite-common/calldata/src/builder/createBuilder.ts
@@ -1,0 +1,67 @@
+import { typedObjectFromEntries } from '@trezor/utils';
+
+import {
+    BuildResult,
+    Builder,
+    BuilderConfig,
+    Encoder,
+    ExtractContext,
+    ExtractEncoderOutput,
+    ExtractInputs,
+    ExtractParamNames,
+    ParamsConfig,
+} from '../types/builder';
+
+export const createBuilder = <
+    E extends Encoder<string, unknown>,
+    Config extends ParamsConfig<ExtractParamNames<E>>,
+>(
+    config: BuilderConfig<E> & { params: ParamsConfig<ExtractParamNames<E>, Config> },
+): Builder<
+    ExtractInputs<ExtractParamNames<E>, Config>,
+    ExtractContext<Config>,
+    ExtractEncoderOutput<E>
+> => {
+    const paramNames = Object.keys(config.params) as ExtractParamNames<E>[];
+
+    return (
+        inputs: Record<string, unknown>,
+        context: unknown = {},
+    ): BuildResult<ExtractEncoderOutput<E>> => {
+        const results = paramNames.map(paramName => ({
+            paramName,
+            ...config.params[paramName](inputs[paramName], paramName, context),
+        }));
+
+        const issues = results.flatMap(r => r.issues);
+        const errors = results.flatMap(r => r.errors);
+        const warnings = results.flatMap(r => r.warnings);
+        const isValid = results.every(r => r.isValid);
+
+        if (!isValid) {
+            return { data: null, issues, errors, warnings, isValid };
+        }
+
+        const values = typedObjectFromEntries(results.map(r => [r.paramName, r.value] as const));
+
+        try {
+            const data = config.encode(values) as ExtractEncoderOutput<E>;
+
+            return { data, issues, errors, warnings, isValid };
+        } catch {
+            const encodingError = {
+                code: 'ENCODING_FAILED' as const,
+                path: null,
+                severity: 'error' as const,
+            };
+
+            return {
+                data: null,
+                issues: [...issues, encodingError],
+                errors: [...errors, encodingError],
+                warnings,
+                isValid: false,
+            };
+        }
+    };
+};

--- a/suite-common/calldata/src/builder/createParam.ts
+++ b/suite-common/calldata/src/builder/createParam.ts
@@ -1,0 +1,18 @@
+import { createPolicy } from '../policy/createPolicy';
+import type { Param, ParamConfig } from '../types/param';
+
+export const createParam = <Input, Output, Context = void>(
+    config: ParamConfig<Input, Output, Context>,
+): Param<Input, Output, Context> => {
+    const policy = config.policy ?? createPolicy();
+
+    return (input, path, context) => {
+        const validationResult = config.validate(input, path, context);
+        const policyResult = policy(validationResult.issues);
+
+        return {
+            ...policyResult,
+            value: validationResult.value,
+        };
+    };
+};

--- a/suite-common/calldata/src/builder/evm/approve.ts
+++ b/suite-common/calldata/src/builder/evm/approve.ts
@@ -1,0 +1,31 @@
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { EvmAddress } from '../../types/evm';
+import { validateAddress } from '../../validation/evm/address';
+import { validateUint256 } from '../../validation/evm/uint256';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+type ApproveContext = {
+    sender: EvmAddress;
+};
+
+const spenderParam = createParam<string, EvmAddress, ApproveContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'warning', SELF_ADDRESS: 'warning' }),
+});
+
+const amountParam = createParam<AmountSubunit, bigint, ApproveContext>({
+    validate: validateUint256,
+});
+
+export const buildApprove = createBuilder({
+    params: {
+        spender: spenderParam,
+        amount: amountParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc20.approve),
+});

--- a/suite-common/calldata/src/builder/evm/deposit.ts
+++ b/suite-common/calldata/src/builder/evm/deposit.ts
@@ -1,0 +1,33 @@
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { EvmAddress } from '../../types/evm';
+import { validateAddress } from '../../validation/evm/address';
+import { validateUint256 } from '../../validation/evm/uint256';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+type DepositContext = {
+    sender: EvmAddress;
+    balance?: bigint;
+};
+
+const assetsParam = createParam<AmountSubunit, bigint, DepositContext>({
+    validate: validateUint256,
+    policy: createPolicy({ ZERO_AMOUNT: 'error' }),
+});
+
+const receiverParam = createParam<string, EvmAddress, DepositContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error', NOT_SAME_AS_SENDER: 'error' }),
+});
+
+export const buildDeposit = createBuilder({
+    params: {
+        assets: assetsParam,
+        receiver: receiverParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc4626.deposit),
+});

--- a/suite-common/calldata/src/builder/evm/redeem.ts
+++ b/suite-common/calldata/src/builder/evm/redeem.ts
@@ -1,0 +1,39 @@
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { EvmAddress } from '../../types/evm';
+import { validateAddress } from '../../validation/evm/address';
+import { validateUint256 } from '../../validation/evm/uint256';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+type RedeemContext = {
+    sender: EvmAddress;
+    balance?: bigint;
+};
+
+const sharesParam = createParam<AmountSubunit, bigint, RedeemContext>({
+    validate: validateUint256,
+    policy: createPolicy({ ZERO_AMOUNT: 'error' }),
+});
+
+const receiverParam = createParam<string, EvmAddress, RedeemContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error', NOT_SAME_AS_SENDER: 'error' }),
+});
+
+const ownerParam = createParam<string, EvmAddress, RedeemContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error', NOT_SAME_AS_SENDER: 'error' }),
+});
+
+export const buildRedeem = createBuilder({
+    params: {
+        shares: sharesParam,
+        receiver: receiverParam,
+        owner: ownerParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc4626.redeem),
+});

--- a/suite-common/calldata/src/builder/evm/transfer.ts
+++ b/suite-common/calldata/src/builder/evm/transfer.ts
@@ -1,0 +1,32 @@
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { EvmAddress } from '../../types/evm';
+import { validateAddress } from '../../validation/evm/address';
+import { validateUint256 } from '../../validation/evm/uint256';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+type TransferContext = {
+    sender: EvmAddress;
+    balance?: bigint;
+};
+
+const toParam = createParam<string, EvmAddress, TransferContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'warning', SELF_ADDRESS: 'warning' }),
+});
+
+const amountParam = createParam<AmountSubunit, bigint, TransferContext>({
+    validate: validateUint256,
+});
+
+export const buildTransfer = createBuilder({
+    params: {
+        to: toParam,
+        amount: amountParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc20.transfer),
+});

--- a/suite-common/calldata/src/builder/evm/withdraw.ts
+++ b/suite-common/calldata/src/builder/evm/withdraw.ts
@@ -1,0 +1,39 @@
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { EvmAddress } from '../../types/evm';
+import { validateAddress } from '../../validation/evm/address';
+import { validateUint256 } from '../../validation/evm/uint256';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+type WithdrawContext = {
+    sender: EvmAddress;
+    balance?: bigint;
+};
+
+const assetsParam = createParam<AmountSubunit, bigint, WithdrawContext>({
+    validate: validateUint256,
+    policy: createPolicy({ ZERO_AMOUNT: 'error' }),
+});
+
+const receiverParam = createParam<string, EvmAddress, WithdrawContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error', NOT_SAME_AS_SENDER: 'error' }),
+});
+
+const ownerParam = createParam<string, EvmAddress, WithdrawContext>({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error', NOT_SAME_AS_SENDER: 'error' }),
+});
+
+export const buildWithdraw = createBuilder({
+    params: {
+        assets: assetsParam,
+        receiver: receiverParam,
+        owner: ownerParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc4626.withdraw),
+});

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -1,0 +1,19 @@
+import { buildApprove } from './builder/evm/approve';
+import { buildDeposit } from './builder/evm/deposit';
+import { buildRedeem } from './builder/evm/redeem';
+import { buildTransfer } from './builder/evm/transfer';
+import { buildWithdraw } from './builder/evm/withdraw';
+
+export const Calldata = {
+    evm: {
+        erc20: {
+            approve: buildApprove,
+            transfer: buildTransfer,
+        },
+        erc4626: {
+            deposit: buildDeposit,
+            withdraw: buildWithdraw,
+            redeem: buildRedeem,
+        },
+    },
+} as const;

--- a/suite-common/calldata/src/constants/evm.ts
+++ b/suite-common/calldata/src/constants/evm.ts
@@ -1,0 +1,13 @@
+import { parseAbi } from 'viem';
+
+export const EVM_ABI = {
+    erc20: {
+        approve: parseAbi(['function approve(address spender, uint256 amount)']),
+        transfer: parseAbi(['function transfer(address to, uint256 amount)']),
+    },
+    erc4626: {
+        deposit: parseAbi(['function deposit(uint256 assets, address receiver)']),
+        withdraw: parseAbi(['function withdraw(uint256 assets, address receiver, address owner)']),
+        redeem: parseAbi(['function redeem(uint256 shares, address receiver, address owner)']),
+    },
+} as const;

--- a/suite-common/calldata/src/encoder/evm.ts
+++ b/suite-common/calldata/src/encoder/evm.ts
@@ -1,0 +1,55 @@
+import { Abi, AbiFunction, AbiParameter, encodeFunctionData } from 'viem';
+
+import { Encoder } from '../types/encoder';
+
+type ExtractAbiFunction<T extends Abi> = Extract<T[number], AbiFunction>;
+
+type NamedAbiParameter = AbiParameter & { name: string };
+
+type AbiParamName<T extends Abi> =
+    ExtractAbiFunction<T> extends infer F extends AbiFunction
+        ? Extract<F['inputs'][number], NamedAbiParameter>['name']
+        : never;
+
+export const createEvmEncoder = <const T extends Abi>(
+    abi: T,
+): Encoder<AbiParamName<T>, `0x${string}`> => {
+    const functions = abi.filter((item): item is AbiFunction => item.type === 'function');
+    if (functions.length === 0) throw new Error('No function in ABI');
+    if (functions.length > 1) throw new Error('ABI must contain exactly one function');
+
+    const fn = functions[0];
+
+    const paramNames = fn.inputs.map(input => {
+        if (!input.name) {
+            throw new Error(`ABI function '${fn.name}' has unnamed parameters`);
+        }
+
+        return input.name;
+    });
+
+    return (values: Record<string, unknown>): `0x${string}` => {
+        const valueKeys = Object.keys(values);
+
+        if (valueKeys.length !== paramNames.length) {
+            throw new Error(
+                `Param count mismatch for '${fn.name}': expected ${paramNames.length}, got ${valueKeys.length}`,
+            );
+        }
+
+        for (const name of paramNames) {
+            if (!(name in values)) {
+                throw new Error(`Missing param '${name}' for function '${fn.name}'`);
+            }
+            if (values[name] === undefined || values[name] === null) {
+                throw new Error(`${fn.name}: Param '${name}' cannot be null/undefined`);
+            }
+        }
+
+        return encodeFunctionData({
+            abi,
+            functionName: fn.name,
+            args: paramNames.map(name => values[name]),
+        } as Parameters<typeof encodeFunctionData>[0]);
+    };
+};

--- a/suite-common/calldata/src/fixtures/policy/createPolicy.fixture.ts
+++ b/suite-common/calldata/src/fixtures/policy/createPolicy.fixture.ts
@@ -1,0 +1,91 @@
+import { PolicyConfig, PolicyResult } from '../../types/policy';
+import { Issue } from '../../types/validation';
+
+interface CreatePolicyTestCase {
+    description: string;
+    overrides?: Partial<PolicyConfig>;
+    issues: Issue[];
+    expected: PolicyResult;
+}
+
+export const createPolicyTestCases: CreatePolicyTestCase[] = [
+    {
+        description: 'default policy with error issue returns isValid false',
+        issues: [{ code: 'INVALID_ADDRESS', path: 'to' }],
+        expected: {
+            issues: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }],
+            errors: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }],
+            warnings: [],
+            isValid: false,
+        },
+    },
+    {
+        description: 'default policy with warning issue returns isValid true',
+        issues: [{ code: 'ZERO_ADDRESS', path: 'to' }],
+        expected: {
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        },
+    },
+    {
+        description: 'override to ignore excludes issue from result',
+        overrides: { ZERO_ADDRESS: 'ignore' },
+        issues: [{ code: 'ZERO_ADDRESS', path: 'to' }],
+        expected: {
+            issues: [],
+            errors: [],
+            warnings: [],
+            isValid: true,
+        },
+    },
+    {
+        description: 'override error to warning makes isValid true',
+        overrides: { INVALID_ADDRESS: 'warning' },
+        issues: [{ code: 'INVALID_ADDRESS', path: 'to' }],
+        expected: {
+            issues: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        },
+    },
+    {
+        description: 'override warning to error makes isValid false',
+        overrides: { ZERO_AMOUNT: 'error' },
+        issues: [{ code: 'ZERO_AMOUNT', path: 'amount' }],
+        expected: {
+            issues: [{ code: 'ZERO_AMOUNT', path: 'amount', severity: 'error' }],
+            errors: [{ code: 'ZERO_AMOUNT', path: 'amount', severity: 'error' }],
+            warnings: [],
+            isValid: false,
+        },
+    },
+    {
+        description: 'multiple issues are categorized correctly',
+        issues: [
+            { code: 'INVALID_ADDRESS', path: 'to' },
+            { code: 'ZERO_AMOUNT', path: 'amount' },
+        ],
+        expected: {
+            issues: [
+                { code: 'INVALID_ADDRESS', path: 'to', severity: 'error' },
+                { code: 'ZERO_AMOUNT', path: 'amount', severity: 'warning' },
+            ],
+            errors: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }],
+            warnings: [{ code: 'ZERO_AMOUNT', path: 'amount', severity: 'warning' }],
+            isValid: false,
+        },
+    },
+    {
+        description: 'empty issues returns empty arrays and isValid true',
+        issues: [],
+        expected: {
+            issues: [],
+            errors: [],
+            warnings: [],
+            isValid: true,
+        },
+    },
+];

--- a/suite-common/calldata/src/fixtures/validation/evm/address.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/address.fixture.ts
@@ -1,0 +1,173 @@
+import { EvmAddress } from '../../../types/evm';
+import { IssueCode } from '../../../types/validation';
+
+type IsValidAddressTestCase = {
+    description: string;
+    input: string;
+    expected: IssueCode | null;
+};
+
+type IsZeroAddressTestCase = {
+    description: string;
+    input: EvmAddress;
+    expected: IssueCode | null;
+};
+
+type IsSameAsSenderTestCase = {
+    description: string;
+    input: EvmAddress;
+    context?: { sender?: EvmAddress };
+    expected: IssueCode | null;
+};
+
+const SENDER = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress;
+
+export const isValidAddressTestCases: IsValidAddressTestCase[] = [
+    {
+        description: 'valid lowercase address',
+        input: '0x1111111111111111111111111111111111111111',
+        expected: null,
+    },
+    {
+        description: 'valid mixed case address',
+        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        expected: null,
+    },
+    {
+        description: 'too short',
+        input: '0x123456789012345678901234567890123456789',
+        expected: 'INVALID_ADDRESS',
+    },
+    {
+        description: 'too long',
+        input: '0x12345678901234567890123456789012345678901',
+        expected: 'INVALID_ADDRESS',
+    },
+    {
+        description: 'missing 0x prefix',
+        input: '1234567890123456789012345678901234567890',
+        expected: 'INVALID_ADDRESS',
+    },
+    {
+        description: 'invalid hex characters',
+        input: '0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+        expected: 'INVALID_ADDRESS',
+    },
+    {
+        description: 'empty string',
+        input: '',
+        expected: 'INVALID_ADDRESS',
+    },
+];
+
+export const isZeroAddressTestCases: IsZeroAddressTestCase[] = [
+    {
+        description: 'zero address returns ZERO_ADDRESS',
+        input: '0x0000000000000000000000000000000000000000' as EvmAddress,
+        expected: 'ZERO_ADDRESS',
+    },
+    {
+        description: 'non-zero address returns null',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        expected: null,
+    },
+];
+
+export const isSameAsSenderTestCases: IsSameAsSenderTestCase[] = [
+    {
+        description: 'same address same case returns SELF_ADDRESS',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        context: { sender: SENDER },
+        expected: 'SELF_ADDRESS',
+    },
+    {
+        description: 'same address different case returns SELF_ADDRESS',
+        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        context: { sender: SENDER },
+        expected: 'SELF_ADDRESS',
+    },
+    {
+        description: 'different address returns null',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        context: { sender: SENDER },
+        expected: null,
+    },
+    {
+        description: 'no sender in context returns null',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        context: {},
+        expected: null,
+    },
+];
+
+export const isNotSameAsSenderTestCases: IsSameAsSenderTestCase[] = [
+    {
+        description: 'different address returns NOT_SAME_AS_SENDER',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        context: { sender: SENDER },
+        expected: 'NOT_SAME_AS_SENDER',
+    },
+    {
+        description: 'same address different case returns null',
+        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        context: { sender: SENDER },
+        expected: null,
+    },
+    {
+        description: 'same address returns null',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        context: { sender: SENDER },
+        expected: null,
+    },
+    {
+        description: 'no sender in context returns null',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        context: {},
+        expected: null,
+    },
+];
+
+type IsNotWhitelistedTestCase = {
+    description: string;
+    input: EvmAddress;
+    context: { addressWhitelist?: EvmAddress[] };
+    expected: IssueCode | null;
+};
+
+const WHITELIST: EvmAddress[] = [
+    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+    '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as EvmAddress,
+];
+
+export const isNotWhitelistedTestCases: IsNotWhitelistedTestCase[] = [
+    {
+        description: 'address in whitelist returns null',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        context: { addressWhitelist: WHITELIST },
+        expected: null,
+    },
+    {
+        description: 'address not in whitelist returns ADDRESS_NOT_WHITELISTED',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        context: { addressWhitelist: WHITELIST },
+        expected: 'ADDRESS_NOT_WHITELISTED',
+    },
+    {
+        description: 'address in whitelist different case returns null',
+        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        context: { addressWhitelist: WHITELIST },
+        expected: null,
+    },
+    {
+        description: 'no whitelist in context returns null',
+        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        context: {},
+        expected: null,
+    },
+    {
+        description: 'empty whitelist rejects all addresses',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        context: { addressWhitelist: [] },
+        expected: 'ADDRESS_NOT_WHITELISTED',
+    },
+];

--- a/suite-common/calldata/src/fixtures/validation/evm/uint256.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/uint256.fixture.ts
@@ -1,0 +1,119 @@
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { AmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { IssueCode } from '../../../types/validation';
+
+type ValidateFnTestCase = {
+    description: string;
+    input: AmountSubunit;
+    expected: IssueCode | null;
+};
+
+type IsZeroTestCase = {
+    description: string;
+    input: bigint;
+    expected: IssueCode | null;
+};
+
+type HasBalanceTestCase = {
+    description: string;
+    input: bigint;
+    context: { balance?: bigint };
+    expected: IssueCode | null;
+};
+
+export const isNegativeTestCases: ValidateFnTestCase[] = [
+    {
+        description: 'positive number returns null',
+        input: new BigNumber('100') as AmountSubunit,
+        expected: null,
+    },
+    {
+        description: 'zero returns null',
+        input: new BigNumber('0') as AmountSubunit,
+        expected: null,
+    },
+    {
+        description: 'negative number returns NEGATIVE_AMOUNT',
+        input: new BigNumber('-1') as AmountSubunit,
+        expected: 'NEGATIVE_AMOUNT',
+    },
+];
+
+export const isNotIntegerTestCases: ValidateFnTestCase[] = [
+    {
+        description: 'integer returns null',
+        input: new BigNumber('100') as AmountSubunit,
+        expected: null,
+    },
+    {
+        description: 'decimal returns NOT_INTEGER',
+        input: new BigNumber('1.5') as AmountSubunit,
+        expected: 'NOT_INTEGER',
+    },
+];
+
+export const exceedsUint256TestCases: ValidateFnTestCase[] = [
+    {
+        description: 'value within range returns null',
+        input: new BigNumber('100') as AmountSubunit,
+        expected: null,
+    },
+    {
+        description: 'value equal to UINT256_MAX returns null',
+        input: new BigNumber(UINT256_MAX) as AmountSubunit,
+        expected: null,
+    },
+    {
+        description: 'value exceeding UINT256_MAX returns EXCEEDS_UINT256',
+        input: new BigNumber(UINT256_MAX).plus(1) as AmountSubunit,
+        expected: 'EXCEEDS_UINT256',
+    },
+];
+
+export const isZeroTestCases: IsZeroTestCase[] = [
+    {
+        description: 'zero returns ZERO_AMOUNT',
+        input: 0n,
+        expected: 'ZERO_AMOUNT',
+    },
+    {
+        description: 'non-zero returns null',
+        input: 100n,
+        expected: null,
+    },
+];
+
+export const hasBalanceTestCases: HasBalanceTestCase[] = [
+    {
+        description: 'balance undefined returns null',
+        input: 100n,
+        context: {},
+        expected: null,
+    },
+    {
+        description: 'input less than balance returns null',
+        input: 50n,
+        context: { balance: 100n },
+        expected: null,
+    },
+    {
+        description: 'input equal to balance returns null',
+        input: 100n,
+        context: { balance: 100n },
+        expected: null,
+    },
+    {
+        description: 'input greater than balance returns INSUFFICIENT_BALANCE',
+        input: 101n,
+        context: { balance: 100n },
+        expected: 'INSUFFICIENT_BALANCE',
+    },
+    {
+        description: 'balance is 0 and input is positive returns INSUFFICIENT_BALANCE',
+        input: 1n,
+        context: { balance: 0n },
+        expected: 'INSUFFICIENT_BALANCE',
+    },
+];

--- a/suite-common/calldata/src/fixtures/validation/evm/validateAddress.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/validateAddress.fixture.ts
@@ -1,0 +1,86 @@
+import { EvmAddress } from '../../../types/evm';
+import { ValidationResult } from '../../../types/validation';
+
+interface ValidateAddressTestCase {
+    description: string;
+    input: string;
+    context?: { sender?: EvmAddress; addressWhitelist?: EvmAddress[] };
+    expected: ValidationResult<EvmAddress>;
+}
+
+const VALID_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as EvmAddress;
+
+export const validateAddressTestCases: ValidateAddressTestCase[] = [
+    {
+        description: 'valid address returns normalized value with no issues',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        expected: {
+            value: VALID_ADDRESS,
+            issues: [],
+        },
+    },
+    {
+        description: 'invalid address returns INVALID_ADDRESS issue',
+        input: 'not-an-address',
+        expected: {
+            value: null,
+            issues: [{ code: 'INVALID_ADDRESS', path: 'to' }],
+        },
+    },
+    {
+        description: 'uppercase address is normalized to lowercase',
+        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        expected: {
+            value: VALID_ADDRESS,
+            issues: [],
+        },
+    },
+    {
+        description: 'mixed case address is normalized to lowercase',
+        input: '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa',
+        expected: {
+            value: VALID_ADDRESS,
+            issues: [],
+        },
+    },
+    {
+        description: 'zero address as sender returns both ZERO_ADDRESS and SELF_ADDRESS issues',
+        input: '0x0000000000000000000000000000000000000000',
+        context: { sender: ZERO_ADDRESS },
+        expected: {
+            value: ZERO_ADDRESS,
+            issues: [
+                { code: 'ZERO_ADDRESS', path: 'to' },
+                { code: 'SELF_ADDRESS', path: 'to' },
+            ],
+        },
+    },
+    {
+        description: 'address different from sender returns NOT_SAME_AS_SENDER issue',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        context: { sender: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as EvmAddress },
+        expected: {
+            value: VALID_ADDRESS,
+            issues: [{ code: 'NOT_SAME_AS_SENDER', path: 'to' }],
+        },
+    },
+    {
+        description: 'address not in whitelist returns ADDRESS_NOT_WHITELISTED issue',
+        input: '0xcccccccccccccccccccccccccccccccccccccccc',
+        context: { addressWhitelist: [VALID_ADDRESS] },
+        expected: {
+            value: '0xcccccccccccccccccccccccccccccccccccccccc' as EvmAddress,
+            issues: [{ code: 'ADDRESS_NOT_WHITELISTED', path: 'to' }],
+        },
+    },
+    {
+        description: 'address in whitelist returns no whitelist issue',
+        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        context: { addressWhitelist: [VALID_ADDRESS] },
+        expected: {
+            value: VALID_ADDRESS,
+            issues: [],
+        },
+    },
+];

--- a/suite-common/calldata/src/fixtures/validation/evm/validateUint256.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/validateUint256.fixture.ts
@@ -1,0 +1,88 @@
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { AmountSubunit, asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { ValidationResult } from '../../../types/validation';
+
+interface ValidateUint256TestCase {
+    description: string;
+    input: AmountSubunit;
+    context?: { balance?: bigint };
+    expected: ValidationResult<bigint>;
+}
+
+export const validateUint256TestCases: ValidateUint256TestCase[] = [
+    {
+        description: 'valid amount returns normalized bigint with no issues',
+        input: asAmountSubunit(new BigNumber('1000000000000000000')),
+        expected: {
+            value: 1000000000000000000n,
+            issues: [],
+        },
+    },
+    {
+        description: 'negative amount returns NEGATIVE_AMOUNT issue',
+        input: asAmountSubunit(new BigNumber('-1')),
+        expected: {
+            value: null,
+            issues: [{ code: 'NEGATIVE_AMOUNT', path: 'amount' }],
+        },
+    },
+    {
+        description: 'non-integer amount returns NOT_INTEGER issue',
+        input: asAmountSubunit(new BigNumber('1.5')),
+        expected: {
+            value: null,
+            issues: [{ code: 'NOT_INTEGER', path: 'amount' }],
+        },
+    },
+    {
+        description: 'negative decimal returns NEGATIVE_AMOUNT (first validation)',
+        input: asAmountSubunit(new BigNumber('-1.5')),
+        expected: {
+            value: null,
+            issues: [{ code: 'NEGATIVE_AMOUNT', path: 'amount' }],
+        },
+    },
+    {
+        description: 'exact UINT256_MAX is valid',
+        input: asAmountSubunit(new BigNumber(UINT256_MAX)),
+        expected: {
+            value: BigInt(UINT256_MAX),
+            issues: [],
+        },
+    },
+    {
+        description: 'amount exceeding uint256 returns EXCEEDS_UINT256 issue',
+        input: asAmountSubunit(new BigNumber(UINT256_MAX).plus(1)),
+        expected: {
+            value: null,
+            issues: [{ code: 'EXCEEDS_UINT256', path: 'amount' }],
+        },
+    },
+    {
+        description: 'zero amount returns ZERO_AMOUNT issue',
+        input: asAmountSubunit(new BigNumber('0')),
+        expected: {
+            value: 0n,
+            issues: [{ code: 'ZERO_AMOUNT', path: 'amount' }],
+        },
+    },
+    {
+        description: 'amount exceeding balance returns INSUFFICIENT_BALANCE issue',
+        input: asAmountSubunit(new BigNumber('1000')),
+        context: { balance: 500n },
+        expected: {
+            value: 1000n,
+            issues: [{ code: 'INSUFFICIENT_BALANCE', path: 'amount' }],
+        },
+    },
+    {
+        description: 'no context provided works without INSUFFICIENT_BALANCE issue',
+        input: asAmountSubunit(new BigNumber('1000')),
+        expected: {
+            value: 1000n,
+            issues: [],
+        },
+    },
+];

--- a/suite-common/calldata/src/index.ts
+++ b/suite-common/calldata/src/index.ts
@@ -1,0 +1,1 @@
+export { Calldata } from './calldata';

--- a/suite-common/calldata/src/policy/createPolicy.ts
+++ b/suite-common/calldata/src/policy/createPolicy.ts
@@ -1,0 +1,42 @@
+import { IssueWithSeverity, PolicyConfig, PolicyResult } from '../types/policy';
+import { Issue } from '../types/validation';
+
+const DEFAULT_POLICY: PolicyConfig = {
+    // Address
+    INVALID_ADDRESS: 'error',
+    ZERO_ADDRESS: 'warning',
+    SELF_ADDRESS: 'ignore',
+    NOT_SAME_AS_SENDER: 'ignore',
+    ADDRESS_NOT_WHITELISTED: 'error',
+
+    // Amount
+    NEGATIVE_AMOUNT: 'error',
+    NOT_INTEGER: 'error',
+    EXCEEDS_UINT256: 'error',
+    ZERO_AMOUNT: 'warning',
+    INSUFFICIENT_BALANCE: 'warning',
+
+    // Encoding
+    ENCODING_FAILED: 'error',
+};
+
+export const createPolicy = (overrides?: Partial<PolicyConfig>) => {
+    const config: PolicyConfig = { ...DEFAULT_POLICY, ...overrides };
+
+    return (issues: Issue[]): PolicyResult => {
+        const categorized = issues.map<IssueWithSeverity>(issue => ({
+            ...issue,
+            severity: config[issue.code],
+        }));
+
+        const errors = categorized.filter(issue => issue.severity === 'error');
+        const warnings = categorized.filter(issue => issue.severity === 'warning');
+
+        return {
+            issues: categorized.filter(issue => issue.severity !== 'ignore'),
+            errors,
+            warnings,
+            isValid: errors.length === 0,
+        };
+    };
+};

--- a/suite-common/calldata/src/tests/builder/createBuilder.test.ts
+++ b/suite-common/calldata/src/tests/builder/createBuilder.test.ts
@@ -1,0 +1,129 @@
+import { createBuilder } from '../../builder/createBuilder';
+import { Encoder } from '../../types/builder';
+
+describe('createBuilder', () => {
+    it('calls params and encode, returns encoded data when all valid', () => {
+        const toParam = jest.fn().mockReturnValue({
+            value: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        });
+        const amountParam = jest.fn().mockReturnValue({
+            value: 1000n,
+            issues: [],
+            errors: [],
+            warnings: [],
+            isValid: true,
+        });
+        const encode: Encoder<'to' | 'amount', string> = jest.fn().mockReturnValue('0xencoded');
+        const context = { sender: '0xsender', balance: 5000n };
+
+        const builder = createBuilder({
+            encode,
+            params: { to: toParam, amount: amountParam },
+        });
+
+        const result = builder(
+            { to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', amount: '1000' },
+            context,
+        );
+
+        expect(toParam).toHaveBeenCalledWith(
+            '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            'to',
+            context,
+        );
+        expect(amountParam).toHaveBeenCalledWith('1000', 'amount', context);
+        expect(encode).toHaveBeenCalledWith({
+            to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            amount: 1000n,
+        });
+        expect(result).toEqual({
+            data: '0xencoded',
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        });
+    });
+
+    it('returns null data and collects all errors when params invalid', () => {
+        const toParam = jest.fn().mockReturnValue({
+            value: null,
+            issues: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }],
+            errors: [{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }],
+            warnings: [],
+            isValid: false,
+        });
+        const amountParam = jest.fn().mockReturnValue({
+            value: null,
+            issues: [{ code: 'NEGATIVE_AMOUNT', path: 'amount', severity: 'error' }],
+            errors: [{ code: 'NEGATIVE_AMOUNT', path: 'amount', severity: 'error' }],
+            warnings: [],
+            isValid: false,
+        });
+        const encode: Encoder<'to' | 'amount', string> = jest.fn();
+
+        const builder = createBuilder({
+            encode,
+            params: { to: toParam, amount: amountParam },
+        });
+
+        const result = builder({ to: 'invalid', amount: '-100' });
+
+        expect(encode).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            data: null,
+            issues: [
+                { code: 'INVALID_ADDRESS', path: 'to', severity: 'error' },
+                { code: 'NEGATIVE_AMOUNT', path: 'amount', severity: 'error' },
+            ],
+            errors: [
+                { code: 'INVALID_ADDRESS', path: 'to', severity: 'error' },
+                { code: 'NEGATIVE_AMOUNT', path: 'amount', severity: 'error' },
+            ],
+            warnings: [],
+            isValid: false,
+        });
+    });
+
+    it('returns ENCODING_FAILED when encoder throws', () => {
+        const toParam = jest.fn().mockReturnValue({
+            value: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            issues: [],
+            errors: [],
+            warnings: [],
+            isValid: true,
+        });
+        const amountParam = jest.fn().mockReturnValue({
+            value: 1000n,
+            issues: [],
+            errors: [],
+            warnings: [],
+            isValid: true,
+        });
+        const encode: Encoder<'to' | 'amount', string> = jest.fn().mockImplementation(() => {
+            throw new Error('Encoding failed');
+        });
+
+        const builder = createBuilder({
+            encode,
+            params: { to: toParam, amount: amountParam },
+        });
+
+        const result = builder({
+            to: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+            amount: '1000',
+        });
+
+        expect(result).toEqual({
+            data: null,
+            issues: [{ code: 'ENCODING_FAILED', path: null, severity: 'error' }],
+            errors: [{ code: 'ENCODING_FAILED', path: null, severity: 'error' }],
+            warnings: [],
+            isValid: false,
+        });
+    });
+});

--- a/suite-common/calldata/src/tests/builder/createParam.test.ts
+++ b/suite-common/calldata/src/tests/builder/createParam.test.ts
@@ -1,0 +1,57 @@
+import { createParam } from '../../builder/createParam';
+
+describe('createParam', () => {
+    it('calls validate and policy, returns combined result', () => {
+        const validate = jest.fn().mockReturnValue({
+            value: 'NORMALIZED',
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to' }],
+        });
+        const policy = jest.fn().mockReturnValue({
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        });
+
+        const param = createParam({ validate, policy });
+        const result = param('input', 'to', undefined);
+
+        expect(validate).toHaveBeenCalledWith('input', 'to', undefined);
+        expect(policy).toHaveBeenCalledWith([{ code: 'ZERO_ADDRESS', path: 'to' }]);
+        expect(result).toEqual({
+            value: 'NORMALIZED',
+            issues: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            errors: [],
+            warnings: [{ code: 'ZERO_ADDRESS', path: 'to', severity: 'warning' }],
+            isValid: true,
+        });
+    });
+
+    it('uses default policy when none provided', () => {
+        const validate = jest.fn().mockReturnValue({
+            value: null,
+            issues: [{ code: 'INVALID_ADDRESS', path: 'to' }],
+        });
+
+        const param = createParam({ validate });
+        const result = param('input', 'to', undefined);
+
+        expect(result.isValid).toBe(false);
+        expect(result.issues).toEqual([{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }]);
+        expect(result.errors).toEqual([{ code: 'INVALID_ADDRESS', path: 'to', severity: 'error' }]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('passes context to validate', () => {
+        const validate = jest.fn().mockReturnValue({
+            value: 'NORMALIZED',
+            issues: [],
+        });
+        const context = { sender: '0xabc', balance: 1000n };
+
+        const param = createParam({ validate });
+        param('input', 'to', context);
+
+        expect(validate).toHaveBeenCalledWith('input', 'to', context);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/approve.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/approve.test.ts
@@ -1,0 +1,80 @@
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { buildApprove } from '../../../builder/evm/approve';
+
+const SPENDER = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
+const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+
+describe('buildApprove', () => {
+    it('encodes valid approve calldata', () => {
+        const result = buildApprove(
+            {
+                spender: SPENDER,
+                amount: asAmountSubunit(new BigNumber('1000000')),
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x095ea7b30000000000000000000000001231deb6f5749ef6ce6943a275a1d3e7486f4eae00000000000000000000000000000000000000000000000000000000000f4240',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('encodes unlimited approval calldata', () => {
+        const result = buildApprove(
+            {
+                spender: SPENDER,
+                amount: asAmountSubunit(new BigNumber(UINT256_MAX)),
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x095ea7b30000000000000000000000001231deb6f5749ef6ce6943a275a1d3e7486f4eaeffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for invalid spender address', () => {
+        const result = buildApprove(
+            {
+                spender: 'invalid-address',
+                amount: asAmountSubunit(new BigNumber('1000000')),
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'INVALID_ADDRESS', path: 'spender', severity: 'error' },
+        ]);
+    });
+
+    it('returns warning for zero amount', () => {
+        const result = buildApprove(
+            {
+                spender: SPENDER,
+                amount: asAmountSubunit(new BigNumber('0')),
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x095ea7b30000000000000000000000001231deb6f5749ef6ce6943a275a1d3e7486f4eae0000000000000000000000000000000000000000000000000000000000000000',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([
+            { code: 'ZERO_AMOUNT', path: 'amount', severity: 'warning' },
+        ]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/deposit.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/deposit.test.ts
@@ -1,0 +1,75 @@
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { buildDeposit } from '../../../builder/evm/deposit';
+
+const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+
+describe('buildDeposit', () => {
+    it('encodes valid deposit calldata', () => {
+        const result = buildDeposit(
+            {
+                assets: asAmountSubunit(new BigNumber('5000000')),
+                receiver: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0x6e553f6500000000000000000000000000000000000000000000000000000000004c4b400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero address receiver', () => {
+        const result = buildDeposit(
+            {
+                assets: asAmountSubunit(new BigNumber('5000000')),
+                receiver: '0x0000000000000000000000000000000000000000',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'ZERO_ADDRESS', path: 'receiver', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+    });
+
+    it('returns error when receiver is different from sender', () => {
+        const result = buildDeposit(
+            {
+                assets: asAmountSubunit(new BigNumber('5000000')),
+                receiver: '0x1111111111111111111111111111111111111111',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+    });
+
+    it('returns error for zero assets', () => {
+        const result = buildDeposit(
+            {
+                assets: asAmountSubunit(new BigNumber('0')),
+                receiver: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([{ code: 'ZERO_AMOUNT', path: 'assets', severity: 'error' }]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/redeem.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/redeem.test.ts
@@ -1,0 +1,135 @@
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { buildRedeem } from '../../../builder/evm/redeem';
+
+const SENDER = '0x44Ab691a7492C3dCb88241AF8aC5371d84B61BB6';
+
+describe('buildRedeem', () => {
+    it('encodes valid redeem calldata', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: SENDER,
+                owner: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0xba0876520000000000000000000000000000000000000000000000000000091835d3be3100000000000000000000000044ab691a7492c3dcb88241af8ac5371d84b61bb600000000000000000000000044ab691a7492c3dcb88241af8ac5371d84b61bb6',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero address receiver', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: '0x0000000000000000000000000000000000000000',
+                owner: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'ZERO_ADDRESS', path: 'receiver', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+    });
+
+    it('returns error for zero address owner', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: SENDER,
+                owner: '0x0000000000000000000000000000000000000000',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'ZERO_ADDRESS', path: 'owner', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'owner', severity: 'error' },
+        ]);
+    });
+
+    it('returns error when receiver is different from sender', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: '0x1111111111111111111111111111111111111111',
+                owner: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+    });
+
+    it('returns error when owner is different from sender', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: SENDER,
+                owner: '0x1111111111111111111111111111111111111111',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'owner', severity: 'error' },
+        ]);
+    });
+
+    it('returns errors when owner and receiver are different from sender', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                receiver: '0x1111111111111111111111111111111111111111',
+                owner: '0x1111111111111111111111111111111111111111',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'owner', severity: 'error' },
+        ]);
+    });
+
+    it('returns error for zero shares', () => {
+        const result = buildRedeem(
+            {
+                shares: asAmountSubunit(new BigNumber('0')),
+                receiver: SENDER,
+                owner: SENDER,
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.warnings).toEqual([]);
+        expect(result.errors).toEqual([{ code: 'ZERO_AMOUNT', path: 'shares', severity: 'error' }]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/transfer.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/transfer.test.ts
@@ -1,0 +1,26 @@
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { buildTransfer } from '../../../builder/evm/transfer';
+
+const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const RECIPIENT = '0xB836472D21991eB9842e15BEaE1AF6c8B63D6a96';
+
+describe('buildTransfer', () => {
+    it('encodes valid transfer calldata', () => {
+        const result = buildTransfer(
+            {
+                to: RECIPIENT,
+                amount: asAmountSubunit(new BigNumber('1000000')),
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0xa9059cbb000000000000000000000000b836472d21991eb9842e15beae1af6c8b63d6a9600000000000000000000000000000000000000000000000000000000000f4240',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/builder/evm/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/withdraw.test.ts
@@ -1,0 +1,116 @@
+import { asAmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { buildWithdraw } from '../../../builder/evm/withdraw';
+
+const SENDER = '0x22E228AdE324185123A54Ad25F3459a99CF51E7a';
+
+describe('buildWithdraw', () => {
+    it('encodes valid withdraw calldata', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('1507906')),
+                receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+                owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0xb460af94000000000000000000000000000000000000000000000000000000000017024200000000000000000000000022e228ade324185123a54ad25f3459a99cf51e7a00000000000000000000000022e228ade324185123a54ad25f3459a99cf51e7a',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero address receiver', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('1507906')),
+                receiver: '0x0000000000000000000000000000000000000000',
+                owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([
+            { code: 'ZERO_ADDRESS', path: 'receiver', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero address owner', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('1507906')),
+                receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+                owner: '0x0000000000000000000000000000000000000000',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([
+            { code: 'ZERO_ADDRESS', path: 'owner', severity: 'error' },
+            { code: 'NOT_SAME_AS_SENDER', path: 'owner', severity: 'error' },
+        ]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error when receiver is different from sender', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('1507906')),
+                receiver: '0x1111111111111111111111111111111111111111',
+                owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'receiver', severity: 'error' },
+        ]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error when owner is different from sender', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('1507906')),
+                receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+                owner: '0x1111111111111111111111111111111111111111',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([
+            { code: 'NOT_SAME_AS_SENDER', path: 'owner', severity: 'error' },
+        ]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero assets', () => {
+        const result = buildWithdraw(
+            {
+                assets: asAmountSubunit(new BigNumber('0')),
+                receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+                owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
+            },
+            { sender: SENDER },
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([{ code: 'ZERO_AMOUNT', path: 'assets', severity: 'error' }]);
+        expect(result.warnings).toEqual([]);
+    });
+});

--- a/suite-common/calldata/src/tests/encoder/evm.test.ts
+++ b/suite-common/calldata/src/tests/encoder/evm.test.ts
@@ -1,0 +1,82 @@
+import { parseAbi } from 'viem';
+
+import { createEvmEncoder } from '../../encoder/evm';
+
+describe('createEvmEncoder', () => {
+    describe('ABI validation', () => {
+        it('throws when no function in ABI', () => {
+            const abi = parseAbi(['event Transfer(address indexed from, address indexed to)']);
+
+            expect(() => createEvmEncoder(abi)).toThrow('No function in ABI');
+        });
+
+        it('throws when multiple functions in ABI', () => {
+            const abi = parseAbi([
+                'function transfer(address to, uint256 amount)',
+                'function approve(address spender, uint256 amount)',
+            ]);
+
+            expect(() => createEvmEncoder(abi)).toThrow('ABI must contain exactly one function');
+        });
+
+        it('throws when function has unnamed parameters', () => {
+            const abi = parseAbi(['function transfer(address, uint256)']);
+
+            expect(() => createEvmEncoder(abi)).toThrow(
+                "ABI function 'transfer' has unnamed parameters",
+            );
+        });
+    });
+
+    describe('encoder', () => {
+        const abi = parseAbi(['function transfer(address to, uint256 amount)']);
+        const encode = createEvmEncoder(abi);
+
+        it('encodes valid params to calldata', () => {
+            const result = encode({
+                to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                amount: 1000n,
+            });
+
+            expect(result).toBe(
+                '0xa9059cbb000000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000000000000000000000000000000000000000003e8',
+            );
+        });
+
+        it('throws when too few params provided', () => {
+            // @ts-expect-error
+            expect(() => encode({ to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' })).toThrow(
+                "Param count mismatch for 'transfer': expected 2, got 1",
+            );
+        });
+
+        it('throws when too many params provided', () => {
+            expect(() =>
+                encode({
+                    to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    amount: 1000n,
+                    // @ts-expect-error
+                    extra: 'value',
+                }),
+            ).toThrow("Param count mismatch for 'transfer': expected 2, got 3");
+        });
+
+        it('throws when param value is null', () => {
+            expect(() =>
+                encode({
+                    to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    amount: null,
+                }),
+            ).toThrow("transfer: Param 'amount' cannot be null/undefined");
+        });
+
+        it('throws when param value is undefined', () => {
+            expect(() =>
+                encode({
+                    to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    amount: undefined,
+                }),
+            ).toThrow("transfer: Param 'amount' cannot be null/undefined");
+        });
+    });
+});

--- a/suite-common/calldata/src/tests/policy/createPolicy.test.ts
+++ b/suite-common/calldata/src/tests/policy/createPolicy.test.ts
@@ -1,0 +1,9 @@
+import { createPolicyTestCases } from '../../fixtures/policy/createPolicy.fixture';
+import { createPolicy } from '../../policy/createPolicy';
+
+describe('createPolicy', () => {
+    it.each(createPolicyTestCases)('$description', ({ overrides, issues, expected }) => {
+        const policy = createPolicy(overrides);
+        expect(policy(issues)).toEqual(expected);
+    });
+});

--- a/suite-common/calldata/src/tests/validation/createValidator.test.ts
+++ b/suite-common/calldata/src/tests/validation/createValidator.test.ts
@@ -1,0 +1,147 @@
+import { createValidator } from '../../validation/createValidator';
+
+describe('createValidator', () => {
+    describe('validation behavior', () => {
+        it('skips validation when validate array is empty', () => {
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+
+            const validator = createValidator({
+                validate: [],
+                normalize,
+            });
+
+            const result = validator('input', 'field');
+
+            expect(normalize).toHaveBeenCalledWith('input');
+            expect(result).toEqual({
+                value: 'NORMALIZED',
+                issues: [],
+            });
+        });
+
+        it('calls all validators and normalize when validation passes', () => {
+            const validator1 = jest.fn().mockReturnValue(null);
+            const validator2 = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+
+            const validator = createValidator({
+                validate: [validator1, validator2],
+                normalize,
+            });
+
+            const result = validator('input', 'field');
+
+            expect(validator1).toHaveBeenCalledWith('input');
+            expect(validator2).toHaveBeenCalledWith('input');
+            expect(normalize).toHaveBeenCalledWith('input');
+            expect(result).toEqual({
+                value: 'NORMALIZED',
+                issues: [],
+            });
+        });
+
+        it('stops at first failing validator and does not call normalize', () => {
+            const validator1 = jest.fn().mockReturnValue('INVALID_ADDRESS');
+            const validator2 = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+
+            const validator = createValidator({
+                validate: [validator1, validator2],
+                normalize,
+            });
+
+            const result = validator('input', 'field');
+
+            expect(validator1).toHaveBeenCalledWith('input');
+            expect(validator2).not.toHaveBeenCalled();
+            expect(normalize).not.toHaveBeenCalled();
+            expect(result).toEqual({
+                value: null,
+                issues: [{ code: 'INVALID_ADDRESS', path: 'field' }],
+            });
+        });
+    });
+
+    describe('inspect behavior', () => {
+        it('returns no issues when inspect returns null', () => {
+            const validate = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+            const inspect = jest.fn().mockReturnValue(null);
+
+            const validator = createValidator({
+                validate: [validate],
+                normalize,
+                inspect: [inspect],
+            });
+
+            const result = validator('input', 'field');
+
+            expect(inspect).toHaveBeenCalledWith('NORMALIZED', undefined);
+            expect(result).toEqual({
+                value: 'NORMALIZED',
+                issues: [],
+            });
+        });
+
+        it('collects issues from multiple failing inspects', () => {
+            const validate = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+            const inspect1 = jest.fn().mockReturnValue(null);
+            const inspect2 = jest.fn().mockReturnValue('ZERO_ADDRESS');
+            const inspect3 = jest.fn().mockReturnValue('SELF_ADDRESS');
+
+            const validator = createValidator({
+                validate: [validate],
+                normalize,
+                inspect: [inspect1, inspect2, inspect3],
+            });
+
+            const result = validator('input', 'field');
+
+            expect(inspect1).toHaveBeenCalled();
+            expect(inspect2).toHaveBeenCalled();
+            expect(inspect3).toHaveBeenCalled();
+            expect(result).toEqual({
+                value: 'NORMALIZED',
+                issues: [
+                    { code: 'ZERO_ADDRESS', path: 'field' },
+                    { code: 'SELF_ADDRESS', path: 'field' },
+                ],
+            });
+        });
+
+        it('works without inspect defined', () => {
+            const validate = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+
+            const validator = createValidator({
+                validate: [validate],
+                normalize,
+            });
+
+            const result = validator('input', 'field');
+
+            expect(result).toEqual({
+                value: 'NORMALIZED',
+                issues: [],
+            });
+        });
+
+        it('passes normalized value and context to inspect', () => {
+            const validate = jest.fn().mockReturnValue(null);
+            const normalize = jest.fn().mockReturnValue('NORMALIZED');
+            const inspect = jest.fn().mockReturnValue(null);
+            const context = { sender: '0xabc' };
+
+            const validator = createValidator({
+                validate: [validate],
+                normalize,
+                inspect: [inspect],
+            });
+
+            validator('input', 'field', context);
+
+            expect(inspect).toHaveBeenCalledWith('NORMALIZED', context);
+        });
+    });
+});

--- a/suite-common/calldata/src/tests/validation/evm/address.test.ts
+++ b/suite-common/calldata/src/tests/validation/evm/address.test.ts
@@ -1,0 +1,44 @@
+import {
+    isNotSameAsSenderTestCases,
+    isNotWhitelistedTestCases,
+    isSameAsSenderTestCases,
+    isValidAddressTestCases,
+    isZeroAddressTestCases,
+} from '../../../fixtures/validation/evm/address.fixture';
+import {
+    isNotSameAsSender,
+    isNotWhitelisted,
+    isSameAsSender,
+    isValidAddress,
+    isZeroAddress,
+} from '../../../validation/evm/address';
+
+describe('isValidAddress', () => {
+    it.each(isValidAddressTestCases)('$description', ({ input, expected }) => {
+        expect(isValidAddress(input)).toBe(expected);
+    });
+});
+
+describe('isZeroAddress', () => {
+    it.each(isZeroAddressTestCases)('$description', ({ input, expected }) => {
+        expect(isZeroAddress(input)).toBe(expected);
+    });
+});
+
+describe('isSameAsSender', () => {
+    it.each(isSameAsSenderTestCases)('$description', ({ input, context, expected }) => {
+        expect(isSameAsSender(input, context)).toBe(expected);
+    });
+});
+
+describe('isNotSameAsSender', () => {
+    it.each(isNotSameAsSenderTestCases)('$description', ({ input, context, expected }) => {
+        expect(isNotSameAsSender(input, context)).toBe(expected);
+    });
+});
+
+describe('isNotWhitelisted', () => {
+    it.each(isNotWhitelistedTestCases)('$description', ({ input, context, expected }) => {
+        expect(isNotWhitelisted(input, context)).toBe(expected);
+    });
+});

--- a/suite-common/calldata/src/tests/validation/evm/uint256.test.ts
+++ b/suite-common/calldata/src/tests/validation/evm/uint256.test.ts
@@ -1,0 +1,44 @@
+import {
+    exceedsUint256TestCases,
+    hasBalanceTestCases,
+    isNegativeTestCases,
+    isNotIntegerTestCases,
+    isZeroTestCases,
+} from '../../../fixtures/validation/evm/uint256.fixture';
+import {
+    exceedsUint256,
+    hasBalance,
+    isNegative,
+    isNotInteger,
+    isZero,
+} from '../../../validation/evm/uint256';
+
+describe('isNegative', () => {
+    it.each(isNegativeTestCases)('$description', ({ input, expected }) => {
+        expect(isNegative(input)).toBe(expected);
+    });
+});
+
+describe('isNotInteger', () => {
+    it.each(isNotIntegerTestCases)('$description', ({ input, expected }) => {
+        expect(isNotInteger(input)).toBe(expected);
+    });
+});
+
+describe('exceedsUint256', () => {
+    it.each(exceedsUint256TestCases)('$description', ({ input, expected }) => {
+        expect(exceedsUint256(input)).toBe(expected);
+    });
+});
+
+describe('isZero', () => {
+    it.each(isZeroTestCases)('$description', ({ input, expected }) => {
+        expect(isZero(input)).toBe(expected);
+    });
+});
+
+describe('hasBalance', () => {
+    it.each(hasBalanceTestCases)('$description', ({ input, context, expected }) => {
+        expect(hasBalance(input, context)).toBe(expected);
+    });
+});

--- a/suite-common/calldata/src/tests/validation/evm/validateAddress.test.ts
+++ b/suite-common/calldata/src/tests/validation/evm/validateAddress.test.ts
@@ -1,0 +1,8 @@
+import { validateAddressTestCases } from '../../../fixtures/validation/evm/validateAddress.fixture';
+import { validateAddress } from '../../../validation/evm/address';
+
+describe('validateAddress', () => {
+    it.each(validateAddressTestCases)('$description', ({ input, context, expected }) => {
+        expect(validateAddress(input, 'to', context)).toEqual(expected);
+    });
+});

--- a/suite-common/calldata/src/tests/validation/evm/validateUint256.test.ts
+++ b/suite-common/calldata/src/tests/validation/evm/validateUint256.test.ts
@@ -1,0 +1,8 @@
+import { validateUint256TestCases } from '../../../fixtures/validation/evm/validateUint256.fixture';
+import { validateUint256 } from '../../../validation/evm/uint256';
+
+describe('validateUint256', () => {
+    it.each(validateUint256TestCases)('$description', ({ input, context, expected }) => {
+        expect(validateUint256(input, 'amount', context)).toEqual(expected);
+    });
+});

--- a/suite-common/calldata/src/types/builder.ts
+++ b/suite-common/calldata/src/types/builder.ts
@@ -1,0 +1,46 @@
+import type { Encoder } from './encoder';
+import type { Param } from './param';
+import type { IssueWithSeverity } from './policy';
+
+export type { Encoder };
+
+export type ParamsConfig<
+    ParamNames extends string,
+    Config = Record<ParamNames, Param<any, any, any>>,
+> = {
+    [K in ParamNames]: Param<any, any, any>;
+} & (Exclude<keyof Config, ParamNames> extends never
+    ? unknown
+    : { [K in Exclude<keyof Config, ParamNames>]: never });
+
+type ExtractParamInput<T> = T extends Param<infer I, any, any> ? I : never;
+export type ExtractParamNames<E> = E extends Encoder<infer P, unknown> ? P : never;
+
+export type ExtractEncoderOutput<E> = E extends Encoder<string, infer O> ? O : never;
+
+export type ExtractInputs<ParamNames extends string, Config extends ParamsConfig<ParamNames>> = {
+    [K in ParamNames]: ExtractParamInput<Config[K]>;
+};
+
+export type ExtractContext<Config> =
+    Config extends Record<string, Param<any, any, infer C>> ? C : void;
+
+export interface BuilderConfig<E extends Encoder> {
+    params: ParamsConfig<ExtractParamNames<E>>;
+    encode: E;
+}
+
+interface BuildResultBase {
+    issues: IssueWithSeverity[];
+    errors: IssueWithSeverity[];
+    warnings: IssueWithSeverity[];
+}
+
+export type BuildResult<Data = unknown> =
+    | ({ isValid: true; data: Data } & BuildResultBase)
+    | ({ isValid: false; data: null } & BuildResultBase);
+
+export type Builder<Inputs extends Record<string, unknown>, Context = void, Data = unknown> = (
+    inputs: Inputs,
+    context?: Context,
+) => BuildResult<Data>;

--- a/suite-common/calldata/src/types/encoder.ts
+++ b/suite-common/calldata/src/types/encoder.ts
@@ -1,0 +1,3 @@
+export type Encoder<ParamNames extends string = string, Output = unknown> = (
+    values: Record<ParamNames, unknown>,
+) => Output;

--- a/suite-common/calldata/src/types/evm.ts
+++ b/suite-common/calldata/src/types/evm.ts
@@ -1,0 +1,3 @@
+import { Branded } from '@trezor/type-utils';
+
+export type EvmAddress = `0x${string}` & Branded<'EvmAddress'>;

--- a/suite-common/calldata/src/types/param.ts
+++ b/suite-common/calldata/src/types/param.ts
@@ -1,0 +1,21 @@
+import { IssueWithSeverity, PolicyResult } from './policy';
+import { Issue, ValidationResult } from './validation';
+
+export interface ParamResult<Output> {
+    value: Output | null;
+    issues: IssueWithSeverity[];
+    errors: IssueWithSeverity[];
+    warnings: IssueWithSeverity[];
+    isValid: boolean;
+}
+
+export interface ParamConfig<Input, Output, Context> {
+    validate: (input: Input, path: string, context: Context) => ValidationResult<Output>;
+    policy?: (issues: Issue[]) => PolicyResult;
+}
+
+export type Param<Input, Output, Context> = (
+    input: Input,
+    path: string,
+    context: Context,
+) => ParamResult<Output>;

--- a/suite-common/calldata/src/types/policy.ts
+++ b/suite-common/calldata/src/types/policy.ts
@@ -1,0 +1,16 @@
+import { Issue, IssueCode } from './validation';
+
+export type Severity = 'error' | 'warning' | 'ignore';
+
+export type PolicyConfig = Record<IssueCode, Severity>;
+
+export interface IssueWithSeverity extends Issue {
+    severity: Severity;
+}
+
+export interface PolicyResult {
+    issues: IssueWithSeverity[];
+    errors: IssueWithSeverity[];
+    warnings: IssueWithSeverity[];
+    isValid: boolean;
+}

--- a/suite-common/calldata/src/types/validation.ts
+++ b/suite-common/calldata/src/types/validation.ts
@@ -1,0 +1,23 @@
+export type ContextWith<T> = Record<string, unknown> & T;
+
+export type ValidationResult<T> = {
+    value: T | null;
+    issues: Issue[];
+};
+export type Issue = {
+    code: IssueCode;
+    path: string | null;
+};
+
+export type IssueCode =
+    | 'INVALID_ADDRESS'
+    | 'ZERO_ADDRESS'
+    | 'SELF_ADDRESS'
+    | 'NOT_SAME_AS_SENDER'
+    | 'ADDRESS_NOT_WHITELISTED'
+    | 'NEGATIVE_AMOUNT'
+    | 'INSUFFICIENT_BALANCE'
+    | 'NOT_INTEGER'
+    | 'ZERO_AMOUNT'
+    | 'EXCEEDS_UINT256'
+    | 'ENCODING_FAILED';

--- a/suite-common/calldata/src/validation/createValidator.ts
+++ b/suite-common/calldata/src/validation/createValidator.ts
@@ -1,0 +1,35 @@
+import { IssueCode, ValidationResult } from '../types/validation';
+
+export type ValidateFn<Input> = (input: Input) => IssueCode | null;
+export type InspectFn<Output, Context = Record<string, unknown>> = (
+    value: Output,
+    context?: Context,
+) => IssueCode | null;
+
+export interface ValidatorConfig<Input, Output, Context = Record<string, unknown>> {
+    validate: Array<ValidateFn<Input>>;
+    normalize: (input: Input) => Output;
+    inspect?: Array<InspectFn<Output, Context>>;
+}
+
+export const createValidator =
+    <Input, Output, Context = Record<string, unknown>>(
+        config: ValidatorConfig<Input, Output, Context>,
+    ) =>
+    (input: Input, path: string, context?: Context): ValidationResult<Output> => {
+        for (const validateFn of config.validate) {
+            const code = validateFn(input);
+            if (code !== null) {
+                return { value: null, issues: [{ code, path }] };
+            }
+        }
+
+        const normalizedValue = config.normalize(input);
+
+        const inspectIssues = (config.inspect ?? [])
+            .map(inspectFn => inspectFn(normalizedValue, context))
+            .filter((code): code is IssueCode => code !== null)
+            .map(code => ({ code, path }));
+
+        return { value: normalizedValue, issues: inspectIssues };
+    };

--- a/suite-common/calldata/src/validation/evm/address.ts
+++ b/suite-common/calldata/src/validation/evm/address.ts
@@ -1,0 +1,41 @@
+import { isAddress } from 'viem';
+
+import { EvmAddress } from '../../types/evm';
+import { ContextWith } from '../../types/validation';
+import { InspectFn, ValidateFn, createValidator } from '../createValidator';
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as EvmAddress;
+
+export const isValidAddress: ValidateFn<string> = input =>
+    isAddress(input, { strict: false }) ? null : 'INVALID_ADDRESS';
+
+export const isZeroAddress: InspectFn<EvmAddress> = value =>
+    value === ZERO_ADDRESS ? 'ZERO_ADDRESS' : null;
+
+type SenderContext = ContextWith<{ sender?: EvmAddress }>;
+
+export const isSameAsSender: InspectFn<EvmAddress, SenderContext> = (value, context) =>
+    context?.sender && value.toLowerCase() === context.sender.toLowerCase() ? 'SELF_ADDRESS' : null;
+
+export const isNotSameAsSender: InspectFn<EvmAddress, SenderContext> = (value, context) =>
+    context?.sender && value.toLowerCase() !== context.sender.toLowerCase()
+        ? 'NOT_SAME_AS_SENDER'
+        : null;
+
+type WhitelistContext = ContextWith<{ addressWhitelist?: EvmAddress[] }>;
+
+export const isNotWhitelisted: InspectFn<EvmAddress, WhitelistContext> = (value, context) =>
+    context?.addressWhitelist &&
+    !context.addressWhitelist.some(addr => addr.toLowerCase() === value.toLowerCase())
+        ? 'ADDRESS_NOT_WHITELISTED'
+        : null;
+
+export const validateAddress = createValidator<
+    string,
+    EvmAddress,
+    SenderContext & WhitelistContext
+>({
+    validate: [isValidAddress],
+    normalize: (input: string) => input.toLowerCase() as EvmAddress,
+    inspect: [isZeroAddress, isSameAsSender, isNotSameAsSender, isNotWhitelisted],
+});

--- a/suite-common/calldata/src/validation/evm/uint256.ts
+++ b/suite-common/calldata/src/validation/evm/uint256.ts
@@ -1,0 +1,27 @@
+import { UINT256_MAX } from '@suite-common/suite-constants';
+import { AmountSubunit } from '@suite-common/wallet-utils';
+
+import { ContextWith } from '../../types/validation';
+import { InspectFn, ValidateFn, createValidator } from '../createValidator';
+
+export const isNegative: ValidateFn<AmountSubunit> = input =>
+    input.isNegative() ? 'NEGATIVE_AMOUNT' : null;
+
+export const isNotInteger: ValidateFn<AmountSubunit> = input =>
+    input.isInteger() ? null : 'NOT_INTEGER';
+
+export const exceedsUint256: ValidateFn<AmountSubunit> = input =>
+    input.gt(UINT256_MAX) ? 'EXCEEDS_UINT256' : null;
+
+export const isZero: InspectFn<bigint> = input => (input === 0n ? 'ZERO_AMOUNT' : null);
+
+type BalanceContext = ContextWith<{ balance?: bigint }>;
+
+export const hasBalance: InspectFn<bigint, BalanceContext> = (input, context) =>
+    context?.balance !== undefined && input > context.balance ? 'INSUFFICIENT_BALANCE' : null;
+
+export const validateUint256 = createValidator<AmountSubunit, bigint, BalanceContext>({
+    validate: [isNegative, isNotInteger, exceedsUint256],
+    normalize: input => BigInt(input.toFixed(0)),
+    inspect: [isZero, hasBalance],
+});

--- a/suite-common/calldata/tsconfig.json
+++ b/suite-common/calldata/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../suite-constants" },
+        { "path": "../wallet-utils" },
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10933,6 +10933,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/calldata@workspace:suite-common/calldata":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/calldata@workspace:suite-common/calldata"
+  dependencies:
+    "@suite-common/suite-constants": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
+    viem: "npm:^2.39.0"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/connect-init@workspace:*, @suite-common/connect-init@workspace:suite-common/connect-init":
   version: 0.0.0-use.local
   resolution: "@suite-common/connect-init@workspace:suite-common/connect-init"
@@ -46273,9 +46285,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:^2.45.0":
-  version: 2.45.0
-  resolution: "viem@npm:2.45.0"
+"viem@npm:^2.39.0, viem@npm:^2.45.0":
+  version: 2.45.1
+  resolution: "viem@npm:2.45.1"
   dependencies:
     "@noble/curves": "npm:1.9.1"
     "@noble/hashes": "npm:1.8.0"
@@ -46290,7 +46302,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/16aa3028ab7e48acc6429cf9089403cdfdd85d4083827741d19d1e53b2b163fb0d0113c0ee4f212349d6cab9d58d8565db104894d9218de6efc5ef9ac2339ecf
+  checksum: 10/88838ca073a0de832b35aa97ef8202d33566cec67680b5e8951a41c94ba4be5b360f9a6991fb21a16ab744b6e80bd5b4bd8983b8de387ed56e131038d7dca47e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR adds `@suite-common/calldata` - type-safe calldata builder for blockchain transactions.

Detailed explanation of the whole package can be found in the `README.md` of the package.

**Features:**
  - Builds encoded calldata for EVM transactions (ERC-20, ERC-4626)
  - Validates inputs, normalizes values, applies configurable policies
  - Chain-agnostic core - add validators and encoders for any chain
  - EVM implementation using viem
  - Extensive unit test coverage

**Flow:** Input → Validate → Normalize → Inspect → Policy → Encode → Calldata

**Included builders:**
  - ERC-20: `transfer`, `approve`
  - ERC-4626: `deposit`, `withdraw`, `redeem`

## Usage

```typescript
  const result = Calldata.evm.erc20.approve(
      {
          spender: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
          amount: asAmountSubunit(new BigNumber('1000000')),
      },
      { sender: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3' },
  );

  if (result.isValid) {
      console.log(result.data);
  } else {
      console.log(result.errors);
  }
```

## Notes for QA



## Related Issue

Resolve #24805

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/calldata-package&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/calldata-package&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/calldata-package&lookback=7)