### PR TITLE
feat(trading): Split trading terms copy into provider vs no-provider

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -15,19 +15,20 @@ export const TradingFooter = ({ provider }: TradingFooterProps) => {
     const currentProviderMetadata = useSelector(selectTradingProviderMetadata);
     const { companyName, termsUrl } = provider ?? currentProviderMetadata ?? {};
 
-    const providerName = companyName ?? <Translation id="TR_TERMS_PROVIDER_PLACEHOLDER" />;
-
     return (
         <Column alignItems="center" margin={{ top: 48 }} gap={12}>
             <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                <Translation
-                    id="TR_TRADING_TERMS"
-                    values={{
-                        provider: providerName,
-                        comp: chunks =>
-                            termsUrl ? <Link href={termsUrl}>{providerName}</Link> : chunks,
-                    }}
-                />
+                {termsUrl ? (
+                    <Translation
+                        id="TR_TRADING_TERMS"
+                        values={{
+                            provider: companyName,
+                            comp: () => <Link href={termsUrl}>{companyName}</Link>,
+                        }}
+                    />
+                ) : (
+                    <Translation id="TR_TRADING_TERMS_NO_PROVIDER" />
+                )}
             </Text>
 
             <InfoSegments typographyStyle="body-sm" intent="neutral" priority="secondary">

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -766,6 +766,11 @@ export const messages = defineMessages({
         defaultMessage:
             'This service is provided by <comp>{provider}</comp> and governed by their Terms & Conditions. Trezor isn’t involved.',
     },
+    TR_TRADING_TERMS_NO_PROVIDER: {
+        id: 'TR_TRADING_TERMS_NO_PROVIDER',
+        defaultMessage:
+            'This service is provided by provider and governed by their Terms & Conditions. Trezor isn’t involved.',
+    },
     TR_BUY_MODAL_SECURITY_HEADER: {
         defaultMessage: 'Security first with your Trezor',
         id: 'TR_BUY_MODAL_SECURITY_HEADER',


### PR DESCRIPTION
## Description
- Add `TR_TRADING_TERMS_NO_PROVIDER` in `suite/intl` for the case when no provider or no terms URL is set, so locales can phrase the sentence without a provider placeholder and avoid awkward spacing (e.g. Chinese).
- In `TradingFooter` (`packages/suite/src/views/wallet/trading/common/TradingFooter/`), render `TR_TRADING_TERMS` with provider/link only when `termsUrl` and `companyName` exist; otherwise render `TR_TRADING_TERMS_NO_PROVIDER` (no link, no placeholder).
- Remove the previous fallback that used `TR_TERMS_PROVIDER_PLACEHOLDER` when `companyName` was missing; the no-provider case is now handled by the dedicated message.

## Notes for QA
- **Where:** Trading (Buy/Sell/Exchange) → footer text under the trading form.
- **With provider:** Select a provider that has terms; footer should show “This service is provided by **&lt;Provider&gt;**…” with the provider name linked to their terms.
- **No provider / no terms:** When no provider is selected or the provider has no terms URL, footer should show the no-provider sentence (e.g. EN: “This service is provided by provider and governed by…”), with no link and no empty/placeholder name. No extra spaces in locales like Chinese.
- **Edge:** Provider with `companyName` but no `termsUrl`: should show the no-provider message (no link).

## Related issue 
Resolves #25409

## Screenshot
<img width="923" height="273" alt="image" src="https://github.com/user-attachments/assets/65de8ab4-3518-4c2e-b02a-bf11dc16b5ab" />
<img width="1061" height="465" alt="image" src="https://github.com/user-attachments/assets/90c097ed-2eac-4b98-b50f-7fe1722bdf59" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/25409/trading-terms-split-no-provider&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/25409/trading-terms-split-no-provider&lookback=7)