### PR TITLE
Revert "Chore/update protobuf messages"

### DIFF
--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -25,6 +25,8 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
         if (thpState) {
             this.params = {
                 thp_credential: thpState.pairingCredentials[0].credential,
+                host_static_public_key:
+                    thpState.handshakeCredentials?.hostStaticPublicKey.toString('hex'),
             };
         }
 

--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -2320,7 +2320,7 @@
                         "Failure_Busy": 15,
                         "Failure_ThpUnallocatedSession": 16,
                         "Failure_InvalidProtocol": 17,
-                        "Failure_InProgress": 19,
+                        "Failure_BufferError": 18,
                         "Failure_FirmwareError": 99
                     }
                 }
@@ -4339,6 +4339,10 @@
                 "thp_credential": {
                     "type": "bytes",
                     "id": 1
+                },
+                "host_static_public_key": {
+                    "type": "bytes",
+                    "id": 2
                 }
             }
         },
@@ -4979,10 +4983,6 @@
                 "no_backup": {
                     "type": "bool",
                     "id": 10
-                },
-                "unfinished_backup": {
-                    "type": "bool",
-                    "id": 11
                 }
             }
         },
@@ -5227,6 +5227,13 @@
                 "firmware_header": {
                     "type": "bytes",
                     "id": 2
+                },
+                "language_data_length": {
+                    "type": "uint32",
+                    "id": 3,
+                    "options": {
+                        "default": 0
+                    }
                 }
             },
             "nested": {
@@ -7035,29 +7042,6 @@
                 }
             }
         },
-        "TelemetryGet": {
-            "fields": {}
-        },
-        "Telemetry": {
-            "fields": {
-                "min_temp_c": {
-                    "type": "sint32",
-                    "id": 1
-                },
-                "max_temp_c": {
-                    "type": "sint32",
-                    "id": 2
-                },
-                "battery_errors": {
-                    "type": "uint32",
-                    "id": 3
-                },
-                "battery_cycles": {
-                    "type": "uint32",
-                    "id": 4
-                }
-            }
-        },
         "TezosGetAddress": {
             "fields": {
                 "address_n": {
@@ -7578,63 +7562,6 @@
                 }
             }
         },
-        "TronFreezeBalanceV2Contract": {
-            "fields": {
-                "owner_address": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 1
-                },
-                "balance": {
-                    "rule": "required",
-                    "type": "uint64",
-                    "id": 2
-                },
-                "resource": {
-                    "type": "TronResourceCode",
-                    "id": 3,
-                    "options": {
-                        "default": "BANDWIDTH"
-                    }
-                }
-            }
-        },
-        "TronUnfreezeBalanceV2Contract": {
-            "fields": {
-                "owner_address": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 1
-                },
-                "balance": {
-                    "rule": "required",
-                    "type": "uint64",
-                    "id": 2
-                },
-                "resource": {
-                    "type": "TronResourceCode",
-                    "id": 3,
-                    "options": {
-                        "default": "BANDWIDTH"
-                    }
-                }
-            }
-        },
-        "TronWithdrawUnfreeze": {
-            "fields": {
-                "owner_address": {
-                    "rule": "required",
-                    "type": "bytes",
-                    "id": 1
-                }
-            }
-        },
-        "TronResourceCode": {
-            "values": {
-                "BANDWIDTH": 0,
-                "ENERGY": 1
-            }
-        },
         "TronSignature": {
             "fields": {
                 "signature": {
@@ -7712,10 +7639,7 @@
                         "TronRawContractType": {
                             "values": {
                                 "TransferContract": 1,
-                                "TriggerSmartContract": 31,
-                                "FreezeBalanceV2Contract": 54,
-                                "UnfreezeBalanceV2Contract": 55,
-                                "WithdrawExpireUnfreezeContract": 56
+                                "TriggerSmartContract": 31
                             }
                         }
                     }
@@ -7976,12 +7900,7 @@
                 "TronSignature": 2203,
                 "TronContractRequest": 2204,
                 "TronTransferContract": 2205,
-                "TronTriggerSmartContract": 2206,
-                "TronFreezeBalanceV2Contract": 2207,
-                "TronUnfreezeBalanceV2Contract": 2208,
-                "TronWithdrawUnfreeze": 2209,
-                "TelemetryGet": 1100,
-                "Telemetry": 1101
+                "TronTriggerSmartContract": 2206
             }
         }
     }

