### PR TITLE
Feat/native/use custom scheme for trading

### DIFF
--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -207,7 +207,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     return {
         ...config,
         name,
-        scheme: buildType === 'production' ? undefined : 'trezorsuite',
+        scheme: 'trezorsuite',
         slug: appSlugs[buildType],
         owner: appOwners[buildType],
         version: suiteNativeVersion,

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -21,7 +21,6 @@
         "@suite-common/trading": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/config": "workspace:*",
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/sentry": "workspace:*",

--- a/suite-native/trading-browser-auth/src/consts.ts
+++ b/suite-native/trading-browser-auth/src/consts.ts
@@ -1,9 +1,2 @@
-import { isProduction } from '@suite-native/config';
-
-const TRADING_URL_BASE_PRODUCTION = 'https://trezor.io/suite/deeplinks/trade';
-const TRADING_URL_BASE_DEV = 'trezorsuite://trading';
-
-// we don't want to expose custom scheme in production,
-// but we want to use custom scheme for develop as dev app has different app package
-export const TRADING_URL_BASE = isProduction() ? TRADING_URL_BASE_PRODUCTION : TRADING_URL_BASE_DEV;
+export const TRADING_URL_BASE = 'trezorsuite://trading';
 export const TRADING_URL_DEFAULT_BACK = `${TRADING_URL_BASE}/back`;

--- a/suite-native/trading-browser-auth/src/utils/__tests__/formUtils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/__tests__/formUtils.test.ts
@@ -1,60 +1,16 @@
-import type { FormResponse } from 'invity-api';
-
 import { trezorLogo } from '@suite-common/suite-constants';
 
-import type { BuildTradingUrlProps } from '../formUtils';
-
-const mockIsProduction = jest.fn();
-
-jest.mock('@suite-native/config', () => ({
-    isProduction: () => mockIsProduction(),
-}));
-
-const importModules = () => {
-    const { TRADING_URL_BASE, TRADING_URL_DEFAULT_BACK } = require('../../consts');
-    const {
-        applyHtmlTemplate,
-        buildTradingUrl,
-        getRequestFormSource,
-        getSourceForForm,
-    } = require('../formUtils');
-
-    return {
-        TRADING_URL_BASE: TRADING_URL_BASE as string,
-        TRADING_URL_DEFAULT_BACK: TRADING_URL_DEFAULT_BACK as string,
-        applyHtmlTemplate: applyHtmlTemplate as (
-            content?: string,
-            options?: Record<string, string>,
-        ) => string,
-        buildTradingUrl: buildTradingUrl as (props: BuildTradingUrlProps) => string,
-        getRequestFormSource: getRequestFormSource as (args: {
-            form?: FormResponse['form'];
-        }) => { uri?: string; html?: string } | null,
-        getSourceForForm: getSourceForForm as (
-            form: FormResponse['form'] | undefined,
-            backUrl?: string,
-        ) => { uri?: string; html?: string } | null,
-    };
-};
+import {
+    applyHtmlTemplate,
+    buildTradingUrl,
+    getRequestFormSource,
+    getSourceForForm,
+} from '../formUtils';
 
 describe('formUtils', () => {
-    describe('dev environment', () => {
-        let applyHtmlTemplate: ReturnType<typeof importModules>['applyHtmlTemplate'];
-        let buildTradingUrl: ReturnType<typeof importModules>['buildTradingUrl'];
-        let getRequestFormSource: ReturnType<typeof importModules>['getRequestFormSource'];
-        let getSourceForForm: ReturnType<typeof importModules>['getSourceForForm'];
-
-        beforeAll(() => {
-            mockIsProduction.mockReturnValue(false);
-            jest.isolateModules(() => {
-                ({ applyHtmlTemplate, buildTradingUrl, getRequestFormSource, getSourceForForm } =
-                    importModules());
-            });
-        });
-
-        describe('applyHtmlTemplate', () => {
-            it('should have content with dev back URL', () => {
-                expect(applyHtmlTemplate('CONTENT_TO_EMBED')).toBe(`
+    describe('applyHtmlTemplate', () => {
+        it('should have content', () => {
+            expect(applyHtmlTemplate('CONTENT_TO_EMBED')).toBe(`
         <!DOCTYPE html>
         <html>
             <head>
@@ -92,16 +48,16 @@ ${' '.repeat(16)}
             </body>
         </html>
     `);
-            });
+        });
 
-            it('should have content with options', () => {
-                expect(
-                    applyHtmlTemplate('CONTENT_TO_EMBED', {
-                        title: 'TITLE',
-                        script: 'SCRIPT',
-                        backUrl: 'BACK_URL',
-                    }),
-                ).toStrictEqual(`
+        it('should have content with options', () => {
+            expect(
+                applyHtmlTemplate('CONTENT_TO_EMBED', {
+                    title: 'TITLE',
+                    script: 'SCRIPT',
+                    backUrl: 'BACK_URL',
+                }),
+            ).toStrictEqual(`
         <!DOCTYPE html>
         <html>
             <head>
@@ -139,132 +95,101 @@ ${' '.repeat(16)}
             </body>
         </html>
     `);
+        });
+    });
+
+    describe('getRequestFormSource', () => {
+        it('should return null when no form is provided', () => {
+            expect(getRequestFormSource({})).toBeNull();
+        });
+
+        it('should return uri for GET formMethod', () => {
+            expect(
+                getRequestFormSource({
+                    form: {
+                        formMethod: 'GET',
+                        formAction: 'get_action',
+                        fields: {},
+                    },
+                }),
+            ).toStrictEqual({
+                uri: 'get_action',
             });
         });
 
-        describe('getRequestFormSource', () => {
-            it('should return null when no form is provided', () => {
-                expect(getRequestFormSource({})).toBeNull();
-            });
+        it('should return null for IFRAME formMethod', () => {
+            expect(
+                getRequestFormSource({
+                    form: {
+                        formMethod: 'IFRAME',
+                        formAction: 'get_action',
+                        fields: {},
+                    },
+                }),
+            ).toBeNull();
+        });
 
-            it('should return uri for GET formMethod', () => {
-                expect(
-                    getRequestFormSource({
-                        form: {
-                            formMethod: 'GET',
-                            formAction: 'get_action',
-                            fields: {},
-                        },
-                    }),
-                ).toStrictEqual({
-                    uri: 'get_action',
-                });
-            });
-
-            it('should return null for IFRAME formMethod', () => {
-                expect(
-                    getRequestFormSource({
-                        form: {
-                            formMethod: 'IFRAME',
-                            formAction: 'get_action',
-                            fields: {},
-                        },
-                    }),
-                ).toBeNull();
-            });
-
-            it('should create script with form for POST formMethod', () => {
-                expect(
-                    getRequestFormSource({
-                        form: {
-                            formMethod: 'POST',
-                            formAction: 'post_action',
-                            fields: { key1: 'value1', key2: 'value2' },
-                        },
-                    }),
-                ).toStrictEqual({
-                    html: `
+        it('should create script with form for POST formMethod', () => {
+            expect(
+                getRequestFormSource({
+                    form: {
+                        formMethod: 'POST',
+                        formAction: 'post_action',
+                        fields: { key1: 'value1', key2: 'value2' },
+                    },
+                }),
+            ).toStrictEqual({
+                html: `
         Forwarding to post_action...
         <form id="buy-form" method="POST" action="post_action" target='_self'>
         <input type="hidden" name="key1" value="value1"><input type="hidden" name="key2" value="value2">
         </form>
         <script type="text/javascript">document.getElementById("buy-form").submit();</script>`,
-                });
-            });
-        });
-
-        describe('getSourceForForm', () => {
-            it('should return null when no form is provided', () => {
-                expect(getSourceForForm(undefined)).toBeNull();
-            });
-
-            it('should return uri object for GET form', () => {
-                expect(
-                    getSourceForForm({
-                        formMethod: 'GET',
-                        formAction: 'get_action',
-                        fields: {},
-                    }),
-                ).toStrictEqual({
-                    uri: 'get_action',
-                });
-            });
-
-            it('should return html object for POST form', () => {
-                const result = getSourceForForm(
-                    {
-                        formMethod: 'POST',
-                        formAction: 'post_action',
-                        fields: { key: 'value' },
-                    },
-                    'custom_back_url',
-                );
-
-                expect(result).toHaveProperty('html');
-                expect(result?.html).toContain('post_action');
-                expect(result?.html).toContain('custom_back_url');
-            });
-        });
-
-        describe('buildTradingUrl', () => {
-            it('should return correct url format with dev base', () => {
-                expect(
-                    buildTradingUrl({
-                        actionType: 'quote',
-                        tradeType: 'buy',
-                        orderId: '1234',
-                    }),
-                ).toBe('trezorsuite://trading?action=quote&tradeType=buy&orderId=1234');
             });
         });
     });
 
-    describe('production environment', () => {
-        let applyHtmlTemplate: ReturnType<typeof importModules>['applyHtmlTemplate'];
-        let buildTradingUrl: ReturnType<typeof importModules>['buildTradingUrl'];
+    describe('getSourceForForm', () => {
+        it('should return null when no form is provided', () => {
+            expect(getSourceForForm(undefined)).toBeNull();
+        });
 
-        beforeAll(() => {
-            mockIsProduction.mockReturnValue(true);
-            jest.isolateModules(() => {
-                ({ applyHtmlTemplate, buildTradingUrl } = importModules());
+        it('should return uri object for GET form', () => {
+            expect(
+                getSourceForForm({
+                    formMethod: 'GET',
+                    formAction: 'get_action',
+                    fields: {},
+                }),
+            ).toStrictEqual({
+                uri: 'get_action',
             });
         });
 
-        it('should use production back URL in applyHtmlTemplate', () => {
-            const html = applyHtmlTemplate('CONTENT_TO_EMBED');
-            expect(html).toContain('href="https://trezor.io/suite/deeplinks/trade/back"');
-        });
+        it('should return html object for POST form', () => {
+            const result = getSourceForForm(
+                {
+                    formMethod: 'POST',
+                    formAction: 'post_action',
+                    fields: { key: 'value' },
+                },
+                'custom_back_url',
+            );
 
-        it('should return correct url format with production base', () => {
+            expect(result).toHaveProperty('html');
+            expect(result?.html).toContain('post_action');
+            expect(result?.html).toContain('custom_back_url');
+        });
+    });
+    describe('buildTradingUrl', () => {
+        it('should return correct url format', () => {
             expect(
                 buildTradingUrl({
                     actionType: 'quote',
                     tradeType: 'buy',
                     orderId: '1234',
                 }),
-            ).toBe(
-                'https://trezor.io/suite/deeplinks/trade?action=quote&tradeType=buy&orderId=1234',
-            );
+            ).toBe('trezorsuite://trading?action=quote&tradeType=buy&orderId=1234');
         });
     });
 });

--- a/suite-native/trading-browser-auth/src/utils/__tests__/utils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/__tests__/utils.test.ts
@@ -1,91 +1,43 @@
-const mockIsProduction = jest.fn();
-
-jest.mock('@suite-native/config', () => ({
-    isProduction: () => mockIsProduction(),
-}));
-
-const importModules = () => {
-    const { TRADING_URL_BASE, TRADING_URL_DEFAULT_BACK } = require('../../consts');
-    const { doesUrlContainCloseCallbackUrl } = require('../utils');
-
-    return { TRADING_URL_BASE, TRADING_URL_DEFAULT_BACK, doesUrlContainCloseCallbackUrl };
-};
+import { TRADING_URL_DEFAULT_BACK } from '../../consts';
+import { doesUrlContainCloseCallbackUrl } from '../utils';
 
 describe('utils', () => {
-    describe('doesUrlContainCloseCallbackUrl - dev', () => {
-        let doesUrlContainCloseCallbackUrl: (url: string, closeCallbackUrl?: string) => boolean;
+    describe('doesUrlContainCloseCallbackUrl', () => {
+        const closeCallbackUrl = 'trezorsuite://trading';
 
-        beforeAll(() => {
-            mockIsProduction.mockReturnValue(false);
-            jest.isolateModules(() => {
-                ({ doesUrlContainCloseCallbackUrl } = importModules());
-            });
-        });
-
-        it('should return true when URL contains dev base', () => {
+        it('should return true when URL contains closeCallbackUrl', () => {
             const url = 'trezorsuite://trading?action=trade&tradeType=buy&orderId=123';
-            expect(doesUrlContainCloseCallbackUrl(url, 'trezorsuite://trading')).toBe(true);
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
         });
 
-        it('should return true when URL contains dev default back', () => {
-            const url = 'trezorsuite://trading/back?action=trade&tradeType=buy&orderId=123';
+        it('should return true when URL contains TRADING_URL_DEFAULT_BACK', () => {
+            const url = `${TRADING_URL_DEFAULT_BACK}?action=trade&tradeType=buy&orderId=123`;
             expect(doesUrlContainCloseCallbackUrl(url)).toBe(true);
         });
 
-        it('should return false when URL does not match', () => {
+        it('should return false when URL does not contain TRADING_URL_DEFAULT_BACK', () => {
             const url = 'https://example.com/trading?action=trade&tradeType=buy&orderId=123';
             expect(doesUrlContainCloseCallbackUrl(url)).toBe(false);
         });
 
         it('should return false when URL does not contain closeCallbackUrl', () => {
             const url = 'https://example.com/trading?action=trade&tradeType=buy&orderId=123';
-            expect(doesUrlContainCloseCallbackUrl(url, 'trezorsuite://trading')).toBe(false);
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(false);
         });
 
         it('should handle empty URL', () => {
-            expect(doesUrlContainCloseCallbackUrl('', 'trezorsuite://trading')).toBe(false);
+            expect(doesUrlContainCloseCallbackUrl('', closeCallbackUrl)).toBe(false);
         });
 
         it('should handle URL with special characters', () => {
             const url =
                 'trezorsuite://trading?action=trade&tradeType=buy&orderId=dd070b73-fe29-4769-8be1-4075d6b43265&transactionId=8c9476a7-958b-412b-a378-3a3f59b6105a&baseCurrencyCode=czk&baseCurrencyAmount=384.78&transactionStatus=completed';
-            expect(doesUrlContainCloseCallbackUrl(url, 'trezorsuite://trading')).toBe(true);
-        });
-    });
-
-    describe('doesUrlContainCloseCallbackUrl - production', () => {
-        let TRADING_URL_BASE: string;
-        let TRADING_URL_DEFAULT_BACK: string;
-        let doesUrlContainCloseCallbackUrl: (url: string, closeCallbackUrl?: string) => boolean;
-
-        beforeAll(() => {
-            mockIsProduction.mockReturnValue(true);
-            jest.isolateModules(() => {
-                ({ TRADING_URL_BASE, TRADING_URL_DEFAULT_BACK, doesUrlContainCloseCallbackUrl } =
-                    importModules());
-            });
+            expect(doesUrlContainCloseCallbackUrl(url, closeCallbackUrl)).toBe(true);
         });
 
-        it('should use production URL base', () => {
-            expect(TRADING_URL_BASE).toBe('https://trezor.io/suite/deeplinks/trade');
-            expect(TRADING_URL_DEFAULT_BACK).toBe('https://trezor.io/suite/deeplinks/trade/back');
-        });
-
-        it('should return true when URL contains production base', () => {
-            const url =
-                'https://trezor.io/suite/deeplinks/trade?action=trade&tradeType=buy&orderId=123';
-            expect(doesUrlContainCloseCallbackUrl(url, TRADING_URL_BASE)).toBe(true);
-        });
-
-        it('should return true when URL contains production default back', () => {
-            const url =
-                'https://trezor.io/suite/deeplinks/trade/back?action=trade&tradeType=buy&orderId=123';
+        it('should handle url without specifying closeCallbackUrl', () => {
+            const url = `${TRADING_URL_DEFAULT_BACK}?action=trade&tradeType=buy&orderId=123`;
             expect(doesUrlContainCloseCallbackUrl(url)).toBe(true);
-        });
-
-        it('should not match dev URL with production base', () => {
-            const url = 'trezorsuite://trading?action=trade&tradeType=buy&orderId=123';
-            expect(doesUrlContainCloseCallbackUrl(url, TRADING_URL_BASE)).toBe(false);
         });
     });
 });

--- a/suite-native/trading-browser-auth/tsconfig.json
+++ b/suite-native/trading-browser-auth/tsconfig.json
@@ -13,7 +13,6 @@
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../atoms" },
-        { "path": "../config" },
         { "path": "../feature-flags" },
         { "path": "../intl" },
         { "path": "../sentry" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14237,7 +14237,6 @@ __metadata:
     "@suite-common/trading": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/config": "workspace:*"
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/sentry": "workspace:*"


### PR DESCRIPTION
- Enable custom scheme for production
- Revert usage of universal links for mobile trading in favour of custom schem

## Notes for QA
Url callbacks for buy and sell should work on prod app


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/use-custom-schem-for-trading&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/use-custom-schem-for-trading&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/use-custom-schem-for-trading&lookback=7)