### PR TITLE
Fix worker paths for windows development

### DIFF
--- a/packages/suite-build/configs/connect.webpack.config.ts
+++ b/packages/suite-build/configs/connect.webpack.config.ts
@@ -5,35 +5,35 @@ const connect: webpack.Configuration = {
     module: {
         rules: [
             {
-                test: /pinger\/pingWorker.ts/i,
+                test: /pinger[\\/]pingWorker.ts/i,
                 loader: 'worker-loader',
                 options: {
                     filename: './workers/ping-worker.[contenthash].js',
                 },
             },
             {
-                test: /workers\/blockbook\/index/i,
+                test: /workers[\\/]blockbook[\\/]index/i,
                 loader: 'worker-loader',
                 options: {
                     filename: './workers/blockbook-worker.[contenthash].js',
                 },
             },
             {
-                test: /workers\/ripple\/index/i,
+                test: /workers[\\/]ripple[\\/]index/i,
                 loader: 'worker-loader',
                 options: {
                     filename: './workers/ripple-worker.[contenthash].js',
                 },
             },
             {
-                test: /workers\/blockfrost\/index/i,
+                test: /workers[\\/]blockfrost[\\/]index/i,
                 loader: 'worker-loader',
                 options: {
                     filename: './workers/blockfrost-worker.[contenthash].js',
                 },
             },
             {
-                test: /workers\/stellar\/index/i,
+                test: /workers[\\/]stellar[\\/]index/i,
                 loader: 'worker-loader',
                 options: {
                     filename: './workers/stellar-worker.[contenthash].js',


### PR DESCRIPTION
## Description

When developing on Windows, connect workers weren't built correctly because of wrong separators in webpack config.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/win-connect-workers&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/win-connect-workers&lookback=7)