### PR TITLE
Mobile Trade: enhance selectExchangeBuyTradeableAssets to filter debug and experimental networks

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeBuyTradeableAssetsFilteredData.ts
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 
+import type { FeatureFlagsRootState } from '@suite-native/feature-flags';
 import {
     type TradingRootState,
     selectExchangeBuyTradeableAssets,
@@ -11,7 +12,7 @@ import { useTradeableAssetsFilteredData } from '../general/useTradeableAssetsFil
 export const useExchangeBuyTradeableAssetsFilteredData = () => {
     const { watch } = useExchangeFormContext();
     const sendAsset = watch('sendAsset');
-    const assets = useSelector((state: TradingRootState) =>
+    const assets = useSelector((state: TradingRootState & FeatureFlagsRootState) =>
         selectExchangeBuyTradeableAssets(state, sendAsset?.cryptoId),
     );
 

--- a/suite-native/trading-fixtures/src/__fixtures__/tradeableAssets.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/tradeableAssets.ts
@@ -100,3 +100,36 @@ export const bnbAsset: TradeableAsset = {
     coingeckoId: 'binancecoin',
     networkId: 'binancecoin',
 };
+
+export const tronTetherAsset: TradeableAsset = {
+    coingeckoId: 'tether',
+    contractAddress: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' as TokenAddress,
+    cryptoId: 'tron--TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' as CryptoId,
+    name: 'Tether',
+    networkId: 'tron',
+    symbol: 'USDT',
+};
+
+export const tronAsset: TradeableAsset = {
+    coingeckoId: 'tron',
+    cryptoId: 'tron' as CryptoId,
+    name: 'TRON',
+    networkId: 'tron',
+    symbol: 'TRX',
+};
+
+export const rippleAsset: TradeableAsset = {
+    coingeckoId: 'ripple',
+    cryptoId: 'ripple' as CryptoId,
+    name: 'XRP',
+    networkId: 'ripple',
+    symbol: 'XRP',
+};
+
+export const unknownAsset: TradeableAsset = {
+    coingeckoId: 'fake-coingecko-id',
+    cryptoId: 'fake-crypto-id' as CryptoId,
+    name: 'Fake Asset',
+    networkId: 'fake-network-id',
+    symbol: 'FAKE',
+};

--- a/suite-native/trading-state/src/__tests__/utils.test.ts
+++ b/suite-native/trading-state/src/__tests__/utils.test.ts
@@ -1,4 +1,43 @@
-import { getFormDraftKeyByTradeType } from '../utils';
+import {
+    btcAsset,
+    rippleAsset,
+    tronAsset,
+    tronTetherAsset,
+    unknownAsset,
+    usdtAsset,
+} from '@suite-native/trading-fixtures';
+
+import { getAssetByEnabledNetworksFilter, getFormDraftKeyByTradeType } from '../utils';
+
+jest.mock('@suite-common/wallet-config', () => {
+    const actual = jest.requireActual('@suite-common/wallet-config');
+
+    return {
+        ...actual,
+        getNetworkByCoingeckoId: (coingeckoId: string) => {
+            const network = actual.getNetworkByCoingeckoId(coingeckoId);
+
+            switch (network?.symbol) {
+                case 'trx':
+                    // mock Tron as debug-only network
+                    return {
+                        ...network,
+                        isDebugOnlyNetwork: true,
+                        isExperimentalOnlyNetwork: false,
+                    };
+                case 'xrp':
+                    // mock Ripple as experimental-only network
+                    return {
+                        ...network,
+                        isExperimentalOnlyNetwork: true,
+                        isDebugOnlyNetwork: false,
+                    };
+                default:
+                    return network;
+            }
+        },
+    };
+});
 
 describe('utils', () => {
     describe('getFormDraftKeyByTradeType', () => {
@@ -10,6 +49,56 @@ describe('utils', () => {
         it('should return correct form draft key for sell trade type', () => {
             const result = getFormDraftKeyByTradeType('sell');
             expect(result).toBe('trading-sell/');
+        });
+    });
+
+    describe('getAssetByEnabledNetworksFilter', () => {
+        it.each([btcAsset, usdtAsset, tronTetherAsset, tronAsset])(
+            `should return true for asset [$symbol] if areDebugOnlyNetworksEnabled FF is enabled`,
+            asset => {
+                const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(true, false);
+
+                expect(assetByEnabledNetworksFilter(asset)).toBe(true);
+            },
+        );
+
+        it.each([btcAsset, usdtAsset, rippleAsset])(
+            `should return true for asset [$symbol] if areExperimentalOnlyNetworksEnable FF is enabled`,
+            asset => {
+                const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(false, true);
+
+                expect(assetByEnabledNetworksFilter(asset)).toBe(true);
+            },
+        );
+
+        it.each([btcAsset, usdtAsset])(
+            `should return true for asset [$symbol] if areDebugOnlyNetworksEnabled and areExperimentalOnlyNetworksEnable FFs are disabled`,
+            asset => {
+                const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(false, false);
+
+                expect(assetByEnabledNetworksFilter(asset)).toBe(true);
+            },
+        );
+
+        it.each([tronTetherAsset, tronAsset])(
+            `should return false for asset [$symbol] if areDebugOnlyNetworksEnabled  FF is disabled`,
+            asset => {
+                const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(false, true);
+
+                expect(assetByEnabledNetworksFilter(asset)).toBe(false);
+            },
+        );
+
+        it(`should return false for asset [XRP] if areExperimentalOnlyNetworksEnable FF is disabled`, () => {
+            const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(true, false);
+
+            expect(assetByEnabledNetworksFilter(rippleAsset)).toBe(false);
+        });
+
+        it('should return false for unknown asset', () => {
+            const assetByEnabledNetworksFilter = getAssetByEnabledNetworksFilter(true, true);
+
+            expect(assetByEnabledNetworksFilter(unknownAsset)).toBe(false);
         });
     });
 });

--- a/suite-native/trading-state/src/reducers/index.ts
+++ b/suite-native/trading-state/src/reducers/index.ts
@@ -1,5 +1,6 @@
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { AccountsRootState } from '@suite-common/wallet-core';
+import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { TradingRootState } from '@suite-native/trading-types';
 
 export type { TradingState, TradingRootState } from '@suite-native/trading-types';
@@ -14,4 +15,7 @@ export { residenceActions } from './residenceSlice';
 export const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
 export const createMemoizedSelectorWithAccounts = createWeakMapSelector.withTypes<
     TradingRootState & AccountsRootState
+>();
+export const createTradingWithFeatureFlagsMemoizedSelector = createWeakMapSelector.withTypes<
+    TradingRootState & FeatureFlagsRootState
 >();

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -1,9 +1,10 @@
 import { Platform } from 'react-native';
 
-import type { BuyTrade } from 'invity-api';
+import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account, AccountKey } from '@suite-common/wallet-types';
+import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { buyQuotes, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 
 import { TradingRootState } from '../../reducers';
@@ -21,14 +22,20 @@ import {
 } from '../buySelectors';
 
 describe('buySelectors', () => {
-    let state: TradingRootState & AccountsRootState;
+    let state: TradingRootState & AccountsRootState & FeatureFlagsRootState;
 
     beforeEach(() => {
         Platform.OS = 'ios';
         jest.spyOn(Platform, 'select').mockImplementation(
             (specifics: any) => specifics.ios ?? specifics.default,
         );
-        state = { wallet: getWalletState() };
+        state = {
+            wallet: getWalletState(),
+            featureFlags: {
+                [FeatureFlag.AreDebugOnlyNetworksEnabled]: false,
+                [FeatureFlag.AreExperimentalOnlyNetworksEnabled]: false,
+            } as FeatureFlagsRootState['featureFlags'],
+        };
     });
 
     it('selectTradingBuy should select trading buy state', () => {
@@ -97,6 +104,54 @@ describe('buySelectors', () => {
             state.wallet.trading.info.coins = undefined;
 
             expect(selectBuyTradeableAssets(state)).toEqual([]);
+        });
+
+        describe('debug-only networks', () => {
+            beforeEach(() => {
+                // Add Tron which is a debug-only network
+                state.wallet.trading.buy.buyInfo!.supportedCryptoCurrencies = [
+                    'ethereum',
+                    'bitcoin',
+                    'tron',
+                ] as CryptoId[];
+                state.wallet.trading.info.coins = {
+                    ...state.wallet.trading.info.coins,
+                    tron: {
+                        symbol: 'trx',
+                        name: 'Tron',
+                        coingeckoId: 'tron',
+                        services: {
+                            buy: true,
+                            sell: true,
+                            exchange: true,
+                        },
+                    },
+                };
+            });
+
+            it('should filter out debug-only networks when flag is disabled', () => {
+                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = false;
+
+                const result = selectBuyTradeableAssets(state);
+
+                expect(result).toEqual([
+                    expect.objectContaining({ cryptoId: 'ethereum' }),
+                    expect.objectContaining({ cryptoId: 'bitcoin' }),
+                ]);
+                expect(result).not.toContainEqual(expect.objectContaining({ cryptoId: 'tron' }));
+            });
+
+            it('should include debug-only networks when flag is enabled', () => {
+                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = true;
+
+                const result = selectBuyTradeableAssets(state);
+
+                expect(result).toEqual([
+                    expect.objectContaining({ cryptoId: 'ethereum' }),
+                    expect.objectContaining({ cryptoId: 'bitcoin' }),
+                    expect.objectContaining({ cryptoId: 'tron', symbol: 'TRX' }),
+                ]);
+            });
         });
     });
 

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -220,10 +220,6 @@ describe('exchangeSelectors', () => {
                 ]);
             });
         });
-
-        describe.skip('experimental-only networks', () => {
-            // There are currently no experimental only networks. Skipping
-        });
     });
 
     describe('selectExchangeQuotes', () => {

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -1,3 +1,5 @@
+import type { CryptoId } from 'invity-api';
+
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account, AccountKey } from '@suite-common/wallet-types';
 import { FeatureFlag, FeatureFlagsRootState } from '@suite-native/feature-flags';
@@ -22,6 +24,8 @@ describe('exchangeSelectors', () => {
             wallet: getWalletState({ tradeType: 'exchange' }),
             featureFlags: {
                 [FeatureFlag.AreTradingExchangeDexesEnabled]: true,
+                [FeatureFlag.AreDebugOnlyNetworksEnabled]: false,
+                [FeatureFlag.AreExperimentalOnlyNetworksEnabled]: false,
             } as FeatureFlagsRootState['featureFlags'],
         };
     });
@@ -120,6 +124,12 @@ describe('exchangeSelectors', () => {
             expect(selectExchangeBuyTradeableAssets(state)).toEqual([]);
         });
 
+        it('should be empty array when cryptoIds are not set', () => {
+            state.wallet.trading.exchange.exchangeInfo = undefined;
+
+            expect(selectExchangeBuyTradeableAssets(state)).toEqual([]);
+        });
+
         it('should filter out forbidden cryptoId', () => {
             const result = selectExchangeBuyTradeableAssets(
                 state,
@@ -129,6 +139,90 @@ describe('exchangeSelectors', () => {
                 expect.objectContaining({ cryptoId: 'ethereum' }),
                 expect.objectContaining({ cryptoId: 'bitcoin' }),
             ]);
+        });
+
+        it('should filter out coins with invalid network symbols', () => {
+            // Add a coin with an invalid symbol that doesn't map to a network
+            state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [
+                'ethereum',
+                'bitcoin',
+                'invalid-crypto-id',
+            ] as CryptoId[];
+            state.wallet.trading.info.coins = {
+                ...state.wallet.trading.info.coins,
+                'invalid-crypto-id': {
+                    symbol: 'invalid',
+                    name: 'Invalid Coin',
+                    coingeckoId: 'invalid',
+                    services: {
+                        buy: true,
+                        sell: true,
+                        exchange: true,
+                    },
+                },
+            };
+
+            const result = selectExchangeBuyTradeableAssets(state);
+
+            expect(result).toEqual([
+                expect.objectContaining({ cryptoId: 'ethereum' }),
+                expect.objectContaining({ cryptoId: 'bitcoin' }),
+            ]);
+            expect(result).not.toContainEqual(
+                expect.objectContaining({ cryptoId: 'invalid-crypto-id' }),
+            );
+        });
+
+        describe('debug-only networks', () => {
+            beforeEach(() => {
+                // Add Tron which is a debug-only network
+                state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [
+                    'ethereum',
+                    'bitcoin',
+                    'tron',
+                ] as CryptoId[];
+                state.wallet.trading.info.coins = {
+                    ...state.wallet.trading.info.coins,
+                    tron: {
+                        symbol: 'trx',
+                        name: 'Tron',
+                        coingeckoId: 'tron',
+                        services: {
+                            buy: true,
+                            sell: true,
+                            exchange: true,
+                        },
+                    },
+                };
+            });
+
+            it('should filter out debug-only networks when flag is disabled', () => {
+                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = false;
+
+                const result = selectExchangeBuyTradeableAssets(state);
+
+                expect(result).toEqual([
+                    expect.objectContaining({ cryptoId: 'ethereum' }),
+                    expect.objectContaining({ cryptoId: 'bitcoin' }),
+                ]);
+                expect(result).not.toContainEqual(expect.objectContaining({ cryptoId: 'tron' }));
+            });
+
+            it('should include debug-only networks when flag is enabled', () => {
+                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = true;
+
+                const result = selectExchangeBuyTradeableAssets(state);
+
+                expect(result).toEqual([
+                    expect.objectContaining({ cryptoId: 'ethereum' }),
+                    expect.objectContaining({ cryptoId: 'bitcoin' }),
+                    expect.objectContaining({ cryptoId: 'tron', symbol: 'TRX' }),
+                ]);
+            });
+        });
+
+        describe.skip('experimental-only networks', () => {
+            // There are currently no experimental only networks. Skipping
         });
     });
 

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -14,6 +14,7 @@ import {
     selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import {
     coinInfoToTradeableAsset,
     getCurrencyLabel,
@@ -21,11 +22,13 @@ import {
 } from '@suite-native/trading-atoms';
 import { BuyFormValues, FiatCurrencyItem } from '@suite-native/trading-types';
 
+import { getAssetByEnabledNetworksFilter } from '../utils';
 import { selectTradingResidenceCountry } from './residenceSelectors';
 import {
     TradingRootState,
     createMemoizedSelector,
     createMemoizedSelectorWithAccounts,
+    createTradingWithFeatureFlagsMemoizedSelector,
 } from '../reducers';
 
 const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
@@ -49,19 +52,28 @@ export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccount
 export const selectBuySupportedFiatCurrencies = (state: TradingRootState) =>
     returnStableArrayIfEmpty(selectTradingBuy(state).buyInfo?.supportedFiatCurrencies);
 
-export const selectBuyTradeableAssets = createMemoizedSelector(
+export const selectBuyTradeableAssets = createTradingWithFeatureFlagsMemoizedSelector(
     [
         selectTradingBuySupportedCryptoIds as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingBuySupportedCryptoIds>,
         ({ wallet }) => wallet.trading.info.coins,
+        state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
+        state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
     ],
-    (cryptoIds, coins) => {
+    (cryptoIds, coins, areDebugOnlyNetworksEnabled, areExperimentalOnlyNetworksEnabled) => {
         if (!coins || !cryptoIds) {
             return [];
         }
 
-        return cryptoIds.map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
+        return cryptoIds
+            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]))
+            .filter(
+                getAssetByEnabledNetworksFilter(
+                    areDebugOnlyNetworksEnabled,
+                    areExperimentalOnlyNetworksEnabled,
+                ),
+            );
     },
 );
 

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -1,11 +1,9 @@
 import type { ExchangeTrade } from 'invity-api';
 
-import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeProviders,
 } from '@suite-common/trading';
