### PR TITLE
fix(suite): display testnet base currency in account detail

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountTopPanel.tsx
@@ -2,7 +2,8 @@ import styled from 'styled-components';
 
 import { Context } from '@suite-common/message-system';
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { selectBaseCurrency, useDisplayBaseCurrency } from '@suite-common/wallet-core';
+import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { isTestnet } from '@suite-common/wallet-utils';
 import { Column, SkeletonCircle, SkeletonRectangle } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
 import { spacingsPx, zIndices } from '@trezor/theme';
@@ -51,7 +52,6 @@ export const AccountTopPanel = () => {
     const { account, loader, status } = useSelector(state => state.wallet.selectedAccount);
     const baseCurrency = useSelector(selectBaseCurrency);
     const { balanceSectionRef } = useAccountHeaderContext();
-    const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account?.symbol);
 
     if (status === 'exception') {
         return null;
@@ -67,12 +67,14 @@ export const AccountTopPanel = () => {
     }
 
     const { symbol, formattedBalance, accountType } = account;
+    const shouldDisplayBaseCurrency = baseCurrency !== symbol;
+    const isMainnet = !isTestnet(symbol);
 
     return (
         <Container>
             <Column ref={balanceSectionRef}>
                 <AmountUnitSwitchWrapper symbol={symbol}>
-                    {shallDisplayBaseCurrency && (
+                    {shouldDisplayBaseCurrency && (
                         <AccountCryptoBalance>
                             <FormattedCryptoAmount
                                 data-testid="@wallet/account-top-panel/crypto-balance"
@@ -82,13 +84,15 @@ export const AccountTopPanel = () => {
                         </AccountCryptoBalance>
                     )}
                 </AmountUnitSwitchWrapper>
-                <FiatHeader
-                    symbol={account.symbol}
-                    amount={account.formattedBalance}
-                    size="large"
-                    localCurrency={baseCurrency}
-                    data-testid="@wallet/account-top-panel/fiat-amount"
-                />
+                {isMainnet && (
+                    <FiatHeader
+                        symbol={account.symbol}
+                        amount={account.formattedBalance}
+                        size="large"
+                        localCurrency={baseCurrency}
+                        data-testid="@wallet/account-top-panel/fiat-amount"
+                    />
+                )}
             </Column>
             <ContextMessage context={Context.getAccount(symbol, accountType)} />
         </Container>

--- a/suite-native/analytics/src/events/deviceConnectEvent.ts
+++ b/suite-native/analytics/src/events/deviceConnectEvent.ts
@@ -1,7 +1,7 @@
 import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { DeviceMode } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import { VersionArray } from '@trezor/utils';
+import type { VersionArray } from '@trezor/utils';
 
 import { EventType } from '../constants';
 

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -1,6 +1,7 @@
 import { Locator, Page, expect } from '@playwright/test';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
+import { isTestnet } from '@suite-common/wallet-utils';
 
 import { step } from '../common';
 
@@ -138,7 +139,10 @@ export class WalletPage {
     @step()
     async openAccount(params: WalletParams = {}) {
         await this.accountButton(params).click();
-        await expect(this.fiatAmount).toBeVisible();
+
+        if (!params.symbol || !isTestnet(params.symbol)) {
+            await expect(this.fiatAmount).toBeVisible();
+        }
     }
 
     @step()


### PR DESCRIPTION
## Description

If the account is a testnet:

- display crypto amount in the header
- hide fiat amount in the header

## Related Issue

Resolve #25325 

## Screenshots:

<img width="1512" height="833" alt="Screenshot 2026-02-24 at 09 50 37" src="https://github.com/user-attachments/assets/aa968988-3cb1-4ad1-950d-094d21e45b47" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/show-testnet-base-currency&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/show-testnet-base-currency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/show-testnet-base-currency&lookback=7)