### PR TITLE
feat(suite-native): allow adding the next account (sequential indices)

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -16,7 +16,7 @@ import {
     changeCoinVisibility,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
-import { prepareNewAccountPayload } from '@suite-common/wallet-utils';
+import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
 import { CollapsibleBox, Modal, Tooltip } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { spacings, spacingsPx } from '@trezor/theme';
@@ -145,21 +145,10 @@ export const AddAccountModal = ({
             return undefined;
         }
 
-        const defaultAccount: NetworkAccount = {
-            bip43Path: selectedNetwork.bip43Path,
-            accountType: 'normal',
-        };
-        const otherAccounts = Object.values(selectedNetwork.accountTypes)
-            /**
-             * Filter out coinjoin account type if it is not visible.
-             * Visibility of coinjoin account type depends on coinjoin feature config in message system.
-             * By default it is visible publicly, but it can be remotely hidden under debug menu.
-             */
-            .filter(({ backendType }) => backendType !== 'coinjoin' || isCoinjoinVisible)
-            .filter(({ isDebugOnlyAccountType }) => !isDebugOnlyAccountType || isDebug);
-
-        // the default account is expected to be the first one
-        return [defaultAccount, ...otherAccounts];
+        return getAvailableAccountTypes(selectedNetwork.symbol, {
+            isCoinjoinVisible,
+            isDebug,
+        });
     }, [isCoinjoinVisible, isDebug, isSelectedNetworkEnabled, selectedNetwork]);
 
     const selectedNetworks = selectedNetwork ? [selectedNetwork.symbol] : [];

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -68,6 +68,9 @@ export const isAccountDiscoverable = ({ accountType }: Account) =>
 export const isEvmLedger = (networkType: NetworkType, accountType: AccountType) =>
     networkType === 'ethereum' && accountType === 'ledger';
 
+export const isEvmNetwork = (networkSymbol: NetworkSymbol): boolean =>
+    getNetwork(networkSymbol).networkType === 'ethereum';
+
 const getAccountIndexOffset = (networkType: NetworkType, accountType: AccountType): number =>
     isEvmLedger(networkType, accountType) ? 1 : 0;
 
@@ -1252,4 +1255,31 @@ export const accumulateAccountCountBySymbolAndType = (
     acc[id] = (acc[id] || 0) + 1;
 
     return acc;
+};
+
+export const getAvailableAccountTypes = (
+    networkSymbol: NetworkSymbol,
+    options: {
+        isCoinjoinVisible?: boolean;
+        isDebug?: boolean;
+    } = { isCoinjoinVisible: false, isDebug: false },
+): NetworkAccount[] => {
+    const { isCoinjoinVisible, isDebug } = options;
+    const network = getNetwork(networkSymbol);
+
+    const defaultAccount: NetworkAccount = {
+        bip43Path: network.bip43Path,
+        accountType: 'normal',
+    };
+    const otherAccounts = Object.values(network.accountTypes)
+        /**
+         * Filter out coinjoin account type if it is not visible.
+         * Visibility of coinjoin account type depends on coinjoin feature config in message system.
+         * By default it is visible publicly, but it can be remotely hidden under debug menu.
+         */
+        .filter(({ backendType }) => backendType !== 'coinjoin' || isCoinjoinVisible)
+        .filter(({ isDebugOnlyAccountType }) => !isDebugOnlyAccountType || isDebug);
+
+    // the default account is expected to be the first one
+    return [defaultAccount, ...otherAccounts];
 };

