### PR TITLE
Mobile Trade: Scale globe on trading residence screen

### DIFF
--- a/suite-native/trading-residence/package.json
+++ b/suite-native/trading-residence/package.json
@@ -33,6 +33,7 @@
         "react": "19.1.0",
         "react-native": "0.81.5",
         "react-native-reanimated": "~4.1.5",
+        "react-native-safe-area-context": "5.6.2",
         "react-native-svg": "15.15.2",
         "react-redux": "9.2.0"
     },

--- a/suite-native/trading-residence/src/components/GlobeSvg.tsx
+++ b/suite-native/trading-residence/src/components/GlobeSvg.tsx
@@ -2,11 +2,20 @@ import Svg, { G, Path, SvgProps } from 'react-native-svg';
 
 import { useIllustrationColors } from '@suite-native/atoms';
 
+export const GLOBE_SIZE_DEFAULT = 224;
+export const GLOBE_SIZE_MINIMUM = 50;
+
 export const GlobeSvg = (props: SvgProps) => {
     const { lineColor, fillColor } = useIllustrationColors();
 
     return (
-        <Svg width={224} height={224} fill="none" {...props}>
+        <Svg
+            width={GLOBE_SIZE_DEFAULT}
+            height={GLOBE_SIZE_DEFAULT}
+            viewBox="0 0 224 224"
+            fill="none"
+            {...props}
+        >
             <G clipPath="url(#a)">
                 <Path
                     d="M222.439 107.473C222.439 166.964 176.315 218.561 117.693 219.291C48.9088 220.153 2.65524 166.96 2.65524 107.473C2.65524 47.986 55.8861 2.13156 114.512 2.13156C173.138 2.13156 222.439 47.986 222.439 107.473Z"

--- a/suite-native/trading-residence/src/components/TradingLocationSettings.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationSettings.tsx
@@ -6,43 +6,51 @@ import { Translation } from '@suite-native/intl';
 
 import { CountryChangeContextCheckContext } from './CountryChangeContextCheckContext';
 import { CountryOfResidencePicker } from './CountrySheet/CountryOfResidencePicker';
-import { GlobeSvg } from './GlobeSvg';
+import { GLOBE_SIZE_DEFAULT, GLOBE_SIZE_MINIMUM, GlobeSvg } from './GlobeSvg';
 import { LocationForm } from './LocationForm';
 import { TradingAvailability } from './TradingAvailability';
+import { useAvailableScreenSquare } from '../hooks/useAvailableScreenSquare';
 
 export type TradingLocationSettingsProps = {
     context: CountryChangeContextCheck;
     children: ReactNode | ReactNode[];
 };
 
-export const TradingLocationSettings = ({ context, children }: TradingLocationSettingsProps) => (
-    <CountryChangeContextCheckContext value={context}>
-        <LocationForm>
-            <VStack justifyContent="space-between" flex={1}>
-                <Box flex={1} alignItems="center" justifyContent="center">
-                    <GlobeSvg />
-                </Box>
-                <VStack paddingTop="sp32" spacing="sp24">
-                    <VStack spacing="sp8">
-                        <Text variant="headline-md" color="textDefault">
-                            <Translation id="tradingResidence.locationSettings.title" />
-                        </Text>
-                        <Text variant="body-md" color="textSubdued">
-                            <Translation id="tradingResidence.locationSettings.description" />
-                        </Text>
+export const TradingLocationSettings = ({ context, children }: TradingLocationSettingsProps) => {
+    const { squareSize, handleContentLayout } = useAvailableScreenSquare(
+        GLOBE_SIZE_MINIMUM,
+        GLOBE_SIZE_DEFAULT,
+    );
+
+    return (
+        <CountryChangeContextCheckContext value={context}>
+            <LocationForm>
+                <VStack justifyContent="space-between" flex={1}>
+                    <Box flex={1} alignItems="center" justifyContent="center">
+                        <GlobeSvg width={squareSize} height={squareSize} />
+                    </Box>
+                    <VStack paddingTop="sp32" spacing="sp24" onLayout={handleContentLayout}>
+                        <VStack spacing="sp8">
+                            <Text variant="headline-md" color="textDefault">
+                                <Translation id="tradingResidence.locationSettings.title" />
+                            </Text>
+                            <Text variant="body-md" color="textSubdued">
+                                <Translation id="tradingResidence.locationSettings.description" />
+                            </Text>
+                        </VStack>
+                        <VStack spacing="sp8">
+                            <Card noPadding>
+                                <CountryOfResidencePicker
+                                    testID="@trading/residence/country"
+                                    context={context}
+                                />
+                            </Card>
+                            <TradingAvailability />
+                        </VStack>
+                        <VStack spacing="sp12">{children}</VStack>
                     </VStack>
-                    <VStack spacing="sp8">
-                        <Card noPadding>
-                            <CountryOfResidencePicker
-                                testID="@trading/residence/country"
-                                context={context}
-                            />
-                        </Card>
-                        <TradingAvailability />
-                    </VStack>
-                    <VStack spacing="sp12">{children}</VStack>
                 </VStack>
-            </VStack>
-        </LocationForm>
-    </CountryChangeContextCheckContext>
-);
+            </LocationForm>
+        </CountryChangeContextCheckContext>
+    );
+};

--- a/suite-native/trading-residence/src/hooks/__tests__/useAvailableScreenSquare.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useAvailableScreenSquare.test.ts
@@ -1,0 +1,70 @@
+import type { LayoutChangeEvent } from 'react-native';
+
+import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+
+import {
+    HEADER_HEIGHT,
+    HORIZONTAL_MARGIN,
+    useAvailableScreenSquare,
+} from '../useAvailableScreenSquare';
+
+// useWindowDimensions returns { width: 750, height: 1334 } by default in jest-expo
+const MOCKED_SCREEN_HEIGHT = 1334;
+const MOCKED_SCREEN_WIDTH = 750;
+
+const MINIMUM_SIZE = 50;
+const MAXIMUM_SIZE = 300;
+
+describe('useAvailableScreenSquare', () => {
+    const mockLayoutEvent = (height: number, width: number = 0): LayoutChangeEvent =>
+        ({
+            nativeEvent: { layout: { height, width, x: 0, y: 0 } },
+        }) as LayoutChangeEvent;
+
+    const renderUseAvailableScreenSpace = (maximumSize = MAXIMUM_SIZE) =>
+        renderHookWithBasicProvider(() => useAvailableScreenSquare(MINIMUM_SIZE, maximumSize));
+
+    it('should return MAXIMUM_SIZE when totalAvailableHeight is larger than MAXIMUM_SIZE', () => {
+        // totalAvailableHeight = 1334 - 100 = 1234 which is > MAXIMUM_SIZE = 300
+
+        const { result } = renderUseAvailableScreenSpace();
+
+        expect(result.current.squareSize).toBe(MAXIMUM_SIZE);
+    });
+
+    it('should return total available height when it is between MINIMUM_SIZE and MAXIMUM_SIZE', () => {
+        // contentHeight = 1000 => totalAvailableHeight = 1334 - 100 - 1000 = 234
+        // 234 > 50 (MINIMUM_SIZE) && 234 < 300 (MAXIMUM_SIZE)
+        const contentHeight = 1000;
+
+        const { result } = renderUseAvailableScreenSpace();
+
+        act(() => {
+            result.current.handleContentLayout(mockLayoutEvent(contentHeight));
+        });
+
+        const expectedHeight = MOCKED_SCREEN_HEIGHT - contentHeight - HEADER_HEIGHT;
+
+        expect(result.current.squareSize).toBe(expectedHeight);
+    });
+
+    it('should return MINIMUM_SIZE when totalAvailableHeight is below MINIMUM_SIZE', () => {
+        // contentHeight = 1185 => totalAvailableHeight = 1334 - 100 - 1185 = 49 which is < 50 (MINIMUM_SIZE)
+        const contentHeight = 1185;
+
+        const { result } = renderUseAvailableScreenSpace();
+
+        act(() => {
+            result.current.handleContentLayout(mockLayoutEvent(contentHeight));
+        });
+
+        expect(result.current.squareSize).toBe(MINIMUM_SIZE);
+    });
+
+    it('should cap squareSize to totalAvailableWidth when height exceeds it', () => {
+        // MAXIMUM_SIZE = 800 > totalAvailableWidth = 730 => squareSize should be 730
+        const { result } = renderUseAvailableScreenSpace(800);
+
+        expect(result.current.squareSize).toBe(MOCKED_SCREEN_WIDTH - HORIZONTAL_MARGIN);
+    });
+});

--- a/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.ts
+++ b/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+import { type LayoutChangeEvent, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// approximate height of the navigation header excluding the status bar
+// status bar is taken into account with `useSafeAreaInsets`
+export const HEADER_HEIGHT = 100;
+export const HORIZONTAL_MARGIN = 20;
+
+export const useAvailableScreenSquare = (minimumSize: number, maximumSize: number) => {
+    const { height, width } = useWindowDimensions();
+    const { top, bottom, left, right } = useSafeAreaInsets();
+    const [contentHeight, setContentHeight] = useState(0);
+
+    const handleContentLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
+        setContentHeight(nativeEvent.layout.height);
+    }, []);
+
+    const availableHeight = height - HEADER_HEIGHT - top - bottom;
+    const availableWidth = width - HORIZONTAL_MARGIN - left - right;
+
+    let squareSize = availableHeight - contentHeight;
+    if (squareSize < minimumSize) {
+        squareSize = minimumSize;
+    } else if (squareSize > maximumSize) {
+        squareSize = maximumSize;
+    }
+
+    if (squareSize > availableWidth) {
+        squareSize = availableWidth;
+    }
+
+    return {
+        squareSize,
+        handleContentLayout,
+    };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14289,6 +14289,7 @@ __metadata:
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-native-reanimated: "npm:~4.1.5"
+    react-native-safe-area-context: "npm:5.6.2"
     react-native-svg: "npm:15.15.2"
     react-redux: "npm:9.2.0"
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Scale globe image according to available space.

Content including buttons should be "always" visible.

Affects only iPhone (but can be tested on android by enabling Trading Residence check FF)

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25448


## Screenshots:

### Before
<img width="300" alt="before-1" src="https://github.com/user-attachments/assets/85ea3b5e-d829-48d1-a61c-69aa176403f6" />
<img width="300" alt="before-2" src="https://github.com/user-attachments/assets/2d40460a-4e22-4baa-b384-e5637ac2b606" />

### After
<img width="300" alt="after-1" src="https://github.com/user-attachments/assets/b8697979-2bd6-4b40-b8f0-6406a054af24" />
<img width="300" alt="after-2" src="https://github.com/user-attachments/assets/358bb299-79ba-4dec-a504-a625510150a8" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mobile-trading-residence-screen-scaling&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mobile-trading-residence-screen-scaling&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mobile-trading-residence-screen-scaling&lookback=7)