### PR TITLE
feat(suite-native): trezorsuite scheme in prod app

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -207,7 +207,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     return {
         ...config,
         name,
-        scheme: buildType === 'production' ? undefined : 'trezorsuite',
+        scheme: 'trezorsuite',
         slug: appSlugs[buildType],
         owner: appOwners[buildType],
         version: suiteNativeVersion,


### PR DESCRIPTION
Previously `trezorsuite://` scheme was not enabled for __production app__ which breaks various callbacks including trade and trezor connect.

## Notes for QA
This link should open both develop and production apps
trezorsuite://trading?action=trade&tradeType=sell&orderId=a10bb954-1315-49d5-a7f3-f7ccd0602006



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/register-trezorsuite-for-prod&lookback=7)