### PR TITLE
Labels truncations on mobile

### DIFF
--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -53,6 +53,7 @@ const textStyle = prepareNativeStyle(
         }: { buttonSize: ButtonSize; isUnderlined: boolean; isBold: boolean },
     ) => ({
         ...utils.typography[buttonToTextSizeMap[buttonSize]],
+        flexShrink: 1,
         extend: [
             {
                 condition: isUnderlined,
@@ -133,6 +134,7 @@ export const TextButton = ({
                 )}
                 <Animated.Text
                     testID={`${testID}/text`}
+                    numberOfLines={1}
                     style={[
                         applyStyle(textStyle, { buttonSize: size, isUnderlined, isBold }),
                         animatedTextStyle,

--- a/suite-native/labeling/src/components/AddressLabel.tsx
+++ b/suite-native/labeling/src/components/AddressLabel.tsx
@@ -2,18 +2,25 @@ import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { SuiteSyncDataRootState, selectSuiteSyncAddressLabel } from '@suite-common/suite-sync';
-import { Text } from '@suite-native/atoms';
+import { Text, TextProps } from '@suite-native/atoms';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { selectIsLabellingAllowed } from '../selectors';
 
-type AddressLabelEProps = {
+type AddressLabelProps = TextProps & {
     address: string;
     deviceStaticSessionId: StaticSessionId;
     fallback: ReactNode;
+    maxLength?: number;
 };
 
-export const AddressLabel = ({ address, deviceStaticSessionId, fallback }: AddressLabelEProps) => {
+export const AddressLabel = ({
+    address,
+    deviceStaticSessionId,
+    fallback,
+    maxLength,
+    ...textProps
+}: AddressLabelProps) => {
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
 
     const label = useSelector((state: SuiteSyncDataRootState) =>
@@ -24,5 +31,12 @@ export const AddressLabel = ({ address, deviceStaticSessionId, fallback }: Addre
         return fallback;
     }
 
-    return <Text numberOfLines={1}>{label}</Text>;
+    const truncatedLabel =
+        maxLength && label.length > maxLength ? `${label.slice(0, maxLength)}…` : label;
+
+    return (
+        <Text numberOfLines={maxLength ? 0 : 1} {...textProps}>
+            {truncatedLabel}
+        </Text>
+    );
 };

--- a/suite-native/labeling/src/components/AddressLabel.tsx
+++ b/suite-native/labeling/src/components/AddressLabel.tsx
@@ -24,5 +24,5 @@ export const AddressLabel = ({ address, deviceStaticSessionId, fallback }: Addre
         return fallback;
     }
 
-    return <Text>{label}</Text>;
+    return <Text numberOfLines={1}>{label}</Text>;
 };

--- a/suite-native/labeling/src/components/SendFormLabelEditable.tsx
+++ b/suite-native/labeling/src/components/SendFormLabelEditable.tsx
@@ -1,5 +1,7 @@
 import { useSelector } from 'react-redux';
 
+import { Box } from '@suite-native/atoms';
+
 import { EditableLabelLayout } from './EditableLabelLayout';
 import { LabelEditForm } from './LabelEditForm';
 import { selectIsLabellingAllowed } from '../selectors';
@@ -15,16 +17,18 @@ export const SendFormLabelEditable = ({ onLabelChange, label }: SendFormLabelEdi
     if (!isLabellingAllowed) return null;
 
     return (
-        <EditableLabelLayout label={label}>
-            {({ onClose }) => (
-                <LabelEditForm
-                    label={label}
-                    onSubmit={newLabel => {
-                        onLabelChange(newLabel);
-                        onClose();
-                    }}
-                />
-            )}
-        </EditableLabelLayout>
+        <Box flex={1} alignItems="flex-end">
+            <EditableLabelLayout label={label}>
+                {({ onClose }) => (
+                    <LabelEditForm
+                        label={label}
+                        onSubmit={newLabel => {
+                            onLabelChange(newLabel);
+                            onClose();
+                        }}
+                    />
+                )}
+            </EditableLabelLayout>
+        </Box>
     );
 };

--- a/suite-native/labeling/src/components/TransactionOutputLabel.tsx
+++ b/suite-native/labeling/src/components/TransactionOutputLabel.tsx
@@ -1,12 +1,12 @@
 import { useSelector } from 'react-redux';
 
 import { SuiteSyncDataRootState, selectSuiteSyncOutputLabel } from '@suite-common/suite-sync';
-import { Text } from '@suite-native/atoms';
+import { Text, TextProps } from '@suite-native/atoms';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { selectIsLabellingAllowed } from '../selectors';
 
-type TransactionOutputLabelProps = {
+type TransactionOutputLabelProps = TextProps & {
     txId: string;
     outputIndex: string;
     deviceStaticSessionId: StaticSessionId;
@@ -16,6 +16,7 @@ export const TransactionOutputLabel = ({
     txId,
     outputIndex,
     deviceStaticSessionId,
+    ...textProps
 }: TransactionOutputLabelProps) => {
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
 
@@ -23,5 +24,13 @@ export const TransactionOutputLabel = ({
         selectSuiteSyncOutputLabel(state, txId, outputIndex, deviceStaticSessionId),
     );
 
-    return isLabellingAllowed ? <Text>{label}</Text> : null;
+    if (!isLabellingAllowed || !label) {
+        return null;
+    }
+
+    return (
+        <Text numberOfLines={1} {...textProps}>
+            {label}
+        </Text>
+    );
 };

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -19,6 +19,7 @@
         "@shopify/flash-list": "2.2.0",
         "@suite-common/device": "workspace:*",
         "@suite-common/formatters": "workspace:*",
+        "@suite-common/suite-sync": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/transaction-search": "workspace:*",
         "@suite-common/validators": "workspace:*",

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -19,12 +19,12 @@ import { SendFormLabelEditable } from '@suite-native/labeling';
 import { useAnalytics } from '@suite-native/services';
 import { HELP_CENTER_EVM_ADDRESS_CHECKSUM, HELP_CENTER_SOLANA_HELP_URL } from '@trezor/urls';
 
+import { AddressInfoMessage } from './AddressInfoMessage';
 import { QrCodeBottomSheetIcon } from './QrCodeBottomSheetIcon';
 import { useAddressValidationAlerts } from '../hooks/useAddressValidationAlerts/useAddressValidationAlerts';
+import { useSolAssociatedTokenAddress } from '../hooks/useAddressValidationAlerts/useSolAssociatedTokenAddress';
 import { SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { getOutputFieldName } from '../utils';
-import { AddressInfoMessage } from './AddressInfoMessage';
-import { useSolAssociatedTokenAddress } from '../hooks/useAddressValidationAlerts/useSolAssociatedTokenAddress';
 
 type AddressInputProps = {
     index: number;
@@ -86,7 +86,7 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
 
     return (
         <VStack spacing="sp12">
-            <HStack flex={1} justifyContent="space-between" alignItems="center">
+            <HStack alignItems="center" spacing="sp12">
                 <Text variant="body-sm">
                     <Translation id="moduleSend.outputs.recipients.addressLabel" />
                 </Text>
@@ -96,7 +96,9 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
                     <SendFormLabelEditable
                         label={utxoLabel ?? null}
                         onLabelChange={newUtxoLabel => {
-                            setValue(utxoLabelFieldName, newUtxoLabel, { shouldValidate: true });
+                            setValue(utxoLabelFieldName, newUtxoLabel, {
+                                shouldValidate: true,
+                            });
                         }}
                     />
                 )}

--- a/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCard.tsx
@@ -24,13 +24,8 @@ import {
     TextButton,
     VStack,
 } from '@suite-native/atoms';
-import {
-    AddressFormatter,
-    BaseCurrencyAmountFormatter,
-    CryptoAmountFormatter,
-} from '@suite-native/formatters';
+import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
-import { AddressLabel, TransactionOutputLabel } from '@suite-native/labeling';
 import {
     RootStackParamList,
     RootStackRoutes,
@@ -42,9 +37,7 @@ import { Utxo } from '@trezor/blockchain-link-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-const accountAddressFormatterStyle = prepareNativeStyle(() => ({
-    maxWidth: '80%',
-}));
+import { UtxoCoinControlLabel } from './UtxoCoinControlLabel';
 
 const cardStyle = prepareNativeStyle(utils => ({
     borderWidth: utils.borders.widths.large,
@@ -122,7 +115,7 @@ export const UtxoCard = ({
                         justifyContent="space-between"
                         alignItems="center"
                     >
-                        <VStack>
+                        <VStack flex={1}>
                             <HStack alignItems="center">
                                 <CryptoAmountFormatter
                                     color="textDefault"
@@ -143,25 +136,12 @@ export const UtxoCard = ({
                                 )}
                             </HStack>
 
-                            <HStack>
-                                <AddressLabel
-                                    address={utxo.address}
-                                    deviceStaticSessionId={deviceStaticSessionId}
-                                    fallback={
-                                        <AddressFormatter
-                                            style={applyStyle(accountAddressFormatterStyle)}
-                                            value={utxo.address}
-                                            variant="body-sm"
-                                            color="textSubdued"
-                                        />
-                                    }
-                                />
-                                <TransactionOutputLabel
-                                    txId={utxo.txid}
-                                    outputIndex={`${utxo.vout}`}
-                                    deviceStaticSessionId={deviceStaticSessionId}
-                                />
-                            </HStack>
+                            <UtxoCoinControlLabel
+                                address={utxo.address}
+                                txId={utxo.txid}
+                                outputIndex={`${utxo.vout}`}
+                                deviceStaticSessionId={deviceStaticSessionId}
+                            />
                         </VStack>
                         <CheckBox isChecked={isSelected} onChange={handleToggle} />
                     </HStack>

--- a/suite-native/module-send/src/components/CoinControl/UtxoCoinControlLabel.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCoinControlLabel.tsx
@@ -1,0 +1,79 @@
+import { useSelector } from 'react-redux';
+
+import {
+    SuiteSyncDataRootState,
+    selectSuiteSyncAddressLabel,
+    selectSuiteSyncOutputLabel,
+} from '@suite-common/suite-sync';
+import { HStack, Text, TextProps } from '@suite-native/atoms';
+import { AddressFormatter } from '@suite-native/formatters';
+import type { StaticSessionId } from '@trezor/connect';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+const ADDRESS_LABEL_MAX_LENGTH = 25;
+
+const truncateAddressLabel = (label: string | null) =>
+    label && label.length > ADDRESS_LABEL_MAX_LENGTH
+        ? `${label.slice(0, ADDRESS_LABEL_MAX_LENGTH)}…`
+        : label;
+
+const textStyle = prepareNativeStyle(() => ({
+    flex: 1,
+}));
+
+const LabelText = (props: TextProps) => (
+    <Text variant="body-sm" color="textSubdued" numberOfLines={1} {...props} />
+);
+
+type UtxoCoinControlLabelProps = {
+    address: string;
+    txId: string;
+    outputIndex: string;
+    deviceStaticSessionId: StaticSessionId;
+};
+
+export const UtxoCoinControlLabel = ({
+    address,
+    txId,
+    outputIndex,
+    deviceStaticSessionId,
+}: UtxoCoinControlLabelProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    const addressLabel = useSelector((state: SuiteSyncDataRootState) =>
+        selectSuiteSyncAddressLabel(state, deviceStaticSessionId, address),
+    );
+    const utxoLabel = useSelector((state: SuiteSyncDataRootState) =>
+        selectSuiteSyncOutputLabel(state, txId, outputIndex, deviceStaticSessionId),
+    );
+
+    if (!utxoLabel && !addressLabel) {
+        return <AddressFormatter value={address} variant="body-sm" color="textSubdued" />;
+    }
+
+    if (!utxoLabel) {
+        return <LabelText>{addressLabel}</LabelText>;
+    }
+
+    const truncatedAddressLabel = truncateAddressLabel(addressLabel);
+
+    const addressPart = truncatedAddressLabel ? (
+        <LabelText>{truncatedAddressLabel}</LabelText>
+    ) : (
+        <AddressFormatter
+            value={address}
+            variant="body-sm"
+            color="textSubdued"
+            style={applyStyle(textStyle)}
+        />
+    );
+
+    return (
+        <HStack alignItems="center">
+            {addressPart}
+            <LabelText>•</LabelText>
+
+            <LabelText style={applyStyle(textStyle)}>{utxoLabel}</LabelText>
+        </HStack>
+    );
+};

--- a/suite-native/module-send/src/components/CoinControl/UtxoCoinControlLabel.tsx
+++ b/suite-native/module-send/src/components/CoinControl/UtxoCoinControlLabel.tsx
@@ -1,23 +1,19 @@
 import { useSelector } from 'react-redux';
 
-import {
-    SuiteSyncDataRootState,
-    selectSuiteSyncAddressLabel,
-    selectSuiteSyncOutputLabel,
-} from '@suite-common/suite-sync';
+import { SuiteSyncDataRootState, selectSuiteSyncOutputLabel } from '@suite-common/suite-sync';
 import { HStack, Text, TextProps } from '@suite-native/atoms';
 import { AddressFormatter } from '@suite-native/formatters';
+import {
+    AddressLabel,
+    TransactionOutputLabel,
+    selectIsLabellingAllowed,
+} from '@suite-native/labeling';
 import type { StaticSessionId } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const ADDRESS_LABEL_MAX_LENGTH = 25;
 
-const truncateAddressLabel = (label: string | null) =>
-    label && label.length > ADDRESS_LABEL_MAX_LENGTH
-        ? `${label.slice(0, ADDRESS_LABEL_MAX_LENGTH)}…`
-        : label;
-
-const textStyle = prepareNativeStyle(() => ({
+const flexStyle = prepareNativeStyle(() => ({
     flex: 1,
 }));
 
@@ -40,40 +36,45 @@ export const UtxoCoinControlLabel = ({
 }: UtxoCoinControlLabelProps) => {
     const { applyStyle } = useNativeStyles();
 
-    const addressLabel = useSelector((state: SuiteSyncDataRootState) =>
-        selectSuiteSyncAddressLabel(state, deviceStaticSessionId, address),
-    );
-    const utxoLabel = useSelector((state: SuiteSyncDataRootState) =>
+    const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
+
+    const outputLabel = useSelector((state: SuiteSyncDataRootState) =>
         selectSuiteSyncOutputLabel(state, txId, outputIndex, deviceStaticSessionId),
     );
 
-    if (!utxoLabel && !addressLabel) {
-        return <AddressFormatter value={address} variant="body-sm" color="textSubdued" />;
-    }
-
-    if (!utxoLabel) {
-        return <LabelText>{addressLabel}</LabelText>;
-    }
-
-    const truncatedAddressLabel = truncateAddressLabel(addressLabel);
-
-    const addressPart = truncatedAddressLabel ? (
-        <LabelText>{truncatedAddressLabel}</LabelText>
-    ) : (
-        <AddressFormatter
-            value={address}
-            variant="body-sm"
-            color="textSubdued"
-            style={applyStyle(textStyle)}
-        />
-    );
+    const hasOutputLabel = isLabellingAllowed && !!outputLabel;
 
     return (
         <HStack alignItems="center">
-            {addressPart}
-            <LabelText>•</LabelText>
-
-            <LabelText style={applyStyle(textStyle)}>{utxoLabel}</LabelText>
+            <AddressLabel
+                address={address}
+                deviceStaticSessionId={deviceStaticSessionId}
+                variant="body-sm"
+                color="textSubdued"
+                style={hasOutputLabel ? undefined : applyStyle(flexStyle)}
+                maxLength={hasOutputLabel ? ADDRESS_LABEL_MAX_LENGTH : undefined}
+                fallback={
+                    <AddressFormatter
+                        value={address}
+                        variant="body-sm"
+                        color="textSubdued"
+                        style={applyStyle(flexStyle)}
+                    />
+                }
+            />
+            {hasOutputLabel && (
+                <>
+                    <LabelText>•</LabelText>
+                    <TransactionOutputLabel
+                        txId={txId}
+                        outputIndex={outputIndex}
+                        deviceStaticSessionId={deviceStaticSessionId}
+                        variant="body-sm"
+                        color="textSubdued"
+                        style={applyStyle(flexStyle)}
+                    />
+                </>
+            )}
         </HStack>
     );
 };

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -7,6 +7,9 @@
             "path": "../../suite-common/formatters"
         },
         {
+            "path": "../../suite-common/suite-sync"
+        },
+        {
             "path": "../../suite-common/token-definitions"
         },
         {

--- a/suite-native/module-transactions/src/components/TransactionDetailAddressesSection.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailAddressesSection.tsx
@@ -62,30 +62,28 @@ export const TransactionDetailAddressesSection = ({
     return (
         <VStack>
             <SummaryRow leftComponent={<TransactionDetailStepper />}>
-                <Box flexDirection="row" justifyContent="space-between" alignItems="center">
-                    <Box>
-                        <Text color="textSubdued" variant="body-sm">
-                            <Translation
-                                id={titleTxKey}
-                                values={{ count: formatAddressesCount(targetAddresses.length) }}
-                            />
-                        </Text>
-                        {targetAddresses.slice(0, 2).map(({ address, txTargetId }) => (
-                            <TransactionUtxoAddress
-                                key={`target-${txTargetId}`}
-                                address={address}
-                                txTargetId={txTargetId}
-                                deviceStaticSessionId={transaction.deviceState}
-                                txId={transaction.txid}
-                                // Todo: input not implemented yet. The idea is, that transaction input is just output
-                                //       of the previous transaction. So for inputs we would need to pass previous txid
-                                //       (and figure out correct `n` output index of the utxo on the previous transaction)
-                                showLabels={shouldShowLabels}
-                                accountDescriptor={transaction.descriptor}
-                                networkSymbol={transaction.symbol}
-                            />
-                        ))}
-                    </Box>
+                <Box>
+                    <Text color="textSubdued" variant="body-sm">
+                        <Translation
+                            id={titleTxKey}
+                            values={{ count: formatAddressesCount(targetAddresses.length) }}
+                        />
+                    </Text>
+                    {targetAddresses.slice(0, 2).map(({ address, txTargetId }) => (
+                        <TransactionUtxoAddress
+                            key={`target-${txTargetId}`}
+                            address={address}
+                            txTargetId={txTargetId}
+                            deviceStaticSessionId={transaction.deviceState}
+                            txId={transaction.txid}
+                            // Todo: input not implemented yet. The idea is, that transaction input is just output
+                            //       of the previous transaction. So for inputs we would need to pass previous txid
+                            //       (and figure out correct `n` output index of the utxo on the previous transaction)
+                            showLabels={shouldShowLabels}
+                            accountDescriptor={transaction.descriptor}
+                            networkSymbol={transaction.symbol}
+                        />
+                    ))}
                 </Box>
             </SummaryRow>
 
@@ -104,25 +102,23 @@ export const TransactionDetailAddressesSection = ({
                 <>
                     <CardDivider horizontalPadding="sp16" />
                     <SummaryRow leftComponent={<TransactionDetailStepper />}>
-                        <Box flexDirection="row" justifyContent="space-between" alignItems="center">
-                            <Box>
-                                <ChangeAddressesHeader addressesCount={changeAddresses.length} />
-                                {changeAddresses.map(({ address, txTargetId }) => (
-                                    <TransactionUtxoAddress
-                                        key={`change-${addressesType}:${txTargetId}`}
-                                        address={address}
-                                        txTargetId={txTargetId}
-                                        deviceStaticSessionId={transaction.deviceState}
-                                        txId={transaction.txid}
-                                        // Todo: input not implemented yet. The idea is, that transaction input is just output
-                                        //       of the previous transaction. So for inputs we would need to pass previous txid
-                                        //       (and figure out correct `n` output index of the utxo on the previous transaction)
-                                        showLabels={shouldShowLabels}
-                                        accountDescriptor={transaction.descriptor}
-                                        networkSymbol={transaction.symbol}
-                                    />
-                                ))}
-                            </Box>
+                        <Box>
+                            <ChangeAddressesHeader addressesCount={changeAddresses.length} />
+                            {changeAddresses.map(({ address, txTargetId }) => (
+                                <TransactionUtxoAddress
+                                    key={`change-${addressesType}:${txTargetId}`}
+                                    address={address}
+                                    txTargetId={txTargetId}
+                                    deviceStaticSessionId={transaction.deviceState}
+                                    txId={transaction.txid}
+                                    // Todo: input not implemented yet. The idea is, that transaction input is just output
+                                    //       of the previous transaction. So for inputs we would need to pass previous txid
+                                    //       (and figure out correct `n` output index of the utxo on the previous transaction)
+                                    showLabels={shouldShowLabels}
+                                    accountDescriptor={transaction.descriptor}
+                                    networkSymbol={transaction.symbol}
+                                />
+                            ))}
                         </Box>
                     </SummaryRow>
                 </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13416,6 +13416,7 @@ __metadata:
     "@shopify/flash-list": "npm:2.2.0"
     "@suite-common/device": "workspace:*"
     "@suite-common/formatters": "workspace:*"
+    "@suite-common/suite-sync": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/transaction-search": "workspace:*"
     "@suite-common/validators": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the truncation of labels on mobile in the Send form, Coin control, and Transaction detail screen.

- `numberOfLines` is set to 1 for all `TextButtons`, we don't have any multiline TextButtons, and the tail ellipsis is a good default...

## Notes for QA

It's easier to edit the labels on the desktop and check them synced on mobile.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24444

## Screenshots:

| Send form | | |
| -------- | ------- | -------- |
<img width="374" height="848" alt="image" src="https://github.com/user-attachments/assets/72263119-ffcd-4794-af56-f71cb47b8acf" />  |  <img width="377" height="849" alt="image" src="https://github.com/user-attachments/assets/8bcf6b69-cf07-4df5-af91-f0e53fe2ff4b" /> |  <img width="375" height="846" alt="image" src="https://github.com/user-attachments/assets/aa970fc4-74e4-4ed6-8ddf-8f404a884bf9" /> |
| Coin control | | |
| <img width="367" height="852" alt="image" src="https://github.com/user-attachments/assets/c3aad985-850b-4fab-8882-25d16cd8f3b8" />  | <img width="370" height="849" alt="image" src="https://github.com/user-attachments/assets/8de761c0-8943-4567-9bf2-a971f76430a3" />   |  <img width="366" height="850" alt="image" src="https://github.com/user-attachments/assets/8083fec7-0697-4c99-afc0-0f1a3050d9ee" /> |
| Transaction detail | | |
| <img width="371" height="848" alt="image" src="https://github.com/user-attachments/assets/f489ca36-d89f-4821-829c-fdf7b6ae08bc" /> | <img width="363" height="847" alt="image" src="https://github.com/user-attachments/assets/a152c03f-b678-4a2f-9ee9-ba92041cea90" /> | |


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/labels-truncations&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/labels-truncations&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/labels-truncations&lookback=7)