### PR TITLE
Memoize selectSuiteSyncAccounts because typedObjectValues return a new array every time

### DIFF
--- a/suite-common/suite-sync/src/data/account/selectSuiteSyncAccounts.ts
+++ b/suite-common/suite-sync/src/data/account/selectSuiteSyncAccounts.ts
@@ -1,3 +1,4 @@
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { SuiteSyncAccount } from '@suite-common/suite-sync-storage';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { StaticSessionId } from '@trezor/connect';
@@ -6,18 +7,25 @@ import { typedObjectValues } from '@trezor/utils';
 import { SuiteSyncDataRootState } from '../suiteSyncDataReducer';
 import { selectWalletById } from '../wallet/suiteSyncWalletSelectors';
 
+const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+
 /**
  * @deprecated Do not use this directly outside the `suite-sync` package.
  *             Prefer `selectAccountsWithSuiteSyncLabel` instead.
  */
-export const selectSuiteSyncAccounts = (
-    state: SuiteSyncDataRootState,
-    deviceStaticSessionId: StaticSessionId | null,
-): SuiteSyncAccount[] => {
-    if (!deviceStaticSessionId) return [];
-    const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
-    const wallet = selectWalletById(state, walletDescriptor);
-    if (!wallet) return [];
+export const selectSuiteSyncAccounts = createMemoizedSelector(
+    [
+        (state: SuiteSyncDataRootState, deviceStaticSessionId: StaticSessionId | null) =>
+            deviceStaticSessionId
+                ? selectWalletById(
+                      state,
+                      parseDeviceStaticSessionId(deviceStaticSessionId).walletDescriptor,
+                  )
+                : null,
+    ],
+    (wallet): SuiteSyncAccount[] => {
+        if (!wallet) return [];
 
-    return typedObjectValues(wallet.accounts);
-};
+        return typedObjectValues(wallet.accounts);
+    },
+);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description


```bash
WARN  An input selector returned a different result when passed same arguments.
This means your output selector will likely run more frequently than intended.
Avoid returning a new reference inside your input selector, e.g.
`createSelector([state => state.todos.map(todo => todo.id)], todoIds => todoIds.length)`

Code: selectors.ts
  61 |     [
  62 |         (state: NativeAccountsRootState) =>
> 63 |             selectAccountsWithSuiteSyncLabel(
     |                                             ^
  64 |                 state,
  65 |                 selectVisibleDeviceAccounts(state),
  66 |                 selectDeviceStaticSessionId(state),
Call Stack
  <anonymous> (suite-native/accounts/src/selectors.ts:63:45)
  useSelector$argument_0 (suite-native/accounts/src/components/AccountsList/AccountsList.tsx:36:64)
  AccountsList (suite-native/accounts/src/components/AccountsList/AccountsList.tsx:35:40)
 WARN  The result function returned its own inputs without modification. e.g
`createSelector([state => state.todos], todos => todos)`
This could lead to inefficient memoization and unnecessary re-renders.
Ensure transformation logic is in the result function, and extraction logic is in the input selectors.

Code: AccountsList.tsx
  34 | }: AccountsListProps) => {
  35 |     const groupedAccounts = useSelector((state: NativeAccountsRootState) =>
> 36 |         selectFilteredDeviceAccountsGroupedByNetworkAccountType(
     |                                                                ^
  37 |             state,
  38 |             filterValue,
  39 |             isSendFilterEnabled,
Call Stack
  useSelector$argument_0 (suite-native/accounts/src/components/AccountsList/AccountsList.tsx:36:64)
  AccountsList (suite-native/accounts/src/components/AccountsList/AccountsList.tsx:35:40)
```

## Notes for QA

Account lists should work the same as before.



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-suite-sync-accounts-memoization&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-suite-sync-accounts-memoization&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/select-suite-sync-accounts-memoization&lookback=7)