### PR TITLE
Fix/common/imports from apps

### DIFF
--- a/eslint-local-rules/rules.test.ts
+++ b/eslint-local-rules/rules.test.ts
@@ -114,6 +114,49 @@ ruleTester.run('no-package-deep-imports', rules['no-package-deep-imports'], {
     ],
 });
 
+ruleTester.run('no-suite-imports-in-suite-common', rules['no-suite-imports-in-suite-common'], {
+    valid: [
+        {
+            code: "import { foo } from '@suite-common/wallet-utils';",
+            filename: '/repo/suite-common/example/src/file.ts',
+        },
+        {
+            code: "import { foo } from '@trezor/utils';",
+            filename: '/repo/suite-common/example/src/file.ts',
+        },
+        {
+            code: "import { foo } from '@suite/intl';",
+            filename: '/repo/suite/app/src/file.ts',
+        },
+        {
+            code: "export { foo } from '@suite-common/wallet-utils';",
+            filename: '/repo/suite-common/example/src/file.ts',
+        },
+    ],
+    invalid: [
+        {
+            code: "import { TranslationKey } from '@suite/intl';",
+            filename: '/repo/suite-common/wallet-types/src/transaction.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportSuiteIntoSuiteCommon',
+                    data: { sourcePath: '@suite/intl' },
+                },
+            ],
+        },
+        {
+            code: "import { getTranslation } from '@suite-native/intl';",
+            filename: '/repo/suite-common/intl-types/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportSuiteIntoSuiteCommon',
+                    data: { sourcePath: '@suite-native/intl' },
+                },
+            ],
+        },
+    ],
+});
+
 ruleTester.run('analytics-event-name', rules['analytics-event-name'], {
     parser: require.resolve('typescript-eslint/parser'),
     parserOptions: { ecmaVersion: 2020, sourceType: 'module' },

--- a/eslint-local-rules/rules.ts
+++ b/eslint-local-rules/rules.ts
@@ -108,6 +108,13 @@ const getNodeSourcePath = (node: Rule.Node): string | null => {
     return null;
 };
 
+const normalizePathSeparators = (filePath: string) => filePath.replace(/\\/g, '/');
+
+const isSuiteCommonFile = (filename: string) => filename.includes('/suite-common/');
+
+const isSuiteOrSuiteNativeImport = (sourcePath: string) =>
+    sourcePath.startsWith('@suite/') || sourcePath.startsWith('@suite-native/');
+
 export default {
     'no-override-ds-component': {
         meta: {
@@ -236,6 +243,54 @@ export default {
                     messageId: 'doNotImportPackageDeepPath',
                     data: {
                         packageImportPath,
+                        sourcePath,
+                    },
+                });
+            };
+
+            return {
+                ImportDeclaration: checkNode,
+                ExportAllDeclaration: checkNode,
+                ExportNamedDeclaration: checkNode,
+            };
+        },
+    },
+    'no-suite-imports-in-suite-common': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Disallows imports from suite and suite-native packages in suite-common code.',
+                category: 'Best Practices',
+                recommended: false,
+            },
+            messages: {
+                doNotImportSuiteIntoSuiteCommon:
+                    "Importing from '{{sourcePath}}' is not allowed in suite-common. Move shared code to @suite-common or @trezor package.",
+            },
+            schema: [],
+        },
+        create(context) {
+            const filename =
+                'filename' in context && typeof context.filename === 'string'
+                    ? normalizePathSeparators(context.filename)
+                    : null;
+
+            if (filename === null || !isSuiteCommonFile(filename)) {
+                return {};
+            }
+
+            const checkNode = (node: Rule.Node) => {
+                const sourcePath = getNodeSourcePath(node);
+
+                if (sourcePath === null || !isSuiteOrSuiteNativeImport(sourcePath)) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: 'doNotImportSuiteIntoSuiteCommon',
+                    data: {
                         sourcePath,
                     },
                 });

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -61,4 +61,10 @@ export const localRulesConfig = [
             'local-rules/analytics-event-name': 'error',
         },
     },
+    {
+        files: ['suite-common/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+        rules: {
+            'local-rules/no-suite-imports-in-suite-common': 'error',
+        },
+    },
 ];

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -1,5 +1,6 @@
 import { type CSSProperties } from 'react';
 
+// eslint-disable-next-line local-rules/no-suite-imports-in-suite-common
 import { TranslationKey } from '@suite/intl';
 import { DesktopAppUpdateState, Protocol } from '@suite-common/suite-constants';
 import { TrezorDevice } from '@suite-common/suite-types';

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -17,6 +17,7 @@ import type {
     WatchSellTradeResponse,
 } from 'invity-api';
 
+// eslint-disable-next-line local-rules/no-suite-imports-in-suite-common
 import { ExtendedMessageDescriptor } from '@suite/intl';
 import { CountryCode } from '@suite-common/geolocation';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line local-rules/no-suite-imports-in-suite-common
 import { TranslationKey } from '@suite/intl';
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { BaseCurrencyCode } from '@trezor/blockchain-link-types';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Disallow importing from `@suite/ or @suite-native/` into `@suite-common/`

## Notes for QA
Nothing to test.


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/common/imports-from-apps&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/common/imports-from-apps&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/common/imports-from-apps&lookback=7)