### PR TITLE
fix: make filterig for account label more explicit

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
@@ -21,6 +21,7 @@ export function useFilterAccountsWithTokens(
                         case 'account':
                             return accountSearchFn(item.account, search, {
                                 tokensMatch: false,
+                                accountLabel: '', // Todo: select label from SuiteSync
                             });
 
                         case 'token':

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
@@ -14,7 +14,10 @@ export function useFilterAccounts(accounts: AccountOption[]) {
         () =>
             accounts.filter(account =>
                 search || networkSymbol
-                    ? accountSearchFn(account.account, search, { coinsFilter: networkSymbol })
+                    ? accountSearchFn(account.account, search, {
+                          coinsFilter: networkSymbol,
+                          accountLabel: '', // Todo: select label from SuiteSync
+                      })
                     : true,
             ),
         [accounts, networkSymbol, search],

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -9,7 +9,7 @@ import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
-import { selectAccountLabels as selectAccountLabelsOld } from 'src/reducers/suite/metadataReducer';
+import { selectAccountLabels as selectAccountLabelsLegacy } from 'src/reducers/suite/metadataReducer';
 import { selectRouterParams } from 'src/reducers/suite/routerReducer';
 import { AccountItemType } from 'src/types/wallet';
 import { RouteParams } from 'src/utils/suite/router';
@@ -89,7 +89,7 @@ export const AccountsList = ({
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const coinjoinIsPreloading = useSelector(state => state.wallet.coinjoin.isPreloading);
-    const accountLabels = useSelector(selectAccountLabelsOld);
+    const accountLabels = useSelector(selectAccountLabelsLegacy);
 
     const suiteSyncAccounts = useSelector(state => {
         if (!device?.state?.staticSessionId) return [];
@@ -111,7 +111,11 @@ export const AccountsList = ({
         searchString || coinFilter
             ? accounts.filter(account => {
                   const { key, accountType, symbol, index } = account;
-                  const accountLabelOld = Object.prototype.hasOwnProperty.call(accountLabels, key)
+
+                  const accountLabelLegacy = Object.prototype.hasOwnProperty.call(
+                      accountLabels,
+                      key,
+                  )
                       ? accountLabels[key]
                       : getDefaultAccountLabel({ accountType, symbol, index });
 
@@ -122,11 +126,13 @@ export const AccountsList = ({
                           accounts: suiteSyncAccounts,
                           accountDescriptor,
                           networkSymbol,
-                      })?.label ?? accountLabelOld;
+                      })?.label ??
+                      accountLabelLegacy ??
+                      '';
 
                   return accountSearchFn(account, searchString, {
                       coinsFilter: coinFilter,
-                      metadataAccountLabel: accountLabel,
+                      accountLabel,
                   });
               })
             : accounts;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -190,6 +190,7 @@ export function useBuildTradingAssetOptions({
                     case 'account':
                         return accountSearchFn(accountOrToken.account, search, {
                             tokensMatch: false,
+                            accountLabel: '', // Todo: select label from SuiteSync
                         });
                     case 'token':
                         return isTokenMatchesSearch(accountOrToken.token, search);

--- a/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataSelectors.ts
@@ -148,7 +148,7 @@ export const findSuiteSyncAccountLabel = (params: {
     accounts: SuiteSyncAccount[];
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
-}) =>
+}): SuiteSyncAccount | undefined =>
     params.accounts.find(
         account =>
             account.accountDescriptor === params.accountDescriptor &&

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -190,41 +190,41 @@ describe('account utils', () => {
                     aesKey: 'foo',
                 },
             },
-            accountLabel: 'meow',
         });
 
-        expect(accountSearchFn(btcAcc, 'btc')).toBe(true);
-        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'btc' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'btc', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'btc', accountLabel: '' })).toBe(true);
         expect(
             accountSearchFn(
                 btcAcc,
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
-                { coinsFilter: 'btc' },
+                { coinsFilter: 'btc', accountLabel: '' },
             ),
         ).toBe(true);
-        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'ltc' })).toBe(false);
-        expect(accountSearchFn(btcAcc, 'bitcoin')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'legacy')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'bitco')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'ltc')).toBe(false);
-        expect(accountSearchFn(btcAcc, 'litecoin')).toBe(false);
-        expect(accountSearchFn(btcAcc, 'meow')).toBe(true);
+        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'ltc', accountLabel: '' })).toBe(false);
+        expect(accountSearchFn(btcAcc, 'bitcoin', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'legacy', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'bitco', { accountLabel: '' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'ltc', { accountLabel: '' })).toBe(false);
+        expect(accountSearchFn(btcAcc, 'litecoin', { accountLabel: '' })).toBe(false);
+        expect(accountSearchFn(btcAcc, 'meow', { accountLabel: 'meow' })).toBe(true);
         expect(
             accountSearchFn(btcAcc, 'wuff', {
-                metadataAccountLabel: 'wuff',
+                accountLabel: 'wuff',
             }),
         ).toBe(true);
-        expect(accountSearchFn(btcAcc, 'meo')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'eow')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'MEOW')).toBe(true);
-        expect(accountSearchFn(btcAcc, 'wuff')).toBe(false);
+        expect(accountSearchFn(btcAcc, 'meo', { accountLabel: 'meow' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'eow', { accountLabel: 'meow' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'MEOW', { accountLabel: 'meow' })).toBe(true);
+        expect(accountSearchFn(btcAcc, 'wuff', { accountLabel: '' })).toBe(false);
         expect(
             accountSearchFn(
                 btcAcc,
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
+                { accountLabel: '' },
             ),
         ).toBe(true);
-        expect(accountSearchFn(btcAcc, '#1', { metadataAccountLabel: 'Bitcoin #1' })).toBe(true);
+        expect(accountSearchFn(btcAcc, '#1', { accountLabel: 'Bitcoin #1' })).toBe(true);
     });
 
     it('getNetworkAccountFeatures', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -810,17 +810,18 @@ export const getAccountIdentifier = (account: Account) => ({
 
 export type AccountSearchParams = {
     coinsFilter?: NetworkSymbol[] | NetworkSymbol;
-    metadataAccountLabel?: string;
-    /**
-     * Return true if the account has token that match the search string
-     */
+
+    /** Needs to be mandatory, so it is no forgotten. */
+    accountLabel: string;
+
+    /** Return true if the account has token that match the search string */
     tokensMatch?: boolean;
 };
 
 export const accountSearchFn = (
     account: Account,
     rawSearchString: string | undefined,
-    { coinsFilter, metadataAccountLabel, tokensMatch = true }: AccountSearchParams = {},
+    { coinsFilter, accountLabel, tokensMatch = true }: AccountSearchParams,
 ) => {
     let coinsFilterArray: NetworkSymbol[] = [];
 
@@ -862,8 +863,7 @@ export const accountSearchFn = (
     const matchXRPAlternativeName =
         network?.networkType === 'ripple' && 'ripple'.includes(searchString);
 
-    const metadataMatch = !!metadataAccountLabel?.toLowerCase().includes(searchString);
-    const accountLabelMatch = !!account.accountLabel?.toLowerCase().includes(searchString);
+    const accountLabelMatch = !!accountLabel?.toLowerCase().includes(searchString);
 
     const filterTokens = (token: TokenInfo) =>
         token.name?.toLowerCase().includes(searchString) ||
@@ -881,7 +881,6 @@ export const accountSearchFn = (
         descriptorMatch ||
         addressMatch ||
         matchXRPAlternativeName ||
-        metadataMatch ||
         accountLabelMatch ||
         tokenMatch
     );


### PR DESCRIPTION
Testing: Filtering of the accounts in the left-panel shall work the same (for both legacy & suite-sync) labeling

<img width="662" height="252" alt="image" src="https://github.com/user-attachments/assets/0e458282-cfdd-44d0-9129-d6342ca588d5" />


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=account-label2&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=account-label2&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=account-label2&lookback=7)