### PR TITLE
fix(suite-sync): clear data for wallet only

### DIFF
--- a/suite-common/suite-sync/src/data/createSuiteSyncListener.ts
+++ b/suite-common/suite-sync/src/data/createSuiteSyncListener.ts
@@ -4,7 +4,7 @@ import { SuiteSyncListener } from '@suite-common/suite-sync-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 
 import {
-    clearAll,
+    clearDataForWallet,
     upsertManyAccounts,
     upsertManyAddresses,
     upsertManyOutputs,
@@ -33,7 +33,7 @@ export const createSuiteSyncListener = (deps: CreateSuiteSyncListenerDeps): Suit
             deps.dispatch(upsertManyOutputs({ walletDescriptor, outputs: entities }));
         },
     },
-    onUnsubscribe: () => {
-        deps.dispatch(clearAll());
+    onUnsubscribe: ({ walletDescriptor }) => {
+        deps.dispatch(clearDataForWallet(walletDescriptor));
     },
 });

--- a/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
+++ b/suite-common/suite-sync/src/data/suiteSyncDataReducer.ts
@@ -101,6 +101,10 @@ export const suiteSyncDataSlice = createSlice({
             });
         },
 
+        clearDataForWallet: (state, action: PayloadAction<WalletDescriptor>) => {
+            delete state.wallets[action.payload];
+        },
+
         clearAll: () => initialSuiteSyncDataState,
     },
 });
@@ -110,6 +114,7 @@ export const {
     upsertManyAccounts,
     upsertManyAddresses,
     upsertManyOutputs,
+    clearDataForWallet,
     clearAll,
 } = suiteSyncDataSlice.actions;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Unsubscribe resulted in clearing all suite sync data. We want to do that just for the current wallet so this change should fix the bug.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25438


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-sync/clear-data-for-wallet&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-sync/clear-data-for-wallet&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-sync/clear-data-for-wallet&lookback=7)