### PR TITLE
fix(suite-native): fix custom fee form confirm button

### DIFF
--- a/suite-native/forms/src/components/FormSubmitButton.tsx
+++ b/suite-native/forms/src/components/FormSubmitButton.tsx
@@ -1,10 +1,5 @@
 import { ComponentProps, PropsWithChildren } from 'react';
-import Animated, {
-    SlideInDown,
-    SlideOutDown,
-    useAnimatedStyle,
-    withTiming,
-} from 'react-native-reanimated';
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
 import { Button } from '@suite-native/atoms';
 
@@ -19,22 +14,15 @@ export const FormSubmitButton = ({
     children,
     ...restProps
 }: FormSubmitButtonProps) => {
-    const animatedButtonContainerStyle = useAnimatedStyle(
-        () => ({
-            height: withTiming(isVisible ? 50 : 0),
-        }),
-        [isVisible],
-    );
+    if (!isVisible) {
+        return null;
+    }
 
     return (
-        <Animated.View style={animatedButtonContainerStyle}>
-            {isVisible && (
-                <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
-                    <Button onPress={onPress} {...restProps}>
-                        {children}
-                    </Button>
-                </Animated.View>
-            )}
+        <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+            <Button onPress={onPress} {...restProps}>
+                {children}
+            </Button>
         </Animated.View>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix custom fee confim button on android

## Notes for QA

Bug report: 

> When you press "Add custom fee", the keyboard appears and you can fill the edit field. However, you cannot press "Confirm custom fee" to confirm the input.. the button seems unresponsive.
> I noticed that the "Confirm custom fee"" button is active when you open the field just confirm the pre-filled value.
> => so the workaround to the issue is to open the edit field once, fill the fee you want, go back via :heavy_multiplication_x: button, open it again, press "Confirm custom fee"".
> 

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

https://github.com/user-attachments/assets/43e9ce4d-3ed1-4419-84a3-83f7bbfc9b0f



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/custom-fee-button-android&lookback=7)