### PR TITLE
feat(suite): add short fiat format experimental feature (PoC)

### DIFF
--- a/packages/suite/src/components/wallet/BigAmountValue.tsx
+++ b/packages/suite/src/components/wallet/BigAmountValue.tsx
@@ -2,17 +2,21 @@ import styled from 'styled-components';
 
 import { Locale } from '@suite-common/suite-types';
 import { redactNumericalSubstring, useShouldRedactNumbers } from '@suite-common/wallet-utils';
-import { Row, Text } from '@trezor/components';
+import { Row, TOOLTIP_DELAY_LONG, Text, Tooltip } from '@trezor/components';
 
 import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from '../../hooks/suite';
 
-const WholeValue = styled.span`
+const FIAT_AMOUNT_CURRENCY_NBSP = '\u00A0';
+// Short format is "48,3K Kč" or "48.35M CZK" – amount part ends with K/M/B/T
+const SHORT_FIAT_AMOUNT_REGEX = /[\d.,\s]+[KMBT]$/;
+
+const PrimaryPart = styled.span`
     font-variant-numeric: tabular-nums;
 `;
 
-const DecimalValue = styled.span`
+const SecondaryPart = styled.span`
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.565px;
 `;
@@ -21,14 +25,60 @@ type BigAmountValueProps = {
     formattedStringAmount: string;
     'data-testid'?: string;
     size: 'large' | 'medium';
+    /** When set (e.g. full fiat amount for short-format tooltip), shown in tooltip with long delay */
+    tooltipContent?: string | null;
+};
+
+const isShortFiatFormat = (str: string): boolean => {
+    const parts = str.split(FIAT_AMOUNT_CURRENCY_NBSP);
+
+    return parts.length === 2 && SHORT_FIAT_AMOUNT_REGEX.test(parts[0].trim());
 };
 
 export const BigAmountValue = ({
     formattedStringAmount,
     'data-testid': dataTestId,
     size,
+    tooltipContent,
 }: BigAmountValueProps) => {
     const language = useSelector(selectLanguage);
+    const shouldRedactNumbers = useShouldRedactNumbers();
+
+    const isShortFiat = isShortFiatFormat(formattedStringAmount);
+
+    const wrapWithTooltip = (content: React.ReactNode) =>
+        tooltipContent ? (
+            <Tooltip
+                hasArrow
+                content={tooltipContent}
+                delayShow={TOOLTIP_DELAY_LONG}
+                display="inline-block"
+            >
+                {content}
+            </Tooltip>
+        ) : (
+            content
+        );
+
+    if (isShortFiat) {
+        const [amountPart, currencyPart] = formattedStringAmount.split(FIAT_AMOUNT_CURRENCY_NBSP);
+        const headlineStyle = size === 'large' ? 'headline-lg' : 'headline-md';
+
+        return wrapWithTooltip(
+            <Row alignItems="baseline" data-testid={dataTestId} gap={8}>
+                <Text typographyStyle={headlineStyle}>
+                    <PrimaryPart>
+                        {shouldRedactNumbers ? redactNumericalSubstring(amountPart) : amountPart}
+                    </PrimaryPart>
+                </Text>
+                {!shouldRedactNumbers && (
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        <SecondaryPart>{currencyPart}</SecondaryPart>
+                    </Text>
+                )}
+            </Row>,
+        );
+    }
 
     // Todo: this is ugly hack, shall be refactored to some more safe alternative
     const shouldFormatLocale: Locale[] = ['en-US', 'ja-JP', 'ko-KR', 'zh-CN', 'zh-TW'];
@@ -36,23 +86,21 @@ export const BigAmountValue = ({
         ? formattedStringAmount.split(/(\.)/)
         : formattedStringAmount.split(/(,)/);
 
-    const shouldRedactNumbers = useShouldRedactNumbers();
-
-    return (
+    return wrapWithTooltip(
         <Row alignItems="baseline" data-testid={dataTestId}>
             <Text typographyStyle={size === 'large' ? 'headline-lg' : 'headline-md'}>
-                <WholeValue>
+                <PrimaryPart>
                     {shouldRedactNumbers ? redactNumericalSubstring(whole) : whole}
-                </WholeValue>
+                </PrimaryPart>
             </Text>
             {!shouldRedactNumbers && (
                 <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                    <DecimalValue>
+                    <SecondaryPart>
                         {separator}
                         {fractional}
-                    </DecimalValue>
+                    </SecondaryPart>
                 </Text>
             )}
-        </Row>
+        </Row>,
     );
 };

--- a/packages/suite/src/components/wallet/FiatHeader.tsx
+++ b/packages/suite/src/components/wallet/FiatHeader.tsx
@@ -5,8 +5,10 @@ import { AmountUnit, BASE_CURRENCY_ZERO } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { HiddenPlaceholder } from 'src/components/suite';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 
 import { BigAmountValue } from './BigAmountValue';
+import { useSelector } from '../../hooks/suite';
 import { useFiatFromCryptoValue } from '../../hooks/suite/useFiatFromCryptoValue';
 
 type UseFiatAmountProps = {
@@ -45,6 +47,7 @@ const FiatHeaderContent = ({
 }: FiatHeaderProps) => {
     const fiatAmount = useFiatAmount({ amount, symbol });
     const { BaseCurrencyAmountFormatter } = useFormatters();
+    const useShortFiatFormat = useSelector(selectHasExperimentalFeature('short-fiat-format'));
 
     const formattedAmount = BaseCurrencyAmountFormatter({
         value: fiatAmount ?? BASE_CURRENCY_ZERO,
@@ -53,11 +56,20 @@ const FiatHeaderContent = ({
 
     const formattedFiatAmount = formattedAmount?.props.children;
 
+    const fullFormattedFiatAmount =
+        useShortFiatFormat && formattedFiatAmount
+            ? BaseCurrencyAmountFormatter.format(fiatAmount ?? BASE_CURRENCY_ZERO, {
+                  currency: localCurrency,
+                  skipShortFormat: true,
+              })
+            : null;
+
     return (
         <BigAmountValue
             formattedStringAmount={formattedFiatAmount}
             data-testid={dataTestId}
             size={size}
+            tooltipContent={fullFormattedFiatAmount}
         />
     );
 };

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -19,7 +19,8 @@ export type ExperimentalFeature =
     | 'nft-section'
     | 'slip24'
     | 'experimental-networks'
-    | 'suite-sync';
+    | 'suite-sync'
+    | 'short-fiat-format';
 
 export type ExperimentalFeatureConfig = {
     title: ExtendedMessageDescriptor;
@@ -91,5 +92,9 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
                 services.suiteSync.turnOffSuiteSync();
             }
         },
+    },
+    'short-fiat-format': {
+        title: { id: 'TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_TITLE' },
+        description: { id: 'TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_DESCRIPTION' },
     },
 };

--- a/packages/suite/src/hooks/suite/useFormattersConfig.ts
+++ b/packages/suite/src/hooks/suite/useFormattersConfig.ts
@@ -2,17 +2,19 @@ import { FormatterProviderConfig } from '@suite-common/formatters';
 import { selectBaseCurrency, selectBitcoinAmountUnit } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectLanguage } from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature, selectLanguage } from 'src/selectors/suite/suiteSelectors';
 
 export const useFormattersConfig = (): FormatterProviderConfig => {
     const locale = useSelector(selectLanguage);
     const bitcoinAmountUnit = useSelector(selectBitcoinAmountUnit);
     const baseCurrency = useSelector(selectBaseCurrency);
+    const useShortFiatFormat = useSelector(selectHasExperimentalFeature('short-fiat-format'));
 
     return {
         locale,
         baseCurrency,
         bitcoinAmountUnit,
         is24HourFormat: true,
+        useShortFiatFormat,
     };
 };

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -88,13 +88,32 @@ const formatShortFiat = ({
     if (!parts) return null;
 
     const { shortValue, suffix } = parts;
-    const formattedNumber = intl.formatNumber(shortValue, {
-        minimumFractionDigits: 2,
+
+    // Use same locale-aware formatting as formatStandard: number + suffix + currency (symbol/code per locale)
+    const partsArray = intl.formatNumberToParts(shortValue, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: 0,
         maximumFractionDigits: 2,
     });
-    const currencySuffix = currency.toUpperCase();
 
-    return `${formattedNumber}${suffix}${FIAT_AMOUNT_CURRENCY_NBSP}${currencySuffix}`;
+    const numberPartTypes = ['integer', 'group', 'decimal', 'fraction'] as const;
+    const numberParts: string[] = [];
+    let currencyPartValue = '';
+
+    for (const p of partsArray) {
+        if (numberPartTypes.includes(p.type as (typeof numberPartTypes)[number])) {
+            const val = p.value as string;
+            numberParts.push(p.type === 'fraction' ? val.replace(/0+$/, '') : val);
+        } else if (p.type === 'currency') {
+            currencyPartValue = p.value as string;
+        }
+    }
+
+    const numberStr = numberParts.join('').replace(/[.,]$/, '');
+    const currencyDisplay = currencyPartValue || currency.toUpperCase();
+
+    return `${numberStr}${suffix}${FIAT_AMOUNT_CURRENCY_NBSP}${currencyDisplay}`;
 };
 
 const formatStandard = ({
@@ -109,7 +128,8 @@ const formatStandard = ({
         return `${value}${FIAT_AMOUNT_CURRENCY_NBSP}${currency}`;
     }
 
-    if (useShortFiatFormat) {
+    const {skipShortFormat} = (dataContext as { skipShortFormat?: boolean });
+    if (useShortFiatFormat && !skipShortFormat) {
         const shortFormatted = formatShortFiat({ intl, currency, value, dataContext });
         if (shortFormatted !== null) {
             return shortFormatted;

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -51,10 +51,68 @@ const formatSats = ({ intl, dataContext, value }: FormatParams) => {
     return `${formatted.replace(BITCOIN_SATS_PLACEHOLDER.toUpperCase(), '')} sat`.trim();
 };
 
-const formatStandard = ({ intl, currency, value, dataContext }: FormatParams) => {
+const THOUSAND = 1e3;
+const MILLION = 1e6;
+const BILLION = 1e9;
+const TRILLION = 1e12;
+
+type ShortFiatSuffix = 'K' | 'M' | 'B' | 'T';
+
+const getShortFiatParts = (
+    value: BaseCurrencyAmount,
+): { shortValue: number; suffix: ShortFiatSuffix } | null => {
+    const n = value.toNumber();
+    if (n >= TRILLION) {
+        return { shortValue: n / TRILLION, suffix: 'T' };
+    }
+    if (n >= BILLION) {
+        return { shortValue: n / BILLION, suffix: 'B' };
+    }
+    if (n >= MILLION) {
+        return { shortValue: n / MILLION, suffix: 'M' };
+    }
+    if (n >= THOUSAND) {
+        return { shortValue: n / THOUSAND, suffix: 'K' };
+    }
+
+    return null;
+};
+
+const formatShortFiat = ({
+    intl,
+    currency,
+    value,
+}: Omit<FormatParams, 'dataContext'> & { dataContext?: FormatParams['dataContext'] }) => {
+    const parts = getShortFiatParts(value);
+    if (!parts) return null;
+
+    const { shortValue, suffix } = parts;
+    const formattedNumber = intl.formatNumber(shortValue, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+    const currencySuffix = currency.toUpperCase();
+
+    return `${formattedNumber}${suffix} ${currencySuffix}`;
+};
+
+const formatStandard = ({
+    intl,
+    currency,
+    value,
+    dataContext,
+    useShortFiatFormat,
+}: FormatParams & { useShortFiatFormat?: boolean }) => {
     if (value.gt(Number.MAX_VALUE)) {
         // backup when number is too big, the formatting is different from what should be for currencies
         return `${value} ${currency}`;
+    }
+
+    if (useShortFiatFormat) {
+        const shortFormatted = formatShortFiat({ intl, currency, value, dataContext });
+        if (shortFormatted !== null) {
+            return shortFormatted;
+        }
     }
 
     const { minimumFractionDigits, maximumFractionDigits, style } = dataContext;
@@ -77,7 +135,7 @@ const handleBigNumberFormatting = (
     dataContext: BaseCurrencyAmountFormatterDataContext<FormatNumberOptions>,
     config: FormatterConfig,
 ) => {
-    const { intl, baseCurrency, bitcoinAmountUnit } = config;
+    const { intl, baseCurrency, bitcoinAmountUnit, useShortFiatFormat } = config;
     const { currency: currencyFromContext } = dataContext;
     const currency =
         (currencyFromContext !== undefined
@@ -94,7 +152,9 @@ const handleBigNumberFormatting = (
         currency,
     };
 
-    return isSats ? formatSats(formatParams) : formatStandard(formatParams);
+    return isSats
+        ? formatSats(formatParams)
+        : formatStandard({ ...formatParams, useShortFiatFormat });
 };
 
 export const prepareBaseCurrencyAmountFormatter = (config: FormatterConfig) =>

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -22,6 +22,7 @@ export type BaseCurrencyAmountFormatterDataContext<T> = {
 
 // `currency` param in intl.formatNumber works only wit 3 letter currencies
 const BITCOIN_SATS_PLACEHOLDER = 'sat';
+const FIAT_AMOUNT_CURRENCY_NBSP = '\u00A0'; // non-breaking space between amount and currency
 
 type FormatParams = {
     value: BaseCurrencyAmount;
@@ -93,7 +94,7 @@ const formatShortFiat = ({
     });
     const currencySuffix = currency.toUpperCase();
 
-    return `${formattedNumber}${suffix} ${currencySuffix}`;
+    return `${formattedNumber}${suffix}${FIAT_AMOUNT_CURRENCY_NBSP}${currencySuffix}`;
 };
 
 const formatStandard = ({
@@ -105,7 +106,7 @@ const formatStandard = ({
 }: FormatParams & { useShortFiatFormat?: boolean }) => {
     if (value.gt(Number.MAX_VALUE)) {
         // backup when number is too big, the formatting is different from what should be for currencies
-        return `${value} ${currency}`;
+        return `${value}${FIAT_AMOUNT_CURRENCY_NBSP}${currency}`;
     }
 
     if (useShortFiatFormat) {
@@ -126,7 +127,7 @@ const formatStandard = ({
     });
 
     return currency.toLowerCase() === 'btc' // In the case of Crypto Base-Currency, we always want to have currency ticker as suffix.
-        ? `${result.replace(/BTC|btc/, '').trim()} ${currency.toUpperCase()}`
+        ? `${result.replace(/BTC|btc/, '').trim()}${FIAT_AMOUNT_CURRENCY_NBSP}${currency.toUpperCase()}`
         : result;
 };
 

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.ts
@@ -18,7 +18,7 @@ import { FormatterConfig } from '../types';
 
 export type BaseCurrencyAmountFormatterDataContext<T> = {
     [K in keyof T]: T[K];
-};
+} & { skipShortFormat?: boolean };
 
 // `currency` param in intl.formatNumber works only wit 3 letter currencies
 const BITCOIN_SATS_PLACEHOLDER = 'sat';
@@ -128,8 +128,7 @@ const formatStandard = ({
         return `${value}${FIAT_AMOUNT_CURRENCY_NBSP}${currency}`;
     }
 
-    const {skipShortFormat} = (dataContext as { skipShortFormat?: boolean });
-    if (useShortFiatFormat && !skipShortFormat) {
+    if (useShortFiatFormat && !dataContext.skipShortFormat) {
         const shortFormatted = formatShortFiat({ intl, currency, value, dataContext });
         if (shortFormatted !== null) {
             return shortFormatted;

--- a/suite-common/formatters/src/types.ts
+++ b/suite-common/formatters/src/types.ts
@@ -8,6 +8,8 @@ export type FormatterProviderConfig = {
     bitcoinAmountUnit: PROTO.AmountUnit;
     baseCurrency: BaseCurrencyCode;
     is24HourFormat: boolean;
+    /** When true, fiat amounts >= 1000 are shown as 21.35K, 1.50M, etc. (desktop/web only) */
+    useShortFiatFormat?: boolean;
 };
 
 export interface FormatterConfig extends FormatterProviderConfig {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5120,6 +5120,15 @@ export const messages = defineMessages({
         defaultMessage:
             'Keep your wallet, account, and transaction labels updated in Trezor Suite on all your devices. Your data stays safe—only your Trezor can decrypt it.',
     },
+    TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_TITLE: {
+        id: 'TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_TITLE',
+        defaultMessage: 'Short fiat amounts',
+    },
+    TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_SHORT_FIAT_FORMAT_DESCRIPTION',
+        defaultMessage:
+            'Show large fiat values in short form (e.g. 21.35K CZK instead of 21,350 CZK). Values under 1,000 are unchanged.',
+    },
     TR_EXPERIMENTAL_SLIP24: {
         id: 'TR_EXPERIMENTAL_SLIP24',
         defaultMessage: 'SLIP-24 (clear signing)',


### PR DESCRIPTION
…ormatting logic

<!--- Provide a general summary of your changes in the Title above -->

## Description

```
< 1 thousand → normal format
> 1 thousand → K
> 1 million → M
> 1 billion → B
> 1 trillion → T
```

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1189" height="672" alt="image" src="https://github.com/user-attachments/assets/80d55f53-506c-4fef-a4a7-87762881b349" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=shortened-fiat-amounts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=shortened-fiat-amounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=shortened-fiat-amounts&lookback=7)