### PR TITLE
chore: update .prettierignore to exclude favicon.js in the suite package

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -146,7 +146,7 @@ packages/suite-data/files/videos/lottie/*.json
 
 /.nx/workspace-data
 
-favicon.js
+packages/suite-data/files/favicon.js
 
 # Symlinks committed to repo, prettier can't handle them (that's ok; it will format the orig files anyway)
 docs/symlink/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix path to favicon.js in prettierignore

## Notes for QA

Just dev thing. No need QA

## Related Issue


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/prettier-ignore&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/prettier-ignore&lookback=7)