### PR TITLE
feat(suite-common): redact more Sentry data before analytics confirmation

### DIFF
--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -27,7 +27,7 @@ export const allowedDomains = [
     'api.dropboxapi.com',
     'content.dropboxapi.com',
     'notify.dropboxapi.com',
-    'o117836.ingest.sentry.io',
+    'o117836.ingest.sentry.io', // TODO is this needed? Seems that the Sentry SDK bypasses interceptor
     'oauth2.googleapis.com',
     'googleapis.com',
     onionDomain,

--- a/packages/suite/src/utils/suite/sentry.ts
+++ b/packages/suite/src/utils/suite/sentry.ts
@@ -22,6 +22,11 @@ export const withSentryScope = Sentry.withScope;
 
 export const captureSentryMessage = Sentry.captureMessage;
 
+/**
+ * Sets a tag to allow or disallow sending Sentry reports. Until then, they are sent, but heavily redacted, see redactSentryEvent function.
+ * Note that in case of Suite Desktop, Sentry tags are shared between Renderer and Main process, sentry has its own IPC:
+ * https://docs.sentry.io/platforms/javascript/guides/electron/features/inter-process-communication/,
+ */
 export const allowSentryReport = (value: boolean) => {
     Sentry.setTag(ALLOW_REPORT_TAG, value);
 };

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -29,9 +29,10 @@ export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
         return null;
     }
     // allow report redacted error before confirm status is loaded
-    if (typeof allowReport === 'undefined') {
+    if (allowReport !== true) {
         delete event.breadcrumbs;
-        delete event.contexts?.device;
+        delete event.contexts;
+        delete event.request;
     }
 
     return event;

--- a/suite-common/sentry/src/redactSentryEvent.ts
+++ b/suite-common/sentry/src/redactSentryEvent.ts
@@ -14,6 +14,9 @@ const incrementOrResetCounter = () => {
 
 /**
  * Common function in all Sentry application to redact a Sentry event or filter it out completely (then returns null).
+ *
+ * Note that in case of Desktop & Mobile, the SDKs share tags and userId between processes
+ * (it consistently handles events e.g. from Electron Main vs. Renderer)
  */
 export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
     incrementOrResetCounter();
@@ -22,18 +25,20 @@ export const redactSentryEvent = (event: ErrorEvent): ErrorEvent | null => {
         return null;
     }
 
-    // sentry events are skipped until user confirm analytics reporting
     const allowReport = event.tags?.[ALLOW_REPORT_TAG];
 
+    // sentry events are skipped after user rejects analytics reporting (or a past decision is loaded)
     if (allowReport === false) {
         return null;
     }
-    // allow report redacted error before confirm status is loaded
+
+    // before the analytics confirm/reject status is known, allow report, but with only minimal info (no data about the host machine)
     if (allowReport !== true) {
         delete event.breadcrumbs;
         delete event.contexts;
         delete event.request;
     }
 
+    // whole event is sent after user confirms analytics (or a past decision is loaded)
     return event;
 };

--- a/suite/sentry/src/ignoreErrors.ts
+++ b/suite/sentry/src/ignoreErrors.ts
@@ -14,4 +14,8 @@ export const ignoreErrors = [
 
     // Common Electron lifecycle errors
     /.*Frame property was accessed after it navigated or was destroyed.*/, // Renderer process already closed while main is still responding to its IPC
+
+    // nodeJS deprecation errors
+    /.*DEP0040.*punycode.*/, // used deep within tech stack, not much we can do about it atm
+    /.*DEP0169.*url\.parse\(\).*/, // TODO https://github.com/trezor/trezor-suite/issues/25255
 ] satisfies Options['ignoreErrors'];


### PR DESCRIPTION
## Description

- redact more data when analytics confirm state is not yet known (before user confirms/rejects, or on app start before the persisted decision is loaded): entire `event.contexts`, `event.request`, [see discussion in slack](https://satoshilabs.slack.com/archives/G019WLX2P7B/p1771324432553969?thread_ts=1770989858.485329&cid=G019WLX2P7B)
- outbound filter for noisy nodeJS deprecation warnings on Desktop app startup, which are sent as errors
- some more commentary on how the Sentry SDK works

I tested sending an error:
- [from Main](https://satoshilabs.sentry.io/issues/7271783216/events/?project=5193825&query=is%3Aunresolved%20TESTING%20ERROR&referrer=issue-stream)
  - first event was with Confirmed analytics
  - the other two events with no decision made yet (no client details
  - no events sent after analytics were Rejected
- [from Renderer](https://satoshilabs.sentry.io/issues/7271371938/events/619c9447d5014d1ba7bb03f075b16ade/), this last event shows properly stripped info, no client details

## Notes for QA

Desktop, Web, Mobile: Sentry testing error still works, if analytics is confirmed.
It should not work if analyics is rejected (no event in Sentry).

## Related Issue

Resolve #25191
Resolve #25116

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/redact-sentry-more&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/redact-sentry-more&lookback=7)