### PR TITLE
Revert "chore(suite-native): ignore all suite/ packages in eas builds"

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -14,7 +14,8 @@ packages/suite-desktop-ui/
 packages/suite-storage/
 packages/suite-web/
 packages/transport-bluetooth/
-suite/*
+suite/e2e/
+suite/test-utils/
 
 
 ### content of all .gitignore files is not applied if .easignore is present


### PR DESCRIPTION
This reverts commit eb4b3430f932e1b6631c46003bbed962c6c718f2.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reverting because `suite-common/` imports from `suite/intl`, so doing a quick fix so builds work as a temporary solution.

## Notes for QA
Nothing to test. 


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/revert-easignore&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/revert-easignore&lookback=7)