### PR TITLE
fix(transport): fix simultaneous acquire

### DIFF
--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -164,14 +164,13 @@ export class SessionsBackground
      * acquire intent
      */
     private async acquireIntent(payload: AcquireIntentRequest) {
-        const pathInternal = this.getInternal(payload.path);
+        await this.waitInQueue();
 
+        const pathInternal = this.getInternal(payload.path);
         if (!pathInternal) {
             return this.error(ERRORS.DEVICE_NOT_FOUND);
         }
-
         const previous = this.descriptors[pathInternal];
-
         if (!previous) {
             return this.error(ERRORS.DEVICE_NOT_FOUND);
         }
@@ -179,8 +178,6 @@ export class SessionsBackground
         if (payload.previous !== previous.session) {
             return this.error(ERRORS.SESSION_WRONG_PREVIOUS);
         }
-
-        await this.waitInQueue();
 
         // in case there are 2 simultaneous acquireIntents, one goes through, the other one waits and gets error here
         if (previous.session !== this.descriptors[pathInternal]?.session) {


### PR DESCRIPTION
During the old bridge deprecation and transition to node-bridge, I created a temporary package called transport-test whose goal was to prove that both versions have identical interfaces. 

You can try it by running:
- yarn workspace @trezor/transport-test test:e2e:old-bridge:hw
- yarn workspace @trezor/transport-test test:e2e:new-bridge:hw

As these commands (hw variant) are obviously not run in the CI [(their emu counterpart is) ](https://github.com/trezor/trezor-suite/actions/workflows/test-transport.yml), no maintenance has happened over time, and they are broken now in develop. There are couple of reasons, simple ones such as #25275. Or more complex ones like the one in this PR that is really bugging me how come it could have gone so long unnoticed? 
