### PR TITLE
chore(connect-web): remove popup opening delay REQUEST_TIMEOUT

### DIFF
--- a/packages/connect-web/src/popup/index.ts
+++ b/packages/connect-web/src/popup/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@trezor/connect-common/src/messageChannel/abstract';
 import { ServiceWorkerWindowChannel } from '@trezor/connect-common/src/messageChannel/serviceworker-window';
 import { WindowWindowChannel } from '@trezor/connect-common/src/messageChannel/window-window';
-import type { IntervalId, TimerId } from '@trezor/type-utils';
+import type { IntervalId } from '@trezor/type-utils';
 import { Deferred, createDeferred, scheduleAction } from '@trezor/utils';
 
 // Util
@@ -29,8 +29,6 @@ const checkIfTabExists = (tabId: number | undefined) =>
         chrome.tabs.get(tabId, callback);
     });
 
-// Event `POPUP_REQUEST_TIMEOUT` is used to close Popup window when there was no handshake from iframe.
-const POPUP_REQUEST_TIMEOUT = 850;
 const POPUP_CLOSE_INTERVAL = 500;
 
 type Params = Pick<ConnectSettings, 'manifest' | 'popupSrc' | 'env' | 'version'> & { logger: Log };
@@ -52,8 +50,6 @@ export class PopupManager {
     channel: AbstractMessageChannel<CoreEventMessage>;
 
     handshakePromise: Deferred<void> | undefined;
-
-    private requestTimeout: TimerId | undefined;
 
     private closeInterval: IntervalId | undefined;
 
@@ -129,14 +125,8 @@ export class PopupManager {
             this.close();
         }
 
-        const openFn = this.open.bind(this);
         this.locked = true;
-
-        const timeout = this.env === 'webextension' ? 1 : POPUP_REQUEST_TIMEOUT;
-        this.requestTimeout = setTimeout(() => {
-            this.requestTimeout = undefined;
-            openFn();
-        }, timeout);
+        this.open();
     }
 
     private open() {
@@ -286,10 +276,6 @@ export class PopupManager {
             this.channel.disconnect();
         }
 
-        if (this.requestTimeout) {
-            clearTimeout(this.requestTimeout);
-            this.requestTimeout = undefined;
-        }
         if (this.closeInterval) {
             clearInterval(this.closeInterval);
             this.closeInterval = undefined;

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -52,9 +52,10 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             // expand method tester
             await page.getByTestId('@api-playground/collapsible-box').click();
             await expect(page.getByTestId('@submit-button')).toBeVisible();
-            await page.getByTestId('@submit-button').click();
-            // await popup opening
-            const suite = await page.waitForEvent('popup');
+            const [suite] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
             const connectPermissionsModal = new ConnectPermissionsModal(suite);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
                 timeout: 10_000,
@@ -96,11 +97,10 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             // expand method tester
             await page.getByTestId('@api-playground/collapsible-box').click();
             await expect(page.getByTestId('@submit-button')).toBeVisible();
-            await page.getByTestId('@submit-button').click();
-
-            // await popup opening
-            const suite = await page.waitForEvent('popup');
-
+            const [suite] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
             const connectPermissionsModal = new ConnectPermissionsModal(suite);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
                 timeout: 10_000,

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -116,4 +116,36 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             await expect(response).toHaveText(/success: false/);
         },
     );
+
+    test(
+        'closing popup window returns Method_Interrupted error',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect: Closing the popup window (not close button) returns a proper error',
+            }),
+        },
+        async ({ page }) => {
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+
+            // expand method tester
+            await page.getByTestId('@api-playground/collapsible-box').click();
+            await expect(page.getByTestId('@submit-button')).toBeVisible();
+            const [suite] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
+            const connectPermissionsModal = new ConnectPermissionsModal(suite);
+            await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
+                timeout: 10_000,
+            });
+
+            // Close the browser popup window directly (simulates user clicking X)
+            await suite.close();
+
+            const response = page.getByTestId('@response');
+            await expect(response).toHaveText(/success: false/);
+            await expect(response).toHaveText(/Method_Interrupted/);
+        },
+    );
 });


### PR DESCRIPTION
before finalizing #24471 I am trying  to figure out in isolation what can possibly be removed. 

my intution is that POPUP_REQUEST_TIMEOUT is no longer needed. The removed comment
```
// Event `POPUP_REQUEST_TIMEOUT` is used to close Popup window when there was no handshake from iframe.
```
gives us a hint that it no logner serves any purpose. Iframe is now gone. Historically, it was probably meant to kill popup when a method that did not need popup was called. We don't have such scenario any more and even if we have one in the future I would suggest changing the logic: 1. figure out whether popup is needed, 2. only after that open it. 

2nd commit adds a new connect-popup test case


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-popup-request-timeout&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-popup-request-timeout&lookback=7)