### PR TITLE
fix(connect): increase required fw version for telemetry

### DIFF
--- a/packages/connect/e2e/__fixtures__/telemetryGet.ts
+++ b/packages/connect/e2e/__fixtures__/telemetryGet.ts
@@ -15,7 +15,7 @@ export default {
             },
             legacyResults: [
                 {
-                    rules: ['<2.10.1', '1'],
+                    rules: ['<2.11.0', '*T3W1'],
                     success: false,
                 },
             ],

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -241,8 +241,8 @@ export const config: Config = {
         {
             capabilities: ['telemetry'],
             methods: ['telemetryGet'],
-            min: { T1B1: '0', T2T1: '2.10.1', T2B1: '2.10.1', T3B1: '2.10.1', T3T1: '2.10.1' },
-            comment: ['Supported since 2.10.1'],
+            min: { T1B1: '0', T2T1: '0', T2B1: '0', T3B1: '0', T3T1: '0', T3W1: '2.11.0' },
+            comment: ['Supported since 2.11.0, only on T3W1'],
         },
     ],
 };

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -208,7 +208,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'no-support',
                 slip24: 'update-required',
-                telemetry: 'update-required',
+                telemetry: 'no-support',
                 tutorial: 'no-support',
                 ...T1B1_UPDATE_REQUIRED,
             });
@@ -242,7 +242,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'update-required',
                 slip24: 'update-required',
-                telemetry: 'update-required',
+                telemetry: 'no-support',
             });
         });
 
@@ -321,7 +321,7 @@ describe('utils/deviceFeaturesUtils', () => {
                 evmApproval: 'update-required',
                 evolu: 'no-support',
                 slip24: 'update-required',
-                telemetry: 'update-required',
+                telemetry: 'no-support',
                 tutorial: 'no-support',
                 monero: 'update-required',
                 ...T1B1_UPDATE_REQUIRED,


### PR DESCRIPTION
## Description

The current release FW version was bumped to 2.11.0 instead of 2.10.1
Also clarify it is only on T3W1
This helps solve issue with CI fails because of old 2.10.1 FW builds

## Notes for QA

Nothing to test


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/telemetry-capability-fw-ver&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/telemetry-capability-fw-ver&lookback=7)