### PR TITLE
chore: add favicon.js to ignored files list

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -36,6 +36,7 @@ export const eslint = [
             'eslint-local-rules/*',
             '**/.cache/*',
             '**/playwright-report/*',
+            '**/suite-data/files/favicon.js',
         ],
     },
     { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description:
- Add packages/suite-data/files/favicon.js to the shared ESLint ignore list in packages/eslint/src/index.mjs.
- The file is a minified build artifact already ignored by Prettier (.prettierignore). ESLint was still formatting it on yarn g:eslint --fix / format scripts, so it showed as modified after checkout and lint/format.
- With this ignore, favicon.js is no longer touched by ESLint and stays minified as committed.

## Notes for QA

Just dev thing


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/favicon-ignore&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/favicon-ignore&lookback=7)