-import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
@@ -18,12 +16,14 @@ import {
     getReceiveAccountFromAccountAndAddressString,
 } from '@suite-native/trading-atoms';
 
-import { TradingRootState, createMemoizedSelectorWithAccounts } from '../reducers';
+import {
+    TradingRootState,
+    createMemoizedSelectorWithAccounts,
+    createTradingWithFeatureFlagsMemoizedSelector,
+} from '../reducers';
+import { getAssetByEnabledNetworksFilter } from '../utils';
 
 export type TradingWithFeatureFlagsRootState = TradingRootState & FeatureFlagsRootState;
-
-const createTradingWithFeatureFlagsMemoizedSelector =
-    createWeakMapSelector.withTypes<TradingWithFeatureFlagsRootState>();
 
 export const selectTradingExchange = (state: TradingRootState) => state.wallet.trading.exchange;
 
@@ -75,28 +75,14 @@ export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMem
         }
 
         return cryptoIds
+            .filter(cryptoId => cryptoId !== forbiddenCryptoId)
             .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]))
-            .filter(({ cryptoId, networkId }) => {
-                if (cryptoId === forbiddenCryptoId) {
-                    return false;
-                }
-
-                const network = getNetworkByCoingeckoId(networkId);
-
-                if (!network) {
-                    return false;
-                }
-
-                if (network.isDebugOnlyNetwork) {
-                    return areDebugOnlyNetworksEnabled;
-                }
-
-                if (network.isExperimentalOnlyNetwork) {
-                    return areExperimentalOnlyNetworksEnabled;
-                }
-
-                return true;
-            });
+            .filter(
+                getAssetByEnabledNetworksFilter(
+                    areDebugOnlyNetworksEnabled,
+                    areExperimentalOnlyNetworksEnabled,
+                ),
+            );
     },
 );
 

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -5,6 +5,7 @@ import {
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeProviders,
 } from '@suite-common/trading';
