### PR TITLE
fix(trading): fixed height in country picker modal

### DIFF
--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -151,7 +151,7 @@ const InnerModalBase = ({
                     <Box position={{ type: 'relative' }} overflow="hidden" flex="1">
                         <ShadowTop />
                         <ScrollContainer onScroll={onScroll} ref={scrollElementRef}>
-                            <Column padding={padding ? padding : spacings.md}>
+                            <Column padding={padding ? padding : spacings.md} height="100%">
                                 {iconName && (
                                     <Box
                                         margin={{

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
@@ -7,7 +7,7 @@ import {
     TradingCountryOption,
     useCountryFilteredData,
 } from '@suite-common/trading';
-import { Column, Flag, Input, Modal, Row, Text } from '@trezor/components';
+import { Column, Flag, Input, Modal, Paragraph, Row } from '@trezor/components';
 import { CardList } from '@trezor/product-components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -40,10 +40,11 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
     return (
         <Modal
             width={400}
+            height="85vh"
             onCancel={onClose}
             heading={heading ? <Translation id={heading} /> : undefined}
         >
-            <Column gap={16}>
+            <Column gap={16} height="100%">
                 <Input
                     onChange={ev => setFilterValue(ev.target.value)}
                     placeholder={translationString('TR_SEARCH_COUNTRY_PLACEHOLDER')}
@@ -68,10 +69,13 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
                     </CardList>
                 )}
                 {!filteredData.length && (
-                    <Column justifyContent="center">
-                        <Text align="center">
+                    <Column justifyContent="center" flex="0.75">
+                        <Paragraph align="center">
                             <Translation id="TR_TRADING_COUNTRY_NOT_FOUND" />
-                        </Text>
+                        </Paragraph>
+                        <Paragraph align="center" typographyStyle="body-sm" color="textSubdued">
+                            <Translation id="TR_TRADING_COUNTRY_NOT_FOUND_DESCRIPTION" />
+                        </Paragraph>
                     </Column>
                 )}
             </Column>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 
  - **Unify trading country picker modal layout** with fixed height and full-height content for consistent scrolling and centering.
  - **Improve empty-state UX for country search** with headline + descriptive helper copy and proper typography.
  - **Adjust shared `Modal` component layout** so modal body stretches vertically, avoiding clipped or awkwardly centered content.
  - **Add new intl key** `TR_TRADING_COUNTRY_NOT_FOUND_DESCRIPTION` for the helper text.

## Notes for QA: 
  - **Web – Trading country picker:** Open buy/sell form, open country modal, verify fixed-height modal, scroll works, close via X, backdrop, and Esc.
  - **Empty state:** Type a query with no results, confirm headline + description “Check the spelling or browse the list to select an option.” are both visible, centered, and not cut off.
  - **Result list:** Clear search, pick a country, confirm form value updates and modal closes normally.
  - **Regression – other modals:** Spot-check a few common modals using `Modal` (settings, confirmations, device/backup) to ensure vertical layout and scrolling still behave correctly (no extra empty space, no clipping).

## Related Issue:
Resolve #23990

## Screenshots:
<img width="426" height="723" alt="image" src="https://github.com/user-attachments/assets/02999607-3024-47d7-9b26-ba33efdfb497" />
<img width="443" height="735" alt="image" src="https://github.com/user-attachments/assets/6f5f0f5a-b40a-49eb-9804-18cc77b368fa" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23990/country-picker-modal&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23990/country-picker-modal&lookback=7)