### PR TITLE
feat(suite): add FakeSelect component and integrate into TradingForm inputs

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -61,7 +61,11 @@ export * from './components/Divider/Divider';
 export * from './components/Dropdown/Dropdown';
 export * from './components/ElevationContext/ElevationContext';
 export * from './components/Flex/Flex';
-export { FormCell, type FormCellProps } from './components/form/FormCell/FormCell';
+export {
+    FormCell,
+    pickFormCellProps,
+    type FormCellProps,
+} from './components/form/FormCell/FormCell';
 export * from './components/form/Input/Input';
 export * from './components/form/Radio/Radio';
 export * from './components/form/Range/Range';

--- a/packages/suite/src/components/suite/FakeSelect.tsx
+++ b/packages/suite/src/components/suite/FakeSelect.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+import {
+    FormCellProps,
+    Icon,
+    Input,
+    InputProps,
+    Spinner,
+    pickFormCellProps,
+} from '@trezor/components';
+
+const FakeSelectContainer = styled.button`
+    border: unset;
+    background: unset;
+    box-shadow: unset;
+    font-size: inherit;
+
+    cursor: pointer;
+
+    & input {
+        cursor: pointer;
+    }
+`;
+
+export type FakeSelectProps = Omit<FormCellProps, 'children'> &
+    Pick<InputProps, 'value' | 'placeholder' | 'size'> & {
+        isLoading?: boolean;
+        onClick: () => void;
+    };
+
+export const FakeSelect = (props: FakeSelectProps) => {
+    const {
+        value,
+        placeholder,
+        isDisabled = false,
+        isLoading = false,
+        size = 'large',
+        onClick,
+        'data-testid': dataTestId,
+        ...rest
+    } = props;
+
+    const formCellProps = pickFormCellProps(rest);
+    const leftContent = isLoading ? <Spinner size={20} /> : undefined;
+
+    return (
+        <FakeSelectContainer type="button" onClick={onClick} disabled={isDisabled}>
+            <Input
+                {...formCellProps}
+                value={value}
+                placeholder={placeholder}
+                size={size}
+                leftContent={leftContent}
+                disabled={isDisabled}
+                rightContent={
+                    <Icon name="caretDown" size={20} intent="neutral" priority="secondary" />
+                }
+                data-testid={dataTestId}
+                readOnly
+            />
+        </FakeSelectContainer>
+    );
+};

--- a/packages/suite/src/components/suite/index.tsx
+++ b/packages/suite/src/components/suite/index.tsx
@@ -8,6 +8,7 @@ import { AccountLabel } from './AccountLabel';
 import { Address } from './Address';
 import { DeviceConfirmImage } from './DeviceConfirmImage';
 import { CheckItem } from './CheckItem';
+import { FakeSelect } from './FakeSelect';
 import { PrerequisitesGuide } from './PrerequisitesGuide/PrerequisitesGuide';
 import { WordInput } from './WordInput';
 import { WordInputAdvanced } from './WordInputAdvanced';
