### PR TITLE
test(connect-web): add more tests, document buggy behaviour

### DIFF
--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -218,6 +218,14 @@ jobs:
             --forbid-only \
             $REPORTER_OPT
 
+
+      - name: Upload Istanbul HTML Coverage Report
+        if: inputs.enable-coverage == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-coverage-html
+          path: coverage/lcov-report/
+
       - name: Extract and Upload Logs
         if: ${{ !cancelled() }}
         uses: ./.github/actions/upload-test-logs

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -145,7 +145,165 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
 
             const response = page.getByTestId('@response');
             await expect(response).toHaveText(/success: false/);
+            // PopupManager.emitClosed() produces { code: 'Method_Interrupted', error: 'popup-closed' }
+            // (the error value is the POPUP.CLOSED constant, not the human-readable ERROR_CODES string)
             await expect(response).toHaveText(/Method_Interrupted/);
+            await expect(response).toHaveText(/popup-closed/);
+        },
+    );
+
+    test(
+        'popup blocked by browser returns handshake failed error',
+        {
+            // note: we may use this test (after small changes) to test missing browser permissions
+            // as proposed in https://github.com/trezor/trezor-suite/pull/23468
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect: When popup is blocked, returns handshake failed error',
+            }),
+        },
+        async ({ page }) => {
+            // When window.open returns null (popup blocked), the handshake
+            // times out and returns { success: false, error: "handshake failed" }.
+            // Note: PopupManager still leaves `locked = true` after this, which
+            // means subsequent calls will try to focus a non-existent window.
+
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+            await page.getByTestId('@api-playground/collapsible-box').click();
+
+            // Block popups
+            await page.evaluate(() => {
+                window.open = () => null;
+            });
+
+            await page.getByTestId('@submit-button').click();
+            const response = page.getByTestId('@response');
+            // todo: there is quite big  timeout before handshake failed appears. Maybe we could detect that popup
+            // did not open earlier and return error faster?
+            await expect(response).toHaveText(/success: false/, { timeout: 15_000 });
+            await expect(response).toHaveText(/handshake failed/i);
+        },
+    );
+
+    test(
+        'second call after popup was closed by user should work',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect: After popup is force-closed, next call should still work',
+            }),
+        },
+        async ({ page, device }) => {
+            // After the user closes the popup window directly (not via close button),
+            // the closeInterval detects the dead window and cleans up state.
+            // The next call should open a fresh popup and succeed.
+
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+            await page.getByTestId('@api-playground/collapsible-box').click();
+
+            // First call — close the popup window directly
+            const [suite1] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
+            const modal1 = new ConnectPermissionsModal(suite1);
+            await expect(modal1.appName).toHaveText('Trezor Connect Explorer', {
+                timeout: 10_000,
+            });
+            await suite1.close();
+
+            await expect(page.getByTestId('@response')).toHaveText(/success: false/);
+            // PopupManager.emitClosed() produces { code: 'Method_Interrupted', error: 'popup-closed' }
+            await expect(page.getByTestId('@response')).toHaveText(/Method_Interrupted/);
+            await expect(page.getByTestId('@response')).toHaveText(/popup-closed/);
+
+            // Second call — should open a new popup and complete successfully
+            const [suite2] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
+            const modal2 = new ConnectPermissionsModal(suite2);
+            await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
+                timeout: 10_000,
+            });
+            await modal2.confirmButton.click();
+            await suite2.getByTestId('@connect-address-confirmation/confirm-button').click();
+            await suite2.waitForTimeout(1000);
+            await device.pressYes();
+            await expect(
+                suite2.getByTestId('@connect-address-confirmation/verified-badge/0'),
+            ).toBeVisible();
+            await suite2.getByTestId('@connect-address-confirmation/close-button').click();
+
+            await expect(page.getByTestId('@response')).toHaveText(/success: true/);
+        },
+    );
+
+    // ---------------------------------------------------------------------------
+    // Edge-case and regression tests
+    //
+    // These document known behavioral issues and edge cases in PopupManager.
+    // Skipped tests serve as a benchmark — enable them after the refactoring to
+    // verify the fix.
+    // ---------------------------------------------------------------------------
+
+    test(
+        'second call immediately after first completes works correctly',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect: Sequential calls — second getAddress after first succeeds',
+            }),
+        },
+        async ({ page, device }) => {
+            // Known issue: after the first popup closes (via close-button), the
+            // close-detection interval fires and emits a second POPUP.CLOSED,
+            // which can corrupt state and prevent the next call from opening a
+            // new popup. This test will pass once the double-emitClosed bug is
+            // fixed.
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+
+            // --- First call ---
+            await page.getByTestId('@api-playground/collapsible-box').click();
+            await expect(page.getByTestId('@submit-button')).toBeVisible();
+            let [suite] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
+            let connectPermissionsModal = new ConnectPermissionsModal(suite);
+            await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
+                timeout: 10_000,
+            });
+            await expect(connectPermissionsModal.rememberCheckbox).toBeVisible();
+            await connectPermissionsModal.rememberCheckbox.click();
+            await connectPermissionsModal.confirmButton.click();
+            await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
+            await suite.waitForTimeout(1000);
+            await device.pressYes();
+            await expect(
+                suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
+            ).toBeVisible();
+            await suite.getByTestId('@connect-address-confirmation/close-button').click();
+
+            await expect(page.getByTestId('@response')).toHaveText(/success: true/);
+
+            // --- Second call: popup should open and complete again ---
+            // And it fails to open. If I put some timeout here, it works so this bug is unlikely to hit a regular user
+            [suite] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.getByTestId('@submit-button').click(),
+            ]);
+
+            // Permissions remembered from first call, so we skip straight to the action
+            await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
+            await suite.waitForTimeout(1000);
+            await device.pressYes();
+            await expect(
+                suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
+            ).toBeVisible();
+            await suite.getByTestId('@connect-address-confirmation/close-button').click();
+
+            await expect(page.getByTestId('@response')).toHaveText(/success: true/);
         },
     );
 });

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -38,7 +38,6 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
     test.beforeEach(async ({ onboardingPage }) => {
         await onboardingPage.completeOnboarding();
     });
