### PR TITLE
Move useTradingFiatValues to common

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -1,144 +1,23 @@
-import { useCallback, useEffect, useMemo } from 'react';
-
-import { CryptoId, FiatCurrencyCode } from 'invity-api';
-
 import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
+    TradingFiatRatesProps,
+    TradingFiatRatesReturn,
     cryptoIdToNetworkAndContractAddress,
-    isCryptoIdForNativeToken,
-    mapTestnetSymbol,
+    useTradingFiatValues as useCommonTradingFiatValues,
 } from '@suite-common/trading';
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    selectBaseCurrency,
-    selectFiatRatesByFiatRateKey,
-    updateFiatRatesThunk,
-} from '@suite-common/wallet-core';
-import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
-import {
-    convertAmountUnitsToSubunits,
-    getFiatRateKey,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
 
-import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
-interface TradingBalanceProps {
-    fiatCurrency?: FiatCurrencyCode;
-    cryptoId?: CryptoId;
-    amount?: string;
-}
-
-interface TradingBalanceReturnProps {
-    fiatValue: string | null;
-    fiatRate: Rate | undefined;
-    accountBalance: string;
-    formattedBalance: string;
-    symbol: NetworkSymbol;
-    networkDecimals: number;
-    tokenAddress: TokenAddress | undefined;
-    fiatRatesUpdater: (
-        value: FiatCurrencyCode | undefined,
-        currentTokenAddress?: TokenAddress,
-    ) => Promise<FiatRatesResult | null>;
-}
+type SuiteTradingFiatRatesProps = Omit<TradingFiatRatesProps, 'shouldSendInSats'>;
 
 export const useTradingFiatValues = ({
     cryptoId,
-    fiatCurrency,
-    amount,
-}: TradingBalanceProps): TradingBalanceReturnProps | null => {
-    const dispatch = useDispatch();
-
-    const isNativeToken = cryptoId && isCryptoIdForNativeToken(cryptoId);
-
-    const { network, contractAddress, symbol } = useMemo(() => {
-        const assetInfo = cryptoId && cryptoIdToNetworkAndContractAddress(cryptoId);
-
-        return {
-            network: assetInfo?.network,
-            contractAddress: isNativeToken
-                ? undefined
-                : (assetInfo?.contractAddress as TokenAddress | undefined),
-            symbol: assetInfo?.network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY,
-        };
-    }, [cryptoId, isNativeToken]);
-
-    const symbolForFiat = mapTestnetSymbol(symbol);
-    const baseCurrencyCode = useSelector(selectBaseCurrency);
-    const fiatRateKey = getFiatRateKey(
-        symbolForFiat,
-        fiatCurrency ?? baseCurrencyCode,
-        contractAddress,
-    );
-
-    const fiatRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+    ...rest
+}: SuiteTradingFiatRatesProps): TradingFiatRatesReturn | null => {
+    const { network } = cryptoIdToNetworkAndContractAddress(cryptoId);
+    const symbol = network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY;
 
     const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
-    const fiatRatesUpdater = useCallback(
-        async (
-            value: FiatCurrencyCode | undefined,
-            currentTokenAddress?: TokenAddress,
-        ): Promise<FiatRatesResult | null> => {
-            if (!value) return null;
-            const tokenAddress = currentTokenAddress ?? contractAddress;
-
-            const updateFiatRatesResult = await dispatch(
-                updateFiatRatesThunk({
-                    tickers: [
-                        {
-                            symbol,
-                            tokenAddress: isNativeToken ? undefined : tokenAddress,
-                        },
-                    ],
-                    baseCurrencyCode: value,
-                    rateType: 'current',
-                    fetchAttemptTimestamp: Date.now() as Timestamp,
-                    forceFetchToken: true,
-                    skipCache: true,
-                }),
-            );
-
-            if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {
-                const fiatRates =
-                    updateFiatRatesResult.payload as PromiseSettledResult<FiatRatesResult>[];
-
-                const successfulResult = fiatRates.find(
-                    (result): result is PromiseFulfilledResult<FiatRatesResult> =>
-                        result.status === 'fulfilled',
-                );
-
-                return successfulResult?.value ?? null;
-            }
-
-            return null;
-        },
-        [contractAddress, dispatch, symbol, isNativeToken],
-    );
-
-    useEffect(() => {
-        if (!fiatCurrency) return;
-
-        fiatRatesUpdater(fiatCurrency);
-    }, [fiatCurrency, fiatRatesUpdater]);
-
-    if (!amount || !fiatCurrency || !network) return null;
-
-    const formattedBalance = shouldSendInSats
-        ? convertAmountUnitsToSubunits(amount, network.decimals)
-        : amount;
-    const fiatValue = toFiatCurrency({ amount, rate: fiatRate?.rate })?.toFixed(2) ?? null;
-
-    return {
-        fiatValue,
-        fiatRate,
-        accountBalance: amount,
-        formattedBalance,
-        symbol,
-        networkDecimals: network.decimals,
-        tokenAddress: contractAddress,
-        fiatRatesUpdater,
-    };
+    return useCommonTradingFiatValues({ ...rest, cryptoId, shouldSendInSats });
 };

