### PR TITLE
fix(suite): show remembered wallet balance when device needs attention

### DIFF
--- a/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/CardWithDevice.tsx
@@ -53,11 +53,9 @@ export const CardWithDevice = ({
                     />
                 )}
 
-                {!needsAttention && (
+                {!isUnknown && (
                     <AnimatePresence initial={false}>
-                        {!isUnknown && (
-                            <motion.div {...motionAnimation.expand}>{children}</motion.div>
-                        )}
+                        <motion.div {...motionAnimation.expand}>{children}</motion.div>
                     </AnimatePresence>
                 )}
             </Column>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display remembered wallet balance when device needs attention (pin locked, used elsewhere and others) 

followup for https://github.com/trezor/trezor-suite/pull/24775

slack https://satoshilabs.slack.com/archives/C01SXSHGK44/p1771579565421609

## Screenshots:

<img width="456" height="350" alt="Screenshot from 2026-02-23 13-49-21" src="https://github.com/user-attachments/assets/c48c0f07-3818-41eb-8af3-3ce131126900" />
<img width="429" height="306" alt="Screenshot from 2026-02-23 13-44-42" src="https://github.com/user-attachments/assets/757e2e68-1f90-4ca9-86af-d269b9cc38d7" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-device-locked&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-device-locked&lookback=7)