### PR TITLE
feat (trading): show country code in the trading form instead of the name

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -29,7 +29,7 @@ export const TradingFormInputCountry = ({
         <>
             {renderInput && (
                 <FakeSelect
-                    value={countryValue?.label ?? defaultCountry?.label ?? ''}
+                    value={countryValue?.shortLabel ?? defaultCountry?.shortLabel ?? ''}
                     placeholder={label ? translationString(label) : undefined}
                     onClick={() => setIsModalOpen(true)}
                     data-testid="@trading/form/country-select"
@@ -50,7 +50,7 @@ export const TradingFormInputCountry = ({
                                 typographyStyle="body-md"
                                 data-testid="@trading/form/country-select/value"
                             >
-                                {countryValue?.label ?? defaultCountry?.label ?? ''}
+                                {countryValue?.shortLabel ?? defaultCountry?.shortLabel ?? ''}
                             </Text>
                             <Icon
                                 name="caretRight"

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
@@ -66,8 +66,6 @@ export const TradingFormInputPaymentMethod = ({
         ? (selectedOption?.label ?? paymentMethod?.label ?? paymentMethods[0]?.label ?? '')
         : translationString('TR_TRADING_NO_METHODS_AVAILABLE');
 
-    console.log('label', label, 'renderInput', renderInput);
-
     return (
         <>
             {renderInput && (

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -3,7 +3,7 @@ import { Locator, Page } from '@playwright/test';
 import { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { calculatePercentageOfBalance, getCountryLabel, step } from '../../common';
+import { calculatePercentageOfBalance, step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
 import { PaymentMethods, PercentageOfBalanceParams } from '../../types';
 
@@ -55,9 +55,8 @@ export class TradingFormInputs {
 
     @step()
     async selectCountryOfResidence(countryCode: TradingCountryCode) {
-        const countryLabel = getCountryLabel(countryCode);
         const currentCountry = await this.countryValue.textContent();
-        if (currentCountry?.includes(countryLabel)) {
+        if (currentCountry?.includes(countryCode)) {
             return;
         }
         await this.countrySelect.click();
@@ -65,7 +64,7 @@ export class TradingFormInputs {
             'TR_TRADING_COUNTRY',
         );
         await this.countryOption(countryCode).click();
-        await expect(this.countryValue).toContainText(countryLabel);
+        await expect(this.countryValue).toContainText(countryCode);
     }
 
     @step()


### PR DESCRIPTION
## Description
- **Trading form (desktop):** Country of residence is shown as **short label** (flag + ISO 3166-1 alpha-3 code, e.g. `DEU`) instead of full country name in:
  - `TradingFormInputCountry` when using `FakeSelect` (inline form)
  - `TradingFormInputCountry` when using `GhostContainer` (e.g. sell flow)
- Country selection modal is unchanged: list still shows full country names and search works as before.

## Notes for QA
- **Where:** Wallet → Trading → Buy/Sell forms (desktop Suite).
- **Check:** After choosing a country in the country of residence selector, the form shows the short label (e.g. `CZE`, `USA`) with flag, not the full name (e.g. “Czechia”, “United States”).
- **Edge cases:** “Worldwide” still shows as `Worldwide` (shortLabel is `🌍 Worldwide`). Verify search and selection in the country modal still work and that the chosen value is reflected correctly in the form and in subsequent quote/trade requests.

## Related Issue
Resolve #24524

## Screenshot
<img width="727" height="278" alt="image" src="https://github.com/user-attachments/assets/78001b28-e6ab-413c-bbb2-19ce397bb6c6" />
