### PR TITLE
test(e2e-suite): new test for suite sync label removal

### DIFF
--- a/packages/product-components/src/components/EditableText/ActionsContainer.tsx
+++ b/packages/product-components/src/components/EditableText/ActionsContainer.tsx
@@ -152,6 +152,7 @@ export const ActionsContainer = ({
                             delayShow={1000}
                         >
                             <IconButton
+                                data-testid="@metadata/delete"
                                 intent="critical"
                                 icon="trash"
                                 onClick={onDelete}

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -141,17 +141,17 @@ export class EvoluClient {
         const omitFields = options?.omit ?? ['id', 'createdAt'];
         const timeout = options?.timeout ?? 5_000;
         const expectFn = options?.softExpect ? expect.soft : expect;
-        const expectedOrdered = orderBy(expectedData, ['label']);
 
         await expectFn(async () => {
             const actualData = await this.readFrom(table);
-            const actualOmitted = actualData.map(item => omit(item, omitFields));
-            // Unfortunately label is the only guaranteed property for ordering
-            // might not be sufficient for more advance test scenarios. YAGNI for now.
-            const actualOrdered = orderBy(actualOmitted, ['label']);
-            if (!isEqual(expectedOrdered, actualOrdered)) {
+            // Sort by createdAt (ascending) before omitting so rows are in insertion order.
+            // Expected data must be provided in the same chronological order.
+            const actualOmitted = orderBy(actualData, ['createdAt']).map(item =>
+                omit(item, omitFields),
+            );
+            if (!isEqual(expectedData, actualOmitted)) {
                 throw new Error(
-                    `Table "${table}" data does not match.\nDiff:\n${diff(expectedOrdered, actualOrdered)}`,
+                    `Table "${table}" data does not match.\nDiff:\n${diff(expectedData, actualOmitted)}`,
                 );
             }
         }).toPass({ timeout });

--- a/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
@@ -6,6 +6,8 @@ import { step } from '../../common';
 export class AccountMetadata extends MetadataBase {
     readonly editLabelButton = (accountId: string) =>
         this.accountLabel(accountId).getByTestId(this.editButtonId);
+    readonly deleteLabelButton = (accountId: string) =>
+        this.accountLabel(accountId).getByTestId(this.deleteButtonId);
     readonly successLabel = (accountId: string) =>
         this.accountLabel(accountId).getByTestId(this.successId);
     readonly accountLabel = (accountId: string) =>
@@ -19,6 +21,16 @@ export class AccountMetadata extends MetadataBase {
     async changeLabel({ accountId, label }: { accountId: string; label: string }) {
         await this.clickEditLabelButton(accountId);
         await this.fillLabelInput(label, { useButton: true });
+        await this.successIconIsVisible(accountId);
+    }
+
+    @step()
+    async removeLabel({ accountId }: { accountId: string }) {
+        await this.page.resetMousePosition();
+        await expect(this.accountLabel(accountId)).toHaveText(/[A-Za-z]+/);
+        await this.accountLabel(accountId).hover();
+        await this.deleteLabelButton(accountId).click();
+        await this.accountLabel(accountId).hover();
         await this.successIconIsVisible(accountId);
     }
 

--- a/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
@@ -6,12 +6,14 @@ import { step } from '../../common';
 export class AddressMetadata extends MetadataBase {
     private readonly addressMetadataTestId = '@metadata/addressLabel';
 
-    private readonly addressHoverContainer = (address: string) =>
+    readonly addressHoverContainer = (address: string) =>
         this.page.getByTestId(`${this.addressMetadataTestId}/${address}/hover-container`);
     readonly label = (address: string) =>
         this.addressHoverContainer(address).getByTestId(this.inputId);
     readonly editLabelButton = (address: string) =>
         this.addressHoverContainer(address).getByTestId(this.editButtonId);
+    readonly deleteLabelButton = (address: string) =>
+        this.addressHoverContainer(address).getByTestId(this.deleteButtonId);
     readonly successLabel = (address: string) =>
         this.addressHoverContainer(address).getByTestId(this.successId);
 
@@ -31,6 +33,14 @@ export class AddressMetadata extends MetadataBase {
     async changeLabel({ address, label }: { address: string; label: string }) {
         await this.clickEditLabel(address);
         await this.fillLabelInput(label);
+        await this.successIconIsVisible(address);
+    }
+
+    @step()
+    async removeLabel({ address }: { address: string }) {
+        await this.addressHoverContainer(address).hover();
+        await this.deleteLabelButton(address).click();
+        await this.addressHoverContainer(address).hover();
         await this.successIconIsVisible(address);
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/metadataBase.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataBase.ts
@@ -11,6 +11,7 @@ export class MetadataBase {
     readonly metadataCancelButton: Locator;
     readonly metadataInput: Locator;
     readonly editButtonId = '@metadata/edit';
+    readonly deleteButtonId = '@metadata/delete';
     readonly inputId = '@metadata/input';
     readonly successId = '@metadata/success';
 

--- a/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
@@ -8,6 +8,10 @@ export class OutputMetadata extends MetadataBase {
         this.page.getByTestId(`${this.getLabelTestId(outputId, txNumber)}/hover-container`);
     readonly outputMetadataInput = (outputId: string, txNumber: number) =>
         this.outputLabel(outputId, txNumber).getByTestId(this.inputId);
+    readonly labelChangeSuccessIcon = (outputId: string, txNumber: number) =>
+        this.outputLabel(outputId, txNumber).getByTestId(this.successId);
+    readonly deleteLabelButton = (outputId: string, txNumber: number) =>
+        this.outputLabel(outputId, txNumber).getByTestId(this.deleteButtonId);
 
     private getLabelTestId(outputId: string, txNumber: number): string {
         return `@metadata/outputLabel/${outputId}-${txNumber}`;
@@ -23,6 +27,12 @@ export class OutputMetadata extends MetadataBase {
     }
 
     @step()
+    async successIconIsVisible(outputId: string, txNumber: number) {
+        await expect(this.labelChangeSuccessIcon(outputId, txNumber)).toBeVisible();
+        await expect(this.labelChangeSuccessIcon(outputId, txNumber)).toBeHidden();
+    }
+
+    @step()
     async changeLabel({
         outputId,
         txNumber,
@@ -35,5 +45,17 @@ export class OutputMetadata extends MetadataBase {
         await this.clickAddLabelButton(outputId, txNumber);
         await this.outputMetadataInput(outputId, txNumber).fill(label);
         await this.page.keyboard.press('Enter');
+        await this.successIconIsVisible(outputId, txNumber);
+    }
+
+    @step()
+    async removeLabel({ outputId, txNumber }: { outputId: string; txNumber: number }) {
+        await this.page.resetMousePosition();
+        await expect(this.outputLabel(outputId, txNumber)).toHaveText(/[A-Za-z]+/);
+        await this.outputLabel(outputId, txNumber).hover();
+        await this.page.waitForTimeout(500); // delete button is unstable without this wait
+        await this.deleteLabelButton(outputId, txNumber).click();
+        await this.outputLabel(outputId, txNumber).hover();
+        await this.successIconIsVisible(outputId, txNumber);
     }
 }

--- a/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
@@ -9,6 +9,8 @@ export class WalletMetadata extends MetadataBase {
         this.page.getByTestId(`@switch-device/wallet-on-index/${index}`);
     readonly labelChangeSuccessIcon = (index: number) =>
         this.walletOnIndex(index).getByTestId(this.successId);
+    readonly deleteLabelButton = (index: number) =>
+        this.walletOnIndex(index).getByTestId(this.deleteButtonId);
 
     @step()
     async clickEditLabel(index: number) {
@@ -29,6 +31,16 @@ export class WalletMetadata extends MetadataBase {
     async changeLabel({ index, label }: { index: number; label: string }) {
         await this.clickEditLabel(index);
         await this.fillLabelInput(label);
+        await this.successIconIsVisible(index);
+    }
+
+    @step()
+    async removeLabel({ index }: { index: number }) {
+        await this.page.resetMousePosition();
+        await expect(this.walletLabel(index)).toHaveText(/[A-Za-z]+/);
+        await this.walletLabel(index).hover();
+        await this.deleteLabelButton(index).click();
+        await this.walletLabel(index).hover();
         await this.successIconIsVisible(index);
     }
 }

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -8,8 +8,8 @@ test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
 
     test.beforeEach(async ({ metadataMock, evoluClient, onboardingPage }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
-        await test.step('Seed Evolu relay server', async () => {
-            await evoluClient.init({ ownerSecret });
+        await test.step('Seed Evolu relay server', () => {
+            evoluClient.init({ ownerSecret });
             evoluClient.writeTo('account', accountSeed);
         });
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -107,7 +107,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
         });
 
         await test.step('Verify data are sync to Relay', async () => {
-            await evoluClient.init({ ownerSecret });
+            evoluClient.init({ ownerSecret });
             await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
             await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
             await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });

--- a/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
@@ -1,0 +1,154 @@
+import { ownerId } from '../../../fixtures/metadata/default-metadata-ids';
+import {
+    accountSeed,
+    addressSeed,
+    outputSeed,
+    ownerSecret,
+    walletSeed,
+} from '../../../fixtures/metadata/suite-sync-data';
+import { AccountLabelId } from '../../../support/enums/accountLabelId';
+import { expect, test } from '../../../support/fixtures';
+
+const defaultWalletIndex = 0;
+
+test.describe('Suite Sync - Remove Labels', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ wipeEvoluRelay: true });
+
+    test.beforeEach(async ({ evoluClient, onboardingPage }) => {
+        await test.step('Seed Evolu relay server with existing labels', () => {
+            evoluClient.init({ ownerSecret });
+            evoluClient.writeTo('wallet', walletSeed);
+            evoluClient.writeTo('account', accountSeed);
+            evoluClient.writeTo('address', addressSeed);
+            evoluClient.writeTo('output', outputSeed);
+        });
+
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+    });
+
+    test('Remove labels syncs null to relay', async ({
+        evoluClient,
+        dashboardPage,
+        walletPage,
+        metadataPage,
+    }) => {
+        await test.step('Enable Suite Sync and sync labels from relay', async () => {
+            await metadataPage.enableSuiteSync();
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText(accountSeed.label, { timeout: 30_000 });
+        });
+
+        await test.step('Remove account label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.account.removeLabel({
+                accountId: AccountLabelId.BitcoinDefault1,
+            });
+            await expect
+                .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))
+                .toHaveText('Bitcoin #1');
+        });
+
+        await test.step('Remove wallet label', async () => {
+            await dashboardPage.openDeviceSwitcher();
+            await metadataPage.wallet.removeLabel({ index: defaultWalletIndex });
+            await expect
+                .soft(metadataPage.wallet.walletLabel(defaultWalletIndex))
+                .toHaveText('Standard wallet');
+            await dashboardPage.deviceSwitchingCloseButton.click();
+        });
+
+        await test.step('Remove address label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await metadataPage.address.removeLabel({ address: addressSeed.address });
+            await expect
+                .soft(metadataPage.address.addressHoverContainer(addressSeed.address))
+                .toHaveText('bc1q kkr2 ... qfxy fa');
+        });
+
+        await test.step('Remove output label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.output.removeLabel({
+                outputId: outputSeed.txId,
+                txNumber: Number(outputSeed.outputIndex),
+            });
+            await expect(
+                metadataPage.output.outputLabel(outputSeed.txId, Number(outputSeed.outputIndex)),
+            ).toHaveText('bc1q lzk7 ... ntm5 xq');
+        });
+
+        await test.step('Verify labels are removed in relay (label is null)', async () => {
+            evoluClient.init({ ownerSecret });
+
+            await evoluClient.expectInTable(
+                'account',
+                [
+                    {
+                        updatedAt: null,
+                        isDeleted: null,
+                        ownerId,
+                        accountDescriptor: accountSeed.accountDescriptor,
+                        networkSymbol: accountSeed.networkSymbol,
+                        label: null,
+                    },
+                ],
+                { softExpect: true },
+            );
+
+            await evoluClient.expectInTable(
+                'wallet',
+                [
+                    {
+                        isDeleted: null,
+                        label: 'Evolu synced wallet',
+                        ownerId: '0Fco3XDgKR59zX5VBvyyGQ',
+                        updatedAt: null,
+                        walletDescriptor: 'mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer',
+                    },
+                    {
+                        updatedAt: null,
+                        isDeleted: null,
+                        ownerId,
+                        walletDescriptor: walletSeed.walletDescriptor,
+                        label: null,
+                    },
+                ],
+                { softExpect: true },
+            );
+
+            await evoluClient.expectInTable(
+                'address',
+                [
+                    {
+                        updatedAt: null,
+                        isDeleted: null,
+                        ownerId,
+                        accountDescriptor: addressSeed.accountDescriptor,
+                        networkSymbol: addressSeed.networkSymbol,
+                        address: addressSeed.address,
+                        label: null,
+                    },
+                ],
+                { softExpect: true },
+            );
+
+            await evoluClient.expectInTable(
+                'output',
+                [
+                    {
+                        updatedAt: null,
+                        isDeleted: null,
+                        ownerId,
+                        accountDescriptor: outputSeed.accountDescriptor,
+                        networkSymbol: outputSeed.networkSymbol,
+                        txId: outputSeed.txId,
+                        outputIndex: outputSeed.outputIndex,
+                        label: null,
+                    },
+                ],
+                { softExpect: true },
+            );
+        });
+    });
+});

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
@@ -14,8 +14,8 @@ test.describe('Suite Sync - Labelling', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
     test.use({ wipeEvoluRelay: true });
 
     test.beforeEach(async ({ evoluClient, onboardingPage }) => {
-        await test.step('Seed Evolu relay server', async () => {
-            await evoluClient.init({ ownerSecret });
+        await test.step('Seed Evolu relay server', () => {
+            evoluClient.init({ ownerSecret });
             evoluClient.writeTo('wallet', walletSeed);
             evoluClient.writeTo('account', accountSeed);
             evoluClient.writeTo('address', addressSeed);


### PR DESCRIPTION
New tests for label removing in Suite Sync

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-suite-sync-remove-label&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-suite-sync-remove-label&lookback=7)