### PR TITLE
chore: add utility command to show affected nx workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "nx:test-unit:native": "yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*'",
         "nx:lint:styles": "yarn nx affected --target=lint:styles",
         "nx:format": "yarn nx format:check",
+        "nx:show-affected": "yarn nx show projects --affected",
         "_______ Commands _______": "Useful commands and scripts.",
         "patch": "yarn patch-package",
         "convert-figma-palette": "yarn tsx ./scripts/convertFigmaPalette.ts",


### PR DESCRIPTION
## Description

Add utility command for developers `yarn nx:show-affected`, which lets you check downstream workspaces affected by your changes (workspaces that you changed or those that depend on them), compared against `develop`.

Those workspaces shall be run with `test:unit`, `type-check`, `depcheck`

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/nx-show-projects-affected&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/nx-show-projects-affected&lookback=7)