### PR TITLE
chore: created CLAUDE.md that is symlinked to AGENTS.md

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -159,3 +159,5 @@ packages/connect-explorer-theme/style.css
 
 # Symlinks committed to repo, prettier can't handle them (that's ok; it will format the orig files anyway)
 docs/symlink/**
+CLAUDE.md
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -150,3 +150,4 @@ favicon.js
 
 # Symlinks committed to repo, prettier can't handle them (that's ok; it will format the orig files anyway)
 docs/symlink/**
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude can't pick up AGENTS.md by default, so we need a symlink.

**Changes**:
- created `CLAUDE.md` symlink to `AGENTS.md`

## Notes for QA

- nothing to test here, move along



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/symlink-claude-md&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/symlink-claude-md&lookback=7)