### PR TITLE
fix(e2e-test): fixes db-migration and pending-tx tests

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -64,7 +64,11 @@ export const AdvancedTxDetails = ({
                     <Translation id="TR_TX_TAB_AMOUNT" />
                 </Tabs.Item>
                 {network.networkType !== 'ripple' && (
-                    <Tabs.Item id="io" onClick={() => setSelectedTab('io')}>
+                    <Tabs.Item
+                        data-testid="@tx-detail/inputs-and-outputs"
+                        id="io"
+                        onClick={() => setSelectedTab('io')}
+                    >
                         <Translation id="TR_INPUTS_OUTPUTS" />
                     </Tabs.Item>
                 )}

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -138,12 +138,19 @@ test.describe(
 
                 await test.step('Compare the address of the first transaction', async () => {
                     await dashboardPage.deviceSwitchingCloseButton.click();
-                    const firstTxLabel = page
-                        .getByTestId('@wallet/transaction/target-address')
-                        .first();
+                    await page.getByTestId('@wallet/transaction-item').first().click();
+                    // replace the with better locator once merged to develop
+                    // await page.getByTestId('@tx-detail/inputs-and-outputs').click();
+                    await page.getByText('Inputs & outputs').click();
+                    await page.getByTestId('@tx-detail/txid-value').last().hover();
+                    const firstTxLabel = page.getByTestId('@tooltip');
                     await expect(firstTxLabel).toBeVisible();
-                    const afterMigrationTxLabel = firstTxLabel;
-                    await expect(afterMigrationTxLabel).toHaveText(originalTxLabel);
+                    const afterMigrationTxLabel = (await firstTxLabel.textContent())?.replace(
+                        /\s/g,
+                        '',
+                    );
+                    expect(afterMigrationTxLabel).toEqual(originalTxLabel);
+                    await page.modalCloseButton.click();
                 });
 
                 // go to receive tab, trigger show address to make sure passphrase is properly cached
@@ -156,13 +163,22 @@ test.describe(
                     await expect(page.getByTestId('@modal')).toBeHidden();
                 });
 
-                await test.step('Reconnect Emulator', async () => {
+                await test.step('Reconnect Emulator and confirm passphrase', async () => {
                     await device.powerOn();
                     await onboardingPage.disableNecessaryFirmwareChecks({
                         skipSuiteLoadedCheck: true,
                     });
+                    await dashboardPage.passphraseInput.fill(walletPassphrase);
+                    await dashboardPage.passphraseSubmitButton.click();
+                    await expect(dashboardPage.passphraseInput).toBeHidden();
+                    await devicePrompt.waitForPromptAndConfirm();
+                    await devicePrompt.waitForPromptAndConfirm();
                     await dashboardPage.openDeviceSwitcher();
-                    await expect(page.getByTestId('@deviceStatus-connected')).toBeVisible();
+                    await expect(
+                        page
+                            .getByTestId('@modal/switch-device')
+                            .getByTestId('@deviceStatus-connected'),
+                    ).toBeVisible();
                     await dashboardPage.deviceSwitchingCloseButton.first().click();
                 });
 

--- a/suite/e2e/tests/wallet/pending-transactions.test.ts
+++ b/suite/e2e/tests/wallet/pending-transactions.test.ts
@@ -86,14 +86,15 @@ test.describe(
                             '@transaction-item/0/prepending/heading',
                         ),
                     ).toBeVisible();
+                    await expect(
+                        page.getByTestId('@transaction-group/pending/count'),
+                    ).toContainText((index + 1).toString());
+
                     await pendingTransactionsList
                         .getByTestId('@transaction-item/0/heading')
                         .click();
 
-                    await expect(
-                        page.getByTestId('@transaction-group/pending/count'),
-                    ).toContainText((index + 1).toString());
-                    const txid = await page.getByTestId('@tx-detail/txid-value').getAttribute('id');
+                    const txid = await page.getByTestId('@tx-detail/txid-value').textContent();
                     if (!txid) {
                         throw new Error('Transaction ID not found');
                     }
@@ -138,7 +139,7 @@ test.describe(
                     address: accounts.miner_account.address,
                     txids: [],
                 });
-                await page.waitForTimeout(2000);
+                await page.waitForTimeout(2000); // wait for block to be processed
                 await walletPage
                     .accountLabel({ symbol: 'regtest', type: 'normal', atIndex: 0 })
                     .click();
@@ -181,7 +182,6 @@ test.describe(
             });
 
             await test.step('New group of transactions appears with the previously pending transaction now confirmed', async () => {
-                // and new group of transactions appears with the previously pending transaction now confirmed
                 const confirmedTransactionsAccount1 = page.getByTestId(
                     '@wallet/accounts/transaction-list/confirmed/group/0',
                 );


### PR DESCRIPTION
adjust db-migration test to new passphrase behaviour 
fixes how pending transaction test gets tx ids

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-tests&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-tests&lookback=7)