### PR TITLE
fix(suite-native): text button story variant prop

### DIFF
--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -13,7 +13,8 @@ import { HStack } from '../Stack';
 import { pressTimingConfig } from '../constants';
 import { ButtonAccessoryView, ButtonProps, ButtonSize, buttonToTextSizeMap } from './Button';
 
-export type TextButtonVariant = 'primary' | 'tertiary' | 'blue';
+export const TEXT_BUTTON_VARIANTS = ['primary', 'tertiary', 'blue'] as const;
+export type TextButtonVariant = (typeof TEXT_BUTTON_VARIANTS)[number];
 
 export type TextButtonProps = Omit<ButtonProps, 'colorScheme'> & {
     isUnderlined?: boolean;

--- a/suite-native/atoms/src/stories/Buttons/TextButton.stories.tsx
+++ b/suite-native/atoms/src/stories/Buttons/TextButton.stories.tsx
@@ -2,14 +2,20 @@ import type { Meta, StoryObj } from '@storybook/react-native';
 
 import { ICON_NAMES } from '@suite-native/icons';
 
-import { BUTTON_COLOR_SCHEMES, BUTTON_SIZES } from '../../Button/Button';
-import { TextButton as TextButtonComponent, TextButtonProps } from '../../Button/TextButton';
+import { BUTTON_SIZES } from '../../Button/Button';
+import {
+    TEXT_BUTTON_VARIANTS,
+    TextButton as TextButtonComponent,
+    TextButtonProps,
+} from '../../Button/TextButton';
 
 type TextButtonStory = StoryObj<TextButtonProps>;
 
 const meta: Meta<TextButtonProps> = {
     title: 'Atoms/Buttons',
     component: TextButtonComponent,
+    // Reanimated useSharedValue is used under the hood, so we need to mount the component again when `variant` is changed.
+    render: args => <TextButtonComponent {...args} key={args.variant} />, //
 };
 
 export default meta;
@@ -22,7 +28,7 @@ export const TextButton: TextButtonStory = {
         },
         variant: {
             control: { type: 'select' },
-            options: BUTTON_COLOR_SCHEMES,
+            options: TEXT_BUTTON_VARIANTS,
         },
         size: {
             control: { type: 'select' },


### PR DESCRIPTION
## Description
- fixes type of  `TextButton`component `variant` prop type
- story re-mounted when `variant` changes to make it work with the underlying Reanimated library

## Screenshots BEFORE:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/fd1de040-0a03-4761-867f-39e92d509b36" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/text-button-storybook&lookback=7)