### PR TITLE
feat(suite-desktop-core): add check for path traversal

### DIFF
--- a/packages/suite-desktop-core/src/__tests__/user-data.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/user-data.test.ts
@@ -1,0 +1,80 @@
+import { open, read, readDir, rename, save } from '../libs/user-data';
+
+jest.mock('electron', () => ({
+    app: {
+        getPath: jest.fn(() => '/tmp/user-data'),
+    },
+}));
+
+jest.mock('@suite-common/suite-utils', () => ({
+    isDevEnv: false,
+}));
+
+describe('user-data path traversal protection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.logger = {
+            error: jest.fn(),
+        } as any;
+    });
+
+    it('rejects file path traversal in save()', async () => {
+        const result = await save('/metadata', '../../../OtherApp/outside.txt', 'payload', 'utf-8');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, file: "../../../OtherApp/outside.txt"',
+        });
+    });
+
+    it('rejects directory and file path traversal in save()', async () => {
+        const result = await save('../../metadata', '../outside.txt', 'payload', 'utf-8');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../../metadata"',
+        });
+    });
+
+    it('rejects file path traversal in read()', async () => {
+        const result = await read('/metadata', '../../outside.txt');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, file: "../../outside.txt"',
+        });
+    });
+
+    it('rejects file path traversal in rename()', async () => {
+        const result = await rename('/metadata', 'labels.json', '../outside.txt');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, file: "../outside.txt"',
+        });
+    });
+
+    it('rejects directory path traversal in readDir()', async () => {
+        const result = await readDir('../../OtherApp');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../../OtherApp"',
+        });
+    });
+
+    it('allows reading user data root directory', async () => {
+        const result = await readDir('');
+
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects directory path traversal in open()', async () => {
+        const result = await open('../../OtherApp');
+
+        expect(result).toStrictEqual({
+            success: false,
+            error: 'Path traversal attempt detected, directory: "../../OtherApp"',
+        });
+    });
+});

--- a/packages/suite-desktop-core/src/libs/user-data.ts
+++ b/packages/suite-desktop-core/src/libs/user-data.ts
@@ -3,7 +3,43 @@ import fs from 'fs';
 import path from 'path';
 
 import { isDevEnv } from '@suite-common/suite-utils';
