### PR TITLE
fix(suite-native): check correct urls for universal links

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -251,7 +251,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                                   {
                                       scheme: 'https',
                                       host: 'trezor.io',
-                                      pathPattern: '/suite/deeplink/.*',
+                                      pathPattern: '/suite/deeplinks/.*',
                                   },
                               ]
                             : [

--- a/suite-native/trading-browser-auth/src/consts.ts
+++ b/suite-native/trading-browser-auth/src/consts.ts
@@ -1,6 +1,6 @@
 import { isProduction } from '@suite-native/config';
 
-const TRADING_URL_BASE_PRODUCTION = 'https://trezor.io/suite/deeplink/trade';
+const TRADING_URL_BASE_PRODUCTION = 'https://trezor.io/suite/deeplinks/trade';
 const TRADING_URL_BASE_DEV = 'trezorsuite://trading';
 
 // we don't want to expose custom scheme in production,

--- a/suite-native/trading-browser-auth/src/utils/__tests__/formUtils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/__tests__/formUtils.test.ts
@@ -252,7 +252,7 @@ ${' '.repeat(16)}
 
         it('should use production back URL in applyHtmlTemplate', () => {
             const html = applyHtmlTemplate('CONTENT_TO_EMBED');
-            expect(html).toContain('href="https://trezor.io/suite/deeplink/trade/back"');
+            expect(html).toContain('href="https://trezor.io/suite/deeplinks/trade/back"');
         });
 
         it('should return correct url format with production base', () => {
@@ -263,7 +263,7 @@ ${' '.repeat(16)}
                     orderId: '1234',
                 }),
             ).toBe(
-                'https://trezor.io/suite/deeplink/trade?action=quote&tradeType=buy&orderId=1234',
+                'https://trezor.io/suite/deeplinks/trade?action=quote&tradeType=buy&orderId=1234',
             );
         });
     });

--- a/suite-native/trading-browser-auth/src/utils/__tests__/utils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/__tests__/utils.test.ts
@@ -67,19 +67,19 @@ describe('utils', () => {
         });
 
         it('should use production URL base', () => {
-            expect(TRADING_URL_BASE).toBe('https://trezor.io/suite/deeplink/trade');
-            expect(TRADING_URL_DEFAULT_BACK).toBe('https://trezor.io/suite/deeplink/trade/back');
+            expect(TRADING_URL_BASE).toBe('https://trezor.io/suite/deeplinks/trade');
+            expect(TRADING_URL_DEFAULT_BACK).toBe('https://trezor.io/suite/deeplinks/trade/back');
         });
 
         it('should return true when URL contains production base', () => {
             const url =
-                'https://trezor.io/suite/deeplink/trade?action=trade&tradeType=buy&orderId=123';
+                'https://trezor.io/suite/deeplinks/trade?action=trade&tradeType=buy&orderId=123';
             expect(doesUrlContainCloseCallbackUrl(url, TRADING_URL_BASE)).toBe(true);
         });
 
         it('should return true when URL contains production default back', () => {
             const url =
-                'https://trezor.io/suite/deeplink/trade/back?action=trade&tradeType=buy&orderId=123';
+                'https://trezor.io/suite/deeplinks/trade/back?action=trade&tradeType=buy&orderId=123';
             expect(doesUrlContainCloseCallbackUrl(url)).toBe(true);
         });
 


### PR DESCRIPTION
I've messed up and there is a differen url path supported in [AASA file](https://trezor.io/.well-known/apple-app-site-association). This aligns those

## Notes for QA

deeplinks like https://trezor.io/suite/deeplinks/ahoj on iOS in production should work

Resolve #25298 for iOS

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/correct-universal-links-deeplinks&lookback=7)