### PR TITLE
fix(suite-native): Propagate BottomSheetModal style prop

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetModal.tsx
@@ -51,7 +51,6 @@ export const BottomSheetModal = forwardRef<BottomSheetModalMethods, BottomSheetM
         {
             children,
             footer,
-            style,
             title,
             isCloseDisplayed = false,
             subtitle,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reverts the unintentional change to BottomSheetModal style prop propagation.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:
### Before
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 12 52 36" src="https://github.com/user-attachments/assets/3a1a7b09-597f-4828-b76f-d1a945f2a44f" />

### After
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-02-26 at 13 06 04" src="https://github.com/user-attachments/assets/6185b19d-3ca4-4fd0-be32-56cefdaa5542" />



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-bottomsheetmodal-style-prop&lookback=7)