### PR TITLE
Abstract label search to use both Legacy and SuiteSync labeling

### DIFF
--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -3,10 +3,8 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { Bip329Label } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    selectAllLabelsForAccount,
     selectIsSuiteSyncEnabled,
-    selectSuiteSyncAccountAddressesByAccount,
-    selectSuiteSyncAccountLabel,
-    selectSuiteSyncOutputLabelsByAccount,
     selectSuiteSyncOwnerForDeviceStaticId,
     suiteSyncToBip329,
 } from '@suite-common/suite-sync';
@@ -66,33 +64,22 @@ export const exportMetadataToBip329File = createThunk<
 
                 const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
 
-                const suiteSyncAccountLabel = selectSuiteSyncAccountLabel(
+                const { accountLabel, addressLabels, outputLabels } = selectAllLabelsForAccount(
                     state,
-                    walletDescriptor,
-                    account.descriptor,
-                    account.symbol,
+                    {
+                        walletDescriptor,
+                        accountDescriptor: account.descriptor,
+                        networkSymbol: account.symbol,
+                    },
                 );
-                if (suiteSyncAccountLabel) {
-                    finalAccountLabel = suiteSyncAccountLabel;
+
+                if (accountLabel) {
+                    finalAccountLabel = accountLabel;
                 }
 
-                const suiteSyncAddressLabels = selectSuiteSyncAccountAddressesByAccount(
-                    state,
-                    walletDescriptor,
-                    account.descriptor,
-                    account.symbol,
-                );
-
-                const suiteSyncOutputLabels = selectSuiteSyncOutputLabelsByAccount(
-                    state,
-                    walletDescriptor,
-                    account.descriptor,
-                    account.symbol,
-                );
-
                 labelsToExport = suiteSyncToBip329({
-                    outputLabels: suiteSyncOutputLabels,
-                    addressLabels: suiteSyncAddressLabels,
+                    outputLabels,
+                    addressLabels,
                     allSpendable: true,
                 });
             } else {

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -1,7 +1,3 @@
-import {
-    fromLegacyMetadataToSearchAccountLabels,
-    selectLabelingDataForAccount,
-} from '@suite/metadata';
 import { createThunk } from '@suite-common/redux-utils';
 import { selectNetworkTokenDefinitions } from '@suite-common/token-definitions';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
@@ -14,6 +10,7 @@ import {
 import { Account, ExportFileType } from '@suite-common/wallet-types';
 import { getAccountTransactions } from '@suite-common/wallet-utils';
 
+import { selectAccountLabelsForSearch } from 'src/selectors/suite/selectAccountLabelsForSearch';
 import { formatData, getExportedFileName } from 'src/utils/wallet/exportTransactionsUtils';
 
 export const exportTransactionsThunk = createThunk(
@@ -33,7 +30,6 @@ export const exportTransactionsThunk = createThunk(
         { getState, extra },
     ) => {
         const { services } = extra;
-        const accountMetadata = selectLabelingDataForAccount(getState(), account.key);
         // Get state of transactions
         const allTransactions = selectTransactions(getState());
         const historicFiatRates = selectHistoricFiatRates(getState());
@@ -66,11 +62,11 @@ export const exportTransactionsThunk = createThunk(
                 })),
             }));
 
-        const metadataLabels = fromLegacyMetadataToSearchAccountLabels(accountMetadata);
+        const searchLabels = selectAccountLabelsForSearch(getState(), account);
 
         const filteredTransaction =
             searchQuery.trim() !== ''
-                ? advancedSearchTransactions(transactions, metadataLabels, searchQuery)
+                ? advancedSearchTransactions(transactions, searchLabels, searchQuery)
                 : transactions;
 
         // getAccountTransactions doesn't guarantee transactions will be sorted

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -1,4 +1,7 @@
-import { selectLabelingDataForAccount } from '@suite/metadata';
+import {
+    fromLegacyMetadataToSearchAccountLabels,
+    selectLabelingDataForAccount,
+} from '@suite/metadata';
 import { createThunk } from '@suite-common/redux-utils';
 import { selectNetworkTokenDefinitions } from '@suite-common/token-definitions';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
@@ -63,9 +66,11 @@ export const exportTransactionsThunk = createThunk(
                 })),
             }));
 
+        const metadataLabels = fromLegacyMetadataToSearchAccountLabels(accountMetadata);
+
         const filteredTransaction =
             searchQuery.trim() !== ''
-                ? advancedSearchTransactions(transactions, accountMetadata, searchQuery)
+                ? advancedSearchTransactions(transactions, metadataLabels, searchQuery)
                 : transactions;
 
         // getAccountTransactions doesn't guarantee transactions will be sorted

