### PR TITLE
chore(suite-native): staking deep imports

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
@@ -6,13 +6,11 @@ import { Account } from '@suite-common/wallet-types';
 import { RoundedIcon, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { NativeStakingRootState } from '@suite-native/staking';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
 import {
+    NativeStakingRootState,
     selectIsCardanoStakedOutsideEverstake,
     selectIsCardanoStakedWithFiveBinaries,
-} from '@suite-native/staking/src/cardanoStakingSelectors';
+} from '@suite-native/staking';
 import { useNativeStyles } from '@trezor/styles';
 
 import { AccountsListItemBase } from './AccountsListItemBase';

--- a/suite-native/accounts/src/components/AccountsList/StakingBadge.tsx
+++ b/suite-native/accounts/src/components/AccountsList/StakingBadge.tsx
@@ -8,9 +8,7 @@ import { Account } from '@suite-common/wallet-types';
 import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
 import { CompoundRoundedIcon } from '@suite-native/atoms';
 import { IconName, IconSize } from '@suite-native/icons';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking';
 import { Color } from '@trezor/theme';
 
 type CompoundIcon = {

--- a/suite-native/module-earn/src/components/AutoStakedBalancesCard.tsx
+++ b/suite-native/module-earn/src/components/AutoStakedBalancesCard.tsx
@@ -4,10 +4,7 @@ import { Box, Card, PressableOpacity, Text } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { useSelector } from '@suite-native/staking';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import { selectIsCardanoStakedOutsideEverstake } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { selectIsCardanoStakedOutsideEverstake, useSelector } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 const stakingItemStyle = prepareNativeStyle(utils => ({

--- a/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
@@ -4,14 +4,10 @@ import { InlineAlertBox } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     selectAPYByAccountKey,
-    useSelector as useNativeStakingSelector,
-} from '@suite-native/staking';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import {
     selectIsCardanoStakedOutsideEverstake,
     selectIsCardanoStakedWithFiveBinaries,
-} from '@suite-native/staking/src/cardanoStakingSelectors';
+    useSelector as useNativeStakingSelector,
+} from '@suite-native/staking';
 
 type CardanoStakingInfoBannerProps = {
     accountKey: AccountKey;

--- a/suite-native/module-earn/src/components/FiveBinariesHomeBanner.tsx
+++ b/suite-native/module-earn/src/components/FiveBinariesHomeBanner.tsx
@@ -5,9 +5,7 @@ import { AccountsRootState } from '@suite-common/wallet-core';
 import { InlineAlertBox } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking/src/cardanoStakingSelectors';
+import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking';
 import { HELP_CENTER_ADA_STAKING } from '@trezor/urls';
 
 export const FiveBinariesHomeBanner = () => {

--- a/suite-native/module-earn/src/components/StakePendingCard.tsx
+++ b/suite-native/module-earn/src/components/StakePendingCard.tsx
@@ -8,14 +8,12 @@ import { Box, Card, InlineAlertBoxProps, PressableOpacity, Text } from '@suite-n
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import {
+    NativeStakingRootState,
     selectIsStakeConfirmingByAccountKey,
     selectIsStakePendingByAccountKey,
     selectTotalStakePendingByAccountKey,
     useSelector as useNativeStakingSelector,
 } from '@suite-native/staking';
-// TODO fix deep import
-// eslint-disable-next-line local-rules/no-package-deep-imports
-import { NativeStakingRootState } from '@suite-native/staking/src/types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 type StakePendingCardProps = {

--- a/suite-native/staking/src/index.ts
+++ b/suite-native/staking/src/index.ts
@@ -1,8 +1,15 @@
-// Do not export anything from coin specific files like ethereumSelectors.ts etc.
-// This package should be expose only coin agnostic staking functionality.
-// Exposing coin specific selectors is not a good practice and should be last resort.
+// Coin-specific selector files (e.g. cardanoStakingSelectors.ts) are intentionally not
+// re-exported whole. However, since selectors.ts already imports from these files,
+// they are always included in the bundle regardless. Selectors needed by external consumers
+// are therefore explicitly exported below rather than forcing deep imports.
 
 export * from './utils';
 export * from './selectors';
 export * from './types';
 export * from './hooks/useSelector';
+
+export {
+    selectFirstCardanoAccountStakedWithFiveBinaries,
+    selectIsCardanoStakedOutsideEverstake,
+    selectIsCardanoStakedWithFiveBinaries,
+} from './cardanoStakingSelectors';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Five components were importing cardanoStakingSelectors directly from inside the @suite-native/staking package rather than through its public API. This was flagged by the no-package-deep-imports ESLint rule and suppressed with eslint-disable comments.

The root cause was a comment in staking/src/index.ts saying "do not export coin-specific selector files" — but this reasoning was flawed. Since selectors.ts already imports from cardanoStakingSelectors.ts, those selectors are always included in the bundle regardless. There was no actual benefit to hiding them from the public API.

The fix explicitly exports the three selectors that consumers need (selectFirstCardanoAccountStakedWithFiveBinaries, selectIsCardanoStakedOutsideEverstake, selectIsCardanoStakedWithFiveBinaries) from index.ts and updates the comment to reflect reality. All five consumer files (StakingBadge, AdaAccountsListStakingItem, FiveBinariesHomeBanner, CardanoStakingInfoBanner, AutoStakedBalancesCard) now import cleanly from @suite-native/staking.

## Notes for QA
Nothing to test, just fixing imports. 

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/staking-deep-imports&lookback=7)