--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -34,7 +34,6 @@ export const ORDER = {
     RecoveryType: 'RecoveryDevice',
     RecoveryDeviceInputMethod: 'RecoveryType',
     EthereumDefinitions: 'EthereumSignTypedData',
-    TronResourceCode: 'TronFreezeBalanceV2Contract',
 };
 
 // enums used as keys (string), used as values (number) by default

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -1299,7 +1299,7 @@ export enum Enum_FailureType {
     Failure_Busy = 15,
     Failure_ThpUnallocatedSession = 16,
     Failure_InvalidProtocol = 17,
-    Failure_InProgress = 19,
+    Failure_BufferError = 18,
     Failure_FirmwareError = 99,
 }
 
@@ -2221,6 +2221,7 @@ export type EvoluGetDelegatedIdentityKey = Static<typeof EvoluGetDelegatedIdenti
 export const EvoluGetDelegatedIdentityKey = Type.Object(
     {
         thp_credential: Type.Optional(Type.String()),
+        host_static_public_key: Type.Optional(Type.String()),
     },
     { $id: 'EvoluGetDelegatedIdentityKey' },
 );
@@ -2640,7 +2641,6 @@ export const LoadDevice = Type.Object(
         u2f_counter: Type.Optional(Type.Number()),
         needs_backup: Type.Optional(Type.Boolean()),
         no_backup: Type.Optional(Type.Boolean()),
-        unfinished_backup: Type.Optional(Type.Boolean()),
     },
     { $id: 'LoadDevice' },
 );
@@ -2777,6 +2777,7 @@ export const RebootToBootloader = Type.Object(
     {
         boot_command: Type.Optional(EnumBootCommand),
         firmware_header: Type.Optional(Type.String()),
+        language_data_length: Type.Optional(Type.Number()),
     },
     { $id: 'RebootToBootloader' },
 );
@@ -3720,20 +3721,6 @@ export const StellarSignedTx = Type.Object(
     { $id: 'StellarSignedTx' },
 );
 
