### PR TITLE
Feat/native/trade compose approval fees

### DIFF
--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -18,6 +18,7 @@ module.exports = {
     watchPathIgnorePatterns,
     moduleNameMapper: {
         ...moduleNameMapper,
+        '^@evolu/common$': '<rootDir>/../../suite-native/test-utils/src/mocks/evoluMock.ts',
         '^@evolu/common/evolu$': '<rootDir>/../../suite-native/test-utils/src/mocks/evoluMock.ts',
         '^@evolu/react-native/expo-sqlite$':
             '<rootDir>/../../suite-native/test-utils/src/mocks/evoluMock.ts',

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -44,6 +44,7 @@ import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingComposedTransactionInfo,
     selectTradingExchange,
+    selectTradingExchangeActiveQuote,
     selectTradingExchangeBuyCryptoIds,
     selectTradingExchangeFormStep,
     selectTradingExchangeInfo,
@@ -596,6 +597,33 @@ describe('tradingSelectors', () => {
         expect(selectTradingExchangeSelectedQuote(state)).toBe(
             state.wallet.trading.exchange.selectedQuote,
         );
+    });
+
+    describe('selectTradingExchangeActiveQuote', () => {
+        it('should return selectedQuote when it is defined', () => {
+            state.wallet.trading.exchange.selectedQuote = invityAPIFixtures.exchangeTrade;
+            state.wallet.trading.exchange.preselectedQuote = {
+                ...invityAPIFixtures.exchangeTrade,
+                exchange: 'preselected-exchange',
+            };
+
+            expect(selectTradingExchangeActiveQuote(state)).toBe(
+                state.wallet.trading.exchange.selectedQuote,
+            );
+        });
+
+        it('should fall back to preselectedQuote when selectedQuote is undefined', () => {
+            state.wallet.trading.exchange.selectedQuote = undefined;
+            state.wallet.trading.exchange.preselectedQuote = invityAPIFixtures.exchangeTrade;
+
+            expect(selectTradingExchangeActiveQuote(state)).toBe(
+                state.wallet.trading.exchange.preselectedQuote,
+            );
+        });
+
+        it('should return undefined when both quotes are undefined', () => {
+            expect(selectTradingExchangeActiveQuote(state)).toBeUndefined();
+        });
     });
 
     it('selectTradingSellSelectedQuote should return correct data', () => {

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -292,6 +292,9 @@ export const selectTradingExchangeSelectedQuote = (state: TradingRootState) =>
 export const selectTradingExchangePreselectedQuote = (state: TradingRootState) =>
     state.wallet.trading.exchange.preselectedQuote;
 
+export const selectTradingExchangeActiveQuote = (state: TradingRootState) =>
+    selectTradingExchangeSelectedQuote(state) ?? selectTradingExchangePreselectedQuote(state);
+
 export const selectTradingSellSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.sell.selectedQuote;
 

--- a/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
@@ -9,7 +9,6 @@ import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeAccountKey,
-    selectTradingExchangeQuotesRequest,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
 } from '../../selectors/tradingSelectors';
@@ -38,7 +37,6 @@ export const confirmApprovalThunk = createThunk(
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
-        const quotesRequest = selectTradingExchangeQuotesRequest(getState());
         const sendAccountKey = selectTradingExchangeAccountKey(getState());
         const receiveAccountKey = selectTradingExchangeReceiveAccountKey(getState());
         const { address: refundAddress } = getUnusedAddressFromAccount(account);
@@ -47,7 +45,7 @@ export const confirmApprovalThunk = createThunk(
             trade = selectedQuote;
         }
 
-        if (!quotesRequest || !trade || !refundAddress || !trade.quoteId || !receiveAddress) {
+        if (!refundAddress || !trade?.quoteId || !receiveAddress) {
             return undefined;
         }
 

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -62,6 +62,8 @@ export const sendDexTransactionThunk = createThunk<
             !selectedQuote.receiveAddress ||
             (selectedQuote.status !== 'APPROVAL_REQ' && selectedQuote.status !== 'CONFIRM')
         ) {
+            console.error('Failed to send dex transaction - invalid quote');
+
             return rejectWithValue({
                 type: 'error',
                 error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
@@ -115,6 +117,8 @@ export const sendDexTransactionThunk = createThunk<
 
         if (isRejectedWithValue(recomposeAndSignTx) || !recomposeAndSignTx.payload?.success) {
             const { payload } = recomposeAndSignTx;
+
+            console.error('Failed to send dex transaction - sign tx error');
 
             return rejectWithValue({
                 type: payload && 'type' in payload ? payload.type : 'sign-tx-error',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2568,6 +2568,7 @@ export const messages = {
             },
         },
         composeAllowanceError: 'Failed to estimate approval fees. Please try again.',
+        confirmApprovalError: 'Failed to confirm approval. Please try again.',
         tradingExchangeApprovalScreen: {
             title: 'Set {symbol} spending',
             subtitle:

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2567,6 +2567,7 @@ export const messages = {
                 },
             },
         },
+        composeAllowanceError: 'Failed to estimate approval fees. Please try again.',
         tradingExchangeApprovalScreen: {
             title: 'Set {symbol} spending',
             subtitle:

--- a/suite-native/module-trading/src/__tests__/thunks.test.ts
+++ b/suite-native/module-trading/src/__tests__/thunks.test.ts
@@ -1,10 +1,27 @@
+import type { ExchangeTrade } from 'invity-api';
+
 import {
     tradingBuyActions,
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
+import { TestStore, initStore } from '@suite-native/test-utils';
+import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
-import { clearTradingStateThunk } from '../thunks';
+import { clearTradingStateThunk, composeEvmApprovalFeeLevelsThunk } from '../thunks';
+
+jest.mock('@trezor/connect', () => ({
+    ...jest.requireActual('@trezor/connect'),
+    default: {
+        blockchainEstimateFee: jest.fn().mockResolvedValue({
+            success: true,
+            payload: {
+                levels: [{ feeLimit: '52000' }],
+            },
+        }),
+    },
+}));
 
 describe('thunks', () => {
     const dispatch = jest.fn();
@@ -27,6 +44,76 @@ describe('thunks', () => {
                 tradingExchangeActions.setLastErrorMessage(undefined),
             );
             expect(dispatch).toHaveBeenCalledWith(tradingBuyActions.setLastErrorMessage(undefined));
+        });
+    });
+
+    describe('composeEvmApprovalFeeLevelsThunk', () => {
+        let store: TestStore;
+
+        const dexQuoteWithApprovalData: ExchangeTrade = {
+            ...exchangeQuotes[3],
+            isDex: true,
+            sendStringAmount: '100',
+            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            dexTx: {
+                to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
+                data: '0x095ea7b3000000000000000000000000def171fe48cf0115b1d80b88dc8eab59176fee570000000000000000000000000000000000000000000000000000000005f5e100',
+                value: '0x0',
+            },
+        };
+
+        const feeInfo = {
+            blockTime: 15,
+            minFee: 1,
+            maxFee: 100,
+            dustLimit: -1,
+            levels: [{ label: 'normal' as const, feePerUnit: '20', blocks: 1 }],
+        };
+
+        beforeEach(() => {
+            const walletState = getWalletState({ tradeType: 'exchange' });
+            walletState.trading.exchange.tradingAccountKey = 'eth-account-1' as AccountKey;
+
+            store = initStore({
+                wallet: walletState,
+            }).store;
+        });
+
+        it('should reject when dexTx data is missing', async () => {
+            const quoteWithoutDexTx = {
+                ...dexQuoteWithApprovalData,
+                dexTx: undefined,
+            } as ExchangeTrade;
+
+            const ethAccount = store
+                .getState()
+                .wallet.accounts.find(a => a.key === ('eth-account-1' as AccountKey));
+
+            const result = await store.dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote: quoteWithoutDexTx,
+                    account: ethAccount!,
+                    feeInfo,
+                }),
+            );
+
+            expect(result.type).toContain('rejected');
+        });
+
+        it('should compose allowance fee levels for a DEX quote', async () => {
+            const ethAccount = store
+                .getState()
+                .wallet.accounts.find(a => a.key === ('eth-account-1' as AccountKey));
+
+            const result = await store.dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote: dexQuoteWithApprovalData,
+                    account: ethAccount!,
+                    feeInfo,
+                }),
+            );
+
+            expect(result.type).toContain('fulfilled');
         });
     });
 });

--- a/suite-native/module-trading/src/__tests__/thunks.test.ts
+++ b/suite-native/module-trading/src/__tests__/thunks.test.ts
@@ -1,12 +1,13 @@
-import type { ExchangeTrade } from 'invity-api';
+import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import {
     tradingBuyActions,
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
-import { AccountKey } from '@suite-common/wallet-types';
-import { TestStore, initStore } from '@suite-native/test-utils';
+import { AccountKey, TokenAddress, TokenInfoBranded } from '@suite-common/wallet-types';
+import { type PreloadedState, TestStore, initStore } from '@suite-native/test-utils';
+import { selectAccountTokenInfo } from '@suite-native/tokens';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { clearTradingStateThunk, composeEvmApprovalFeeLevelsThunk } from '../thunks';
@@ -20,7 +21,82 @@ jest.mock('@trezor/connect', () => ({
                 levels: [{ feeLimit: '52000' }],
             },
         }),
+        composeTransaction: jest.fn().mockResolvedValue({
+            success: true,
+            payload: [
+                {
+                    type: 'final',
+                    totalSpent: '100000',
+                    fee: '21000',
+                    feePerByte: '1',
+                    feeLimit: '21000',
+                    estimatedFeeLimit: '21000',
+                    bytes: 250,
+                },
+            ],
+        }),
+        ethereumSignTransaction: jest.fn().mockResolvedValue({
+            success: true,
+            payload: {
+                serializedTx: '0x1234567890abcdef',
+            },
+        }),
+        getAccountInfo: jest.fn().mockResolvedValue({
+            success: true,
+            payload: {
+                availableBalance: '1000000',
+            },
+        }),
     },
+}));
+
+const mockPrecomposedLevels = {
+    normal: {
+        type: 'final' as const,
+        fee: '21000',
+        feePerByte: '20',
+        feeLimit: '52000',
+        estimatedFeeLimit: '52000',
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
+        token: undefined,
+        totalSpent: '0',
+        bytes: 0,
+        inputs: [],
+        outputsPermutation: [0],
+        outputs: [],
+    },
+};
+
+const mockTokenInfo = {
+    standard: 'ERC20' as const,
+    name: 'USDC',
+    contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
+    symbol: 'usdc',
+    decimals: 6,
+    balance: '100000000',
+} as TokenInfoBranded;
+
+jest.mock('@suite-common/wallet-core', () => {
+    const actual = jest.requireActual('@suite-common/wallet-core');
+
+    return {
+        ...actual,
+        composeAllowanceTransactionThunk: () => () =>
+            Promise.resolve({
+                type: '@common/wallet-core/approval/composeAllowanceTransactionThunk/fulfilled',
+                payload: mockPrecomposedLevels,
+                meta: {
+                    requestId: 'test-request-id',
+                    requestStatus: 'fulfilled' as const,
+                },
+            }),
+    };
+});
+
+jest.mock('@suite-native/tokens', () => ({
+    ...jest.requireActual('@suite-native/tokens'),
+    selectAccountTokenInfo: jest.fn(() => mockTokenInfo),
 }));
 
 describe('thunks', () => {
@@ -30,6 +106,7 @@ describe('thunks', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.mocked(selectAccountTokenInfo).mockReturnValue(mockTokenInfo);
     });
 
     describe('clearTradingStateThunk', () => {
@@ -54,8 +131,9 @@ describe('thunks', () => {
             ...exchangeQuotes[3],
             isDex: true,
             sendStringAmount: '100',
-            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as CryptoId,
             dexTx: {
+                from: '0x0000000000000000000000000000000000000000',
                 to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
                 data: '0x095ea7b3000000000000000000000000def171fe48cf0115b1d80b88dc8eab59176fee570000000000000000000000000000000000000000000000000000000005f5e100',
                 value: '0x0',
@@ -63,9 +141,11 @@ describe('thunks', () => {
         };
 
         const feeInfo = {
+            blockHeight: 0,
             blockTime: 15,
             minFee: 1,
             maxFee: 100,
+            minPriorityFee: 0,
             dustLimit: -1,
             levels: [{ label: 'normal' as const, feePerUnit: '20', blocks: 1 }],
         };
@@ -74,9 +154,16 @@ describe('thunks', () => {
             const walletState = getWalletState({ tradeType: 'exchange' });
             walletState.trading.exchange.tradingAccountKey = 'eth-account-1' as AccountKey;
 
-            store = initStore({
+            const preloadedState: PreloadedState = {
                 wallet: walletState,
-            }).store;
+                device: {
+                    selectedDevice: {
+                        state: { staticSessionId: 'device1@test:123' },
+                        features: { major_version: 2, minor_version: 6, patch_version: 0 },
+                    },
+                },
+            };
+            store = initStore(preloadedState).store;
         });
 
         it('should reject when dexTx data is missing', async () => {
@@ -98,6 +185,7 @@ describe('thunks', () => {
             );
 
             expect(result.type).toContain('rejected');
+            expect(result.payload).toBe('DEX quote with dexTx data is required');
         });
 
         it('should compose allowance fee levels for a DEX quote', async () => {

--- a/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.tsx
@@ -2,50 +2,56 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectTradingExchangePreselectedQuote } from '@suite-common/trading';
-import { AsyncButton, Box } from '@suite-native/atoms';
+import { parseCryptoId, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
+import { TokenAddress } from '@suite-common/wallet-types';
+import { Box, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     StackNavigationProps,
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
-import { useExchangeFlow } from '../../../hooks/exchange/useExchangeFlow';
+export type ApprovalButtonProps = {
+    isReady: boolean;
+    isDisabled?: boolean;
+};
 
-export const ApprovalButton = () => {
+export const ApprovalButton = ({ isReady, isDisabled }: ApprovalButtonProps) => {
     const navigation =
         useNavigation<
             StackNavigationProps<TradingStackParamList, TradingStackRoutes.TradingExchangeApproval>
         >();
 
-    const { confirmTrade } = useExchangeFlow();
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
+    const fromAccount = useSelector(selectExchangeSelectedSendAccount);
 
-    const quote = useSelector(selectTradingExchangePreselectedQuote);
-
-    const handleContinue = async () => {
-        const success = await confirmTrade({
-            receiveAddress: quote?.receiveAddress ?? '',
-            trade: quote,
-            approvalFlow: true,
-            nextStep: () => {},
-        });
-
-        if (success) {
-            // TODO
-            navigation.navigate(TradingStackRoutes.TradingExchangePreview, { isApproved: true });
-        }
-    };
-
-    if (!quote) {
+    if (!quote || !isReady) {
         return null;
     }
 
+    const handleContinue = () => {
+        const tokenContract = quote.send
+            ? (parseCryptoId(quote.send)?.contractAddress as TokenAddress)
+            : undefined;
+        if (!fromAccount || !tokenContract) {
+            console.warn('account or tokenContract is not defined');
+
+            return;
+        }
+        navigation.navigate(TradingStackRoutes.TradingExchangeOutputsReview, {
+            accountKey: fromAccount.key,
+            tokenContract,
+            orderId: quote.orderId ?? '',
+        });
+    };
+
     return (
         <Box paddingTop="sp20">
-            <AsyncButton onPress={handleContinue}>
+            <Button onPress={handleContinue} isDisabled={isDisabled}>
                 <Translation id="generic.buttons.continue" />
-            </AsyncButton>
+            </Button>
         </Box>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetailsCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetailsCard.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { cryptoIdToSymbol, selectTradingExchangePreselectedQuote } from '@suite-common/trading';
+import { selectTradingExchangeActiveQuote } from '@suite-common/trading';
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { Card } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
@@ -9,18 +10,24 @@ import { LimitPicker } from './LimitPicker';
 import { FeePicker } from '../../fees/FeePicker';
 import { ProviderInfoRow } from '../../general/TradeInfo/ProviderInfoRow';
 
-export const ExchangeApprovalDetailsCard = () => {
-    const quote = useSelector(selectTradingExchangePreselectedQuote);
+type ExchangeApprovalDetailsCardProps = {
+    fee: string | undefined;
+    isLoading: boolean;
+    networkSymbol: NetworkSymbol | undefined;
+};
 
-    if (!quote) {
+const noop = () => {};
+
+export const ExchangeApprovalDetailsCard = ({
+    fee,
+    isLoading,
+    networkSymbol,
+}: ExchangeApprovalDetailsCardProps) => {
+    const quote = useSelector(selectTradingExchangeActiveQuote);
+
+    if (!quote || !networkSymbol) {
         return null;
     }
-
-    // TODO 22293 - set real values
-    const fee = '4.76';
-    const areFeesLoading = false;
-    const goToFeeSelection = () => {};
-    const networkSymbol = cryptoIdToSymbol(quote.send!)!;
 
     return (
         <Card noPadding>
@@ -32,10 +39,10 @@ export const ExchangeApprovalDetailsCard = () => {
             <ProviderInfoRow exchange={quote.exchange} />
             <LimitPicker />
             <FeePicker
-                fee={fee}
+                fee={fee ?? '0'}
                 symbol={networkSymbol}
-                onPress={goToFeeSelection}
-                isLoading={areFeesLoading}
+                onPress={noop}
+                isLoading={isLoading}
             />
         </Card>
     );

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.tsx
@@ -6,7 +6,7 @@ import {
     type TradingRootState,
     cryptoIdToNetworkAndContractAddress,
     selectTradingCoinSymbolByCryptoId,
-    selectTradingExchangePreselectedQuote,
+    selectTradingExchangeActiveQuote,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
 import { HStack, Text, VStack } from '@suite-native/atoms';
@@ -19,7 +19,7 @@ import { useApprovalTypeControls } from '../../../hooks/exchange/Approval/useApp
 import { TradingCoinAmountFormatter } from '../../general/TradingCoinAmountFormatter';
 
 export const LimitPicker = () => {
-    const quote = useSelector(selectTradingExchangePreselectedQuote);
+    const quote = useSelector(selectTradingExchangeActiveQuote);
 
     const { approvalType, isSheetVisible, showSheet, hideSheet, handleApprovalTypeChange } =
         useApprovalTypeControls(quote);

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
@@ -1,4 +1,5 @@
 import { tradingExchangeActions } from '@suite-common/trading';
+import { AccountKey } from '@suite-common/wallet-types';
 import {
     TestStore,
     initStore,
@@ -7,10 +8,9 @@ import {
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
-import { ApprovalButton } from '../ApprovalButton';
+import { ApprovalButton, ApprovalButtonProps } from '../ApprovalButton';
 
 const mockNavigate = jest.fn();
-const mockConfirmTrade = jest.fn();
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
@@ -19,55 +19,54 @@ jest.mock('@react-navigation/native', () => ({
     }),
 }));
 
-jest.mock('../../../../hooks/exchange/useExchangeFlow', () => ({
-    useExchangeFlow: () => ({
-        confirmTrade: mockConfirmTrade,
-    }),
-}));
-
 describe('ApprovalButton', () => {
     let store: TestStore;
 
-    const renderApprovalButton = () => renderWithStoreProviderAsync(<ApprovalButton />, { store });
+    const renderApprovalButton = (props: ApprovalButtonProps) =>
+        renderWithStoreProviderAsync(<ApprovalButton {...props} />, { store });
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockConfirmTrade.mockResolvedValue(true);
 
         const preloadedState = {
             wallet: getWalletState({
                 tradeType: 'exchange',
             }),
         };
-        preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
+        preloadedState!.wallet!.trading!.exchange!.selectedQuote = exchangeQuotes[0];
+        preloadedState!.wallet!.trading!.exchange!.tradingAccountKey =
+            'eth-account-1' as AccountKey;
         store = initStore(preloadedState).store;
     });
 
-    it('should render continue button', async () => {
-        const { getByText } = await renderApprovalButton();
+    it('should render continue button when isReady is true', async () => {
+        const { getByText } = await renderApprovalButton({ isReady: true });
 
         expect(getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should confirmTrade and navigate to TradingExchangePreview on press', async () => {
-        const { getByText } = await renderApprovalButton();
+    it('should render nothing when isReady is false', async () => {
+        const { toJSON } = await renderApprovalButton({ isReady: false });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should navigate to TradingExchangeOutputsReview on press', async () => {
+        const { getByText } = await renderApprovalButton({ isReady: true });
 
         await userEvent.press(getByText('Continue'));
 
-        expect(mockConfirmTrade).toHaveBeenCalledWith({
-            receiveAddress: '',
-            trade: exchangeQuotes[0],
-            approvalFlow: true,
-            nextStep: expect.any(Function),
+        expect(mockNavigate).toHaveBeenCalledWith('TradingExchangeOutputsReview', {
+            accountKey: 'eth-account-1',
+            tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            orderId: 'c2de24a5-b923-42af-b70e-44bda8fa41dd',
         });
-
-        expect(mockNavigate).toHaveBeenCalledWith('TradingExchangePreview', { isApproved: true });
     });
 
-    it('should render nothing when no preselected quote is provided', async () => {
-        store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+    it('should render nothing when no selected quote is provided', async () => {
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = await renderApprovalButton();
+        const { toJSON } = await renderApprovalButton({ isReady: true });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.test.tsx
@@ -1,3 +1,4 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
 import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
@@ -6,8 +7,19 @@ import { ExchangeApprovalDetailsCard } from '../ExchangeApprovalDetailsCard';
 describe('ExchangeApprovalDetailsCard', () => {
     let preloadedState: PreloadedState;
 
-    const renderExchangeApprovalDetailsCard = () =>
-        renderWithStoreProviderAsync(<ExchangeApprovalDetailsCard />, { preloadedState });
+    const renderExchangeApprovalDetailsCard = (
+        fee: string | undefined = '100000',
+        isLoading = false,
+        networkSymbol: NetworkSymbol | undefined,
+    ) =>
+        renderWithStoreProviderAsync(
+            <ExchangeApprovalDetailsCard
+                fee={fee}
+                isLoading={isLoading}
+                networkSymbol={networkSymbol}
+            />,
+            { preloadedState },
+        );
 
     beforeEach(() => {
         preloadedState = {
@@ -20,7 +32,7 @@ describe('ExchangeApprovalDetailsCard', () => {
     it('should render card', async () => {
         preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
 
-        const { getByText } = await renderExchangeApprovalDetailsCard();
+        const { getByText } = await renderExchangeApprovalDetailsCard('100000', false, 'eth');
 
         expect(getByText('Approval details')).toBeTruthy();
         expect(getByText('Provider')).toBeTruthy();
@@ -28,8 +40,16 @@ describe('ExchangeApprovalDetailsCard', () => {
         expect(getByText('Fee')).toBeTruthy();
     });
 
-    it('should render nothing without preselectedQuote', async () => {
-        const { toJSON } = await renderExchangeApprovalDetailsCard();
+    it('should render nothing without quote', async () => {
+        const { toJSON } = await renderExchangeApprovalDetailsCard('100000', false, 'eth');
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing without networkSymbol', async () => {
+        preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
+
+        const { toJSON } = await renderExchangeApprovalDetailsCard('100000', false, undefined);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -1,7 +1,4 @@
-import {
-    selectTradingExchangePreselectedQuote,
-    tradingExchangeActions,
-} from '@suite-common/trading';
+import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
 import {
     TestStore,
     initStore,
@@ -39,7 +36,7 @@ describe('LimitPicker', () => {
         expect(
             within(picker).getByText(/^Approve unlimited USDC to skip future approval requests/),
         ).toBeOnTheScreen();
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'INFINITE' }),
         );
     });
@@ -56,7 +53,7 @@ describe('LimitPicker', () => {
         expect(
             within(picker).getByText(/^Approve only the amount needed for this swap/),
         ).toBeOnTheScreen();
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'MINIMAL' }),
         );
     });

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
@@ -1,9 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import {
-    selectTradingExchangePreselectedQuote,
-    tradingExchangeActions,
-} from '@suite-common/trading';
+import { selectTradingExchangeActiveQuote, tradingExchangeActions } from '@suite-common/trading';
 import {
     TestStore,
     act,
@@ -20,7 +17,7 @@ describe('useApprovalTypeControls', () => {
     const renderUseApprovalTypeControls = () =>
         renderHookWithStoreProviderAsync(
             () => {
-                const quote = useSelector(selectTradingExchangePreselectedQuote)!;
+                const quote = useSelector(selectTradingExchangeActiveQuote);
 
                 return useApprovalTypeControls(quote);
             },
@@ -47,7 +44,7 @@ describe('useApprovalTypeControls', () => {
             hideSheet: expect.any(Function),
             handleApprovalTypeChange: expect.any(Function),
         });
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'INFINITE' }),
         );
     });
@@ -64,12 +61,12 @@ describe('useApprovalTypeControls', () => {
                 approvalType: 'MINIMAL',
             }),
         );
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toEqual(
+        expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
             expect.objectContaining({ approvalType: 'MINIMAL' }),
         );
     });
 
-    it('should do nothing when no preselected quote is provided', async () => {
+    it('should do nothing when no quote is provided', async () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
         const { result } = await renderUseApprovalTypeControls();
 
@@ -80,7 +77,7 @@ describe('useApprovalTypeControls', () => {
             hideSheet: expect.any(Function),
             handleApprovalTypeChange: expect.any(Function),
         });
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
+        expect(selectTradingExchangeActiveQuote(store.getState())).toBeUndefined();
 
         act(() => {
             result.current.handleApprovalTypeChange('MINIMAL');
@@ -91,6 +88,6 @@ describe('useApprovalTypeControls', () => {
                 approvalType: 'INFINITE',
             }),
         );
-        expect(selectTradingExchangePreselectedQuote(store.getState())).toBeUndefined();
+        expect(selectTradingExchangeActiveQuote(store.getState())).toBeUndefined();
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.hook.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.hook.test.ts
@@ -1,0 +1,97 @@
+import { AccountKey } from '@suite-common/wallet-types';
+import {
+    PreloadedState,
+    TestStore,
+    initStore,
+    renderHookWithStoreProviderAsync,
+} from '@suite-native/test-utils';
+import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
+
+import { useEvmApprovalFees } from '../useEvmApprovalFees';
+
+const mockUnwrap = jest.fn(() => Promise.resolve({}));
+
+jest.mock('../../../../thunks', () => ({
+    composeEvmApprovalFeeLevelsThunk: (payload: unknown) => ({
+        type: 'composeEvmApprovalFeeLevelsThunkMock',
+        payload,
+        unwrap: mockUnwrap,
+    }),
+}));
+
+describe('useEvmApprovalFees', () => {
+    let store: TestStore;
+    let preloadedState: PreloadedState;
+
+    const dexQuoteWithApprovalData = {
+        ...exchangeQuotes[3],
+        isDex: true,
+        sendStringAmount: '100',
+        send: 'ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        dexTx: {
+            to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
+            data: '0x095ea7b3000000000000000000000000def171fe48cf0115b1d80b88dc8eab59176fee570000000000000000000000000000000000000000000000000000000005f5e100',
+            value: '0x0',
+        },
+    };
+
+    beforeEach(() => {
+        mockUnwrap.mockReset().mockResolvedValue({});
+
+        preloadedState = {
+            wallet: getWalletState({ tradeType: 'exchange' }),
+        };
+        preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'eth-account-1' as AccountKey;
+        preloadedState.wallet!.trading!.exchange!.preselectedQuote = dexQuoteWithApprovalData;
+
+        store = initStore(preloadedState).store;
+    });
+
+    const renderUseEvmApprovalFees = (params?: Parameters<typeof useEvmApprovalFees>[0]) =>
+        renderHookWithStoreProviderAsync(() => useEvmApprovalFees(params), { store });
+
+    it('should return isLoading true when fee is undefined', async () => {
+        const { result } = await renderUseEvmApprovalFees();
+
+        expect(result.current).toEqual(
+            expect.objectContaining({
+                fee: undefined,
+                error: null,
+                isLoading: true,
+                composeFees: expect.any(Function),
+            }),
+        );
+    });
+
+    it('should return fee and isLoading false when composed transaction info is available', async () => {
+        preloadedState!.wallet!.trading!.composedTransactionInfo = {
+            composed: { fee: '50000' },
+        };
+        store = initStore(preloadedState).store;
+
+        const { result } = await renderUseEvmApprovalFees();
+
+        expect(result.current.fee).toBe('50000');
+        expect(result.current.error).toBeNull();
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should return translated error when composing fails', async () => {
+        mockUnwrap.mockRejectedValue(new Error('compose failed'));
+
+        const { result } = await renderUseEvmApprovalFees();
+
+        expect(result.current.error).toBe('Failed to estimate approval fees. Please try again.');
+        expect(result.current.isLoading).toBe(true);
+    });
+
+    it('should accept approvalTypeOverride parameter', async () => {
+        const { result } = await renderUseEvmApprovalFees({ approvalTypeOverride: 'ZERO' });
+
+        expect(result.current).toEqual(
+            expect.objectContaining({
+                composeFees: expect.any(Function),
+            }),
+        );
+    });
+});

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
@@ -1,22 +1,21 @@
+import { tradingActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
 import {
     PreloadedState,
     TestStore,
     initStore,
     renderHookWithStoreProviderAsync,
+    waitFor,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { useEvmApprovalFees } from '../useEvmApprovalFees';
 
-const mockUnwrap = jest.fn(() => Promise.resolve({}));
+const mockComposeEvmApprovalFeeLevelsThunk = jest.fn();
 
 jest.mock('../../../../thunks', () => ({
-    composeEvmApprovalFeeLevelsThunk: (payload: unknown) => ({
-        type: 'composeEvmApprovalFeeLevelsThunkMock',
-        payload,
-        unwrap: mockUnwrap,
-    }),
+    composeEvmApprovalFeeLevelsThunk: (...args: any[]) =>
+        mockComposeEvmApprovalFeeLevelsThunk(...args),
 }));
 
 describe('useEvmApprovalFees', () => {
@@ -36,13 +35,16 @@ describe('useEvmApprovalFees', () => {
     };
 
     beforeEach(() => {
-        mockUnwrap.mockReset().mockResolvedValue({});
+        mockComposeEvmApprovalFeeLevelsThunk.mockReset().mockImplementation(() => ({
+            type: 'composeEvmApprovalFeeLevelsThunk',
+            unwrap: jest.fn().mockResolvedValue({}),
+        }));
 
         preloadedState = {
             wallet: getWalletState({ tradeType: 'exchange' }),
         };
         preloadedState.wallet!.trading!.exchange!.tradingAccountKey = 'eth-account-1' as AccountKey;
-        preloadedState.wallet!.trading!.exchange!.preselectedQuote = dexQuoteWithApprovalData;
+        preloadedState.wallet!.trading!.exchange!.selectedQuote = dexQuoteWithApprovalData;
 
         store = initStore(preloadedState).store;
     });
@@ -64,10 +66,15 @@ describe('useEvmApprovalFees', () => {
     });
 
     it('should return fee and isLoading false when composed transaction info is available', async () => {
-        preloadedState!.wallet!.trading!.composedTransactionInfo = {
-            composed: { fee: '50000' },
-        };
+        preloadedState!.wallet!.trading!.exchange!.selectedQuote = undefined;
         store = initStore(preloadedState).store;
+
+        store.dispatch(
+            tradingActions.saveComposedTransactionInfo({
+                selectedFee: 'normal',
+                composed: { fee: '50000', feePerByte: '0' },
+            }),
+        );
 
         const { result } = await renderUseEvmApprovalFees();
 
@@ -77,12 +84,34 @@ describe('useEvmApprovalFees', () => {
     });
 
     it('should return translated error when composing fails', async () => {
-        mockUnwrap.mockRejectedValue(new Error('compose failed'));
+        mockComposeEvmApprovalFeeLevelsThunk.mockImplementation(() => ({
+            type: 'composeEvmApprovalFeeLevelsThunk',
+            unwrap: jest.fn().mockRejectedValue(new Error('compose failed')),
+        }));
+
+        preloadedState!.wallet!.fees = {
+            eth: {
+                status: 'loaded',
+                data: {
+                    blockHeight: 1000,
+                    blockTime: 15,
+                    minFee: 1,
+                    maxFee: 100,
+                    levels: [{ label: 'normal', feePerUnit: '20', blocks: 1 }],
+                },
+            },
+        };
+        store = initStore(preloadedState).store;
 
         const { result } = await renderUseEvmApprovalFees();
 
-        expect(result.current.error).toBe('Failed to estimate approval fees. Please try again.');
-        expect(result.current.isLoading).toBe(true);
+        await waitFor(() => {
+            expect(result.current.error).toBe(
+                'Failed to estimate approval fees. Please try again.',
+            );
+        });
+
+        expect(result.current.isLoading).toBe(false);
     });
 
     it('should accept approvalTypeOverride parameter', async () => {

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalFlow.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import type { ExchangeTrade } from 'invity-api';
+
+import { exchangeThunks, selectTradingExchangeActiveQuote } from '@suite-common/trading';
+import { useTranslate } from '@suite-native/intl';
+import {
+    selectExchangeSelectedReceiveAccount,
+    selectExchangeSelectedSendAccount,
+} from '@suite-native/trading-state';
+
+import { getReceiveAccountAddressText } from '../../../utils/general/receiveAccountUtils';
+
+export const useApprovalFlow = () => {
+    const dispatch = useDispatch();
+    const { translate } = useTranslate();
+
+    const quote = useSelector(selectTradingExchangeActiveQuote);
+    const sendAccount = useSelector(selectExchangeSelectedSendAccount);
+    const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
+    const receiveAddress = getReceiveAccountAddressText(toAccount);
+
+    const [isConfirming, setIsConfirming] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const confirmApproval = useCallback(
+        async (quoteToConfirm: ExchangeTrade) => {
+            if (!sendAccount || !receiveAddress || !quoteToConfirm) {
+                return undefined;
+            }
+
+            setIsConfirming(true);
+            setError(null);
+
+            try {
+                const response = await dispatch(
+                    exchangeThunks.confirmApprovalThunk({
+                        trade: quoteToConfirm,
+                        receiveAddress,
+                        account: sendAccount,
+                        processResponseData: () => {},
+                    }),
+                ).unwrap();
+
+                if (!response) {
+                    setError(translate('moduleTrading.confirmApprovalError'));
+
+                    return undefined;
+                }
+
+                return response;
+            } catch (e) {
+                console.error('Failed to confirm approval trade', e);
+                setError(translate('moduleTrading.confirmApprovalError'));
+
+                return undefined;
+            } finally {
+                setIsConfirming(false);
+            }
+        },
+        [dispatch, receiveAddress, sendAccount, translate],
+    );
+
+    return {
+        quote,
+        isConfirming,
+        error,
+        confirmApproval,
+    };
+};

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
@@ -11,9 +11,9 @@ export const useApprovalTypeControls = (quote: ExchangeTrade | undefined) => {
     const { isSheetVisible, showSheet, hideSheet } = useBottomSheetControls();
 
     useEffect(() => {
-        if (!!quote && !quote?.approvalType) {
+        if (quote && !quote.approvalType) {
             dispatch(
-                tradingExchangeActions.savePreselectedQuote({
+                tradingExchangeActions.saveSelectedQuote({
                     ...quote,
                     approvalType: 'INFINITE',
                 }),
@@ -25,7 +25,7 @@ export const useApprovalTypeControls = (quote: ExchangeTrade | undefined) => {
         (newApprovalType: DexApprovalType) => {
             if (quote) {
                 dispatch(
-                    tradingExchangeActions.savePreselectedQuote({
+                    tradingExchangeActions.saveSelectedQuote({
                         ...quote,
                         approvalType: newApprovalType,
                     }),

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
@@ -5,7 +5,7 @@ import { DexApprovalType } from 'invity-api';
 
 import {
     selectTradingComposedTransactionInfo,
-    selectTradingExchangePreselectedQuote,
+    selectTradingExchangeActiveQuote,
 } from '@suite-common/trading';
 import {
     AccountsRootState,
@@ -28,8 +28,7 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
     const [isComposing, setIsComposing] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
-    // quote will be selected after the approval is done
-    const quote = useSelector(selectTradingExchangePreselectedQuote);
+    const quote = useSelector(selectTradingExchangeActiveQuote);
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, sendAccount?.key),
@@ -42,10 +41,10 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
     const approvalType =
         approvalTypeOverride ?? ((quote?.approvalType ?? 'INFINITE') as DexApprovalType);
     const fee = composedTransactionInfo?.composed?.fee;
-    const isLoading = isComposing || fee === undefined;
+    const isLoading = isComposing || (fee === undefined && !error);
 
     const composeFees = useCallback(async () => {
-        if (!quote || !account || !feeInfo) {
+        if (!quote?.dexTx?.data || !account || !feeInfo) {
             return;
         }
 
@@ -60,8 +59,8 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
                     approvalTypeOverride,
                 }),
             ).unwrap();
-        } catch (error) {
-            console.error('Failed to compose allowance fees:', error);
+        } catch (composeError) {
+            console.error('Failed to compose allowance fees:', composeError);
             setError(translate('moduleTrading.composeAllowanceError'));
         } finally {
             setIsComposing(false);

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { DexApprovalType } from 'invity-api';
+
+import {
+    selectTradingComposedTransactionInfo,
+    selectTradingExchangePreselectedQuote,
+} from '@suite-common/trading';
+import {
+    AccountsRootState,
+    FeesRootState,
+    selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
+} from '@suite-common/wallet-core';
+import { useTranslate } from '@suite-native/intl';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+
+import { composeEvmApprovalFeeLevelsThunk } from '../../../thunks';
+
+interface UseEvmApprovalFeesParams {
+    approvalTypeOverride?: DexApprovalType;
+}
+
+export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesParams = {}) => {
+    const dispatch = useDispatch();
+    const { translate } = useTranslate();
+    const [isComposing, setIsComposing] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // quote will be selected after the approval is done
+    const quote = useSelector(selectTradingExchangePreselectedQuote);
+    const sendAccount = useSelector(selectExchangeSelectedSendAccount);
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, sendAccount?.key),
+    );
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, sendAccount?.symbol),
+    );
+    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
+
+    const approvalType =
+        approvalTypeOverride ?? ((quote?.approvalType ?? 'INFINITE') as DexApprovalType);
+    const fee = composedTransactionInfo?.composed?.fee;
+    const isLoading = isComposing || fee === undefined;
+
+    const composeFees = useCallback(async () => {
+        if (!quote || !account || !feeInfo) {
+            return;
+        }
+
+        setIsComposing(true);
+        setError(null);
+        try {
+            await dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote,
+                    account,
+                    feeInfo,
+                    approvalTypeOverride,
+                }),
+            ).unwrap();
+        } catch (error) {
+            console.error('Failed to compose allowance fees:', error);
+            setError(translate('moduleTrading.composeAllowanceError'));
+        } finally {
+            setIsComposing(false);
+        }
+    }, [dispatch, quote, account, feeInfo, approvalTypeOverride, translate]);
+
+    // Keep a ref to the latest composeFees so the effect always calls the
+    // current version without needing it as a dependency.
+    const composeFeesRef = useRef(composeFees);
+    composeFeesRef.current = composeFees;
+
+    // Recompose only when the approval type or dex transaction data changes.
+    useEffect(() => {
+        composeFeesRef.current();
+    }, [approvalType, quote?.dexTx?.data]);
+
+    return {
+        fee,
+        error,
+        isLoading,
+        composeFees,
+    };
+};

--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
     TradingRootState,
     selectTradingCoinSymbolByCryptoId,
-    selectTradingExchangePreselectedQuote,
+    selectTradingExchangeActiveQuote,
     selectTradingProviderByNameAndTradeType,
     tradingExchangeActions,
 } from '@suite-common/trading';
@@ -18,10 +18,13 @@ import {
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
 import { ApprovalButton } from '../components/exchange/Approval/ApprovalButton';
 import { ExchangeApprovalDetailsCard } from '../components/exchange/Approval/ExchangeApprovalDetailsCard';
 import { ExchangeApprovalForCard } from '../components/exchange/Approval/ExchangeApprovalForCard';
+import { useApprovalFlow } from '../hooks/exchange/Approval/useApprovalFlow';
+import { useEvmApprovalFees } from '../hooks/exchange/Approval/useEvmApprovalFees';
 
 type TradingExchangeApprovalScreenProps = StackToStackCompositeScreenProps<
     TradingStackParamList,
@@ -35,7 +38,10 @@ export const TradingExchangeApprovalScreen = ({
     const { shouldIncreaseLimit, isRevoked } = params;
     const dispatch = useDispatch();
 
-    const quote = useSelector(selectTradingExchangePreselectedQuote);
+    const quote = useSelector(selectTradingExchangeActiveQuote);
+
+    const { isConfirming, error: confirmError, confirmApproval } = useApprovalFlow();
+    const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 
     const providerInfo = useSelector((state: TradingRootState) =>
         selectTradingProviderByNameAndTradeType(state, quote?.exchange, 'exchange'),
@@ -45,10 +51,28 @@ export const TradingExchangeApprovalScreen = ({
         selectTradingCoinSymbolByCryptoId(state, quote?.send),
     );
 
+    const { fee, isLoading: isComposingFees, error: feeError } = useEvmApprovalFees();
+
+    const isLoading = isConfirming || isComposingFees;
+    const error = confirmError || feeError;
+    const isApprovalReady = !isLoading && !error && fee !== undefined;
+
     useEffect(
-        () => () => {
-            dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+        () => {
+            if (!quote) {
+                console.error('No quote to confirm approval');
+
+                return;
+            }
+
+            confirmApproval(quote);
+
+            return () => {
+                dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+            };
         },
+        // We only want to confirm once on mount, not on every quote change.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [dispatch],
     );
 
@@ -96,9 +120,13 @@ export const TradingExchangeApprovalScreen = ({
                 )}
 
                 <ExchangeApprovalForCard />
-                <ExchangeApprovalDetailsCard />
+                <ExchangeApprovalDetailsCard
+                    fee={fee}
+                    isLoading={isLoading}
+                    networkSymbol={sendAccount?.symbol}
+                />
             </VStack>
-            <ApprovalButton />
+            <ApprovalButton isReady={isApprovalReady} isDisabled={!!error} />
         </Screen>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -1,9 +1,6 @@
 import { RouteProp } from '@react-navigation/native';
 
-import {
-    selectTradingExchangePreselectedQuote,
-    tradingExchangeActions,
-} from '@suite-common/trading';
+import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@suite-common/trading';
 import { AccountKey } from '@suite-common/wallet-types';
 import { TradingStackParamList, TradingStackRoutes } from '@suite-native/navigation';
 import {
@@ -18,11 +15,23 @@ import { TradingExchangeApprovalScreen } from '../TradingExchangeApprovalScreen'
 
 const mockShowSheet = jest.fn();
 const mockHideSheet = jest.fn();
+const mockConfirmApproval = jest.fn().mockResolvedValue({});
 
-jest.mock('../../hooks/exchange/useExchangeFlow', () => ({
-    useExchangeFlow: () => ({
-        confirmTrade: jest.fn().mockResolvedValue(true),
-        fetchFeesAndCompose: jest.fn(),
+jest.mock('../../hooks/exchange/Approval/useApprovalFlow', () => ({
+    useApprovalFlow: () => ({
+        quote: undefined,
+        isConfirming: false,
+        error: null,
+        confirmApproval: mockConfirmApproval,
+    }),
+}));
+
+jest.mock('../../hooks/exchange/Approval/useEvmApprovalFees', () => ({
+    useEvmApprovalFees: () => ({
+        fee: '100000',
+        isLoading: false,
+        error: null,
+        composeFees: jest.fn(),
     }),
 }));
 
@@ -120,21 +129,23 @@ describe('TradingExchangeApprovalScreen', () => {
         expect(buttons).toBeTruthy();
     });
 
-    it('should render nothing when no preselected quote is provided', async () => {
+    it('should render nothing when no quote is provided', async () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
         const { toJSON } = await renderScreen();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should clear preselected quote on unmount', async () => {
+    it('should clear selected quote on unmount', async () => {
+        store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
         const { unmount: localUnmount } = await renderScreen();
 
         localUnmount();
         unmount = undefined;
 
-        const preselectedQuote = selectTradingExchangePreselectedQuote(store.getState());
-        expect(preselectedQuote).toBeUndefined();
+        const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
+        expect(selectedQuote).toBeUndefined();
     });
 });

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -1,4 +1,5 @@
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
+import { DexApprovalType, ExchangeTrade } from 'invity-api';
 
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
@@ -6,6 +7,7 @@ import {
     TradingExchangeType,
     TradingSellType,
     TradingSignAndPushSendFormTransactionProps,
+    parseCryptoId,
     selectTradingExchangeProviders,
     selectTradingExchangeReceiveAccountKey,
     selectTradingExchangeSelectedQuote,
@@ -18,6 +20,7 @@ import {
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
 import {
+    composeAllowanceTransactionThunk,
     composeSendFormTransactionFeeLevelsThunk,
     enhancePrecomposedTransactionThunk,
     formDraftActions,
@@ -32,10 +35,17 @@ import {
     FeeInfo,
     FeeLevelLabel,
     PrecomposedTransactionFinal,
+    TokenAddress,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
-import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import {
+    buildApprovalTransactionData,
+    getAllowanceAmount,
+    getEvmApprovalTxData,
+    tryGetAccountIdentity,
+} from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
+import { selectAccountTokenInfo } from '@suite-native/tokens';
 import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
 import {
     UpdateSelectedFeeLevelThunkParams,
@@ -239,6 +249,137 @@ export const composeTradingTransactionThunk = createThunk(
             return rejectWithValue(`Failed to compose transaction: ${errStr}`);
         } catch (error) {
             console.error('Compose trading transaction error:', error);
+
+            return rejectWithValue(getErrorStrFromThunkRejectedValue(error));
+        }
+    },
+);
+
+export const composeEvmApprovalFeeLevelsThunk = createThunk(
+    `${NATIVE_TRADING_EXCHANGE_THUNK_PREFIX}/composeEvmApprovalFeeLevels`,
+    async (
+        {
+            quote,
+            account,
+            feeInfo,
+            selectedFeeLevel = 'normal',
+            customFee,
+            approvalTypeOverride,
+        }: {
+            quote: ExchangeTrade;
+            account: Account;
+            feeInfo: FeeInfo;
+            selectedFeeLevel?: FeeLevelLabel;
+            customFee?: {
+                feeLimit: string;
+                feePerUnit: string;
+                maxFeePerGas?: string;
+                maxPriorityFeePerGas?: string;
+            };
+            approvalTypeOverride?: DexApprovalType;
+        },
+        { dispatch, getState, rejectWithValue, fulfillWithValue },
+    ) => {
+        try {
+            const { dexTx, send, sendStringAmount, approvalType: quoteApprovalType } = quote;
+
+            if (!dexTx?.data || !send || !sendStringAmount) {
+                return rejectWithValue('DEX quote with dexTx data is required');
+            }
+
+            const approvalData = getEvmApprovalTxData(dexTx.data);
+            if (!approvalData?.spender) {
+                return rejectWithValue('Could not extract spender from dexTx data');
+            }
+
+            const { contractAddress } = parseCryptoId(send);
+            if (!contractAddress) {
+                return rejectWithValue('Could not extract token contract address');
+            }
+
+            const token = selectAccountTokenInfo(
+                getState(),
+                account.key,
+                contractAddress as TokenAddress,
+            );
+
+            if (!token) {
+                return rejectWithValue('Token not found in account');
+            }
+
+            const approvalType =
+                approvalTypeOverride ?? ((quoteApprovalType ?? 'INFINITE') as DexApprovalType);
+            const { allowanceAmount } = getAllowanceAmount({
+                rawAmount: sendStringAmount,
+                approvalType,
+                token,
+            });
+
+            if (!allowanceAmount) {
+                return rejectWithValue('Could not compute allowance amount');
+            }
+
+            const data = buildApprovalTransactionData({
+                amount: allowanceAmount,
+                spender: approvalData.spender,
+            });
+
+            const response = await dispatch(
+                composeAllowanceTransactionThunk({
+                    account,
+                    contract: contractAddress,
+                    data,
+                    feeInfo,
+                    selectedFee: selectedFeeLevel,
+                    customFee,
+                }),
+            );
+
+            if (isFulfilled(response)) {
+                const feeLevels = response.payload;
+                dispatch(transactionManagementActions.storeFeeLevels({ feeLevels }));
+
+                const selectedLevel = feeLevels[selectedFeeLevel];
+                if (selectedLevel && isFinalPrecomposedTransaction(selectedLevel)) {
+                    const composed = selectedLevel as PrecomposedTransactionFinal;
+
+                    dispatch(
+                        tradingCommonActions.saveComposedTransactionInfo({
+                            selectedFee: selectedFeeLevel,
+                            composed: {
+                                fee: composed.fee,
+                                feePerByte: composed.feePerByte,
+                                feeLimit: composed.feeLimit,
+                                estimatedFeeLimit: composed.estimatedFeeLimit,
+                                maxFeePerGas: composed.maxFeePerGas,
+                                maxPriorityFeePerGas: composed.maxPriorityFeePerGas,
+                                token: composed.token,
+                            },
+                        }),
+                    );
+
+                    const formDraftKey = getFormDraftKeyByTradeType('exchange');
+
+                    dispatch(
+                        formDraftActions.storeDraft({
+                            key: formDraftKey,
+                            formDraft: {
+                                selectedFee: selectedFeeLevel,
+                                feePerUnit: composed.feePerByte,
+                                feeLimit: composed.feeLimit ?? '',
+                            },
+                        }),
+                    );
+                }
+
+                return fulfillWithValue(response.payload);
+            }
+
+            const errStr = getErrorStrFromThunkRejectedValue(response);
+
+            return rejectWithValue(`Failed to compose allowance transaction: ${errStr}`);
+        } catch (error) {
+            console.error('Compose allowance fee levels error:', error);
 
             return rejectWithValue(getErrorStrFromThunkRejectedValue(error));
         }

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -151,6 +151,7 @@ export const composeTradingTransactionThunk = createThunk(
                 tradeType === 'exchange'
                     ? selectTradingExchangeSelectedQuote(getState())
                     : selectTradingSellSelectedQuote(getState());
+
             const providers =
                 tradeType === 'exchange'
                     ? (selectTradingExchangeProviders(getState()) ?? {})
@@ -367,6 +368,10 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                                 selectedFee: selectedFeeLevel,
                                 feePerUnit: composed.feePerByte,
                                 feeLimit: composed.feeLimit ?? '',
+                                maxFeePerGas: composed.maxFeePerGas ?? '',
+                                maxPriorityFeePerGas: composed.maxPriorityFeePerGas ?? '',
+                                estimatedFeeLimit: composed.estimatedFeeLimit,
+                                transactionData: data,
                             },
                         }),
                     );

--- a/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
+++ b/suite-native/module-trading/src/utils/__tests__/tradingFormUtils.test.ts
@@ -194,6 +194,98 @@ describe('createFormStateForSendForm', () => {
             ).toThrow('Invalid quote type: must be ExchangeTrade or SellFiatTrade');
         });
 
+        it('should set transactionData and output address from dexTx for DEX quotes', () => {
+            const dexQuote: ExchangeTrade = {
+                exchange: '1inch',
+                send: 'ethereum' as any,
+                sendStringAmount: '1.0',
+                sendAddress: '0xUserAddress',
+                receive: 'ethereum--0xTokenAddress' as any,
+                receiveStringAmount: '1000.0',
+                status: 'CONFIRM',
+                orderId: 'dex-order-123',
+                quoteId: 'dex-quote-456',
+                isDex: true,
+                dexTx: {
+                    from: '0xUserAddress',
+                    to: '0xDexRouterAddress',
+                    data: '0xabcdef1234567890',
+                    value: '1000000000000000000',
+                },
+            };
+
+            const providers = { '1inch': exchangeInvity };
+            const formState = createFormStateForSendForm({
+                quote: dexQuote,
+                providers,
+                sendAccountKey,
+            });
+
+            // DEX output address should come from dexTx.to, not sendAddress
+            expect(formState.outputs[0].address).toBe('0xDexRouterAddress');
+            expect(formState.transactionData).toBe('0xabcdef1234567890');
+            expect(formState.ethereumAdjustGasLimit).toBe('1.25');
+        });
+
+        it('should not apply gas limit adjustment for DEX approval transactions', () => {
+            const dexApprovalQuote: ExchangeTrade = {
+                exchange: '1inch',
+                send: 'ethereum--0xTokenAddress' as any,
+                sendStringAmount: '100.0',
+                sendAddress: '0xUserAddress',
+                receive: 'ethereum' as any,
+                receiveStringAmount: '0.5',
+                status: 'APPROVAL_REQ',
+                orderId: 'dex-approval-123',
+                quoteId: 'dex-approval-456',
+                isDex: true,
+                dexTx: {
+                    from: '0xUserAddress',
+                    to: '0xDexRouterAddress',
+                    data: '0xapprovaldata',
+                    value: '0',
+                },
+            };
+
+            const providers = { '1inch': exchangeInvity };
+            const formState = createFormStateForSendForm({
+                quote: dexApprovalQuote,
+                providers,
+                sendAccountKey,
+            });
+
+            expect(formState.outputs[0].address).toBe('0xDexRouterAddress');
+            expect(formState.transactionData).toBe('0xapprovaldata');
+            // No gas adjustment for approval transactions
+            expect(formState.ethereumAdjustGasLimit).toBe('');
+        });
+
+        it('should not set DEX fields for CEX exchange quotes', () => {
+            const cexQuote: ExchangeTrade = {
+                exchange: 'changelly',
+                send: 'ethereum' as any,
+                sendStringAmount: '1.0',
+                sendAddress: '0xChangellyDepositAddress',
+                receive: 'bitcoin' as any,
+                receiveStringAmount: '0.05',
+                status: 'CONFIRM',
+                orderId: 'cex-order-123',
+                quoteId: 'cex-quote-456',
+                isDex: false,
+            };
+
+            const providers = { changelly: exchangeInvity };
+            const formState = createFormStateForSendForm({
+                quote: cexQuote,
+                providers,
+                sendAccountKey,
+            });
+
+            expect(formState.outputs[0].address).toBe('0xChangellyDepositAddress');
+            expect(formState.transactionData).toBe('');
+            expect(formState.ethereumAdjustGasLimit).toBe('');
+        });
+
         it('should use default fee level when not provided', () => {
             const quote: ExchangeTrade = {
                 exchange: 'test',

--- a/suite-native/module-trading/src/utils/tradingFormUtils.ts
+++ b/suite-native/module-trading/src/utils/tradingFormUtils.ts
@@ -11,6 +11,7 @@ import {
     isExchangeTrade,
     isSellFiatTrade,
 } from '@suite-common/trading';
+import { ETHEREUM_ADJUST_GAS_LIMIT } from '@suite-common/wallet-core';
 import { AccountKey, FormState, FormStateTrading } from '@suite-common/wallet-types';
 import { FeeLevel } from '@trezor/connect';
 
@@ -46,6 +47,8 @@ export const createFormStateForSendForm = ({
     let outputAddress: string;
     let outputAmount: string;
     let sendTokenContract: string | undefined;
+    let transactionData = '';
+    let ethereumAdjustGasLimit = '';
 
     // Handle extra field for networks that require it (e.g., destinationTag for XRP)
     let destinationTag: string | undefined;
@@ -61,6 +64,16 @@ export const createFormStateForSendForm = ({
         const exchangeProviders = providers as Record<string, ExchangeProviderInfo>;
         outputAddress = exchangeQuote.sendAddress || '';
         outputAmount = exchangeQuote.sendStringAmount || '';
+
+        // DEX quotes carry transaction data for correct fee estimation
+        if (exchangeQuote.isDex && exchangeQuote.dexTx) {
+            outputAddress = exchangeQuote.dexTx.to;
+            transactionData = exchangeQuote.dexTx.data;
+            // Gas limit adjustment only for the swap itself, not for approval transactions
+            if (exchangeQuote.status === 'CONFIRM') {
+                ethereumAdjustGasLimit = ETHEREUM_ADJUST_GAS_LIMIT;
+            }
+        }
 
         if (exchangeQuote.send) {
             const { contractAddress } = cryptoIdToNetworkAndContractAddress(exchangeQuote.send);
@@ -128,8 +141,8 @@ export const createFormStateForSendForm = ({
         bitcoinLocktimeDatetime: '',
         ethereumNonce: '',
         ethereumDataAscii: '',
-        ethereumAdjustGasLimit: '',
-        transactionData: '',
+        ethereumAdjustGasLimit,
+        transactionData,
         destinationTag,
         rbfParams: undefined,
         isCoinControlEnabled: false,

--- a/suite-native/test-utils/src/mocks/evoluMock.ts
+++ b/suite-native/test-utils/src/mocks/evoluMock.ts
@@ -1,7 +1,36 @@
 export const createEvolu = jest.fn();
 export const evolu = jest.fn();
+export const SyncOwner = jest.fn();
+export const createOwnerWebSocketTransport = jest.fn();
+export const Evolu = jest.fn();
 
 export const evoluReactNativeDeps = {
     reload: jest.fn(),
     platformInfo: {},
 };
+
+export const systemColumns = {
+    difference: jest.fn(() => []),
+};
+
+export const Schema = {
+    systemColumns,
+};
+
+export const id = jest.fn((name: string) => ({
+    Type: Symbol(name),
+    name,
+}));
+
+export const table = jest.fn(() => ({}));
+export const database = jest.fn(() => ({}));
+export const column = jest.fn(() => ({}));
+export const cast = jest.fn((value: any) => value);
+export const nullOr = jest.fn((schema: any) => schema);
+export const NonEmptyString1000 = jest.fn();
+export const NonEmptyString100 = jest.fn();
+export const String = jest.fn();
+export const Boolean = jest.fn();
+export const Int = jest.fn();
+export const SqliteBoolean = jest.fn();
+export const Nullable = jest.fn();


### PR DESCRIPTION
This PR adds basic preparation of approval transactions with fees, txn signing and send. It is not fully finished:

- `selectTradingExchangeActiveQuote` uses selectedQuote or preselectedQuote if the first does not exist
- `createFormStateForSendForm` is updated to be able to prepare dex transactions with txData

## Notes for review TBD in following PRs: 
- User has to go through approval flow even if he previously approved limits
- There is no fee selection
- In txn review, name of the approved contract is chunked even if it is not an address, but a name of the contract
- After approval txn is sent, nothing happens in UI (txn lands on chain though)


## Notes for QA

**Dont test.** Will be part of bigger testing later

## Related Issue

Part of #22293



🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/trade-compose-approval-fees&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/trade-compose-approval-fees&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/trade-compose-approval-fees&lookback=7)