### PR TITLE
refactor(suite): unified naming of firmware and onboarding THP components

### DIFF
--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeEntryStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeEntryStep.tsx
@@ -6,11 +6,12 @@ import { spacings } from '@trezor/theme';
 
 import { ThpPairingCodeEntry } from '../../../components/connection/thp/ThpPairingCodeEntry';
 
-type StepThpPairingProps = {
+type ThpCodeEntryStepProps = {
     modalHeading: ReactNode;
 };
 
-export const StepThpPairing = ({ modalHeading }: StepThpPairingProps) => (
+// reflection of components/onboarding/ThpPairing/ThpCodeEntryStep
+export const ThpCodeEntryStep = ({ modalHeading }: ThpCodeEntryStepProps) => (
     <Modal.ModalBase
         onCancel={undefined} // intentionally NOT cancellable here, cancellable on the device only
         data-testid="@firmware-modal"

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeInvalidStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeInvalidStep.tsx
@@ -8,11 +8,12 @@ import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk'
 import { ThpPairingFailedForFirmwareInstallation } from '../../../components/connection/thp/ThpPairingFailedForFirmwareInstallation';
 import { useDispatch } from '../../../hooks/suite';
 
-type StepThpFailedProps = {
+type ThpCodeInvalidStepProps = {
     modalHeading: ReactNode;
 };
 
-export const StepThpFailed = ({ modalHeading }: StepThpFailedProps) => {
+// reflection of components/onboarding/ThpPairing/ThpCodeInvalidStep
+export const ThpCodeInvalidStep = ({ modalHeading }: ThpCodeInvalidStepProps) => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingConfirmStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingConfirmStep.tsx
@@ -4,11 +4,12 @@ import { Translation } from '@suite/intl';
 import { Card, Column, Modal, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-type StepThpPairingRequestProps = {
+type ThpPairingConfirmStepProps = {
     modalHeading: ReactNode;
 };
 
-export const StepThpPairingRequest = ({ modalHeading }: StepThpPairingRequestProps) => (
+// reflection of components/onboarding/ThpPairing/ThpPairingConfirmStep
+export const ThpPairingConfirmStep = ({ modalHeading }: ThpPairingConfirmStepProps) => (
     <Modal.ModalBase
         onCancel={undefined} // intentionally NOT cancellable here,  cancellable on the device only
         data-testid="@firmware-modal"

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStartStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStartStep.tsx
@@ -7,11 +7,12 @@ import { spacings } from '@trezor/theme';
 import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk';
 import { useDispatch } from '../../../hooks/suite';
 
-type StepThpStartProps = {
+type ThpPairingStartStepProps = {
     modalHeading: ReactNode;
 };
 
-export const StepThpStart = ({ modalHeading }: StepThpStartProps) => {
+// reflection of components/onboarding/ThpPairing/ThpPairingStartStep
+export const ThpPairingStartStep = ({ modalHeading }: ThpPairingStartStepProps) => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStep.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+
+import { ThpStep } from '@suite-common/thp';
+import { exhaustive } from '@trezor/type-utils';
+
+import { ThpCodeEntryStep } from './ThpCodeEntryStep';
+import { ThpCodeInvalidStep } from './ThpCodeInvalidStep';
+import { ThpPairingConfirmStep } from './ThpPairingConfirmStep';
+import { ThpPairingStartStep } from './ThpPairingStartStep';
+
+// reflection of components/onboarding/ThpPairingStep/ThpPairingStep.tsx
+export const ThpPairingStep = ({
+    thpStep,
+    heading,
+}: {
+    thpStep: NonNullable<ThpStep>;
+    heading: ReactNode;
+}) => {
+    switch (thpStep) {
+        case 'BeforeConnectionInfo':
+            return <ThpPairingStartStep modalHeading={heading} />;
+        case 'ConfirmOnlyConnection':
+        case 'ConfirmConnectionBeforePairing':
+            return <ThpPairingConfirmStep modalHeading={heading} />;
+        case 'CodeEntry':
+            return <ThpCodeEntryStep modalHeading={heading} />;
+        case 'CodeInvalid':
+            return <ThpCodeInvalidStep modalHeading={heading} />;
+
+        default:
+            exhaustive(thpStep);
+    }
+};

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeEntryStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeEntryStep.tsx
@@ -8,7 +8,8 @@ import TrezorConnect from '@trezor/connect';
 import { ThpPairingCodeEntry } from 'src/components/connection/thp/ThpPairingCodeEntry';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 
-export const ThpPairingStep = () => {
+// reflection of components/firmware/ThpPairing/ThpCodeEntryStep
+export const ThpCodeEntryStep = () => {
     const intl = useIntl();
 
     const abort = useCallback(

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeInvalidStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpCodeInvalidStep.tsx
@@ -8,7 +8,8 @@ import { ThpPairingFailedForFirmwareInstallation } from 'src/components/connecti
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { useDispatch } from 'src/hooks/suite';
 
-export const ThpPairingFailedStep = () => {
+// reflection of components/firmware/ThpPairing/ThpCodeInvalidStep
+export const ThpCodeInvalidStep = () => {
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);
 

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingConfirmStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingConfirmStep.tsx
@@ -1,11 +1,12 @@
 import { TrezorDevice } from '@suite-common/suite-types';
 
-import { ConfirmActionModal } from '../../../components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
+import { ConfirmActionModal } from 'src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmActionModal';
 
 type ThpPairingConfirmStepParams = {
     device: TrezorDevice;
 };
 
+// reflection of components/firmware/ThpPairing/ThpPairingConfirmStep
 export const ThpPairingConfirmStep = ({ device }: ThpPairingConfirmStepParams) => (
     <ConfirmActionModal
         device={device}

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStartStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStartStep.tsx
@@ -6,6 +6,7 @@ import { startThpSessionThunk } from 'src/actions/thp/startThpSessionThunk';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { useDispatch } from 'src/hooks/suite';
 
+// reflection of components/firmware/ThpPairing/ThpPairingStartStep
 export const ThpPairingStartStep = () => {
     const [isLoading, setIsLoading] = useState(false);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStep.tsx
+++ b/packages/suite/src/components/onboarding/ThpPairingStep/ThpPairingStep.tsx
@@ -1,0 +1,35 @@
+import { ThpStep } from '@suite-common/thp';
+import { selectSelectedDevice } from '@suite-common/wallet-core';
+import { exhaustive } from '@trezor/type-utils';
+
+import { useSelector } from 'src/hooks/suite/useSelector';
+import { DeviceDisconnectedStep } from 'src/views/onboarding/UnexpectedState/DeviceDisconnectedStep';
+
+import { ThpCodeEntryStep } from './ThpCodeEntryStep';
+import { ThpCodeInvalidStep } from './ThpCodeInvalidStep';
+import { ThpPairingConfirmStep } from './ThpPairingConfirmStep';
+import { ThpPairingStartStep } from './ThpPairingStartStep';
+
+// reflection of components/firmware/ThpPairingStep/ThpPairingStep.tsx
+export const ThpPairingStep = ({ thpStep }: { thpStep: NonNullable<ThpStep> }) => {
+    const device = useSelector(selectSelectedDevice);
+
+    if (!device?.connected) {
+        return <DeviceDisconnectedStep />;
+    }
+
+    switch (thpStep) {
+        case 'BeforeConnectionInfo':
+            return <ThpPairingStartStep />;
+        case 'ConfirmOnlyConnection':
+        case 'ConfirmConnectionBeforePairing':
+            return <ThpPairingConfirmStep device={device} />;
+        case 'CodeEntry':
+            return <ThpCodeEntryStep />;
+        case 'CodeInvalid':
+            return <ThpCodeInvalidStep />;
+
+        default:
+            exhaustive(thpStep);
+    }
+};

--- a/packages/suite/src/views/firmware/FirmwareModal.tsx
+++ b/packages/suite/src/views/firmware/FirmwareModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
 import { closeModalApp } from 'src/actions/suite/routerActions';
+import { ThpPairingStep } from 'src/components/firmware/ThpPairingStep/ThpPairingStep';
 import { useDispatch, useFirmwareInstallationProgressCheck, useSelector } from 'src/hooks/suite';
 import { useFirmwareDesktopUpdate } from 'src/hooks/suite/useFirmwareDesktopUpdate';
 
@@ -14,10 +15,6 @@ import { StepDone } from './Steps/StepDone';
 import { StepError } from './Steps/StepError';
 import { StepInitial } from './Steps/StepInitial';
 import { StepStarted } from './Steps/StepStarted';
-import { StepThpFailed } from './Steps/StepThpFailed';
-import { StepThpPairing } from './Steps/StepThpPairing';
-import { StepThpPairingRequest } from './Steps/StepThpPairingRequest';
-import { StepThpStart } from './Steps/StepThpStart';
 import * as modalActions from '../../actions/suite/modalActions';
 import { FirmwareInstallationProgressCheck } from '../../components/firmware';
 
@@ -60,23 +57,7 @@ export const FirmwareModal = ({
 
     const getContent = () => {
         if (thpStep !== null) {
-            switch (thpStep) {
-                case 'BeforeConnectionInfo':
-                    return <StepThpStart modalHeading={heading} />;
-                case 'ConfirmConnectionBeforePairing':
-                case 'ConfirmOnlyConnection':
-                    return device !== undefined ? (
-                        <StepThpPairingRequest modalHeading={heading} />
-                    ) : null;
-                case 'CodeEntry':
-                    return device !== undefined ? <StepThpPairing modalHeading={heading} /> : null;
-
-                case 'CodeInvalid':
-                    return <StepThpFailed modalHeading={heading} />;
-
-                default:
-                    exhaustive(thpStep);
-            }
+            return <ThpPairingStep thpStep={thpStep} heading={heading} />;
         }
 
         switch (status) {

--- a/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/FirmwareStep/index.tsx
@@ -10,6 +10,7 @@ import { exhaustive } from '@trezor/type-utils';
 import { MODAL } from 'src/actions/suite/constants';
 import { Fingerprint, FirmwareInstallationProgressCheck } from 'src/components/firmware';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
+import { ThpPairingStep } from 'src/components/onboarding/ThpPairingStep/ThpPairingStep';
 import { useFirmwareInstallationProgressCheck, useOnboarding, useSelector } from 'src/hooks/suite';
 import { useFirmwareDesktopUpdate } from 'src/hooks/suite/useFirmwareDesktopUpdate';
 import { getSuiteFirmwareTypeString } from 'src/utils/firmware';
@@ -17,10 +18,6 @@ import { getSuiteFirmwareTypeString } from 'src/utils/firmware';
 import { FirmwareInitialStep } from './FirmwareInitialStep';
 import { FirmwareInstallationStep } from './FirmwareInstallationStep';
 import { DeviceDisconnectedStep } from '../../UnexpectedState/DeviceDisconnectedStep';
-import { ThpPairingConfirmStep } from '../ThpPairingConfirmStep';
-import { ThpPairingFailedStep } from '../ThpPairingFailedStep';
-import { ThpPairingStartStep } from '../ThpPairingStartStep';
-import { ThpPairingStep } from '../ThpPairingStep';
 
 export const FirmwareStep = () => {
     const device = useSelector(selectSelectedDevice);
@@ -143,24 +140,7 @@ export const FirmwareStep = () => {
     }
 
     if (thpStep !== null) {
-        if (device === undefined) {
-            return <DeviceDisconnectedStep />;
-        }
-
-        switch (thpStep) {
-            case 'BeforeConnectionInfo':
-                return <ThpPairingStartStep />;
-            case 'ConfirmOnlyConnection':
-            case 'ConfirmConnectionBeforePairing':
-                return <ThpPairingConfirmStep device={device} />;
-            case 'CodeEntry':
-                return <ThpPairingStep />;
-            case 'CodeInvalid':
-                return <ThpPairingFailedStep />;
-
-            default:
-                exhaustive(thpStep);
-        }
+        return <ThpPairingStep thpStep={thpStep} />;
     }
 
     switch (status) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

THP components moved from **views** to `src/components`

- firmware/Steps/StepThpStart.tsx => `ThpPairingStartStep`
- firmware/Steps/StepThpPairingRequest => `ThpPairingConfirmStep`
- firmware/Steps/StepThpPairing > `ThpCodeEntryStep`
  onboarding/steps/ThpPairingStep => `ThpCodeEntryStep`
 - firmware/Steps/StepThpFailed => `ThpCodeInvalidStep`
  onboarding/steps/ThpPairingFailedStep => `ThpCodeInvalidStep`
 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-fw-update-components&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-fw-update-components&lookback=7)