### PR TITLE
fix(suite-sync): disconnected key retrieval not blocked

### DIFF
--- a/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createRefreshSuiteSyncKeys.ts
@@ -35,13 +35,6 @@ export const createRefreshSuiteSync =
 
         const deviceStaticId = device.state.staticSessionId;
 
-        if (
-            !device.connected || // disconnected device cannot resolve Evolu-Keys
-            device.mode !== 'normal' // bootloader
-        ) {
-            return err(SuiteSyncUnavailableOnDeviceError());
-        }
-
         const getDelegatedIdentityKeys = async () => {
             const delegatedKeyResult = await deps.ensureDelegatedIdentityKey({ device });
 

--- a/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/tests/createRefreshSuiteSync.test.ts
@@ -62,18 +62,6 @@ describe(createRefreshSuiteSync.name, () => {
         expect(!result.success && result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
     });
 
-    it('fails to get keys when device is disconnected', async () => {
-        const deps = createMockDeps();
-
-        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
-        const result = await refreshSuiteSyncKeys({
-            device: createDevice({ connected: false }),
-        });
-
-        expect(result.success).toEqual(false);
-        expect(!result.success && result.error.type).toEqual('SuiteSyncUnavailableOnDeviceError');
-    });
-
     it('ensures that the delegated identity key is available', async () => {
         const deps = createMockDeps();
         deps.dispatch.mockImplementation(() => Promise.resolve(ok()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Key retrieval was blocked on disconnected devices leading to the evolu storage now being set. This will hotfix it for disconnected devices which already have the correct keys but there will need to be follow up for when user doesn't have the keys in redux storage at all. There is at least toast notification for it though. 

Resolve https://github.com/trezor/trezor-suite/issues/25357

## Notes for QA
Test that when you turn on suite sync and then disconnect device, you are able to edit labels.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/ensure-keys&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/ensure-keys&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/ensure-keys&lookback=7)