### PR TITLE
chore(suite-common): remove obsolete state property lastResult

### DIFF
--- a/suite-common/thp/src/index.ts
+++ b/suite-common/thp/src/index.ts
@@ -6,7 +6,6 @@ export {
     selectIsThpInProgress,
     selectThpStep,
     selectThpAutoconnectStep,
-    selectThpLastResult,
     selectThpCredentials,
     selectThpLastCode,
 } from './thpSelectors';

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -34,7 +34,6 @@ export type ThpState = {
     step: ThpStep;
     autoconnectStep: ThpAutoconnectStep | null;
     lastThpCode?: string;
-    lastResult?: 'finished' | 'canceled' | 'failed';
     credentials: ThpSuiteCredentials[];
 };
 
@@ -42,7 +41,6 @@ export const initialThpState: ThpState = {
     step: null,
     autoconnectStep: null,
     lastThpCode: undefined,
-    lastResult: undefined,
     credentials: [] as ThpSuiteCredentials[],
 };
 
@@ -93,11 +91,9 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
             })
             .addCase(thpActions.finishThpFlow, state => {
                 state.step = null;
-                state.lastResult = 'finished';
             })
             .addCase(thpActions.cancelThpFlow, state => {
                 state.step = null;
-                state.lastResult = 'canceled';
             })
             .addCase(thpActions.finishAutoconnectFlow, state => {
                 state.autoconnectStep = null;
@@ -123,7 +119,6 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                     if (payload.status === 'finished') {
                         state.step = null;
                         state.lastThpCode = undefined;
-                        state.lastResult = 'finished';
 
                         // find credential and increment connectionCounter or set autoconnectStep
                         const credential = state.credentials.find(stateCredential =>
@@ -148,7 +143,6 @@ export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
                     } else if (payload.status === 'canceled' || payload.status === 'failed') {
                         state.step = null;
                         state.lastThpCode = undefined;
-                        state.lastResult = payload.status;
                     }
                 },
             )

--- a/suite-common/thp/src/thpSelectors.ts
+++ b/suite-common/thp/src/thpSelectors.ts
@@ -14,6 +14,4 @@ export const selectThpAutoconnectStep = (state: ThpRootState) => state.thp.autoc
 
 export const selectThpLastCode = (state: ThpRootState) => state.thp.lastThpCode;
 
-export const selectThpLastResult = (state: ThpRootState) => state.thp.lastResult;
-
 export const selectThpCredentials = (state: ThpRootState) => state.thp.credentials;

--- a/suite-common/thp/tests/thpReducer.test.ts
+++ b/suite-common/thp/tests/thpReducer.test.ts
@@ -12,7 +12,7 @@ import {
     thpActions,
 } from '../src';
 import { createCredential, createDeviceThp } from '../src/support/mocks';
-import { selectThpCredentials, selectThpLastCode, selectThpLastResult } from '../src/thpSelectors';
+import { selectThpCredentials, selectThpLastCode } from '../src/thpSelectors';
 
 const thpReduce = prepareThpReducer(extraDependenciesCommonMock);
 
@@ -20,7 +20,6 @@ const initialState: ThpState = {
     step: null,
     autoconnectStep: null,
     lastThpCode: undefined,
-    lastResult: undefined,
     credentials: [],
 };
 
@@ -52,7 +51,6 @@ describe('thpReducer', () => {
 
         const state = store.getState();
         expect(selectThpStep(state)).toEqual(null);
-        expect(selectThpLastResult(state)).toEqual('finished');
     });
 
     test('cancelThpFlow', () => {
@@ -66,7 +64,6 @@ describe('thpReducer', () => {
 
         const state = store.getState();
         expect(selectThpStep(state)).toEqual(null);
-        expect(selectThpLastResult(state)).toEqual('canceled');
     });
 
     describe('THP pairing status event handling', () => {
@@ -105,7 +102,6 @@ describe('thpReducer', () => {
             expect(selectThpStep(state)).toBeNull();
             expect(selectThpAutoconnectStep(state)).toEqual(expectedAutoconnectStep);
             expect(selectThpLastCode(state)).toBeUndefined();
-            expect(selectThpLastResult(state)).toEqual('finished');
             expect(selectThpCredentials(state).map(c => c.connectionCounter)).toEqual([
                 0,
                 expectedCounter,
@@ -130,7 +126,6 @@ describe('thpReducer', () => {
             const state = store.getState();
             expect(selectThpStep(state)).toBeNull();
             expect(selectThpLastCode(state)).toBeUndefined();
-            expect(selectThpLastResult(state)).toEqual('canceled');
         });
 
         test('failed', () => {
@@ -152,7 +147,6 @@ describe('thpReducer', () => {
             const state = store.getState();
             expect(selectThpStep(state)).toBeNull();
             expect(selectThpLastCode(state)).toBeUndefined();
-            expect(selectThpLastResult(state)).toEqual('failed');
         });
 
         test('invalid-tag', () => {
@@ -174,7 +168,6 @@ describe('thpReducer', () => {
             const state = store.getState();
             expect(selectThpStep(state)).toEqual('CodeInvalid');
             expect(selectThpLastCode(state)).toEqual('1234');
-            expect(selectThpLastResult(state)).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
Follow-up for #24952.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/common/remove-thp-last-result&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/common/remove-thp-last-result&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/common/remove-thp-last-result&lookback=7)