### PR TITLE
chore(utils): use VersionArray from device-utils

### DIFF
--- a/packages/connect/src/api/firmware/calculateFirmwareHash.ts
+++ b/packages/connect/src/api/firmware/calculateFirmwareHash.ts
@@ -1,7 +1,8 @@
 import { blake2sHex } from 'blakejs';
 
-import { DeviceModelInternal, VersionArray } from '@trezor/device-utils';
+import { DeviceModelInternal } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 // Size values are taken from
 // https://github.com/trezor/trezor-firmware/blob/56f9490c01b40e99d94fe5d8a283955800d86562/core/embed/models/T3T1/memory.h#L62

--- a/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
+++ b/packages/connect/src/api/firmware/parseFirmwareHeaders.ts
@@ -1,4 +1,4 @@
-import type { VersionArray } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 /**
  * parse firmware headers
  * based on

--- a/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.bootloader.test.ts
@@ -1,9 +1,5 @@
-import {
-    DeviceModelInternal,
-    FirmwareRelease,
-    FirmwareType,
-    VersionArray,
-} from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { getReleaseInfo } from '../firmwareInfo';
 

--- a/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.firmware.test.ts
@@ -1,9 +1,5 @@
-import {
-    DeviceModelInternal,
-    FirmwareRelease,
-    FirmwareType,
-    VersionArray,
-} from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { getReleaseInfo } from '../firmwareInfo';
 

--- a/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.fresh.test.ts
@@ -1,9 +1,5 @@
-import {
-    DeviceModelInternal,
-    FirmwareRelease,
-    FirmwareType,
-    VersionArray,
-} from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { getReleaseInfo } from '../firmwareInfo';
 

--- a/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
+++ b/packages/connect/src/data/__tests__/getReleaseInfo.required.test.ts
@@ -1,4 +1,5 @@
-import { FirmwareRelease, FirmwareType, VersionArray } from '@trezor/device-utils';
+import { FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { getReleaseInfo } from '../firmwareInfo';
 

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -7,12 +7,12 @@ import {
     FirmwareReleaseConfig,
     FirmwareType,
     IntermediaryReleaseConfig,
-    VersionArray,
     getBootloaderVersionArray,
     getFirmwareOrBootloaderVersionArray,
     getFirmwareVersionArray,
 } from '@trezor/device-utils';
 import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from './DataManager';
 import { Features, StrictFeatures } from '../types/device';

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -18,6 +18,7 @@ import { Session, TRANSPORT, TRANSPORT_ERROR } from '@trezor/transport';
 import { type Descriptor, type Transport } from '@trezor/transport';
 import { TransportDeviceEvent } from '@trezor/transport/src/transports/abstract';
 import { Deferred, TypedEmitter, createDeferred, isArrayMember, versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DeviceCommands } from './DeviceCommands';
 import { FIRMWARE, PROTO } from '../constants';
@@ -59,7 +60,6 @@ import {
     FirmwareType,
     KnownDevice,
     UnavailableCapabilities,
-    VersionArray,
     asBluetoothDeviceId,
 } from '../types';
 import { handshakeCancel } from './workflow/handshake';

--- a/packages/connect/src/device/calculateRevisionForDevice.ts
+++ b/packages/connect/src/device/calculateRevisionForDevice.ts
@@ -1,4 +1,4 @@
-import { VersionArray } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 import { isNewer } from '@trezor/utils/src/versionUtils';
 
 type calculateRevisionForDeviceParams = {

--- a/packages/connect/src/device/checkFirmwareRevision.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.ts
@@ -1,6 +1,7 @@
-import type { FirmwareType, VersionArray } from '@trezor/device-utils';
+import type { FirmwareType } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { serializeError, versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 import { getOnlineReleaseByVersion } from '../data/firmwareInfo';

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -1,10 +1,10 @@
-import type { VersionArray } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type {
     DecodedTrezorPushNotification,
     ThpCredentials,
     ThpPairingMethod,
 } from '@trezor/protocol';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import type { Device } from '../types/device';
 import type { MessageFactoryFn } from '../types/utils';

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -1,13 +1,9 @@
 /*
  * messages to UI emitted as UI_EVENT
  */
-import {
-    DeviceModelInternal,
-    FirmwareRelease,
-    FirmwareType,
-    VersionArray,
-} from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';