-import { InvokeResult } from '@trezor/suite-desktop-api';
+import type { InvokeResult } from '@trezor/suite-desktop-api';
+import type { Result } from '@trezor/type-utils';
+
+const resolveDirectoryInUserDataDir = (directory: string): Result<{ dir: string }, string> => {
+    const userDataDir = path.resolve(app.getPath('userData'));
+    const dir = path.resolve(path.join(userDataDir, directory));
+
+    if (!dir.startsWith(userDataDir)) {
+        return {
+            success: false,
+            error: `Path traversal attempt detected, directory: "${directory}"`,
+        };
+    }
+
+    return { success: true, payload: { dir } };
+};
+
+const resolvePathInUserDataDir = (
+    directory: string,
+    filename: string,
+): Result<{ dir: string; file: string }, string> => {
+    const dirResult = resolveDirectoryInUserDataDir(directory);
+    if (!dirResult.success) {
+        return dirResult;
+    }
+    const { dir } = dirResult.payload;
+    const file = path.resolve(dir, filename);
+
+    if (!file.startsWith(dir + path.sep)) {
+        return {
+            success: false,
+            error: `Path traversal attempt detected, file: "${filename}"`,
+        };
+    }
+
+    return { success: true, payload: { dir, file } };
+};
 
 export const clearAppCache = () =>
     new Promise<void>((resolve, reject) => {
@@ -13,7 +49,7 @@ export const clearAppCache = () =>
 
 /**
  * By default, Electron uses the app name from package.json to construct the userData directory.
- * It's overriten in electron-builder-config.js for builds. And here for local development.
+ * It's overwritten in electron-builder-config.js for builds. And here for local development.
  * Default (codesigned builds): @trezor/suite-desktop,
  * Dev (non-production builds): @trezor/suite-desktop-dev
  * Local development: @trezor/suite-desktop-local
@@ -40,8 +76,11 @@ export const save: {
         encoding: 'binary',
     ): Promise<InvokeResult>;
 } = async (directory, name, content, encoding) => {
-    const dir = path.join(app.getPath('userData'), directory);
-    const file = path.join(dir, name);
+    const resolvedPathResult = resolvePathInUserDataDir(directory, name);
+    if (!resolvedPathResult.success) {
+        return { success: false, error: resolvedPathResult.error };
+    }
+    const { dir, file } = resolvedPathResult.payload;
 
     let data: string | Buffer;
     if (encoding === 'binary') {
@@ -68,8 +107,11 @@ export const save: {
 };
 
 export const read = async (directory: string, name: string): Promise<InvokeResult<string>> => {
-    const dir = path.join(app.getPath('userData'), directory);
-    const file = path.join(dir, name);
+    const resolvedPathResult = resolvePathInUserDataDir(directory, name);
+    if (!resolvedPathResult.success) {
+        return { success: false, error: resolvedPathResult.error };
+    }
+    const { file } = resolvedPathResult.payload;
 
     try {
         await fs.promises.access(file, fs.constants.R_OK);
@@ -89,7 +131,11 @@ export const read = async (directory: string, name: string): Promise<InvokeResul
 };
 
 export const readDir = async (directory: string): Promise<InvokeResult<string[]>> => {
-    const dir = path.join(app.getPath('userData'), directory);
+    const resolvedDirResult = resolveDirectoryInUserDataDir(directory);
+    if (!resolvedDirResult.success) {
+        return { success: false, error: resolvedDirResult.error };
+    }
+    const { dir } = resolvedDirResult.payload;
 
     try {
         await fs.promises.access(dir, fs.constants.R_OK);
@@ -116,10 +162,20 @@ export const rename = async (
     from: string,
     to: string,
 ): Promise<InvokeResult> => {
-    const dir = path.join(app.getPath('userData'), directory);
+    const resolvedFromResult = resolvePathInUserDataDir(directory, from);
+    if (!resolvedFromResult.success) {
+        return { success: false, error: resolvedFromResult.error };
+    }
+    const { file: fromPath } = resolvedFromResult.payload;
+
+    const resolvedToResult = resolvePathInUserDataDir(directory, to);
+    if (!resolvedToResult.success) {
+        return { success: false, error: resolvedToResult.error };
+    }
+    const { file: toPath } = resolvedToResult.payload;
 
     try {
-        await fs.promises.rename(path.join(dir, from), path.join(dir, to));
+        await fs.promises.rename(fromPath, toPath);
 
         return { success: true };
     } catch (error) {
@@ -148,7 +204,12 @@ export const getInfo = () => ({
 });
 
 export const open = async (directory: string): Promise<InvokeResult> => {
-    const dir = path.join(app.getPath('userData'), directory);
+    const resolvedDirResult = resolveDirectoryInUserDataDir(directory);
+    if (!resolvedDirResult.success) {
+        return { success: false, error: resolvedDirResult.error };
+    }
+    const { dir } = resolvedDirResult.payload;
+
     try {
         const errorMessage = await shell.openPath(dir);
         if (errorMessage) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is just a precaution in case Suite's database was compromised. When using local storage for labels, the filename is stored in the database. If the filename was prefixed by `../`, user could unintentionally override their files with labelling data.

## Notes for QA

Not really reproducible unless some other vulnerability allows for it. You can play with it on this [testing branch](https://github.com/trezor/trezor-suite/tree/feat/path-traversal-guard-testing). If you enable filesystem storage for labeling and try adding a label for an account name, you should see the error toast. If you drop the commit in this PR, the label will be saved but the file will be outside of Suite directory in Application Support root 😬 

## Screenshots:
<img width="511" height="240" alt="Screenshot 2026-02-20 at 17 43 53" src="https://github.com/user-attachments/assets/f374a70e-8033-4a8e-95a5-cd5f1b392094" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/path-traversal-guard&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/path-traversal-guard&lookback=7)