+import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
 import {
@@ -17,11 +18,7 @@ import {
     getReceiveAccountFromAccountAndAddressString,
 } from '@suite-native/trading-atoms';
 
-import {
-    TradingRootState,
-    createMemoizedSelector,
-    createMemoizedSelectorWithAccounts,
-} from '../reducers';
+import { TradingRootState, createMemoizedSelectorWithAccounts } from '../reducers';
 
 export type TradingWithFeatureFlagsRootState = TradingRootState & FeatureFlagsRootState;
 
@@ -56,22 +53,50 @@ export const selectExchangeSelectedReceiveAccount = createMemoizedSelectorWithAc
     },
 );
 
-export const selectExchangeBuyTradeableAssets = createMemoizedSelector(
+export const selectExchangeBuyTradeableAssets = createTradingWithFeatureFlagsMemoizedSelector(
     [
         selectTradingExchangeBuyCryptoIds as unknown as (
             state: TradingRootState,
         ) => ReturnType<typeof selectTradingExchangeBuyCryptoIds>,
         ({ wallet }) => wallet.trading.info.coins,
         (_state: TradingRootState, forbiddenCryptoId?: string) => forbiddenCryptoId,
+        state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
+        state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
     ],
-    (cryptoIds, coins, forbiddenCryptoId) => {
+    (
+        cryptoIds,
+        coins,
+        forbiddenCryptoId,
+        areDebugOnlyNetworksEnabled,
+        areExperimentalOnlyNetworksEnabled,
+    ) => {
         if (!coins || !cryptoIds) {
             return [];
         }
 
         return cryptoIds
-            .filter(cryptoId => cryptoId !== forbiddenCryptoId)
-            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]));
+            .map(cryptoId => coinInfoToTradeableAsset(cryptoId, coins[cryptoId]))
+            .filter(({ cryptoId, networkId }) => {
+                if (cryptoId === forbiddenCryptoId) {
+                    return false;
+                }
+
+                const network = getNetworkByCoingeckoId(networkId);
+
+                if (!network) {
+                    return false;
+                }
+
+                if (network.isDebugOnlyNetwork) {
+                    return areDebugOnlyNetworksEnabled;
+                }
+
+                if (network.isExperimentalOnlyNetwork) {
+                    return areExperimentalOnlyNetworksEnabled;
+                }
+
+                return true;
+            });
     },
 );
 