-export type TelemetryGet = Static<typeof TelemetryGet>;
-export const TelemetryGet = Type.Object({}, { $id: 'TelemetryGet' });
-
-export type Telemetry = Static<typeof Telemetry>;
-export const Telemetry = Type.Object(
-    {
-        min_temp_c: Type.Optional(Type.Number()),
-        max_temp_c: Type.Optional(Type.Number()),
-        battery_errors: Type.Optional(Type.Number()),
-        battery_cycles: Type.Optional(Type.Number()),
-    },
-    { $id: 'Telemetry' },
-);
-
 export type TezosGetAddress = Static<typeof TezosGetAddress>;
 export const TezosGetAddress = Type.Object(
     {
@@ -3979,42 +3966,6 @@ export const TronTriggerSmartContract = Type.Object(
     { $id: 'TronTriggerSmartContract' },
 );
 
-export enum TronResourceCode {
-    BANDWIDTH = 0,
-    ENERGY = 1,
-}
-
-export type EnumTronResourceCode = Static<typeof EnumTronResourceCode>;
-export const EnumTronResourceCode = Type.Enum(TronResourceCode);
-
-export type TronFreezeBalanceV2Contract = Static<typeof TronFreezeBalanceV2Contract>;
-export const TronFreezeBalanceV2Contract = Type.Object(
-    {
-        owner_address: Type.String(),
-        balance: Type.Number(),
-        resource: Type.Optional(EnumTronResourceCode),
-    },
-    { $id: 'TronFreezeBalanceV2Contract' },
-);
-
-export type TronUnfreezeBalanceV2Contract = Static<typeof TronUnfreezeBalanceV2Contract>;
-export const TronUnfreezeBalanceV2Contract = Type.Object(
-    {
-        owner_address: Type.String(),
-        balance: Type.Number(),
-        resource: Type.Optional(EnumTronResourceCode),
-    },
-    { $id: 'TronUnfreezeBalanceV2Contract' },
-);
-
-export type TronWithdrawUnfreeze = Static<typeof TronWithdrawUnfreeze>;
-export const TronWithdrawUnfreeze = Type.Object(
-    {
-        owner_address: Type.String(),
-    },
-    { $id: 'TronWithdrawUnfreeze' },
-);
-
 export type TronSignature = Static<typeof TronSignature>;
 export const TronSignature = Type.Object(
     {
@@ -4035,9 +3986,6 @@ export const TronRawParameter = Type.Object(
 export enum TronRawContractType {
     TransferContract = 1,
     TriggerSmartContract = 31,
-    FreezeBalanceV2Contract = 54,
-    UnfreezeBalanceV2Contract = 55,
-    WithdrawExpireUnfreezeContract = 56,
 }
 
 export type EnumTronRawContractType = Static<typeof EnumTronRawContractType>;
@@ -4375,8 +4323,6 @@ export const MessageType = Type.Object(
         StellarBumpSequenceOp,
         StellarClaimClaimableBalanceOp,
         StellarSignedTx,
-        TelemetryGet,
-        Telemetry,
         TezosGetAddress,
         TezosAddress,
         TezosGetPublicKey,
@@ -4398,9 +4344,6 @@ export const MessageType = Type.Object(
         TronContractRequest,
         TronTransferContract,
         TronTriggerSmartContract,
-        TronFreezeBalanceV2Contract,
-        TronUnfreezeBalanceV2Contract,
-        TronWithdrawUnfreeze,
         TronSignature,
         TronRawParameter,
         TronRawContract,

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -870,7 +870,7 @@ export enum Enum_FailureType {
     Failure_Busy = 15,
     Failure_ThpUnallocatedSession = 16,
     Failure_InvalidProtocol = 17,
-    Failure_InProgress = 19,
+    Failure_BufferError = 18,
     Failure_FirmwareError = 99,
 }
 
@@ -1439,6 +1439,7 @@ export type EvoluRegistrationRequest = {
 
 export type EvoluGetDelegatedIdentityKey = {
     thp_credential?: string;
+    host_static_public_key?: string;
 };
 
 export type EvoluDelegatedIdentityKey = {
@@ -1729,7 +1730,6 @@ export type LoadDevice = {
     u2f_counter?: number;
     needs_backup?: boolean;
     no_backup?: boolean;
-    unfinished_backup?: boolean;
 };
 
 export type ResetDevice = {
@@ -1810,6 +1810,7 @@ export enum BootCommand {
 export type RebootToBootloader = {
     boot_command?: BootCommand;
     firmware_header?: string;
+    language_data_length?: number;
 };
 
 export type GetNonce = {};
@@ -2394,15 +2395,6 @@ export type StellarSignedTx = {
     signature: string;
 };
 
-export type TelemetryGet = {};
-
-export type Telemetry = {
-    min_temp_c?: number;
-    max_temp_c?: number;
-    battery_errors?: number;
-    battery_cycles?: number;
-};
-
 export type TezosGetAddress = {
     address_n: number[];
     show_display?: boolean;
@@ -2561,27 +2553,6 @@ export type TronTriggerSmartContract = {
     data: string;
 };
 
-export enum TronResourceCode {
-    BANDWIDTH = 0,
-    ENERGY = 1,
-}
-
-export type TronFreezeBalanceV2Contract = {
-    owner_address: string;
-    balance: number;
-    resource?: TronResourceCode;
-};
-
-export type TronUnfreezeBalanceV2Contract = {
-    owner_address: string;
-    balance: number;
-    resource?: TronResourceCode;
-};
-
-export type TronWithdrawUnfreeze = {
-    owner_address: string;
-};
-
 export type TronSignature = {
     signature: string;
 };
@@ -2594,9 +2565,6 @@ export type TronRawParameter = {
 export enum TronRawContractType {
     TransferContract = 1,
     TriggerSmartContract = 31,
-    FreezeBalanceV2Contract = 54,
-    UnfreezeBalanceV2Contract = 55,
-    WithdrawExpireUnfreezeContract = 56,
 }
 
 export type TronRawContract = {
@@ -2922,8 +2890,6 @@ export type MessageType = {
     StellarBumpSequenceOp: StellarBumpSequenceOp;
     StellarClaimClaimableBalanceOp: StellarClaimClaimableBalanceOp;
     StellarSignedTx: StellarSignedTx;
-    TelemetryGet: TelemetryGet;
-    Telemetry: Telemetry;
     TezosGetAddress: TezosGetAddress;
     TezosAddress: TezosAddress;
     TezosGetPublicKey: TezosGetPublicKey;
@@ -2945,9 +2911,6 @@ export type MessageType = {
     TronContractRequest: TronContractRequest;
     TronTransferContract: TronTransferContract;
     TronTriggerSmartContract: TronTriggerSmartContract;
-    TronFreezeBalanceV2Contract: TronFreezeBalanceV2Contract;
-    TronUnfreezeBalanceV2Contract: TronUnfreezeBalanceV2Contract;
-    TronWithdrawUnfreeze: TronWithdrawUnfreeze;
     TronSignature: TronSignature;
     TronRawParameter: TronRawParameter;
     TronRawContract: TronRawContract;


### PR DESCRIPTION
Reverts trezor/trezor-suite#25373

Causes this issue: revert-25373-chore/update-protobuf-messages

Please see: https://github.com/trezor/trezor-suite/pull/24744#discussion_r2737730608 for explanation

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert-25373-chore/update-protobuf-messages&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert-25373-chore/update-protobuf-messages&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=revert-25373-chore/update-protobuf-messages&lookback=7)