### PR TITLE
chore(suite): remove unit tests from yarn validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "refs": "yarn update-project-references",
         "types": "yarn type-check",
         "messages": "yarn message-system-sign-config",
-        "validate": "yarn verify-project-references && yarn lint:js && yarn nx:lint:styles && yarn nx:build:libs && yarn nx:type-check && yarn nx:test-unit && yarn check-workspace-resolutions && yarn depcheck",
+        "validate": "yarn verify-project-references && yarn lint:js && yarn nx:lint:styles && yarn nx:build:libs && yarn nx:type-check && yarn check-workspace-resolutions && yarn depcheck",
         "a": "yarn native:android",
         "ios": "yarn native:ios",
         "p": "yarn native:prebuild",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unit tests, even when cached are taking quite a lot of time lately. `yarn validate` is meant for local development to check whether your branch passes type-checks, depcheck etc. It's useful but with unit tests it just makes the development feedback take too long. 

I propose removing unit tests from validate script altogether and we can run unit tests separately, if needed. Alternatively we could potentially add another script that would run unit tests together with validate. 

## Notes for QA
Nothing to test. 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unit-tests-from-validate&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unit-tests-from-validate&lookback=7)