### PR TITLE
chore(suite-native): Mobile Trade: Adjust font size in trading form

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.tsx
@@ -35,7 +35,7 @@ const BuyPaymentMethodPickerRight = ({
         return (
             <Text
                 color="textSubdued"
-                variant="body-md"
+                variant="body-sm"
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedPaymentMethod')}
                 testID={PAYMENT_METHOD_PICKER_TEST_ID + '/value'}
             >
@@ -47,7 +47,7 @@ const BuyPaymentMethodPickerRight = ({
     return (
         <Text
             color="textDisabled"
-            variant="body-md"
+            variant="body-sm"
             accessibilityLabel={translate('moduleTrading.tradingScreen.noPaymentMethod')}
         >
             <Translation id="moduleTrading.notSelected" />

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.tsx
@@ -51,7 +51,7 @@ const BuyProviderPickerRight = ({ isLoading, selectedValue }: BuyProviderPickerR
             <ProviderLogo logo={logo} />
             <Text
                 color="textSubdued"
-                variant="body-md"
+                variant="body-sm"
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedProvider')}
                 testID={PROVIDER_PICKER_TEST_ID + '/value'}
             >

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
@@ -47,7 +47,7 @@ const ExchangeProviderPickerRight = ({
             <ProviderLogo logo={logo} />
             <Text
                 color="textSubdued"
-                variant="body-md"
+                variant="body-sm"
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedProvider')}
             >
                 {companyName}

--- a/suite-native/module-trading/src/components/fees/FeePicker.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePicker.tsx
@@ -26,7 +26,7 @@ export const FeePicker = ({ fee, symbol, onPress, isLoading = false }: FeePicker
                 </Text>
             )}
             <CryptoToFiatAmountFormatter
-                variant="body-md"
+                variant="body-sm"
                 color="textDefault"
                 value={fee}
                 symbol={symbol}

--- a/suite-native/module-trading/src/components/general/FiatAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/general/FiatAmountBadge.tsx
@@ -14,7 +14,7 @@ export const FiatAmountBadge = ({ amount }: FiatAmountBadgeProps) => {
     }
 
     return (
-        <Text variant="body-md" color="textDefault">
+        <Text variant="body-sm" color="textDefault">
             <BaseCurrencyAmountFormatter value={amount} minimumFractionDigits={2} />
         </Text>
     );

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.tsx
@@ -24,7 +24,7 @@ export const FiatCurrencyListItem = ({
                 <Text variant="body-md" color="textDefault">
                     {label}
                 </Text>
-                <Text variant="body-md" color="textSubdued">
+                <Text variant="body-sm" color="textSubdued">
                     {displayValue}
                 </Text>
             </VStack>

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.tsx
@@ -47,7 +47,7 @@ export type NavigationProps = StackToStackCompositeNavigationProps<
     RootStackParamList
 >;
 
-const RightText = ({ color, variant = 'body-md', testID, children }: RightTextProps) => (
+const RightText = ({ color, variant = 'body-sm', testID, children }: RightTextProps) => (
     <Text
         color={color}
         variant={variant}

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.tsx
@@ -42,7 +42,7 @@ const SellReceiveMethodPickerRight = ({
         return (
             <Text
                 color="textSubdued"
-                variant="body-md"
+                variant="body-sm"
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedReceiveMethod')}
                 testID={RECEIVE_METHOD_PICKER_TEST_ID + '/value'}
             >
@@ -54,7 +54,7 @@ const SellReceiveMethodPickerRight = ({
     return (
         <Text
             color="textSubdued"
-            variant="body-md"
+            variant="body-sm"
             accessibilityLabel={translate('moduleTrading.tradingScreen.noReceiveMethod')}
             testID={RECEIVE_METHOD_PICKER_TEST_ID + '/value'}
         >

--- a/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.tsx
@@ -48,7 +48,7 @@ const SellProviderPickerRight = ({ isLoading, selectedValue }: SellProviderPicke
             <ProviderLogo logo={logo} />
             <Text
                 color="textSubdued"
-                variant="body-md"
+                variant="body-sm"
                 accessibilityLabel={translate('moduleTrading.tradingScreen.selectedProvider')}
                 testID={PROVIDER_PICKER_TEST_ID + '/value'}
             >

--- a/suite-native/trading-atoms/src/components/CardTitle.tsx
+++ b/suite-native/trading-atoms/src/components/CardTitle.tsx
@@ -8,7 +8,7 @@ export type CardTitleProps = {
 
 export const CardTitle = ({ children }: CardTitleProps) => (
     <Box paddingHorizontal="sp8" flex={1}>
-        <Text variant="body-md" color="textDefault" numberOfLines={1}>
+        <Text variant="body-sm" color="textDefault" numberOfLines={1}>
             {children}
         </Text>
     </Box>

--- a/suite-native/trading-atoms/src/components/OverviewRow.tsx
+++ b/suite-native/trading-atoms/src/components/OverviewRow.tsx
@@ -54,7 +54,7 @@ export const OverviewRow = ({
             <VStack spacing={0}>
                 <HStack paddingHorizontal="sp12" justifyContent="space-between">
                     <Box paddingVertical="sp20" paddingHorizontal="sp8" flex={0}>
-                        <Text color="textDefault" variant="body-md">
+                        <Text color="textDefault" variant="body-sm">
                             {title}
                         </Text>
                     </Box>

--- a/suite-native/trading-atoms/src/components/ProviderLogo.tsx
+++ b/suite-native/trading-atoms/src/components/ProviderLogo.tsx
@@ -17,7 +17,7 @@ const imageStyle = prepareNativeStyle<{ size: NativeTypographyStyle }>(
     }),
 );
 
-export const ProviderLogo = ({ logo, size = 'body-md' }: TradingProviderLogoProps) => {
+export const ProviderLogo = ({ logo, size = 'body-sm' }: TradingProviderLogoProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed `body-md` to `body-sm` hopefully on all relevant places.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25474

## Screenshots:

### Before
<img width="300" alt="before" src="https://github.com/user-attachments/assets/40e0fd3c-e123-47e6-9c11-6b6b7e37c0d1" />

### After
<img width="300" alt="after" src="https://github.com/user-attachments/assets/26587b5b-e9b5-4698-a5f9-ae10e3cd7004" />





🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25474-mobile-trade-wrong-font-size-for-trading-form-labels&lookback=7)