### PR TITLE
fix(suite-native): ignore suite/test-utils in easignore

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -15,6 +15,7 @@ packages/suite-storage/
 packages/suite-web/
 packages/transport-bluetooth/
 suite/e2e/
+suite/test-utils/
 
 
 ### content of all .gitignore files is not applied if .easignore is present


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore `suite/test-utils` in `.easignore` to avoid pulling this dependency into our native builds.

## Notes for QA:
Nothing to test.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/eas-failing-build&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/eas-failing-build&lookback=7)