### PR TITLE
chore: send os name to invity api instead of platform

### DIFF
--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -27,7 +27,7 @@ import type {
     SellVoucherTradeRequest,
 } from 'invity-api';
 
-import { getPlatform, getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
+import { getOsName, getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
 
 import {
     InvityServerEnvironment,
@@ -147,7 +147,7 @@ class InvityAPI {
             headers: {
                 [apiHeader]: apiHeaderValue || this.getInvityAPIKey(),
                 'X-Suite-Version': getSuiteVersion(),
-                'X-Suite-Platform': getPlatform(),
+                'X-Suite-Platform': getOsName(),
                 ...(method === 'POST' && {
                     'Cache-Control': 'no-cache',
                     'Content-Type': 'application/json',


### PR DESCRIPTION
Previously platform was sent and it could include odd things like `MacIntel`. Now it sends just `macos` so it is clearer



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/send-os-name-for-trading&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/send-os-name-for-trading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/send-os-name-for-trading&lookback=7)