### PR TITLE
fix(suite): turn off meta checks in debug mode to work with emulator

### DIFF
--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -17,6 +17,7 @@ import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { AppState } from 'src/types/suite';
 
 import {
+    selectIsDebugModeActive,
     selectIsEntropyCheckEnabled,
     selectIsFirmwareHashCheckEnabled,
     selectIsFirmwareRevisionCheckEnabled,
@@ -96,17 +97,19 @@ export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
 };
 
 export const selectIsDeviceIdCheckEnabledAndFailed = (state: AppState) => {
+    const isDebugMode = selectIsDebugModeActive(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.idCheck);
     const isDeviceIdValid = selectIsDeviceIdCheckSuccess(state);
 
-    return !isDisabledByMessageSystem && !isDeviceIdValid;
+    return !isDebugMode && !isDisabledByMessageSystem && !isDeviceIdValid;
 };
 
 export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AppState) => {
+    const isDebugMode = selectIsDebugModeActive(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.invariabilityCheck);
     const isDeviceInvariabilityCheckSuccess = selectIsDeviceInvariabilityCheckSuccess(state);
 
-    return !isDisabledByMessageSystem && !isDeviceInvariabilityCheckSuccess;
+    return !isDebugMode && !isDisabledByMessageSystem && !isDeviceInvariabilityCheckSuccess;
 };
 
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {


### PR DESCRIPTION
## Description

Turn off the new device meta checks, because apparentely the emulator can sometimes produce different devices with the same id. This will enable people to work with emulator as before.

## Notes for QA

N/A, device meta check failure is not reproducible.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/turn-off-meta-checks-in-debug&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/turn-off-meta-checks-in-debug&lookback=7)