### PR TITLE
Mobile Trade: unify package.json scripts in trading packages

### DIFF
--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -8,8 +8,10 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest --coverage"
+        "test:unit": "yarn g:jest --coverage",
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@react-navigation/native": "7.1.26",

--- a/suite-native/trading-consts/package.json
+++ b/suite-native/trading-consts/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite-native/trading-debug/package.json
+++ b/suite-native/trading-debug/package.json
@@ -8,8 +8,10 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "test:unit": "yarn g:jest",
-        "type-check": "yarn g:tsc --build"
+        "lint:js:fix": "yarn lint:js --fix",
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest --coverage",
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite-native/trading-residence/package.json
+++ b/suite-native/trading-residence/package.json
@@ -8,8 +8,10 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
+        "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest --coverage",
-        "type-check": "yarn g:tsc --build"
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@react-navigation/native": "7.1.26",

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -8,8 +8,10 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest --coverage"
+        "test:unit": "yarn g:jest --coverage",
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build"
     },
     "devDependencies": {

--- a/suite-native/transaction-management/package.json
+++ b/suite-native/transaction-management/package.json
@@ -8,8 +8,10 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "lint:js:fix": "yarn lint:js --fix",
+        "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest --coverage",
-        "type-check": "yarn g:tsc --build"
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@mobily/ts-belt": "^3.13.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Unifies scripts section in `package.json` for all suite-native trading packages.

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore-sn-unify-trading-scripts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore-sn-unify-trading-scripts&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore-sn-unify-trading-scripts&lookback=7)