### PR TITLE
feat(suite): erase QM data when turning SS off

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -20,7 +20,7 @@ export {
     quotaManagerDeviceFetched,
     quotaManagerFetchError,
     suiteSyncQuotaManagerActions,
-    eraseFetchedDataDebug,
+    eraseFetchedData as eraseFetchedDataDebug,
     noQuotaLeftWarningDismissed,
 } from './quotaManagerActions';
 

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
@@ -34,7 +34,7 @@ export const quotaManagerDeviceUnspentStorageFetched = createAction(
     }),
 );
 
-export const eraseFetchedDataDebug = createAction(`${QUOTA_MANAGER_PREFIX}/eraseFetchedData`);
+export const eraseFetchedData = createAction(`${QUOTA_MANAGER_PREFIX}/eraseFetchedData`);
 
 export const quotaManagerOwnerFetched = createAction(
     `${QUOTA_MANAGER_PREFIX}/ownerFetched`,
@@ -55,6 +55,6 @@ export const suiteSyncQuotaManagerActions = {
     quotaManagerFetchError,
     quotaManagerDeviceFetched,
     quotaManagerOwnerFetched,
-    eraseFetchedDataDebug,
+    eraseFetchedData,
     noQuotaLeftWarningDismissed,
 };

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
@@ -1,7 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit';
 
 import {
-    eraseFetchedDataDebug,
+    eraseFetchedData,
     noQuotaLeftWarningDismissed,
     quotaManagerDeviceFetched,
     quotaManagerDeviceUnspentStorageFetched,
@@ -34,7 +34,7 @@ export const suiteSyncQuotaManagerReducer = createReducer<SuiteSyncQuotaManagerS
                 state.registeredDevices = [];
                 state.ownersAllowance = [];
             })
-            .addCase(eraseFetchedDataDebug, state => {
+            .addCase(eraseFetchedData, state => {
                 state.registeredDevices = [];
                 state.ownersAllowance = [];
             })

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
+import { eraseFetchedDataDebug } from '@suite-common/suite-sync-quota-manager';
 import {
     SuiteSyncAppReloaderDep,
     TurnOffSuiteSync,
@@ -27,6 +28,7 @@ export const createTurnOffSuiteSync =
         }
 
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: false }));
+        deps.dispatch(eraseFetchedDataDebug());
 
         const deviceStaticSessionIds = deps.getAllDeviceSessionIds();
 


### PR DESCRIPTION
changes:
- when suite sync is turning off -> erase fetched data from QM

## Notes for QA

- see if you have fetched data from QM (in debug)
- navigate to the application settings and turn labeling off
- now see the debug QM data again and verify that it is erased

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25341

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/ss/erase-data-when-ss-turning-off&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/ss/erase-data-when-ss-turning-off&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/ss/erase-data-when-ss-turning-off&lookback=7)