### PR TITLE
Test e2e refactor asset picker locators

### DIFF
--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -81,7 +81,7 @@ export const Control = ({
                     gap={4}
                     padding={isClean ? undefined : { horizontal: INPUT_PADDING }}
                     overflow="hidden"
-                    data-testid={dataTest ? `${dataTest}/control` : undefined}
+                    data-testid={dataTest ? `${dataTest}/input` : undefined}
                     cursor="pointer"
                 >
                     {children}

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -81,7 +81,7 @@ export const Control = ({
                     gap={4}
                     padding={isClean ? undefined : { horizontal: INPUT_PADDING }}
                     overflow="hidden"
-                    data-testid={dataTest ? `${dataTest}/input` : undefined}
+                    data-testid={dataTest ? `${dataTest}/control` : undefined}
                     cursor="pointer"
                 >
                     {children}

--- a/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SearchAsset.tsx
@@ -7,7 +7,6 @@ export type SearchAssetProps = {
     searchPlaceholder: string;
     search: string;
     setSearch: (value: string) => void;
-    'data-testid'?: string;
     selectConfig?: SearchAssetSelectConfig;
     autoFocus?: boolean;
 };
@@ -16,11 +15,11 @@ export const SearchAsset = ({
     searchPlaceholder,
     search,
     setSearch,
-    'data-testid': dataTestId,
     selectConfig,
     autoFocus = false,
 }: SearchAssetProps) => {
     const { options, selectedOption } = useNetworkSelect(selectConfig);
+    const dataTestIdBase = '@asset-picker/search';
 
     const networkSelect = selectConfig ? (
         <Select
@@ -34,8 +33,8 @@ export const SearchAsset = ({
                     gap={8}
                     data-testid={
                         meta.context === 'menu'
-                            ? `${dataTestId}/select-option/${option.value ?? 'all-networks'}`
-                            : `${dataTestId}/select-option-value/${option.value ?? 'all-networks'}`
+                            ? `${dataTestIdBase}/filter/select-option/${option.value ?? 'all-networks'}`
+                            : `${dataTestIdBase}/filter/select-option-value/${option.value ?? 'all-networks'}`
                     }
                 >
                     {option.value && <CoinLogo size={20} symbol={option.value} type="network" />}
@@ -44,14 +43,14 @@ export const SearchAsset = ({
                     </Text>
                 </Row>
             )}
-            data-testid={`${dataTestId}/select`}
+            data-testid={`${dataTestIdBase}/filter`}
             openMenuOnFocus={false}
         />
     ) : undefined;
 
     return (
         <Input
-            data-testid={dataTestId ?? '@search-asset-input'}
+            data-testid={`${dataTestIdBase}/input`}
             placeholder={searchPlaceholder}
             value={search}
             onChange={event => setSearch(event.target.value)}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
@@ -19,12 +19,7 @@ export function AssetRowAccountWithBalance({
 }: AssetRowAccountWithBalanceProps) {
     return (
         <ItemClickableContainer onClick={() => onClick(account)}>
-            <Row
-                data-testid={dataTestId ? `${dataTestId}/${account.symbol}` : undefined}
-                gap={12}
-                alignItems="center"
-                overflow="hidden"
-            >
+            <Row data-testid={dataTestId} gap={12} alignItems="center" overflow="hidden">
                 <CoinLogo symbol={account.symbol} size={40} type="tokenWithNetwork" />
                 <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
                     <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -19,12 +19,7 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
                 onClick(asset);
             }}
         >
-            <Row
-                data-testid={dataTestId ? `${dataTestId}/${asset.id}` : undefined}
-                gap={12}
-                overflow="hidden"
-                maxWidth="100%"
-            >
+            <Row data-testid={dataTestId} gap={12} overflow="hidden" maxWidth="100%">
                 {asset.isNativeToken ? (
                     <CoinLogo
                         size={40}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -32,13 +32,7 @@ export function AssetRowToken({
             padding={isHiddenToken ? { left: 16, vertical: 8, right: 16 } : undefined}
             isDisabled={!onClick}
         >
-            <Row
-                data-testid={
-                    dataTestId ? `${dataTestId}/${account.symbol}/${token.symbol}` : undefined
-                }
-                gap={12}
-                overflow="hidden"
-            >
+            <Row data-testid={dataTestId} gap={12} overflow="hidden">
                 <AssetLogo
                     size={40}
                     coingeckoId={getCoingeckoId(account.symbol)!}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -45,6 +45,7 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
             searchPlaceholder={translationString(placeholder)}
             search={search}
             setSearch={setSearch}
+            data-testid="@asset-picker/search"
             selectConfig={{
                 networks,
                 selectedNetwork: networkFilter,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -45,7 +45,6 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
             searchPlaceholder={translationString(placeholder)}
             search={search}
             setSearch={setSearch}
-            data-testid="@asset-picker/search"
             selectConfig={{
                 networks,
                 selectedNetwork: networkFilter,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -83,7 +83,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                 case 'account':
                     return (
                         <AssetRowAccountWithBalance
-                            dataTestId={`@asset-picker/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}`}
+                            dataTestId={`@asset-picker/send/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}`}
                             account={item.account}
                             onClick={handleAccountClick}
                         />
@@ -92,7 +92,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                 case 'token':
                     return (
                         <AssetRowToken
-                            dataTestId={`@asset-picker/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}/token/${item.token.symbol}`}
+                            dataTestId={`@asset-picker/send/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}/token/${item.token.symbol}`}
                             token={item.token}
                             account={item.account}
                             onClick={handleTokenClick}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/GlobalSendModal.tsx
@@ -83,7 +83,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                 case 'account':
                     return (
                         <AssetRowAccountWithBalance
-                            dataTestId={`@global-send-account/${item.account.accountType}/${item.account.symbol}/${item.account.index}`}
+                            dataTestId={`@asset-picker/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}`}
                             account={item.account}
                             onClick={handleAccountClick}
                         />
@@ -92,6 +92,7 @@ export function GlobalSendModal({ onCancel, onSubmit }: GlobalSendModalProps) {
                 case 'token':
                     return (
                         <AssetRowToken
+                            dataTestId={`@asset-picker/option/${item.account.accountType}/${item.account.symbol}/${item.account.index}/token/${item.token.symbol}`}
                             token={item.token}
                             account={item.account}
                             onClick={handleTokenClick}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -96,7 +96,6 @@ export const TradingBuyFormInputs = () => {
                         inputDisabled={hasBitcoinOnlyFirmware(device)}
                         onAssetSelect={handleCryptoSelect}
                         includedCryptoIds={buySupportedCryptoIds}
-                        dataTestId="@trading/form/select-crypto-for-buy"
                     />
                 </TradingFormSection>
                 {cryptoSelect && !isLoading && <TradingReceiveAddress />}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -132,7 +132,6 @@ export const TradingExchangeFormInputs = () => {
                     }
                     includedCryptoIds={exchangeSellSupportedCryptoIds}
                     excludedCryptoId={receiveCryptoSelect?.id}
-                    dataTestId="@trading/form/select-crypto-for-sell"
                     onAssetSelect={handleSellAssetSelect}
                 />
                 <Column gap={8}>
@@ -184,7 +183,6 @@ export const TradingExchangeFormInputs = () => {
                     includedCryptoIds={exchangeBuySupportedCryptoIds}
                     excludedCryptoId={sendCryptoSelect?.id}
                     onAssetSelect={handleReceiveAssetSelect}
-                    dataTestId="@trading/form/select-crypto-for-buy"
                 />
             </TradingFormSection>
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
@@ -65,7 +65,7 @@ export const AssetPickerInput = memo(function AssetPickerInputInner({
     const leftContent = useMemo(() => {
         if (value) {
             // @ts-expect-error
-            return <AssetPickerInputContent name={name} value={value} dataTestId={dataTestId} />;
+            return <AssetPickerInputContent name={name} value={value} />;
         }
 
         if (isLoading) {
@@ -73,7 +73,7 @@ export const AssetPickerInput = memo(function AssetPickerInputInner({
         }
 
         return undefined;
-    }, [value, isLoading, name, dataTestId]);
+    }, [value, isLoading, name]);
 
     return (
         <OpenModalButton
@@ -92,7 +92,7 @@ export const AssetPickerInput = memo(function AssetPickerInputInner({
                     !value && !isLoading && placeholder ? translationString(placeholder) : undefined
                 }
                 isDisabled={disabled}
-                data-testid={`${dataTestId}/input`}
+                data-testid={`${dataTestId ?? '@asset-picker'}/input`}
                 labelLeft={
                     label && (
                         <Text typographyStyle="body-md" intent="neutral" priority="secondary">

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -9,9 +9,7 @@ import { NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet
 import { Column, Row, Text } from '@trezor/components';
 import { AssetLogo, CoinLogo } from '@trezor/product-components';
 
-export type AssetPickerInputContentProps = {
-    dataTestId?: string;
-} & (
+export type AssetPickerInputContentProps = {} & (
     | {
           name: typeof TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT;
           value: TradingAssetSellOption;
@@ -24,7 +22,7 @@ export type AssetPickerInputContentProps = {
       }
 );
 
-export function AssetPickerInputContent({ value, dataTestId }: AssetPickerInputContentProps) {
+export function AssetPickerInputContent({ value }: AssetPickerInputContentProps) {
     const {
         isNativeToken,
         networkSymbol,
@@ -53,9 +51,7 @@ export function AssetPickerInputContent({ value, dataTestId }: AssetPickerInputC
                 />
             )}
             <Column alignItems="start">
-                <Text data-testid={dataTestId ? `${dataTestId}/display-symbol` : undefined}>
-                    {displayName}
-                </Text>
+                <Text data-testid="@asset-picker/display-symbol">{displayName}</Text>
                 {showNetwork && (
                     <Text intent="neutral" priority="secondary" typographyStyle="body-xs">
                         {networkName}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -13,7 +13,6 @@ export interface AssetSearchWithNetworkFilterProps {
     networkFilter: NetworkSymbol | undefined;
     setNetworkFilter: (networkFilter: NetworkSymbol | undefined) => void;
     networks: NetworkSymbol[];
-    dataTestId?: string;
 }
 
 export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetworkFilterInner({
@@ -23,7 +22,6 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
     networkFilter,
     setNetworkFilter,
     networks,
-    dataTestId,
 }: AssetSearchWithNetworkFilterProps) {
     const { translationString } = useTranslation();
 
@@ -40,7 +38,7 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
                     includeAllOption: true,
                     allLabel: translationString('TR_ALL_NETWORKS'),
                 }}
-                data-testid={dataTestId ? `${dataTestId}/search` : undefined}
+                data-testid="@asset-picker/search"
             />
         </Box>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -38,7 +38,6 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
                     includeAllOption: true,
                     allLabel: translationString('TR_ALL_NETWORKS'),
                 }}
-                data-testid="@asset-picker/search"
             />
         </Box>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -26,7 +26,6 @@ import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker'
 export type AssetPickerModalProps = {
     closeModal: () => void;
     heading: TranslationKey;
-    dataTestId: string;
     onAssetSelect: UseUpdateFormInputProps['onAssetSelect'];
 };
 
@@ -34,7 +33,6 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
     closeModal,
     heading,
     onAssetSelect,
-    dataTestId,
 }: AssetPickerModalProps) {
     const { search, throttledSearch, setSearch } = useSearchFilter();
     const [networkSymbol, setNetworkSymbol] = useState<NetworkSymbol | undefined>(undefined);
@@ -61,7 +59,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                                         height: ASSET_ROW_HEIGHT,
                                     })
                                 }
-                                data-testid={`${dataTestId}/top-assets`}
+                                data-testId="@asset-picker/option/top-assets"
                             />
                         </Box>
                     );
@@ -71,7 +69,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAccountWithBalance
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`${dataTestId}/account`}
+                            dataTestId={`@asset-picker/option/${item.account.symbol}`}
                         />
                     );
 
@@ -81,7 +79,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             token={item.token}
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`${dataTestId}/token`}
+                            dataTestId={`@asset-picker/option/${item.account.symbol}/${item.token.symbol}`}
                         />
                     );
 
@@ -90,7 +88,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAsset
                             asset={item.asset}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`${dataTestId}/asset`}
+                            dataTestId={`@asset-picker/option/asset/${item.asset.id}`}
                         />
                     );
 
@@ -98,7 +96,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                     return <AssetGroupLabel label={item.label} />;
             }
         },
-        [dataTestId, handleAssetClick],
+        [handleAssetClick],
     );
 
     return (
@@ -110,7 +108,6 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 networkFilter={networkSymbol}
                 setNetworkFilter={setNetworkSymbol}
                 networks={networks}
-                dataTestId={dataTestId}
             />
 
             <Divider margin={{ top: 16 }} />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -59,7 +59,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                                         height: ASSET_ROW_HEIGHT,
                                     })
                                 }
-                                data-testId="@asset-picker/option/top-assets"
+                                data-testid="@asset-picker/buy/option/top-assets"
                             />
                         </Box>
                     );
@@ -69,7 +69,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAccountWithBalance
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`@asset-picker/option/${item.account.symbol}`}
+                            dataTestId={`@asset-picker/buy/option/${item.account.symbol}`}
                         />
                     );
 
@@ -79,7 +79,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             token={item.token}
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`@asset-picker/option/${item.account.symbol}/${item.token.symbol}`}
+                            dataTestId={`@asset-picker/buy/option/${item.account.symbol}/${item.token.symbol}`}
                         />
                     );
 
@@ -88,7 +88,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAsset
                             asset={item.asset}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`@asset-picker/option/asset/${item.asset.id}`}
+                            dataTestId={`@asset-picker/buy/option/asset/${item.asset.id}`}
                         />
                     );
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/TradingFormInputBuyAsset.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/TradingFormInputBuyAsset.tsx
@@ -21,8 +21,6 @@ export interface TradingFormInputBuyAssetProps {
 
     includedCryptoIds: CryptoId[];
     excludedCryptoId?: CryptoId | undefined;
-
-    dataTestId: string;
 }
 
 export const TradingFormInputBuyAsset = memo(function TradingFormInputBuyAssetInner({
@@ -30,7 +28,6 @@ export const TradingFormInputBuyAsset = memo(function TradingFormInputBuyAssetIn
     inputLabel,
     inputName,
     inputDisabled,
-    dataTestId,
     includedCryptoIds,
     excludedCryptoId,
     onAssetSelect,
@@ -53,13 +50,12 @@ export const TradingFormInputBuyAsset = memo(function TradingFormInputBuyAssetIn
                 placeholder={inputPlaceholder}
                 isDisabled={inputDisabled}
                 onClick={modal.openModal}
-                dataTestId={dataTestId}
+                dataTestId="@trading/buy/asset-picker"
             />
             {modal.open && (
                 <AssetPickerModal
                     heading={inputLabel}
                     closeModal={modal.closeModal}
-                    dataTestId={dataTestId}
                     onAssetSelect={onAssetSelect}
                 />
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -26,7 +26,6 @@ import { AssetSearchWithNetworkFilter } from '../../TradingFormInputAssetPicker'
 export type AssetPickerModalProps = {
     closeModal: () => void;
     heading: TranslationKey;
-    dataTestId: string;
     onAssetSelect: UseUpdateFormInputProps['onAssetSelect'];
 };
 
@@ -34,7 +33,6 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
     closeModal,
     heading,
     onAssetSelect,
-    dataTestId,
 }: AssetPickerModalProps) {
     const { search, throttledSearch, setSearch } = useSearchFilter();
 
@@ -58,7 +56,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAccountWithBalance
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`${dataTestId}/account`}
+                            dataTestId={`@asset-picker/option/${item.account.symbol}`}
                         />
                     );
 
@@ -68,7 +66,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             token={item.token}
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`${dataTestId}/token`}
+                            dataTestId={`@asset-picker/option/${item.account.symbol}/${item.token.symbol}`}
                         />
                     );
 
@@ -87,13 +85,13 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             expanded={item.expanded}
                             onExpandToggle={updateExpandableAccountGroups}
                             height={item.height}
-                            dataTestId={`${dataTestId}/non-tradable-tokens`}
+                            dataTestId={`@asset-picker/option/non-tradable-tokens/${item.account.symbol}}`}
                             showTokensPreview
                         />
                     );
             }
         },
-        [dataTestId, handleAssetClick, updateExpandableAccountGroups],
+        [handleAssetClick, updateExpandableAccountGroups],
     );
 
     return (
@@ -105,7 +103,6 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 networkFilter={networkFilter}
                 setNetworkFilter={setNetworkFilter}
                 networks={networks}
-                dataTestId={dataTestId}
             />
 
             <Divider margin={{ top: 16 }} />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -56,7 +56,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                         <AssetRowAccountWithBalance
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`@asset-picker/option/${item.account.symbol}`}
+                            dataTestId={`@asset-picker/sell/option/${item.account.symbol}`}
                         />
                     );
 
@@ -66,7 +66,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             token={item.token}
                             account={item.account}
                             onClick={() => handleAssetClick(item)}
-                            dataTestId={`@asset-picker/option/${item.account.symbol}/${item.token.symbol}`}
+                            dataTestId={`@asset-picker/sell/option/${item.account.symbol}/${item.token.symbol}`}
                         />
                     );
 
@@ -85,7 +85,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             expanded={item.expanded}
                             onExpandToggle={updateExpandableAccountGroups}
                             height={item.height}
-                            dataTestId={`@asset-picker/option/non-tradable-tokens/${item.account.symbol}}`}
+                            dataTestId={`@asset-picker/sell/option/non-tradable-tokens/${item.account.symbol}`}
                             showTokensPreview
                         />
                     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/TradingFormInputSellAsset.tsx
@@ -22,8 +22,6 @@ export interface TradingFormInputSellAssetProps {
 
     includedCryptoIds: CryptoId[] | undefined;
     excludedCryptoId?: CryptoId | undefined;
-
-    dataTestId: string;
 }
 
 export const TradingFormInputSellAsset = memo(function TradingFormInputSellAssetInner({
@@ -32,7 +30,6 @@ export const TradingFormInputSellAsset = memo(function TradingFormInputSellAsset
     inputName,
     inputDisabled,
     inputBottomText,
-    dataTestId,
     onAssetSelect,
     includedCryptoIds,
     excludedCryptoId,
@@ -55,14 +52,13 @@ export const TradingFormInputSellAsset = memo(function TradingFormInputSellAsset
                 placeholder={inputPlaceholder}
                 isDisabled={inputDisabled}
                 onClick={modal.openModal}
-                dataTestId={dataTestId}
+                dataTestId="@trading/sell/asset-picker"
                 bottomText={inputBottomText}
             />
             {modal.open && (
                 <AssetPickerModal
                     heading={inputLabel}
                     closeModal={modal.closeModal}
-                    dataTestId={dataTestId}
                     onAssetSelect={onAssetSelect}
                 />
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -88,7 +88,6 @@ export const TradingSellFormInputs = () => {
                         <AssetPickerInputBalance name={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT} />
                     }
                     includedCryptoIds={sellSupportedCryptoIds}
-                    dataTestId="@trading/form/select-crypto-for-sell"
                     onAssetSelect={handleSellAssetSelect}
                 />
                 <Column gap={8}>

--- a/suite/e2e/archive/trading/sell-bitcoin-fees.test.ts
+++ b/suite/e2e/archive/trading/sell-bitcoin-fees.test.ts
@@ -1,6 +1,6 @@
 import { invityEndpoint, sellQuotesBTC, sellTradeBTC, sellWatchBTC } from '../../fixtures/invity';
 import { expect, test } from '../../support/fixtures';
-import { FeeTypes } from '../../support/pageObjects/trading/fees';
+import { FeeTypes } from '../../support/pageObjects/trading/feeSection';
 
 interface FeeSwitchTestCase {
     feeType: FeeTypes | 'custom';
@@ -11,7 +11,7 @@ interface FeeSwitchTestCase {
 const cryptoAmount = sellQuotesBTC[0].cryptoStringAmount;
 
 test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () => {
-    test.use({ emulatorSetupConf: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
     test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage }) => {
         await test.step('Mocking responses', async () => {
             await page.route(invityEndpoint.sellQuotes, async route => {
@@ -78,7 +78,7 @@ test.describe('Trading - Sell BTC', { tag: ['@group=trading', '@webOnly'] }, () 
                 await tradingPage.waitForRedirectCompletion();
 
                 await test.step('Initiate send and verify Fee', async () => {
-                    await tradingPage.initiateSendConfirmation();
+                    await tradingPage.confirmation.initiateSendConfirmation();
                     await expect(devicePrompt.headerParagraph).toContainText('Bitcoin #1');
                     await expect(devicePrompt.cryptoAmountOf('fee')).toHaveTextGreaterThan(0);
                     const errorMessage = `expected ${feeType} fee on Device Prompt to be:`;

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -6,71 +6,73 @@ import { NetworkSymbol } from '@suite-common/wallet-config';
 import { step } from '../../common';
 import { AssetPickerNetworkFilter, BuyAsset, SellAsset } from '../../types';
 
-export class TradingAssetsModal {
-    readonly openSellAssetPickerModal: Locator;
-    readonly openBuyAssetPickerModal: Locator;
-    readonly assetPickerSearchInput: Locator;
-    readonly assetPickerDisplaySymbol: Locator;
-    readonly assetPickerNetworkFilter: Locator;
-    readonly assetPickerNetworkFilterOption = (tab: AssetPickerNetworkFilter) =>
+export class TradingAssetPicker {
+    readonly openSellModal: Locator;
+    readonly openBuyModal: Locator;
+    readonly searchInput: Locator;
+    readonly displaySymbol: Locator;
+    readonly networkFilterButton: Locator;
+    readonly networkFilterOption = (tab: AssetPickerNetworkFilter) =>
         this.page.getByTestId(`@asset-picker/search/filter/select-option/${tab}`);
-    readonly addAccountButton: Locator;
+    readonly globalAddAccountButton: Locator;
 
     // buy and sell options
-    readonly assetPickerOption = (networkSymbol: NetworkSymbol, tokenSymbol?: string) =>
+    readonly sellOption = (networkSymbol: NetworkSymbol, tokenSymbol?: string) =>
         this.page.getByTestId(
-            `@asset-picker/option/${networkSymbol}${tokenSymbol ? `/${tokenSymbol}` : ''}`,
+            `@asset-picker/sell/option/${networkSymbol}${tokenSymbol ? `/${tokenSymbol}` : ''}`,
         );
-    readonly buyAssetPickerAssetOption = (assetCryptoId: CryptoId) =>
-        this.page.getByTestId(`@asset-picker/option/asset/${assetCryptoId}`);
+    readonly buyOption = (networkSymbol: NetworkSymbol, tokenSymbol?: string) =>
+        this.page.getByTestId(
+            `@asset-picker/buy/option/${networkSymbol}${tokenSymbol ? `/${tokenSymbol}` : ''}`,
+        );
+    readonly buyAssetOption = (assetCryptoId: CryptoId) =>
+        this.page.getByTestId(`@asset-picker/buy/option/asset/${assetCryptoId}`);
 
     // send and receive options
-    readonly sendAssetPickerOption = (params: {
+    readonly sendOption = (params: {
         accountSymbol: NetworkSymbol;
         accountType: string;
         index: number;
         tokenSymbol?: string;
     }) =>
         this.page.getByTestId(
-            `@asset-picker/option/${params.accountType}/${params.accountSymbol}/${params.index}${
+            `@asset-picker/send/option/${params.accountType}/${params.accountSymbol}/${params.index}${
                 params.tokenSymbol ? `/token/${params.tokenSymbol}` : ''
             }`,
         );
-    readonly receiveAssetPickerOption = (params: {
+    readonly receiveOption = (params: {
         accountSymbol: NetworkSymbol;
         accountType: string;
         index: number;
     }) =>
         this.page.getByTestId(
-            `@asset-picker/option/${params.accountType}/${params.accountSymbol}/${params.index}`,
+            `@global-receive-account/${params.accountType}/${params.accountSymbol}/${params.index}`,
         );
 
     constructor(private readonly page: Page) {
-        this.openSellAssetPickerModal = this.page.getByTestId('@trading/sell/asset-picker/input');
-        this.openBuyAssetPickerModal = this.page.getByTestId('@trading/buy/asset-picker/input');
-        this.assetPickerSearchInput = this.page.getByTestId('@asset-picker/search/input');
-        this.assetPickerDisplaySymbol = this.page.getByTestId('@asset-picker/display-symbol');
-        this.assetPickerNetworkFilter = this.page.getByTestId(
-            '@asset-picker/search/filter/control',
-        );
-        this.addAccountButton = this.page.getByTestId('@asset-picker/add-account');
+        this.openSellModal = this.page.getByTestId('@trading/sell/asset-picker/input');
+        this.openBuyModal = this.page.getByTestId('@trading/buy/asset-picker/input');
+        this.searchInput = this.page.getByTestId('@asset-picker/search/input');
+        this.displaySymbol = this.page.getByTestId('@asset-picker/display-symbol');
+        this.networkFilterButton = this.page.getByTestId('@asset-picker/search/filter/input');
+        this.globalAddAccountButton = this.page.getByTestId('@global-send-receive/add-account');
     }
 
     @step()
     async filterByNetwork(networkFilter: AssetPickerNetworkFilter) {
-        await this.assetPickerNetworkFilter.click();
-        await this.assetPickerNetworkFilterOption(networkFilter).click();
+        await this.networkFilterButton.click();
+        await this.networkFilterOption(networkFilter).click();
     }
 
     @step()
     async searchAsset(searchFilter: string) {
-        await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
-        await this.assetPickerSearchInput.blur();
+        await this.searchInput.pressSequentially(searchFilter, { delay: 250 });
+        await this.searchInput.blur();
     }
 
     @step()
     async selectSellAsset({ searchFilter, networkFilter, networkSymbol, tokenSymbol }: SellAsset) {
-        await this.openSellAssetPickerModal.click();
+        await this.openSellModal.click();
 
         if (networkFilter) {
             await this.filterByNetwork(networkFilter);
@@ -80,7 +82,7 @@ export class TradingAssetsModal {
             await this.searchAsset(searchFilter);
         }
 
-        await this.assetPickerOption(networkSymbol, tokenSymbol).click();
+        await this.sellOption(networkSymbol, tokenSymbol).click();
     }
 
     @step()
@@ -91,7 +93,7 @@ export class TradingAssetsModal {
         networkSymbol,
         tokenSymbol,
     }: BuyAsset) {
-        await this.openBuyAssetPickerModal.click();
+        await this.openBuyModal.click();
 
         if (networkFilter) {
             await this.filterByNetwork(networkFilter);
@@ -102,9 +104,9 @@ export class TradingAssetsModal {
         }
 
         if (assetCryptoId) {
-            await this.buyAssetPickerAssetOption(assetCryptoId).click();
+            await this.buyAssetOption(assetCryptoId).click();
         } else if (networkSymbol) {
-            await this.assetPickerOption(networkSymbol, tokenSymbol).click();
+            await this.buyOption(networkSymbol, tokenSymbol).click();
         } else {
             throw new Error('Either assetCryptoId or networkSymbol must be provided');
         }

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -1,106 +1,50 @@
 import { Locator, Page } from '@playwright/test';
 import { CryptoId } from 'invity-api';
 
-import { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../../common';
-
-type AssetPickerNetworkFilter = 'all-networks' | NetworkConfigWithoutTestnets['symbol'];
+import { AssetPickerNetworkFilter, BuyAsset, SellAsset } from '../../types';
 
 export class TradingAssetsModal {
-    // `From` field asset picker in swap/sell form
     readonly sellAssetPickerInput: Locator;
-    readonly sellAssetPickerSearchInput: Locator;
-    readonly sellAssetPickerNetworkFilter: Locator;
-    readonly sellAssetPickerDisplaySymbol: Locator;
-
-    readonly sellAssetPickerNetworkFilterOption = (tab: AssetPickerNetworkFilter) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-sell/search/select-option/${tab}`);
-
-    readonly sellAssetPickerTokenOption = (networkSymbol?: NetworkSymbol, tokenSymbol?: string) =>
-        this.page.getByTestId(
-            `@trading/form/select-crypto-for-sell/token/${networkSymbol}/${tokenSymbol}`,
-        );
-    readonly sellAssetPickerAccountOption = (networkSymbol?: NetworkSymbol) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-sell/account/${networkSymbol}`);
-
-    // `To` field asset picker in swap/buy form
     readonly buyAssetPickerInput: Locator;
-    readonly buyAssetPickerSearchInput: Locator;
-    readonly buyAssetPickerNetworkFilter: Locator;
-    readonly buyAssetPickerDisplaySymbol: Locator;
 
-    readonly buyAssetPickerNetworkFilterOption = (tab: AssetPickerNetworkFilter) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-buy/search/select-option/${tab}`);
-
-    readonly buyAssetPickerTokenOption = (networkSymbol?: NetworkSymbol, tokenSymbol?: string) =>
+    readonly assetPickerSearchInput: Locator;
+    readonly assetPickerNetworkFilter: Locator;
+    readonly assetPickerDisplaySymbol: Locator;
+    readonly assetPickerNetworkFilterOption = (tab: AssetPickerNetworkFilter) =>
+        this.page.getByTestId(`@asset-picker/search/select-option/${tab}`);
+    readonly assetPickerOption = (networkSymbol: NetworkSymbol, tokenSymbol?: string) =>
         this.page.getByTestId(
-            `@trading/form/select-crypto-for-buy/token/${networkSymbol}/${tokenSymbol}`,
+            `@asset-picker/option/${networkSymbol}${tokenSymbol ? `/${tokenSymbol}` : ''}`,
         );
-    readonly buyAssetPickerAccountOption = (networkSymbol?: NetworkSymbol) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-buy/account/${networkSymbol}`);
-    readonly buyAssetPickerTopAssetOption = (id: CryptoId) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-buy/top-assets/asset/${id}`);
-    readonly buyAssetPickerAssetOption = (id: CryptoId) =>
-        this.page.getByTestId(`@trading/form/select-crypto-for-buy/asset/${id}`);
+    readonly buyAssetPickerAssetOption = (assetCryptoId: CryptoId) =>
+        this.page.getByTestId(`@asset-picker/option/asset/${assetCryptoId}`);
 
     constructor(private readonly page: Page) {
-        this.sellAssetPickerInput = this.page.getByTestId(
-            '@trading/form/select-crypto-for-sell/input',
-        );
-        this.sellAssetPickerDisplaySymbol = this.page.getByTestId(
-            '@trading/form/select-crypto-for-sell/display-symbol',
-        );
-        this.sellAssetPickerSearchInput = this.page.getByTestId(
-            '@trading/form/select-crypto-for-sell/search',
-        );
-        this.sellAssetPickerNetworkFilter = this.page.getByTestId(
-            '@trading/form/select-crypto-for-sell/search/select/input',
-        );
-
-        this.buyAssetPickerInput = this.page.getByTestId(
-            '@trading/form/select-crypto-for-buy/input',
-        );
-        this.buyAssetPickerDisplaySymbol = this.page.getByTestId(
-            '@trading/form/select-crypto-for-buy/display-symbol',
-        );
-        this.buyAssetPickerSearchInput = this.page.getByTestId(
-            '@trading/form/select-crypto-for-buy/search',
-        );
-        this.buyAssetPickerNetworkFilter = this.page.getByTestId(
-            '@trading/form/select-crypto-for-buy/search/select/input',
-        );
+        this.sellAssetPickerInput = this.page.getByTestId('@trading/sell/asset-picker/input');
+        this.buyAssetPickerInput = this.page.getByTestId('@trading/buy/asset-picker/input');
+        this.assetPickerDisplaySymbol = this.page.getByTestId('@asset-picker/display-symbol');
+        this.assetPickerSearchInput = this.page.getByTestId('@asset-picker/search');
+        this.assetPickerNetworkFilter = this.page.getByTestId('@asset-picker/search/select/input');
     }
 
     @step()
-    async selectSellAsset({
-        searchFilter,
-        networkFilter,
-        networkSymbol,
-        tokenSymbol,
-    }: {
-        searchFilter?: string;
-        networkFilter?: AssetPickerNetworkFilter;
-        networkSymbol?: NetworkSymbol;
-        tokenSymbol?: string;
-    }) {
+    async selectSellAsset({ searchFilter, networkFilter, networkSymbol, tokenSymbol }: SellAsset) {
         await this.sellAssetPickerInput.click();
 
         if (networkFilter) {
-            await this.sellAssetPickerNetworkFilter.click();
-            await this.sellAssetPickerNetworkFilterOption(networkFilter).click();
+            await this.assetPickerNetworkFilter.click();
+            await this.assetPickerNetworkFilterOption(networkFilter).click();
         }
 
         if (searchFilter) {
-            await this.sellAssetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
-            await this.sellAssetPickerSearchInput.blur();
+            await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
+            await this.assetPickerSearchInput.blur();
         }
 
-        if (networkSymbol && tokenSymbol) {
-            await this.sellAssetPickerTokenOption(networkSymbol, tokenSymbol).click();
-        } else if (networkSymbol) {
-            await this.sellAssetPickerAccountOption(networkSymbol).click();
-        }
+        await this.assetPickerOption(networkSymbol, tokenSymbol).click();
     }
 
     @step()
@@ -110,32 +54,25 @@ export class TradingAssetsModal {
         assetCryptoId,
         networkSymbol,
         tokenSymbol,
-    }: {
-        searchFilter?: string;
-        networkFilter?: AssetPickerNetworkFilter;
-
-        assetCryptoId?: CryptoId;
-        networkSymbol?: NetworkSymbol;
-        tokenSymbol?: string;
-    }) {
+    }: BuyAsset) {
         await this.buyAssetPickerInput.click();
 
         if (networkFilter) {
-            await this.buyAssetPickerNetworkFilter.click();
-            await this.buyAssetPickerNetworkFilterOption(networkFilter).click();
+            await this.assetPickerNetworkFilter.click();
+            await this.assetPickerNetworkFilterOption(networkFilter).click();
         }
 
         if (searchFilter) {
-            await this.buyAssetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
-            await this.buyAssetPickerSearchInput.blur();
+            await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
+            await this.assetPickerSearchInput.blur();
         }
 
-        if (networkSymbol && tokenSymbol) {
-            await this.buyAssetPickerTokenOption(networkSymbol, tokenSymbol).click();
-        } else if (networkSymbol) {
-            await this.buyAssetPickerAccountOption(networkSymbol).click();
-        } else if (assetCryptoId) {
+        if (assetCryptoId) {
             await this.buyAssetPickerAssetOption(assetCryptoId).click();
+        } else if (networkSymbol) {
+            await this.assetPickerOption(networkSymbol, tokenSymbol).click();
+        } else {
+            throw new Error('Either assetCryptoId or networkSymbol must be provided');
         }
     }
 }

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -7,14 +7,16 @@ import { step } from '../../common';
 import { AssetPickerNetworkFilter, BuyAsset, SellAsset } from '../../types';
 
 export class TradingAssetsModal {
-    readonly sellAssetPickerInput: Locator;
-    readonly buyAssetPickerInput: Locator;
-
+    readonly openSellAssetPickerModal: Locator;
+    readonly openBuyAssetPickerModal: Locator;
     readonly assetPickerSearchInput: Locator;
-    readonly assetPickerNetworkFilter: Locator;
     readonly assetPickerDisplaySymbol: Locator;
+    readonly assetPickerNetworkFilter: Locator;
     readonly assetPickerNetworkFilterOption = (tab: AssetPickerNetworkFilter) =>
-        this.page.getByTestId(`@asset-picker/search/select-option/${tab}`);
+        this.page.getByTestId(`@asset-picker/search/filter/select-option/${tab}`);
+    readonly addAccountButton: Locator;
+
+    // buy and sell options
     readonly assetPickerOption = (networkSymbol: NetworkSymbol, tokenSymbol?: string) =>
         this.page.getByTestId(
             `@asset-picker/option/${networkSymbol}${tokenSymbol ? `/${tokenSymbol}` : ''}`,
@@ -22,26 +24,60 @@ export class TradingAssetsModal {
     readonly buyAssetPickerAssetOption = (assetCryptoId: CryptoId) =>
         this.page.getByTestId(`@asset-picker/option/asset/${assetCryptoId}`);
 
+    // send and receive options
+    readonly sendAssetPickerOption = (params: {
+        accountSymbol: NetworkSymbol;
+        accountType: string;
+        index: number;
+        tokenSymbol?: string;
+    }) =>
+        this.page.getByTestId(
+            `@asset-picker/option/${params.accountType}/${params.accountSymbol}/${params.index}${
+                params.tokenSymbol ? `/token/${params.tokenSymbol}` : ''
+            }`,
+        );
+    readonly receiveAssetPickerOption = (params: {
+        accountSymbol: NetworkSymbol;
+        accountType: string;
+        index: number;
+    }) =>
+        this.page.getByTestId(
+            `@asset-picker/option/${params.accountType}/${params.accountSymbol}/${params.index}`,
+        );
+
     constructor(private readonly page: Page) {
-        this.sellAssetPickerInput = this.page.getByTestId('@trading/sell/asset-picker/input');
-        this.buyAssetPickerInput = this.page.getByTestId('@trading/buy/asset-picker/input');
+        this.openSellAssetPickerModal = this.page.getByTestId('@trading/sell/asset-picker/input');
+        this.openBuyAssetPickerModal = this.page.getByTestId('@trading/buy/asset-picker/input');
+        this.assetPickerSearchInput = this.page.getByTestId('@asset-picker/search/input');
         this.assetPickerDisplaySymbol = this.page.getByTestId('@asset-picker/display-symbol');
-        this.assetPickerSearchInput = this.page.getByTestId('@asset-picker/search');
-        this.assetPickerNetworkFilter = this.page.getByTestId('@asset-picker/search/select/input');
+        this.assetPickerNetworkFilter = this.page.getByTestId(
+            '@asset-picker/search/filter/control',
+        );
+        this.addAccountButton = this.page.getByTestId('@asset-picker/add-account');
+    }
+
+    @step()
+    async filterByNetwork(networkFilter: AssetPickerNetworkFilter) {
+        await this.assetPickerNetworkFilter.click();
+        await this.assetPickerNetworkFilterOption(networkFilter).click();
+    }
+
+    @step()
+    async searchAsset(searchFilter: string) {
+        await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
+        await this.assetPickerSearchInput.blur();
     }
 
     @step()
     async selectSellAsset({ searchFilter, networkFilter, networkSymbol, tokenSymbol }: SellAsset) {
-        await this.sellAssetPickerInput.click();
+        await this.openSellAssetPickerModal.click();
 
         if (networkFilter) {
-            await this.assetPickerNetworkFilter.click();
-            await this.assetPickerNetworkFilterOption(networkFilter).click();
+            await this.filterByNetwork(networkFilter);
         }
 
         if (searchFilter) {
-            await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
-            await this.assetPickerSearchInput.blur();
+            await this.searchAsset(searchFilter);
         }
 
         await this.assetPickerOption(networkSymbol, tokenSymbol).click();
@@ -55,16 +91,14 @@ export class TradingAssetsModal {
         networkSymbol,
         tokenSymbol,
     }: BuyAsset) {
-        await this.buyAssetPickerInput.click();
+        await this.openBuyAssetPickerModal.click();
 
         if (networkFilter) {
-            await this.assetPickerNetworkFilter.click();
-            await this.assetPickerNetworkFilterOption(networkFilter).click();
+            await this.filterByNetwork(networkFilter);
         }
 
         if (searchFilter) {
-            await this.assetPickerSearchInput.pressSequentially(searchFilter, { delay: 250 });
-            await this.assetPickerSearchInput.blur();
+            await this.searchAsset(searchFilter);
         }
 
         if (assetCryptoId) {

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -1,5 +1,4 @@
 import { Locator, Page } from '@playwright/test';
-import { CryptoId } from 'invity-api';
 
 import { messages } from '@suite/intl';
 import { TradingCountryCode } from '@suite-common/trading';
@@ -15,6 +14,7 @@ import { TradingReceiveAccount } from './receiveAccount';
 import { invityEndpoint } from '../../../fixtures/invity';
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
+import { BuyAsset, SellAsset } from '../../types';
 
 export class TradingPage {
     readonly fees: FeeSection;
@@ -77,17 +77,44 @@ export class TradingPage {
         this.transactionDetailStatus = this.page.getByTestId('@trading/transaction/detail/status');
     }
 
+    /**
+     * Fills the buy form with the specified amount and configuration.
+     * Asset should be selected beforehand using asset picker.
+     *
+     * @param params - The buy form parameters
+     * @param params.amount - The amount to buy (as a string, e.g., "1000", "0.01")
+     * @param params.wantCrypto - Whether the amount is specified in crypto (true) or fiat (false). Default: false
+     * @param params.fiatCurrencyCode - The fiat currency code (e.g., 'czk', 'eur', 'usd'). Default: 'czk'
+     * @param params.country - The country code for residence (e.g., 'CZ', 'US', 'GB'). Default: 'CZ'
+     * @param params.selectReceiveAddress - Optional async callback to select a custom receive address
+     *
+     * @example
+     * // Buy Bitcoin with fiat amount (CZK)
+     * await tradingPage.fillBuyForm({
+     *     amount: '1000',
+     *     selectReceiveAddress: async () => {
+     *         await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
+     *     }
+     * });
+     *
+     * @example
+     * // Buy with EUR currency from specific country
+     * await tradingPage.fillBuyForm({
+     *     amount: '500',
+     *     fiatCurrencyCode: 'eur',
+     *     country: 'DE'
+     * });
+     *
+     */
     @step()
     async fillBuyForm({
         amount,
-        cryptoCurrency = 'bitcoin',
         wantCrypto = false,
         fiatCurrencyCode = 'czk',
         country = 'CZ',
         selectReceiveAddress,
     }: {
         amount: string;
-        cryptoCurrency?: string;
         wantCrypto?: boolean;
         fiatCurrencyCode?: BaseCurrencyCode;
         country?: TradingCountryCode;
@@ -107,25 +134,51 @@ export class TradingPage {
             await selectReceiveAddress();
         }
 
-        const quotesRequestPromise = this.page.waitForRequest(invityEndpoint.buyQuotes);
         const quotesResponsePromise = this.page.waitForResponse(invityEndpoint.buyQuotes);
         await inputField.fill(amount);
-        await expect.soft(quotesRequestPromise).toHavePayload({
-            wantCrypto,
-            fiatCurrency: fiatCurrencyCode.toUpperCase(),
-            receiveCurrency: cryptoCurrency,
-            country,
-            ...(wantCrypto ? { cryptoStringAmount: amount } : { fiatStringAmount: amount }),
-        });
         await quotesResponsePromise;
         await this.quotes.waitForSync();
     }
 
+    /**
+     * Fills the sell form with the specified amount and configuration.
+     * Asset should be selected beforehand using asset picker.
+     *
+     * @param params - The sell form parameters
+     * @param params.cryptoAmount - The amount of crypto to sell (as a string, e.g., "0.001", "100")
+     * @param params.networkSymbolOrTokenId - The network symbol or token ID to sell from. Default: 'btc'
+     *   - For coins: 'btc', 'eth', 'sol'
+     *   - For tokens: '{network}-{tokenAddress}' (e.g., 'eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+     * @param params.fiatCurrencyCode - The fiat currency code (e.g., 'eur', 'czk', 'usd'). Default: 'eur'
+     * @param params.country - The country code for residence (e.g., 'CZ', 'US', 'GB'). Default: 'CZ'
+     *
+     * @example
+     * // Sell Solana for EUR with explicit network symbol
+     * await tradingPage.fillSellForm({
+     *     cryptoAmount: '0.5',
+     *     networkSymbolOrTokenId: 'sol',
+     * });
+     *
+     * @example
+     * // Sell Ethereum for CZK
+     * await tradingPage.fillSellForm({
+     *     cryptoAmount: '0.008',
+     *     networkSymbolOrTokenId: 'eth',
+     *     fiatCurrencyCode: 'czk'
+     * });
+     *
+     * @example
+     * // Sell Ethereum USDC token for EUR
+     * await tradingPage.fillSellForm({
+     *     cryptoAmount: '100',
+     *     networkSymbolOrTokenId: 'eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+     * });
+     *
+     */
     @step()
     async fillSellForm({
         cryptoAmount,
         networkSymbolOrTokenId = 'btc',
-        cryptoCurrency = 'bitcoin',
         fiatCurrencyCode = 'eur',
         country = 'CZ',
     }: {
@@ -139,23 +192,11 @@ export class TradingPage {
         await this.inputs.selectFiatCurrency(fiatCurrencyCode);
         const isFiatRateLoadingFlag = `wallet.fiat.current.${networkSymbolOrTokenId}-${fiatCurrencyCode}.isLoading`;
         await this.page.expectReduxObjectToEqual(isFiatRateLoadingFlag, false);
-        const quoteRequestPromise = this.page.waitForRequest(invityEndpoint.sellQuotes);
         await this.inputs.cryptoAmount.fill(cryptoAmount);
         await expect(
             this.page.getByText(messages['AMOUNT_IS_NOT_ENOUGH'].defaultMessage),
             'Insufficient funds in the account to run sell flow test. Please contact the "tech_qa" Slack group immediately.',
         ).toBeHidden();
-        await expect.soft(quoteRequestPromise).toHavePayload(
-            {
-                amountInCrypto: true,
-                cryptoCurrency,
-                fiatCurrency: fiatCurrencyCode.toUpperCase(),
-                country,
-                cryptoStringAmount: cryptoAmount,
-                flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
-            },
-            { omit: ['fiatStringAmount'] },
-        );
         await this.quotes.waitForSync();
     }
 
@@ -175,6 +216,63 @@ export class TradingPage {
         await expect(this.quotes.loadingSpinner).toBeHidden({ timeout: 30000 });
     }
 
+    /**
+     * Fills the swap form with the specified sell and buy assets and amount.
+     *
+     * @param params - The swap form parameters
+     * @param params.amount - The amount to swap (as a string, e.g., "0.001")
+     * @param params.sellAsset - The asset to sell (required: networkSymbol)
+     * @param params.sellAsset.networkSymbol - The network symbol to sell from (e.g., 'btc', 'eth', 'sol')
+     * @param params.sellAsset.tokenSymbol - Optional token symbol if selling a token (e.g., 'USDT', 'USDC')
+     * @param params.sellAsset.searchFilter - Optional search string to filter assets in picker (e.g., 'Solana #1', 'USDT')
+     * @param params.sellAsset.networkFilter - Optional network filter ('all-networks' or specific network symbol like 'sol', 'btc')
+     * @param params.buyAsset - The asset to buy (requires EITHER assetCryptoId OR networkSymbol, not both)
+     * @param params.buyAsset.assetCryptoId - The Invity crypto ID for the asset to buy (e.g., token mint address for Solana tokens)
+     * @param params.buyAsset.networkSymbol - Alternative to assetCryptoId: network symbol to buy (e.g., 'btc', 'eth')
+     * @param params.buyAsset.tokenSymbol - Optional token symbol if buying a token (e.g., 'USDT', 'USDC')
+     * @param params.buyAsset.searchFilter - Optional search string to filter assets in picker (e.g., 'Bitcoin', 'USDC')
+     * @param params.buyAsset.networkFilter - Optional network filter ('all-networks' or specific network symbol like 'eth', 'btc')
+     * @param params.selectReceiveAddress - Optional async callback to select a custom receive address (e.g., selecting specific account)
+     *
+     * @example
+     * // Swap coin to coin (Solana to Bitcoin) with search filters
+     * await tradingPage.fillSwapForm({
+     *     amount: '0.001',
+     *     sellAsset: {
+     *         searchFilter: 'Solana #1',
+     *         networkSymbol: 'sol'
+     *     },
+     *     buyAsset: {
+     *         searchFilter: 'Bitcoin',
+     *         assetCryptoId: getCryptoId('btc')
+     *     },
+     *     selectReceiveAddress: async () => {
+     *         await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');
+     *     }
+     * });
+     *
+     *
+     * @example
+     * // Swap token to token (Solana USDT to Solana USDC) both using crypto IDs
+     * await tradingPage.fillSwapForm({
+     *     amount: '100',
+     *     sellAsset: {
+     *         networkFilter: 'sol',
+     *         networkSymbol: 'sol',
+     *         tokenSymbol: 'USDT',
+     *         searchFilter: 'USDT'
+     *     },
+     *     buyAsset: {
+     *         searchFilter: 'USDC',
+     *         networkFilter: 'sol',
+     *         assetCryptoId: usdcMint as CryptoId
+     *     },
+     *     selectReceiveAddress: async () => {
+     *         await tradingPage.receiveAccount.selectSuiteReceiveAccount(0);
+     *     }
+     * });
+     *
+     */
     @step()
     async fillSwapForm({
         sellAsset,
@@ -183,12 +281,8 @@ export class TradingPage {
         amount,
     }: {
         amount: string;
-        sellAsset: Parameters<TradingAssetsModal['selectSellAsset']>[0] & {
-            assetCryptoId: CryptoId;
-        };
-        buyAsset: Omit<Parameters<TradingAssetsModal['selectBuyAsset']>[0], 'assetCryptoId'> & {
-            assetCryptoId: CryptoId;
-        };
+        sellAsset: SellAsset;
+        buyAsset: BuyAsset;
         selectReceiveAddress?: () => Promise<void>;
     }) {
         await this.assets.selectSellAsset(sellAsset);
@@ -228,19 +322,19 @@ export class TradingPage {
 
     @step()
     async verifyBuyFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.buyAssetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('You buy')).toBeVisible();
     }
 
     @step()
     async verifySellFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.sellAssetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('You sell')).toBeVisible();
     }
 
     @step()
     async verifySwapFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.sellAssetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('Swap amount')).toBeVisible();
     }
 }

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -4,7 +4,7 @@ import { messages } from '@suite/intl';
 import { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { TradingAssetsModal } from './assetsModal';
+import { TradingAssetPicker } from './assetsModal';
 import { TradingConfirmationModal } from './confirmationModal';
 import { DevicePrompt } from '../devicePrompt';
 import { FeeSection } from './feeSection';
@@ -18,7 +18,7 @@ import { BuyAsset, SellAsset } from '../../types';
 
 export class TradingPage {
     readonly fees: FeeSection;
-    readonly assets: TradingAssetsModal;
+    readonly assetPicker: TradingAssetPicker;
     readonly receiveAccount: TradingReceiveAccount;
     readonly quotes: TradingQuotesSection;
     readonly confirmation: TradingConfirmationModal;
@@ -51,7 +51,7 @@ export class TradingPage {
         devicePrompt: DevicePrompt,
     ) {
         this.fees = new FeeSection(page);
-        this.assets = new TradingAssetsModal(page);
+        this.assetPicker = new TradingAssetPicker(page);
         this.receiveAccount = new TradingReceiveAccount(page);
         this.quotes = new TradingQuotesSection(page);
         this.confirmation = new TradingConfirmationModal(page, devicePrompt);
@@ -285,8 +285,8 @@ export class TradingPage {
         buyAsset: BuyAsset;
         selectReceiveAddress?: () => Promise<void>;
     }) {
-        await this.assets.selectSellAsset(sellAsset);
-        await this.assets.selectBuyAsset(buyAsset);
+        await this.assetPicker.selectSellAsset(sellAsset);
+        await this.assetPicker.selectBuyAsset(buyAsset);
 
         // We should not fill in amount until account change takes effect = correct ticker is displayed
         await expect(this.inputs.swapAmountCurrencyTicker).toHaveText(
@@ -322,19 +322,19 @@ export class TradingPage {
 
     @step()
     async verifyBuyFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assetPicker.displaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('You buy')).toBeVisible();
     }
 
     @step()
     async verifySellFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assetPicker.displaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('You sell')).toBeVisible();
     }
 
     @step()
     async verifySwapFormOpened(displaySymbol: RegExp) {
-        await expect.soft(this.assets.assetPickerDisplaySymbol).toHaveText(displaySymbol);
+        await expect.soft(this.assetPicker.displaySymbol).toHaveText(displaySymbol);
         await expect.soft(this.page.getByText('Swap amount')).toBeVisible();
     }
 }

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -1,5 +1,8 @@
+import { CryptoId } from 'invity-api';
+import { RequireExactlyOne } from 'type-fest';
+
 import { AnalyticsDesktopEvents } from '@suite/analytics';
-import { NetworkSymbol } from '@suite-common/wallet-config';
+import { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/wallet-config';
 import { urlSearchParams } from '@trezor/suite/src//utils/suite/metadata';
 import { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
@@ -48,6 +51,7 @@ export type ElectronConf = Pick<
     LaunchSuiteParams,
     'keepUserData' | 'bridgeDaemon' | 'exposeConnectWs' | 'offlineMode'
 >;
+
 export type TrezorUserEnv = Pick<
     TrezorUserEnvLinkClass,
     | 'logTestDetails'
@@ -59,3 +63,23 @@ export type TrezorUserEnv = Pick<
     | 'mineBlocks'
     | 'sendToAddressAndMineBlock'
 >;
+
+export type AssetPickerNetworkFilter = 'all-networks' | NetworkConfigWithoutTestnets['symbol'];
+
+export type BuyAsset = RequireExactlyOne<
+    {
+        searchFilter?: string;
+        networkFilter?: AssetPickerNetworkFilter;
+        assetCryptoId?: CryptoId;
+        networkSymbol?: NetworkSymbol;
+        tokenSymbol?: string;
+    },
+    'assetCryptoId' | 'networkSymbol'
+>;
+
+export type SellAsset = {
+    searchFilter?: string;
+    networkFilter?: AssetPickerNetworkFilter;
+    networkSymbol: NetworkSymbol;
+    tokenSymbol?: string;
+};

--- a/suite/e2e/tests/tradeing-live/live-swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/tradeing-live/live-swap-coin-to-token.test.ts
@@ -5,7 +5,6 @@ import { expect, test } from '../../support/fixtures';
 
 const tenMinutes = 10 * 60 * 1000;
 const sendAmount = '0.053329';
-const usdcMint = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
 const formattedSendAmount = `${localizeNumber(sendAmount)} SOL`;
 const accountLabel = 'Solana #1';
 
@@ -37,14 +36,12 @@ test.describe(
                     sellAsset: {
                         searchFilter: 'Solana #1',
                         networkSymbol: 'sol',
-                        assetCryptoId: getCryptoId('sol'),
                     },
                     buyAsset: {
                         searchFilter: 'USDC',
                         networkFilter: 'base',
                         tokenSymbol: 'USDC',
                         networkSymbol: 'base',
-                        assetCryptoId: getCryptoId('base', usdcMint),
                     },
 
                     selectReceiveAddress: async () => {
@@ -127,7 +124,6 @@ test.describe(
                         searchFilter: 'USDC',
                         networkSymbol: 'base',
                         tokenSymbol: 'USDC',
-                        assetCryptoId: getCryptoId('base', usdcMint),
                     },
                     buyAsset: {
                         searchFilter: 'Solana',

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -27,7 +27,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
     }) => {
         await test.step('Request to buy Ethereum', async () => {
             await walletPage.openTradingGlobalButton.click();
-            await tradingPage.assets.selectBuyAsset({
+            await tradingPage.assetPicker.selectBuyAsset({
                 searchFilter: 'Ethereum',
                 networkFilter: 'eth',
                 assetCryptoId: getCryptoId('eth'),

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -34,7 +34,6 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             });
             await tradingPage.fillBuyForm({
                 amount: fiatAmount,
-                cryptoCurrency: 'ethereum',
                 selectReceiveAddress: async () => {
                     await tradingPage.receiveAccount.selectAddSuiteReceiveAccount(0);
                 },

--- a/suite/e2e/tests/trading/buy-negative.test.ts
+++ b/suite/e2e/tests/trading/buy-negative.test.ts
@@ -15,7 +15,7 @@ test.describe('Trading - Buy Negative scenarios', { tag: ['@webOnly', '@T3W1', '
             await walletPage.openTradingGlobalButton.click();
 
             await expect(tradingPage.inputs.fiatAmount).toHaveValue(''); // waits for trading form to load
-            await tradingPage.assets.buyAssetPickerInput.click({ trial: true }); // checking actionability of the dropdown, which means page is properly loaded
+            await tradingPage.assets.openBuyAssetPickerModal.click({ trial: true }); // checking actionability of the dropdown, which means page is properly loaded
 
             await tradingPage.inputs.selectFiatCurrency('eur');
         });

--- a/suite/e2e/tests/trading/buy-negative.test.ts
+++ b/suite/e2e/tests/trading/buy-negative.test.ts
@@ -15,7 +15,7 @@ test.describe('Trading - Buy Negative scenarios', { tag: ['@webOnly', '@T3W1', '
             await walletPage.openTradingGlobalButton.click();
 
             await expect(tradingPage.inputs.fiatAmount).toHaveValue(''); // waits for trading form to load
-            await tradingPage.assets.openBuyAssetPickerModal.click({ trial: true }); // checking actionability of the dropdown, which means page is properly loaded
+            await tradingPage.assetPicker.openBuyModal.click({ trial: true }); // checking actionability of the dropdown, which means page is properly loaded
 
             await tradingPage.inputs.selectFiatCurrency('eur');
         });

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -35,7 +35,7 @@ test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, (
     test('Buy Solana Jupiter token - amount specified in crypto', async ({ page, tradingPage }) => {
         await test.step('Request a specific crypto amount of Jupiter token to buy', async () => {
             const cryptoId = 'solana--JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN' as CryptoId;
-            await tradingPage.assets.selectBuyAsset({
+            await tradingPage.assetPicker.selectBuyAsset({
                 networkFilter: 'sol',
                 searchFilter: 'Jupiter',
                 assetCryptoId: cryptoId,

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -45,7 +45,6 @@ test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, (
             const isCryptoInput = true;
             await tradingPage.fillBuyForm({
                 amount: cryptoAmount,
-                cryptoCurrency: cryptoId,
                 wantCrypto: isCryptoInput,
                 selectReceiveAddress: async () => {
                     await tradingPage.receiveAccount.selectSuiteReceiveAccount(0);

--- a/suite/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -51,7 +51,6 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
             await tradingPage.fillSellForm({
                 cryptoAmount,
                 networkSymbolOrTokenId: 'eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-                cryptoCurrency: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             });
             await expect(tradingPage.quotes.bestOfferAmount).toHaveText(fiatAmount);
             await expect(tradingPage.quotes.provider).toHaveText(capitalizeFirstLetter(provider));

--- a/suite/e2e/tests/trading/sell-ethereum.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum.test.ts
@@ -72,7 +72,6 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
             await tradingPage.fillSellForm({
                 cryptoAmount,
                 networkSymbolOrTokenId: 'eth',
-                cryptoCurrency: 'ethereum',
             });
             await tradingPage.fees.setEthereumCustomFees({
                 gasLimit,

--- a/suite/e2e/tests/trading/sell-solana.test.ts
+++ b/suite/e2e/tests/trading/sell-solana.test.ts
@@ -66,7 +66,6 @@ test.describe('Trading - Sell Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
             await tradingPage.fillSellForm({
                 cryptoAmount,
                 networkSymbolOrTokenId: 'sol',
-                cryptoCurrency: 'solana',
             });
             // Automation is too fast, we need to wait for Fees to be resolved
             await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
@@ -134,7 +133,6 @@ test.describe('Trading - Sell Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
         await test.step('Fill input amount and opens offer comparison', async () => {
             await tradingPage.fillSellForm({
                 cryptoAmount,
-                cryptoCurrency: 'solana',
                 networkSymbolOrTokenId: 'sol',
             });
             // Automation is too fast, we need to wait for Fees to be resolved

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -1,6 +1,5 @@
 import { CryptoId } from 'invity-api';
 
-import { getCryptoId } from '@suite-common/trading';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import {
@@ -52,7 +51,6 @@ test.describe('Trading - Swap coin to token', { tag: ['@webOnly', '@T3W1', '@T3T
                 sellAsset: {
                     searchFilter: 'Solana #1',
                     networkSymbol: 'sol',
-                    assetCryptoId: getCryptoId('sol'),
                 },
                 buyAsset: {
                     searchFilter: 'USDC',

--- a/suite/e2e/tests/trading/swap-coins.test.ts
+++ b/suite/e2e/tests/trading/swap-coins.test.ts
@@ -74,7 +74,6 @@ test.describe('Trading - Swap coins', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, (
                 sellAsset: {
                     searchFilter: 'Solana #1',
                     networkSymbol: 'sol',
-                    assetCryptoId: getCryptoId('sol'),
                 },
                 buyAsset: {
                     searchFilter: 'Bitcoin',

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -1,4 +1,3 @@
-import { getCryptoId } from '@suite-common/trading';
 import { BigNumber } from '@trezor/utils';
 
 import { invityEndpoint, swapQuotesBTCEthereum, swapTradeBTCEthereum } from '../../fixtures/invity';
@@ -33,13 +32,11 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@webOnly', '@T3T1', '@T3W1
                 sellAsset: {
                     networkFilter: 'btc',
                     networkSymbol: 'btc',
-                    assetCryptoId: getCryptoId('btc'),
                 },
                 buyAsset: {
                     searchFilter: 'Ethereum',
                     networkFilter: 'eth',
                     networkSymbol: 'eth',
-                    assetCryptoId: getCryptoId('eth'),
                 },
             });
             await tradingPage.fees.switchToCustom();

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -41,7 +41,6 @@ test.describe('Trading - Swap fees', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
                 amount: sendAmount,
                 sellAsset: {
                     networkSymbol: 'eth',
-                    assetCryptoId: getCryptoId('eth'),
                 },
                 buyAsset: {
                     searchFilter: 'Bitcoin',

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -1,5 +1,3 @@
-import { CryptoId } from 'invity-api';
-
 import { getCryptoId } from '@suite-common/trading';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
@@ -18,7 +16,7 @@ const receiveAmount = localizeNumber(swapQuotesTetherBTC[0].receiveStringAmount!
 const provider = getCompanyNameFromList(swapQuotesTetherBTC[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${receiveAmount} BTC`;
-const { sendAddress, send: tetherMint } = swapTradeTetherBTC;
+const { sendAddress } = swapTradeTetherBTC;
 const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
@@ -49,7 +47,6 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
                 sellAsset: {
                     networkSymbol: 'sol',
                     tokenSymbol: 'USDT',
-                    assetCryptoId: tetherMint as CryptoId,
                 },
                 buyAsset: {
                     searchFilter: 'Bitcoin',

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -17,7 +17,7 @@ const receiveAmount = localizeNumber(swapQuotesSolanaTokens[0].receiveStringAmou
 const provider = getCompanyNameFromList(swapQuotesSolanaTokens[0].exchange, 'swapList');
 const formattedSendAmount = `${localizeNumber(sendAmount)} USDT`;
 const formattedReceiveAmount = `${receiveAmount} USDC`;
-const { sendAddress, send: tetherMint, receive: usdcMint } = swapTradeSolanaTokens;
+const { sendAddress, receive: usdcMint } = swapTradeSolanaTokens;
 const formattedSendAddress = formatAddressWithNewlines(sendAddress);
 
 test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
@@ -49,7 +49,6 @@ test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
                     networkFilter: 'sol',
                     networkSymbol: 'sol',
                     tokenSymbol: 'USDT',
-                    assetCryptoId: tetherMint as CryptoId,
                     searchFilter: 'USDT',
                 },
                 buyAsset: {

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -16,15 +16,15 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
 
         await test.step('Add ETH account', async () => {
-            await tradingPage.assets.addAccountButton.click();
+            await tradingPage.assetPicker.globalAddAccountButton.click();
             await page.getByTestId('@settings/wallet/network/eth').click();
             await tradingPage.receiveAccount.findAccountButton.click();
         });
 
         await test.step('Filter and select account', async () => {
-            await tradingPage.assets.filterByNetwork('eth');
-            await tradingPage.assets
-                .receiveAssetPickerOption({
+            await tradingPage.assetPicker.filterByNetwork('eth');
+            await tradingPage.assetPicker
+                .receiveOption({
                     accountType: 'normal',
                     accountSymbol: 'eth',
                     index: 2,
@@ -59,10 +59,10 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
 
         await test.step('Bitcoin account selection', async () => {
-            await tradingPage.assets.filterByNetwork('btc');
-            await tradingPage.assets.searchAsset('3');
-            await tradingPage.assets
-                .sendAssetPickerOption({
+            await tradingPage.assetPicker.filterByNetwork('btc');
+            await tradingPage.assetPicker.searchAsset('3');
+            await tradingPage.assetPicker
+                .sendOption({
                     accountType: 'normal',
                     accountSymbol: 'btc',
                     index: 2,

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -9,31 +9,27 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         await onboardingPage.completeOnboarding();
     });
 
-    test(`Global receive`, async ({
-        page,
-        devicePrompt,
-        settingsPage,
-        tradingPage,
-        walletPage,
-    }) => {
+    test(`Global receive`, async ({ page, devicePrompt, tradingPage, walletPage }) => {
         await test.step('Open receive form', async () => {
             await page.getByTestId('@wallet/menu/wallet-global-receive').click();
             await expect(devicePrompt.header).toHaveTranslation('TR_NAV_RECEIVE');
         });
 
         await test.step('Add ETH account', async () => {
-            await page.getByTestId('@global-send-receive/add-account').click();
-            await settingsPage.coinsTab.networkButton('eth').click();
+            await tradingPage.assets.addAccountButton.click();
+            await page.getByTestId('@settings/wallet/network/eth').click();
+            await tradingPage.receiveAccount.findAccountButton.click();
         });
 
         await test.step('Filter and select account', async () => {
-            await tradingPage.receiveAccount.findAccountButton.click();
-            await page.getByText('All networks').click();
-            await page
-                .getByTestId('undefined/select-option/eth')
-                .getByText('Ethereum', { exact: true })
+            await tradingPage.assets.filterByNetwork('eth');
+            await tradingPage.assets
+                .receiveAssetPickerOption({
+                    accountType: 'normal',
+                    accountSymbol: 'eth',
+                    index: 2,
+                })
                 .click();
-            await page.getByTestId(`@global-receive-account/normal/eth/2`).click();
         });
 
         await test.step('Generate and compare addresses', async () => {
@@ -56,17 +52,22 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
     });
 
-    test(`Global send`, async ({ page, devicePrompt }) => {
+    test(`Global send`, async ({ page, devicePrompt, tradingPage }) => {
         await test.step('Open send form', async () => {
             await page.getByTestId('@wallet/menu/wallet-global-send').click();
             await expect(devicePrompt.header).toHaveTranslation('TR_NAV_SEND');
         });
 
         await test.step('Bitcoin account selection', async () => {
-            await page.getByText('All networks').click();
-            await page.getByTestId('undefined/select-option/btc').click();
-            await page.getByTestId('@search-asset-input').fill('3');
-            await page.getByTestId(`@global-send-account/normal/btc/2`).click();
+            await tradingPage.assets.filterByNetwork('btc');
+            await tradingPage.assets.searchAsset('3');
+            await tradingPage.assets
+                .sendAssetPickerOption({
+                    accountType: 'normal',
+                    accountSymbol: 'btc',
+                    index: 2,
+                })
+                .click();
         });
 
         await test.step('Send form validation', async () => {

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -66,7 +66,7 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
             await page.getByText('All networks').click();
             await page.getByTestId('undefined/select-option/btc').click();
             await page.getByTestId('@search-asset-input').fill('3');
-            await page.getByTestId(`@global-send-account/normal/btc/2/btc`).click();
+            await page.getByTestId(`@global-send-account/normal/btc/2`).click();
         });
 
         await test.step('Send form validation', async () => {


### PR DESCRIPTION
Testing support methods `FillBuyForm`, `FillSellForm`, `FillSwapForm` are very robust but became complicated to use. It took me a lot of time to correctly choose parameters last time.
More over we had a clash in @asset-picker locators with new feature global send and receive. Plus the logic whether to click on account, token or asset was hard to understand during creation of new tests.
@cermakjiri did already great job in this area and this PR continues on that.

Refactors 3 methods `FillBuyForm`, `FillSellForm`, `FillSwapForm` 
- ditches request verification (value low and should be its own test)
- simplifies parameters 
- add docs with examples

Locator refactor for `AssetPicker` and methods `SelectSellAsset` / `SelectBuyAsset`
- unites lot of locator to same format and reusage. Example search bar has now same locator for sell, buy, send and receive flow
- simplifies conditional logic in SelectSellAsset and Buy counterpart and also improves their typing to not allow invalid combinations.
- lot of renames to improve readability



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-refactor-asset-picker-locators&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-refactor-asset-picker-locators&lookback=7)