### PR TITLE
fix(suite-native): handle undefined dismissBrowser return

### DIFF
--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
@@ -71,7 +71,7 @@ describe('useBrowserAuth', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockLinkingURL = null;
-        mockDismissBrowser.mockResolvedValue({ type: WebBrowserResultType.DISMISS });
+        mockDismissBrowser.mockReturnValue(Promise.resolve({ type: WebBrowserResultType.DISMISS }));
         ({ store } = initStore({ wallet: getWalletState() }));
     });
 
@@ -239,6 +239,22 @@ describe('useBrowserAuth', () => {
                 expect.objectContaining({
                     data: expect.objectContaining({ orderId: 'trade-order-id-1' }),
                 }),
+            );
+            expect(mockDismissBrowser).toHaveBeenCalledTimes(1);
+        });
+
+        it('should handle dismissBrowser returning undefined', () => {
+            mockLinkingURL = TRADING_URL_DEFAULT_BACK;
+            mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
+            mockDismissBrowser.mockReturnValue(undefined);
+            const { result } = renderUseBrowserAuth();
+
+            act(() => {
+                result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK);
+            });
+
+            expect(selectTradingProviderConfirmationStatus(store.getState())).toBe(
+                'window_closed_with_success',
             );
             expect(mockDismissBrowser).toHaveBeenCalledTimes(1);
         });

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -79,8 +79,8 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
         }
 
         handleBrowserSuccess();
-        dismissBrowser().catch(_ => {
-            // Ignore the error, browser might have been already closed.
+        dismissBrowser()?.catch(_ => {
+            // Ignore the error, the browser might have been already closed.
             // (And in fact it most probably already is.)
         });
     }, [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Somehow `dismissBrowser` on android no longer returns promise.


<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25324


## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25324-mobile-sell-on-android-crashes-after-provider-confirmation&lookback=7)