### PR TITLE
chore: remove komret from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 
 /docker @vdovhanych @mroz22
 
-/scripts/list-outdated-dependencies/connect-dependencies.txt @mroz22
-/scripts/list-outdated-dependencies/foundation-dependencies.txt @komret
+/scripts/list-outdated-dependencies/connect-dependencies.txt @martykan
+/scripts/list-outdated-dependencies/foundation-dependencies.txt @matejkriz
 /scripts/list-outdated-dependencies/growth-dependencies.txt @jvaclavik
 /scripts/list-outdated-dependencies/trade-dependencies.txt @vytick
 /scripts/list-outdated-dependencies/qa-dependencies.txt @HajekOndrej
@@ -47,14 +47,6 @@
 /suite-common/message-system @tomasklim @matejkriz @MiroslavProchazka @pavelmario
 
 /suite-common/token-definitions @tomasklim
-
-/packages/suite-build @komret
-
-/packages/suite-data @komret
-
-/packages/suite-desktop @komret
-
-/packages/suite-desktop-ui @komret
 
 /packages/suite-desktop-api @szymonlesisz @marekrjpolak
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removing myself from code owners. I never got any benefit out of being assigned as code owner to the Suite packages so I don't think I need to be replaced by anyone.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/codeowners-komret&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/codeowners-komret&lookback=7)