@@ -60,6 +61,7 @@ export {
     AccountLabel,
     DeviceConfirmImage,
     CheckItem,
+    FakeSelect,
     PrerequisitesGuide,
     BaseCurrencyValue,
     WordInput,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -1,16 +1,25 @@
 import { useState } from 'react';
 
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
 import { TRADING_FORM_COUNTRY_SELECT } from '@suite-common/trading';
 import { GhostContainer, Icon, Row, Text } from '@trezor/components';
 
+import { FakeSelect } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import { TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
 
 import { CountrySelectModal } from './CountrySelectModal';
 
-export const TradingFormInputCountry = ({ label }: TradingFormInputDefaultProps) => {
+interface TradingFormInputCountryProps extends TradingFormInputDefaultProps {
+    renderInput?: boolean;
+}
+
+export const TradingFormInputCountry = ({
+    label,
+    renderInput = false,
+}: TradingFormInputCountryProps) => {
+    const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const { watch, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
 
@@ -18,20 +27,33 @@ export const TradingFormInputCountry = ({ label }: TradingFormInputDefaultProps)
 
     return (
         <>
-            <GhostContainer onClick={() => setIsModalOpen(true)} borderRadius={0}>
-                <Row alignItems="center" justifyContent="space-between" padding={20}>
-                    <Text typographyStyle="body" align="start">
-                        {label && <Translation id={label} />}
-                    </Text>
-
-                    <Row gap={16}>
-                        <Text typographyStyle="body">
-                            {countryValue?.label ?? defaultCountry?.label ?? ''}
+            {renderInput && (
+                <FakeSelect
+                    value={countryValue?.label ?? defaultCountry?.label ?? ''}
+                    placeholder={label ? translationString(label) : undefined}
+                    onClick={() => setIsModalOpen(true)}
+                />
+            )}
+            {!renderInput && (
+                <GhostContainer onClick={() => setIsModalOpen(true)} borderRadius={0}>
+                    <Row alignItems="center" justifyContent="space-between" padding={20}>
+                        <Text typographyStyle="body-md" align="start">
+                            {label && <Translation id={label} />}
                         </Text>
-                        <Icon name="caretRight" size={20} variant="tertiary" />
+                        <Row gap={16}>
+                            <Text typographyStyle="body-md">
+                                {countryValue?.label ?? defaultCountry?.label ?? ''}
+                            </Text>
+                            <Icon
+                                name="caretRight"
+                                size={20}
+                                intent="neutral"
+                                priority="secondary"
+                            />
+                        </Row>
                     </Row>
-                </Row>
-            </GhostContainer>
+                </GhostContainer>
+            )}
             {isModalOpen && (
                 <CountrySelectModal onClose={() => setIsModalOpen(false)} heading={label} />
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import type { ReactNode } from 'react';
 
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
 import { TRADING_FORM_PAYMENT_METHOD_SELECT } from '@suite-common/trading';
 import { GhostContainer, Icon, Row, SkeletonRectangle, Text } from '@trezor/components';
 
+import { FakeSelect } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import { TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
@@ -26,13 +27,23 @@ const TradingFormInputPaymentMethodValueContent = ({
 
     return (
         <Row gap={16}>
-            <Text typographyStyle={hasPaymentMethods ? 'body' : undefined}>{displayLabel}</Text>
-            {hasPaymentMethods && <Icon name="caretRight" size={20} variant="tertiary" />}
+            <Text typographyStyle={hasPaymentMethods ? 'body-md' : undefined}>{displayLabel}</Text>
+            {hasPaymentMethods && (
+                <Icon name="caretRight" size={20} intent="neutral" priority="secondary" />
+            )}
         </Row>
     );
 };
 
-export const TradingFormInputPaymentMethod = ({ label }: TradingFormInputDefaultProps) => {
+interface TradingFormInputPaymentMethodProps extends TradingFormInputDefaultProps {
+    renderInput?: boolean;
+}
+
+export const TradingFormInputPaymentMethod = ({
+    label,
+    renderInput = false,
+}: TradingFormInputPaymentMethodProps) => {
+    const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const {
@@ -51,30 +62,39 @@ export const TradingFormInputPaymentMethod = ({ label }: TradingFormInputDefault
         ? paymentMethods.find(item => item.value === (paymentMethod?.value ?? defaultPaymentMethod))
         : undefined;
 
-    const displayLabel = hasPaymentMethods ? (
-        (selectedOption?.label ?? paymentMethod?.label ?? paymentMethods[0]?.label ?? '')
-    ) : (
-        <Translation id="TR_TRADING_NO_METHODS_AVAILABLE" />
-    );
+    const displayLabel = hasPaymentMethods
+        ? (selectedOption?.label ?? paymentMethod?.label ?? paymentMethods[0]?.label ?? '')
+        : translationString('TR_TRADING_NO_METHODS_AVAILABLE');
 
     return (
         <>
-            <GhostContainer
-                onClick={() => setIsModalOpen(true)}
-                isDisabled={!hasPaymentMethods || isFormLoading}
-                borderRadius={0}
-            >
-                <Row alignItems="center" justifyContent="space-between" padding={20}>
-                    <Text typographyStyle="body" align="start">
-                        {label && <Translation id={label} />}
-                    </Text>
-                    <TradingFormInputPaymentMethodValueContent
-                        isFormLoading={isFormLoading}
-                        hasPaymentMethods={hasPaymentMethods}
-                        displayLabel={displayLabel}
-                    />
-                </Row>
-            </GhostContainer>
+            {renderInput && (
+                <FakeSelect
+                    value={displayLabel}
+                    placeholder={label ? translationString(label) : undefined}
+                    onClick={() => setIsModalOpen(true)}
+                    isLoading={isFormLoading}
+                    isDisabled={isFormLoading || !hasPaymentMethods}
+                />
+            )}
+            {!renderInput && (
+                <GhostContainer
+                    onClick={() => setIsModalOpen(true)}
+                    isDisabled={!hasPaymentMethods || isFormLoading}
+                    borderRadius={0}
+                >
+                    <Row alignItems="center" justifyContent="space-between" padding={20}>
+                        <Text typographyStyle="body-md" align="start">
+                            {label && <Translation id={label} />}
+                        </Text>
+                        <TradingFormInputPaymentMethodValueContent
+                            isFormLoading={isFormLoading}
+                            hasPaymentMethods={hasPaymentMethods}
+                            displayLabel={displayLabel}
+                        />
+                    </Row>
+                </GhostContainer>
+            )}
             {isModalOpen && hasPaymentMethods && (
                 <PaymentMethodModal onClose={() => setIsModalOpen(false)} heading={label} />
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
@@ -60,10 +60,10 @@ export const TradingHeaderFilter = () => {
                 </InputWrapper>
             )}
             <InputWrapper>
-                <TradingFormInputPaymentMethod />
+                <TradingFormInputPaymentMethod renderInput />
             </InputWrapper>
             <InputWrapper>
-                <TradingFormInputCountry />
+                <TradingFormInputCountry renderInput />
             </InputWrapper>
         </Row>
     );


### PR DESCRIPTION
## Title
**feat(suite): add FakeSelect component and integrate into TradingForm inputs**

## Description

- **FakeSelect component**  
  New reusable component in `packages/suite/src/components/suite/FakeSelect.tsx` that renders an input-style control (read-only, with caret icon) and triggers a callback on click instead of opening a native select. It supports `Input` props such as `labelLeft`, `labelRight`, `bottomText`, `hasError`, loading and disabled states, and is exported from the suite components index.

- **Trading form integration**  
  - **Country:** `TradingFormInputCountry` uses `FakeSelect` when `renderInput` is true, showing the selected country label and opening `CountrySelectModal` on click; the existing `GhostContainer` row is still used when `renderInput` is false.  
  - **Payment method:** `TradingFormInputPaymentMethod` uses `FakeSelect` when `renderInput` is true, with loading/disabled handling and opening `PaymentMethodModal` on click; the `GhostContainer` variant remains for the non-input layout.

- **Consistency**  
  Trading form “select” fields that open modals now share the same input-like look and behavior where the form is rendered in input mode, improving consistency and UX.


## Notes for QA

- **Trading flow (Buy/Sell):**  
  - Go to a view where the trading form uses the input layout (e.g. country and payment method shown as input-like fields).  
  - Confirm country and payment method show as a single line with value and caret, open the correct modal on click, and update the displayed value after selection.  
  - For payment method, confirm loading and disabled states (e.g. no methods) are reflected and the field is not clickable when disabled.

- **Other layouts:**  
  Where the form uses the non-input layout (e.g. row with label + value + caret), behavior should be unchanged (still opens the same modals).

- **Accessibility / UX:**  
  - Keyboard: ensure the control is focusable and activates with Enter/Space where applicable.  
  - Check that error and bottom text (if used) still display correctly with `FakeSelect`.

## Related Issue

Resolve #25330 

<img width="1215" height="437" alt="image" src="https://github.com/user-attachments/assets/0a5a4a4b-a107-4fc9-813a-dd5cefb6e35d" />
