### PR TITLE
fix(native): place usePreventRemove to screen to prevent unmount

### DIFF
--- a/suite-native/receive/src/components/ReceiveScreenHeader.tsx
+++ b/suite-native/receive/src/components/ReceiveScreenHeader.tsx
@@ -1,7 +1,5 @@
 import { useSelector } from 'react-redux';
 
-import { useNavigation, usePreventRemove } from '@react-navigation/native';
-
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
@@ -15,22 +13,18 @@ import {
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { TokensRootState, selectAccountTokenSymbol } from '@suite-native/tokens';
-import TrezorConnect from '@trezor/connect';
 
 type ReceiveScreenHeaderProps = {
     accountKey?: AccountKey;
     tokenContract?: TokenAddress;
     closeActionType: CloseActionType;
-    onLeave?: () => void;
 };
 
 export const ReceiveScreenHeader = ({
     accountKey,
     tokenContract,
     closeActionType,
-    onLeave,
 }: ReceiveScreenHeaderProps) => {
-    const navigation = useNavigation();
     const navigateToInitialScreen = useNavigateToInitialScreen();
 
     const symbol = useSelector((state: AccountsRootState) =>
@@ -39,14 +33,6 @@ export const ReceiveScreenHeader = ({
     const tokenSymbol = useSelector((state: TokensRootState) =>
         selectAccountTokenSymbol(state, accountKey, tokenContract),
     );
-
-    usePreventRemove(true, ({ data }) => {
-        TrezorConnect.cancel();
-
-        navigation.dispatch(data.action);
-
-        onLeave?.();
-    });
 
     if (accountKey === undefined) {
         return null;

--- a/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
@@ -3,7 +3,7 @@ import { FadeOut } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { G } from '@mobily/ts-belt';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, usePreventRemove } from '@react-navigation/native';
 
 import { selectIsDeviceBackupRequired } from '@suite-common/device';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
@@ -68,6 +68,14 @@ export const ReceiveAddressScreen = ({
     const { address, isReceiveApproved, isUnverifiedAddressRevealed, handleShowAddress } =
         useAccountReceiveAddress(accountKey);
 
+    usePreventRemove(true, ({ data }) => {
+        TrezorConnect.cancel();
+        navigation.dispatch(data.action);
+        if (isReceiveApproved) {
+            askForRating();
+        }
+    });
+
     const handleShowReceiveAddress = useCallback(() => {
         handleShowAddress();
 
@@ -124,7 +132,6 @@ export const ReceiveAddressScreen = ({
                     accountKey={accountKey}
                     tokenContract={tokenContract}
                     closeActionType={isReceiveApproved ? 'close' : closeActionType}
-                    onLeave={isReceiveApproved ? askForRating : undefined}
                 />
             }
         >


### PR DESCRIPTION
`usePreventRemove` was placed in `ReceiveScreenHeader.tsx` component which was unmounted, because when `revealConfirmOnTrezorSheet` is called -> isFullscreen mode is set to false and that unmounts the `defaultHeader` which was `ReceiveScreenHeader.tsx`.

I fixed it by moving the `usePreventRemove` into a `ReceiveAddressScreen.tsx`.


## Notes for QA

- when you go back, using the os back button, the call on device should be canceled
- please test other cases like returning back when address is confirmed, etc.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25111


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/receive-address-stuck&lookback=7)