--- a/suite-common/trading/src/hooks/useTradingFiatValues.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { CryptoId, FiatCurrencyCode } from 'invity-api';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    FiatRatesRootState,
+    selectBaseCurrency,
+    selectFiatRatesByFiatRateKey,
+    updateFiatRatesThunk,
+} from '@suite-common/wallet-core';
+import { FiatRatesResult, Rate, Timestamp, TokenAddress } from '@suite-common/wallet-types';
+import {
+    convertAmountUnitsToSubunits,
+    getFiatRateKey,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
+
+import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
+import { TradingRootState } from '../reducers/tradingCommonReducer';
+import {
+    cryptoIdToNetworkAndContractAddress,
+    isCryptoIdForNativeToken,
+    mapTestnetSymbol,
+} from '../utils';
+
+export interface TradingFiatRatesProps {
+    fiatCurrency?: FiatCurrencyCode;
+    cryptoId?: CryptoId;
+    amount?: string;
+    shouldSendInSats?: boolean;
+}
+
+export interface TradingFiatRatesReturn {
+    fiatValue: string | null;
+    fiatRate: Rate | undefined;
+    accountBalance: string;
+    formattedBalance: string;
+    symbol: NetworkSymbol;
+    networkDecimals: number;
+    tokenAddress: TokenAddress | undefined;
+    fiatRatesUpdater: (
+        value: FiatCurrencyCode | undefined,
+        currentTokenAddress?: TokenAddress,
+    ) => Promise<FiatRatesResult | null>;
+}
+
+export const useTradingFiatValues = ({
+    cryptoId,
+    fiatCurrency,
+    amount,
+    shouldSendInSats,
+}: TradingFiatRatesProps): TradingFiatRatesReturn | null => {
+    const dispatch = useDispatch();
+
+    const isNativeToken = cryptoId && isCryptoIdForNativeToken(cryptoId);
+
+    const { network, contractAddress, symbol } = useMemo(() => {
+        const assetInfo = cryptoId && cryptoIdToNetworkAndContractAddress(cryptoId);
+
+        return {
+            network: assetInfo?.network,
+            contractAddress: isNativeToken
+                ? undefined
+                : (assetInfo?.contractAddress as TokenAddress | undefined),
+            symbol: assetInfo?.network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY,
+        };
+    }, [cryptoId, isNativeToken]);
+
+    const symbolForFiat = mapTestnetSymbol(symbol);
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const fiatRateKey = getFiatRateKey(
+        symbolForFiat,
+        fiatCurrency ?? baseCurrencyCode,
+        contractAddress,
+    );
+
+    const fiatRate = useSelector((state: TradingRootState & FiatRatesRootState) =>
+        selectFiatRatesByFiatRateKey(state, fiatRateKey),
+    );
+
+    const fiatRatesUpdater = useCallback(
+        async (
+            value: FiatCurrencyCode | undefined,
+            currentTokenAddress?: TokenAddress,
+        ): Promise<FiatRatesResult | null> => {
+            if (!value) return null;
+            const tokenAddress = currentTokenAddress ?? contractAddress;
+
+            const updateFiatRatesResult = await dispatch(
+                updateFiatRatesThunk({
+                    tickers: [
+                        {
+                            symbol,
+                            tokenAddress: isNativeToken ? undefined : tokenAddress,
+                        },
+                    ],
+                    baseCurrencyCode: value,
+                    rateType: 'current',
+                    fetchAttemptTimestamp: Date.now() as Timestamp,
+                    forceFetchToken: true,
+                    skipCache: true,
+                }),
+            );
+
+            if (updateFiatRatesResult.meta.requestStatus === 'fulfilled') {
+                const fiatRates =
+                    updateFiatRatesResult.payload as PromiseSettledResult<FiatRatesResult>[];
+
+                const successfulResult = fiatRates.find(
+                    (result): result is PromiseFulfilledResult<FiatRatesResult> =>
+                        result.status === 'fulfilled',
+                );
+
+                return successfulResult?.value ?? null;
+            }
+
+            return null;
+        },
+        [contractAddress, dispatch, symbol, isNativeToken],
+    );
+
+    useEffect(() => {
+        if (!fiatCurrency) return;
+
+        fiatRatesUpdater(fiatCurrency);
+    }, [fiatCurrency, fiatRatesUpdater]);
+
+    if (!amount || !fiatCurrency || !network) return null;
+
+    const formattedBalance = shouldSendInSats
+        ? convertAmountUnitsToSubunits(amount, network.decimals)
+        : amount;
+    const fiatValue = toFiatCurrency({ amount, rate: fiatRate?.rate })?.toFixed(2) ?? null;
+
+    return {
+        fiatValue,
+        fiatRate,
+        accountBalance: amount,
+        formattedBalance,
+        symbol,
+        networkDecimals: network.decimals,
+        tokenAddress: contractAddress,
+        fiatRatesUpdater,
+    };
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -7,6 +7,7 @@ export * from './hooks/useTradingUtils';
 export * from './hooks/useListDataFilter';
 export * from './hooks/useCountryFilteredData';
 export * from './hooks/useProviderMetadataChangeEffect';
+export * from './hooks/useTradingFiatValues';
 export * from './invityAPI';
 export * from './reducers/buyReducer';
 export * from './reducers/exchangeReducer';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Move `useTradingFiatValues` from `suite` to `suite-common`

<!--- Describe your changes in detail -->

## Notes for QA

No changes

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #22292

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=22292-mobile-trade-move-usetradingfiatvalues-to-common-to-be-reusable-on-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=22292-mobile-trade-move-usetradingfiatvalues-to-common-to-be-reusable-on-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=22292-mobile-trade-move-usetradingfiatvalues-to-common-to-be-reusable-on-mobile&lookback=7)