### PR TITLE
feat(suite-native): Suite sync FW alert

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -174,6 +174,11 @@ export const messages = {
                 'Allow Suite Sync to view and edit your labels, wallet names, and account names.',
             button: 'Allow',
         },
+        suiteSyncFirmwareUpdateAlert: {
+            title: 'Firmware update required',
+            description: 'Update firmware on the device to use Suite Sync.',
+            button: 'Update',
+        },
     },
     accounts: {
         accountLabelFieldHint: {

--- a/suite-native/module-home/src/screens/HomeScreen/components/HomescreenAlerts.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/HomescreenAlerts.tsx
@@ -5,18 +5,27 @@ import { selectShouldDisplayOutOfQuotaAlert } from '@suite-common/suite-sync-quo
 import { SuiteSyncKeysAlert } from './SuiteSyncKeysAlert';
 import {
     selectShouldDisplaySuiteSyncAlert,
+    selectShouldDisplaySuiteSyncFirmwareUpdateAlert,
     selectShouldDisplayUpgradeFirmwareAlert,
 } from '../homescreenSelectors';
 import { FirmwareUpdateAlert } from './FirmwareUpdateAlert';
 import { OutOfQuotaAlert } from './OutOfQuotaAlert';
+import { SuiteSyncFirmwareUpdateAlert } from './SuiteSyncFirmwareUpdateAlert';
 
 export const HomescreenAlerts = () => {
     const shouldDisplayOutOfQuotaAlert = useSelector(selectShouldDisplayOutOfQuotaAlert);
     const shouldDisplaySuiteSyncAlert = useSelector(selectShouldDisplaySuiteSyncAlert);
+    const shouldDisplaySuiteSyncFirmwareUpdateAlert = useSelector(
+        selectShouldDisplaySuiteSyncFirmwareUpdateAlert,
+    );
     const shouldDisplayFirmwareUpdateAlert = useSelector(selectShouldDisplayUpgradeFirmwareAlert);
 
     if (shouldDisplaySuiteSyncAlert) {
         return <SuiteSyncKeysAlert />;
+    }
+
+    if (shouldDisplaySuiteSyncFirmwareUpdateAlert) {
+        return <SuiteSyncFirmwareUpdateAlert />;
     }
 
     if (shouldDisplayFirmwareUpdateAlert) {

--- a/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncFirmwareUpdateAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncFirmwareUpdateAlert.tsx
@@ -1,0 +1,46 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { selectIsDeviceConnected } from '@suite-common/device';
+import { AnimatedFullAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    DeviceSettingsStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
+
+import { selectShouldDisplaySuiteSyncFirmwareUpdateAlert } from '../homescreenSelectors';
+
+export const SuiteSyncFirmwareUpdateAlert = () => {
+    const shouldDisplaySuiteSyncFirmwareUpdateAlert = useSelector(
+        selectShouldDisplaySuiteSyncFirmwareUpdateAlert,
+    );
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.AppTabs>>();
+
+    if (!shouldDisplaySuiteSyncFirmwareUpdateAlert || !isDeviceConnected) {
+        return null;
+    }
+
+    const handleUpdateFirmware = () => {
+        navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
+            screen: DeviceSettingsStackRoutes.DeviceFirmware,
+            params: { closeActionType: 'close' },
+        });
+    };
+
+    return (
+        <AnimatedFullAlertBox
+            variant="info"
+            title={<Translation id="moduleHome.suiteSyncFirmwareUpdateAlert.title" />}
+            description={<Translation id="moduleHome.suiteSyncFirmwareUpdateAlert.description" />}
+            primaryButtonLabel={<Translation id="moduleHome.suiteSyncFirmwareUpdateAlert.button" />}
+            onPressPrimaryButton={handleUpdateFirmware}
+            marginHorizontal="sp16"
+        />
+    );
+};

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -60,3 +60,11 @@ export const selectShouldDisplaySuiteSyncAlert = createMemoizedSelector(
     (hasSuiteSyncError, isDeviceConnected, interactionNeeded) =>
         interactionNeeded === 'keys-needed' && (hasSuiteSyncError || !isDeviceConnected),
 );
+
+export const selectShouldDisplaySuiteSyncFirmwareUpdateAlert = createMemoizedSelector(
+    [
+        (state: WithSuiteSyncState & DeviceRootState) =>
+            selectSuiteSyncInteraction(state, selectDeviceStaticSessionId(state)),
+    ],
+    interactionNeeded => interactionNeeded === 'firmware-upgrade-needed',
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- FW alert for suite sync unsupported device
- It's similar to general FW alert, but the displaying logic is quite different, so I decided not to overcomplicate it and just separate them

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24290



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-sync/firmware-alert&lookback=7)