### PR TITLE
fix(suite-common): remove suite/intl dependency

### DIFF
--- a/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
+++ b/packages/suite/src/utils/wallet/__fixtures__/coinjoinUtils.ts
@@ -1,3 +1,5 @@
+import { TranslationKey } from '@suite/intl';
+import { NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { RoundPhase, SessionPhase } from '@trezor/coinjoin';
 
 import { ANONYMITY_GAINS_HINDSIGHT_COUNT } from 'src/services/coinjoin';
@@ -197,4 +199,14 @@ export const averageAnonymityGainsParams: Array<{
     { params: [2, [{ level: 1, timestamp: Date.now() }]], checkResult: x => x < 2 },
     { params: [2, [{ level: 2, timestamp: Date.now() }]], checkResult: x => x === 2 },
     { params: [2, undefined], checkResult: x => x === 2 },
+];
+
+export const accountTitleCoinjoinFixture: Array<{
+    symbol: NetworkSymbolExtended;
+    title: TranslationKey;
+}> = [
+    { symbol: 'btc', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
+    { symbol: 'eth', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
+    { symbol: 'test', title: 'TR_NETWORK_COINJOIN_BITCOIN_TESTNET' },
+    { symbol: 'regtest', title: 'TR_NETWORK_COINJOIN_BITCOIN_REGTEST' },
 ];

--- a/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
+++ b/packages/suite/src/utils/wallet/__tests__/accountUtils.test.ts
@@ -1,6 +1,8 @@
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 
+import { accountTitleCoinjoinFixture } from '../__fixtures__/coinjoinUtils';
 import * as accountUtils from '../accountUtils';
 
 describe('account utils', () => {
@@ -116,5 +118,13 @@ describe('account utils', () => {
                 },
             ),
         ).toBeNull();
+    });
+});
+
+describe('get title for coinjoin accounts', () => {
+    accountTitleCoinjoinFixture.forEach(fixture => {
+        it(fixture.symbol, () => {
+            expect(getTitleForCoinjoinAccount(fixture.symbol)).toBe(fixture.title);
+        });
     });
 });

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -21,7 +21,6 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
-        "@suite/intl": "workspace:*",
         "@trezor/address-validator": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -1,21 +1,6 @@
-import { TranslationKey } from '@suite/intl';
-import type {
-    Bip43Path,
-    Bip43PathTemplate,
-    NetworkSymbolExtended,
-} from '@suite-common/wallet-config';
+import type { Bip43Path, Bip43PathTemplate } from '@suite-common/wallet-config';
 
 import { ACCOUNTS } from './accounts';
-
-export const accountTitleCoinjoinFixture: Array<{
-    symbol: NetworkSymbolExtended;
-    title: TranslationKey;
-}> = [
-    { symbol: 'btc', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
-    { symbol: 'eth', title: 'TR_NETWORK_COINJOIN_BITCOIN' },
-    { symbol: 'test', title: 'TR_NETWORK_COINJOIN_BITCOIN_TESTNET' },
-    { symbol: 'regtest', title: 'TR_NETWORK_COINJOIN_BITCOIN_REGTEST' },
-];
 
 export const parseBIP44Path = [
     {

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -12,7 +12,6 @@ import {
     getBip43Type,
     getFirstFreshAddress,
     getNetworkAccountFeatures,
-    getTitleForCoinjoinAccount,
     getUtxoFromSignedTransaction,
     getUtxoOutpoint,
     hasNetworkFeatures,
@@ -60,14 +59,6 @@ describe('account utils', () => {
     fixtures.sortByCoin.forEach(f => {
         it('accountUtils.sortByCoin', () => {
             expect(sortByCoin(f.accounts as Account[])).toEqual(f.result);
-        });
-    });
-
-    describe('get title for coinjoin accounts', () => {
-        fixtures.accountTitleCoinjoinFixture.forEach(fixture => {
-            it(fixture.symbol, () => {
-                expect(getTitleForCoinjoinAccount(fixture.symbol)).toBe(fixture.title);
-            });
         });
     });
 

--- a/suite-common/wallet-utils/tsconfig.json
+++ b/suite-common/wallet-utils/tsconfig.json
@@ -12,7 +12,6 @@
         { "path": "../wallet-config" },
         { "path": "../wallet-constants" },
         { "path": "../wallet-types" },
-        { "path": "../../suite/intl" },
         {
             "path": "../../packages/address-validator"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11774,7 +11774,6 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    "@suite/intl": "workspace:*"
     "@trezor/address-validator": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `suite/intl` dependency in `suite-common/`. We should never import from `suite/` in common packages.

## Notes for QA
No testing needed.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/remove-suite-intl-dependency&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/remove-suite-intl-dependency&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/remove-suite-intl-dependency&lookback=7)