### PR TITLE
fix(suite-native): centered title translation clipping

### DIFF
--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -16,6 +16,7 @@ export interface PressableTextProps extends Omit<RNTextProps, 'style'>, TestProp
     variant?: NativeTypographyStyle;
     color?: Color;
     textAlign?: TextStyle['textAlign'];
+    alignSelf?: TextStyle['alignSelf'];
     style?: NativeStyleObject;
 }
 

--- a/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectDeviceModel } from '@suite-common/wallet-core';
-import { Button, Card, CenteredTitleHeader, VStack } from '@suite-native/atoms';
+import { Box, Button, Card, CenteredTitleHeader, VStack } from '@suite-native/atoms';
 import { ConfirmOnTrezorAnimation } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
@@ -18,7 +18,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 const cardStyle = prepareNativeStyle(utils => ({
     flex: 1,
     justifyContent: 'center',
-    alignItems: 'center',
     paddingTop: utils.spacings.sp32,
     paddingBottom: utils.spacings.sp16,
     paddingHorizontal: utils.spacings.sp16,
@@ -26,7 +25,6 @@ const cardStyle = prepareNativeStyle(utils => ({
 
 const contentStyle = prepareNativeStyle(_ => ({
     width: '100%',
-    alignItems: 'center',
 }));
 
 const buttonStyle = prepareNativeStyle(_ => ({
@@ -52,13 +50,17 @@ export const UninitializedConnectedDeviceState = () => {
     return (
         <Card style={applyStyle(cardStyle)}>
             <VStack spacing="sp24" style={applyStyle(contentStyle)}>
-                <ConfirmOnTrezorAnimation />
+                {/* Prevents translation clipping on CenteredTitleHeader in some languages. */}
+                <Box alignItems="center">
+                    <ConfirmOnTrezorAnimation />
+                </Box>
                 <CenteredTitleHeader
                     title={<Translation id="moduleHome.emptyState.uninitializedDevice.title" />}
                     subtitle={
                         <Translation id="moduleHome.emptyState.uninitializedDevice.subtitle" />
                     }
                     testID="@homescreen/uninitializedConnectedDeviceText"
+                    alignSelf="stretch"
                 />
                 <Button size="large" onPress={handleAddAccount} style={applyStyle(buttonStyle)}>
                     <Translation id="moduleHome.emptyState.uninitializedDevice.button" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Quick fix for CenteredTitleHeader clipping in case of some weird characters at the end of the title resulting in the last word for not being rendered. The `alignSelf: "stretch"` should probably be applied to the `TitleHeader` component itself but before freeze, I opted to fix the issue locally just in case. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25088

## Screenshots:
<img width="362" height="815" alt="image" src="https://github.com/user-attachments/assets/4508911f-9aec-448f-869f-c8af72e3bf98" />


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/clipped-title&lookback=7)