### PR TITLE
fix(vite): add suite aliases to Vite configuration

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -94,7 +94,14 @@ const createWorkspaceAliases = () => {
             replacement: resolve(__dirname, '../', dirent.name),
         }));
 
-    return [...suiteCommonAliases, ...trezorPackagesAliases];
+    const suiteAliases = readdirSync(resolve(__dirname, '../../suite'), { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => ({
+            find: `@suite/${dirent.name}`,
+            replacement: resolve(__dirname, '../../suite', dirent.name),
+        }));
+
+    return [...suiteCommonAliases, ...trezorPackagesAliases, ...suiteAliases];
 };
 
 const alias = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- `createWorkspaceAliases()` in `vite.config.mts` previously generated aliases for `@suite-common/*` and `@trezor/*` packages, but was missing `@suite/*` packages (e.g. `@suite/intl`, `@suite/analytics`, etc.)
- Without these aliases, Vite resolved `@suite/*` imports through the `node_modules` symlinks; combined with `preserveSymlinks: true`, Vite treated them as external dependencies and pre-bundled them into the cache
- Pre-bundled `@suite/intl` caused `messages.ts` changes to be ignored — newly added translation keys were not visible in the Vite dev server (while Webpack worked correctly)
- Added a `suiteAliases` scan of `../../suite/` mirroring the existing `suiteCommonAliases` and `trezorPackagesAliases` patterns, so all `@suite/*` packages resolve directly to their source paths

## Notes for QA

Just dev thing, no need to test

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/vite-transaltions&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/vite-transaltions&lookback=7)