### PR TITLE
chore: update @types/invity-api to version 1.1.13 across multiple packages

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -141,7 +141,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.12",
+        "@types/invity-api": "^1.1.13",
         "@types/pako": "^2.0.3",
         "@types/pdfmake": "^0.2.11",
         "@types/react": "19.1.6",

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -39,6 +39,6 @@
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
         "@testing-library/react": "^16.3.2",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-common/trading/src/__fixtures__/invityAPI.ts
+++ b/suite-common/trading/src/__fixtures__/invityAPI.ts
@@ -84,6 +84,7 @@ const buyList: BuyProviderInfo[] = [
         paymentMethods: [],
         statusUrl: 'https://test.io/buy/txs/{{orderId}}',
         supportUrl: 'https://support.test.io',
+        supportedSubdivisions: {},
     },
 ];
 
@@ -139,6 +140,7 @@ const sellList: SellProviderInfo[] = [
         paymentMethods: [],
         statusUrl: 'https://test.io/sell/txs/{{orderId}}',
         supportUrl: 'https://support.test.io',
+        supportedSubdivisions: {},
     },
 ];
 

--- a/suite-common/trading/src/thunks/buy/__tests__/loadBuyInfoThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/loadBuyInfoThunk.test.ts
@@ -86,6 +86,7 @@ describe('loadBuyInfoThunk', () => {
             isActive: true,
             paymentMethods: [] as BuyCryptoPaymentMethod[],
             supportedCountries: [],
+            supportedSubdivisions: {},
         };
 
         const buyInfoAPI = {

--- a/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
@@ -66,6 +66,7 @@ describe('selectBuyQuoteThunk', () => {
                     paymentMethods: [quote.paymentMethod as BuyCryptoPaymentMethod],
                     tradedFiatCurrencies: [fiat],
                     supportedCountries: [country],
+                    supportedSubdivisions: {},
                 },
             },
             supportedFiatCurrencies: [fiat],

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellTradeThunk.test.ts
@@ -334,6 +334,7 @@ describe('handleSellTradeThunk', () => {
                         tradedCoins: ['bitcoin'] as CryptoId[],
                         supportedCountries: ['CZ'],
                         flow: 'BANK_ACCOUNT',
+                        supportedSubdivisions: {},
                     },
                 },
                 supportedCryptoCurrencies: ['bitcoin'] as CryptoId[],

--- a/suite-common/trading/src/thunks/sell/__tests__/loadSellInfoThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/loadSellInfoThunk.test.ts
@@ -25,6 +25,7 @@ describe('loadSellInfoThunk', () => {
         tradedFiatCurrencies: ['CZK', 'USD'],
         type: 'Fiat',
         supportedCountries: ['CZ'],
+        supportedSubdivisions: {},
     };
 
     const store = configureMockStore({

--- a/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
@@ -46,6 +46,7 @@ describe('selectSellQuoteThunk', () => {
                     type: 'Fiat',
                     supportedCountries: ['CZ'],
                     flow: 'BANK_ACCOUNT',
+                    supportedSubdivisions: {},
                 },
             },
             country: 'CZ',

--- a/suite-common/trading/src/utils/sell/__tests__/sellUtils.test.ts
+++ b/suite-common/trading/src/utils/sell/__tests__/sellUtils.test.ts
@@ -109,6 +109,7 @@ describe('sellUtils', () => {
                     type: 'Fiat',
                     supportedCountries: ['CZ'],
                     flow: 'BANK_ACCOUNT',
+                    supportedSubdivisions: {},
                 },
             },
             supportedFiatCurrencies: new Set(),

--- a/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/__tests__/signatureUtils.test.ts
@@ -254,6 +254,7 @@ describe('signatureUtils', () => {
             statusUrl: 'https://test.com/status',
             supportUrl: 'https://test.com/support',
             type: 'Fiat',
+            supportedSubdivisions: {},
         };
 
         const defaultSellProps = {

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -19,7 +19,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
-        "@types/invity-api": "^1.1.12",
+        "@types/invity-api": "^1.1.13",
         "react": "19.1.0"
     }
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -90,6 +90,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -35,7 +35,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "@types/invity-api": "^1.1.12",
+        "@types/invity-api": "^1.1.13",
         "expo-system-ui": "~6.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",

--- a/suite-native/trading-analytics/package.json
+++ b/suite-native/trading-analytics/package.json
@@ -25,6 +25,6 @@
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -35,6 +35,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -42,6 +42,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -20,6 +20,6 @@
     },
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -41,6 +41,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -19,6 +19,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@types/invity-api": "^1.1.12"
+        "@types/invity-api": "^1.1.13"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11641,7 +11641,7 @@ __metadata:
     "@trezor/react-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     react: "npm:19.1.0"
     react-redux: "npm:9.2.0"
     uuid: "npm:^13.0.0"
@@ -11744,7 +11744,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:^"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     react: "npm:19.1.0"
   languageName: unknown
   linkType: soft
@@ -13656,7 +13656,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     expo-linear-gradient: "npm:~15.0.8"
     react: "npm:19.1.0"
     react-intl: "npm:^8.0.6"
@@ -13733,7 +13733,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     expo-system-ui: "npm:~6.0.9"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -14211,7 +14211,7 @@ __metadata:
     "@suite-native/test-utils": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     react: "npm:19.1.0"
     react-redux: "npm:9.2.0"
   languageName: unknown
@@ -14237,7 +14237,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-native-gesture-handler: "npm:2.29.0"
@@ -14270,7 +14270,7 @@ __metadata:
     "@suite-native/trading-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     expo-linking: "npm:~8.0.11"
     expo-web-browser: "npm:~15.0.10"
     react: "npm:19.1.0"
@@ -14318,7 +14318,7 @@ __metadata:
     "@suite-native/trading-consts": "workspace:*"
     "@suite-native/trading-types": "workspace:*"
     "@trezor/connect": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
   languageName: unknown
   linkType: soft
 
@@ -14381,7 +14381,7 @@ __metadata:
     "@suite-native/trading-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     react-native: "npm:0.81.5"
   languageName: unknown
   linkType: soft
@@ -14398,7 +14398,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
   languageName: unknown
   linkType: soft
 
@@ -15943,7 +15943,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.12"
+    "@types/invity-api": "npm:^1.1.13"
     "@types/pako": "npm:^2.0.3"
     "@types/pdfmake": "npm:^0.2.11"
     "@types/react": "npm:19.1.6"
@@ -17006,10 +17006,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "@types/invity-api@npm:1.1.12"
-  checksum: 10/8c89c855cd0f3ba9da923ae894b52fd737eef15fc7c8f244d732613ce98f7b8172cda62c8c767b5c020b20f0b52e69c08b6393f89c9502cdef92f88e45b8038b
+"@types/invity-api@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "@types/invity-api@npm:1.1.13"
+  checksum: 10/7f0b558bf92a51f3ca398386d9a46556352790354bafdfa01ad0c6d696c75977cd57ffa9734c7156045eab81984b9328dc993efb28bd95daecdf9b56824bac71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

@types/invity-api updated to the latest version `1.1.13`

## Notes for QA

Dev thing - no need to test

## Related Issue

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/invity-api-update&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/invity-api-update&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/invity-api-update&lookback=7)