### PR TITLE
feat(ci): use rebase bot to remove empty commits

### DIFF
--- a/.github/workflows/bot-rebase.yml
+++ b/.github/workflows/bot-rebase.yml
@@ -37,11 +37,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.trezor-bot-token.outputs.token }}
       - name: Auto rebase pull request
-        uses: cirrus-actions/rebase@1.8
-        with:
-          autosquash: true
         env:
           GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+          INPUT_AUTOSQUASH: true
+        run: |
+          bash scripts/ci/bot-rebase.sh
       - name: Report failure
         if: ${{ failure() }}
         uses: actions/github-script@v6

--- a/scripts/ci/bot-rebase.sh
+++ b/scripts/ci/bot-rebase.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# From: https://github.com/cirrus-actions/rebase/
+
+set -e
+
+if [ -z "$PR_NUMBER" ]; then
+	PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+	fi
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		echo "Failed to determine PR Number."
+		exit 1
+	fi
+fi
+
+echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+	echo "Set the GITHUB_TOKEN env variable."
+	exit 1
+fi
+
+URI=https://api.github.com
+API_HEADER="Accept: application/vnd.github.v3+json"
+AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+
+MAX_RETRIES=${MAX_RETRIES:-6}
+RETRY_INTERVAL=${RETRY_INTERVAL:-10}
+REBASEABLE=""
+pr_resp=""
+for ((i = 0 ; i < MAX_RETRIES ; i++)); do
+	pr_resp=$(curl -X GET -s -H "${AUTH_HEADER}" -H "${API_HEADER}" \
+		"${URI}/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+	REBASEABLE=$(echo "$pr_resp" | jq -r .rebaseable)
+	if [[ "$REBASEABLE" == "null" ]]; then
+		echo "The PR is not ready to rebase, retry after $RETRY_INTERVAL seconds"
+		sleep "$RETRY_INTERVAL"
+		continue
+	else
+		break
+	fi
+done
+
+if [[ "$REBASEABLE" != "true" ]] ; then
+	echo "GitHub doesn't think that the PR is rebaseable!"
+	exit 1
+fi
+
+#BASE_REPO=$(echo "$pr_resp" | jq -r .base.repo.full_name)
+BASE_BRANCH=$(echo "$pr_resp" | jq -r .base.ref)
+
+USER_LOGIN=$(jq -r ".comment.user.login" "$GITHUB_EVENT_PATH")
+          
+if [[ "$USER_LOGIN" == "null" ]]; then
+	USER_LOGIN=$(jq -r ".pull_request.user.login" "$GITHUB_EVENT_PATH")
+fi
+
+user_resp=$(curl -X GET -s -H "${AUTH_HEADER}" -H "${API_HEADER}" \
+	"${URI}/users/${USER_LOGIN}")
+
+USER_NAME=$(echo "$user_resp" | jq -r ".name")
+if [[ "$USER_NAME" == "null" ]]; then
+	USER_NAME=$USER_LOGIN
+fi
+USER_NAME="${USER_NAME} (Rebase PR Action)"
+
+USER_EMAIL=$(echo "$user_resp" | jq -r ".email")
+if [[ "$USER_EMAIL" == "null" ]]; then
+	USER_EMAIL="$USER_LOGIN@users.noreply.github.com"
+fi
+
+if [[ -z "$BASE_BRANCH" ]]; then
+	echo "Cannot get base branch information for PR #$PR_NUMBER!"
+	exit 1
+fi
+
+HEAD_REPO=$(echo "$pr_resp" | jq -r .head.repo.full_name)
+HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
+
+echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
+
+USER_TOKEN=${USER_LOGIN//-/_}_TOKEN
+UNTRIMMED_COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
+COMMITTER_TOKEN="$(echo -e "${UNTRIMMED_COMMITTER_TOKEN}" | tr -d '[:space:]')"
+
+# See https://github.com/actions/checkout/issues/766 for motivation.
+git config --global --add safe.directory /github/workspace
+
+git remote set-url origin "https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+git config --global user.email "$USER_EMAIL"
+git config --global user.name "$USER_NAME"
+
+git remote add fork "https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REPO.git"
+
+set -o xtrace
+
+# make sure branches are up-to-date
+git fetch origin "$BASE_BRANCH"
+git fetch fork "$HEAD_BRANCH"
+
+# do the rebase
+git checkout -b "fork/$HEAD_BRANCH" "fork/$HEAD_BRANCH"
+if [[ $INPUT_AUTOSQUASH == 'true' ]]; then
+	GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash --force-rebase --no-keep-empty "origin/$BASE_BRANCH"
+else
+	git rebase --force-rebase --no-keep-empty "origin/$BASE_BRANCH"
+fi
+
+# push back
+git push --force-with-lease fork "fork/$HEAD_BRANCH:$HEAD_BRANCH"


### PR DESCRIPTION
## Description

Use our rebase bot to remove empty commits. 
The main use case for this is getting rid of "Initial plan" commits from GitHub Copilot.

To do this I had to modify the rebase action script, I pulled it into our repo. 

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=rebase-bot-remove-empty-commits&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=rebase-bot-remove-empty-commits&lookback=7)