--- a/suite-native/trading-state/src/utils.ts
+++ b/suite-native/trading-state/src/utils.ts
@@ -1,5 +1,7 @@
 import { TradingExchangeType, TradingSellType } from '@suite-common/trading';
+import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
+import { TradeableAsset } from '@suite-native/trading-types';
 import { exhaustive } from '@trezor/type-utils';
 
 export const getFormDraftKeyByTradeType = (tradeType: TradingSellType | TradingExchangeType) => {
@@ -12,3 +14,23 @@ export const getFormDraftKeyByTradeType = (tradeType: TradingSellType | TradingE
             return exhaustive(tradeType);
     }
 };
+
+export const getAssetByEnabledNetworksFilter =
+    (areDebugOnlyNetworksEnabled: boolean, areExperimentalOnlyNetworksEnabled: boolean) =>
+    ({ networkId }: TradeableAsset) => {
+        const network = getNetworkByCoingeckoId(networkId);
+
+        if (!network) {
+            return false;
+        }
+
+        if (network.isDebugOnlyNetwork) {
+            return areDebugOnlyNetworksEnabled;
+        }
+
+        if (network.isExperimentalOnlyNetwork) {
+            return areExperimentalOnlyNetworksEnabled;
+        }
+
+        return true;
+    };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `selectExchangeBuyTradeableAssets` now filters debug and experimental networks based on respektive FF flags
- `selectBuyTradeableAssets` now filters debug and experimental networks based on respektive FF flags

<!--- Describe your changes in detail -->

## Notes for QA

Both buy and swap should be fixed.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25090 

## Screenshots:

### With debug only networks FF disabled
<img width="300" alt="ff-disabled" src="https://github.com/user-attachments/assets/f51f1bd7-f5f7-4d79-8216-6b05fff962b2" />

### With debug only networks FF enabled
<img width="300" alt="ff-enabled" src="https://github.com/user-attachments/assets/e5019063-6033-4492-8735-41cb3f586a96" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25090-swapmobile-tron-tokens-incorrectly-available-in-swap-app-crash-1&lookback=7)