### PR TITLE
Improve testing dx for suite-common

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -57,6 +57,7 @@
     - [Playwright contribution guide](./symlink/tests/e2e-playwright-contribution-guide.md)
     - [GitHub Test Reporter](./symlink/tests/e2e-github-reporter.md)
     - [regtest](./tests/regtest.md)
+    - [@suite-common/test-utils](./tests/suite-common-test-utils.md)
     - [@suite-native/test-utils](./tests/suite-native-test-utils.md)
 - [Miscellaneous](./misc/index.md)
     - [build](./misc/build.md)

--- a/docs/tests/index.md
+++ b/docs/tests/index.md
@@ -8,5 +8,6 @@ This chapter contains information about tests.
 - [GitHub Test Reporter](../symlink/tests/e2e-github-reporter.md)
 - [regtest](./regtest.md)
 - [@suite-native/test-utils](./suite-native-test-utils.md)
+- [@suite-common/test-utils](./suite-common-test-utils.md)
 
 See also general [code-style-guide/tests](../symlink/code-style-guide/tests.md) for more information about writing tests in Trezor Suite.

--- a/docs/tests/suite-common-test-utils.md
+++ b/docs/tests/suite-common-test-utils.md
@@ -1,0 +1,173 @@
+# @suite-common/test-utils
+
+This package provides common utilities for testing React hooks that depend on Redux store.
+It also re-exports everything from `@testing-library/react`, so you should use it as a drop-in replacement.
+
+## configureMockStore
+
+`configureMockStore` is a utility for creating a Redux store configured for testing. It wraps `@reduxjs/toolkit`'s `configureStore` with additional testing features like action logging.
+
+### Usage example
+
+```ts
+import { configureMockStore } from '@suite-common/test-utils';
+
+const store = configureMockStore({
+    reducer: {
+        counter: (state = { value: 0 }, action) => {
+            if (action.type === 'counter/increment') {
+                return { value: state.value + 1 };
+            }
+
+            return state;
+        },
+    },
+    preloadedState: {
+        counter: { value: 5 },
+    },
+});
+
+// Dispatch actions
+store.dispatch({ type: 'counter/increment' });
+
+// Get current state
+expect(store.getState().counter.value).toBe(6);
+
+// Get all dispatched actions
+expect(store.getActions()).toEqual([{ type: 'counter/increment' }]);
+
+// Clear action log
+store.clearActions();
+```
+
+### Configuration options
+
+- `reducer` - Redux reducer or reducer map
+- `preloadedState` - Initial state for the store
+- `middleware` - Additional middleware to include
+- `extra` - Extra dependencies for thunk middleware
+- `serializableCheck` - Configuration for serializable check middleware
+
+## initPreloadedState
+
+`initPreloadedState` is a utility for merging partial state with the initial state from a reducer. This is useful when you want to override only specific parts of the state while keeping the rest at their default values.
+
+### Usage example
+
+```ts
+import { configureMockStore, initPreloadedState } from '@suite-common/test-utils';
+
+const rootReducer = (state = { counter: { value: 0 }, user: { name: 'John' } }, action) => {
+    // reducer logic
+    return state;
+};
+
+const preloadedState = initPreloadedState({
+    rootReducer,
+    partialState: {
+        counter: { value: 10 },
+        // user.name will remain 'John' from default state
+    },
+});
+
+const store = configureMockStore({
+    reducer: rootReducer,
+    preloadedState,
+});
+
+expect(store.getState()).toEqual({
+    counter: { value: 10 },
+    user: { name: 'John' },
+});
+```
+
+## Testing hooks
+
+```mermaid
+flowchart TD
+    A{{Do you need redux store?}} -- Yes --> B[Use 'renderHookWithStoreProvider']
+    A -- No --> C[Use 'renderHook']
+```
+
+### Using renderHook
+
+`renderHook` function is just re-exported from `@testing-library/react`. For more information, please refer to
+the [official documentation](https://testing-library.com/docs/react-testing-library/intro/).
+
+You should use it when your hook does not depend on any context providers.
+
+### Using renderHookWithStoreProvider
+
+`renderHookWithStoreProvider` is a custom utility that wraps your hook with Redux `Provider`.
+Use this when your hook depends on Redux store.
+
+**Note:** Unlike `@suite-native/test-utils`, this utility requires you to provide your own store instance.
+There is no `preloadedState` option - you must create and configure the store yourself.
+
+#### Usage example
+
+```ts
+import {
+    type TestStore,
+    act,
+    renderHookWithStoreProvider,
+    configureMockStore,
+} from '@suite-common/test-utils';
+
+describe('useCounter', () => {
+    const createStore = (initialValue: number) =>
+        configureMockStore({
+            reducer: {
+                counter: (state = { value: initialValue }, action) => {
+                    if (action.type === 'counter/increment') {
+                        return { value: state.value + 1 };
+                    }
+
+                    return state;
+                },
+            },
+        });
+
+    const renderUseCounter = (store: TestStore) =>
+        renderHookWithStoreProvider(() => useCounter(), { store });
+
+    it('should initialize with count from store', () => {
+        const store = createStore(5);
+        const { result } = renderUseCounter(store);
+
+        expect(result.current.count).toBe(5);
+    });
+
+    it('should increment count and update store', () => {
+        const store = createStore(0);
+        const { result } = renderUseCounter(store);
+
+        act(() => {
+            result.current.increment();
+        });
+
+        expect(result.current.count).toBe(1);
+        expect(store.getState().counter.value).toBe(1);
+    });
+});
+```
+
+#### Injecting custom providers
+
+To inject a custom provider, you can use the `wrapper` option. The custom wrapper will be rendered inside
+the Redux `Provider`.
+
+```tsx
+import { type TestStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+
+const renderUseCounterA = (store: TestStore) =>
+    renderHookWithStoreProvider(() => useCounter(), { store, wrapper: MyCustomProvider });
+
+const renderUseCounterB = (store: TestStore) =>
+    renderHookWithStoreProvider(() => useCounter(), {
+        store,
+        wrapper: ({ children }) => (
+            <MyCustomProvider someProp={someValue}>{children}</MyCustomProvider>
+        ),
+    });
+```

--- a/packages/requirements/src/requirements/agents-skills/requireAgentsSkills.ts
+++ b/packages/requirements/src/requirements/agents-skills/requireAgentsSkills.ts
@@ -8,7 +8,8 @@ const AGENTS_FILE = 'AGENTS.md';
 const IGNORED_SKILL_LINKS = new Set([
     'skills/skills-and-code-style-contribution.md', // not a skill
     'skills/dependency-injection.md', // only for some `packages`
-    'skills/tests-native.md', // only for `native`
+    'skills/tests-native.md', // only for `suite-native`
+    'skills/tests-common.md', // only for `suite-common`
 ]);
 
 const stripComments = (content: string) => {

--- a/skills/tests-common.md
+++ b/skills/tests-common.md
@@ -1,0 +1,38 @@
+# Writing Common Tests (TDD)
+
+This skill enforces Test-Driven Development (TDD) practices for suite-common packages and ensures proper usage of the
+`@suite-common/test-utils` package.
+
+## Core Principles
+
+### 1. Test-First Development
+
+- **ALWAYS** write tests before implementing features in suite-common packages.
+- Follow the Red-Green-Refactor cycle:
+    1. **Red**: Write a failing test that describes the desired behavior. Run test to confirm it fails for the right
+       reason (e.g., "Expected value to be X but got Y").
+    2. **Green**: Write the minimum code to make the test pass. Run test to confirm it passes.
+    3. **Refactor**: Clean up the code while keeping tests green. Run test to confirm it still passes after refactoring.
+
+### 2. Writing tests
+
+- Focus on testing behavior and user interactions, not implementation details.
+- Follow arrange-act-assert pattern for test structure.
+
+### 3. Use @suite-common/test-utils Package
+
+- **REQUIRED**: Use `@suite-common/test-utils` for all suite-common testing that involves React hooks.
+- **NEVER** import directly from `@testing-library/react` when testing hooks.
+- The test-utils package provides all necessary utilities including `renderHookWithStoreProvider`.
+
+## Checklist
+
+Before submitting code, ensure:
+
+- [ ] Tests were written BEFORE implementation
+- [ ] Using `@suite-common/test-utils` for hook tests (not direct `@testing-library/react`)
+- [ ] Correct render function used (`renderHookWithStoreProvider` for hooks needing store, `renderHook` otherwise)
+- [ ] Fixtures are properly typed
+- [ ] Tests focus on behavior, not implementation
+- [ ] Tests follow naming conventions (.hook.test.ts, .test.ts)
+- [ ] All tests pass locally

--- a/suite-common/AGENTS.md
+++ b/suite-common/AGENTS.md
@@ -1,0 +1,5 @@
+## Skills
+
+Apart from [top-level AGENTS.md](../AGENTS.md), the following skills are mandatory for this package:
+
+- [Tests Common](../skills/tests-common.md) – Guidelines for writing tests for suite-common hooks and functions

--- a/suite-common/test-utils/package.json
+++ b/suite-common/test-utils/package.json
@@ -18,6 +18,8 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
@@ -25,6 +27,8 @@
         "@trezor/utils": "workspace:*",
         "core-js": "^3.48.0",
         "fake-indexeddb": "^6.2.5",
+        "react": "19.1.0",
+        "react-redux": "9.2.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0"
     }

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -12,6 +12,14 @@ import { mergeDeepObject } from '@trezor/utils';
 
 import { extraDependenciesCommonMock } from './extraDependenciesCommonMock';
 
+export type MockStoreConfig<S = any, A extends AnyAction = AnyAction> = {
+    middleware?: any[];
+    extra?: ExtraDependenciesPartial;
+    reducer?: Reducer<S, A, {}> | ReducersMapObject<S, A, {}>;
+    preloadedState?: any;
+    serializableCheck?: { ignoredActions?: string[] };
+};
+
 export const initPreloadedState = ({
     rootReducer,
     partialState,
@@ -29,13 +37,7 @@ export function configureMockStore<S = any, A extends AnyAction = AnyAction>({
     reducer = (state: any) => state,
     preloadedState,
     serializableCheck = {},
-}: {
-    middleware?: any[];
-    extra?: ExtraDependenciesPartial;
-    reducer?: Reducer<S, A, {}> | ReducersMapObject<S, A, {}>;
-    preloadedState?: any;
-    serializableCheck?: { ignoredActions?: string[] };
-} = {}) {
+}: MockStoreConfig<S, A> = {}) {
     let actions: A[] = [];
 
     const actionLoggerMiddleware = createMiddleware((action, { next }) => {

--- a/suite-common/test-utils/src/index.ts
+++ b/suite-common/test-utils/src/index.ts
@@ -2,3 +2,6 @@ export * from './mocks';
 export * from './configureMockStore';
 export * from './extraDependenciesCommonMock';
 export * from './conditionalDescribe';
+export { renderHookWithStoreProvider, type TestStore } from './renderWithStore';
+
+export * from '@testing-library/react';

--- a/suite-common/test-utils/src/renderWithStore.tsx
+++ b/suite-common/test-utils/src/renderWithStore.tsx
@@ -1,0 +1,21 @@
+import { Provider } from 'react-redux';
+
+import { type Store } from '@reduxjs/toolkit';
+import { RenderHookOptions, renderHook } from '@testing-library/react';
+
+export type TestStore = Store;
+
+type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
+    store: TestStore;
+};
+
+export const renderHookWithStoreProvider = <Result, Props>(
+    callback: (props: Props) => Result,
+    { wrapper: Wrapper, store, ...options }: RenderHookOptionsExtended<Props>,
+) =>
+    renderHook(callback, {
+        wrapper: ({ children }) => (
+            <Provider store={store}>{Wrapper ? <Wrapper>{children}</Wrapper> : children}</Provider>
+        ),
+        ...options,
+    });

--- a/suite-common/trading/src/__tests__/testUtils.tsx
+++ b/suite-common/trading/src/__tests__/testUtils.tsx
@@ -1,10 +1,15 @@
-import { ReactNode } from 'react';
-import { Provider } from 'react-redux';
-
 import { combineReducers } from '@reduxjs/toolkit';
-import { RenderHookOptions, renderHook } from '@testing-library/react';
 
-import { configureMockStore } from '@suite-common/test-utils';
+import {
+    RenderHookOptions,
+    configureMockStore,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+import {
+    FiatRatesState,
+    WalletSettingsState,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 
 import { TradingState, initialState, tradingCommonReducer } from '../reducers/tradingCommonReducer';
 import { regional } from '../regional';
@@ -21,8 +26,16 @@ export type TradingTestState = {
     };
 };
 
+export type TradingTestStateWithWalletSettings = {
+    wallet: {
+        trading: TradingState;
+        settings: WalletSettingsState;
+        fiat: FiatRatesState;
+    };
+};
+
 type RenderHookWithTradingStoreOptions<Props> = RenderHookOptions<Props> & {
-    preloadedState?: Partial<TradingTestState>;
+    preloadedState?: Partial<TradingTestStateWithWalletSettings> | Partial<TradingTestState>;
 };
 
 /**
@@ -47,6 +60,21 @@ export const createTradingTestState = (
             ...initialState,
             ...overrides,
         },
+    },
+});
+
+export const createTestStateWithWalletSettings = (
+    overrides: Partial<TradingTestStateWithWalletSettings['wallet']> = {},
+): TradingTestStateWithWalletSettings => ({
+    wallet: {
+        trading: initialState,
+        settings: initialWalletSettingsState,
+        fiat: {
+            current: {},
+            lastWeek: {},
+            historic: {},
+        },
+        ...overrides,
     },
 });
 
@@ -156,17 +184,21 @@ export const renderHookWithTradingStore = <Result, Props = unknown>(
         reducer: combineReducers({
             wallet: combineReducers({
                 trading: tradingCommonReducer,
+                settings: (state = { localCurrency: 'usd' }) => state,
+                fiat: (
+                    state = {
+                        current: {},
+                        lastWeek: {},
+                        historic: {},
+                    },
+                ) => state,
             }),
         }),
         preloadedState: preloadedState || createTradingTestState(),
     });
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-        <Provider store={store}>{children}</Provider>
-    );
-
     return {
-        ...renderHook(callback, { wrapper, ...options }),
+        ...renderHookWithStoreProvider(callback, { store, ...options }),
         store,
     };
 };

--- a/suite-common/trading/src/hooks/__tests__/useTradingFiatValues.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useTradingFiatValues.test.ts
@@ -1,0 +1,284 @@
+import { CryptoId, FiatCurrencyCode } from 'invity-api';
+
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { Rate, Timestamp } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+
+import {
+    TradingTestStateWithWalletSettings,
+    createTestStateWithWalletSettings,
+    renderHookWithTradingStore,
+} from '../../__tests__/testUtils';
+import {
+    TradingFiatRatesProps,
+    TradingFiatRatesReturn,
+    useTradingFiatValues,
+} from '../useTradingFiatValues';
+
+// Mock crypto IDs for testing
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+
+const createMockRate = (rate: number, symbol: NetworkSymbol = 'btc'): Rate => ({
+    rate,
+    lastTickerTimestamp: 1000000 as Timestamp,
+    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+    isLoading: false,
+    error: null,
+    ticker: {
+        symbol,
+    },
+});
+
+const getPreloadedState = () => {
+    const btcRate = createMockRate(50000);
+    const fiatRateKey = getFiatRateKey('btc', 'usd');
+
+    return createTestStateWithWalletSettings({
+        fiat: {
+            current: {
+                [fiatRateKey]: btcRate,
+            },
+            lastWeek: {},
+            historic: {},
+        },
+    });
+};
+
+const renderUseTradingFiatValues = (
+    props: TradingFiatRatesProps,
+    preloadedState: TradingTestStateWithWalletSettings = createTestStateWithWalletSettings(),
+) => renderHookWithTradingStore(() => useTradingFiatValues(props), { preloadedState });
+
+describe('useTradingFiatValues', () => {
+    describe('returns null when required parameters are missing', () => {
+        it('should return null when cryptoId is undefined', () => {
+            const { result } = renderUseTradingFiatValues({
+                cryptoId: undefined,
+                fiatCurrency: 'usd' as FiatCurrencyCode,
+                amount: '100',
+            });
+
+            expect(result.current).toBeNull();
+        });
+
+        it('should return null when fiatCurrency is undefined', () => {
+            const { result } = renderUseTradingFiatValues({
+                cryptoId: BITCOIN_CRYPTO_ID,
+                fiatCurrency: undefined,
+                amount: '100',
+            });
+
+            expect(result.current).toBeNull();
+        });
+
+        it('should return null when amount is undefined', () => {
+            const { result } = renderUseTradingFiatValues({
+                cryptoId: BITCOIN_CRYPTO_ID,
+                fiatCurrency: 'usd' as FiatCurrencyCode,
+                amount: undefined,
+            });
+
+            expect(result.current).toBeNull();
+        });
+
+        it('should return null when all parameters are missing', () => {
+            const { result } = renderUseTradingFiatValues({});
+
+            expect(result.current).toBeNull();
+        });
+    });
+
+    describe('returns correct values for native tokens', () => {
+        it('should calculate fiat value for Bitcoin', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            expect(result.current?.fiatValue).toBe('50000.00');
+            expect(result.current?.symbol).toBe('btc');
+            expect(result.current?.accountBalance).toBe('1');
+            expect(result.current?.tokenAddress).toBeUndefined();
+        });
+
+        it('should calculate fiat value for Ethereum', () => {
+            const ethRate = createMockRate(3000, 'eth');
+            const fiatRateKey = getFiatRateKey('eth', 'eur');
+
+            const preloadedState = createTestStateWithWalletSettings({
+                settings: {
+                    ...initialWalletSettingsState,
+                    localCurrency: 'eur',
+                },
+                fiat: {
+                    current: {
+                        [fiatRateKey]: ethRate,
+                    },
+                    lastWeek: {},
+                    historic: {},
+                },
+            });
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: ETHEREUM_CRYPTO_ID,
+                    fiatCurrency: 'eur' as FiatCurrencyCode,
+                    amount: '2.5',
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            expect(result.current?.fiatValue).toBe('7500.00');
+            expect(result.current?.symbol).toBe('eth');
+            expect(result.current?.tokenAddress).toBeUndefined();
+        });
+
+        it('should return correct network decimals for Bitcoin', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            expect(result.current?.networkDecimals).toBe(8);
+        });
+    });
+
+    describe('handles fiat rate unavailability', () => {
+        it('should return null fiatValue when rate is not available', () => {
+            const preloadedState = createTestStateWithWalletSettings({
+                fiat: {
+                    current: {},
+                    lastWeek: {},
+                    historic: {},
+                },
+            });
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            expect(result.current?.fiatValue).toBeNull();
+            expect(result.current?.fiatRate).toBeUndefined();
+        });
+    });
+
+    describe('handles shouldSendInSats option', () => {
+        it('should convert amount to satoshis when shouldSendInSats is true', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                    shouldSendInSats: true,
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            // 1 BTC = 100,000,000 satoshis
+            expect(result.current?.formattedBalance).toBe('100000000');
+            expect(result.current?.accountBalance).toBe('1');
+        });
+
+        it('should not convert amount when shouldSendInSats is false', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                    shouldSendInSats: false,
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            expect(result.current?.formattedBalance).toBe('1');
+            expect(result.current?.accountBalance).toBe('1');
+        });
+    });
+
+    describe('fiatRatesUpdater function', () => {
+        it('should return fiatRatesUpdater function', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            expect(result.current).not.toBeNull();
+            expect(typeof result.current?.fiatRatesUpdater).toBe('function');
+        });
+
+        it('should return null when fiatRatesUpdater is called with undefined value', async () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            const updaterResult = await result.current?.fiatRatesUpdater(undefined);
+            expect(updaterResult).toBeNull();
+        });
+    });
+
+    describe('return value structure', () => {
+        it('should return all expected properties', () => {
+            const preloadedState = getPreloadedState();
+
+            const { result } = renderUseTradingFiatValues(
+                {
+                    cryptoId: BITCOIN_CRYPTO_ID,
+                    fiatCurrency: 'usd' as FiatCurrencyCode,
+                    amount: '1',
+                },
+                preloadedState,
+            );
+
+            const returnValue = result.current as TradingFiatRatesReturn;
+            expect(returnValue).toHaveProperty('fiatValue');
+            expect(returnValue).toHaveProperty('fiatRate');
+            expect(returnValue).toHaveProperty('accountBalance');
+            expect(returnValue).toHaveProperty('formattedBalance');
+            expect(returnValue).toHaveProperty('symbol');
+            expect(returnValue).toHaveProperty('networkDecimals');
+            expect(returnValue).toHaveProperty('tokenAddress');
+            expect(returnValue).toHaveProperty('fiatRatesUpdater');
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11543,6 +11543,8 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/react": "npm:^16.3.2"
     "@trezor/analytics-uploader": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
@@ -11550,6 +11552,8 @@ __metadata:
     "@trezor/utils": "workspace:*"
     core-js: "npm:^3.48.0"
     fake-indexeddb: "npm:^6.2.5"
+    react: "npm:19.1.0"
+    react-redux: "npm:9.2.0"
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added renderHookWithStoreProvider utility to @suite-common/test-utils for testing React hooks that depend on Redux store
- Implemented comprehensive tests for useTradingFiatValues hook using the new testing utility
- Created documentation and guidelines for writing tests in suite-common packages
- Refactored trading test utilities to use the new renderHookWithStoreProvider pattern

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25165


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25165-improve-testing-dx-for-suite-common&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25165-improve-testing-dx-for-suite-common&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25165-improve-testing-dx-for-suite-common&lookback=7)