### PR TITLE
test(e2e-suite): new test for multi wallet labeling with Suite sync

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
@@ -26,12 +26,12 @@ type SuiteSyncBannerInteraction = 'keys-needed' | 'firmware-upgrade-needed';
 
 const bannerConfigs: Record<SuiteSyncBannerInteraction, BannerConfig> = {
     'keys-needed': {
-        testId: '@notification/suite-sync-keys/button',
+        testId: '@notification/suite-sync-keys',
         buttonLabel: 'TR_SUITE_SYNC_GET_KEYS',
         description: 'TR_SUITE_SYNC_KEYS_NEEDED_BANNER',
     },
     'firmware-upgrade-needed': {
-        testId: '@notification/suite-sync-firmware-update/button',
+        testId: '@notification/suite-sync-firmware-update',
         buttonLabel: 'TR_SUITE_SYNC_FIRMWARE_UPDATE',
         description: 'TR_SUITE_SYNC_FIRMWARE_UPDATE_NEEDED_BANNER',
     },
@@ -67,12 +67,13 @@ const SuiteSyncBannerContent = ({
                 <Banner.Button
                     isDisabled={!isDeviceConnected}
                     onClick={onClick}
-                    data-testid={config.testId}
+                    data-testid={`${config.testId}/button`}
                 >
                     <Translation id={config.buttonLabel} />
                 </Banner.Button>
             </Tooltip>
         }
+        data-testid={config.testId}
         description={<Translation id={config.description} />}
     />
 );

--- a/suite/e2e/fixtures/metadata/default-metadata-ids.ts
+++ b/suite/e2e/fixtures/metadata/default-metadata-ids.ts
@@ -9,7 +9,6 @@ export const ownerSecret = asSuiteSyncOwnerSecretHex(
     'd5cafbfc837fcdba7fd54025ce352fac369db9383d41d73dbd4f3353b63bc4644585f41195021419707ccdf76bbdf0b1cb0e11f07ff19a41b5f22602dfee3b63',
 );
 export const walletDescriptor = asWalletDescriptor('mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer');
-export const WALLET_INDEX = 0;
 export const accountDescriptor = asAccountDescriptor(
     'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',
 );

--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 import { ApplySettings } from '@trezor/protobuf/src/messages-schema';
 import {
     Model,
@@ -15,18 +17,9 @@ import {
 const EMULATOR_CENTER_COORDINATES: Record<Model, { x: number; y: number }> = {
     [Model.T3T1]: { x: 125, y: 150 },
     [Model.T3W1]: { x: 200, y: 480 },
-    [Model.T1B1]: {
-        x: 0,
-        y: 0,
-    },
-    [Model.T2T1]: {
-        x: 0,
-        y: 0,
-    },
-    [Model.T3B1]: {
-        x: 0,
-        y: 0,
-    },
+    [Model.T1B1]: { x: 0, y: 0 },
+    [Model.T2T1]: { x: 0, y: 0 },
+    [Model.T3B1]: { x: 0, y: 0 },
 };
 
 export class DeviceFixture {
@@ -253,36 +246,33 @@ export class DeviceFixture {
         const EMULATOR_BURGER_MENU_COORDINATES: Record<Model, { x: number; y: number }> = {
             [Model.T3T1]: { x: 200, y: 20 },
             [Model.T3W1]: { x: 300, y: 20 },
-            [Model.T1B1]: {
-                x: 0,
-                y: 0,
-            },
-            [Model.T2T1]: {
-                x: 0,
-                y: 0,
-            },
-            [Model.T3B1]: {
-                x: 0,
-                y: 0,
-            },
+            [Model.T1B1]: { x: 0, y: 0 },
+            [Model.T2T1]: { x: 0, y: 0 },
+            [Model.T3B1]: { x: 0, y: 0 },
         };
         await TrezorUserEnvLink.clickEmu(EMULATOR_BURGER_MENU_COORDINATES[this.model]);
         const EMULATOR_FEE_INFO_COORDINATES: Record<Model, { x: number; y: number }> = {
             [Model.T3T1]: { x: 125, y: buttonIndexT3T1 * 100 },
             [Model.T3W1]: { x: 125, y: buttonIndexT3W1 * 100 },
-            [Model.T1B1]: {
-                x: 0,
-                y: 0,
-            },
-            [Model.T2T1]: {
-                x: 0,
-                y: 0,
-            },
-            [Model.T3B1]: {
-                x: 0,
-                y: 0,
-            },
+            [Model.T1B1]: { x: 0, y: 0 },
+            [Model.T2T1]: { x: 0, y: 0 },
+            [Model.T3B1]: { x: 0, y: 0 },
         };
         await TrezorUserEnvLink.clickEmu(EMULATOR_FEE_INFO_COORDINATES[this.model]);
+    }
+
+    @step()
+    async expectToContainOnDisplay(expectedText: string) {
+        await expect(async () => {
+            const displayBodyContent = (await this.getDisplayContent()).body;
+            const flattenedLines = displayBodyContent.map(line => line.join(' '));
+            const found = flattenedLines.some(line => line.includes(expectedText));
+
+            if (!found) {
+                throw new Error(
+                    `Expected text "${expectedText}" not found on the device display. Actual display text:\n"${JSON.stringify(flattenedLines, null, 2)}"`,
+                );
+            }
+        }).toPass({ timeout: 5_000 });
     }
 }

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -85,25 +85,28 @@ export class EvoluClient {
     }
 
     @step()
-    async readFrom(table: TableName) {
-        return await this.evolu.loadQuery(
-            this.evolu.createQuery(db => db.selectFrom(table).selectAll()),
+    async subscribeToTable(table: TableName) {
+        const ownerId = (await this.evolu.appOwner).id;
+        const query = this.evolu.createQuery(db =>
+            db.selectFrom(table).where('ownerId', '=', ownerId).selectAll(),
         );
+
+        return this.evolu.subscribeQuery(query)(() => {
+            const rows = this.evolu.getQueryRows(query);
+            console.error(
+                `Evolu subscription update for table "${table}": ${JSON.stringify(rows, null, 2)}`,
+            );
+        });
     }
 
-    // Suite sync by design will first return data from local storage
-    // and then update it with data from the server.
-    // Because of that we need to retry reads until we get expected data
     @step()
-    async readWithRetryFrom(table: TableName) {
-        const result = await expect(async () => {
-            const data = await this.readFrom(table);
-            expect(data).not.toEqual([]);
+    async readFrom(table: TableName) {
+        const ownerId = (await this.evolu.appOwner).id;
+        const query = this.evolu.createQuery(db =>
+            db.selectFrom(table).where('ownerId', '=', ownerId).selectAll(),
+        );
 
-            return data;
-        }).toPass({ timeout: 5_000 });
-
-        return result;
+        return await this.evolu.loadQuery(query);
     }
 
     @step()
@@ -122,6 +125,9 @@ export class EvoluClient {
         }).toPass({ timeout: 3_000, intervals: [1000, 2000, 2500] });
     }
 
+    // Suite sync by design will first return data from local storage
+    // and then update it with data from the server.
+    // Because of that we need to retry reads until we get expected data
     @step()
     async expectInTable<T extends TableName>(
         table: T,
@@ -135,6 +141,7 @@ export class EvoluClient {
         const omitFields = options?.omit ?? ['id', 'createdAt'];
         const timeout = options?.timeout ?? 5_000;
         const expectFn = options?.softExpect ? expect.soft : expect;
+        const expectedOrdered = orderBy(expectedData, ['label']);
 
         await expectFn(async () => {
             const actualData = await this.readFrom(table);
@@ -142,7 +149,6 @@ export class EvoluClient {
             // Unfortunately label is the only guaranteed property for ordering
             // might not be sufficient for more advance test scenarios. YAGNI for now.
             const actualOrdered = orderBy(actualOmitted, ['label']);
-            const expectedOrdered = orderBy(expectedData, ['label']);
             if (!isEqual(expectedOrdered, actualOrdered)) {
                 throw new Error(
                     `Table "${table}" data does not match.\nDiff:\n${diff(expectedOrdered, actualOrdered)}`,

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -172,7 +172,10 @@ export class DashboardPage {
     }
 
     @step()
-    async addUnusedHiddenWallet(passphrase: string) {
+    async addUnusedHiddenWallet(
+        passphrase: string,
+        options?: { suiteSync?: 'enable' | 'decline' },
+    ) {
         await this.addHiddenWalletButton.click();
         await this.addNewHiddenWalletButton.click();
         await this.openUnusedWalletButton2.click();
@@ -194,6 +197,18 @@ export class DashboardPage {
 
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await this.device.pressYes();
+
+        if (options?.suiteSync === 'enable') {
+            await this.device.expectToContainOnDisplay('Suite Sync');
+            await this.devicePrompt.confirmOnDevicePromptIsShown();
+            await this.device.pressYes();
+            // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
+            await this.page.waitForTimeout(2000);
+        } else if (options?.suiteSync === 'decline') {
+            await this.device.expectToContainOnDisplay('Suite Sync');
+            await this.devicePrompt.confirmOnDevicePromptIsShown();
+            await this.device.pressNo();
+        }
 
         await expect(
             this.devicePrompt.confirmOnDevicePrompt,

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -12,13 +12,15 @@ import { QUOTA_URL, RELAY_URL } from '../../helpers/evoluClient';
 import { SettingsPage } from '../settings/settingsPage';
 
 export class MetadataPage {
-    readonly metadataModal: Locator;
-    readonly copyAddressButton: Locator;
     readonly account: AccountMetadata;
     readonly output: OutputMetadata;
     readonly wallet: WalletMetadata;
     readonly address: AddressMetadata;
 
+    readonly metadataModal: Locator;
+    readonly copyAddressButton: Locator;
+    readonly suiteSyncBanner: Locator;
+    readonly suiteSyncBannerButton: Locator;
     readonly metadataProviderButton = (provider: MetadataProvider) =>
         this.page.getByTestId(`@modal/metadata-provider/${provider}-button`);
 
@@ -28,13 +30,15 @@ export class MetadataPage {
         private readonly settingsPage: SettingsPage,
         private readonly devicePrompt: DevicePrompt,
     ) {
-        this.metadataModal = page.getByTestId('@modal/metadata-provider');
-        this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
-
         this.account = new AccountMetadata(page);
         this.output = new OutputMetadata(page);
         this.wallet = new WalletMetadata(page);
         this.address = new AddressMetadata(page);
+
+        this.metadataModal = page.getByTestId('@modal/metadata-provider');
+        this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
+        this.suiteSyncBanner = page.getByTestId('@notification/suite-sync-keys');
+        this.suiteSyncBannerButton = page.getByTestId('@notification/suite-sync-keys/button');
     }
 
     @step()

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -1,5 +1,4 @@
 import {
-    WALLET_INDEX,
     accountDescriptor,
     ownerId,
     ownerSecret,
@@ -8,6 +7,7 @@ import {
 import { AccountLabelId } from '../../../support/enums/accountLabelId';
 import { expect, test } from '../../../support/fixtures';
 
+const defaultWalletIndex = 0;
 const expectedWallet = {
     updatedAt: null,
     isDeleted: null,
@@ -70,11 +70,11 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
         await test.step('Change wallet label', async () => {
             await dashboardPage.openDeviceSwitcher();
             await metadataPage.wallet.changeLabel({
-                index: WALLET_INDEX,
+                index: defaultWalletIndex,
                 label: expectedWallet.label,
             });
             await expect
-                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .soft(metadataPage.wallet.walletLabel(defaultWalletIndex))
                 .toHaveText(expectedWallet.label);
             await dashboardPage.deviceSwitchingCloseButton.click();
         });

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -1,0 +1,165 @@
+import { OwnerId } from '@evolu/common';
+
+import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-types';
+import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+
+import {
+    ownerId as defaultWalletOwnerId,
+    ownerSecret as defaultWalletOwnerSecret,
+    walletDescriptor,
+} from '../../../fixtures/metadata/default-metadata-ids';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+
+const walletOne = {
+    index: 1,
+    passphrase: 'First passphrase',
+    ownerId: OwnerId.orThrow('nv3sJB3YFuddnYPsMy03BA'),
+    ownerSecret: asSuiteSyncOwnerSecretHex(
+        'a42c516df49ec13ef4df8d2edfd33a893ddb3c5bb5423fb55e5f33a1852e2bc2d2fc70db8b35db609c730763f81c2d2bb491abf4f07505b0449386d54285b267',
+    ),
+};
+
+const walletTwo = {
+    index: 2,
+    passphrase: 'Second passphrase',
+    ownerId: OwnerId.orThrow('Mvz4DxvvznAgmppCU67NPw'),
+    ownerSecret: asSuiteSyncOwnerSecretHex(
+        '2b1643b805e3dec4ec2c3f57e707bce641f197ddd468070ffd4225393c4cb1a8e3935be81dd63f1e6d55145a73415d330328ba9c6eaa65fa56be8234fe512690',
+    ),
+};
+
+const expectedDefaultWalletLabel = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId: defaultWalletOwnerId,
+    walletDescriptor,
+    label: 'Evolu Default wallet',
+};
+
+const expectedWalletOneLabel = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId: walletOne.ownerId,
+    walletDescriptor: asWalletDescriptor('mokyaSGybeX7XrG5VWGoMtQepBXXK1RNW9'),
+    label: 'Evolu wallet #1',
+};
+
+const expectedAccountLabelWalletOne = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId: walletOne.ownerId,
+    accountDescriptor: asAccountDescriptor(
+        'zpub6r4imip23CwVmWTfqudEXK2PKZaw2bn8PEC1tju3d4oxQMfLK1QME9aN2o8t7potfCfz6f8T4jNafTyBVfEnqfXVUT8y4PWZ1JSc2HR8pRB',
+    ),
+    networkSymbol: 'btc',
+    label: 'Evolu BTC acc Wallet #1',
+};
+
+const expectedWalletTwoLabel = {
+    updatedAt: null,
+    isDeleted: null,
+    ownerId: walletTwo.ownerId,
+    walletDescriptor: asWalletDescriptor('n4YWykLsjHxToK8LwXJ7e8gwabBbAUDTk2'),
+    label: 'Evolu wallet #2',
+};
+
+test.describe('Suite Sync - Passphrase wallets', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true, deviceSetup: { passphrase_protection: true } });
+
+    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await metadataPage.setupQuotaManager();
+        await metadataPage.enableSuiteSync();
+    });
+
+    test('Labels on multiple wallets', async ({
+        page,
+        evoluClient,
+        dashboardPage,
+        metadataPage,
+        walletPage,
+    }) => {
+        await test.step('Change default wallet label', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.changeLabel({
+                index: 0,
+                label: expectedDefaultWalletLabel.label,
+            });
+        });
+
+        await test.step('Add passphrase #1 and enable Suite sync', async () => {
+            await dashboardPage.addUnusedHiddenWallet(walletOne.passphrase, {
+                suiteSync: 'enable',
+            });
+            await expect(metadataPage.suiteSyncBanner).toBeHidden();
+        });
+
+        await test.step('Set label for passphrase wallet #1', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await page.waitForTimeout(500); // wait for the walletSwitcher to completely open
+            await metadataPage.wallet.changeLabel({
+                index: walletOne.index,
+                label: expectedWalletOneLabel.label,
+            });
+        });
+
+        await test.step('Add passphrase #2 and decline Suite sync', async () => {
+            await dashboardPage.addUnusedHiddenWallet(walletTwo.passphrase, {
+                suiteSync: 'decline',
+            });
+            await expect(metadataPage.suiteSyncBanner).toContainTranslation(
+                'TR_SUITE_SYNC_KEYS_NEEDED_BANNER',
+            );
+        });
+
+        await test.step('Set account label for passphrase wallet #1', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.openDevice(walletOne.index);
+            await expect(metadataPage.suiteSyncBanner).toBeHidden();
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.account.changeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+                label: expectedAccountLabelWalletOne.label,
+            });
+        });
+
+        await test.step('Enable Suite sync on passphrase wallet #2 thru banner', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.openDevice(walletTwo.index);
+            await metadataPage.suiteSyncBannerButton.click();
+            await metadataPage.confirmSuiteSyncSetup();
+            await expect(metadataPage.suiteSyncBanner).toBeHidden();
+        });
+
+        await test.step('Set label for passphrase wallet #2', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await page.waitForTimeout(500); // wait for the walletSwitcher to completely open
+            await metadataPage.wallet.changeLabel({
+                index: walletTwo.index,
+                label: expectedWalletTwoLabel.label,
+            });
+        });
+
+        await test.step('Verify data are synced to Relay', async () => {
+            // Default wallet data
+            evoluClient.init({ ownerSecret: defaultWalletOwnerSecret });
+            await evoluClient.expectInTable('wallet', [expectedDefaultWalletLabel], {
+                softExpect: true,
+            });
+            // Passphrase #1 data
+            evoluClient.init({ ownerSecret: walletOne.ownerSecret });
+            await evoluClient.expectInTable('wallet', [expectedWalletOneLabel], {
+                softExpect: true,
+            });
+            await evoluClient.expectInTable('account', [expectedAccountLabelWalletOne], {
+                softExpect: true,
+            });
+            // Passphrase #2 data
+            evoluClient.init({ ownerSecret: walletTwo.ownerSecret });
+            await evoluClient.expectInTable('wallet', [expectedWalletTwoLabel], {
+                softExpect: true,
+            });
+        });
+    });
+});

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-server.test.ts
@@ -1,5 +1,4 @@
 import {
-    WALLET_INDEX,
     accountDescriptor,
     ownerSecret,
     walletDescriptor,
@@ -7,6 +6,7 @@ import {
 import { isWebProject } from '../../../support/common';
 import { expect, test } from '../../../support/fixtures';
 
+const defaultWalletIndex = 0;
 const walletSeed = {
     id: 'ya1CCDTCVPyRa6egTac7yg',
     walletDescriptor,
@@ -28,6 +28,15 @@ const addressSeed = {
     networkSymbol: 'btc',
 };
 
+const outputSeed = {
+    id: 'TR7Axj6suVoVTBJO5saruA',
+    accountDescriptor,
+    label: 'Evolu synced output',
+    networkSymbol: 'btc',
+    outputIndex: '0',
+    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
+};
+
 test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
@@ -37,6 +46,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             evoluClient.writeTo('wallet', walletSeed);
             evoluClient.writeTo('account', accountSeed);
             evoluClient.writeTo('address', addressSeed);
+            evoluClient.writeTo('output', outputSeed);
         });
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
     });
@@ -95,17 +105,29 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
         await test.step('Verify wallet label is synced', async () => {
             await dashboardPage.openDeviceSwitcher();
             await expect
-                .soft(metadataPage.wallet.walletLabel(WALLET_INDEX))
+                .soft(metadataPage.wallet.walletLabel(defaultWalletIndex))
                 .toHaveText(walletSeed.label);
             await dashboardPage.deviceSwitchingCloseButton.click();
         });
 
         await test.step('Verify address label is synced', async () => {
-            await walletPage.openAccount();
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
             await walletPage.receiveButton.click();
             await expect
                 .soft(metadataPage.address.label(addressSeed.address))
                 .toHaveText(addressSeed.label);
+        });
+
+        await test.step('Verify output label is synced', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await expect
+                .soft(
+                    metadataPage.output.outputLabel(
+                        outputSeed.txId,
+                        Number(outputSeed.outputIndex),
+                    ),
+                )
+                .toHaveText(outputSeed.label);
         });
     });
 });


### PR DESCRIPTION
Expanding coverage of suite sync. This test focuses on multiwallet labeling.

contains:
- rename of test file suite-sync to create-new-labels
- extra verification of output labels in sync-from-server test
- minor refactoring (formating)
- extra support method `device.expectToContainOnDisplay(string)`
- cleanup of evoluClient methods


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-multi-wallet&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-multi-wallet&lookback=7)