### PR TITLE
fix: update copy for the recovery of t1b1 with/out standard recovery

### DIFF
--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -2,10 +2,12 @@ import { Translation, TranslationKey } from '@suite/intl';
 import { isDeviceWithButtonOnlyNoTouchscreen } from '@suite-common/suite-utils';
 import { selectSelectedDevice } from '@suite-common/wallet-core';
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 
 import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
 import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/OnboardingCard';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
+import { TrezorLink } from 'src/components/suite';
 import { useDispatch, useRecovery, useSelector } from 'src/hooks/suite';
 import { isStandardRecoveryDisabled } from 'src/utils/suite/recovery';
 
@@ -18,6 +20,7 @@ export const RecoveryStep = () => {
     const {
         status,
         error,
+        wordsCount,
         wordRequestInputType,
         setWordsCount,
         setAdvancedRecovery,
@@ -95,7 +98,22 @@ export const RecoveryStep = () => {
         return (
             <RecoveryStepBox
                 heading={<Translation id="TR_SELECT_RECOVERY_METHOD" />}
-                description={<Translation id="TR_RECOVERY_TYPES_DESCRIPTION" />}
+                description={
+                    deviceModelInternal === DeviceModelInternal.T1B1 && wordsCount === 24 ? (
+                        <Translation
+                            id="TR_RECOVERY_TYPES_DESCRIPTION_24_T1B1_ONLY"
+                            values={{
+                                a: chunks => (
+                                    <TrezorLink href={HELP_CENTER_ADVANCED_RECOVERY_URL}>
+                                        {chunks}
+                                    </TrezorLink>
+                                ),
+                            }}
+                        />
+                    ) : (
+                        <Translation id="TR_RECOVERY_TYPES_DESCRIPTION" />
+                    )
+                }
             >
                 <SelectRecoveryType onSelect={handleSelect} />
             </RecoveryStepBox>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2869,6 +2869,13 @@ export const messages = defineMessages({
             'There are two methods of recovery for T1B1. This is a short explanation text.',
         id: 'TR_RECOVERY_TYPES_DESCRIPTION',
     },
+    TR_RECOVERY_TYPES_DESCRIPTION_24_T1B1_ONLY: {
+        defaultMessage:
+            'Standard recovery is sufficiently secure and more efficient. Choose advanced recovery if you prefer entering your wallet backup on your Trezor’s screen for ultimate security. To learn more, visit <a>our guide</a>.',
+        description:
+            'The updated recovery types description for T1B1 with standard or advanced recovery for 24 words backup. It is a short explanation text.',
+        id: 'TR_RECOVERY_TYPES_DESCRIPTION_24_T1B1_ONLY',
+    },
     TR_RETRY: {
         defaultMessage: 'Retry',
         description: 'Retry button',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I didn't notice that guys requested copy update.

## Notes for QA

Please check that this copy is displayed as it should and link works.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25106#issuecomment-3914769295

## Screenshots:
BFR
<img width="831" height="412" alt="Screenshot 2026-02-18 at 12 23 53 PM" src="https://github.com/user-attachments/assets/dd2af0ab-6be5-485e-8ffb-ae6c8d269a79" />


AFTER
<img width="1079" height="614" alt="Screenshot 2026-02-18 at 12 12 21 PM" src="https://github.com/user-attachments/assets/4a7a8b89-8f55-489e-bf08-117d5889ca76" />




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25106-update-the-copy&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25106-update-the-copy&lookback=7)