### PR TITLE
feat(suite): enable turn on and off suite sycn when device not connected

### DIFF
--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -192,11 +192,20 @@ export const Option = ({
         >
             <Box
                 borderRadius={8}
-                backgroundColor={props.isFocused ? 'stateFillElementGhostHovered' : undefined}
-                cursor="pointer"
+                backgroundColor={
+                    props.isFocused && !props.isDisabled
+                        ? 'stateFillElementGhostHovered'
+                        : undefined
+                }
+                cursor={props.isDisabled ? 'default' : 'pointer'}
                 padding={{ vertical: 6, horizontal: 8 }}
             >
-                <Text as="div" typographyStyle={mapSizeToTypographyStyle(size)}>
+                <Text
+                    as="div"
+                    intent="neutral"
+                    typographyStyle={mapSizeToTypographyStyle(size)}
+                    isDisabled={props.isDisabled}
+                >
                     {children}
                 </Text>
             </Box>

--- a/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Labeling.tsx
@@ -123,6 +123,15 @@ export const Labeling = () => {
             : LABELING_SELECT_TRANSLATED_OPTIONS_MAP.off;
     };
 
+    const isOptionDisabled = (option: LabelingSelectValue) => {
+        switch (option) {
+            case 'legacy':
+                return isDeviceLabelingDisabled;
+            default:
+                return false;
+        }
+    };
+
     return (
         <>
             {legacyModalWarningVisible && (
@@ -154,7 +163,8 @@ export const Labeling = () => {
                         value={getSelectedOption()}
                         onChange={handleOnChange}
                         data-testid="@settings/labeling-select"
-                        isDisabled={isDeviceLabelingDisabled}
+                        isDisabled={isDeviceLabelingDisabled && !showSuiteSync}
+                        isOptionDisabled={option => isOptionDisabled(option.value)}
                     />
                 </ActionColumn>
             </SettingsSectionItem>


### PR DESCRIPTION
**Changes**:
- labeling select is enabled when suite sync is enabled in experimental and device is disconnected
  - legacy still needs to have device connected in order to turn off and on (for obvious reasons)
  - suite sync can be turned on and off anytime

**Know issue**: disabled options are not greyed out

## Notes for QA
- go into application labeling settings
  - legacy still needs to have device connected in order to turn off and on (for obvious reasons)
  - suite sync can be turned on and off anytime

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24729

### Screenshots
Device disconnected
<img width="949" height="310" alt="Screenshot 2026-02-24 at 0 14 45" src="https://github.com/user-attachments/assets/654bc395-b822-4329-a384-a6908bef4abc" />
Device connected
<img width="937" height="224" alt="Screenshot 2026-02-24 at 0 15 25" src="https://github.com/user-attachments/assets/1684bd6d-2e19-4d3e-97c6-bd7d73241fd1" />




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/ss/undisable-select-options&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/ss/undisable-select-options&lookback=7)