### PR TITLE
Prevent jumping of bottomsheet with input behind the keyboard

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
@@ -91,6 +91,7 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
                 maxDynamicContentSize={maxDynamicContentSize}
                 backgroundStyle={applyStyle(backgroundStyle)}
                 backdropComponent={renderBackdrop}
+                keyboardBlurBehavior="restore"
                 handleComponent={() => (
                     <BottomSheetHeader
                         title={title}

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -53,6 +53,7 @@
         "date-fns": "^4.1.0",
         "jotai": "2.15.0",
         "react": "19.1.0",
+        "react-hook-form": "^7.71.1",
         "react-native": "0.81.5",
         "react-redux": "9.2.0"
     }

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -60,7 +60,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
         // Also, it's needed to prevent the keyboard from opening when the modal is animating.
         const timeout = setTimeout(() => {
             inputRef.current?.focus();
-        }, 300);
+        }, 1000); // If this is lower, than the position is sometimes miscalculated and the keybord jumps behind the keyboard.
 
         return () => clearTimeout(timeout);
     }, [inputRef]);

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react';
+import { useWatch } from 'react-hook-form';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { AccountsRootState, accountsActions, selectAccountByKey } from '@suite-common/wallet-core';
 import { AccountKey } from '@suite-common/wallet-types';
 import {
     AccountFormValues,
-    AccountLabelFieldHint,
     MAX_ACCOUNT_LABEL_LENGTH,
     useAccountLabelForm,
 } from '@suite-native/accounts';
@@ -49,6 +49,8 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
         formState: { isValid },
         control,
     } = form;
+
+    const accountLabelLength = useWatch({ control, name: 'accountLabel' })?.length ?? 0;
 
     useEffect(() => {
         // Focus account label input field and open keyboard on the first render.
@@ -98,6 +100,11 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
         onSubmit();
     });
 
+    const hint = translate('accounts.accountLabelFieldHint.letterCount', {
+        current: accountLabelLength,
+        max: MAX_ACCOUNT_LABEL_LENGTH,
+    });
+
     const coinLabelFieldLabel = translate(
         'moduleAccountManagement.accountSettingsScreen.renameForm.coinLabel',
     );
@@ -110,11 +117,11 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
                         ref={inputRef}
                         name="accountLabel"
                         label={coinLabelFieldLabel}
+                        hint={isValid ? hint : undefined}
                         maxLength={MAX_ACCOUNT_LABEL_LENGTH}
                         asBottomSheetInput
                         testID="@account-detail/settings/account-rename/input"
                     />
-                    <AccountLabelFieldHint formControl={control} />
                     <Button
                         onPress={handleRenameAccount}
                         size="large"

--- a/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountRenameForm.tsx
@@ -46,9 +46,11 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
     const form = useAccountLabelForm(accountLabel ?? undefined);
     const {
         handleSubmit,
-        formState: { isValid },
+        formState: { errors },
         control,
     } = form;
+
+    const hasErrors = Object.keys(errors).length > 0;
 
     const accountLabelLength = useWatch({ control, name: 'accountLabel' })?.length ?? 0;
 
@@ -117,7 +119,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
                         ref={inputRef}
                         name="accountLabel"
                         label={coinLabelFieldLabel}
-                        hint={isValid ? hint : undefined}
+                        hint={hasErrors ? undefined : hint}
                         maxLength={MAX_ACCOUNT_LABEL_LENGTH}
                         asBottomSheetInput
                         testID="@account-detail/settings/account-rename/input"
@@ -125,7 +127,7 @@ export const AccountRenameForm = ({ accountKey, onSubmit }: AccountRenameFormPro
                     <Button
                         onPress={handleRenameAccount}
                         size="large"
-                        isDisabled={!isValid}
+                        isDisabled={hasErrors}
                         testID="@account-detail/settings/account-rename/confirm-button"
                     >
                         <Translation id="generic.buttons.confirm" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -12952,6 +12952,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     jotai: "npm:2.15.0"
     react: "npm:19.1.0"
+    react-hook-form: "npm:^7.71.1"
     react-native: "npm:0.81.5"
     react-redux: "npm:9.2.0"
   languageName: unknown


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- The only workaround that seems to help is prolonging the timeout before autofocus happens. If autofocus happens too early, the bottom sheet position is miscalculated, and that could lead to unexpected behavior. 
For the ultimate solution, we would need to change the design, I'm afraid.

There are 2 more small changes in this PR:
- Forcing validation on text change, because it happened to me many times, that I didn't see the "Field is mandatory" error for empty input. (I thought that it was related to the main bug, but I don't think so anymore)
- Deleting custom hint for input length and use default hint feature of the text input field.

## Notes for QA

Try it many times, please.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23673

## Screenshots:


https://github.com/user-attachments/assets/8b3d778f-0cd3-40ef-b32b-9aa99e9ef2e6

https://github.com/user-attachments/assets/7b871cf3-edba-4bd2-9a0b-51b86b62d0df




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/bottomsheet-inputs&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/bottomsheet-inputs&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bottomsheet-inputs&lookback=7)