-
     test(
         'TrezorConnect.getAddress',
         {
@@ -239,73 +238,43 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
         },
     );
 
-    // ---------------------------------------------------------------------------
-    // Edge-case and regression tests
-    //
-    // These document known behavioral issues and edge cases in PopupManager.
-    // Skipped tests serve as a benchmark — enable them after the refactoring to
-    // verify the fix.
-    // ---------------------------------------------------------------------------
-
     test(
-        'second call immediately after first completes works correctly',
+        'focuses existing popup if already open',
         {
             annotation: createTestAnnotation({
                 testCase:
-                    'Suite Web Connect: Sequential calls — second getAddress after first succeeds',
+                    'Suite Web Connect: If popup is already open, it should be focused instead of opening a new one',
             }),
         },
-        async ({ page, device }) => {
-            // Known issue: after the first popup closes (via close-button), the
-            // close-detection interval fires and emits a second POPUP.CLOSED,
-            // which can corrupt state and prevent the next call from opening a
-            // new popup. This test will pass once the double-emitClosed bug is
-            // fixed.
+        async ({ page }) => {
             await gotoConnectExplorer(page, 'bitcoin/getAddress');
-
-            // --- First call ---
             await page.getByTestId('@api-playground/collapsible-box').click();
-            await expect(page.getByTestId('@submit-button')).toBeVisible();
-            let [suite] = await Promise.all([
+
+            // Open the popup for the first call, but do not close it
+            const [popup1] = await Promise.all([
                 page.waitForEvent('popup'),
                 page.getByTestId('@submit-button').click(),
             ]);
-            let connectPermissionsModal = new ConnectPermissionsModal(suite);
-            await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 10_000,
+
+            // Initiate a second call while the popup is still open
+            // Listen for new popup events
+            let newPopupOpened = false;
+            page.once('popup', () => {
+                newPopupOpened = true;
             });
-            await expect(connectPermissionsModal.rememberCheckbox).toBeVisible();
-            await connectPermissionsModal.rememberCheckbox.click();
-            await connectPermissionsModal.confirmButton.click();
-            await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
-            await suite.waitForTimeout(1000);
-            await device.pressYes();
-            await expect(
-                suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
-            ).toBeVisible();
-            await suite.getByTestId('@connect-address-confirmation/close-button').click();
+            await page.getByTestId('@submit-button').click();
 
-            await expect(page.getByTestId('@response')).toHaveText(/success: true/);
+            // Wait a short time to see if a new popup is opened
+            await page.waitForTimeout(1000);
 
-            // --- Second call: popup should open and complete again ---
-            // And it fails to open. If I put some timeout here, it works so this bug is unlikely to hit a regular user
-            [suite] = await Promise.all([
-                page.waitForEvent('popup'),
-                page.getByTestId('@submit-button').click(),
-            ]);
+            // Assert that no new popup was opened
+            expect(newPopupOpened).toBe(false);
 
-            // Permissions remembered from first call, so we skip straight to the action
-            await suite.getByTestId('@connect-address-confirmation/confirm-button').click();
-            await suite.waitForTimeout(1000);
-            await device.pressYes();
-            await expect(
-                suite.getByTestId('@connect-address-confirmation/verified-badge/0'),
-            ).toBeVisible();
-            await suite.getByTestId('@connect-address-confirmation/close-button').click();
+            // Optionally, check that the original popup is still open
+            expect(await popup1.isClosed()).toBe(false);
 
-            await expect(page.getByTestId('@response')).toHaveText(/success: true/);
+            // Clean up
+            await popup1.close();
         },
     );
-
-    // trigger test run
 });

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -306,4 +306,6 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             await expect(page.getByTestId('@response')).toHaveText(/success: true/);
         },
     );
+
+    // trigger test run
 });


### PR DESCRIPTION
## Add e2e tests for TrezorConnect popup edge cases

Extends `connectPopupWeb.test.ts` with tests covering popup lifecycle scenarios beyond the existing happy path and cancellation tests.

### New tests

| Test | What it verifies |
|------|-----------------|
| **closing popup window returns Method_Interrupted error** | When the user closes the browser popup window directly (not via the in-app close button), the caller receives `{ code: 'Method_Interrupted', error: 'popup-closed' }` — a fake response produced by PopupManager.emitClosed() since core dies with the popup. |
| **popup blocked by browser returns handshake failed error** | When `window.open` returns `null` (popup blocker), the handshake times out and returns `{ success: false, error: 'handshake failed' }`. |
| **second call after popup was closed by user should work** | After the user force-closes the popup, the `closeInterval` cleanup resets PopupManager state so the next call can open a fresh popup and complete successfully. |
| **second call immediately after first completes works correctly** | Two sequential getAddress calls — the first uses "remember permissions" checkbox so the second skips the permissions screen. Documents a known race: if the second call fires before `closeInterval` cleans up, the popup fails to open. |


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/popup-bug-documentation&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/popup-bug-documentation&lookback=7)