--- a/packages/suite/src/selectors/suite/selectAccountLabelsForSearch.ts
+++ b/packages/suite/src/selectors/suite/selectAccountLabelsForSearch.ts
@@ -2,6 +2,7 @@ import {
     fromLegacyMetadataToSearchAccountLabels,
     selectLabelingDataForAccount,
 } from '@suite/metadata';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import {
     fromSuiteSyncToSearchAccountLabels,
     selectAllLabelsForAccount,
@@ -12,21 +13,24 @@ import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 
 import { AppState } from 'src/types/suite';
 
-export const selectAccountLabelsForSearch = (state: AppState, account: Account) => {
-    const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
+const createMemoizedSelector = createWeakMapSelector.withTypes<AppState>();
 
-    if (isSuiteSyncEnabled) {
-        const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
-        const allLabels = selectAllLabelsForAccount(state, {
-            walletDescriptor,
-            accountDescriptor: account.descriptor,
-            networkSymbol: account.symbol,
-        });
+export const selectAccountLabelsForSearch = createMemoizedSelector(
+    [
+        selectIsSuiteSyncEnabled,
+        (state: AppState, account: Account) =>
+            selectAllLabelsForAccount(state, {
+                walletDescriptor: parseDeviceStaticSessionId(account.deviceState).walletDescriptor,
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
+            }),
+        (state: AppState, account: Account) => selectLabelingDataForAccount(state, account.key),
+    ],
+    (isSuiteSyncEnabled, allLabels, accountMetadata) => {
+        if (isSuiteSyncEnabled) {
+            return fromSuiteSyncToSearchAccountLabels(allLabels);
+        }
 
-        return fromSuiteSyncToSearchAccountLabels(allLabels);
-    }
-
-    const accountMetadata = selectLabelingDataForAccount(state, account.key);
-
-    return fromLegacyMetadataToSearchAccountLabels(accountMetadata);
-};
+        return fromLegacyMetadataToSearchAccountLabels(accountMetadata);
+    },
+);

--- a/packages/suite/src/selectors/suite/selectAccountLabelsForSearch.ts
+++ b/packages/suite/src/selectors/suite/selectAccountLabelsForSearch.ts
@@ -1,0 +1,32 @@
+import {
+    fromLegacyMetadataToSearchAccountLabels,
+    selectLabelingDataForAccount,
+} from '@suite/metadata';
+import {
+    fromSuiteSyncToSearchAccountLabels,
+    selectAllLabelsForAccount,
+    selectIsSuiteSyncEnabled,
+} from '@suite-common/suite-sync';
+import { Account } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+
+import { AppState } from 'src/types/suite';
+
+export const selectAccountLabelsForSearch = (state: AppState, account: Account) => {
+    const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
+
+    if (isSuiteSyncEnabled) {
+        const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
+        const allLabels = selectAllLabelsForAccount(state, {
+            walletDescriptor,
+            accountDescriptor: account.descriptor,
+            networkSymbol: account.symbol,
+        });
+
+        return fromSuiteSyncToSearchAccountLabels(allLabels);
+    }
+
+    const accountMetadata = selectLabelingDataForAccount(state, account.key);
+
+    return fromLegacyMetadataToSearchAccountLabels(accountMetadata);
+};

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -3,10 +3,6 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import {
-    fromLegacyMetadataToSearchOutputLabels,
-    selectLabelingDataForSelectedAccount,
-} from '@suite/metadata';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
@@ -32,6 +28,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { selectCurrentTargetAnonymity } from 'src/reducers/wallet/coinjoinReducer';
+import { selectAccountLabelsForSearch } from 'src/selectors/suite/selectAccountLabelsForSearch';
 
 import { UtxoSearch } from './UtxoSearch';
 import { UtxoSelectionList } from './UtxoSelectionList/UtxoSelectionList';
@@ -50,11 +47,6 @@ type CoinControlProps = {
 export const CoinControl = ({ close }: CoinControlProps) => {
     const [currentPage, setSelectedPage] = useState(1);
     const [searchQuery, setSearchQuery] = useState('');
-    const { outputLabels: legacyOutputLabels } = useSelector(selectLabelingDataForSelectedAccount);
-    const outputLabels = fromLegacyMetadataToSearchOutputLabels(legacyOutputLabels);
-    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
-    const dispatch = useDispatch();
-
     const {
         account,
         formState: { errors },
@@ -74,6 +66,9 @@ export const CoinControl = ({ close }: CoinControlProps) => {
             toggleCoinControl,
         },
     } = useSendFormContext();
+    const { outputLabels } = useSelector(state => selectAccountLabelsForSearch(state, account));
+    const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
+    const dispatch = useDispatch();
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
 

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
+import {
+    fromLegacyMetadataToSearchOutputLabels,
+    selectLabelingDataForSelectedAccount,
+} from '@suite/metadata';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
@@ -47,7 +50,8 @@ type CoinControlProps = {
 export const CoinControl = ({ close }: CoinControlProps) => {
     const [currentPage, setSelectedPage] = useState(1);
     const [searchQuery, setSearchQuery] = useState('');
-    const { outputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const { outputLabels: legacyOutputLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const outputLabels = fromLegacyMetadataToSearchOutputLabels(legacyOutputLabels);
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const dispatch = useDispatch();
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -65,7 +65,7 @@ export const TransactionList = ({
     const [searchQuery, setSearchQuery] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
 
-    const searchLabels = useMemo(
+    const legacyLabels = useMemo(
         () => fromLegacyMetadataToSearchAccountLabels(accountMetadata),
         [accountMetadata],
     );
@@ -74,11 +74,11 @@ export const TransactionList = ({
 
     useDebounce(
         () => {
-            const results = advancedSearchTransactions(transactions, searchLabels, searchQuery);
+            const results = advancedSearchTransactions(transactions, legacyLabels, searchQuery);
             setSearchedTransactions(results);
         },
         200,
-        [transactions, searchQuery, searchLabels],
+        [transactions, searchQuery, legacyLabels],
     );
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -65,7 +65,7 @@ export const TransactionList = ({
     const [searchQuery, setSearchQuery] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
 
-    const legacyLabels = useMemo(
+    const searchLabels = useMemo(
         () => fromLegacyMetadataToSearchAccountLabels(accountMetadata),
         [accountMetadata],
     );
@@ -74,11 +74,11 @@ export const TransactionList = ({
 
     useDebounce(
         () => {
-            const results = advancedSearchTransactions(transactions, legacyLabels, searchQuery);
+            const results = advancedSearchTransactions(transactions, searchLabels, searchQuery);
             setSearchedTransactions(results);
         },
         200,
-        [transactions, searchQuery, legacyLabels],
+        [transactions, searchQuery, searchLabels],
     );
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -3,10 +3,6 @@ import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import { Translation } from '@suite/intl';
-import {
-    fromLegacyMetadataToSearchAccountLabels,
-    selectLabelingDataForAccount,
-} from '@suite/metadata';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
 import { groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
@@ -16,6 +12,7 @@ import { arrayPartition } from '@trezor/utils';
 import { DashboardSection } from 'src/components/dashboard';
 import { Pagination } from 'src/components/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectAccountLabelsForSearch } from 'src/selectors/suite/selectAccountLabelsForSearch';
 import { Account, WalletAccountTransaction } from 'src/types/wallet';
 import { findAnchorTransactionPage } from 'src/utils/suite/anchor';
 
@@ -57,18 +54,13 @@ export const TransactionList = ({
 }: TransactionListProps) => {
     const anchor = useSelector(state => state.router.anchor);
     const dispatch = useDispatch();
-    const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, account.key));
+    const searchLabels = useSelector(state => selectAccountLabelsForSearch(state, account));
 
     const { fetchPage, fetchedAll, fetchAll } = useFetchTransactions(account, allTransactions);
 
     // Search
     const [searchQuery, setSearchQuery] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
-
-    const searchLabels = useMemo(
-        () => fromLegacyMetadataToSearchAccountLabels(accountMetadata),
-        [accountMetadata],
-    );
 
     const sectionRef = useRef<HTMLDivElement>(null);
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -3,7 +3,10 @@ import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import { Translation } from '@suite/intl';
-import { selectLabelingDataForAccount } from '@suite/metadata';
+import {
+    fromLegacyMetadataToSearchAccountLabels,
+    selectLabelingDataForAccount,
+} from '@suite/metadata';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
 import { groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
@@ -62,15 +65,20 @@ export const TransactionList = ({
     const [searchQuery, setSearchQuery] = useState('');
     const [searchedTransactions, setSearchedTransactions] = useState(transactions);
 
+    const searchLabels = useMemo(
+        () => fromLegacyMetadataToSearchAccountLabels(accountMetadata),
+        [accountMetadata],
+    );
+
     const sectionRef = useRef<HTMLDivElement>(null);
 
     useDebounce(
         () => {
-            const results = advancedSearchTransactions(transactions, accountMetadata, searchQuery);
+            const results = advancedSearchTransactions(transactions, searchLabels, searchQuery);
             setSearchedTransactions(results);
         },
         200,
-        [transactions, account.metadata, searchQuery, accountMetadata],
+        [transactions, searchQuery, searchLabels],
     );
 
     useEffect(() => {

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -25,6 +25,7 @@
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
+        "@suite-common/transaction-search": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-common/suite-sync/src/data/account/selectSuiteSyncAccountLabel.ts
+++ b/suite-common/suite-sync/src/data/account/selectSuiteSyncAccountLabel.ts
@@ -11,7 +11,7 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRoot
 export const selectSuiteSyncAccountLabel = createMemoizedSelector(
     [
         (state: SuiteSyncDataRootState, walletDescriptor: WalletDescriptor | null) =>
-            walletDescriptor ? selectAllAccountsForWallet(state, walletDescriptor) : [],
+            selectAllAccountsForWallet(state, walletDescriptor),
         (
             _state: SuiteSyncDataRootState,
             _walletDescriptor: WalletDescriptor | null,

--- a/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
+++ b/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
@@ -1,0 +1,37 @@
+import { SuiteSyncAddress, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import { SearchAccountLabels, SearchOutputLabels, TxId } from '@suite-common/transaction-search';
+import { asTxTargetId } from '@suite-common/wallet-types';
+
+import { AllLabelsForAccount } from './selectAllLabelsForAccount';
+
+export const fromSuiteSyncToSearchOutputLabels = (
+    outputLabels: SuiteSyncOutput[] = [],
+): SearchOutputLabels =>
+    outputLabels.reduce<SearchOutputLabels>((acc, { txId, txTargetId, label }) => {
+        if (label === null) return acc;
+
+        if (!acc.has(txId as TxId)) {
+            acc.set(txId as TxId, new Map([[asTxTargetId(`${txTargetId}`), label]]));
+        } else {
+            acc.get(txId as TxId)?.set(asTxTargetId(`${txTargetId}`), label);
+        }
+
+        return acc;
+    }, new Map());
+
+const fromSuiteSyncToSearchAddressLabels = (
+    addressLabels: SuiteSyncAddress[] = [],
+): Map<string, string> =>
+    new Map(
+        addressLabels.flatMap(({ address, label }) =>
+            label === null ? [] : ([[address, label]] as const),
+        ),
+    );
+
+export const fromSuiteSyncToSearchAccountLabels = (
+    accountLabels: AllLabelsForAccount,
+): SearchAccountLabels => ({
+    accountLabel: accountLabels.accountLabel,
+    outputLabels: fromSuiteSyncToSearchOutputLabels(accountLabels.outputLabels),
+    addressLabels: fromSuiteSyncToSearchAddressLabels(accountLabels.addressLabels),
+});

--- a/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
+++ b/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.ts
@@ -19,7 +19,7 @@ export const fromSuiteSyncToSearchOutputLabels = (
         return acc;
     }, new Map());
 
-const fromSuiteSyncToSearchAddressLabels = (
+export const fromSuiteSyncToSearchAddressLabels = (
     addressLabels: SuiteSyncAddress[] = [],
 ): Map<string, string> =>
     new Map(

--- a/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
+++ b/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
@@ -1,3 +1,4 @@
+import { createWeakMapSelector } from '@suite-common/redux-utils';
 import type { SuiteSyncAddress, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
@@ -19,26 +20,38 @@ export type AllLabelsForAccount = {
     outputLabels: SuiteSyncOutput[];
 };
 
-export const selectAllLabelsForAccount = (
-    state: SuiteSyncDataRootState,
-    { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
-): AllLabelsForAccount => ({
-    accountLabel: selectSuiteSyncAccountLabel(
-        state,
-        walletDescriptor,
-        accountDescriptor,
-        networkSymbol,
-    ),
-    addressLabels: selectSuiteSyncAccountAddressesByAccount(
-        state,
-        walletDescriptor,
-        accountDescriptor,
-        networkSymbol,
-    ),
-    outputLabels: selectSuiteSyncOutputLabelsByAccount(
-        state,
-        walletDescriptor,
-        accountDescriptor,
-        networkSymbol,
-    ),
-});
+const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+
+export const selectAllLabelsForAccount = createMemoizedSelector(
+    [
+        (
+            state,
+            { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
+        ) => selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
+        (
+            state,
+            { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
+        ) =>
+            selectSuiteSyncAccountAddressesByAccount(
+                state,
+                walletDescriptor,
+                accountDescriptor,
+                networkSymbol,
+            ),
+        (
+            state,
+            { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
+        ) =>
+            selectSuiteSyncOutputLabelsByAccount(
+                state,
+                walletDescriptor,
+                accountDescriptor,
+                networkSymbol,
+            ),
+    ],
+    (accountLabel, addressLabels, outputLabels): AllLabelsForAccount => ({
+        accountLabel,
+        addressLabels,
+        outputLabels,
+    }),
+);

--- a/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
+++ b/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
@@ -1,3 +1,4 @@
+import type { SuiteSyncAddress, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
 
@@ -12,10 +13,16 @@ type SelectAllLabelsForAccountParams = {
     networkSymbol: NetworkSymbol;
 };
 
+export type AllLabelsForAccount = {
+    accountLabel: string | null;
+    addressLabels: SuiteSyncAddress[];
+    outputLabels: SuiteSyncOutput[];
+};
+
 export const selectAllLabelsForAccount = (
     state: SuiteSyncDataRootState,
     { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
-) => ({
+): AllLabelsForAccount => ({
     accountLabel: selectSuiteSyncAccountLabel(
         state,
         walletDescriptor,

--- a/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
+++ b/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
@@ -1,0 +1,37 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
+
+import { selectSuiteSyncAccountLabel } from '../account/selectSuiteSyncAccountLabel';
+import { selectSuiteSyncAccountAddressesByAccount } from '../address/suiteSyncAddressSelectors';
+import { selectSuiteSyncOutputLabelsByAccount } from '../output/suiteSyncOutputSelectors';
+import { SuiteSyncDataRootState } from '../suiteSyncDataReducer';
+
+type SelectAllLabelsForAccountParams = {
+    walletDescriptor: WalletDescriptor;
+    accountDescriptor: AccountDescriptor;
+    networkSymbol: NetworkSymbol;
+};
+
+export const selectAllLabelsForAccount = (
+    state: SuiteSyncDataRootState,
+    { walletDescriptor, accountDescriptor, networkSymbol }: SelectAllLabelsForAccountParams,
+) => ({
+    accountLabel: selectSuiteSyncAccountLabel(
+        state,
+        walletDescriptor,
+        accountDescriptor,
+        networkSymbol,
+    ),
+    addressLabels: selectSuiteSyncAccountAddressesByAccount(
+        state,
+        walletDescriptor,
+        accountDescriptor,
+        networkSymbol,
+    ),
+    outputLabels: selectSuiteSyncOutputLabelsByAccount(
+        state,
+        walletDescriptor,
+        accountDescriptor,
+        networkSymbol,
+    ),
+});

--- a/suite-common/suite-sync/src/data/labeling/tests/fromSuiteSyncToSearchAccountLabels.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/fromSuiteSyncToSearchAccountLabels.test.ts
@@ -8,7 +8,6 @@ import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 import {
     fromSuiteSyncToSearchAccountLabels,
-    fromSuiteSyncToSearchAddressLabels,
     fromSuiteSyncToSearchOutputLabels,
 } from '../fromSuiteSyncToSearchAccountLabels';
 
@@ -69,14 +68,6 @@ describe(fromSuiteSyncToSearchOutputLabels.name, () => {
 });
 
 describe(fromSuiteSyncToSearchAccountLabels.name, () => {
-    it('converts address labels to Map', () => {
-        const addressLabels = fromSuiteSyncToSearchAddressLabels(addressLabelsFixture);
-
-        expect(addressLabels).toBeInstanceOf(Map);
-        expect(addressLabels.get('tb1qaddress1')).toBe('Address label 1');
-        expect(addressLabels.get('tb1qaddress2')).toBeUndefined();
-    });
-
     it('converts account labels to search labels shape', () => {
         const searchLabels = fromSuiteSyncToSearchAccountLabels({
             accountLabel: null,
@@ -84,7 +75,7 @@ describe(fromSuiteSyncToSearchAccountLabels.name, () => {
             addressLabels: addressLabelsFixture,
         });
 
-        expect(searchLabels.accountLabel).toBeUndefined();
+        expect(searchLabels.accountLabel).toBeNull();
         expect(searchLabels.outputLabels).toBeInstanceOf(Map);
         expect(searchLabels.outputLabels.get('txid1')?.get('0')).toBe('Label A');
         expect(searchLabels.addressLabels).toBeInstanceOf(Map);

--- a/suite-common/suite-sync/src/data/labeling/tests/fromSuiteSyncToSearchAccountLabels.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/fromSuiteSyncToSearchAccountLabels.test.ts
@@ -1,0 +1,93 @@
+import {
+    SuiteSyncAddress,
+    SuiteSyncOutput,
+    createSuiteSyncAddressId,
+    createSuiteSyncOutputId,
+} from '@suite-common/suite-sync-storage';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+
+import {
+    fromSuiteSyncToSearchAccountLabels,
+    fromSuiteSyncToSearchAddressLabels,
+    fromSuiteSyncToSearchOutputLabels,
+} from '../fromSuiteSyncToSearchAccountLabels';
+
+const outputLabelsFixture: SuiteSyncOutput[] = [
+    {
+        id: createSuiteSyncOutputId('txid1', '0'),
+        txId: 'txid1',
+        txTargetId: '0',
+        label: 'Label A',
+        accountDescriptor: asAccountDescriptor('xpub...'),
+        networkSymbol: 'btc',
+    },
+    {
+        id: createSuiteSyncOutputId('txid1', '1'),
+        txId: 'txid1',
+        txTargetId: '1',
+        label: 'Label B',
+        accountDescriptor: asAccountDescriptor('xpub...'),
+        networkSymbol: 'btc',
+    },
+    {
+        id: createSuiteSyncOutputId('txid2', '0'),
+        txId: 'txid2',
+        txTargetId: '0',
+        label: null,
+        accountDescriptor: asAccountDescriptor('xpub...'),
+        networkSymbol: 'btc',
+    },
+];
+
+const addressLabelsFixture: SuiteSyncAddress[] = [
+    {
+        id: createSuiteSyncAddressId('tb1qaddress1', 'btc'),
+        address: 'tb1qaddress1',
+        label: 'Address label 1',
+        accountDescriptor: asAccountDescriptor('xpub...'),
+        networkSymbol: 'btc',
+    },
+    {
+        id: createSuiteSyncAddressId('tb1qaddress2', 'btc'),
+        address: 'tb1qaddress2',
+        label: null,
+        accountDescriptor: asAccountDescriptor('xpub...'),
+        networkSymbol: 'btc',
+    },
+];
+
+describe(fromSuiteSyncToSearchOutputLabels.name, () => {
+    it('converts output labels to nested Maps', () => {
+        const outputLabels = fromSuiteSyncToSearchOutputLabels(outputLabelsFixture);
+
+        expect(outputLabels).toBeInstanceOf(Map);
+        expect(outputLabels.get('txid1')).toBeInstanceOf(Map);
+        expect(outputLabels.get('txid1')?.get('0')).toBe('Label A');
+        expect(outputLabels.get('txid1')?.get('1')).toBe('Label B');
+        expect(outputLabels.get('txid2')).toBeUndefined();
+    });
+});
+
+describe(fromSuiteSyncToSearchAccountLabels.name, () => {
+    it('converts address labels to Map', () => {
+        const addressLabels = fromSuiteSyncToSearchAddressLabels(addressLabelsFixture);
+
+        expect(addressLabels).toBeInstanceOf(Map);
+        expect(addressLabels.get('tb1qaddress1')).toBe('Address label 1');
+        expect(addressLabels.get('tb1qaddress2')).toBeUndefined();
+    });
+
+    it('converts account labels to search labels shape', () => {
+        const searchLabels = fromSuiteSyncToSearchAccountLabels({
+            accountLabel: null,
+            outputLabels: outputLabelsFixture,
+            addressLabels: addressLabelsFixture,
+        });
+
+        expect(searchLabels.accountLabel).toBeUndefined();
+        expect(searchLabels.outputLabels).toBeInstanceOf(Map);
+        expect(searchLabels.outputLabels.get('txid1')?.get('0')).toBe('Label A');
+        expect(searchLabels.addressLabels).toBeInstanceOf(Map);
+        expect(searchLabels.addressLabels.get('tb1qaddress1')).toBe('Address label 1');
+    });
+});

--- a/suite-common/suite-sync/src/data/wallet/suiteSyncWalletSelectors.ts
+++ b/suite-common/suite-sync/src/data/wallet/suiteSyncWalletSelectors.ts
@@ -13,8 +13,9 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRoot
 
 export const selectWalletById = (
     state: SuiteSyncDataRootState,
-    walletDescriptor: WalletDescriptor,
-): WalletData | null => state.suiteSyncData.wallets[walletDescriptor] ?? null;
+    walletDescriptor: WalletDescriptor | null,
+): WalletData | null =>
+    walletDescriptor !== null ? (state.suiteSyncData.wallets[walletDescriptor] ?? null) : null;
 
 export const selectAllAccountsForWallet = createMemoizedSelector(
     [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
@@ -30,7 +31,7 @@ export const selectAllAccountsForWallet = createMemoizedSelector(
 export const selectAllAddressesForWallet = createMemoizedSelector(
     [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
     wallet => {
-        if (!wallet) {
+        if (wallet === null) {
             return returnStableArrayIfEmpty<SuiteSyncAddress>();
         }
 
@@ -41,7 +42,7 @@ export const selectAllAddressesForWallet = createMemoizedSelector(
 export const selectAllOutputsForWallet = createMemoizedSelector(
     [(state, walletDescriptor) => selectWalletById(state, walletDescriptor)],
     wallet => {
-        if (!wallet) {
+        if (wallet === null) {
             return returnStableArrayIfEmpty<SuiteSyncOutput>();
         }
 

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -50,6 +50,7 @@ export {
     selectSuiteSyncOutputLabel,
     selectSuiteSyncOutputLabels,
 } from './data/output/suiteSyncOutputSelectors';
+export { selectAllLabelsForAccount } from './data/labeling/selectAllLabelsForAccount';
 export { suiteSyncToBip329 } from './data/labeling/suiteSyncToBip329';
 export {
     isSuiteSyncSupportedByDevice,

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -53,6 +53,10 @@ export {
 export { selectAllLabelsForAccount } from './data/labeling/selectAllLabelsForAccount';
 export { suiteSyncToBip329 } from './data/labeling/suiteSyncToBip329';
 export {
+    fromSuiteSyncToSearchAccountLabels,
+    fromSuiteSyncToSearchOutputLabels,
+} from './data/labeling/fromSuiteSyncToSearchAccountLabels';
+export {
     isSuiteSyncSupportedByDevice,
     isFwUpgradeNeededForSuiteSync,
     getIsSuiteSyncLabelingActionEnabled,

--- a/suite-common/suite-sync/tsconfig.json
+++ b/suite-common/suite-sync/tsconfig.json
@@ -20,6 +20,7 @@
         { "path": "../suite-types" },
         { "path": "../suite-utils" },
         { "path": "../toast-notifications" },
+        { "path": "../transaction-search" },
         { "path": "../wallet-config" },
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },

--- a/suite-common/transaction-search/package.json
+++ b/suite-common/transaction-search/package.json
@@ -12,7 +12,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@suite-common/metadata-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",

--- a/suite-common/transaction-search/src/__fixtures__/filterAndCategorizeUtxosFixtures.ts
+++ b/suite-common/transaction-search/src/__fixtures__/filterAndCategorizeUtxosFixtures.ts
@@ -149,7 +149,7 @@ const filterByLabel: FilterAndCategorize[] = [
                     ...baseUtxo,
                 },
             ],
-            outputLabels: new Map([['2', new Map([[1, 'label']])]]),
+            outputLabels: new Map([['2', new Map([['1', 'label']])]]),
         },
         checkResult: result =>
             result.filteredUtxos.length == 1 &&

--- a/suite-common/transaction-search/src/__fixtures__/filterAndCategorizeUtxosFixtures.ts
+++ b/suite-common/transaction-search/src/__fixtures__/filterAndCategorizeUtxosFixtures.ts
@@ -1,5 +1,10 @@
 import { Utxo } from '@trezor/blockchain-link';
 
+import {
+    FilterAndCategorizeUtxosParams,
+    FilterAndCategorizeUtxosResult,
+} from '../filterAndCategorizeUtxos';
+
 export const baseUtxo: Omit<Utxo, 'address'> = {
     txid: '1',
     vout: 1,
@@ -9,25 +14,9 @@ export const baseUtxo: Omit<Utxo, 'address'> = {
     confirmations: 100,
 };
 
-type FilterUtxosParams = {
-    searchQuery: string;
-    utxos: Utxo[];
-    spendableUtxos: Utxo[];
-    lowAnonymityUtxos: Utxo[];
-    dustUtxos: Utxo[];
-    outputLabels: { [txid: string]: any };
-};
-
-type FilterUtxosResult = {
-    filteredUtxos: Utxo[];
-    filteredSpendableUtxos: Utxo[];
-    filteredLowAnonymityUtxos: Utxo[];
-    filteredDustUtxos: Utxo[];
-};
-
 type FilterAndCategorize = {
-    params: FilterUtxosParams;
-    checkResult: (result: FilterUtxosResult) => boolean;
+    params: FilterAndCategorizeUtxosParams;
+    checkResult: (result: FilterAndCategorizeUtxosResult) => boolean;
 };
 
 const filterByAddress: FilterAndCategorize[] = [
@@ -66,7 +55,7 @@ const filterByAddress: FilterAndCategorize[] = [
                     ...baseUtxo,
                 },
             ],
-            outputLabels: {},
+            outputLabels: new Map(),
         },
         checkResult: result =>
             result.filteredUtxos.length == 1 &&
@@ -112,7 +101,7 @@ const filterByTxid: FilterAndCategorize[] = [
                     ...baseUtxo,
                 },
             ],
-            outputLabels: {},
+            outputLabels: new Map(),
         },
         checkResult: result =>
             result.filteredUtxos.length == 3 &&
@@ -160,11 +149,7 @@ const filterByLabel: FilterAndCategorize[] = [
                     ...baseUtxo,
                 },
             ],
-            outputLabels: {
-                '2': {
-                    1: 'label',
-                },
-            },
+            outputLabels: new Map([['2', new Map([[1, 'label']])]]),
         },
         checkResult: result =>
             result.filteredUtxos.length == 1 &&

--- a/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
@@ -23,7 +23,7 @@ const toSearchOutputLabels = (
 const toSearchAccountLabels = (labels: {
     outputLabels: Record<string, Record<string, string>>;
     addressLabels: Record<string, string>;
-    accountLabel?: string;
+    accountLabel: string | null;
 }): SearchAccountLabels => ({
     ...labels,
     outputLabels: toSearchOutputLabels(labels.outputLabels),

--- a/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
@@ -1,16 +1,39 @@
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
+import { typedObjectEntries } from '@trezor/utils';
 
 import { searchTransactionsFixture } from '../__fixtures__/searchTransactions.fixture';
 import stMock from '../__fixtures__/searchTransactions.json';
 import { advancedSearchTransactions } from '../advancedSearchTransactions';
+import { SearchAccountLabels, SearchOutputLabels } from '../searchLabels';
+
+// Todo: this is the legacy-metadata => search type
+const asSearchOutputLabels = (
+    outputLabels: Record<string, Record<string, string>>,
+): SearchOutputLabels =>
+    new Map(
+        typedObjectEntries(outputLabels).map(([txid, outputs]) => [
+            txid,
+            new Map(typedObjectEntries(outputs).map(([targetId, label]) => [targetId, label])),
+        ]),
+    );
+
+const asSearchAccountLabels = (labels: {
+    outputLabels: Record<string, Record<string, string>>;
+    addressLabels: Record<string, string>;
+    accountLabel?: string;
+}): SearchAccountLabels => ({
+    ...labels,
+    outputLabels: asSearchOutputLabels(labels.outputLabels),
+    addressLabels: new Map(Object.entries(labels.addressLabels)),
+});
 
 describe(advancedSearchTransactions.name, () => {
     const transactions = stMock.transactions as unknown as WalletAccountTransaction[];
-    const metadata = stMock.labels;
+    const accountLabels = asSearchAccountLabels(stMock.labels);
 
     searchTransactionsFixture.forEach(f => {
         it(f.description, () => {
-            const search = advancedSearchTransactions(transactions, metadata, f.search);
+            const search = advancedSearchTransactions(transactions, accountLabels, f.search);
 
             if (f.result) {
                 // expect(search.length).toBe(f.result.length);

--- a/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/__tests__/advancedSearchTransactions.test.ts
@@ -6,8 +6,9 @@ import stMock from '../__fixtures__/searchTransactions.json';
 import { advancedSearchTransactions } from '../advancedSearchTransactions';
 import { SearchAccountLabels, SearchOutputLabels } from '../searchLabels';
 
-// Todo: this is the legacy-metadata => search type
-const asSearchOutputLabels = (
+// Original Fixtures were create with legacy metadata structure,
+// so we need to transform them to fit the new SearchAccountLabels structure used in the tests
+const toSearchOutputLabels = (
     outputLabels: Record<string, Record<string, string>>,
 ): SearchOutputLabels =>
     new Map(
@@ -17,19 +18,21 @@ const asSearchOutputLabels = (
         ]),
     );
 
-const asSearchAccountLabels = (labels: {
+// Original Fixtures were create with legacy metadata structure,
+// so we need to transform them to fit the new SearchAccountLabels structure used in the tests
+const toSearchAccountLabels = (labels: {
     outputLabels: Record<string, Record<string, string>>;
     addressLabels: Record<string, string>;
     accountLabel?: string;
 }): SearchAccountLabels => ({
     ...labels,
-    outputLabels: asSearchOutputLabels(labels.outputLabels),
+    outputLabels: toSearchOutputLabels(labels.outputLabels),
     addressLabels: new Map(Object.entries(labels.addressLabels)),
 });
 
 describe(advancedSearchTransactions.name, () => {
     const transactions = stMock.transactions as unknown as WalletAccountTransaction[];
-    const accountLabels = asSearchAccountLabels(stMock.labels);
+    const accountLabels = toSearchAccountLabels(stMock.labels);
 
     searchTransactionsFixture.forEach(f => {
         it(f.description, () => {

--- a/suite-common/transaction-search/src/__tests__/filterAndCategrizeUtxos.test.ts
+++ b/suite-common/transaction-search/src/__tests__/filterAndCategrizeUtxos.test.ts
@@ -36,7 +36,7 @@ describe(filterAndCategorizeUtxos.name, () => {
             spendableUtxos: [],
             lowAnonymityUtxos: [],
             utxos: [{ ...baseUtxo, address: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q' }],
-            outputLabels: {},
+            outputLabels: new Map(),
         });
 
         expect(categorized.filteredUtxos.map(utxo => utxo.address)).toStrictEqual([

--- a/suite-common/transaction-search/src/advancedSearchTransactions.ts
+++ b/suite-common/transaction-search/src/advancedSearchTransactions.ts
@@ -1,16 +1,16 @@
-import { AccountLabels } from '@suite-common/metadata-types';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 
+import { SearchAccountLabels } from './searchLabels';
 import { simpleSearchTransactions } from './simpleSearchTransactions';
 
 export const advancedSearchTransactions = (
     transactions: WalletAccountTransaction[],
-    accountMetadata: AccountLabels,
+    accountLabels: SearchAccountLabels,
     search: string,
 ) => {
     // No AND/OR operators, just run a simple search
     if (!search.includes('&') && !search.includes('|')) {
-        return simpleSearchTransactions(transactions, accountMetadata, search);
+        return simpleSearchTransactions(transactions, accountLabels, search);
     }
 
     // Split by OR operator first
@@ -27,13 +27,13 @@ export const advancedSearchTransactions = (
             if (!andSplit || andSplit.length === 1) {
                 return simpleSearchTransactions(
                     transactions,
-                    accountMetadata,
+                    accountLabels,
                     or.replace('&', ''),
                 ).flatMap(t => t.txid);
             }
 
             const andTxs = andSplit.flatMap(and =>
-                simpleSearchTransactions(transactions, accountMetadata, and).map(t => t.txid),
+                simpleSearchTransactions(transactions, accountLabels, and).map(t => t.txid),
             );
 
             const transactionCount: { [txid: string]: number } = {};

--- a/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
+++ b/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
@@ -1,29 +1,36 @@
-import { AccountOutputLabels } from '@suite-common/metadata-types';
 import { Utxo } from '@trezor/blockchain-link';
 
-export type OutputLabels = { [txid: string]: AccountOutputLabels };
+import { SearchOutputLabels } from './searchLabels';
 
-type FilterAndCategorizeUtxosParams = {
+export type FilterAndCategorizeUtxosParams = {
     searchQuery: string;
     utxos: Utxo[];
     spendableUtxos: Utxo[];
     lowAnonymityUtxos: Utxo[];
     dustUtxos: Utxo[];
-    outputLabels: OutputLabels;
+    outputLabels: SearchOutputLabels;
+};
+
+export type FilterAndCategorizeUtxosResult = {
+    filteredUtxos: Utxo[];
+    filteredSpendableUtxos: Utxo[];
+    filteredLowAnonymityUtxos: Utxo[];
+    filteredDustUtxos: Utxo[];
 };
 
 export const filterUtxos = (
     utxo: Utxo,
     searchQuery: string,
-    outputLabels?: OutputLabels,
+    outputLabels?: SearchOutputLabels,
 ): boolean => {
     const lowerCaseSearchQuery = searchQuery.toLowerCase();
+    const outputLabel = outputLabels?.get(utxo.txid)?.get(utxo.vout);
 
     return (
         utxo.address.toLowerCase().includes(lowerCaseSearchQuery) ||
         utxo.txid.toLowerCase().includes(lowerCaseSearchQuery) ||
-        (typeof outputLabels?.[utxo.txid]?.[utxo.vout] === 'string'
-            ? outputLabels[utxo.txid][utxo.vout].toLowerCase().includes(lowerCaseSearchQuery)
+        (typeof outputLabel === 'string'
+            ? outputLabel.toLowerCase().includes(lowerCaseSearchQuery)
             : false)
     );
 };
@@ -38,7 +45,7 @@ export const filterAndCategorizeUtxos = ({
     lowAnonymityUtxos,
     dustUtxos,
     outputLabels,
-}: FilterAndCategorizeUtxosParams) => {
+}: FilterAndCategorizeUtxosParams): FilterAndCategorizeUtxosResult => {
     const lowerCaseSearchQuery = searchQuery.toLowerCase();
 
     return {

--- a/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
+++ b/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
@@ -25,6 +25,9 @@ export const filterUtxos = (
 ): boolean => {
     const lowerCaseSearchQuery = searchQuery.toLowerCase();
     const accountOutputLabels = outputLabels?.get(utxo.txid);
+
+    // Todo: This `utxo.vout` is bad nad will not work for SuiteSync & Tokens
+    //       The `TxTargetId` type shall be constructed and used instead of `vout` number
     const outputLabel = accountOutputLabels?.get(String(utxo.vout));
 
     return (

--- a/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
+++ b/suite-common/transaction-search/src/filterAndCategorizeUtxos.ts
@@ -24,7 +24,8 @@ export const filterUtxos = (
     outputLabels?: SearchOutputLabels,
 ): boolean => {
     const lowerCaseSearchQuery = searchQuery.toLowerCase();
-    const outputLabel = outputLabels?.get(utxo.txid)?.get(utxo.vout);
+    const accountOutputLabels = outputLabels?.get(utxo.txid);
+    const outputLabel = accountOutputLabels?.get(String(utxo.vout));
 
     return (
         utxo.address.toLowerCase().includes(lowerCaseSearchQuery) ||

--- a/suite-common/transaction-search/src/index.ts
+++ b/suite-common/transaction-search/src/index.ts
@@ -3,3 +3,10 @@ export { filterAndCategorizeUtxos } from './filterAndCategorizeUtxos';
 export { useFilteredUtxos } from './useFilteredUtxos';
 export { useExcludedUtxos } from './useExcludedUtxos';
 export { getExcludedUtxos } from './getExcludedUtxos';
+export type {
+    SearchAccountLabels,
+    SearchAccountOutputLabels,
+    SearchOutputLabels,
+    TxId,
+    Address,
+} from './searchLabels';

--- a/suite-common/transaction-search/src/searchLabels.ts
+++ b/suite-common/transaction-search/src/searchLabels.ts
@@ -11,7 +11,7 @@ export type SearchAccountOutputLabels = Map<TxTargetId, string>;
 export type SearchOutputLabels = Map<TxId, SearchAccountOutputLabels>;
 
 export interface SearchAccountLabels {
-    accountLabel?: string;
+    accountLabel: string | null;
     outputLabels: SearchOutputLabels;
     addressLabels: Map<Address, string>;
 }

--- a/suite-common/transaction-search/src/searchLabels.ts
+++ b/suite-common/transaction-search/src/searchLabels.ts
@@ -1,7 +1,10 @@
 import { TxTargetId } from '@suite-common/wallet-types';
 
-export type TxId = string; // Todo: hopefully Branded type one day
-export type Address = string; // Todo: hopefully Branded type one day
+/** @deprecated hopefully Branded type one day */
+export type TxId = string;
+
+/** @deprecated hopefully Branded type one day */
+export type Address = string;
 
 export type SearchAccountOutputLabels = Map<TxTargetId, string>;
 

--- a/suite-common/transaction-search/src/searchLabels.ts
+++ b/suite-common/transaction-search/src/searchLabels.ts
@@ -1,0 +1,14 @@
+import { TxTargetId } from '@suite-common/wallet-types';
+
+export type TxId = string; // Todo: hopefully Branded type one day
+export type Address = string; // Todo: hopefully Branded type one day
+
+export type SearchAccountOutputLabels = Map<TxTargetId, string>;
+
+export type SearchOutputLabels = Map<TxId, SearchAccountOutputLabels>;
+
+export interface SearchAccountLabels {
+    accountLabel?: string;
+    outputLabels: SearchOutputLabels;
+    addressLabels: Map<Address, string>;
+}

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -73,7 +73,7 @@ const groupAddressesByLabel = (accountLabels: SearchAccountLabels) => {
 
 export const simpleSearchTransactions = (
     transactions: WalletAccountTransaction[],
-    accountLabels: SearchAccountLabels, // Todo: this is wrong, this shall reflect SuiteSync labels. See https://github.com/trezor/trezor-suite/issues/24803
+    accountLabels: SearchAccountLabels,
     search: string,
 ) => {
     // Trim

--- a/suite-common/transaction-search/src/simpleSearchTransactions.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.ts
@@ -1,10 +1,10 @@
-import { AccountLabels } from '@suite-common/metadata-types';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { isTokenTransferMatchesSearch } from '@suite-common/wallet-utils';
 import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
 import { getTargetAmounts } from './getTargetAmounts';
 import { numberSearchFilter } from './numberSearchFilter';
+import { SearchAccountLabels } from './searchLabels';
 import { searchOperators } from './searchOperations';
 
 const searchDateRegex = new RegExp(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/);
@@ -39,12 +39,12 @@ const groupTransactionIdsByAddress = (transactions: WalletAccountTransaction[]) 
     return addresses;
 };
 
-const groupTransactionsByLabel = (accountMetadata: AccountLabels) => {
+const groupTransactionsByLabel = (accountLabels: SearchAccountLabels) => {
     const labels: Record<string, string[]> = {};
-    const { outputLabels } = accountMetadata;
+    const { outputLabels } = accountLabels;
 
-    typedObjectKeys(outputLabels).forEach(txid => {
-        Object.values(outputLabels[txid]).forEach(label => {
+    outputLabels.forEach((accountOutputLabels, txid) => {
+        accountOutputLabels.forEach(label => {
             if (!labels[label]) {
                 labels[label] = [];
             }
@@ -56,13 +56,11 @@ const groupTransactionsByLabel = (accountMetadata: AccountLabels) => {
     return labels;
 };
 
-const groupAddressesByLabel = (accountMetadata: AccountLabels) => {
+const groupAddressesByLabel = (accountLabels: SearchAccountLabels) => {
     const labels: Record<string, string[]> = {};
-    const { addressLabels } = accountMetadata;
+    const { addressLabels } = accountLabels;
 
-    typedObjectKeys(addressLabels).forEach(address => {
-        const label = addressLabels[address];
-
+    addressLabels.forEach((label, address) => {
         if (!labels[label]) {
             labels[label] = [];
         }
@@ -75,7 +73,7 @@ const groupAddressesByLabel = (accountMetadata: AccountLabels) => {
 
 export const simpleSearchTransactions = (
     transactions: WalletAccountTransaction[],
-    accountMetadata: AccountLabels, // Todo: this is wrong, this shall reflect SuiteSync labels. See https://github.com/trezor/trezor-suite/issues/24803
+    accountLabels: SearchAccountLabels, // Todo: this is wrong, this shall reflect SuiteSync labels. See https://github.com/trezor/trezor-suite/issues/24803
     search: string,
 ) => {
     // Trim
@@ -151,7 +149,7 @@ export const simpleSearchTransactions = (
     }
 
     // Find by output label
-    const txsForOutputLabels = groupTransactionsByLabel(accountMetadata);
+    const txsForOutputLabels = groupTransactionsByLabel(accountLabels);
     const foundTxsForOutputLabel = typedObjectKeys(txsForOutputLabels).flatMap(label => {
         if (label.toLowerCase().includes(search.toLowerCase())) {
             return txsForOutputLabels[label];
@@ -162,7 +160,7 @@ export const simpleSearchTransactions = (
     txsToSearch.push(...foundTxsForOutputLabel);
 
     // Find by address label
-    const addressesForLabel = groupAddressesByLabel(accountMetadata);
+    const addressesForLabel = groupAddressesByLabel(accountLabels);
     const foundAddressesForLabel = typedObjectKeys(addressesForLabel).flatMap(label => {
         if (label.toLowerCase().includes(search.toLowerCase())) {
             return addressesForLabel[label];

--- a/suite-common/transaction-search/src/useFilteredUtxos.ts
+++ b/suite-common/transaction-search/src/useFilteredUtxos.ts
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 
 import { Utxo } from '@trezor/blockchain-link-types';
 
-import { OutputLabels, filterUtxos } from './filterAndCategorizeUtxos';
+import { filterUtxos } from './filterAndCategorizeUtxos';
+import { SearchOutputLabels } from './searchLabels';
 
 export const useFilteredUtxos = (
     utxos: Utxo[] = [],
     query: string = '',
-    outputLabels?: OutputLabels,
+    outputLabels?: SearchOutputLabels,
 ) =>
     useMemo(() => {
         if (!query.trim()) {

--- a/suite-common/transaction-search/tsconfig.json
+++ b/suite-common/transaction-search/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": { "outDir": "libDev" },
     "include": [".", "**/*.json"],
     "references": [
-        { "path": "../metadata-types" },
         { "path": "../test-utils" },
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -20,6 +20,7 @@
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
+        "@suite-common/transaction-search": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",

--- a/suite/metadata/src/__tests__/fromLegacyMatadataToSearchLabels.test.ts
+++ b/suite/metadata/src/__tests__/fromLegacyMatadataToSearchLabels.test.ts
@@ -1,0 +1,58 @@
+import { AccountLabels } from '@suite-common/metadata-types';
+
+import {
+    fromLegacyMetadataToSearchAccountLabels,
+    fromLegacyMetadataToSearchOutputLabels,
+} from '../fromLegacyMetadataToSearchLabels';
+
+describe('fromLegacyMetadataToSearchLabels', () => {
+    const accountLabelsFixture: AccountLabels = {
+        accountLabel: 'Account label',
+        outputLabels: {
+            txid1: {
+                '0': 'Label A',
+                '1': 'Label B',
+            },
+            txid2: {
+                abc: 'Label C',
+            },
+        },
+        addressLabels: {
+            tb1qaddress1: 'Address label 1',
+            tb1qaddress2: 'Address label 2',
+        },
+    };
+
+    it('converts output labels to nested Maps', () => {
+        const outputLabels = fromLegacyMetadataToSearchOutputLabels(
+            accountLabelsFixture.outputLabels,
+        );
+
+        expect(outputLabels).toBeInstanceOf(Map);
+        expect(outputLabels.get('txid1')).toBeInstanceOf(Map);
+        expect(outputLabels.get('txid1')?.get('0')).toBe('Label A');
+        expect(outputLabels.get('txid1')?.get('1')).toBe('Label B');
+        expect(outputLabels.get('txid2')?.get('abc')).toBe('Label C');
+    });
+
+    it('converts account labels to search labels shape', () => {
+        const searchLabels = fromLegacyMetadataToSearchAccountLabels(accountLabelsFixture);
+
+        expect(searchLabels.accountLabel).toBe('Account label');
+        expect(searchLabels.outputLabels).toBeInstanceOf(Map);
+        expect(searchLabels.outputLabels.get('txid1')?.get('0')).toBe('Label A');
+        expect(searchLabels.addressLabels).toBeInstanceOf(Map);
+        expect(searchLabels.addressLabels.get('tb1qaddress1')).toBe('Address label 1');
+    });
+
+    it('handles empty legacy structures', () => {
+        const searchLabels = fromLegacyMetadataToSearchAccountLabels({
+            accountLabel: '',
+            outputLabels: {},
+            addressLabels: {},
+        });
+
+        expect(searchLabels.outputLabels.size).toBe(0);
+        expect(searchLabels.addressLabels.size).toBe(0);
+    });
+});

--- a/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
+++ b/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
@@ -20,7 +20,7 @@ export const fromLegacyMetadataToSearchOutputLabels = (
 export const fromLegacyMetadataToSearchAccountLabels = (
     legacyLabels: AccountLabels,
 ): SearchAccountLabels => ({
-    accountLabel: legacyLabels.accountLabel,
+    accountLabel: legacyLabels.accountLabel ?? null,
     outputLabels: fromLegacyMetadataToSearchOutputLabels(legacyLabels.outputLabels),
     addressLabels: new Map(typedObjectEntries(legacyLabels.addressLabels ?? {})),
 });

--- a/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
+++ b/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
@@ -1,22 +1,17 @@
 import { AccountLabels, AccountOutputLabels } from '@suite-common/metadata-types';
-
-type SearchOutputLabels = Map<string, Map<string, string>>;
-
-type SearchAccountLabels = {
-    accountLabel?: string;
-    outputLabels: SearchOutputLabels;
-    addressLabels: Map<string, string>;
-};
+import { SearchAccountLabels, SearchOutputLabels, TxId } from '@suite-common/transaction-search';
+import { asTxTargetId } from '@suite-common/wallet-types';
+import { typedObjectEntries } from '@trezor/utils';
 
 export const fromLegacyMetadataToSearchOutputLabels = (
     outputLabels: AccountLabels['outputLabels'] = {},
 ): SearchOutputLabels =>
     new Map(
-        Object.entries(outputLabels).map(([txid, accountOutputLabels]) => [
-            txid,
+        typedObjectEntries(outputLabels).map(([txid, accountOutputLabels]) => [
+            txid as TxId,
             new Map(
-                Object.entries(accountOutputLabels as AccountOutputLabels).map(
-                    ([targetId, label]) => [targetId, label],
+                typedObjectEntries(accountOutputLabels as AccountOutputLabels).map(
+                    ([targetId, label]) => [asTxTargetId(`${targetId}`), label],
                 ),
             ),
         ]),
@@ -27,5 +22,5 @@ export const fromLegacyMetadataToSearchAccountLabels = (
 ): SearchAccountLabels => ({
     accountLabel: legacyLabels.accountLabel,
     outputLabels: fromLegacyMetadataToSearchOutputLabels(legacyLabels.outputLabels),
-    addressLabels: new Map(Object.entries(legacyLabels.addressLabels ?? {})),
+    addressLabels: new Map(typedObjectEntries(legacyLabels.addressLabels ?? {})),
 });

--- a/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
+++ b/suite/metadata/src/fromLegacyMetadataToSearchLabels.ts
@@ -1,0 +1,31 @@
+import { AccountLabels, AccountOutputLabels } from '@suite-common/metadata-types';
+
+type SearchOutputLabels = Map<string, Map<string, string>>;
+
+type SearchAccountLabels = {
+    accountLabel?: string;
+    outputLabels: SearchOutputLabels;
+    addressLabels: Map<string, string>;
+};
+
+export const fromLegacyMetadataToSearchOutputLabels = (
+    outputLabels: AccountLabels['outputLabels'] = {},
+): SearchOutputLabels =>
+    new Map(
+        Object.entries(outputLabels).map(([txid, accountOutputLabels]) => [
+            txid,
+            new Map(
+                Object.entries(accountOutputLabels as AccountOutputLabels).map(
+                    ([targetId, label]) => [targetId, label],
+                ),
+            ),
+        ]),
+    );
+
+export const fromLegacyMetadataToSearchAccountLabels = (
+    legacyLabels: AccountLabels,
+): SearchAccountLabels => ({
+    accountLabel: legacyLabels.accountLabel,
+    outputLabels: fromLegacyMetadataToSearchOutputLabels(legacyLabels.outputLabels),
+    addressLabels: new Map(Object.entries(legacyLabels.addressLabels ?? {})),
+});

--- a/suite/metadata/src/index.ts
+++ b/suite/metadata/src/index.ts
@@ -10,6 +10,7 @@ export { moveLabelsForRbfOldMetadataThunk } from './moveLabelsForRbfOldMetadataT
 export { MetadataProviderModal } from './MetadataProviderModal';
 export { slip15ToBip329 } from './slip15ToBip329';
 export { metadataMiddleware } from './metadataMiddleware';
+export * from './fromLegacyMetadataToSearchLabels';
 
 // used in e2e tests
 export * from './metadataUtils';

--- a/suite/metadata/tsconfig.json
+++ b/suite/metadata/tsconfig.json
@@ -34,6 +34,9 @@
             "path": "../../suite-common/toast-notifications"
         },
         {
+            "path": "../../suite-common/transaction-search"
+        },
+        {
             "path": "../../suite-common/wallet-config"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11408,6 +11408,7 @@ __metadata:
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
+    "@suite-common/transaction-search": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11592,7 +11592,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/transaction-search@workspace:suite-common/transaction-search"
   dependencies:
-    "@suite-common/metadata-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14504,6 +14504,7 @@ __metadata:
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
+    "@suite-common/transaction-search": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/24803

This PR adds a SuiteSync labels to the Transaction search. So you can filter transactions based on Suite Sync labels. 


<img width="1555" height="510" alt="image" src="https://github.com/user-attachments/assets/8b062b78-29d4-4e10-ae7e-dc83523fd070" />

<img width="951" height="476" alt="image" src="https://github.com/user-attachments/assets/66e97b7e-4683-49fc-b6f9-9cc1c39f8eb8" />




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tx-search&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tx-search&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tx-search&lookback=7)