### PR TITLE
chore(suite-native): ignore all suite/ packages in eas builds

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -14,8 +14,7 @@ packages/suite-desktop-ui/
 packages/suite-storage/
 packages/suite-web/
 packages/transport-bluetooth/
-suite/e2e/
-suite/test-utils/
+suite/*
 
 
 ### content of all .gitignore files is not applied if .easignore is present


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Follow up for https://github.com/trezor/trezor-suite/pull/25371

We will never want to include any of the `suite/` packages into our native builds in eas, so it makes sense to ignore all of them so our builds don't break when new package in `suite/` is created and then imported into `packages/suite/` which would break our builds since that's already excluded as well. 

As we're about to break down suite repo from packages into `suite/`, it makes sense to do it like this to prevent build outage. 

## Notes for QA
Nothing to test.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/ignore-all-suite-packages-in-easignore&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/ignore-all-suite-packages-in-easignore&lookback=7)