--- a/suite-native/module-add-accounts/package.json
+++ b/suite-native/module-add-accounts/package.json
@@ -19,6 +19,7 @@
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/accounts": "workspace:*",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/atoms": "workspace:*",

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -22,6 +22,11 @@ import {
     selectDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { Account } from '@suite-common/wallet-types';
+import {
+    getAvailableAccountTypes,
+    isEvmNetwork,
+    prepareNewAccountPayload,
+} from '@suite-common/wallet-utils';
 import { useAccountAlerts } from '@suite-native/accounts';
 import { useBottomSheetModal } from '@suite-native/atoms';
 import {
@@ -257,7 +262,7 @@ export const useAddCoinAccount = () => {
         closeModal();
     };
 
-    const checkCanAddAccount = (accounts: Account[]) => {
+    const checkCanAddAccount = (accounts: Account[], networkSymbol: NetworkSymbol) => {
         if (isDeviceInViewOnlyMode) {
             showViewOnlyAddAccountAlert();
 
@@ -271,7 +276,10 @@ export const useAddCoinAccount = () => {
             return false;
         }
 
-        // Do not allow showing another empty account if there is already one
+        if (isEvmNetwork(networkSymbol)) {
+            return true;
+        }
+
         const hasVisibleEmptyAccount = accounts.some(account => account.empty && account.visible);
 
         if (hasVisibleEmptyAccount) {
@@ -281,6 +289,63 @@ export const useAddCoinAccount = () => {
         }
 
         return true;
+    };
+
+    const createNewEvmAccount = async ({
+        symbol,
+        accountType,
+        accounts,
+        flowType,
+    }: {
+        symbol: NetworkSymbol;
+        accountType: AccountType;
+        accounts: Account[];
+        flowType: AddCoinFlowType;
+    }) => {
+        if (!device) {
+            showGeneralErrorAlert();
+
+            return;
+        }
+
+        const lastVisibleAccount = pipe(
+            accounts,
+            A.filter(account => account.visible),
+            A.sortBy(account => account.index),
+            A.last,
+        );
+
+        const nextIndex = lastVisibleAccount ? lastVisibleAccount.index + 1 : 0;
+        const network = networks[symbol];
+        const networkAccount = network.accountTypes[accountType];
+        const allAccountTypes = getAvailableAccountTypes(symbol);
+
+        const newAccountPayload = await prepareNewAccountPayload({
+            accountType,
+            networkSymbol: symbol,
+            index: nextIndex,
+            backendType:
+                lastVisibleAccount?.backendType !== 'coinjoin'
+                    ? lastVisibleAccount?.backendType
+                    : undefined,
+            selectedAccount: networkAccount,
+            accountTypes: allAccountTypes,
+            device,
+        });
+
+        if (newAccountPayload instanceof Error) {
+            showGeneralErrorAlert();
+
+            return;
+        }
+
+        dispatch(accountsActions.createAccount(newAccountPayload));
+        navigateToSuccessorScreen({
+            flowType,
+            symbol,
+            accountType,
+            accountIndex: nextIndex,
+        });
     };
 
     const handleAccountTypeSelection = (flowType: AddCoinFlowType) => {
@@ -297,7 +362,7 @@ export const useAddCoinAccount = () => {
         }
     };
 
-    const addCoinAccount = ({
+    const addCoinAccount = async ({
         symbol,
         flowType,
         accountType = NORMAL_ACCOUNT_TYPE,
@@ -306,46 +371,58 @@ export const useAddCoinAccount = () => {
         flowType: AddCoinFlowType;
         accountType?: AccountType;
     }) => {
-        clearNetworkWithTypeToBeAdded();
-        if (!device?.state) {
+        try {
+            clearNetworkWithTypeToBeAdded();
+
+            if (!device?.state) {
+                showGeneralErrorAlert();
+
+                return;
+            }
+
+            const accounts = deviceAccounts.filter(
+                account => account.symbol === symbol && account.accountType === accountType,
+            );
+
+            const canAddAccount = checkCanAddAccount(accounts, symbol);
+
+            if (!canAddAccount) {
+                return;
+            }
+
+            const firstHiddenEmptyAccount = pipe(
+                accounts,
+                A.filter(account => account.empty && !account.visible),
+                A.sortBy(account => account.index),
+                A.head,
+            );
+
+            // the account should already exist, but be invisible, so make it visible
+            if (firstHiddenEmptyAccount && !firstHiddenEmptyAccount.failed) {
+                dispatch(accountsActions.changeAccountVisibility(firstHiddenEmptyAccount));
+                navigateToSuccessorScreen({
+                    flowType,
+                    symbol,
+                    accountType,
+                    accountIndex: firstHiddenEmptyAccount.index ?? accounts.length,
+                });
+
+                return;
+            }
+
+            // For EVM networks: allow adding next account even if previous is empty
+            if (isEvmNetwork(symbol)) {
+                await createNewEvmAccount({ symbol, accountType, accounts, flowType });
+
+                return;
+            }
+
+            // or the account discovery might have failed
+            if (firstHiddenEmptyAccount?.failed) {
+                navigateToFailureScreen({ flowType, errorString: firstHiddenEmptyAccount.error });
+            }
+        } catch {
             showGeneralErrorAlert();
-
-            return;
-        }
-
-        const accounts = deviceAccounts.filter(
-            account => account.symbol === symbol && account.accountType === accountType,
-        );
-
-        const firstHiddenEmptyAccount = pipe(
-            accounts,
-            A.filter(account => account.empty && !account.visible),
-            A.sortBy(account => account.index),
-            A.head,
-        );
-
-        const canAddAccount = checkCanAddAccount(accounts);
-
-        if (!canAddAccount) {
-            return;
-        }
-
-        // the account should already exist, but be invisible, so make it visible
-        if (firstHiddenEmptyAccount && !firstHiddenEmptyAccount.failed) {
-            dispatch(accountsActions.changeAccountVisibility(firstHiddenEmptyAccount));
-            navigateToSuccessorScreen({
-                flowType,
-                symbol,
-                accountType,
-                accountIndex: firstHiddenEmptyAccount.index ?? accounts.length,
-            });
-
-            return;
-        }
-
-        // or the account discovery might have failed
-        if (firstHiddenEmptyAccount?.failed) {
-            navigateToFailureScreen({ flowType, errorString: firstHiddenEmptyAccount.error });
         }
     };
 
@@ -397,7 +474,7 @@ export const useAddCoinAccount = () => {
             clearNetworkWithTypeToBeAdded();
             // TODO why timeout?
             await new Promise(resolve => setTimeout(resolve, 100));
-            addCoinAccount({
+            await addCoinAccount({
                 symbol: networkSymbolWithTypeToBeAdded[0],
                 accountType: networkSymbolWithTypeToBeAdded[1],
                 flowType,

--- a/suite-native/module-add-accounts/tsconfig.json
+++ b/suite-native/module-add-accounts/tsconfig.json
@@ -15,6 +15,9 @@
         {
             "path": "../../suite-common/wallet-types"
         },
+        {
+            "path": "../../suite-common/wallet-utils"
+        },
         { "path": "../accounts" },
         { "path": "../alerts" },
         { "path": "../atoms" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12976,6 +12976,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/accounts": "workspace:*"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/atoms": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the user chooses to add another account, discovery now targets the immediate next index (N+1) for the selected network.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24374

## Screenshots:


https://github.com/user-attachments/assets/dcaca925-6b64-42cb-88ec-e7ce76f81ca8




🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/discovery-next-account&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/discovery-next-account&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/discovery-next-account&lookback=7)