### PR TITLE
test(transport-test): remove dust

### DIFF
--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -147,28 +147,43 @@ describe('bridge', () => {
             // cancel RebootToBootloader procedure
             await bridge.send({ session, name: 'Cancel', data: {} });
 
-            // receive response
-            const receiveResponse1 = await bridge.receive({ session });
-
-            // we did 2x send, but no read. it means that now the next receive read the response from the first send
-            expect(receiveResponse1).toMatchObject({
-                success: true,
-                payload: {
-                    type: 'ButtonRequest',
-                },
-            });
-
-            // and the next receive read the response from the second send
-            const receiveResponse2 = await bridge.receive({ session });
-            expect(receiveResponse2).toMatchObject({
-                success: true,
-                payload: {
-                    message: {
-                        code: 'Failure_ActionCancelled',
+            // documenting model One odd behavior
+            // old bridge does not return rich descriptor so I am using env.USE_HW here
+            if (!env.USE_HW || descriptors[0].type === 1) {
+                // receive response
+                const receiveResponse1 = await bridge.receive({ session });
+                // we did 2x send, but no read. it means that now the next receive read the response from the first send
+                expect(receiveResponse1).toMatchObject({
+                    success: true,
+                    payload: {
+                        type: 'ButtonRequest',
                     },
-                    type: 'Failure',
-                },
-            });
+                });
+
+                // and the next receive read the response from the second send
+                const receiveResponse2 = await bridge.receive({ session });
+                expect(receiveResponse2).toMatchObject({
+                    success: true,
+                    payload: {
+                        message: {
+                            code: 'Failure_ActionCancelled',
+                        },
+                        type: 'Failure',
+                    },
+                });
+            } else {
+                // receive response
+                const receiveResponse1 = await bridge.receive({ session });
+                expect(receiveResponse1).toMatchObject({
+                    success: true,
+                    payload: {
+                        message: {
+                            code: 'Failure_ActionCancelled',
+                        },
+                        type: 'Failure',
+                    },
+                });
+            }
         });
     }
 

--- a/packages/transport-test/e2e/bridge/controller.ts
+++ b/packages/transport-test/e2e/bridge/controller.ts
@@ -99,7 +99,10 @@ class Controller extends TrezorUserEnvLinkClass {
 
         return scheduleAction(
             async () => {
-                const devices = (await webusb.getDevices()).filter(d => d.productName === 'TREZOR');
+                const devices = (await webusb.getDevices()).filter(d =>
+                    d.productName.toLowerCase().includes('trezor'),
+                );
+
                 if (devices.length === expected) {
                     return null;
                 }

--- a/packages/transport-test/e2e/bridge/expect.ts
+++ b/packages/transport-test/e2e/bridge/expect.ts
@@ -13,6 +13,10 @@ const vendor = USE_HW ? 4617 : 0;
 const id = USE_NODE_BRIDGE ? expect.any(String) : undefined;
 const apiType = 'usb' as const;
 const type = USE_NODE_BRIDGE ? expect.toBeOneOf(Object.values(DEVICE_TYPE)) : undefined;
+const model = USE_NODE_BRIDGE && USE_HW ? expect.any(Number) : undefined;
+const sessionOwner = USE_NODE_BRIDGE
+    ? expect.toBeOneOf([expect.any(String), undefined])
+    : undefined;
 
 /**
  * internal path has variable length
@@ -22,7 +26,18 @@ const type = USE_NODE_BRIDGE ? expect.toBeOneOf(Object.values(DEVICE_TYPE)) : un
  */
 export const pathLength = 1;
 
-export const descriptor = { debug, debugSession, path, product, vendor, type, id, apiType };
+export const descriptor = {
+    debug,
+    debugSession,
+    path,
+    product,
+    vendor,
+    type,
+    id,
+    apiType,
+    model,
+    sessionOwner,
+};
 
 export const errorCase1 =
     !USE_NODE_BRIDGE && !USE_HW

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -12,6 +12,7 @@ const getDescriptor = (descriptor: Partial<Descriptor>): Descriptor => {
     const d = {
         ...fixtureDescriptor,
         session: Session('1'),
+        model: expect.toBeOneOf([expect.any(Number), undefined]),
         ...descriptor,
     };
 


### PR DESCRIPTION
- tests only changes. 
- There were some additions to the Descriptor type that need to be added to transport-test package to make these tests runnable locally. 
- adaptation to newer device models

cherry-picked from #25243 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=transport-test-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=transport-test-update&lookback=7)