### PR TITLE
fix(suite): hide network filter in global send modal for btc-only fw

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -1,6 +1,7 @@
 import { RefObject, memo } from 'react';
 
 import { TranslationKey, useTranslation } from '@suite/intl';
+import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { GlobalSendReceiveType } from '@suite-common/wallet-types';
@@ -23,6 +24,8 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
     listRef,
     modal,
 }: AssetSearchWithNetworkFilterProps) {
+    const isBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
+
     const [search, setSearch] = useSearchFilter();
     const [networkFilter, setNetworkFilter] = useNetworkFilter({
         modal,
@@ -40,18 +43,22 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
 
     useListScrollReset(listRef, search);
 
+    const selectConfig = isBitcoinOnlyFirmware
+        ? undefined
+        : {
+              networks,
+              selectedNetwork: networkFilter,
+              onChange: setNetworkFilter,
+              includeAllOption: !protocolSymbol,
+              allLabel: translationString('TR_ALL_NETWORKS'),
+          };
+
     return (
         <SearchAsset
             searchPlaceholder={translationString(placeholder)}
             search={search}
             setSearch={setSearch}
-            selectConfig={{
-                networks,
-                selectedNetwork: networkFilter,
-                onChange: setNetworkFilter,
-                includeAllOption: !protocolSymbol,
-                allLabel: translationString('TR_ALL_NETWORKS'),
-            }}
+            selectConfig={selectConfig}
         />
     );
 });


### PR DESCRIPTION
## Description

When bitcoin-only firmware device is selected, hide networks filter in global send modal.

## Related Issue

Resolve #24949 

## Screenshots:

<img width="1512" height="833" alt="Screenshot 2026-02-23 at 14 05 26" src="https://github.com/user-attachments/assets/a7c665bd-57c8-4329-ad4f-01de224520e3" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/global-send-form-btc-only-fw&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/global-send-form-btc-only-fw&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/global-send-form-btc-only-fw&lookback=7)