### PR TITLE
fix(protbuf): selectively revert evolu breaking change

### DIFF
--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -25,6 +25,8 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
         if (thpState) {
             this.params = {
                 thp_credential: thpState.pairingCredentials[0].credential,
+                host_static_public_key:
+                    thpState.handshakeCredentials?.hostStaticPublicKey.toString('hex'),
             };
         }
 

--- a/packages/protobuf/messages.json
+++ b/packages/protobuf/messages.json
@@ -4339,6 +4339,10 @@
                 "thp_credential": {
                     "type": "bytes",
                     "id": 1
+                },
+                "host_static_public_key": {
+                    "type": "bytes",
+                    "id": 2
                 }
             }
         },

--- a/packages/protobuf/src/messages-schema.ts
+++ b/packages/protobuf/src/messages-schema.ts
@@ -2221,6 +2221,7 @@ export type EvoluGetDelegatedIdentityKey = Static<typeof EvoluGetDelegatedIdenti
 export const EvoluGetDelegatedIdentityKey = Type.Object(
     {
         thp_credential: Type.Optional(Type.String()),
+        host_static_public_key: Type.Optional(Type.String()),
     },
     { $id: 'EvoluGetDelegatedIdentityKey' },
 );

--- a/packages/protobuf/src/messages.ts
+++ b/packages/protobuf/src/messages.ts
@@ -1439,6 +1439,7 @@ export type EvoluRegistrationRequest = {
 
 export type EvoluGetDelegatedIdentityKey = {
     thp_credential?: string;
+    host_static_public_key?: string;
 };
 
 export type EvoluDelegatedIdentityKey = {


### PR DESCRIPTION
## Description

Latest protobuf update introduces a breaking change in Evolu 

@peter-sanderson

> Basically, I like to wait with this until we have released signed FW that has it. Otherwise, with this change, we would need to use current main FW which is pain for both development & testing.

Instead of #25415


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evolu-protobuf-revert&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evolu-protobuf-revert&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evolu-protobuf-revert&lookback=7)