--- a/packages/connect/src/types/api/firmwareUpdate.ts
+++ b/packages/connect/src/types/api/firmwareUpdate.ts
@@ -1,5 +1,5 @@
-import type { VersionArray } from '@trezor/device-utils';
 import { Static, Type } from '@trezor/schema-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import type { Params, Response } from '../params';
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -4,8 +4,8 @@ import type {
     FirmwareRelease,
     FirmwareType,
     IntermediaryReleaseConfig,
-    VersionArray,
 } from '@trezor/device-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 export type FirmwareRange = Record<
     DeviceModelInternal,

--- a/packages/connect/src/types/index.ts
+++ b/packages/connect/src/types/index.ts
@@ -42,5 +42,5 @@ export type {
     AccountBalanceHistory as BlockchainAccountBalanceHistory,
 } from '@trezor/blockchain-link';
 
-export { FirmwareType, type VersionArray } from '@trezor/device-utils';
+export { FirmwareType } from '@trezor/device-utils';
 export { ThpPairingMethod } from '@trezor/protocol/src/protocol-thp/messages';

--- a/packages/connect/src/utils/assetUtils.ts
+++ b/packages/connect/src/utils/assetUtils.ts
@@ -1,11 +1,7 @@
 import { firmwareAssets } from '@trezor/connect-data';
-import {
-    DeviceModelInternal,
-    FirmwareRelease,
-    FirmwareType,
-    VersionArray,
-} from '@trezor/device-utils';
+import { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 export class HttpRequestError extends Error {
     response: Response;

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -1,6 +1,7 @@
 import { FirmwareType } from '@trezor/device-utils';
-import type { DeviceModelInternal, FirmwareRelease, VersionArray } from '@trezor/device-utils';
+import type { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from '../data/DataManager';
 import type { CurrentVersion } from '../data/firmwareInfo';

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -31,6 +31,7 @@
     },
     "devDependencies": {
         "@trezor/protobuf": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "tsx": "^4.21.0"
     }
 }

--- a/packages/device-utils/src/bootloaderUtils.ts
+++ b/packages/device-utils/src/bootloaderUtils.ts
@@ -1,6 +1,8 @@
+import { VersionArray } from '@trezor/utils/src/versionUtils';
+
 import { getFirmwareOrBootloaderVersionArray } from './firmwareUtils';
 import { isDeviceInBootloaderMode } from './modeUtils';
-import { FirmwareVersionString, PartialDevice, VersionArray } from './types';
+import { FirmwareVersionString, PartialDevice } from './types';
 
 export const getBootloaderHash = (device?: PartialDevice) =>
     device?.features?.bootloader_hash || '';

--- a/packages/device-utils/src/firmwareUtils.ts
+++ b/packages/device-utils/src/firmwareUtils.ts
@@ -1,13 +1,8 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { isDeviceInBootloaderMode } from './modeUtils';
-import {
-    FirmwareSource,
-    FirmwareType,
-    FirmwareVersionString,
-    PartialDevice,
-    VersionArray,
-} from './types';
+import { FirmwareSource, FirmwareType, FirmwareVersionString, PartialDevice } from './types';
 
 export const getFirmwareSource = (device?: PartialDevice): FirmwareSource => {
     if (device?.mode === 'bootloader') {

--- a/packages/device-utils/src/types.ts
+++ b/packages/device-utils/src/types.ts
@@ -1,4 +1,5 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DeviceModelInternal } from './deviceModelInternal';
 
@@ -8,8 +9,6 @@ export enum FirmwareType {
     BitcoinOnly = 'bitcoin-only',
     Universal = 'universal',
 }
-
-export type VersionArray = [number, number, number];
 
 export type FeaturesNarrowing =
     | {

--- a/packages/device-utils/tsconfig.json
+++ b/packages/device-utils/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../protobuf" }]
+    "references": [
+        { "path": "../protobuf" },
+        { "path": "../utils" }
+    ]
 }

--- a/packages/device-utils/tsconfig.lib.json
+++ b/packages/device-utils/tsconfig.lib.json
@@ -7,6 +7,9 @@
     "references": [
         {
             "path": "../protobuf"
+        },
+        {
+            "path": "../utils"
         }
     ]
 }

--- a/packages/device-utils/tsconfig.libESM.json
+++ b/packages/device-utils/tsconfig.libESM.json
@@ -7,6 +7,9 @@
     "references": [
         {
             "path": "../protobuf"
+        },
+        {
+            "path": "../utils"
         }
     ]
 }

