### PR TITLE
fix(e2e-suite): fix sell input test

### DIFF
--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -74,6 +74,7 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
         });
 
         await test.step('Try all % inputs for Bitcoin', async () => {
+            await tradingPage.inputs.selectFiatCurrency('eur');
             for (const percentage of [10, 25, 50]) {
                 await test.step(`${percentage}% of BTC balance`, async () => {
                     await tradingPage.inputs.fractionButtons
@@ -114,6 +115,7 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
             await walletPage.openAccount({ symbol: 'sol', atIndex: 0 });
             await walletPage.sellButton.click();
             await expect(tradingPage.inputs.swapAmountCurrencyTicker).toHaveText('SOL');
+            await tradingPage.inputs.selectFiatCurrency('eur');
 
             for (const percentage of [10, 25, 50]) {
                 await test.step(`${percentage}% of Solana balance`, async () => {
@@ -123,21 +125,12 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
                         balance: solanaBalance,
                         symbol: 'sol',
                     });
-                    await expect(page.getByTestId('@trading/best-offer/amount')).not.toHaveText(
-                        '0',
-                        {
-                            timeout: 30_000,
-                        },
-                    );
                 });
             }
 
             //TODO: Bug in production
             await test.step.skip('Max of Solana balance', async () => {
                 await page.getByRole('button', { name: 'Max' }).click();
-                await expect(page.getByTestId('@trading/best-offer/amount')).not.toHaveText('0', {
-                    timeout: 30_000,
-                });
                 const resultingFee = await tradingPage.fees.getSolanaFee();
                 const maxValue = (parseFloat(solanaBalance!) - resultingFee).toString();
                 await expect


### PR DESCRIPTION
due to changes on partner side, we dont get offers for some combinations. So I am removing these asserts from input sell tests where the main value is calculation of balance percentage and not the quote itself.
Originally this check was put there for some stability reason. So I will monitor the test and adjust.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-trading-partner-change&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-trading-partner-change&lookback=7)