### PR TITLE
Mobile trade: Prevent selection of the same asset in both from and to pickers in mobile swap

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.hook.test.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.hook.test.tsx
@@ -1,0 +1,69 @@
+import { PreloadedState, act, renderHookWithStoreProvider } from '@suite-native/test-utils';
+import { btcAsset, ethAsset, getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
+
+import { useExchangeBuyTradeableAssetsFilteredData } from '../useExchangeBuyTradeableAssetsFilteredData';
+
+const mockWatch = jest.fn();
+
+jest.mock('../useExchangeFormContext', () => ({
+    ...jest.requireActual('../useExchangeFormContext'),
+    useExchangeFormContext: () => ({
+        watch: mockWatch,
+    }),
+}));
+
+describe('useExchangeBuyTradeableAssetsFilteredData', () => {
+    const renderUseExchangeBuyTradeableAssetsFilteredData = () => {
+        const preloadedState: PreloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+
+        return renderHookWithStoreProvider(() => useExchangeBuyTradeableAssetsFilteredData(), {
+            preloadedState,
+        });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return all available exchange buy assets when sendAsset is not selected', () => {
+        mockWatch.mockReturnValue(undefined);
+
+        const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
+
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ cryptoId: usdcAsset.cryptoId }),
+            expect.objectContaining({ cryptoId: ethAsset.cryptoId }),
+            expect.objectContaining({ cryptoId: btcAsset.cryptoId }),
+        ]);
+    });
+
+    it('should exclude sendAsset from the filtered list', () => {
+        mockWatch.mockReturnValue(btcAsset);
+
+        const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
+
+        expect(result.current.filteredData).toHaveLength(2);
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ cryptoId: usdcAsset.cryptoId }),
+            expect.objectContaining({ cryptoId: ethAsset.cryptoId }),
+        ]);
+        expect(result.current.filteredData).not.toContainEqual(
+            expect.objectContaining({ cryptoId: btcAsset.cryptoId }),
+        );
+    });
+
+    it('should filter assets by search text', () => {
+        mockWatch.mockReturnValue(undefined);
+
+        const { result } = renderUseExchangeBuyTradeableAssetsFilteredData();
+
+        act(() => {
+            result.current.setFilterValue('usdc');
+        });
+
+        expect(result.current.filteredData).toHaveLength(1);
+        expect(result.current.filteredData[0].cryptoId).toBe(usdcAsset.cryptoId);
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -314,6 +314,17 @@ describe('useExchangeForm', () => {
 
             expect(dispatchSpy).toHaveBeenCalledWith(exchangeActions.sendAssetChanged());
         });
+
+        it('should clear receiveAsset when sendAsset has same cryptoId as receiveAsset', () => {
+            const { result } = renderUseExchangeForm();
+
+            act(() => {
+                result.current.setValue('receiveAsset', btcAsset);
+                result.current.setValue('sendAsset', btcAsset);
+            });
+
+            expect(result.current.getValues('receiveAsset')).toBeUndefined();
+        });
     });
 
     describe('receiveAccount', () => {

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,11 +1,19 @@
 import { useSelector } from 'react-redux';
 
-import { selectExchangeBuyTradeableAssets } from '@suite-native/trading-state';
+import {
+    type TradingRootState,
+    selectExchangeBuyTradeableAssets,
+} from '@suite-native/trading-state';
 
+import { useExchangeFormContext } from './useExchangeFormContext';
 import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFilteredData';
 
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
-    const assets = useSelector(selectExchangeBuyTradeableAssets);
+    const { watch } = useExchangeFormContext();
+    const sendAsset = watch('sendAsset');
+    const assets = useSelector((state: TradingRootState) =>
+        selectExchangeBuyTradeableAssets(state, sendAsset?.cryptoId),
+    );
 
     return useTradeableAssetsFilteredData({ assets });
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -114,6 +114,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
     const prevSendCryptoId = useRef<CryptoId | undefined>(undefined);
     const prevReceiveCryptoId = useRef<CryptoId | undefined>(undefined);
     const analytics = useAnalytics();
+
     useEffect(() => {
         const { unsubscribe } = watch(({ sendAsset, receiveAsset }, { name }) => {
             switch (name) {
@@ -129,6 +130,7 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
 
                         prevSendCryptoId.current = sendAsset?.cryptoId as CryptoId | undefined;
                         setValue('sendCryptoAmount', undefined, { shouldValidate: true });
+                        // TODO
                         dispatch(exchangeActions.sendAssetChanged());
                     }
                     break;

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -130,7 +130,9 @@ const useAmountAndCurrencyFieldsChangeEffect = ({ setValue, watch }: ExchangeFor
 
                         prevSendCryptoId.current = sendAsset?.cryptoId as CryptoId | undefined;
                         setValue('sendCryptoAmount', undefined, { shouldValidate: true });
-                        // TODO
+                        if (sendAsset?.cryptoId === receiveAsset?.cryptoId) {
+                            setValue('receiveAsset', undefined);
+                        }
                         dispatch(exchangeActions.sendAssetChanged());
                     }
                     break;

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -119,6 +119,17 @@ describe('exchangeSelectors', () => {
 
             expect(selectExchangeBuyTradeableAssets(state)).toEqual([]);
         });
+
+        it('should filter out forbidden cryptoId', () => {
+            const result = selectExchangeBuyTradeableAssets(
+                state,
+                'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            );
+            expect(result).toEqual([
+                expect.objectContaining({ cryptoId: 'ethereum' }),
+                expect.objectContaining({ cryptoId: 'bitcoin' }),
+            ]);
+        });
     });
 
     describe('selectExchangeQuotes', () => {

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -62,13 +62,16 @@ export const selectExchangeBuyTradeableAssets = createMemoizedSelector(
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingExchangeBuyCryptoIds>,
         ({ wallet }) => wallet.trading.info.coins,
+        (_state: TradingRootState, forbiddenCryptoId?: string) => forbiddenCryptoId,
     ],
-    (cryptoIds, coins) => {
+    (cryptoIds, coins, forbiddenCryptoId) => {
         if (!coins || !cryptoIds) {
             return [];
         }
 
-        return cryptoIds.map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
+        return cryptoIds
+            .filter(cryptoId => cryptoId !== forbiddenCryptoId)
+            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
     },
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Do not display asset selected as "you pay" in "you get" asset list
- When user selects same asset in "you pay" as is already selected in "you get", clear "you get" section.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24722

## Screenshots:

https://github.com/user-attachments/assets/f38f260b-26a7-4b55-8022-e59c046528c0



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24722-prevent-selection-of-the-same-asset-in-both-from-and-to-pickers-in-mobile-swap&lookback=7)