### PR TITLE
Fix: expot version array from index

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * as bufferUtils from './bufferUtils';
 export * as enumUtils from './enumUtils';
 export * as versionUtils from './versionUtils';
+export type { VersionArray } from './versionUtils';
 export * as xssFilters from './xssFilters';
 export * from './addDashesToSpaces';
 export * from './arrayDistinct';

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -14,7 +14,7 @@ import {
     Unsuccessful,
 } from '@trezor/connect';
 import { Branded, UnionSubset } from '@trezor/type-utils';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 // Extend original ButtonRequestMessage from @trezor/connect
 // suite (deviceReducer) stores them in slightly different shape:

--- a/suite-native/analytics/src/events/deviceConnectEvent.ts
+++ b/suite-native/analytics/src/events/deviceConnectEvent.ts
@@ -1,7 +1,7 @@
 import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { DeviceMode } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
-import { VersionArray } from '@trezor/utils/src/versionUtils';
+import { VersionArray } from '@trezor/utils';
 
 import { EventType } from '../constants';
 

--- a/suite-native/device/src/utils.ts
+++ b/suite-native/device/src/utils.ts
@@ -20,7 +20,7 @@ import {
     hasBitcoinOnlyFirmware,
 } from '@trezor/device-utils';
 import { exhaustive } from '@trezor/type-utils';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 export const minimalSupportedFirmwareVersion = {
     UNKNOWN: [0, 0, 0] as VersionArray,

--- a/suite-native/firmware/src/components/FirmwareVersionCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareVersionCard.tsx
@@ -20,7 +20,7 @@ import {
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 import { FirmwareChangelogButton } from './FirmwareChangelogButton';
 import { FirmwareInfoBox } from './FirmwareInfoBox';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This https://github.com/trezor/trezor-suite/pull/25303 probably got merged at same time as https://github.com/trezor/trezor-suite/pull/25238 and the error got into develop. Fixing it.

## Notes for QA
Nothing to test

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/expot-VersionArray-from-index&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/expot-VersionArray-from-index&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/expot-VersionArray-from-index&lookback=7)