### PR TITLE
fix(e2e): update account selection method for global receive send test

### DIFF
--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -60,8 +60,11 @@ export class TradingAssetPicker {
 
     @step()
     async filterByNetwork(networkFilter: AssetPickerNetworkFilter) {
-        await this.networkFilterButton.click();
-        await this.networkFilterOption(networkFilter).click();
+        // use global retry helper since opening the dropdown is flaky in automation
+        await this.page.selectDropdownOptionWithRetry(
+            this.networkFilterButton,
+            this.networkFilterOption(networkFilter),
+        );
     }
 
     @step()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed flakiness for e2e global-receive-send-test by using new retry method to open dropdown in account selection.



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/e2e/global-receive-send&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/e2e/global-receive-send&lookback=7)