### PR TITLE
Feat: connect thp pairing status event

### DIFF
--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -165,6 +165,14 @@ const run = async () => {
                 writeCliState(state);
             }
         }
+
+        if (event.type === 'device-thp_pairing_status_changed') {
+            if (event.payload.status === 'failed') {
+                console.warn('THP phase error', event.payload.message);
+            } else {
+                console.warn('THP phase changed', event.payload.status);
+            }
+        }
     });
 
     TrezorConnect.on('UI_EVENT', async event => {

--- a/packages/connect/e2e/tests/device/thpPairing.test.ts
+++ b/packages/connect/e2e/tests/device/thpPairing.test.ts
@@ -188,11 +188,41 @@ describe('THP pairing', () => {
             }
         };
 
+    it('ThpPairing invalid CodeEntry', async () => {
+        const device = await waitForDevice({ pairingMethods: ['CodeEntry'] });
+
+        const statusChangeEvents: string[] = [];
+        TrezorConnect.on('device-thp_pairing_status_changed', ({ status }) => {
+            statusChangeEvents.push(status);
+        });
+
+        TrezorConnect.on('ui-request_thp_pairing', () => {
+            TrezorConnect.removeAllListeners('ui-request_thp_pairing');
+            TrezorConnect.uiResponse({
+                type: 'ui-receive_thp_pairing_tag',
+                payload: { tag: '111111' },
+            });
+        });
+
+        const result = await TrezorConnect.getFeatures({ device });
+        if (result.success) throw ERR;
+
+        expect(statusChangeEvents).toEqual(['started', 'invalid-tag']);
+        expect(result.payload.code).toMatch('Device_ThpPairingTagInvalid');
+    });
+
     it('ThpPairing cancel workflow', async () => {
         const device = await waitForDevice({
             pairingMethods: ['CodeEntry'],
             knownCredentials: [],
         });
+
+        const statusChangeEvents: string[] = [];
+        TrezorConnect.on('device-thp_pairing_status_changed', ({ status }) => {
+            statusChangeEvents.push(status);
+        });
+        const expectedStatusChangeEvents = (runs: number) =>
+            Array(runs).fill(['started', 'canceled']).flat();
 
         let result;
 
@@ -201,6 +231,7 @@ describe('THP pairing', () => {
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.payload.error).toMatch(CANCEL_ERR);
+        expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(1));
 
         // Emulate user interaction delay in order to let the device recover with ThpTransportBusy
         await new Promise(resolve => setTimeout(resolve, 1000));
@@ -213,6 +244,7 @@ describe('THP pairing', () => {
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(2));
 
         // Emulate user interaction delay in order to let the device recover with ThpTransportBusy
         await new Promise(resolve => setTimeout(resolve, 1000));
@@ -225,6 +257,7 @@ describe('THP pairing', () => {
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.payload.error).toMatch(FW_CANCEL_ERR);
+        expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(3));
 
         // 3. reject pairing confirmation from host
         TrezorConnect.removeAllListeners('ui-button');
@@ -232,6 +265,7 @@ describe('THP pairing', () => {
         result = await TrezorConnect.getFeatures({ device });
         if (result.success) throw ERR;
         expect(result.payload.error).toMatch(FW_CANCEL_ERR); // canceled gracefully on Trezor
+        expect(statusChangeEvents).toEqual(expectedStatusChangeEvents(4));
 
         // check if pairing is still responsive
         TrezorConnect.removeAllListeners('ui-button');
@@ -246,6 +280,11 @@ describe('THP pairing', () => {
         });
         result = await TrezorConnect.getFeatures({ device });
         expect(result).toMatchObject({ success: true });
+        expect(statusChangeEvents).toEqual([
+            ...expectedStatusChangeEvents(4),
+            'started',
+            'finished',
+        ]);
     });
 
     it('ThpState cancel workflow', async () => {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -560,6 +560,19 @@ const onThpCredentialsChangedHandler =
         );
     };
 
+const onThpPhaseChangedHandler =
+    (device: Device, context: CoreContext) =>
+    (payload: DeviceEvents['device-thp_pairing_status_changed']) => {
+        const { sendCoreMessage } = context;
+
+        sendCoreMessage(
+            createDeviceMessage(DEVICE.THP_PAIRING_STATUS_CHANGED, {
+                device: device.toMessageObject(),
+                ...payload,
+            }),
+        );
+    };
+
 const registerDeviceEvents =
     (context: CoreContext, method?: AbstractMethod<any>) => (device: Device) => {
         device.removeAllListeners();
@@ -585,6 +598,7 @@ const registerDeviceEvents =
         });
         device.on(DEVICE.THP_PAIRING, onThpPairingHandler(device, context));
         device.on(DEVICE.THP_CREDENTIALS_CHANGED, onThpCredentialsChangedHandler(device, context));
+        device.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPhaseChangedHandler(device, context));
     };
 
 /**

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -37,6 +37,7 @@ import {
     DeviceButtonRequestPayload,
     DeviceThpCredentialsChangedPayload,
     DeviceThpPairingPayload,
+    DeviceThpPairingStatus,
     DeviceVersionChanged,
     UI,
     UiResponsePassphrase,
@@ -112,6 +113,7 @@ export interface DeviceEvents {
         callback: (response: Result<UiResponseThpPairingTag['payload']>) => void;
     };
     [DEVICE.THP_CREDENTIALS_CHANGED]: DeviceThpCredentialsChangedPayload;
+    [DEVICE.THP_PAIRING_STATUS_CHANGED]: DeviceThpPairingStatus;
 }
 
 interface DeviceLifecycleEvents {

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -39,16 +39,36 @@ export const getThpChannel = async (device: Device, withInteraction?: boolean) =
                 await thpHandshake(device, isPinLocked);
             }
         }
-        if (thpState.phase === 'pairing' && withInteraction) {
+        const startPairing = thpState.phase === 'pairing' && withInteraction;
+        if (startPairing) {
+            device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, { status: 'started' });
             // start pairing with UI interaction
             await thpPairing(device);
         }
 
         if (thpState.phase !== 'paired') {
+            device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, {
+                status: 'failed',
+                message: 'THP Locked',
+            });
+
             return 'thp-locked';
+        } else if (startPairing) {
+            device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, { status: 'finished' });
         }
     } catch (error) {
         thpState.resetState();
+
+        if (error.code === 'Device_ThpPairingTagInvalid') {
+            // ignore. phase already changed to 'invalid-tag'
+        } else if (error.code === 'Failure_ActionCancelled') {
+            device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, { status: 'canceled' });
+        } else {
+            device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, {
+                status: 'failed',
+                message: error.message,
+            });
+        }
 
         throw error;
     }

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -208,6 +208,13 @@ const waitForPairingTag = async (device: Device) => {
         // catch pairing tag mismatch
         // DataError since 2.10.0 https://github.com/trezor/trezor-firmware/commit/b0c3be9b1d95946471ebdab27918a3f652cf11e9
         if (e.code === 'Failure_FirmwareError' || e.code === 'Failure_DataError') {
+            if ('tag' in pairingResponse) {
+                device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, {
+                    status: 'invalid-tag',
+                    tag: pairingResponse.tag,
+                });
+            }
+
             // 'Unexpected Code Entry Tag'
             throw ERRORS.TypedError('Device_ThpPairingTagInvalid', e.message);
         }

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -103,6 +103,7 @@ export const abortThpWorkflow = async (device: Device) => {
         await thpState.pairingTagPromise.abort();
         await device.getCurrentSession().cancelCall();
         thpState.resetState();
+        device.emit(DEVICE.THP_PAIRING_STATUS_CHANGED, { status: 'canceled' });
     } else if (thpState.cancelablePromise) {
         thpState.sync('send', 'Cancel');
         await device.getCurrentSession().send('Cancel', {});

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -39,6 +39,7 @@ export const DEVICE = {
     PASSPHRASE_ON_DEVICE: 'passphrase_on_device',
     WORD: 'word',
     THP_PAIRING: 'thp_pairing', // ask UI for pairing tag
+    THP_PAIRING_STATUS_CHANGED: 'device-thp_pairing_status_changed',
 } as const;
 
 export interface DeviceButtonRequestPayload extends Omit<PROTO.ButtonRequest, 'code'> {
@@ -62,6 +63,26 @@ export interface DeviceVersionChanged {
 export type DeviceThpCredentialsChangedPayload = {
     credentials: ThpCredentials;
 };
+
+export type DeviceThpPairingStatus =
+    | {
+          status: 'started' | 'canceled' | 'finished';
+      }
+    | {
+          status: 'failed';
+          message: string;
+      }
+    | {
+          status: 'invalid-tag';
+          tag: string;
+      };
+
+export interface DeviceThpPairingStatusChanged {
+    type: typeof DEVICE.THP_PAIRING_STATUS_CHANGED;
+    payload: DeviceThpPairingStatus & {
+        device: Device;
+    };
+}
 
 export type DeviceThpPairingPayload = {
     availableMethods: ThpPairingMethod[];
@@ -94,6 +115,7 @@ export type DeviceEvent =
       }
     | DeviceButtonRequest
     | DeviceThpCredentialsChanged
+    | DeviceThpPairingStatusChanged
     | DeviceVersionChanged
     | DeviceTrezorPushNotification;
 

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -44,6 +44,17 @@ export const events = (api: TrezorConnect) => {
         if (event.type === 'device-trezor_push_notification') {
             return;
         }
+        if (event.type === 'device-thp_pairing_status_changed') {
+            const { payload } = event;
+            if (payload.status === 'invalid-tag') {
+                payload.tag.toLowerCase();
+            }
+            if (payload.status === 'failed') {
+                payload.message.toLowerCase();
+            }
+
+            return;
+        }
         const { payload } = event;
         payload.path.toLowerCase();
         if (payload.type === 'acquired') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cherrypicked from https://github.com/trezor/trezor-suite/pull/24952

added `TrezorConnect` THP_PAIRING_STATUS_CHANGED event emitted during THP pairing phases.





🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-thp-pairing-status-event&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-thp-pairing-status-event&lookback=7)