--- a/packages/utils/src/versionUtils.ts
+++ b/packages/utils/src/versionUtils.ts
@@ -1,6 +1,7 @@
 import { throwError } from './throwError';
 
-type VersionArray = [number, number, number];
+export type VersionArray = [number, number, number];
+
 type VersionInput = VersionArray | string;
 
 export const isVersionArray = (arr: unknown): arr is VersionArray =>

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -13,8 +13,8 @@ import {
     UnreadableDevice as UnreadableDeviceBase,
     Unsuccessful,
 } from '@trezor/connect';
-import { VersionArray } from '@trezor/device-utils';
 import { Branded, UnionSubset } from '@trezor/type-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 // Extend original ButtonRequestMessage from @trezor/connect
 // suite (deviceReducer) stores them in slightly different shape:

--- a/suite-native/analytics/package.json
+++ b/suite-native/analytics/package.json
@@ -22,6 +22,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
+        "@trezor/utils": "workspace:^",
         "react-native": "0.81.5"
     }
 }

--- a/suite-native/analytics/src/events/deviceConnectEvent.ts
+++ b/suite-native/analytics/src/events/deviceConnectEvent.ts
@@ -1,6 +1,7 @@
 import type { AttributeDef, EventDef } from '@suite-common/analytics';
-import { DeviceMode, VersionArray } from '@trezor/connect';
+import { DeviceMode } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { EventType } from '../constants';
 

--- a/suite-native/analytics/tsconfig.json
+++ b/suite-native/analytics/tsconfig.json
@@ -26,6 +26,7 @@
         },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
-        { "path": "../../packages/env-utils" }
+        { "path": "../../packages/env-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-native/device/src/utils.ts
+++ b/suite-native/device/src/utils.ts
@@ -13,13 +13,14 @@ import {
 import type { AnalyticsNativeEvents } from '@suite-native/analytics';
 import { events } from '@suite-native/analytics';
 import { Analytics } from '@trezor/analytics-uploader';
-import { Device, DeviceEvent, VersionArray } from '@trezor/connect';
+import { Device, DeviceEvent } from '@trezor/connect';
 import {
     DeviceModelInternal,
     getFirmwareVersionArray,
     hasBitcoinOnlyFirmware,
 } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 export const minimalSupportedFirmwareVersion = {
     UNKNOWN: [0, 0, 0] as VersionArray,

--- a/suite-native/firmware/package.json
+++ b/suite-native/firmware/package.json
@@ -39,6 +39,7 @@
         "@trezor/react-native-usb": "workspace:*",
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
+        "@trezor/utils": "workspace:^",
         "expo-keep-awake": "~15.0.8",
         "react": "19.1.0",
         "react-native": "0.81.5",

--- a/suite-native/firmware/src/components/FirmwareVersionCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareVersionCard.tsx
@@ -19,8 +19,8 @@ import {
 } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { VersionArray } from '@trezor/device-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { FirmwareChangelogButton } from './FirmwareChangelogButton';
 import { FirmwareInfoBox } from './FirmwareInfoBox';

--- a/suite-native/firmware/tsconfig.json
+++ b/suite-native/firmware/tsconfig.json
@@ -36,6 +36,7 @@
             "path": "../../packages/react-native-usb"
         },
         { "path": "../../packages/styles" },
-        { "path": "../../packages/theme" }
+        { "path": "../../packages/theme" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11900,6 +11900,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
+    "@trezor/utils": "workspace:^"
     react-native: "npm:0.81.5"
   languageName: unknown
   linkType: soft
@@ -12596,6 +12597,7 @@ __metadata:
     "@trezor/react-native-usb": "workspace:*"
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/utils": "workspace:^"
     expo-keep-awake: "npm:~15.0.8"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -15334,6 +15336,7 @@ __metadata:
   resolution: "@trezor/device-utils@workspace:packages/device-utils"
   dependencies:
     "@trezor/protobuf": "workspace:*"
+    "@trezor/utils": "workspace:*"
     tsx: "npm:^4.21.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We had 2 different VersionArray in different packages, having only one is more consistent.

I had to make `@trezor/device-utils` a dependency of `@trezor/utils` which I don't really like but I think it is OK since it is just type and now we have only one VersionArray type.

## Notes for QA

Nothing to test.

## Related Issue

Related to https://github.com/trezor/trezor-suite/pull/25221


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/VersionArray-in-one-place&lookback=7)