### PR TITLE
25072 add fiat rates into trading mobile

### DIFF
--- a/packages/blockchain-link-types/jest.config.js
+++ b/packages/blockchain-link-types/jest.config.js
@@ -1,0 +1,3 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = { ...baseConfig };

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -30,6 +30,7 @@
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
         "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
         "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
+        "test:unit": "yarn g:jest --coverage -c jest.config.js",
         "prepublishOnly": "yarn tsx ../../scripts/publish/prepublishNPM.js"
     },
     "dependencies": {

--- a/packages/blockchain-link-types/src/__tests__/baseCurrency.test.ts
+++ b/packages/blockchain-link-types/src/__tests__/baseCurrency.test.ts
@@ -1,0 +1,45 @@
+import {
+    isBaseCurrencyCode,
+    isFiatBaseCurrencyCode,
+    isValuablesBaseCurrencyCode,
+} from '../baseCurrency';
+
+describe('baseCurrency', () => {
+    describe('isBaseCurrencyCode', () => {
+        it.each(['usd', 'eur', 'btc', 'xag'])(`should return true for [%s]`, code => {
+            expect(isBaseCurrencyCode(code)).toBe(true);
+        });
+
+        it('should be false for unknown code', () => {
+            expect(isBaseCurrencyCode('dnd')).toBe(false);
+        });
+    });
+
+    describe('isFiatBaseCurrencyCode', () => {
+        it.each(['usd', 'eur'])(`should return true for [%s]`, code => {
+            expect(isFiatBaseCurrencyCode(code)).toBe(true);
+        });
+
+        it.each(['btc', 'xag'])('should be false for [%s]', code => {
+            expect(isFiatBaseCurrencyCode(code)).toBe(false);
+        });
+
+        it('should be false for unknown code', () => {
+            expect(isFiatBaseCurrencyCode('dnd')).toBe(false);
+        });
+    });
+
+    describe('isValuablesBaseCurrencyCode', () => {
+        it.each(['btc', 'xag'])(`should return true for [%s]`, code => {
+            expect(isValuablesBaseCurrencyCode(code)).toBe(true);
+        });
+
+        it.each(['usd', 'eur'])('should be false for [%s]', code => {
+            expect(isValuablesBaseCurrencyCode(code)).toBe(false);
+        });
+
+        it('should be false for unknown code', () => {
+            expect(isValuablesBaseCurrencyCode('dnd')).toBe(false);
+        });
+    });
+});

--- a/packages/blockchain-link-types/src/baseCurrency.ts
+++ b/packages/blockchain-link-types/src/baseCurrency.ts
@@ -64,3 +64,11 @@ export type BaseCurrency = (typeof baseCurrencies)[BaseCurrencyCode];
 
 export const isBaseCurrencyCode = (code: string): code is BaseCurrencyCode =>
     typeof code === 'string' && code in baseCurrencies;
+
+export const isFiatBaseCurrencyCode = (code: string): code is keyof typeof fiatBaseCurrencies =>
+    typeof code === 'string' && code in fiatBaseCurrencies;
+
+export const isValuablesBaseCurrencyCode = (
+    code: string,
+): code is keyof typeof valuablesBaseCurrencies =>
+    typeof code === 'string' && code in valuablesBaseCurrencies;

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -25,6 +25,7 @@
         "@suite-common/wallet-utils": "workspace:*",
         "@suite/intl": "workspace:*",
         "@trezor/address-validator": "workspace:*",
+        "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "@trezor/connect-plugin-ethereum": "workspace:*",

--- a/suite-common/trading/src/hooks/useTradingFiatValues.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CryptoId, FiatCurrencyCode } from 'invity-api';
+import { CryptoId } from 'invity-api';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -16,6 +16,7 @@ import {
     getFiatRateKey,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
+import { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import { TradingRootState } from '../reducers/tradingCommonReducer';
@@ -26,7 +27,7 @@ import {
 } from '../utils';
 
 export interface TradingFiatRatesProps {
-    fiatCurrency?: FiatCurrencyCode;
+    fiatCurrency?: BaseCurrencyCode;
     cryptoId?: CryptoId;
     amount?: string;
     shouldSendInSats?: boolean;
@@ -41,7 +42,7 @@ export interface TradingFiatRatesReturn {
     networkDecimals: number;
     tokenAddress: TokenAddress | undefined;
     fiatRatesUpdater: (
-        value: FiatCurrencyCode | undefined,
+        value: BaseCurrencyCode | undefined,
         currentTokenAddress?: TokenAddress,
     ) => Promise<FiatRatesResult | null>;
 }
@@ -82,7 +83,7 @@ export const useTradingFiatValues = ({
 
     const fiatRatesUpdater = useCallback(
         async (
-            value: FiatCurrencyCode | undefined,
+            value: BaseCurrencyCode | undefined,
             currentTokenAddress?: TokenAddress,
         ): Promise<FiatRatesResult | null> => {
             if (!value) return null;

--- a/suite-common/trading/src/hooks/useTradingFiatValues.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -16,7 +16,7 @@ import {
     getFiatRateKey,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
-import { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import { TradingRootState } from '../reducers/tradingCommonReducer';

--- a/suite-common/trading/tsconfig.json
+++ b/suite-common/trading/tsconfig.json
@@ -16,6 +16,9 @@
         {
             "path": "../../packages/address-validator"
         },
+        {
+            "path": "../../packages/blockchain-link-types"
+        },
         { "path": "../../packages/connect" },
         {
             "path": "../../packages/connect-common"

--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -12,6 +12,7 @@ import { BuyReceiveAccountCryptoBalance } from './BuyReceiveAccountCryptoBalance
 import { BuyReceiveAccountPicker } from './BuyReceiveAccountPicker';
 import { BuyTradeableAssetPicker } from './BuyTradeableAssetPicker';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { CryptoToFiatValueBadge } from '../general/CryptoToFiatValueBadge';
 import { TradeableAssetNetworkInfo } from '../general/TradeableAssetNetworkInfo';
 
 type BuyCardProps = {
@@ -45,7 +46,7 @@ export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardP
     const animatedStyle = useAnimatedBorderStyle(isAmountInputActive);
     const { watch } = useBuyFormContext();
 
-    const asset = watch('asset');
+    const [cryptoValue, asset] = watch(['cryptoValue', 'asset']);
 
     // on android fade animation looks ugly on view with shadows, better to skip it
     const enteringAnimation = shouldAnimateEntering && Platform.OS === 'ios' ? FadeIn : undefined;
@@ -75,7 +76,12 @@ export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardP
                         <CardTitle>
                             <Translation id="moduleTrading.selectCoin.title" />
                         </CardTitle>
-                        <BuyFormFieldErrorBadge fieldName="cryptoValue" />
+                        <BuyFormFieldErrorBadge fieldName="cryptoValue">
+                            <CryptoToFiatValueBadge
+                                amount={cryptoValue}
+                                cryptoId={asset?.cryptoId}
+                            />
+                        </BuyFormFieldErrorBadge>
                     </HStack>
                     <BuyTradeableAssetPicker />
                     <HStack

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useFormatters } from '@suite-common/formatters';
@@ -15,9 +16,9 @@ import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
 import { useConvertFormValueToBaseUnit } from '../../hooks/general/useConvertFormValueToBaseUnit';
 import { truncateDecimals } from '../../utils/general/amountUtils';
 
-export type BuyFormFieldErrorBadgeProps = {
+export type BuyFormFieldErrorBadgeProps = PropsWithChildren<{
     fieldName: keyof BuyFormValues;
-};
+}>;
 
 const asNonEmptyStringValue = (value: unknown): string => (value as string) ?? '0';
 
@@ -78,23 +79,21 @@ const useMismatchedAmountMessage = (fieldName: keyof BuyFormValues) => {
     return undefined;
 };
 
-export const BuyFormFieldErrorBadge = ({ fieldName }: BuyFormFieldErrorBadgeProps) => {
+export const BuyFormFieldErrorBadge = ({ fieldName, children }: BuyFormFieldErrorBadgeProps) => {
     const isLoading = useSelector(selectTradingBuyIsLoading);
 
     const { errorMessage, hasError } = useField({ name: fieldName });
     const mismatchedAmountMessage = useMismatchedAmountMessage(fieldName);
 
-    if (isLoading) {
-        return null;
+    if (!isLoading) {
+        if (hasError) {
+            return <Badge label={errorMessage} variant="red" size="small" />;
+        }
+
+        if (mismatchedAmountMessage) {
+            return <Badge label={mismatchedAmountMessage} variant="neutral" size="small" />;
+        }
     }
 
-    if (hasError) {
-        return <Badge label={errorMessage} variant="red" size="small" />;
-    }
-
-    if (mismatchedAmountMessage) {
-        return <Badge label={mismatchedAmountMessage} variant="neutral" size="small" />;
-    }
-
-    return null;
+    return children;
 };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.test.tsx
@@ -1,11 +1,12 @@
 import type { CryptoId } from 'invity-api';
 
+import { Text } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 import { BuyFormType } from '@suite-native/trading-types';
@@ -17,8 +18,8 @@ import { BuyFormFieldErrorBadge, BuyFormFieldErrorBadgeProps } from '../BuyFormF
 describe('BuyFormFieldErrorBadge', () => {
     let tradingForm: BuyFormType;
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
@@ -30,37 +31,38 @@ describe('BuyFormFieldErrorBadge', () => {
         form: BuyFormType,
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
-            <Form form={form}>
-                <BuyFormFieldErrorBadge {...props} />
-            </Form>,
-            { preloadedState },
-        );
+        renderWithStoreProvider(<BuyFormFieldErrorBadge {...props} />, {
+            preloadedState,
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+        });
 
-    beforeEach(async () => {
-        tradingForm = await renderUseTradingBuyForm();
+    beforeEach(() => {
+        tradingForm = renderUseTradingBuyForm();
     });
 
-    it('should render nothing where there is no error in form', async () => {
-        const { toJSON } = await renderBuyFormFieldErrorBadge(
-            { fieldName: 'fiatValue' },
-            tradingForm,
-        );
+    it('should render nothing when there is no error in form', () => {
+        const { toJSON } = renderBuyFormFieldErrorBadge({ fieldName: 'fiatValue' }, tradingForm);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render error when field has error', async () => {
+    it('should render children when there is no error in form', () => {
+        const { getByText } = renderBuyFormFieldErrorBadge(
+            { fieldName: 'fiatValue', children: <Text>CHILDREN</Text> },
+            tradingForm,
+        );
+
+        expect(getByText('CHILDREN')).toBeOnTheScreen();
+    });
+
+    it('should render error when field has error', () => {
         act(() => {
             tradingForm.setError('fiatValue', {
                 type: 'manual',
                 message: 'Error message',
             });
         });
-        const { getByText } = await renderBuyFormFieldErrorBadge(
-            { fieldName: 'fiatValue' },
-            tradingForm,
-        );
+        const { getByText } = renderBuyFormFieldErrorBadge({ fieldName: 'fiatValue' }, tradingForm);
 
         expect(getByText('Error message')).toBeTruthy();
     });
@@ -87,7 +89,7 @@ describe('BuyFormFieldErrorBadge', () => {
             });
         });
 
-        it('should render badge when quote has different crypto value than requested', async () => {
+        it('should render badge when quote has different crypto value than requested', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -95,7 +97,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
 
-            const { getByText } = await renderBuyFormFieldErrorBadge(
+            const { getByText } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -103,7 +105,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(getByText('Provider offer: 0.0005 BTC')).toBeTruthy();
         });
 
-        it('should not render badge when crypto amount does not differ', async () => {
+        it('should not render badge when crypto amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -111,7 +113,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0005');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -119,7 +121,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -127,7 +129,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0005000');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -135,7 +137,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge while quotes are loading', async () => {
+        it('should not render badge while quotes are loading', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -147,7 +149,7 @@ describe('BuyFormFieldErrorBadge', () => {
             };
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 preloadedState,
@@ -156,12 +158,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render badge when quote has different fiat value than requested', async () => {
+        it('should render badge when quote has different fiat value than requested', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '11.0');
             });
 
-            const { getByText } = await renderBuyFormFieldErrorBadge(
+            const { getByText } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -169,12 +171,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(getByText('Provider offer: $10.00')).toBeTruthy();
         });
 
-        it('should not render badge when fiat amount does not differ', async () => {
+        it('should not render badge when fiat amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '10.0');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -182,7 +184,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for cryptoValue when rendering different form field badge', async () => {
+        it('should not render badge for cryptoValue when rendering different form field badge', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -190,7 +192,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0006');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -198,12 +200,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for fiatValue when rendering different form field badge', async () => {
+        it('should not render badge for fiatValue when rendering different form field badge', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '11.0');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -211,12 +213,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '10.000');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -224,7 +226,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly compare with amount in sats', async () => {
+        it('should correctly compare with amount in sats', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -232,7 +234,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '50000');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 {
@@ -247,7 +249,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly display amount in sats', async () => {
+        it('should correctly display amount in sats', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -255,7 +257,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '51000');
             });
 
-            const { getByText } = await renderBuyFormFieldErrorBadge(
+            const { getByText } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
                 {
@@ -293,7 +295,7 @@ describe('BuyFormFieldErrorBadge', () => {
             });
         });
 
-        it('should not render badge when crypto amount does not differ', async () => {
+        it('should not render badge when crypto amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -301,7 +303,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0005');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -309,7 +311,7 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -317,7 +319,7 @@ describe('BuyFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoValue', '0.0005000');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'cryptoValue' },
                 tradingForm,
             );
@@ -325,12 +327,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ', async () => {
+        it('should not render badge when fiat amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '10.0');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );
@@ -338,12 +340,12 @@ describe('BuyFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('fiatValue', '10.000');
             });
 
-            const { toJSON } = await renderBuyFormFieldErrorBadge(
+            const { toJSON } = renderBuyFormFieldErrorBadge(
                 { fieldName: 'fiatValue' },
                 tradingForm,
             );

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
@@ -8,20 +8,18 @@ import { AccountLabel } from '@suite-native/labeling';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
 
 export type ExchangeFromAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
-    fromStringValue: string | undefined;
-    fromValue?: string;
 };
 
 export const ExchangeFromAccountTradePreviewCard = ({
     quote,
-    fromStringValue,
-    fromValue,
 }: ExchangeFromAccountTradePreviewCardProps) => {
     const fromAccount = useSelector(selectExchangeSelectedSendAccount);
+    const { fromStringValue, fromValue } = useChangeStringsExtractor(quote);
 
     if (!quote?.send || !fromAccount) {
         return null;

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.tsx
@@ -8,14 +8,18 @@ import { AccountLabel } from '@suite-native/labeling';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
+import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
+
 export type ExchangeFromAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
     fromStringValue: string | undefined;
+    fromValue?: string;
 };
 
 export const ExchangeFromAccountTradePreviewCard = ({
     quote,
     fromStringValue,
+    fromValue,
 }: ExchangeFromAccountTradePreviewCardProps) => {
     const fromAccount = useSelector(selectExchangeSelectedSendAccount);
 
@@ -33,6 +37,15 @@ export const ExchangeFromAccountTradePreviewCard = ({
                 </Text>
             }
             title={<Translation id="moduleTrading.tradingExchangePreviewScreen.fromAccount" />}
-        />
+        >
+            {!!fromValue && (
+                <CryptoToFiatValueBadge
+                    amount={fromValue}
+                    cryptoId={quote.send}
+                    color="textSubdued"
+                    textAlign="right"
+                />
+            )}
+        </TradeSideCard>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -10,7 +10,6 @@ import { ExchangeFeePickerCard } from './ExchangeFeePickerCard';
 import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
 import { ExchangeFusionPlusInfo } from './ExchangeFusionPlusInfo';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
-import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 import { LastErrorMessage } from '../../general/Error/LastErrorMessage';
 
 export type ExchangePreviewViewProps = {
@@ -21,8 +20,6 @@ export type ExchangePreviewViewProps = {
 
 export const ExchangePreviewView = memo(
     ({ quote, txnErrorString, isApproved }: ExchangePreviewViewProps) => {
-        const { fromStringValue, toStringValue, fromValue, toValue } =
-            useChangeStringsExtractor(quote);
         const isTxnError = !!txnErrorString;
         const isFusionPlus = quote?.exchange === '1inchfusionplus';
 
@@ -42,16 +39,8 @@ export const ExchangePreviewView = memo(
                         <InlineAlertBox variant="critical" title={txnErrorString} />
                     </Animated.View>
                 )}
-                <ExchangeFromAccountTradePreviewCard
-                    quote={quote}
-                    fromStringValue={fromStringValue}
-                    fromValue={fromValue}
-                />
-                <ExchangeToAccountTradePreviewCard
-                    quote={quote}
-                    toStringValue={toStringValue}
-                    toValue={toValue}
-                />
+                <ExchangeFromAccountTradePreviewCard quote={quote} />
+                <ExchangeToAccountTradePreviewCard quote={quote} />
                 <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
                 {isFusionPlus && <ExchangeFusionPlusInfo />}
             </VStack>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -21,7 +21,8 @@ export type ExchangePreviewViewProps = {
 
 export const ExchangePreviewView = memo(
     ({ quote, txnErrorString, isApproved }: ExchangePreviewViewProps) => {
-        const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+        const { fromStringValue, toStringValue, fromValue, toValue } =
+            useChangeStringsExtractor(quote);
         const isTxnError = !!txnErrorString;
         const isFusionPlus = quote?.exchange === '1inchfusionplus';
 
@@ -44,8 +45,13 @@ export const ExchangePreviewView = memo(
                 <ExchangeFromAccountTradePreviewCard
                     quote={quote}
                     fromStringValue={fromStringValue}
+                    fromValue={fromValue}
                 />
-                <ExchangeToAccountTradePreviewCard quote={quote} toStringValue={toStringValue} />
+                <ExchangeToAccountTradePreviewCard
+                    quote={quote}
+                    toStringValue={toStringValue}
+                    toValue={toValue}
+                />
                 <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
                 {isFusionPlus && <ExchangeFusionPlusInfo />}
             </VStack>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -8,14 +8,18 @@ import { AccountLabel } from '@suite-native/labeling';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
 
+import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
+
 export type ExchangeToAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
     toStringValue: string | undefined;
+    toValue?: string;
 };
 
 export const ExchangeToAccountTradePreviewCard = ({
     quote,
     toStringValue,
+    toValue,
 }: ExchangeToAccountTradePreviewCardProps) => {
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
 
@@ -35,6 +39,15 @@ export const ExchangeToAccountTradePreviewCard = ({
                 )
             }
             title={<Translation id="moduleTrading.tradingExchangePreviewScreen.toAccount" />}
-        />
+        >
+            {!!toValue && (
+                <CryptoToFiatValueBadge
+                    amount={toValue}
+                    cryptoId={quote.receive}
+                    color="textSubdued"
+                    textAlign="right"
+                />
+            )}
+        </TradeSideCard>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -8,20 +8,18 @@ import { AccountLabel } from '@suite-native/labeling';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
 
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
 
 export type ExchangeToAccountTradePreviewCardProps = {
     quote?: ExchangeTrade;
-    toStringValue: string | undefined;
-    toValue?: string;
 };
 
 export const ExchangeToAccountTradePreviewCard = ({
     quote,
-    toStringValue,
-    toValue,
 }: ExchangeToAccountTradePreviewCardProps) => {
     const toAccount = useSelector(selectExchangeSelectedReceiveAccount);
+    const { toStringValue, toValue } = useChangeStringsExtractor(quote);
 
     if (!quote?.receive || !toAccount?.account) {
         return null;

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -17,12 +17,9 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
 
-        return renderWithStoreProvider(
-            <ExchangeFromAccountTradePreviewCard fromStringValue="100" {...props} />,
-            {
-                preloadedState,
-            },
-        );
+        return renderWithStoreProvider(<ExchangeFromAccountTradePreviewCard {...props} />, {
+            preloadedState,
+        });
     };
 
     it('should render nothing when there is no quote', () => {
@@ -46,7 +43,8 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         });
 
         expect(getByText('Account')).toBeOnTheScreen();
-        expect(getByText('-100')).toBeOnTheScreen();
+        expect(getByText('-100 USDC')).toBeOnTheScreen();
+        expect(getByText(`100-${exchangeQuotes[0].send}`)).toBeOnTheScreen();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
@@ -55,14 +53,5 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
             quote: exchangeQuotes[0],
         });
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
-    });
-
-    it('should render value in fiat when fromValue is provided', () => {
-        const { getByText } = renderExchangeFromAccountTradePreviewCard({
-            quote: exchangeQuotes[0],
-            fromValue: '1',
-        });
-
-        expect(getByText(`1-${exchangeQuotes[0].send}`)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -1,9 +1,9 @@
-import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {
     ExchangeFromAccountTradePreviewCard,
-    ExchangeFromAccountTradePreviewCardProps,
+    type ExchangeFromAccountTradePreviewCardProps,
 } from '../ExchangeFromAccountTradePreviewCard';
 
 describe('ExchangeFromAccountTradePreviewCard', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -1,4 +1,4 @@
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -17,7 +17,7 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <ExchangeFromAccountTradePreviewCard fromStringValue="100" {...props} />,
             {
                 preloadedState,
@@ -25,14 +25,14 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         );
     };
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderExchangeFromAccountTradePreviewCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderExchangeFromAccountTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', async () => {
-        const { toJSON } = await renderExchangeFromAccountTradePreviewCard(
+    it('should render nothing when account is not found', () => {
+        const { toJSON } = renderExchangeFromAccountTradePreviewCard(
             { quote: exchangeQuotes[0] },
             'unknown-account-key',
         );
@@ -40,14 +40,29 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render TradeSideCard otherwise', async () => {
-        const { getByText } = await renderExchangeFromAccountTradePreviewCard({
+    it('should render TradeSideCard otherwise', () => {
+        const { getByText } = renderExchangeFromAccountTradePreviewCard({
             quote: exchangeQuotes[0],
         });
 
         expect(getByText('Account')).toBeOnTheScreen();
-        expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('-100')).toBeOnTheScreen();
+    });
+
+    // Todo: https://github.com/trezor/trezor-suite/issues/24906
+    it.skip('should display correct account name', () => {
+        const { getByText } = renderExchangeFromAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+        });
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+    });
+
+    it('should render value in fiat when fromValue is provided', () => {
+        const { getByText } = renderExchangeFromAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+            fromValue: '1',
+        });
+
+        expect(getByText(`1-${exchangeQuotes[0].send}`)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
@@ -1,4 +1,4 @@
-import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
@@ -17,10 +17,9 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.receiveAccountKey = receiveAccountKey;
 
-        return renderWithStoreProvider(
-            <ExchangeToAccountTradePreviewCard toStringValue="100" {...props} />,
-            { preloadedState },
-        );
+        return renderWithStoreProvider(<ExchangeToAccountTradePreviewCard {...props} />, {
+            preloadedState,
+        });
     };
 
     it('should render nothing when there is no quote', () => {
@@ -44,7 +43,8 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         });
 
         expect(getByText('Account')).toBeOnTheScreen();
-        expect(getByText('+100')).toBeOnTheScreen();
+        expect(getByText('+0.00083554 BTC')).toBeOnTheScreen();
+        expect(getByText(`0.00083554-${exchangeQuotes[0].receive}`)).toBeOnTheScreen();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
@@ -54,14 +54,5 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         });
 
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
-    });
-
-    it('should render value in fiat when toValue is provided', () => {
-        const { getByText } = renderExchangeToAccountTradePreviewCard({
-            quote: exchangeQuotes[0],
-            toValue: '1',
-        });
-
-        expect(getByText(`1-${exchangeQuotes[0].receive}`)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
@@ -1,4 +1,4 @@
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -17,20 +17,20 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.receiveAccountKey = receiveAccountKey;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <ExchangeToAccountTradePreviewCard toStringValue="100" {...props} />,
             { preloadedState },
         );
     };
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderExchangeToAccountTradePreviewCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderExchangeToAccountTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', async () => {
-        const { toJSON } = await renderExchangeToAccountTradePreviewCard(
+    it('should render nothing when account is not found', () => {
+        const { toJSON } = renderExchangeToAccountTradePreviewCard(
             { quote: exchangeQuotes[0] },
             'unknown-account-key',
         );
@@ -38,14 +38,30 @@ describe('ExchangeToAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render TradeSideCard otherwise', async () => {
-        const { getByText } = await renderExchangeToAccountTradePreviewCard({
+    it('should render TradeSideCard otherwise', () => {
+        const { getByText } = renderExchangeToAccountTradePreviewCard({
             quote: exchangeQuotes[0],
         });
 
         expect(getByText('Account')).toBeOnTheScreen();
-        expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('+100')).toBeOnTheScreen();
+    });
+
+    // Todo: https://github.com/trezor/trezor-suite/issues/24906
+    it.skip('should render correct account name', () => {
+        const { getByText } = renderExchangeToAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+        });
+
+        expect(getByText('BTC Account #1')).toBeOnTheScreen();
+    });
+
+    it('should render value in fiat when toValue is provided', () => {
+        const { getByText } = renderExchangeToAccountTradePreviewCard({
+            quote: exchangeQuotes[0],
+            toValue: '1',
+        });
+
+        expect(getByText(`1-${exchangeQuotes[0].receive}`)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveCard.tsx
@@ -6,6 +6,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { ExchangeReceiveAccountCryptoBalance } from './ExchangeReceiveAccountCryptoBalance';
 import { ExchangeTradeableAssetPicker } from './ExchangeTradeableAssetPicker';
 import { useExchangeFormContext } from '../../../hooks/exchange/useExchangeFormContext';
+import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
 import { TradeableAssetNetworkInfo } from '../../general/TradeableAssetNetworkInfo';
 
 const nonEditableCardStyle = prepareNativeStyle(({ colors, borders }) => ({
@@ -18,7 +19,7 @@ export const ExchangeReceiveCard = () => {
     const { applyStyle } = useNativeStyles();
     const { watch } = useExchangeFormContext();
 
-    const asset = watch('receiveAsset');
+    const [asset, cryptoAmount] = watch(['receiveAsset', 'receiveCryptoAmount']);
 
     return (
         <Card style={applyStyle(nonEditableCardStyle)}>
@@ -27,6 +28,7 @@ export const ExchangeReceiveCard = () => {
                     <CardTitle>
                         <Translation id="moduleTrading.selectCoin.title" />
                     </CardTitle>
+                    <CryptoToFiatValueBadge cryptoId={asset?.cryptoId} amount={cryptoAmount} />
                 </HStack>
                 <ExchangeTradeableAssetPicker />
                 <HStack

--- a/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
@@ -8,13 +8,11 @@ import { useTradingFiatValues } from '../../hooks/general/useTradingFiatValues';
 export type CryptoToFiatValueBadgeProps = {
     amount: string | undefined;
     cryptoId: CryptoId | undefined;
-    prefix?: string;
 } & TextProps;
 
 export const CryptoToFiatValueBadge = ({
     amount,
     cryptoId,
-    prefix,
     ...textProps
 }: CryptoToFiatValueBadgeProps) => {
     const baseCurrencyAmount = useTradingFiatValues(amount, cryptoId)?.baseCurrencyAmount;
@@ -26,7 +24,6 @@ export const CryptoToFiatValueBadge = ({
 
     return (
         <Text variant="body-sm" {...textProps}>
-            {prefix}
             <BaseCurrencyAmountFormatter value={baseCurrencyAmount} />
         </Text>
     );

--- a/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
@@ -1,0 +1,32 @@
+import type { CryptoId } from 'invity-api';
+
+import { useFormatters } from '@suite-common/formatters';
+import { Text } from '@suite-native/atoms';
+
+import { useTradingFiatValues } from '../../hooks/general/useTradingFiatValues';
+
+export type CryptoToFiatValueBadgeProps = {
+    amount: string | undefined;
+    cryptoId: CryptoId | undefined;
+    prefix?: string;
+};
+
+export const CryptoToFiatValueBadge = ({
+    amount,
+    cryptoId,
+    prefix,
+}: CryptoToFiatValueBadgeProps) => {
+    const baseCurrencyAmount = useTradingFiatValues(amount, cryptoId)?.baseCurrencyAmount;
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    if (!baseCurrencyAmount) {
+        return null;
+    }
+
+    return (
+        <Text variant="body-sm">
+            {prefix}
+            <BaseCurrencyAmountFormatter value={baseCurrencyAmount} />
+        </Text>
+    );
+};

--- a/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
+++ b/suite-native/module-trading/src/components/general/CryptoToFiatValueBadge.tsx
@@ -1,7 +1,7 @@
 import type { CryptoId } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
-import { Text } from '@suite-native/atoms';
+import { Text, type TextProps } from '@suite-native/atoms';
 
 import { useTradingFiatValues } from '../../hooks/general/useTradingFiatValues';
 
@@ -9,12 +9,13 @@ export type CryptoToFiatValueBadgeProps = {
     amount: string | undefined;
     cryptoId: CryptoId | undefined;
     prefix?: string;
-};
+} & TextProps;
 
 export const CryptoToFiatValueBadge = ({
     amount,
     cryptoId,
     prefix,
+    ...textProps
 }: CryptoToFiatValueBadgeProps) => {
     const baseCurrencyAmount = useTradingFiatValues(amount, cryptoId)?.baseCurrencyAmount;
     const { BaseCurrencyAmountFormatter } = useFormatters();
@@ -24,7 +25,7 @@ export const CryptoToFiatValueBadge = ({
     }
 
     return (
-        <Text variant="body-sm">
+        <Text variant="body-sm" {...textProps}>
             {prefix}
             <BaseCurrencyAmountFormatter value={baseCurrencyAmount} />
         </Text>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -2,10 +2,10 @@ import { Pressable } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import {
-    TradingProviderInfo,
-    TradingRootState,
-    TradingTradeType,
-    TradingType,
+    type TradingProviderInfo,
+    type TradingRootState,
+    type TradingTradeType,
+    type TradingType,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
 import { Card, CardDivider, HStack, Radio, Text, VStack } from '@suite-native/atoms';

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -6,18 +6,14 @@ import {
     TradingRootState,
     TradingTradeType,
     TradingType,
-    isBuyTrade,
-    isSellFiatTrade,
     selectTradingProviderByNameAndTradeType,
 } from '@suite-common/trading';
-import { Card, HStack, Radio, Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Card, CardDivider, HStack, Radio, Text, VStack } from '@suite-native/atoms';
 import { ProviderLogo } from '@suite-native/trading-atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-import { InfoLineItem } from './InfoLineItem';
-import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
-import { getKycPolicyWarningTranslation } from '../../../utils/general/kycUtils';
+import { ProviderListItemInfo } from './ProviderListItemInfo';
+import { ProviderListItemValueRow } from './ProviderListItemValueRow';
 
 export type ProviderListItemProps<T extends TradingTradeType> = {
     isSelected: boolean;
@@ -38,8 +34,6 @@ export const ProviderListItem = <T extends TradingTradeType>({
 }: ProviderListItemProps<T>) => {
     const { applyStyle } = useNativeStyles();
 
-    const { toStringValue, formattedRate } = useChangeStringsExtractor(quote);
-
     const provider =
         useSelector((state: TradingRootState) =>
             selectTradingProviderByNameAndTradeType(state, quote.exchange, tradingType),
@@ -50,21 +44,6 @@ export const ProviderListItem = <T extends TradingTradeType>({
 
     if (!orderId) {
         return null;
-    }
-
-    let isDex = false;
-    let isAnonymous = false;
-    let kycWarning;
-
-    if ('kycPolicyType' in provider) {
-        const kycPolicy = provider.kycPolicyType;
-
-        isDex = kycPolicy === 'DEX';
-
-        isAnonymous = kycPolicy === 'noKYC' || isDex;
-        kycWarning = getKycPolicyWarningTranslation(kycPolicy);
-    } else if (isBuyTrade(quote) || isSellFiatTrade(quote)) {
-        kycWarning = <Translation id="moduleTrading.providerListItem.kycRequired" />;
     }
 
     return (
@@ -84,49 +63,9 @@ export const ProviderListItem = <T extends TradingTradeType>({
                             isChecked={isSelected}
                         />
                     </HStack>
-                    {!!formattedRate && (
-                        <InfoLineItem
-                            iconName="check"
-                            text={<Translation id="moduleTrading.providerListItem.rate" />}
-                            textRight={formattedRate}
-                        />
-                    )}
-                    {!!toStringValue && (
-                        <InfoLineItem
-                            iconName="check"
-                            text={<Translation id="moduleTrading.providerListItem.youGet" />}
-                            iconColor="textSubdued"
-                            textRight={toStringValue}
-                        />
-                    )}
-
-                    <InfoLineItem
-                        iconName="check"
-                        text={
-                            isDex ? (
-                                <Translation id="moduleTrading.providerListItem.decentralizedExchange" />
-                            ) : (
-                                <Translation id="moduleTrading.providerListItem.centralizedExchange" />
-                            )
-                        }
-                    />
-
-                    {isAnonymous && (
-                        <InfoLineItem
-                            iconName="info"
-                            text={<Translation id="moduleTrading.providerListItem.anonymous" />}
-                            iconColor="baseContentBrand"
-                            textColor="baseContentBrand"
-                        />
-                    )}
-                    {kycWarning && (
-                        <InfoLineItem
-                            iconName="warning"
-                            text={kycWarning}
-                            iconColor="iconAlertRed"
-                            textColor="textAlertRed"
-                        />
-                    )}
+                    <ProviderListItemInfo provider={provider} quote={quote} />
+                    <CardDivider />
+                    <ProviderListItemValueRow quote={quote} />
                 </VStack>
             </Card>
         </Pressable>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
@@ -1,6 +1,6 @@
 import {
-    TradingProviderInfo,
-    TradingTradeType,
+    type TradingProviderInfo,
+    type TradingTradeType,
     isBuyTrade,
     isSellFiatTrade,
 } from '@suite-common/trading';

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
@@ -1,0 +1,66 @@
+import {
+    TradingProviderInfo,
+    TradingTradeType,
+    isBuyTrade,
+    isSellFiatTrade,
+} from '@suite-common/trading';
+import { Translation } from '@suite-native/intl';
+
+import { InfoLineItem } from './InfoLineItem';
+import { getKycPolicyWarningTranslation } from '../../../utils/general/kycUtils';
+
+export type ProviderListItemInfoProps<T extends TradingTradeType> = {
+    quote: T;
+    provider: TradingProviderInfo;
+};
+
+export const ProviderListItemInfo = <T extends TradingTradeType>({
+    quote,
+    provider,
+}: ProviderListItemInfoProps<T>) => {
+    let isDex = false;
+    let isAnonymous = false;
+    let kycWarning;
+
+    if ('kycPolicyType' in provider) {
+        const kycPolicy = provider.kycPolicyType;
+
+        isDex = kycPolicy === 'DEX';
+
+        isAnonymous = kycPolicy === 'noKYC' || isDex;
+        kycWarning = getKycPolicyWarningTranslation(kycPolicy);
+    } else if (isBuyTrade(quote) || isSellFiatTrade(quote)) {
+        kycWarning = <Translation id="moduleTrading.providerListItem.kycRequired" />;
+    }
+
+    return (
+        <>
+            <InfoLineItem
+                iconName="info"
+                text={
+                    isDex ? (
+                        <Translation id="moduleTrading.providerListItem.decentralizedExchange" />
+                    ) : (
+                        <Translation id="moduleTrading.providerListItem.centralizedExchange" />
+                    )
+                }
+            />
+            {isAnonymous && (
+                <InfoLineItem
+                    iconName="info"
+                    text={<Translation id="moduleTrading.providerListItem.anonymous" />}
+                    iconColor="baseContentBrand"
+                    textColor="baseContentBrand"
+                />
+            )}
+            {kycWarning && (
+                <InfoLineItem
+                    iconName="warning"
+                    text={kycWarning}
+                    iconColor="iconAlertRed"
+                    textColor="textAlertRed"
+                />
+            )}
+        </>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
@@ -1,0 +1,31 @@
+import { TradingTradeType } from '@suite-common/trading';
+import { HStack, Text } from '@suite-native/atoms';
+
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+import { CryptoToFiatValueBadge } from '../CryptoToFiatValueBadge';
+
+export type ProviderListItemValueRowProps<T extends TradingTradeType> = {
+    quote: T;
+};
+
+export const ProviderListItemValueRow = <T extends TradingTradeType>({
+    quote,
+}: ProviderListItemValueRowProps<T>) => {
+    const { toStringValue, isToCrypto, toValue, toCurrency } = useChangeStringsExtractor(quote);
+
+    return (
+        <HStack justifyContent="space-between" alignItems="center" paddingTop="sp8">
+            <Text variant="body-md" color="textDefault">
+                {toStringValue}
+            </Text>
+            {isToCrypto && (
+                <CryptoToFiatValueBadge
+                    amount={toValue}
+                    cryptoId={toCurrency}
+                    prefix="≈ "
+                    color="textSubdued"
+                />
+            )}
+        </HStack>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
@@ -1,4 +1,4 @@
-import { TradingTradeType } from '@suite-common/trading';
+import type { TradingTradeType } from '@suite-common/trading';
 import { HStack, Text } from '@suite-native/atoms';
 
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
@@ -22,7 +22,6 @@ export const ProviderListItemValueRow = <T extends TradingTradeType>({
                 <CryptoToFiatValueBadge
                     amount={toValue}
                     cryptoId={toCurrency}
-                    prefix="≈ "
                     color="textSubdued"
                 />
             )}

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -1,16 +1,24 @@
 import { TradingTradeType } from '@suite-common/trading';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
-import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import {
+    getInitializedTradingStateWithQuotes,
+    mockWalletFiatRatesAndSettings,
+} from '@suite-native/trading-fixtures';
 
 import { ProviderListItem, ProviderListItemProps } from '../ProviderListItem';
+
+jest.mock('@suite-common/fiat-services', () => ({
+    ...jest.requireActual('@suite-common/fiat-services'),
+    fetchCurrentFiatRates: () => Promise.resolve(null),
+}));
 
 describe('ProviderListItem', () => {
     const renderProviderListItem = (
         quote: TradingTradeType,
-        preloadedState: PreloadedState = {},
+        overrides: PreloadedState = {},
         props?: Partial<ProviderListItemProps<TradingTradeType>>,
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ProviderListItem
                 isSelected={false}
                 onPress={jest.fn()}
@@ -18,79 +26,88 @@ describe('ProviderListItem', () => {
                 tradingType="buy"
                 {...props}
             />,
-            { preloadedState },
+            {
+                preloadedState: {
+                    ...overrides,
+                    wallet: {
+                        ...mockWalletFiatRatesAndSettings(),
+                        ...overrides?.wallet,
+                    },
+                },
+            },
         );
 
-    it('should render provider information correctly', async () => {
+    it('should render provider information correctly', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
+        const { getByText } = renderProviderListItem(quote, preloadedState, {});
 
-        expect(queryByText('Mercuryo')).toBeTruthy();
+        expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render trading information with formatted strings', async () => {
+    it('should render trading information with formatted strings', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
+        const { getByText } = renderProviderListItem(quote, preloadedState, {});
 
-        expect(queryByText('Rate')).toBeTruthy();
-        expect(queryByText('You get')).toBeTruthy();
+        // estimated rate in base currency
+        expect(getByText(/≈[ \n]+\$[0-9.]+$/)).toBeOnTheScreen();
+        expect(getByText('Centralized exchange')).toBeOnTheScreen();
     });
 
-    it('should render KYC information when provider has KYC policy', async () => {
+    it('should render KYC information when provider has KYC policy', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.exchange.quotes[2];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
+        const { getByText } = renderProviderListItem(quote, preloadedState, {
             tradingType: 'exchange',
         });
 
-        expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
+        expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
     });
 
-    it('should render anonymous information for DEX providers', async () => {
+    it('should render anonymous information for DEX providers', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.exchange.quotes[3];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
+        const { getByText } = renderProviderListItem(quote, preloadedState, {
             tradingType: 'exchange',
         });
 
-        expect(queryByText('Anonymous')).toBeTruthy();
-        expect(queryByText('Decentralized exchange')).toBeTruthy();
+        expect(getByText('Anonymous')).toBeOnTheScreen();
+        expect(getByText('Decentralized exchange')).toBeOnTheScreen();
     });
 
-    it('should not render when quote has no orderId', async () => {
+    it('should not render when quote has no orderId', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const baseQuote = preloadedState.wallet.trading.buy.quotes[0];
         const { orderId, ...quoteWithoutOrderId } = baseQuote;
         const quote = quoteWithoutOrderId as TradingTradeType;
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
+        const { queryByText } = renderProviderListItem(quote, preloadedState, {});
 
         expect(queryByText('TestProvider')).toBeNull();
     });
 
-    it('should render KYC warning for buy quote', async () => {
+    it('should render KYC warning for buy quote', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.buy.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {});
+        const { getByText } = renderProviderListItem(quote, preloadedState, {});
 
-        expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
+        expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
     });
 
-    it('should render KYC warning for sell quote', async () => {
+    it('should render KYC warning for sell quote', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         const quote = preloadedState.wallet.trading.sell.quotes[0];
 
-        const { queryByText } = await renderProviderListItem(quote, preloadedState, {
+        const { getByText } = renderProviderListItem(quote, preloadedState, {
             tradingType: 'sell',
         });
 
-        expect(queryByText('This provider requires to verify identity.')).toBeTruthy();
+        expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -1,11 +1,11 @@
-import { TradingTradeType } from '@suite-common/trading';
-import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import type { TradingTradeType } from '@suite-common/trading';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     getInitializedTradingStateWithQuotes,
     mockWalletFiatRatesAndSettings,
 } from '@suite-native/trading-fixtures';
 
-import { ProviderListItem, ProviderListItemProps } from '../ProviderListItem';
+import { ProviderListItem, type ProviderListItemProps } from '../ProviderListItem';
 
 describe('ProviderListItem', () => {
     const renderProviderListItem = (

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -7,11 +7,6 @@ import {
 
 import { ProviderListItem, ProviderListItemProps } from '../ProviderListItem';
 
-jest.mock('@suite-common/fiat-services', () => ({
-    ...jest.requireActual('@suite-common/fiat-services'),
-    fetchCurrentFiatRates: () => Promise.resolve(null),
-}));
-
 describe('ProviderListItem', () => {
     const renderProviderListItem = (
         quote: TradingTradeType,
@@ -52,8 +47,8 @@ describe('ProviderListItem', () => {
 
         const { getByText } = renderProviderListItem(quote, preloadedState, {});
 
-        // estimated rate in base currency
-        expect(getByText(/≈[ \n]+\$[0-9.]+$/)).toBeOnTheScreen();
+        // estimated rate in base currency (component is mocked)
+        expect(getByText(/^0.001[0-9]+-bitcoin$/)).toBeOnTheScreen();
         expect(getByText('Centralized exchange')).toBeOnTheScreen();
     });
 

--- a/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
@@ -1,0 +1,116 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { FullAppState } from '@suite-native/state';
+import { PreloadedState, act, renderWithStoreProvider } from '@suite-native/test-utils';
+import { btcAsset, ethAsset } from '@suite-native/trading-fixtures';
+import { PROTO } from '@trezor/connect';
+
+import { CryptoToFiatValueBadge, CryptoToFiatValueBadgeProps } from '../CryptoToFiatValueBadge';
+
+jest.mock('@suite-common/fiat-services', () => ({
+    ...jest.requireActual('@suite-common/fiat-services'),
+    fetchCurrentFiatRates: () => Promise.resolve(null),
+}));
+
+describe('CryptoToFiatValueBadge', () => {
+    const createMockRate = (rate: number, symbol: NetworkSymbol): Rate => ({
+        rate,
+        lastTickerTimestamp: 1000000 as Timestamp,
+        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+        isLoading: false,
+        error: null,
+        ticker: { symbol },
+    });
+
+    const getPreloadedState = (
+        walletOverrides: Partial<FullAppState['wallet']> = {},
+    ): Partial<FullAppState> => ({
+        wallet: {
+            settings: {
+                localCurrency: 'usd',
+                bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
+            } as WalletSettings,
+            fiat: {
+                current: {
+                    [getFiatRateKey('btc', 'usd')]: createMockRate(50000, 'btc'),
+                },
+                lastWeek: {},
+                historic: {},
+            },
+            ...walletOverrides,
+        } as FullAppState['wallet'],
+    });
+
+    const renderCryptoToFiatValueBadge = async (
+        props: CryptoToFiatValueBadgeProps,
+        preloadedState: PreloadedState = {},
+    ) => {
+        const res = renderWithStoreProvider(<CryptoToFiatValueBadge {...props} />, {
+            preloadedState,
+        });
+
+        // await mocked loading of rates
+        await act(() => Promise.resolve());
+
+        return res;
+    };
+
+    it('should render nothing when no rate is loaded', async () => {
+        const { toJSON } = await renderCryptoToFiatValueBadge(
+            { amount: '1', cryptoId: ethAsset.cryptoId },
+            getPreloadedState(),
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it.each([undefined, ''])(
+        'should render nothing when cryptoValue is [%s]',
+        async cryptoValue => {
+            const { toJSON } = await renderCryptoToFiatValueBadge(
+                { amount: cryptoValue, cryptoId: btcAsset.cryptoId },
+
+                getPreloadedState(),
+            );
+
+            expect(toJSON()).toBeNull();
+        },
+    );
+
+    it('should render rate for 0', async () => {
+        const { getByText } = await renderCryptoToFiatValueBadge(
+            { amount: '0', cryptoId: btcAsset.cryptoId },
+            getPreloadedState(),
+        );
+
+        expect(getByText('$0.00')).toBeOnTheScreen();
+    });
+
+    it('should render rate otherwise', async () => {
+        const { getByText } = await renderCryptoToFiatValueBadge(
+            { amount: '1', cryptoId: btcAsset.cryptoId },
+            getPreloadedState(),
+        );
+
+        expect(getByText('$50,000.00')).toBeOnTheScreen();
+    });
+
+    it('should render prefix, if specified', async () => {
+        const { getByText } = await renderCryptoToFiatValueBadge(
+            { amount: '1', cryptoId: btcAsset.cryptoId, prefix: ':fire: ' },
+            getPreloadedState(),
+        );
+
+        expect(getByText(':fire: $50,000.00')).toBeOnTheScreen();
+    });
+
+    it('should not render prefix when no value is rendered ', async () => {
+        const { toJSON } = await renderCryptoToFiatValueBadge(
+            { amount: '1', cryptoId: ethAsset.cryptoId, prefix: ':sweat_drops: ' },
+            getPreloadedState(),
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
@@ -1,7 +1,10 @@
 import { act, renderWithStoreProvider } from '@suite-native/test-utils';
 import { btcAsset, ethAsset, mockWalletFiatRatesAndSettings } from '@suite-native/trading-fixtures';
 
-import { CryptoToFiatValueBadge, CryptoToFiatValueBadgeProps } from '../CryptoToFiatValueBadge';
+import {
+    CryptoToFiatValueBadge,
+    type CryptoToFiatValueBadgeProps,
+} from '../CryptoToFiatValueBadge';
 
 jest.mock('@suite-common/fiat-services', () => ({
     ...jest.requireActual('@suite-common/fiat-services'),

--- a/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
@@ -8,6 +8,8 @@ jest.mock('@suite-common/fiat-services', () => ({
     fetchCurrentFiatRates: () => Promise.resolve(null),
 }));
 
+jest.mock('../CryptoToFiatValueBadge', () => jest.requireActual('../CryptoToFiatValueBadge'));
+
 describe('CryptoToFiatValueBadge', () => {
     const getPreloadedState = () => ({
         wallet: mockWalletFiatRatesAndSettings(),
@@ -61,25 +63,5 @@ describe('CryptoToFiatValueBadge', () => {
         });
 
         expect(getByText('$50,000.00')).toBeOnTheScreen();
-    });
-
-    it('should render prefix, if specified', async () => {
-        const { getByText } = await renderCryptoToFiatValueBadge({
-            amount: '1',
-            cryptoId: btcAsset.cryptoId,
-            prefix: ':fire: ',
-        });
-
-        expect(getByText(':fire: $50,000.00')).toBeOnTheScreen();
-    });
-
-    it('should not render prefix when no value is rendered ', async () => {
-        const { toJSON } = await renderCryptoToFiatValueBadge({
-            amount: '1',
-            cryptoId: ethAsset.cryptoId,
-            prefix: ':sweat_drops: ',
-        });
-
-        expect(toJSON()).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
@@ -1,10 +1,5 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
-import { getFiatRateKey } from '@suite-common/wallet-utils';
-import { FullAppState } from '@suite-native/state';
-import { PreloadedState, act, renderWithStoreProvider } from '@suite-native/test-utils';
-import { btcAsset, ethAsset } from '@suite-native/trading-fixtures';
-import { PROTO } from '@trezor/connect';
+import { act, renderWithStoreProvider } from '@suite-native/test-utils';
+import { btcAsset, ethAsset, mockWalletFiatRatesAndSettings } from '@suite-native/trading-fixtures';
 
 import { CryptoToFiatValueBadge, CryptoToFiatValueBadgeProps } from '../CryptoToFiatValueBadge';
 
@@ -14,40 +9,13 @@ jest.mock('@suite-common/fiat-services', () => ({
 }));
 
 describe('CryptoToFiatValueBadge', () => {
-    const createMockRate = (rate: number, symbol: NetworkSymbol): Rate => ({
-        rate,
-        lastTickerTimestamp: 1000000 as Timestamp,
-        lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
-        isLoading: false,
-        error: null,
-        ticker: { symbol },
+    const getPreloadedState = () => ({
+        wallet: mockWalletFiatRatesAndSettings(),
     });
 
-    const getPreloadedState = (
-        walletOverrides: Partial<FullAppState['wallet']> = {},
-    ): Partial<FullAppState> => ({
-        wallet: {
-            settings: {
-                localCurrency: 'usd',
-                bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
-            } as WalletSettings,
-            fiat: {
-                current: {
-                    [getFiatRateKey('btc', 'usd')]: createMockRate(50000, 'btc'),
-                },
-                lastWeek: {},
-                historic: {},
-            },
-            ...walletOverrides,
-        } as FullAppState['wallet'],
-    });
-
-    const renderCryptoToFiatValueBadge = async (
-        props: CryptoToFiatValueBadgeProps,
-        preloadedState: PreloadedState = {},
-    ) => {
+    const renderCryptoToFiatValueBadge = async (props: CryptoToFiatValueBadgeProps) => {
         const res = renderWithStoreProvider(<CryptoToFiatValueBadge {...props} />, {
-            preloadedState,
+            preloadedState: getPreloadedState(),
         });
 
         // await mocked loading of rates
@@ -57,10 +25,10 @@ describe('CryptoToFiatValueBadge', () => {
     };
 
     it('should render nothing when no rate is loaded', async () => {
-        const { toJSON } = await renderCryptoToFiatValueBadge(
-            { amount: '1', cryptoId: ethAsset.cryptoId },
-            getPreloadedState(),
-        );
+        const { toJSON } = await renderCryptoToFiatValueBadge({
+            amount: '1',
+            cryptoId: ethAsset.cryptoId,
+        });
 
         expect(toJSON()).toBeNull();
     });
@@ -68,48 +36,49 @@ describe('CryptoToFiatValueBadge', () => {
     it.each([undefined, ''])(
         'should render nothing when cryptoValue is [%s]',
         async cryptoValue => {
-            const { toJSON } = await renderCryptoToFiatValueBadge(
-                { amount: cryptoValue, cryptoId: btcAsset.cryptoId },
-
-                getPreloadedState(),
-            );
+            const { toJSON } = await renderCryptoToFiatValueBadge({
+                amount: cryptoValue,
+                cryptoId: btcAsset.cryptoId,
+            });
 
             expect(toJSON()).toBeNull();
         },
     );
 
     it('should render rate for 0', async () => {
-        const { getByText } = await renderCryptoToFiatValueBadge(
-            { amount: '0', cryptoId: btcAsset.cryptoId },
-            getPreloadedState(),
-        );
+        const { getByText } = await renderCryptoToFiatValueBadge({
+            amount: '0',
+            cryptoId: btcAsset.cryptoId,
+        });
 
         expect(getByText('$0.00')).toBeOnTheScreen();
     });
 
     it('should render rate otherwise', async () => {
-        const { getByText } = await renderCryptoToFiatValueBadge(
-            { amount: '1', cryptoId: btcAsset.cryptoId },
-            getPreloadedState(),
-        );
+        const { getByText } = await renderCryptoToFiatValueBadge({
+            amount: '1',
+            cryptoId: btcAsset.cryptoId,
+        });
 
         expect(getByText('$50,000.00')).toBeOnTheScreen();
     });
 
     it('should render prefix, if specified', async () => {
-        const { getByText } = await renderCryptoToFiatValueBadge(
-            { amount: '1', cryptoId: btcAsset.cryptoId, prefix: ':fire: ' },
-            getPreloadedState(),
-        );
+        const { getByText } = await renderCryptoToFiatValueBadge({
+            amount: '1',
+            cryptoId: btcAsset.cryptoId,
+            prefix: ':fire: ',
+        });
 
         expect(getByText(':fire: $50,000.00')).toBeOnTheScreen();
     });
 
     it('should not render prefix when no value is rendered ', async () => {
-        const { toJSON } = await renderCryptoToFiatValueBadge(
-            { amount: '1', cryptoId: ethAsset.cryptoId, prefix: ':sweat_drops: ' },
-            getPreloadedState(),
-        );
+        const { toJSON } = await renderCryptoToFiatValueBadge({
+            amount: '1',
+            cryptoId: ethAsset.cryptoId,
+            prefix: ':sweat_drops: ',
+        });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
@@ -1,0 +1,60 @@
+import type { CryptoId } from 'invity-api';
+
+import {
+    cryptoIdToNetworkAndContractAddress,
+    isCryptoIdForNativeToken,
+} from '@suite-common/trading';
+import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { HStack, Text, VStack } from '@suite-native/atoms';
+import { CryptoIcon } from '@suite-native/icons';
+
+import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
+
+type TradeDetailAmountStackProps = {
+    isCrypto: boolean | undefined;
+    amountString: string | undefined;
+    amountValue: string | undefined;
+    currency: string | CryptoId | undefined;
+    testID?: string;
+};
+
+type CryptoIdIconProps = { cryptoId: CryptoId | undefined };
+
+const CryptoIdIcon = ({ cryptoId }: CryptoIdIconProps) => {
+    const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(cryptoId);
+    if (!network || !cryptoId) {
+        return null;
+    }
+
+    return isCryptoIdForNativeToken(cryptoId) ? (
+        <CryptoIcon symbol={network.displaySymbol as NetworkDisplaySymbol} size="tiny" />
+    ) : (
+        <CryptoIcon symbol={network.symbol} contractAddress={contractAddress} size="tiny" />
+    );
+};
+
+export const TradeDetailAmountStack = ({
+    isCrypto,
+    amountString,
+    amountValue,
+    currency,
+    testID,
+}: TradeDetailAmountStackProps) => (
+    <VStack>
+        <HStack alignItems="center" spacing="sp2">
+            {isCrypto && <CryptoIdIcon cryptoId={currency as CryptoId} />}
+            <Text variant="body-sm" testID={testID}>
+                {amountString}
+            </Text>
+        </HStack>
+        {isCrypto && (
+            <CryptoToFiatValueBadge
+                amount={amountValue}
+                cryptoId={currency as CryptoId}
+                prefix="≈ "
+                color="textSubdued"
+                textAlign="right"
+            />
+        )}
+    </VStack>
+);

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
@@ -51,7 +51,6 @@ export const TradeDetailAmountStack = ({
             <CryptoToFiatValueBadge
                 amount={amountValue}
                 cryptoId={currency as CryptoId}
-                prefix="≈ "
                 color="textSubdued"
                 textAlign="right"
             />

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAmountStack.tsx
@@ -4,7 +4,7 @@ import {
     cryptoIdToNetworkAndContractAddress,
     isCryptoIdForNativeToken,
 } from '@suite-common/trading';
-import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
+import type { NetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
 

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -2,20 +2,14 @@ import { useSelector } from 'react-redux';
 
 import type { CryptoId } from 'invity-api';
 
-import {
-    TradingRootState,
-    cryptoIdToNetworkAndContractAddress,
-    isCryptoIdForNativeToken,
-    selectTradingTradeByOrderId,
-} from '@suite-common/trading';
-import { NetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
 import { AccountsRootState } from '@suite-common/wallet-core';
-import { Card, HStack, Text } from '@suite-native/atoms';
-import { CryptoIcon } from '@suite-native/icons';
+import { Card } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { CombinedLabelingState } from '@suite-native/labeling';
 import { selectAccountLabelWithNetworkFallback } from '@suite-native/trading-state';
 
+import { TradeDetailAmountStack } from './TradeDetailAmountStack';
 import { TradeDetailInfoRow } from './TradeDetailInfoRow';
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 
@@ -23,22 +17,7 @@ export type TradeDetailTransactionInfoProps = {
     orderId: string;
 };
 
-type CryptoIdIconProps = { cryptoId: CryptoId | undefined };
-
 const TRADE_DETAIL_TEST_ID = '@trading/history/detail';
-
-const CryptoIdIcon = ({ cryptoId }: CryptoIdIconProps) => {
-    const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(cryptoId);
-    if (!network || !cryptoId) {
-        return null;
-    }
-
-    return isCryptoIdForNativeToken(cryptoId) ? (
-        <CryptoIcon symbol={network.displaySymbol as NetworkDisplaySymbol} size="tiny" />
-    ) : (
-        <CryptoIcon symbol={network.symbol} contractAddress={contractAddress} size="tiny" />
-    );
-};
 
 export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionInfoProps) => {
     const { translate } = useTranslate();
@@ -49,8 +28,16 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
     const isSell = tradeType === 'sell';
     const isBuy = tradeType === 'buy';
 
-    const { fromStringValue, toStringValue, fromCurrency, toCurrency, isFromCrypto, isToCrypto } =
-        useChangeStringsExtractor(trade?.data);
+    const {
+        fromStringValue,
+        toStringValue,
+        fromCurrency,
+        toCurrency,
+        isFromCrypto,
+        isToCrypto,
+        fromValue,
+        toValue,
+    } = useChangeStringsExtractor(trade?.data);
 
     const fromAccountLabel = useSelector((state: AccountsRootState & CombinedLabelingState) => {
         if (isBuy) {
@@ -85,12 +72,13 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
             <TradeDetailInfoRow
                 title={<Translation id="moduleTrading.tradeHistory.detail.paid" />}
                 content={
-                    <HStack alignItems="center" spacing="sp2">
-                        {isFromCrypto && <CryptoIdIcon cryptoId={fromCurrency} />}
-                        <Text variant="body-sm" testID={TRADE_DETAIL_TEST_ID + '/paid'}>
-                            {fromStringValue}
-                        </Text>
-                    </HStack>
+                    <TradeDetailAmountStack
+                        isCrypto={isFromCrypto}
+                        amountValue={fromValue}
+                        amountString={fromStringValue}
+                        currency={fromCurrency}
+                        testID={TRADE_DETAIL_TEST_ID + '/paid'}
+                    />
                 }
             />
             {!isBuy && (
@@ -102,10 +90,13 @@ export const TradeDetailTransactionInfo = ({ orderId }: TradeDetailTransactionIn
             <TradeDetailInfoRow
                 title={<Translation id="moduleTrading.tradeHistory.detail.received" />}
                 content={
-                    <HStack alignItems="center" spacing="sp2">
-                        {isToCrypto && <CryptoIdIcon cryptoId={toCurrency} />}
-                        <Text variant="body-sm">{toStringValue}</Text>
-                    </HStack>
+                    <TradeDetailAmountStack
+                        isCrypto={isToCrypto}
+                        amountValue={toValue}
+                        amountString={toStringValue}
+                        currency={toCurrency}
+                        testID={TRADE_DETAIL_TEST_ID + '/received'}
+                    />
                 }
             />
             {!isSell && (

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailTransactionInfo.tsx
@@ -2,8 +2,8 @@ import { useSelector } from 'react-redux';
 
 import type { CryptoId } from 'invity-api';
 
-import { TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
-import { AccountsRootState } from '@suite-common/wallet-core';
+import { type TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
+import { type AccountsRootState } from '@suite-common/wallet-core';
 import { Card } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { CombinedLabelingState } from '@suite-native/labeling';

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
@@ -1,26 +1,7 @@
-import type { CryptoId } from 'invity-api';
-
-import { Text as MockText } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { btcAsset } from '@suite-native/trading-fixtures';
 
 import { TradeDetailAmountStack } from '../TradeDetailAmountStack';
-
-jest.mock('../../../general/CryptoToFiatValueBadge', () => ({
-    CryptoToFiatValueBadge: ({
-        prefix,
-        amount,
-        cryptoId,
-    }: {
-        prefix?: string;
-        amount?: string;
-        cryptoId?: CryptoId;
-    }) => (
-        <MockText>
-            {prefix}-{amount}-{cryptoId}
-        </MockText>
-    ),
-}));
 
 describe('TradeDetailAmountStack', () => {
     it('should render fiat amount without crypto icon and fiat badge', () => {
@@ -48,6 +29,6 @@ describe('TradeDetailAmountStack', () => {
         );
 
         expect(getByText('0.5 BTC')).toBeOnTheScreen();
-        expect(getByText(`≈ -0.5-${btcAsset.cryptoId}`)).toBeOnTheScreen();
+        expect(getByText(`0.5-${btcAsset.cryptoId}`)).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
@@ -1,0 +1,53 @@
+import type { CryptoId } from 'invity-api';
+
+import { Text as MockText } from '@suite-native/atoms';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { btcAsset } from '@suite-native/trading-fixtures';
+
+import { TradeDetailAmountStack } from '../TradeDetailAmountStack';
+
+jest.mock('../../../general/CryptoToFiatValueBadge', () => ({
+    CryptoToFiatValueBadge: ({
+        prefix,
+        amount,
+        cryptoId,
+    }: {
+        prefix?: string;
+        amount?: string;
+        cryptoId?: CryptoId;
+    }) => (
+        <MockText>
+            {prefix}-{amount}-{cryptoId}
+        </MockText>
+    ),
+}));
+
+describe('TradeDetailAmountStack', () => {
+    it('should render fiat amount without crypto icon and fiat badge', () => {
+        const { getByText, queryByText } = renderWithBasicProvider(
+            <TradeDetailAmountStack
+                isCrypto={false}
+                amountString="$100.00"
+                amountValue="0.002"
+                currency="USD"
+            />,
+        );
+
+        expect(getByText('$100.00')).toBeOnTheScreen();
+        expect(queryByText(/0.002/)).toBeNull();
+    });
+
+    it('should render crypto amount with fiat badge', () => {
+        const { getByText } = renderWithBasicProvider(
+            <TradeDetailAmountStack
+                isCrypto={true}
+                amountString="0.5 BTC"
+                amountValue="0.5"
+                currency="bitcoin"
+            />,
+        );
+
+        expect(getByText('0.5 BTC')).toBeOnTheScreen();
+        expect(getByText(`≈ -0.5-${btcAsset.cryptoId}`)).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
@@ -1,5 +1,5 @@
-import { TradingTransaction } from '@suite-common/trading';
-import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import type { TradingTransaction } from '@suite-common/trading';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     accounts,
     getBuyTrade,
@@ -7,11 +7,11 @@ import {
     getInitializedTradingState,
     getSellTrade,
 } from '@suite-native/trading-fixtures';
-import { StaticSessionId } from '@trezor/connect';
+import type { StaticSessionId } from '@trezor/connect';
 
 import {
     TradeDetailTransactionInfo,
-    TradeDetailTransactionInfoProps,
+    type TradeDetailTransactionInfoProps,
 } from '../TradeDetailTransactionInfo';
 
 const getPreloadedState = (trades: TradingTransaction[]): PreloadedState => ({

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
@@ -1,5 +1,5 @@
 import { TradingTransaction } from '@suite-common/trading';
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     accounts,
     getBuyTrade,
@@ -39,52 +39,72 @@ describe('TradeDetailTransactionInfo', () => {
         orderId: TradeDetailTransactionInfoProps['orderId'],
         preloadedState = getPreloadedState([]),
     ) =>
-        renderWithStoreProviderAsync(<TradeDetailTransactionInfo orderId={orderId} />, {
+        renderWithStoreProvider(<TradeDetailTransactionInfo orderId={orderId} />, {
             preloadedState,
         });
 
-    it('should not render when trade is not found', async () => {
-        const { toJSON } = await renderComponent('nonexistent_order_id', getPreloadedState([]));
+    it('should not render when trade is not found', () => {
+        const { toJSON } = renderComponent('nonexistent_order_id', getPreloadedState([]));
 
         expect(toJSON()).toBeNull();
     });
 
-    // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render buy trade transaction info correctly', async () => {
+    it('should render buy trade transaction info correctly', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByText, queryByText } = await renderComponent(
+        const { getByText, queryByText } = renderComponent(
             buyTrade.data.orderId!,
             getPreloadedState([buyTrade]),
         );
 
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
-        expect(getByText('ETH Account #1')).toBeTruthy();
         expect(queryByText('From')).toBeNull();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render exchange trade transaction info correctly', async () => {
+    it.skip('should render correct account name for buy trade', () => {
+        const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
+
+        const { getByText } = renderComponent(
+            buyTrade.data.orderId!,
+            getPreloadedState([buyTrade]),
+        );
+
+        expect(getByText('ETH Account #1')).toBeTruthy();
+    });
+
+    it('should render exchange trade transaction info correctly', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
-        const { getByText, getAllByText } = await renderComponent(
+        const { getByText } = renderComponent(
             exchangeTrade.data.orderId!,
             getPreloadedState([exchangeTrade]),
         );
 
         expect(getByText('10.1232 JTO')).toBeTruthy();
         expect(getByText('0.462586 SOL')).toBeTruthy();
+    });
+
+    // Todo: https://github.com/trezor/trezor-suite/issues/24906
+    it.skip('should render correct account name for exchange trade', () => {
+        const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
+
+        const { getAllByText } = renderComponent(
+            exchangeTrade.data.orderId!,
+            getPreloadedState([exchangeTrade]),
+        );
+
         // For exchange trades, both from and to accounts are displayed and they are the same account
         expect(getAllByText('SOL Account #1')).toHaveLength(2);
     });
 
-    it('should render exchange trade even when accounts are not found', async () => {
+    it('should render exchange trade even when accounts are not found', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         const preloadedState = getPreloadedState([exchangeTrade]);
         preloadedState!.wallet!.accounts = []; // remove all accounts
 
-        const { getByText, getAllByText } = await renderComponent(
+        const { getByText, getAllByText } = renderComponent(
             exchangeTrade.data.orderId!,
             preloadedState,
         );
@@ -94,30 +114,40 @@ describe('TradeDetailTransactionInfo', () => {
         expect(getAllByText('Solana')).toHaveLength(2);
     });
 
-    it('should render "Unknown" when asset network is not found', async () => {
+    it('should render "Unknown" when asset network is not found', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         exchangeTrade.data.send = 'unknown-asset' as any;
         exchangeTrade.data.receive = 'unknown-asset' as any;
         const preloadedState = getPreloadedState([exchangeTrade]);
         preloadedState!.wallet!.accounts = []; // remove all accounts
 
-        const { getAllByText } = await renderComponent(exchangeTrade.data.orderId!, preloadedState);
+        const { getAllByText } = renderComponent(exchangeTrade.data.orderId!, preloadedState);
 
         expect(getAllByText('Unknown')).toHaveLength(2);
     });
 
-    // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render sell trade transaction info correctly', async () => {
+    it('should render sell trade transaction info correctly', () => {
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
 
-        const { getByText, queryByText } = await renderComponent(
+        const { getByText, queryByText } = renderComponent(
             sellTrade.data.orderId!,
             getPreloadedState([sellTrade]),
         );
 
         expect(getByText('1.22 BTC')).toBeTruthy();
         expect(getByText('$100.00')).toBeTruthy();
-        expect(getByText('BTC Account #1')).toBeTruthy();
         expect(queryByText('From')).toBeTruthy();
+    });
+
+    // Todo: https://github.com/trezor/trezor-suite/issues/24906
+    it.skip('should render correct account name for sell trade', () => {
+        const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
+
+        const { getByText } = renderComponent(
+            sellTrade.data.orderId!,
+            getPreloadedState([sellTrade]),
+        );
+
+        expect(getByText('BTC Account #1')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
@@ -7,14 +7,18 @@ import { Translation } from '@suite-native/intl';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 
+import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
+
 export type SellFromAccountTradePreviewCardProps = {
     cryptoId?: CryptoId;
     fromStringValue?: string;
+    fromValue?: string;
 };
 
 export const SellFromAccountTradePreviewCard = ({
     cryptoId,
     fromStringValue,
+    fromValue,
 }: SellFromAccountTradePreviewCardProps) => {
     const fromAccount = useSelector(selectSellSelectedSendAccount);
 
@@ -34,6 +38,15 @@ export const SellFromAccountTradePreviewCard = ({
                 ) : null
             }
             title={<Translation id="moduleTrading.tradingSellPreviewScreen.fromAccount" />}
-        />
+        >
+            {!!fromValue && (
+                <CryptoToFiatValueBadge
+                    amount={fromValue}
+                    cryptoId={cryptoId}
+                    color="textSubdued"
+                    textAlign="right"
+                />
+            )}
+        </TradeSideCard>
     );
 };

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.tsx
@@ -1,26 +1,25 @@
 import { useSelector } from 'react-redux';
 
-import type { CryptoId } from 'invity-api';
+import type { SellFiatTrade } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeSideCard } from '@suite-native/trading-atoms';
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 import { CryptoToFiatValueBadge } from '../../general/CryptoToFiatValueBadge';
 
 export type SellFromAccountTradePreviewCardProps = {
-    cryptoId?: CryptoId;
-    fromStringValue?: string;
-    fromValue?: string;
+    quote?: SellFiatTrade;
 };
 
 export const SellFromAccountTradePreviewCard = ({
-    cryptoId,
-    fromStringValue,
-    fromValue,
+    quote,
 }: SellFromAccountTradePreviewCardProps) => {
     const fromAccount = useSelector(selectSellSelectedSendAccount);
+    const { fromStringValue, fromValue } = useChangeStringsExtractor(quote);
+    const cryptoId = quote?.cryptoCurrency;
 
     if (!cryptoId || !fromAccount) {
         return null;

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -21,7 +21,7 @@ export type SellPreviewViewProps = {
 export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewProps) => {
     const formStep = useSelector(selectTradingSellFormStep);
 
-    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+    const { fromStringValue, toStringValue, fromValue } = useChangeStringsExtractor(quote);
     const [selectedBankAccountIban, setSelectedBankAccountIban] = useState(
         quote?.bankAccounts?.[0].bankAccount,
     );
@@ -45,6 +45,7 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
             <SellFromAccountTradePreviewCard
                 cryptoId={quote?.cryptoCurrency}
                 fromStringValue={fromStringValue}
+                fromValue={fromValue}
             />
             <SellToFiatTradePreviewCard quote={quote} toStringValue={toStringValue} />
             <SellFeePickerCard quote={quote} isTxnError={isTxnError} />

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.tsx
@@ -11,7 +11,6 @@ import { SellBankAccountPicker } from './BankAccount/SellBankAccountPicker';
 import { SellFeePickerCard } from './SellFeePickerCard';
 import { SellFromAccountTradePreviewCard } from './SellFromAccountTradePreviewCard';
 import { SellToFiatTradePreviewCard } from './SellToFiatTradePreviewCard';
-import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 
 export type SellPreviewViewProps = {
     quote: SellFiatTrade | undefined;
@@ -21,7 +20,6 @@ export type SellPreviewViewProps = {
 export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewProps) => {
     const formStep = useSelector(selectTradingSellFormStep);
 
-    const { fromStringValue, toStringValue, fromValue } = useChangeStringsExtractor(quote);
     const [selectedBankAccountIban, setSelectedBankAccountIban] = useState(
         quote?.bankAccounts?.[0].bankAccount,
     );
@@ -42,12 +40,8 @@ export const SellPreviewView = memo(({ quote, txnErrorString }: SellPreviewViewP
                     <InlineAlertBox variant="critical" title={txnErrorString} />
                 </Animated.View>
             )}
-            <SellFromAccountTradePreviewCard
-                cryptoId={quote?.cryptoCurrency}
-                fromStringValue={fromStringValue}
-                fromValue={fromValue}
-            />
-            <SellToFiatTradePreviewCard quote={quote} toStringValue={toStringValue} />
+            <SellFromAccountTradePreviewCard quote={quote} />
+            <SellToFiatTradePreviewCard quote={quote} />
             <SellFeePickerCard quote={quote} isTxnError={isTxnError} />
             {showBankAccountPicker && (
                 <SellBankAccountPicker

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.tsx
@@ -3,18 +3,17 @@ import type { SellFiatTrade } from 'invity-api';
 import { Text } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
 import { TradeFiatSideCard } from '../../general/TradeInfo/TradeFiatSideCard';
 
 export type SellToFiatTradePreviewCardProps = {
     quote?: SellFiatTrade;
-    toStringValue: string | undefined;
 };
 
-export const SellToFiatTradePreviewCard = ({
-    quote,
-    toStringValue,
-}: SellToFiatTradePreviewCardProps) => {
-    if (!quote?.fiatCurrency || !quote.paymentMethod) {
+export const SellToFiatTradePreviewCard = ({ quote }: SellToFiatTradePreviewCardProps) => {
+    const { toStringValue } = useChangeStringsExtractor(quote);
+
+    if (!quote || !quote.paymentMethod || !quote.fiatCurrency || !toStringValue) {
         return null;
     }
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
@@ -1,7 +1,5 @@
-import type { CryptoId } from 'invity-api';
-
 import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
-import { getWalletState } from '@suite-native/trading-fixtures';
+import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import {
     SellFromAccountTradePreviewCard,
@@ -18,10 +16,9 @@ describe('SellFromAccountTradePreviewCard', () => {
         };
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
 
-        return renderWithStoreProvider(
-            <SellFromAccountTradePreviewCard fromStringValue="0.0233" {...props} />,
-            { preloadedState },
-        );
+        return renderWithStoreProvider(<SellFromAccountTradePreviewCard {...props} />, {
+            preloadedState,
+        });
     };
 
     it('should render nothing when there is no quote', () => {
@@ -32,7 +29,7 @@ describe('SellFromAccountTradePreviewCard', () => {
 
     it('should render nothing when account is not found', () => {
         const { toJSON } = renderSellFromAccountTradePreviewCard(
-            { cryptoId: 'bitcoin' as CryptoId },
+            { quote: sellQuotes[0] },
             'unknown-account-key',
         );
 
@@ -40,21 +37,11 @@ describe('SellFromAccountTradePreviewCard', () => {
     });
 
     it('should render TradeSideCard otherwise', () => {
-        const { getByText } = renderSellFromAccountTradePreviewCard({
-            cryptoId: 'bitcoin' as CryptoId,
-        });
+        const { getByText } = renderSellFromAccountTradePreviewCard({ quote: sellQuotes[0] });
 
         expect(getByText('From')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
-        expect(getByText('-0.0233')).toBeOnTheScreen();
-    });
-
-    it('should render value in fiat when fromValue is provided', () => {
-        const { getByText } = renderSellFromAccountTradePreviewCard({
-            cryptoId: 'bitcoin' as CryptoId,
-            fromValue: '1',
-        });
-
-        expect(getByText('1-bitcoin')).toBeOnTheScreen();
+        expect(getByText('-0.0233 ETH')).toBeOnTheScreen();
+        expect(getByText('0.0233-ethereum')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
@@ -1,11 +1,11 @@
 import type { CryptoId } from 'invity-api';
 
-import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import {
     SellFromAccountTradePreviewCard,
-    SellFromAccountTradePreviewCardProps,
+    type SellFromAccountTradePreviewCardProps,
 } from '../SellFromAccountTradePreviewCard';
 
 describe('SellFromAccountTradePreviewCard', () => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
@@ -1,6 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
-import { PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -18,20 +18,20 @@ describe('SellFromAccountTradePreviewCard', () => {
         };
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <SellFromAccountTradePreviewCard fromStringValue="0.0233" {...props} />,
             { preloadedState },
         );
     };
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderSellFromAccountTradePreviewCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderSellFromAccountTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', async () => {
-        const { toJSON } = await renderSellFromAccountTradePreviewCard(
+    it('should render nothing when account is not found', () => {
+        const { toJSON } = renderSellFromAccountTradePreviewCard(
             { cryptoId: 'bitcoin' as CryptoId },
             'unknown-account-key',
         );
@@ -39,13 +39,22 @@ describe('SellFromAccountTradePreviewCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render TradeSideCard otherwise', async () => {
-        const { getByText } = await renderSellFromAccountTradePreviewCard({
+    it('should render TradeSideCard otherwise', () => {
+        const { getByText } = renderSellFromAccountTradePreviewCard({
             cryptoId: 'bitcoin' as CryptoId,
         });
 
         expect(getByText('From')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
         expect(getByText('-0.0233')).toBeOnTheScreen();
+    });
+
+    it('should render value in fiat when fromValue is provided', () => {
+        const { getByText } = renderSellFromAccountTradePreviewCard({
+            cryptoId: 'bitcoin' as CryptoId,
+            fromValue: '1',
+        });
+
+        expect(getByText('1-bitcoin')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
@@ -14,10 +14,9 @@ describe('SellToFiatTradePreviewCard', () => {
             wallet: getWalletState({ tradeType: 'sell' }),
         };
 
-        return renderWithStoreProviderAsync(
-            <SellToFiatTradePreviewCard toStringValue="90.17" {...props} />,
-            { preloadedState },
-        );
+        return renderWithStoreProviderAsync(<SellToFiatTradePreviewCard {...props} />, {
+            preloadedState,
+        });
     };
 
     it('should render nothing when there is no quote', async () => {
@@ -51,17 +50,16 @@ describe('SellToFiatTradePreviewCard', () => {
 
         expect(getByText('To')).toBeOnTheScreen();
         expect(getByText('Credit/Debit Card')).toBeOnTheScreen();
-        expect(getByText('+90.17')).toBeOnTheScreen();
+        expect(getByText('+$90.17')).toBeOnTheScreen();
     });
 
     it('should render bank transfer payment method', async () => {
         const { getByText } = await renderSellToFiatTradePreviewCard({
             quote: sellQuotes[1], // This quote has bankTransfer payment method
-            toStringValue: '100.00', // Override the default toStringValue
         });
 
         expect(getByText('To')).toBeOnTheScreen();
         expect(getByText('Bank Transfer')).toBeOnTheScreen();
-        expect(getByText('+100.00')).toBeOnTheScreen();
+        expect(getByText('+$100.00')).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
@@ -1,15 +1,17 @@
 import type { CryptoId } from 'invity-api';
 
-import type { NetworkSymbol } from '@suite-common/wallet-config';
-import type { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
+import type { WalletSettings } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import {
     type FullAppState,
+    type PreloadedState,
     act,
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     btcAsset,
+    createMockRate,
+    mockWalletFiatRatesAndSettings,
     usdcAsset,
 } from '@suite-native/trading-fixtures';
 import { PROTO } from '@trezor/connect';
@@ -22,42 +24,21 @@ jest.mock('@suite-common/fiat-services', () => ({
     fetchCurrentFiatRates: () => Promise.resolve(null),
 }));
 
-const createMockRate = (rate: number, symbol: NetworkSymbol): Rate => ({
-    rate,
-    lastTickerTimestamp: 1000000 as Timestamp,
-    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
-    isLoading: false,
-    error: null,
-    ticker: { symbol },
-});
-
 const getPreloadedState = (
     walletOverrides: Partial<FullAppState['wallet']> = {},
-): Partial<FullAppState> => ({
+): PreloadedState => ({
     wallet: {
-        settings: {
-            localCurrency: 'usd',
-            bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
-        } as WalletSettings,
-        fiat: {
-            current: {
-                [getFiatRateKey('btc', 'usd')]: createMockRate(50000, 'btc'),
-                [getFiatRateKey('eth', 'usd', usdcAsset.contractAddress!)]: createMockRate(
-                    1,
-                    'eth',
-                ),
-            },
-            lastWeek: {},
-            historic: {},
-        },
+        ...mockWalletFiatRatesAndSettings({
+            [getFiatRateKey('eth', 'usd', usdcAsset.contractAddress!)]: createMockRate(1, 'eth'),
+        }),
         ...walletOverrides,
-    } as FullAppState['wallet'],
+    },
 });
 
 const renderUseTradingFiatValues = async (
     amount: string | undefined,
     cryptoId: CryptoId | undefined,
-    preloadedState: Partial<FullAppState> = getPreloadedState(),
+    preloadedState: PreloadedState = getPreloadedState(),
 ) => {
     const res = renderHookWithStoreProvider(() => useTradingFiatValues(amount, cryptoId), {
         preloadedState,

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
@@ -1,0 +1,144 @@
+import type { CryptoId } from 'invity-api';
+
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import {
+    type FullAppState,
+    act,
+    renderHookWithStoreProvider,
+} from '@suite-native/test-utils';
+import {
+    btcAsset,
+    usdcAsset,
+} from '@suite-native/trading-fixtures';
+import { PROTO } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
+
+import { useTradingFiatValues } from '../useTradingFiatValues';
+
+jest.mock('@suite-common/fiat-services', () => ({
+    ...jest.requireActual('@suite-common/fiat-services'),
+    fetchCurrentFiatRates: () => Promise.resolve(null),
+}));
+
+const createMockRate = (rate: number, symbol: NetworkSymbol): Rate => ({
+    rate,
+    lastTickerTimestamp: 1000000 as Timestamp,
+    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+    isLoading: false,
+    error: null,
+    ticker: { symbol },
+});
+
+const getPreloadedState = (
+    walletOverrides: Partial<FullAppState['wallet']> = {},
+): Partial<FullAppState> => ({
+    wallet: {
+        settings: {
+            localCurrency: 'usd',
+            bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
+        } as WalletSettings,
+        fiat: {
+            current: {
+                [getFiatRateKey('btc', 'usd')]: createMockRate(50000, 'btc'),
+                [getFiatRateKey('eth', 'usd', usdcAsset.contractAddress!)]: createMockRate(
+                    1,
+                    'eth',
+                ),
+            },
+            lastWeek: {},
+            historic: {},
+        },
+        ...walletOverrides,
+    } as FullAppState['wallet'],
+});
+
+const renderUseTradingFiatValues = async (
+    amount: string | undefined,
+    cryptoId: CryptoId | undefined,
+    preloadedState: Partial<FullAppState> = getPreloadedState(),
+) => {
+    const res = renderHookWithStoreProvider(() => useTradingFiatValues(amount, cryptoId), {
+        preloadedState,
+    });
+
+    // await mocked loading of rates
+    await act(() => Promise.resolve());
+
+    return res;
+};
+
+describe('useTradingFiatValues', () => {
+    describe('returns null when required parameters are missing', () => {
+        it('should return null when amount is undefined', async () => {
+            const { result } = await renderUseTradingFiatValues(undefined, btcAsset.cryptoId);
+
+            expect(result.current).toBeNull();
+        });
+
+        it('should return null when cryptoId is undefined', async () => {
+            const { result } = await renderUseTradingFiatValues('1', undefined);
+
+            expect(result.current).toBeNull();
+        });
+
+        it('should return null when amount is empty', async () => {
+            const { result } = await renderUseTradingFiatValues('', btcAsset.cryptoId);
+
+            expect(result.current).toBeNull();
+        });
+    });
+
+    describe('returns correct values for native tokens', () => {
+        it('should calculate fiat value for Bitcoin', async () => {
+            const { result } = await renderUseTradingFiatValues('1', btcAsset.cryptoId);
+
+            expect(result.current?.fiatValue).toBe('50000.00');
+            expect(result.current?.symbol).toBe('btc');
+            expect(result.current?.baseCurrencyAmount).toBeInstanceOf(BigNumber);
+            expect(result.current?.baseCurrencyAmount?.toString()).toBe('50000');
+        });
+    });
+
+    describe('returns correct values for ERC-20 tokens', () => {
+        it('should calculate fiat value for USDC token', async () => {
+            const { result } = await renderUseTradingFiatValues('100', usdcAsset.cryptoId);
+
+            expect(result.current).not.toBeNull();
+            expect(result.current?.fiatValue).toBe('100.00');
+            expect(result.current?.symbol).toBe('eth');
+            expect(result.current?.tokenAddress).toBe(usdcAsset.contractAddress!);
+            expect(result.current?.baseCurrencyAmount).toBeInstanceOf(BigNumber);
+            expect(result.current?.baseCurrencyAmount?.toString()).toBe('100');
+        });
+    });
+
+    describe('handles shouldSendInSats option', () => {
+        it('should convert amount to satoshis when bitcoinAmountUnit is SATOSHI', async () => {
+            const preloadedState = getPreloadedState({
+                settings: {
+                    localCurrency: 'usd',
+                    bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI,
+                } as WalletSettings,
+            });
+
+            const { result } = await renderUseTradingFiatValues(
+                '1',
+                btcAsset.cryptoId,
+                preloadedState,
+            );
+
+            expect(result.current?.formattedBalance).toBe('100000000');
+            expect(result.current?.accountBalance).toBe('1');
+        });
+    });
+
+    describe('fiatRatesUpdater', () => {
+        it('should return fiatRatesUpdater as a function', async () => {
+            const { result } = await renderUseTradingFiatValues('1', btcAsset.cryptoId);
+
+            expect(typeof result.current?.fiatRatesUpdater).toBe('function');
+        });
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useTradingFiatValues.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingFiatValues.ts
@@ -1,13 +1,13 @@
 import { useSelector } from 'react-redux';
 
-import { CryptoId } from 'invity-api';
+import type { CryptoId } from 'invity-api';
 
 import {
     cryptoIdToSymbol,
     useTradingFiatValues as useCommonTradingFiatValues,
 } from '@suite-common/trading';
 import {
-    WalletSettingsRootState,
+    type WalletSettingsRootState,
     selectBaseCurrency,
     selectIsAmountInSats,
 } from '@suite-common/wallet-core';

--- a/suite-native/module-trading/src/hooks/general/useTradingFiatValues.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingFiatValues.ts
@@ -1,0 +1,44 @@
+import { useSelector } from 'react-redux';
+
+import { CryptoId } from 'invity-api';
+
+import {
+    cryptoIdToSymbol,
+    useTradingFiatValues as useCommonTradingFiatValues,
+} from '@suite-common/trading';
+import {
+    WalletSettingsRootState,
+    selectBaseCurrency,
+    selectIsAmountInSats,
+} from '@suite-common/wallet-core';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+export const useTradingFiatValues = (
+    amount: string | undefined,
+    cryptoId: CryptoId | undefined,
+) => {
+    const symbol = cryptoIdToSymbol(cryptoId);
+    const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
+        selectIsAmountInSats(state, symbol),
+    );
+    const fiatCurrency = useSelector(selectBaseCurrency);
+
+    const ret = useCommonTradingFiatValues({
+        shouldSendInSats,
+        fiatCurrency,
+        cryptoId,
+        amount,
+    });
+
+    if (!ret) {
+        return null;
+    }
+
+    const { fiatValue } = ret;
+
+    return {
+        ...ret,
+        baseCurrencyAmount: fiatValue ? asBaseCurrencyAmount(new BigNumber(fiatValue)) : undefined,
+    };
+};

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -25,7 +25,6 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: false,
             isToCrypto: true,
-            formattedRate: '$2,667.61 / 1 ETH',
         });
     });
 
@@ -45,7 +44,6 @@ describe('useChangeStringsExtractor', () => {
             toValue: '100',
             isFromCrypto: true,
             isToCrypto: false,
-            formattedRate: '0.0122 BTC / $1.00',
         });
     });
 
@@ -65,7 +63,6 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: true,
             isToCrypto: true,
-            formattedRate: '21.883930771791626 JTO / 1 SOL',
         });
     });
 
@@ -84,7 +81,6 @@ describe('useChangeStringsExtractor', () => {
             toValue: undefined,
             isFromCrypto: undefined,
             isToCrypto: undefined,
-            formattedRate: undefined,
         });
     });
 
@@ -110,7 +106,6 @@ describe('useChangeStringsExtractor', () => {
             toValue: undefined,
             isFromCrypto: false,
             isToCrypto: true,
-            formattedRate: undefined,
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -15,7 +15,6 @@ export const useChangeStringsExtractor = (
 ): TradeOperationData & {
     fromStringValue: string | undefined;
     toStringValue: string | undefined;
-    formattedRate?: string | undefined;
 } => {
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { cryptoIdToCoinSymbol } = useTradingUtils();
@@ -59,35 +58,6 @@ export const useChangeStringsExtractor = (
         );
     };
 
-    const formatExchangeRate = () => {
-        if (!fromValue || !toValue || !fromCurrency || !toCurrency) {
-            return undefined;
-        }
-
-        const fromNumericValue = parseFloat(fromValue);
-        const toNumericValue = parseFloat(toValue);
-
-        if (isNaN(fromNumericValue) || isNaN(toNumericValue) || toNumericValue === 0) {
-            return undefined;
-        }
-
-        const rate = fromNumericValue / toNumericValue;
-
-        const rateFormatted = isFromCrypto
-            ? formatCryptoValue(rate.toString(), fromCurrency, false)
-            : formatFiatValue(asBaseCurrencyAmount(new BigNumber(rate)), fromCurrency);
-
-        const targetCurrencyFormatted = isToCrypto
-            ? formatCryptoValue('1', toCurrency, false)
-            : formatFiatValue(asBaseCurrencyAmount(new BigNumber('1')), toCurrency);
-
-        if (!rateFormatted || !targetCurrencyFormatted) {
-            return undefined;
-        }
-
-        return `${rateFormatted} / ${targetCurrencyFormatted}`;
-    };
-
     const fromStringValue = isFromCrypto
         ? formatCryptoValue(fromValue, fromCurrency)
         : formatFiatValue(
@@ -102,12 +72,9 @@ export const useChangeStringsExtractor = (
               toCurrency,
           );
 
-    const formattedRate = formatExchangeRate();
-
     return {
         ...tradeOperationData,
         fromStringValue,
         toStringValue,
-        formattedRate,
     };
 };

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -1,12 +1,12 @@
 import type { CryptoId } from 'invity-api';
 
 import { useFormatters } from '@suite-common/formatters';
-import { TradingTradeType, useTradingUtils } from '@suite-common/trading';
-import { NetworkSymbol, getNetworkDecimals } from '@suite-common/wallet-config';
-import { BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type TradingTradeType, useTradingUtils } from '@suite-common/trading';
+import { type NetworkSymbol, getNetworkDecimals } from '@suite-common/wallet-config';
+import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
-import { TradeOperationData, getTradeOperationData } from '../../utils/general/utils';
+import { type TradeOperationData, getTradeOperationData } from '../../utils/general/utils';
 
 const TOKEN_DECIMALS_LENGTH = 16;
 

--- a/suite-native/module-trading/src/jest.setup.tsx
+++ b/suite-native/module-trading/src/jest.setup.tsx
@@ -1,3 +1,5 @@
+import { Text as MockText } from 'react-native';
+
 // avoid some unexpected re-renders in tests by disabling this hook logic
 jest.mock('./hooks/general/useMountedRecentlyFlag', () => ({
     useMountedRecentlyFlag: () => false,
@@ -5,4 +7,12 @@ jest.mock('./hooks/general/useMountedRecentlyFlag', () => ({
 
 jest.mock('./hooks/general/useFocusedValueWatch', () => ({
     useFocusedValueWatch: () => false,
+}));
+
+jest.mock('./components/general/CryptoToFiatValueBadge', () => ({
+    CryptoToFiatValueBadge: ({ amount, cryptoId }: { amount?: string; cryptoId?: string }) => (
+        <MockText>
+            {amount}-{cryptoId}
+        </MockText>
+    ),
 }));

--- a/suite-native/test-utils/src/index.tsx
+++ b/suite-native/test-utils/src/index.tsx
@@ -1,6 +1,6 @@
 export * from '@testing-library/react-native';
 
-export { type PreloadedState, initStore } from '@suite-native/state';
+export { type PreloadedState, type FullAppState, initStore } from '@suite-native/state';
 
 export * from './BasicProviderForTests';
 export * from './StoreProviderForTests';

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, ReactNode } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import type { CryptoId } from 'invity-api';
 

--- a/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/TradeSideCard.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
 import type { CryptoId } from 'invity-api';
 
@@ -14,9 +14,15 @@ export type TradeSideCardProps = {
     cryptoId?: CryptoId;
     amount: ReactNode;
     title: ReactNode;
-};
+} & PropsWithChildren;
 
-export const TradeSideCard = ({ accountLabel, cryptoId, amount, title }: TradeSideCardProps) => {
+export const TradeSideCard = ({
+    accountLabel,
+    cryptoId,
+    amount,
+    title,
+    children,
+}: TradeSideCardProps) => {
     const { symbol, contractAddress } = cryptoIdToNetworkSymbolAndContractAddress(cryptoId);
 
     if (!symbol) {
@@ -26,13 +32,16 @@ export const TradeSideCard = ({ accountLabel, cryptoId, amount, title }: TradeSi
     return (
         <NetworkAndAccountCard title={title} accountLabel={accountLabel} symbol={symbol}>
             <TradeInfoRow>
-                <HStack alignItems="center">
-                    <CryptoIcon
-                        symbol={symbol}
-                        contractAddress={contractAddress}
-                        size="extraSmall"
-                    />
-                    {amount}
+                <HStack justifyContent="space-between" alignItems="center" flex={1}>
+                    <HStack alignItems="center">
+                        <CryptoIcon
+                            symbol={symbol}
+                            contractAddress={contractAddress}
+                            size="extraSmall"
+                        />
+                        {amount}
+                    </HStack>
+                    {children}
                 </HStack>
             </TradeInfoRow>
         </NetworkAndAccountCard>

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
@@ -30,4 +30,13 @@ describe('TradeSideCard', () => {
         expect(getByText('AMOUNT')).toBeOnTheScreen();
         expect(getByText('ACCOUNT LABEL')).toBeOnTheScreen();
     });
+
+    it('should render children when provided', () => {
+        const { getByText } = renderTradeSideCard({
+            cryptoId: 'bitcoin' as CryptoId,
+            children: <Text>CHILDREN</Text>,
+        });
+
+        expect(getByText('CHILDREN')).toBeOnTheScreen();
+    });
 });

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
@@ -4,7 +4,7 @@ import type { CryptoId } from 'invity-api';
 
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { TradeSideCard, TradeSideCardProps } from '../TradeSideCard';
+import { TradeSideCard, type TradeSideCardProps } from '../TradeSideCard';
 
 describe('TradeSideCard', () => {
     const renderTradeSideCard = (props: Partial<TradeSideCardProps>) =>

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -13,8 +13,10 @@
     },
     "dependencies": {
         "@suite-common/trading": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/trading-consts": "workspace:*",
         "@trezor/connect": "workspace:*"

--- a/suite-native/trading-fixtures/src/__fixtures__/fiat.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/fiat.ts
@@ -1,5 +1,5 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-import { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
 

--- a/suite-native/trading-fixtures/src/__fixtures__/fiat.ts
+++ b/suite-native/trading-fixtures/src/__fixtures__/fiat.ts
@@ -1,0 +1,28 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { Rate, Timestamp, WalletSettings } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { PROTO } from '@trezor/connect';
+
+export const createMockRate = (rate: number, symbol: NetworkSymbol): Rate => ({
+    rate,
+    lastTickerTimestamp: 1000000 as Timestamp,
+    lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
+    isLoading: false,
+    error: null,
+    ticker: { symbol },
+});
+
+export const mockWalletFiatRatesAndSettings = (customRates: { [x: string]: Rate } = {}) => ({
+    settings: {
+        localCurrency: 'usd',
+        bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
+    } as WalletSettings,
+    fiat: {
+        current: {
+            [getFiatRateKey('btc', 'usd')]: createMockRate(50000, 'btc'),
+            ...customRates,
+        },
+        lastWeek: {},
+        historic: {},
+    },
+});

--- a/suite-native/trading-fixtures/src/index.ts
+++ b/suite-native/trading-fixtures/src/index.ts
@@ -6,6 +6,7 @@ export * from './__fixtures__/buyQuotes';
 export * from './__fixtures__/coins';
 export * from './__fixtures__/exchangeProviders';
 export * from './__fixtures__/exchangeQuotes';
+export * from './__fixtures__/fiat';
 export * from './__fixtures__/platforms';
 export * from './__fixtures__/residenceCheckState';
 export * from './__fixtures__/sellProviders';

--- a/suite-native/trading-fixtures/tsconfig.json
+++ b/suite-native/trading-fixtures/tsconfig.json
@@ -4,10 +4,16 @@
     "references": [
         { "path": "../../suite-common/trading" },
         {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {
             "path": "../../suite-common/wallet-types"
+        },
+        {
+            "path": "../../suite-common/wallet-utils"
         },
         { "path": "../feature-flags" },
         { "path": "../trading-consts" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11574,6 +11574,7 @@ __metadata:
     "@suite/intl": "workspace:*"
     "@testing-library/react": "npm:^16.3.2"
     "@trezor/address-validator": "workspace:*"
+    "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/connect-plugin-ethereum": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14276,8 +14276,10 @@ __metadata:
   resolution: "@suite-native/trading-fixtures@workspace:suite-native/trading-fixtures"
   dependencies:
     "@suite-common/trading": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/trading-consts": "workspace:*"
     "@suite-native/trading-types": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Displays fiat are on all places according to figma
- Adds global `CryptoToFiatValueBadge` mock to avoid fetching rates during tests
- Adds fixture for fiat rates state to `trading-fixtures`

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25072

## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 16 15 47" src="https://github.com/user-attachments/assets/6dccb129-d311-4e7e-bc05-87936993ea2c" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 16 16 09" src="https://github.com/user-attachments/assets/53c39ffd-1d89-4d75-af54-2dc8e031f811" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 16 16 33" src="https://github.com/user-attachments/assets/df10cce1-c4f5-4533-83bb-49081c48c689" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 16 16 46" src="https://github.com/user-attachments/assets/d61e7ded-da19-4d27-afd0-aac06e43a073" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 16 17 04" src="https://github.com/user-attachments/assets/7604c4d6-3790-4df5-b3bd-a2fa5702e72e" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25072-add-fiat-rates-into-trading-mobile&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25072-add-fiat-rates-into-trading-mobile&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25072-add-fiat-rates-into-trading-mobile&lookback=7)