### PR TITLE
test(e2e-suite): enable suite sync tests on desktop

### DIFF
--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -199,13 +199,13 @@ export class DashboardPage {
         await this.device.pressYes();
 
         if (options?.suiteSync === 'enable') {
-            await this.device.expectToContainOnDisplay('Suite Sync');
+            await this.device.expectToContainOnDisplay('Sync');
             await this.devicePrompt.confirmOnDevicePromptIsShown();
             await this.device.pressYes();
             // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
             await this.page.waitForTimeout(2000);
         } else if (options?.suiteSync === 'decline') {
-            await this.device.expectToContainOnDisplay('Suite Sync');
+            await this.device.expectToContainOnDisplay('Sync');
             await this.devicePrompt.confirmOnDevicePromptIsShown();
             await this.device.pressNo();
         }

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -81,10 +81,11 @@ export class MetadataPage {
 
     @step()
     async confirmSuiteSyncSetup() {
+        await this.device.expectToContainOnDisplay('Sync');
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         await this.device.pressYes();
         // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
-        await this.page.waitForTimeout(2000);
+        await this.page.waitForTimeout(2_000);
     }
 
     @step()

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -46,12 +46,11 @@ const expectedOutput = {
     txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
 };
 
-test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
     test.beforeEach(async ({ onboardingPage, metadataPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-        await metadataPage.setupQuotaManager();
         await metadataPage.enableSuiteSync();
     });
 

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -64,12 +64,11 @@ const expectedWalletTwoLabel = {
     label: 'Evolu wallet #2',
 };
 
-test.describe('Suite Sync - Passphrase wallets', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true, deviceSetup: { passphrase_protection: true } });
 
     test.beforeEach(async ({ onboardingPage, metadataPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-        await metadataPage.setupQuotaManager();
         await metadataPage.enableSuiteSync();
     });
 

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
@@ -10,7 +10,7 @@ import { expect, test } from '../../../support/fixtures';
 
 const defaultWalletIndex = 0;
 
-test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
     test.beforeEach(async ({ evoluClient, onboardingPage }) => {
@@ -32,7 +32,6 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
         metadataPage,
     }) => {
         await test.step('Enable Suite Sync', async () => {
-            await metadataPage.setupQuotaManager();
             await metadataPage.initiateSuiteSyncSetup();
             if (isWebProject(target)) {
                 // eslint-disable-next-line playwright/no-conditional-expect


### PR DESCRIPTION
There was a bug on Desktop that with local Relay the solution does not activate tru normal configuration. the bug was resolved.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-desktop&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-desktop&lookback=7)