### PR TITLE
feat(suite-native): Select atom Storybook story and decorator refactor

### DIFF
--- a/suite-native/atoms/src/Select/Select.tsx
+++ b/suite-native/atoms/src/Select/Select.tsx
@@ -19,7 +19,7 @@ export type SelectItemType<TItemValue extends SelectItemValue> = {
     badge?: ReactNode;
 };
 
-type SelectProps<TItemValue extends SelectItemValue> = {
+export type SelectProps<TItemValue extends SelectItemValue> = {
     title: ReactNode;
     items: SelectItemType<TItemValue>[];
     value: TItemValue;

--- a/suite-native/atoms/src/stories/Inputs/Select.stories.tsx
+++ b/suite-native/atoms/src/stories/Inputs/Select.stories.tsx
@@ -1,0 +1,62 @@
+import { type Meta, type StoryObj } from '@storybook/react-native';
+import { useArgs } from 'storybook/preview-api';
+
+import { Select as SelectComponent, SelectItemType, SelectProps } from '../../Select/Select';
+
+const OPTIONS = ['option1', 'option2', 'option3'] as const;
+type SelectValue = (typeof OPTIONS)[number];
+
+type SelectArgs = SelectProps<SelectValue>;
+type SelectStory = StoryObj<SelectArgs>;
+
+const items: SelectItemType<SelectValue>[] = [
+    { value: OPTIONS[0], label: 'Option 1' },
+    { value: OPTIONS[1], label: 'Option 2' },
+    { value: OPTIONS[2], label: 'Option 3' },
+];
+
+const meta: Meta<SelectArgs> = {
+    title: 'Atoms/Inputs',
+    render: args => {
+        const [{ value }, updateArgs] = useArgs<SelectArgs>();
+
+        return (
+            <SelectComponent
+                {...args}
+                value={value}
+                onSelectItem={(selectedValue: SelectValue) => updateArgs({ value: selectedValue })}
+            />
+        );
+    },
+};
+
+export default meta;
+
+export const Select: SelectStory = {
+    name: 'Select',
+    args: {
+        title: 'Label',
+        value: 'option1',
+        isLabelShown: true,
+        isConfirmable: false,
+        items,
+    },
+    argTypes: {
+        title: {
+            control: { type: 'text' },
+        },
+        value: {
+            options: Object.values(OPTIONS),
+            control: { type: 'select' },
+        },
+        isConfirmable: {
+            control: { type: 'boolean' },
+        },
+        isLabelShown: {
+            control: { type: 'boolean' },
+        },
+        items: {
+            control: { type: 'object' },
+        },
+    },
+};

--- a/suite-native/atoms/src/stories/Inputs/TextInput.stories.tsx
+++ b/suite-native/atoms/src/stories/Inputs/TextInput.stories.tsx
@@ -13,16 +13,14 @@ const meta: Meta<TextInputArgs> = {
     component: InputComponent,
     decorators: [
         (Story, { context: { args } }) => {
-            const [{ value }, updateArgs] = useArgs();
+            const [_, updateArgs] = useArgs();
 
             return (
                 <InputWrapper hint={args.hint} label={args.wrapperLabel} error={args.error}>
                     <Story
                         args={{
                             ...args,
-                            label: undefined,
                             hasError: !!args.error,
-                            value,
                             onChangeText: (text: string) => updateArgs({ value: text }),
                         }}
                     />
@@ -38,9 +36,9 @@ export const TextInput: TextInputStory = {
     name: 'TextInput',
     args: {
         value: '',
-        wrapperLabel: 'Label',
-        hint: 'This is a hint',
-        placeholder: 'placeholder',
+        wrapperLabel: 'Wrapper label',
+        hint: 'This is a hint: always define only label or placeholder, never both',
+        label: 'Label',
     },
     argTypes: {
         label: {

--- a/suite-native/storybook/decorators/bottomSheetDecorator.tsx
+++ b/suite-native/storybook/decorators/bottomSheetDecorator.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+
+export const bottomSheetDecorator = (Story: React.FC) => (
+    <BottomSheetModalProvider>
+        <Story />
+    </BottomSheetModalProvider>
+);

--- a/suite-native/storybook/decorators/decorators.ts
+++ b/suite-native/storybook/decorators/decorators.ts
@@ -1,4 +1,13 @@
+import { bottomSheetDecorator } from './bottomSheetDecorator';
 import { intlDecorator } from './intlDecorator';
+import { layoutDecorator } from './layoutDecorator';
+import { safeAreaDecorator } from './safeAreaDecorator';
 import { themeDecorator } from './themeDecorator';
 
-export const SHARED_DECORATORS = [intlDecorator, themeDecorator] as const;
+export const SHARED_DECORATORS = [
+    layoutDecorator,
+    bottomSheetDecorator,
+    intlDecorator,
+    safeAreaDecorator,
+    themeDecorator,
+] as const;

--- a/suite-native/storybook/decorators/layoutDecorator.tsx
+++ b/suite-native/storybook/decorators/layoutDecorator.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const storyContainerStyle = prepareNativeStyle(utils => ({
+    flex: 1,
+    paddingTop: utils.spacings.sp32,
+    paddingHorizontal: utils.spacings.sp16,
+    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+    ...StyleSheet.absoluteFillObject,
+}));
+
+const LayoutWrapper = ({ children }: { children: React.ReactNode }) => {
+    const { applyStyle } = useNativeStyles();
+
+    return <View style={applyStyle(storyContainerStyle)}>{children}</View>;
+};
+
+export const layoutDecorator = (Story: React.FC) => (
+    <LayoutWrapper>
+        <Story />
+    </LayoutWrapper>
+);

--- a/suite-native/storybook/decorators/safeAreaDecorator.tsx
+++ b/suite-native/storybook/decorators/safeAreaDecorator.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export const safeAreaDecorator = (Story: React.FC) => (
+    <SafeAreaProvider>
+        <Story />
+    </SafeAreaProvider>
+);

--- a/suite-native/storybook/decorators/themeDecorator.tsx
+++ b/suite-native/storybook/decorators/themeDecorator.tsx
@@ -9,11 +9,7 @@ import { ThemeColorVariant, prepareNativeTheme } from '@trezor/theme';
 
 const renderer = createRenderer();
 
-const storyContainerStyle = prepareNativeStyle(utils => ({
-    flex: 1,
-    paddingTop: utils.spacings.sp32,
-    paddingHorizontal: utils.spacings.sp16,
-    backgroundColor: utils.colors.backgroundSurfaceElevation0,
+const storyContainerStyle = prepareNativeStyle(_ => ({
     ...StyleSheet.absoluteFillObject,
 }));
 

--- a/suite-native/storybook/package.json
+++ b/suite-native/storybook/package.json
@@ -15,6 +15,7 @@
         "storybook:web:build": "yarn storybook build -c .storybook -o .build-storybook"
     },
     "dependencies": {
+        "@gorhom/bottom-sheet": "5.2.6",
         "@lottiefiles/dotlottie-react": "^0.17.8",
         "@react-native-community/datetimepicker": "^8.5.0",
         "@react-native-community/slider": "^5.1.1",
@@ -32,6 +33,7 @@
         "react-intl": "^8.0.6",
         "react-native": "0.81.4",
         "react-native-mmkv": "~4.1.2",
+        "react-native-safe-area-context": "5.6.1",
         "react-native-web": "^0.21.0",
         "storybook": "^10.1.0",
         "vite": "^7.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14047,6 +14047,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/storybook@workspace:suite-native/storybook"
   dependencies:
+    "@gorhom/bottom-sheet": "npm:5.2.6"
     "@lottiefiles/dotlottie-react": "npm:^0.17.8"
     "@react-native-community/datetimepicker": "npm:^8.5.0"
     "@react-native-community/slider": "npm:^5.1.1"
@@ -14064,6 +14065,7 @@ __metadata:
     react-intl: "npm:^8.0.6"
     react-native: "npm:0.81.4"
     react-native-mmkv: "npm:~4.1.2"
+    react-native-safe-area-context: "npm:5.6.1"
     react-native-web: "npm:^0.21.0"
     storybook: "npm:^10.1.0"
     vite: "npm:^7.0.6"


### PR DESCRIPTION
## Summary

- Adds a Storybook story for the `Select` atom creates
	- Refactors shared Storybook decorators: extracts layout (`layoutDecorator`), safe area (`safeAreaDecorator`), and bottom sheet (`bottomSheetDecorator`) that are needed to make select bottom sheet work
- Fixes `TextInput` story labels and removes redundant value/label forwarding in its decorator

## Notes for QA
- test `TextInput` and `Select` components in https://dev.suite.sldev.cz/suite-mobile/components/develop/

## Issues
closes #25312 

## Screenshots

https://github.com/user-attachments/assets/46fe3ef7-7b37-49c5-8b4e-c00d07021d34



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/select-storybook&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/select-storybook&lookback=7)