### PR TITLE
refactor(suite): Refactor EventType names

### DIFF
--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -1,6 +1,6 @@
 import { JSX, useCallback, useEffect } from 'react';
 
-import { AppUpdateEventStatus, events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { AppUpdateEventStatus, asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { isArrayMember } from '@trezor/utils';
 

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater.tsx
@@ -1,6 +1,6 @@
 import { JSX, useCallback, useEffect } from 'react';
 
-import { AppUpdateEventStatus, EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { AppUpdateEventStatus, events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { isArrayMember } from '@trezor/utils';
 
@@ -85,7 +85,7 @@ export const DesktopUpdater = () => {
         });
 
         asTypedDesktopAnalytics(analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
     }, [dispatch, desktopUpdate.allowPrerelease, desktopUpdate.latest, analytics]);

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectSelectedDevice } from '@suite-common/wallet-core';

--- a/packages/suite/src/actions/backup/backupActions.ts
+++ b/packages/suite/src/actions/backup/backupActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
@@ -76,7 +76,7 @@ export const backupDevice =
                 payload: result.payload.error,
             });
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.CreateBackup,
+                type: events.createBackupEvent.name,
                 payload: {
                     status: 'error',
                     error: result.payload.error,
@@ -91,7 +91,7 @@ export const backupDevice =
                 payload: false,
             });
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.CreateBackup,
+                type: events.createBackupEvent.name,
                 payload: {
                     status: 'finished',
                     error: '',

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,4 +1,4 @@
-import { EventType, OnboardingAnalytics, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, OnboardingAnalytics, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { BackupType } from '@suite-common/suite-types';
 import { selectSelectedDevice, startDiscoveryThunk } from '@suite-common/wallet-core';
@@ -132,7 +132,7 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
         delete payload.startTime;
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.DeviceSetupCompleted,
+            type: events.deviceSetupCompletedEvent.name,
             payload,
         });
     };

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,4 +1,4 @@
-import { events, OnboardingAnalytics, asTypedDesktopAnalytics } from '@suite/analytics';
+import { OnboardingAnalytics, asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { BackupType } from '@suite-common/suite-types';
 import { selectSelectedDevice, startDiscoveryThunk } from '@suite-common/wallet-core';

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { PROTO, RecoveryDevice, UI } from '@trezor/connect';
@@ -86,7 +86,7 @@ const checkSeed =
         if (!response.success) {
             dispatch(setError(response.payload.error));
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.SettingsDeviceCheckSeed,
+                type: events.settingsDeviceCheckSeedEvent.name,
                 payload: {
                     status: 'error',
                     error: response.payload.code,
@@ -94,7 +94,7 @@ const checkSeed =
             });
         } else {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.SettingsDeviceCheckSeed,
+                type: events.settingsDeviceCheckSeedEvent.name,
                 payload: {
                     status: 'finished',
                 },

--- a/packages/suite/src/actions/recovery/recoveryActions.ts
+++ b/packages/suite/src/actions/recovery/recoveryActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect, { PROTO, RecoveryDevice, UI } from '@trezor/connect';

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -3,7 +3,7 @@
  * @docs docs/misc/analytics.md
  */
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import {
     analyticsActions,
     selectAnalyticsInstanceId,
@@ -29,7 +29,7 @@ export const enableAnalyticsThunk =
     (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
         if (sendReport) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.SettingsAnalytics,
+                type: events.settingsAnalyticsEvent.name,
                 payload: { value: true },
             });
         }
@@ -43,7 +43,7 @@ export const disableAnalyticsThunk =
     (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
         if (sendReport) {
             asTypedDesktopAnalytics(extra.services.analytics).report(
-                { type: EventType.SettingsAnalytics, payload: { value: false } },
+                { type: events.settingsAnalyticsEvent.name, payload: { value: false } },
                 { force: true },
             );
         }

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -3,7 +3,7 @@
  * @docs docs/misc/analytics.md
  */
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import {
     analyticsActions,
     selectAnalyticsInstanceId,

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -1,4 +1,4 @@
-import { AppUpdateEventStatus, EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { AppUpdateEventStatus, events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { UpdateInfo, UpdateProgress, desktopApi } from '@trezor/suite-desktop-api';
@@ -35,7 +35,7 @@ export const available =
             updateInfo: info,
         });
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
 
@@ -63,7 +63,7 @@ export const download =
             updateInfo: latest,
         });
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
 
@@ -93,7 +93,7 @@ export const ready =
             updateInfo: latest,
         });
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
         dispatch({
@@ -117,7 +117,7 @@ export const installUpdate =
         });
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
 
@@ -144,7 +144,7 @@ export const error = () => (dispatch: Dispatch, getState: GetState, extra: Extra
             updateInfo: latest,
         });
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.AppUpdate,
+            type: events.appUpdateEvent.name,
             payload,
         });
     }

