### PR TITLE
fix(suite): walletconnect max fee calculation

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -16,7 +16,7 @@ import {
     fetchAndUpdateAccountThunk,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { FormState, PrecomposedLevels } from '@suite-common/wallet-types';
+import { FormState } from '@suite-common/wallet-types';
 import { formatNetworkAmount, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { BASE_INFO } from '@trezor/blockchain-link-utils/src/stellar';
 import { Banner, Button, Column, Modal, Row, Text } from '@trezor/components';
@@ -25,6 +25,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useComposedLevelsPlaceholder } from 'src/hooks/wallet/form/useComposedLevelsPlaceholder';
 import { useFees } from 'src/hooks/wallet/form/useFees';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -79,34 +80,14 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
     });
 
     const { watch, handleSubmit } = methods;
-
     const selectedFee = watch('selectedFee');
     const feePerUnit = watch('feePerUnit');
 
-    const composedLevels = useMemo(() => {
-        const levels: PrecomposedLevels = {};
-
-        const createComposedTx = (feeValue: string) => ({
-            type: 'final' as const,
-            totalSpent: '0',
-            fee: feeValue,
-            feePerByte: feeValue,
-            bytes: 0,
-            inputs: [],
-            outputs: [],
-            outputsPermutation: [],
-        });
-
-        feeInfo.levels.forEach(level => {
-            levels[level.label] = createComposedTx(level.feePerUnit);
-        });
-
-        if (selectedFee === 'custom' && feePerUnit) {
-            levels.custom = createComposedTx(feePerUnit);
-        }
-
-        return levels;
-    }, [feeInfo.levels, feePerUnit, selectedFee]);
+    const composedLevels = useComposedLevelsPlaceholder({
+        feeInfo,
+        selectedFee,
+        feePerUnit,
+    });
 
     const composedTx = composedLevels[selectedFee || 'normal'];
     const currentFee = composedTx?.type === 'final' ? composedTx.fee : '0';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/TxSimulationModalInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/TxSimulationModalInner.tsx
@@ -28,7 +28,7 @@ interface TxSimulationModalInnerProps {
 export function TxSimulationModalInner({ action, account }: TxSimulationModalInnerProps) {
     const [disclaimerAccepted, setDisclaimerAccepted] = useState(false);
 
-    const { form, changeFeeLevel, feeInfo, defaultGasLimit } = useTxFeesForm({
+    const { form, changeFeeLevel, feeInfo, defaultGasLimit, composedLevels } = useTxFeesForm({
         networkType: account.networkType,
         networkSymbol: account.symbol,
         defaultGasLimit:
@@ -55,6 +55,8 @@ export function TxSimulationModalInner({ action, account }: TxSimulationModalInn
             }
         },
     });
+    // Show only after simulation is loaded
+    const composedLevelsFiltered = txSimulationQuery.isLoading ? null : composedLevels;
 
     const { confirm, cancel } = useTxSimulationActions({
         method: action.method,
@@ -157,7 +159,7 @@ export function TxSimulationModalInner({ action, account }: TxSimulationModalInn
                                     account={account}
                                     feeInfo={feeInfo}
                                     changeFeeLevel={changeFeeLevel}
-                                    composedLevels={null}
+                                    composedLevels={composedLevelsFiltered}
                                 />
                             )}
                         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/hooks/useTxFeesForm.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxSimulationModal/hooks/useTxFeesForm.ts
@@ -1,12 +1,14 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { NetworkSymbol, NetworkType } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
+import { useComposedLevelsPlaceholder } from 'src/hooks/wallet/form/useComposedLevelsPlaceholder';
 import { FeesFormValues, useFees } from 'src/hooks/wallet/form/useFees';
 
 interface UseTxFeesFormProps {
@@ -43,10 +45,31 @@ export function useTxFeesForm({
         composeRequest: () => {},
     });
 
+    const { watch } = form;
+    const selectedFee = watch('selectedFee');
+    const feePerUnit = watch('feePerUnit');
+    const maxFeePerGas = watch('maxFeePerGas');
+    const feeLimit = watch('feeLimit');
+
+    // calculate levels with total max fee
+    const feeTotalCalculation = useCallback(
+        (feeValue: string) =>
+            new BigNumber(feeValue).multipliedBy(1e9).multipliedBy(feeLimit).toString(),
+        [feeLimit],
+    );
+    const composedLevels = useComposedLevelsPlaceholder({
+        feeTotalCalculation,
+        feeInfo,
+        selectedFee,
+        feePerUnit,
+        maxFeePerGas,
+    });
+
     return {
         form,
         changeFeeLevel,
         feeInfo,
         defaultGasLimit,
+        composedLevels,
     };
 }

--- a/packages/suite/src/hooks/wallet/form/useComposedLevelsPlaceholder.tsx
+++ b/packages/suite/src/hooks/wallet/form/useComposedLevelsPlaceholder.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+import { FeeInfo, PrecomposedLevels } from '@suite-common/wallet-types';
+import { FeeLevel } from '@trezor/connect';
+
+export const useComposedLevelsPlaceholder = ({
+    feeInfo,
+    selectedFee,
+    feePerUnit,
+    maxFeePerGas,
+    feeTotalCalculation,
+}: {
+    feeInfo: FeeInfo;
+    selectedFee?: FeeLevel['label'];
+    feePerUnit: string;
+    maxFeePerGas?: string;
+    feeTotalCalculation?: (feeValue: string) => string;
+}) => {
+    const composedLevels = useMemo(() => {
+        const levels: PrecomposedLevels = {};
+
+        const createComposedTx = (feeValue: string) => ({
+            type: 'final' as const,
+            totalSpent: '0',
+            fee: feeTotalCalculation ? feeTotalCalculation(feeValue) : feeValue,
+            feePerByte: feeValue,
+            bytes: 0,
+            inputs: [],
+            outputs: [],
+            outputsPermutation: [],
+        });
+
+        feeInfo.levels.forEach(level => {
+            levels[level.label] = createComposedTx(level.maxFeePerGas ?? level.feePerUnit);
+        });
+
+        if (selectedFee === 'custom' && feePerUnit) {
+            levels.custom = createComposedTx(maxFeePerGas ?? feePerUnit);
+        }
+
+        return levels;
+    }, [feeInfo.levels, feePerUnit, maxFeePerGas, selectedFee, feeTotalCalculation]);
+
+    return composedLevels;
+};


### PR DESCRIPTION
## Description

Fix WalletConnect max fee calculation. The Fees component was missing `composedLevels` parameter that is needed to show the max fee

## Screenshots:

<img width="650" height="519" alt="Screenshot 2026-02-25 at 10 53 17" src="https://github.com/user-attachments/assets/ee8c3d47-67b1-4526-857b-3d439329a171" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-max-fee&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-max-fee&lookback=7)