--- a/packages/suite/src/actions/suite/desktopUpdateActions.ts
+++ b/packages/suite/src/actions/suite/desktopUpdateActions.ts
@@ -1,4 +1,4 @@
-import { AppUpdateEventStatus, events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { AppUpdateEventStatus, asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { UpdateInfo, UpdateProgress, desktopApi } from '@trezor/suite-desktop-api';

--- a/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     selectDeviceByStaticSessionId,
@@ -638,7 +638,7 @@ export const init =
             const providerResult = await dispatch(metadataProviderActions.initProvider());
             if (!providerResult) {
                 asTypedDesktopAnalytics(extra.services.analytics).report({
-                    type: EventType.SettingsGeneralLabelingProvider,
+                    type: events.settingsGeneralLabelingProviderEvent.name,
                     payload: {
                         provider: 'missing-provider',
                     },

--- a/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataLabelingActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     selectDeviceByStaticSessionId,

--- a/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -138,7 +138,7 @@ export const disconnectProvider =
             });
 
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.SettingsGeneralLabelingProvider,
+                type: events.settingsGeneralLabelingProviderEvent.name,
                 payload: {
                     provider: '',
                 },
@@ -279,7 +279,7 @@ export const connectProvider =
         });
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.SettingsGeneralLabelingProvider,
+            type: events.settingsGeneralLabelingProviderEvent.name,
             payload: {
                 provider: providerDetails.payload.type,
             },

--- a/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
+++ b/packages/suite/src/actions/suite/metadata/metadataProviderThunks.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
@@ -54,7 +54,7 @@ export const handleProtocolRequest =
 
         if (protocol) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.AppUriHandler,
+                type: events.appUriHandlerEvent.name,
                 payload: {
                     scheme: protocol.scheme,
                     isAmountPresent: 'amount' in protocol && protocol.amount !== undefined,

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import type { TranslationKey } from '@suite/intl';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import type { Locale } from '@suite-common/suite-types';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import type { TranslationKey } from '@suite/intl';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import type { Locale } from '@suite-common/suite-types';
@@ -228,7 +228,7 @@ export const toggleTor =
 
         if (ipcResponse.success) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.SettingsTor,
+                type: events.settingsTorEvent.name,
                 payload: {
                     value: shouldEnable,
                     location: selectRouterUrl(getState()),

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { UserContextPayload } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -66,7 +66,7 @@ export const showAddress =
             );
 
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.CreateReceiveAddressShowAddress,
+                type: events.createReceiveAddressShowAddressEvent.name,
                 payload: {
                     assetSymbol: account.symbol,
                     type: 'unverified',
@@ -79,7 +79,7 @@ export const showAddress =
         dispatch(modalActions.preserve());
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.CreateReceiveAddressShowAddress,
+            type: events.createReceiveAddressShowAddressEvent.name,
             payload: {
                 assetSymbol: account.symbol,
                 type: 'verified',
@@ -98,7 +98,7 @@ export const showAddress =
             dispatch(openAddressModal({ ...modalPayload, isConfirmed: true }));
 
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.CreateReceiveAddressConfirmOnTrezor,
+                type: events.createReceiveAddressConfirmOnTrezorEvent.name,
                 payload: { assetSymbol: account.symbol },
             });
         } else {

--- a/packages/suite/src/actions/wallet/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/receiveActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import { UserContextPayload } from '@suite-common/suite-types';
 import { notificationsActions } from '@suite-common/toast-notifications';

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -1,7 +1,7 @@
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';

--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -1,7 +1,7 @@
 import { G } from '@mobily/ts-belt';
 import { isRejected } from '@reduxjs/toolkit';
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { MetadataAddPayload } from '@suite-common/metadata-types';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
@@ -232,7 +232,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         dispatch(modalActions.preserve());
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.SendInitialised,
+            type: events.sendInitialisedEvent.name,
             payload: {
                 assetSymbol: selectedAccount.symbol,
             },
@@ -248,7 +248,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         );
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: EventType.SendConfirmedOnDevice,
+            type: events.sendConfirmedOnDeviceEvent.name,
             payload: {
                 assetSymbol: selectedAccount.symbol,
             },

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -1,4 +1,4 @@
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     calculate,

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -1,4 +1,4 @@
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     calculate,
@@ -376,7 +376,7 @@ export const signTransaction =
 
         if (!signedTx.success) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.TransactionCancel,
+                type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',
                     networkSymbol: account.symbol,

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,6 +1,6 @@
 import { toWei } from 'web3-utils';
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     getStakeTxGasLimit,

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,6 +1,6 @@
 import { toWei } from 'web3-utils';
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     getStakeTxGasLimit,
@@ -219,7 +219,7 @@ export const signTransaction =
 
         if (!signedTx.success) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.TransactionCancel,
+                type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',
                     networkSymbol: account.symbol,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -1,6 +1,6 @@
 import { address } from '@solana/kit';
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     calculate,
@@ -308,7 +308,7 @@ export const signTransaction =
 
         if (!signedTx.success) {
             asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: EventType.TransactionCancel,
+                type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',
                     networkSymbol: account.symbol,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -1,6 +1,6 @@
 import { address } from '@solana/kit';
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { ExtraDependencies } from '@suite-common/redux-utils';
 import {
     calculate,

--- a/packages/suite/src/constants/suite/staking.ts
+++ b/packages/suite/src/constants/suite/staking.ts
@@ -1,8 +1,8 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 
 export const earnFlowToEventTypeMap = {
-    [EarnFlow.Stake]: EventType.StakingStake,
-    [EarnFlow.Yield]: EventType.StakingYield,
-    [EarnFlow.UpdateProvider]: EventType.StakingUpdateProvider,
-} as const satisfies Record<EarnFlow, EventType>;
+    [EarnFlow.Stake]: events.stakingStakeEvent.name,
+    [EarnFlow.Yield]: events.stakingYieldEvent.name,
+    [EarnFlow.UpdateProvider]: events.stakingUpdateProviderEvent.name,
+} as const satisfies Record<EarnFlow, string>;

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -1,6 +1,6 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
-import { EventType, asTypedDesktopAnalytics } from '@suite/analytics';
+import { events, asTypedDesktopAnalytics } from '@suite/analytics';
 import { firmwareUpdate } from '@suite-common/firmware';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';
@@ -72,7 +72,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
             if (device?.features) {
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.DeviceUpdateFirmware,
+                    type: events.deviceUpdateFirmwareEvent.name,
                     payload: {
                         model: device.features.internal_model,
                         fromFwVersion:
@@ -90,7 +90,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
         switch (action.type) {
             case deviceActions.addAuthorizedDevice.type:
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.SelectWalletType,
+                    type: events.selectWalletTypeEvent.name,
                     payload: {
                         type: action.payload.device.walletNumber ? 'hidden' : 'standard',
                     },
@@ -100,7 +100,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
             case SUITE.READY:
                 getSuiteReadyPayload(state).then(payload => {
                     asTypedDesktopAnalytics(analytics).report({
-                        type: EventType.SuiteReady,
+                        type: events.suiteReadyEvent.name,
                         payload,
                     });
                 });
@@ -108,7 +108,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
             case TRANSPORT.START:
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.TransportType,
+                    type: events.transportTypeEvent.name,
                     payload: {
                         type: action.payload.type,
                         version: action.payload.version,
@@ -124,7 +124,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
                 if (!isDeviceInBootloaderMode(device)) {
                     asTypedDesktopAnalytics(analytics).report({
-                        type: EventType.DeviceConnect,
+                        type: events.deviceConnectEvent.name,
                         payload: {
                             mode,
                             firmware: getFirmwareVersion(device),
@@ -148,7 +148,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     });
                 } else {
                     asTypedDesktopAnalytics(analytics).report({
-                        type: EventType.DeviceConnect,
+                        type: events.deviceConnectEvent.name,
                         payload: {
                             mode: 'bootloader',
                             firmware: getFirmwareVersion(device),
@@ -162,7 +162,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
             case DEVICE.DISCONNECT:
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.DeviceDisconnect,
+                    type: events.deviceDisconnectEvent.name,
                 });
                 break;
 
@@ -203,7 +203,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     .reduce(accumulateAccountCountBySymbolAndType, {});
 
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.AccountsStatus,
+                    type: events.accountsStatusEvent.name,
                     payload: getAccountsWithSomeTransactionHistory(state.wallet.accounts).reduce(
                         accumulateAccountCountBySymbolAndType,
                         {},
@@ -211,17 +211,17 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                 });
 
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.AccountsNonZeroBalance,
+                    type: events.accountsNonZeroBalanceEvent.name,
                     payload: accountsWithNonZeroBalance,
                 });
 
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.AccountsTokensStatus,
+                    type: events.accountsTokensStatusEvent.name,
                     payload: accountsWithTokens,
                 });
 
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.AccountsActiveStaking,
+                    type: events.accountsActiveStakingEvent.name,
                     payload: accountsWithStaking,
                 });
 
@@ -234,7 +234,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     state.suite.lifecycle.status !== 'loading'
                 ) {
                     asTypedDesktopAnalytics(analytics).report({
-                        type: EventType.RouterLocationChange,
+                        type: events.routerLocationChangeEvent.name,
                         payload: {
                             prevRouterUrl: redactRouterUrl(prevRouterUrl),
                             nextRouterUrl: redactRouterUrl(selectRouterUrl(state)),
@@ -247,7 +247,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
             case ROUTER.ANCHOR_CHANGE:
                 if (action.payload) {
                     asTypedDesktopAnalytics(analytics).report({
-                        type: EventType.RouterLocationChange,
+                        type: events.routerLocationChangeEvent.name,
                         payload: {
                             prevRouterUrl: redactRouterUrl(prevRouterUrl),
                             nextRouterUrl: redactRouterUrl(prevRouterUrl),
@@ -272,7 +272,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                 if (coinjoinAccount && anonymityGainToReport !== null) {
                     asTypedDesktopAnalytics(analytics).report(
                         {
-                            type: EventType.CoinjoinAnonymityGain,
+                            type: events.coinjoinAnonymityGainEvent.name,
                             payload: {
                                 networkSymbol: coinjoinAccount.symbol,
                                 value: anonymityGainToReport,
@@ -288,8 +288,8 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
             case deviceActions.setRememberDevice.type:
                 asTypedDesktopAnalytics(analytics).report({
                     type: action.payload.remember
-                        ? EventType.SwitchDeviceRemember
-                        : EventType.SwitchDeviceForget,
+                        ? events.switchDeviceRememberEvent.name
+                        : events.switchDeviceForgetEvent.name,
                 });
                 break;
 
@@ -298,14 +298,14 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     dispatch(setFlag('discreetModeCompleted', true));
                 }
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.MenuToggleDiscreet,
+                    type: events.menuToggleDiscreetEvent.name,
                     payload: { value: action.toggled },
                 });
                 break;
 
             case WALLET_SETTINGS.CHANGE_COIN_VISIBILITY:
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.SettingsCoins,
+                    type: events.settingsCoinsEvent.name,
                     payload: {
                         symbol: action.payload.symbol,
                         value: action.payload.shouldBeVisible,
@@ -315,7 +315,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
             case WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS:
                 asTypedDesktopAnalytics(analytics).report({
-                    type: EventType.SettingsGeneralChangeBitcoinUnit,
+                    type: events.settingsGeneralChangeBitcoinUnitEvent.name,
                     payload: {
                         unit: UNIT_ABBREVIATIONS[action.payload],
                     },

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -1,6 +1,6 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
-import { events, asTypedDesktopAnalytics } from '@suite/analytics';
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { firmwareUpdate } from '@suite-common/firmware';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { UNIT_ABBREVIATIONS } from '@suite-common/suite-constants';

--- a/suite-common/analytics/src/index.ts
+++ b/suite-common/analytics/src/index.ts
@@ -1,4 +1,3 @@
-export { EventType } from './constants';
 export { type AnalyticsSharedEvents } from './analyticsEvents';
 export type { AttributeDef, EventDef, EventInstance, AppVersion } from './eventDefinition';
 

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -1,6 +1,6 @@
 import { ThunkDispatch } from '@reduxjs/toolkit';
 
-import { EventType } from '@suite-common/analytics';
+import { events } from '@suite-common/analytics';
 import {
     AnyAction,
     ExtraDependencies,
@@ -283,7 +283,7 @@ const trackCompleteDiscoveryResult = (
     typedObjectEntries(accountsBySymbol).forEach(([symbol, accounts]) => {
         if (isNetworkSymbol(symbol)) {
             analytics.report({
-                type: EventType.CoinDiscovery,
+                type: events.coinDiscoveryEvent.name,
                 payload: {
                     discoveryId: deviceStaticSessionId,
                     symbol,

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -8,7 +8,7 @@ import {
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
 import { createThunk } from '@suite-common/redux-utils';
-import { events, asTypedNativeAnalytics } from '@suite-native/analytics';
+import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
 import { isDevelopEnv } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
@@ -32,7 +32,10 @@ const disableAnalyticsThunk = createThunk(
     `${ACTION_PREFIX}/disableAnalyticsThunk`,
     (_, { dispatch, extra }) => {
         asTypedNativeAnalytics(extra.services.analytics).report(
-            { type: events.settingsDataPermissionEvent.name, payload: { analyticsPermission: false } },
+            {
+                type: events.settingsDataPermissionEvent.name,
+                payload: { analyticsPermission: false },
+            },
             { force: true },
         );
         allowSentryReport(false);

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -8,7 +8,7 @@ import {
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
 import { createThunk } from '@suite-common/redux-utils';
-import { EventType, asTypedNativeAnalytics } from '@suite-native/analytics';
+import { events, asTypedNativeAnalytics } from '@suite-native/analytics';
 import { isDevelopEnv } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
@@ -20,7 +20,7 @@ const enableAnalyticsThunk = createThunk(
     `${ACTION_PREFIX}/enableAnalyticsThunk`,
     (_, { dispatch, extra }) => {
         asTypedNativeAnalytics(extra.services.analytics).report({
-            type: EventType.SettingsDataPermission,
+            type: events.settingsDataPermissionEvent.name,
             payload: { analyticsPermission: true },
         });
         allowSentryReport(true);
@@ -32,7 +32,7 @@ const disableAnalyticsThunk = createThunk(
     `${ACTION_PREFIX}/disableAnalyticsThunk`,
     (_, { dispatch, extra }) => {
         asTypedNativeAnalytics(extra.services.analytics).report(
-            { type: EventType.SettingsDataPermission, payload: { analyticsPermission: false } },
+            { type: events.settingsDataPermissionEvent.name, payload: { analyticsPermission: false } },
             { force: true },
         );
         allowSentryReport(false);

--- a/suite-native/analytics/src/index.ts
+++ b/suite-native/analytics/src/index.ts
@@ -1,4 +1,3 @@
-export { EventType } from './constants';
 export type {
     AnalyticsSendFlowStep,
     CountryChangeContextCheck,

--- a/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.comp.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.comp.test.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
@@ -66,7 +66,7 @@ describe('TradingLocationOnboardingScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingParameterChanged,
+            type: events.tradingParameterChangedEvent.name,
             payload: {
                 type: 'onboarding',
                 parameter: 'country',

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -1,7 +1,7 @@
 import { EnhancedStore } from '@reduxjs/toolkit';
 
 import { tradingBuyActions } from '@suite-common/trading';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -129,7 +129,7 @@ describe('BuyPaymentMethodPicker', () => {
                 fireEvent.press(getByText('Credit Card'));
 
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingParameterChanged,
+                    type: events.tradingParameterChangedEvent.name,
                     payload: {
                         type: 'buy',
                         parameter: 'paymentMethod',

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -149,13 +149,13 @@ describe('BuyProviderPicker', () => {
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingCompareOffers,
+                    type: events.tradingCompareOffersEvent.name,
                     payload: {
                         type: 'buy',
                     },
                 });
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingParameterChanged,
+                    type: events.tradingParameterChangedEvent.name,
                     payload: {
                         type: 'buy',
                         parameter: 'provider',
@@ -181,7 +181,7 @@ describe('BuyProviderPicker', () => {
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingCompareOffers,
+                    type: events.tradingCompareOffersEvent.name,
                     payload: {
                         type: 'buy',
                     },

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -97,13 +97,13 @@ describe('ExchangeRateAndProviderPicker', () => {
 
             expect(reportMock).toHaveBeenCalledTimes(2);
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingCompareOffers,
+                type: events.tradingCompareOffersEvent.name,
                 payload: {
                     type: 'exchange',
                 },
             });
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'exchange',
                     parameter: 'provider',
@@ -119,7 +119,7 @@ describe('ExchangeRateAndProviderPicker', () => {
 
             expect(reportMock).toHaveBeenCalledTimes(1);
             expect(reportMock).not.toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'exchange',
                     parameter: 'provider',

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -223,7 +223,7 @@ describe('Header', () => {
             fireEvent.press(renderer.getByText('Swap'));
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingNavigate,
+                type: events.tradingNavigateEvent.name,
                 payload: {
                     action: 'navigate',
                     type: 'exchange',
@@ -258,7 +258,7 @@ describe('Header', () => {
             fireEvent.press(renderer.getByText('Buy'));
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingNavigate,
+                type: events.tradingNavigateEvent.name,
                 payload: {
                     action: 'navigate',
                     type: 'buy',

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.comp.test.tsx
@@ -1,6 +1,6 @@
 import { TradingCountryOption } from '@suite-common/trading';
 import { yup } from '@suite-common/validators';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form, useForm } from '@suite-native/forms';
 import type { UseFormReturn } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
@@ -87,7 +87,7 @@ describe('TradingCountryOfResidencePicker', () => {
         await userEvent.press(getByText(/Algeria/));
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingParameterChanged,
+            type: events.tradingParameterChangedEvent.name,
             payload: {
                 type: 'buy',
                 parameter: 'country',

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -117,7 +117,7 @@ describe('SellForm', () => {
         await renderSellForm({}, result.current);
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingSell,
+            type: events.tradingSellEvent.name,
             payload: expect.objectContaining({
                 step: 'sell-form',
                 action: 'visit',

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -120,7 +120,7 @@ describe('SellReceiveMethodPicker', () => {
                 fireEvent.press(getByText('Credit Card'));
 
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingParameterChanged,
+                    type: events.tradingParameterChangedEvent.name,
                     payload: {
                         type: 'sell',
                         parameter: 'paymentMethod',

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form } from '@suite-native/forms';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -128,13 +128,13 @@ describe('SellProviderPicker', () => {
 
                 expect(reportMock).toHaveBeenCalledTimes(2);
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingCompareOffers,
+                    type: events.tradingCompareOffersEvent.name,
                     payload: {
                         type: 'sell',
                     },
                 });
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingParameterChanged,
+                    type: events.tradingParameterChangedEvent.name,
                     payload: {
                         type: 'sell',
                         parameter: 'provider',
@@ -150,7 +150,7 @@ describe('SellProviderPicker', () => {
 
                 expect(reportMock).toHaveBeenCalledTimes(1);
                 expect(reportMock).toHaveBeenCalledWith({
-                    type: EventType.TradingCompareOffers,
+                    type: events.tradingCompareOffersEvent.name,
                     payload: {
                         type: 'sell',
                     },

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -1,5 +1,5 @@
 import { AccountKey } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import {
     PreloadedState,
@@ -242,7 +242,7 @@ describe('useExchangeFlow', () => {
             triggerAnalyticsTradeConfirmation();
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingConfirmTrade,
+                type: events.tradingConfirmTradeEvent.name,
                 payload: {
                     type: 'exchange',
                 },

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -2,7 +2,7 @@ import type { ExchangeTrade } from 'invity-api';
 
 import { selectTradingProviderMetadata, tradingExchangeActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 import {
     PreloadedState,
@@ -296,7 +296,7 @@ describe('useExchangeForm', () => {
             });
 
             expect(mockReport).toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'exchange',
                     parameter: 'cryptoFrom',
@@ -358,7 +358,7 @@ describe('useExchangeForm', () => {
             });
 
             expect(mockReport).toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'exchange',
                     parameter: 'cryptoTo',

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -6,7 +6,7 @@ import {
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import {
     PreloadedState,
     TestStore,
@@ -420,7 +420,7 @@ describe('useExchangeQuotes', () => {
             await renderUseExchangeQuotesWithFilledForm(store);
 
             expect(mockReport).toHaveBeenCalledWith({
-                type: EventType.TradingQuoteReceived,
+                type: events.tradingQuoteReceivedEvent.name,
                 payload: {
                     type: 'exchange',
                 },

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { tradingExchangeActions, tradingSettingsActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import {
     PreloadedState,
@@ -214,7 +214,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingExchange,
+                type: events.tradingExchangeEvent.name,
                 payload: expect.objectContaining({
                     step: 'account-selection',
                     action: 'continue',

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { TradingTransaction } from '@suite-common/trading';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { renderHook, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade } from '@suite-native/trading-fixtures';
@@ -84,7 +84,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         rerender({ trades: [updatedBuyTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'success' },
         });
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -114,11 +114,11 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(2);
         expect(reportMock).toHaveBeenNthCalledWith(1, {
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'success' },
         });
         expect(reportMock).toHaveBeenNthCalledWith(2, {
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'exchange', status: 'success' },
         });
     });
@@ -163,7 +163,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         rerender({ trades: [updatedTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'success' },
         });
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -188,7 +188,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         rerender({ trades: [updatedTrade] });
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'success' },
         });
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -217,7 +217,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         const kycTrade = getExchangeTrade({ status: 'KYC' });
         rerender({ trades: [kycTrade] });
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'exchange', status: 'kyc' },
         });
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -225,7 +225,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         const successTrade = getExchangeTrade({ status: 'SUCCESS' });
         rerender({ trades: [successTrade] });
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'exchange', status: 'success' },
         });
         expect(reportMock).toHaveBeenCalledTimes(2);
@@ -241,7 +241,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         const errorTrade = getBuyTrade({ status: 'ERROR' });
         rerender({ trades: [errorTrade] });
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'error' },
         });
         expect(reportMock).toHaveBeenCalledTimes(1);
@@ -261,7 +261,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         rerender({ trades: [buyTrade] });
         expect(reportMock).toHaveBeenCalledTimes(2);
         expect(reportMock).toHaveBeenNthCalledWith(2, {
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'waiting' },
         });
     });
@@ -306,7 +306,7 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
         rerender({ trades: [updatedBuyTrade] });
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingStatus,
+            type: events.tradingStatusEvent.name,
             payload: { type: 'buy', status: 'success' },
         });
     });

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -2,7 +2,7 @@ import type { SellFiatTrade } from 'invity-api';
 
 import { tradingSellActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { Form, useField } from '@suite-native/forms';
 import {
     PreloadedState,
@@ -104,7 +104,7 @@ describe('useSellForm', () => {
             });
 
             expect(mockReport).toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'sell',
                     parameter: 'cryptoFrom',
@@ -147,7 +147,7 @@ describe('useSellForm', () => {
             });
 
             expect(mockReport).toHaveBeenCalledWith({
-                type: EventType.TradingParameterChanged,
+                type: events.tradingParameterChangedEvent.name,
                 payload: {
                     type: 'sell',
                     parameter: 'fiat',

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.comp.test.tsx
@@ -2,7 +2,7 @@ import { RouteProp } from '@react-navigation/native';
 import type { ExchangeTrade } from 'invity-api';
 
 import { AccountKey, GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import {
@@ -226,7 +226,7 @@ describe('TradingExchangePreviewScreen', () => {
 
             expect(mockConfirmTrade).toHaveBeenCalledTimes(2);
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingExchange,
+                type: events.tradingExchangeEvent.name,
                 payload: expect.objectContaining({
                     step: 'transaction-preview',
                     action: 'retry',
@@ -250,7 +250,7 @@ describe('TradingExchangePreviewScreen', () => {
 
             expect(mockPopToTop).toHaveBeenCalledTimes(1);
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingExchange,
+                type: events.tradingExchangeEvent.name,
                 payload: expect.objectContaining({
                     step: 'transaction-preview',
                     action: 'cancel',
@@ -274,7 +274,7 @@ describe('TradingExchangePreviewScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'transaction-preview',
                 action: 'visit',
@@ -290,7 +290,7 @@ describe('TradingExchangePreviewScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'transaction-preview',
                 action: 'continue',

--- a/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.comp.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.comp.test.tsx
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import {
@@ -119,7 +119,7 @@ describe('TradingFeesScreen', () => {
         const { reportMock } = await renderScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'fee-selection',
                 action: 'visit',
@@ -136,7 +136,7 @@ describe('TradingFeesScreen', () => {
         const { reportMock } = await renderScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'fee-selection',
                 action: 'visit',
@@ -159,7 +159,7 @@ describe('TradingFeesScreen', () => {
         const { reportMock } = await renderScreen(sellPreloadedState);
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingSell,
+            type: events.tradingSellEvent.name,
             payload: expect.objectContaining({
                 step: 'fee-selection',
                 action: 'visit',

--- a/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import {
     BottomSheetModal,
     Box,
@@ -27,15 +27,10 @@ type TransactionDetailSheetProps = {
 
 type SheetType = 'parameters' | 'values' | 'inputs';
 
-type TransactionSheetAnalyticsEventType =
-    | EventType.TransactionDetailParameters
-    | EventType.TransactionDetailCompareValues
-    | EventType.TransactionDetailInputOutput;
-
-const sheetToAnalyticsEventMap: Record<SheetType, TransactionSheetAnalyticsEventType> = {
-    parameters: EventType.TransactionDetailParameters,
-    values: EventType.TransactionDetailCompareValues,
-    inputs: EventType.TransactionDetailInputOutput,
+const sheetToAnalyticsEventMap: Record<SheetType, string> = {
+    parameters: events.transactionDetailParametersEvent.name,
+    values: events.transactionDetailCompareValuesEvent.name,
+    inputs: events.transactionDetailInputOutputEvent.name,
 };
 
 const triggerStyle = prepareNativeStyle(() => ({

--- a/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailSheet.tsx
@@ -27,11 +27,11 @@ type TransactionDetailSheetProps = {
 
 type SheetType = 'parameters' | 'values' | 'inputs';
 
-const sheetToAnalyticsEventMap: Record<SheetType, string> = {
+const sheetToAnalyticsEventMap = {
     parameters: events.transactionDetailParametersEvent.name,
     values: events.transactionDetailCompareValuesEvent.name,
     inputs: events.transactionDetailInputOutputEvent.name,
-};
+} as const satisfies Record<SheetType, string>;
 
 const triggerStyle = prepareNativeStyle(() => ({
     flexDirection: 'row',

--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -8,7 +8,7 @@ import {
 } from '@react-navigation/native';
 import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 
-import { EventType, events } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { addSentryBreadcrumb, setSentryTag } from '@suite-native/sentry';
 import { useAnalytics } from '@suite-native/services';
 import { useNativeStyles } from '@trezor/styles';
@@ -83,7 +83,7 @@ export const NavigationContainerWithAnalytics = ({ children }: { children: React
             });
 
             addSentryBreadcrumb({
-                category: EventType.ScreenChange,
+                category: events.screenChangeEvent.name,
                 message: 'screen changed',
                 level: 'info',
                 data: {

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -24,7 +24,7 @@ import {
     TokenAddress,
 } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
-import { EventType, asTypedNativeAnalytics } from '@suite-native/analytics';
+import { events, asTypedNativeAnalytics } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { selectAccountTokenSymbol } from '@suite-native/tokens';
 import {
@@ -218,7 +218,7 @@ export const sendTransactionThunk = createThunk<
             );
 
             asTypedNativeAnalytics(extra.services.analytics).report({
-                type: EventType.SendTransactionDispatched,
+                type: events.sendTransactionDispatchedEvent.name,
                 payload: {
                     symbol: selectedAccount.symbol,
                     tokenAddresses: tokenContract ? [tokenContract] : undefined,

--- a/suite-native/send/src/sendFormThunks.ts
+++ b/suite-native/send/src/sendFormThunks.ts
@@ -24,7 +24,7 @@ import {
     TokenAddress,
 } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
-import { events, asTypedNativeAnalytics } from '@suite-native/analytics';
+import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import { selectAccountTokenSymbol } from '@suite-native/tokens';
 import {

--- a/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
@@ -1,6 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
@@ -43,7 +43,7 @@ describe('useExchangeAnalyticReportCallback', () => {
         result.current('exchange-form', 'continue');
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'exchange-form',
                 action: 'continue',
@@ -60,7 +60,7 @@ describe('useExchangeAnalyticReportCallback', () => {
         result.current('exchange-form', 'continue');
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: {
                 step: 'exchange-form',
                 action: 'continue',
@@ -79,7 +79,7 @@ describe('useExchangeAnalyticReportCallback', () => {
         result.current('exchange-form', 'continue');
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: expect.objectContaining({
                 step: 'exchange-form',
                 action: 'continue',
@@ -100,7 +100,7 @@ describe('useExchangeAnalyticReportCallback', () => {
         result.current('exchange-form', 'continue');
 
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingExchange,
+            type: events.tradingExchangeEvent.name,
             payload: {
                 step: 'exchange-form',
                 action: 'continue',

--- a/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
@@ -1,9 +1,9 @@
 import {
-    events,
     TradingExchangeAction,
     TradingExchangeStep,
     TradingSellAction,
     TradingSellStep,
+    events,
 } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';

--- a/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
@@ -1,5 +1,5 @@
 import {
-    EventType,
+    events,
     TradingExchangeAction,
     TradingExchangeStep,
     TradingSellAction,
@@ -53,7 +53,7 @@ describe('useTradingAnalyticReportCallback', () => {
             );
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingSell,
+                type: events.tradingSellEvent.name,
                 payload: expect.objectContaining({
                     step: 'sell-form',
                     action: 'visit',
@@ -82,7 +82,7 @@ describe('useTradingAnalyticReportCallback', () => {
             );
 
             expect(reportMock).toHaveBeenCalledWith({
-                type: EventType.TradingExchange,
+                type: events.tradingExchangeEvent.name,
                 payload: expect.objectContaining({
                     step: 'exchange-form',
                     action: 'continue',

--- a/suite-native/trading-residence/src/hooks/__tests__/useCountrySelectionAnalyticsReport.comp.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useCountrySelectionAnalyticsReport.comp.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
@@ -36,7 +36,7 @@ describe('useCountrySelectionAnalyticsReport', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingCountrySelection,
+            type: events.tradingCountrySelectionEvent.name,
             payload: {
                 type: 'settings',
                 action: 'submitCustom',

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.comp.test.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import { SettingsStackParamList, SettingsStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import { renderWithStoreProvider, screen, userEvent } from '@suite-native/test-utils';
@@ -73,7 +73,7 @@ describe('TradingLocationSettingsScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingParameterChanged,
+            type: events.tradingParameterChangedEvent.name,
             payload: {
                 type: 'settings',
                 parameter: 'country',
@@ -88,7 +88,7 @@ describe('TradingLocationSettingsScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingCountrySelection,
+            type: events.tradingCountrySelectionEvent.name,
             payload: {
                 type: 'settings',
                 action: 'cancel',

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.comp.test.tsx
@@ -1,6 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 
-import { EventType } from '@suite-native/analytics';
+import { events } from '@suite-native/analytics';
 import {
     RootStackRoutes,
     TradingStackParamList,
@@ -86,7 +86,7 @@ describe('TradingLocationModalScreen', () => {
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
-            type: EventType.TradingParameterChanged,
+            type: events.tradingParameterChangedEvent.name,
             payload: {
                 type: 'onboarding',
                 parameter: 'country',

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -5,7 +5,6 @@ export {
     type FirmwareSource,
     AppUpdateEventStatus,
 } from './definitions';
-export { EventType } from './constants';
 export { asTypedDesktopAnalytics } from './asTypedDesktopAnalytics';
 export type { AnalyticsDesktopEvents, SuiteReadyPayload } from './analyticsEvents';
 

--- a/suite/e2e/support/analytics.ts
+++ b/suite/e2e/support/analytics.ts
@@ -1,6 +1,5 @@
 import { Page } from '@playwright/test';
 
-import { EventType } from '@suite/analytics';
 import { urlSearchParams } from '@trezor/suite/src//utils/suite/metadata';
 
 import { step } from './common';
@@ -35,7 +34,7 @@ export class AnalyticsFixture {
         return [...this.requests].reverse().find(req => req.c_type === eventType);
     }
 
-    findLatestRequestByType(eventType: EventType) {
+    findLatestRequestByType(eventType: string) {
         return [...this.requests].reverse().find(req => req.c_type === eventType);
     }
 

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -166,8 +166,14 @@ test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
 
         await test.step('Wait for analytics events and validate event types', async () => {
             await analytics.waitForAnalyticsRequests(4);
-            expect(analytics.requests[0]).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
-            expect(analytics.requests[1]).toHaveProperty('c_type', events.routerLocationChangeEvent.name);
+            expect(analytics.requests[0]).toHaveProperty(
+                'c_type',
+                events.settingsAnalyticsEvent.name,
+            );
+            expect(analytics.requests[1]).toHaveProperty(
+                'c_type',
+                events.routerLocationChangeEvent.name,
+            );
             expect(analytics.requests[2]).toHaveProperty('c_type', events.suiteReadyEvent.name);
         });
 

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
 import { Model } from '@trezor/trezor-user-env-link';
 
@@ -34,8 +34,8 @@ test.describe(
 
                 await test.step('Validate SuiteReady event', () => {
                     const suiteReadyEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<EventType.SuiteReady>
-                    >(EventType.SuiteReady);
+                        ExtractByEventType<(typeof events.suiteReadyEvent)['name']>
+                    >(events.suiteReadyEvent.name);
                     expect(suiteReadyEvent).toContainSubObject({
                         language: 'en-US',
                         enabledNetworks: 'btc',
@@ -61,8 +61,8 @@ test.describe(
 
                 await test.step('Validate DeviceConnect event', () => {
                     const deviceConnectEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<EventType.DeviceConnect>
-                    >(EventType.DeviceConnect);
+                        ExtractByEventType<(typeof events.deviceConnectEvent)['name']>
+                    >(events.deviceConnectEvent.name);
                     expect(deviceConnectEvent).toContainSubObject({
                         mode: 'normal',
                         firmware: firmwareVersion,
@@ -82,8 +82,8 @@ test.describe(
 
                 await test.step('Validate TransportType event', () => {
                     const transportTypeEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<EventType.TransportType>
-                    >(EventType.TransportType);
+                        ExtractByEventType<(typeof events.transportTypeEvent)['name']>
+                    >(events.transportTypeEvent.name);
                     expect(transportTypeEvent.type).toBe('BridgeTransport');
                     expect(parseInt(transportTypeEvent.version, 10)).not.toBeNaN();
                 });
@@ -92,7 +92,7 @@ test.describe(
                     await device.powerOff();
                     await analytics.waitForAnalyticsRequests(1); // Poll to prevent race condition
                     expect(
-                        analytics.findLatestRequestByLegacyType(EventType.DeviceDisconnect),
+                        analytics.findLatestRequestByLegacyType(events.deviceDisconnectEvent.name),
                     ).toBeDefined();
                 });
             },
@@ -166,22 +166,22 @@ test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
 
         await test.step('Wait for analytics events and validate event types', async () => {
             await analytics.waitForAnalyticsRequests(4);
-            expect(analytics.requests[0]).toHaveProperty('c_type', EventType.SettingsAnalytics);
-            expect(analytics.requests[1]).toHaveProperty('c_type', EventType.RouterLocationChange);
-            expect(analytics.requests[2]).toHaveProperty('c_type', EventType.SuiteReady);
+            expect(analytics.requests[0]).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
+            expect(analytics.requests[1]).toHaveProperty('c_type', events.routerLocationChangeEvent.name);
+            expect(analytics.requests[2]).toHaveProperty('c_type', events.suiteReadyEvent.name);
         });
 
         await test.step('Validate SettingsAnalytics event', () => {
             const settingsAnalyticsEvent = analytics.findAnalyticsEventByType<
-                ExtractByEventType<EventType.SettingsAnalytics>
-            >(EventType.SettingsAnalytics);
+                ExtractByEventType<(typeof events.settingsAnalyticsEvent)['name']>
+            >(events.settingsAnalyticsEvent.name);
             expect(settingsAnalyticsEvent.value).toBe('true');
         });
 
         await test.step('Validate SuiteReady event reflects changed settings', () => {
             const suiteReadyEvent = analytics.findAnalyticsEventByType<
-                ExtractByEventType<EventType.SuiteReady>
-            >(EventType.SuiteReady);
+                ExtractByEventType<(typeof events.suiteReadyEvent)['name']>
+            >(events.suiteReadyEvent.name);
             expect(suiteReadyEvent).toContainSubObject({
                 language: 'en-US',
                 enabledNetworks: 'eth,thod',

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -116,7 +116,10 @@ test.describe(
                 const deviceModalRequest = analytics.findLatestRequestByType(
                     events.routerLocationChangeEvent.name,
                 );
-                expect(deviceModalRequest).toHaveProperty('c_type', events.routerLocationChangeEvent.name);
+                expect(deviceModalRequest).toHaveProperty(
+                    'c_type',
+                    events.routerLocationChangeEvent.name,
+                );
             });
         });
 
@@ -134,7 +137,9 @@ test.describe(
                 await analytics.waitForAnalyticsRequests(3);
 
                 expect(analytics.requests.length).toBeGreaterThan(1);
-                expect(analytics.findLatestRequestByLegacyType(events.suiteReadyEvent.name)).toBeDefined();
+                expect(
+                    analytics.findLatestRequestByLegacyType(events.suiteReadyEvent.name),
+                ).toBeDefined();
                 expect(
                     analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
                 ).toBeDefined();
@@ -163,7 +168,9 @@ test.describe(
                     analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
                 ).toBeDefined();
                 expect(
-                    analytics.findLatestRequestByLegacyType(events.settingsGeneralChangeFiatEvent.name),
+                    analytics.findLatestRequestByLegacyType(
+                        events.settingsGeneralChangeFiatEvent.name,
+                    ),
                 ).not.toBeDefined();
             });
         });

--- a/suite/e2e/tests/analytics/toggle.test.ts
+++ b/suite/e2e/tests/analytics/toggle.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 
 import { expect, test } from '../../support/fixtures';
 
@@ -34,9 +34,9 @@ test.describe(
                     await analytics.waitForAnalyticsRequests();
                     // assert that only "analytics/dispose" event was fired
                     const request = analytics.findLatestRequestByLegacyType(
-                        EventType.SettingsAnalytics,
+                        events.settingsAnalyticsEvent.name,
                     );
-                    expect(request).toHaveProperty('c_type', EventType.SettingsAnalytics);
+                    expect(request).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
                     expect(request).toHaveProperty('value', 'false');
                     expect(request).toHaveProperty('c_session_id');
                     expect(request).toHaveProperty('c_instance_id');
@@ -71,9 +71,9 @@ test.describe(
                 await analytics.waitForAnalyticsRequests();
 
                 const enableRequest = analytics.findLatestRequestByLegacyType(
-                    EventType.SettingsAnalytics,
+                    events.settingsAnalyticsEvent.name,
                 );
-                expect(enableRequest).toHaveProperty('c_type', EventType.SettingsAnalytics);
+                expect(enableRequest).toHaveProperty('c_type', events.settingsAnalyticsEvent.name);
                 expect(enableRequest).toHaveProperty('c_session_id');
                 expect(enableRequest).toHaveProperty('c_instance_id');
                 expect(enableRequest).toHaveProperty('c_timestamp');
@@ -91,16 +91,16 @@ test.describe(
 
             await test.step('Change fiat and check analytics event', async () => {
                 const enableRequest = analytics.findLatestRequestByLegacyType(
-                    EventType.SettingsAnalytics,
+                    events.settingsAnalyticsEvent.name,
                 );
                 await settingsPage.changeFiatCurrency('huf');
                 await analytics.waitForAnalyticsRequests();
                 const changeFiatRequest = analytics.findLatestRequestByLegacyType(
-                    EventType.SettingsGeneralChangeFiat,
+                    events.settingsGeneralChangeFiatEvent.name,
                 );
                 expect(changeFiatRequest).toHaveProperty(
                     'c_type',
-                    EventType.SettingsGeneralChangeFiat,
+                    events.settingsGeneralChangeFiatEvent.name,
                 );
                 expect(changeFiatRequest).toHaveProperty('fiat', 'huf');
                 expect(changeFiatRequest).toHaveProperty(
@@ -114,9 +114,9 @@ test.describe(
                 await analytics.waitForAnalyticsRequests();
 
                 const deviceModalRequest = analytics.findLatestRequestByType(
-                    EventType.RouterLocationChange,
+                    events.routerLocationChangeEvent.name,
                 );
-                expect(deviceModalRequest).toHaveProperty('c_type', EventType.RouterLocationChange);
+                expect(deviceModalRequest).toHaveProperty('c_type', events.routerLocationChangeEvent.name);
             });
         });
 
@@ -134,9 +134,9 @@ test.describe(
                 await analytics.waitForAnalyticsRequests(3);
 
                 expect(analytics.requests.length).toBeGreaterThan(1);
-                expect(analytics.findLatestRequestByLegacyType(EventType.SuiteReady)).toBeDefined();
+                expect(analytics.findLatestRequestByLegacyType(events.suiteReadyEvent.name)).toBeDefined();
                 expect(
-                    analytics.findLatestRequestByLegacyType(EventType.SettingsAnalytics),
+                    analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
                 ).toBeDefined();
             });
 
@@ -160,10 +160,10 @@ test.describe(
                 await settingsPage.changeFiatCurrency('huf');
                 await analytics.waitForAnalyticsRequests();
                 expect(
-                    analytics.findLatestRequestByLegacyType(EventType.SettingsAnalytics),
+                    analytics.findLatestRequestByLegacyType(events.settingsAnalyticsEvent.name),
                 ).toBeDefined();
                 expect(
-                    analytics.findLatestRequestByLegacyType(EventType.SettingsGeneralChangeFiat),
+                    analytics.findLatestRequestByLegacyType(events.settingsGeneralChangeFiatEvent.name),
                 ).not.toBeDefined();
             });
         });

--- a/suite/e2e/tests/backup/t2t1-success.test.ts
+++ b/suite/e2e/tests/backup/t2t1-success.test.ts
@@ -51,7 +51,9 @@ test.describe('Backup success', { tag: ['@T2T1'] }, () => {
         await onboardingPage.backup.willHideSeedCheckbox.click();
         await expect(onboardingPage.backup.closeButton).toBeEnabled();
 
-        const createBackupRequest = analytics.findLatestRequestByType(events.createBackupEvent.name);
+        const createBackupRequest = analytics.findLatestRequestByType(
+            events.createBackupEvent.name,
+        );
         expect(createBackupRequest).toMatchObject({ status: 'finished', error: '' });
     });
 });

--- a/suite/e2e/tests/backup/t2t1-success.test.ts
+++ b/suite/e2e/tests/backup/t2t1-success.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 
 import { expect, test } from '../../support/fixtures';
 
@@ -51,7 +51,7 @@ test.describe('Backup success', { tag: ['@T2T1'] }, () => {
         await onboardingPage.backup.willHideSeedCheckbox.click();
         await expect(onboardingPage.backup.closeButton).toBeEnabled();
 
-        const createBackupRequest = analytics.findLatestRequestByType(EventType.CreateBackup);
+        const createBackupRequest = analytics.findLatestRequestByType(events.createBackupEvent.name);
         expect(createBackupRequest).toMatchObject({ status: 'finished', error: '' });
     });
 });

--- a/suite/e2e/tests/dashboard/discreet-mode.test.ts
+++ b/suite/e2e/tests/dashboard/discreet-mode.test.ts
@@ -1,6 +1,6 @@
 import { Locator } from '@playwright/test';
 
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -76,8 +76,8 @@ test.describe('Discreet Mode', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify analytics event', () => {
                 const menuToggleDiscreetEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.MenuToggleDiscreet>
-                >(EventType.MenuToggleDiscreet);
+                    ExtractByEventType<(typeof events.menuToggleDiscreetEvent)['name']>
+                >(events.menuToggleDiscreetEvent.name);
                 expect(menuToggleDiscreetEvent.value).toBe('true');
             });
         },

--- a/suite/e2e/tests/passphrase/passphrase.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
 import { formatAddress } from '../../support/common';
@@ -67,8 +67,8 @@ test.describe('Passphrase', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await element.first().click();
 
                 const selectWalletEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.SelectWalletType>
-                >(EventType.SelectWalletType);
+                    ExtractByEventType<(typeof events.selectWalletTypeEvent)['name']>
+                >(events.selectWalletTypeEvent.name);
                 expect(selectWalletEvent.type).toEqual('hidden');
             });
 

--- a/suite/e2e/tests/settings/general.test.ts
+++ b/suite/e2e/tests/settings/general.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -39,8 +39,8 @@ test.describe('General settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await page.getByTestId(`@settings/fiat-select/option/${Currency.EUR}`).click();
 
                 const settingsGeneralChangeFiatEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.SettingsGeneralChangeFiat>
-                >(EventType.SettingsGeneralChangeFiat);
+                    ExtractByEventType<(typeof events.settingsGeneralChangeFiatEvent)['name']>
+                >(events.settingsGeneralChangeFiatEvent.name);
                 expect(settingsGeneralChangeFiatEvent.fiat).toBe('eur');
             });
 
@@ -54,8 +54,8 @@ test.describe('General settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await settingsPage.changeTheme(Theme.Dark);
 
                 const settingsGeneralChangeThemeEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.SettingsGeneralChangeTheme>
-                >(EventType.SettingsGeneralChangeTheme);
+                    ExtractByEventType<(typeof events.settingsGeneralChangeThemeEvent)['name']>
+                >(events.settingsGeneralChangeThemeEvent.name);
                 expect(settingsGeneralChangeThemeEvent.platformTheme).toBe(Theme.Light);
                 expect(settingsGeneralChangeThemeEvent.previousTheme).toBe(Theme.Light);
                 expect(settingsGeneralChangeThemeEvent.previousAutodetectTheme).toBe('true');
@@ -71,8 +71,8 @@ test.describe('General settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await settingsPage.changeLanguage(Language.Spanish);
 
                 const settingsGeneralChangeLanguageEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.SettingsGeneralChangeLanguage>
-                >(EventType.SettingsGeneralChangeLanguage);
+                    ExtractByEventType<(typeof events.settingsGeneralChangeLanguageEvent)['name']>
+                >(events.settingsGeneralChangeLanguageEvent.name);
                 expect(settingsGeneralChangeLanguageEvent.language).toBe('es-ES');
                 expect(settingsGeneralChangeLanguageEvent.previousLanguage).toBe('en-US');
                 expect(settingsGeneralChangeLanguageEvent.autodetectLanguage).toBe('false');
@@ -90,8 +90,8 @@ test.describe('General settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 ).not.toBeChecked();
 
                 const settingsAnalyticsEvent = analytics.findAnalyticsEventByType<
-                    ExtractByEventType<EventType.SettingsAnalytics>
-                >(EventType.SettingsAnalytics);
+                    ExtractByEventType<(typeof events.settingsAnalyticsEvent)['name']>
+                >(events.settingsAnalyticsEvent.name);
                 expect(settingsAnalyticsEvent.value).toBe('false');
             });
 

--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -1,4 +1,4 @@
-import { EventType } from '@suite/analytics';
+import { events } from '@suite/analytics';
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import { TestCategory, TestPriority } from '@trezor/e2e-utils';
 
@@ -136,8 +136,8 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
                     expect(numberOfAccountsAfter).toEqual(numberOfAccountsBefore + 1);
 
                     const newAccountEvent = analytics.findAnalyticsEventByType<
-                        ExtractByEventType<EventType.AccountsNewAccount>
-                    >(EventType.AccountsNewAccount);
+                        ExtractByEventType<(typeof events.accountsNewAccountEvent)['name']>
+                    >(events.accountsNewAccountEvent.name);
                     expect(newAccountEvent.symbol).toEqual(coin.symbol);
                     expect(newAccountEvent.path).toEqual(coin.path);
                     expect(newAccountEvent.type).toEqual('normal');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Deletes EventType imports from all package indexes

Motivation: If we import data through events, we have better context if we click through the event to its definition than just a name. 

## Notes for QA

nothing should change

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-event-type-names&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-event-type-names&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-event-type-names&lookback=7)