### PR TITLE
fix(suite-native): Process other cancel code in recovery

### DIFF
--- a/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
@@ -24,7 +24,11 @@ export const WalletRecoveryScreen = ({
             });
         }
         // Do not retry if user cancelled the flow via the app UI
-        if (response.error.code && response.error.code === 'Method_Interrupted') return;
+        if (
+            response.error.code === 'Failure_ActionCancelled' ||
+            response.error.code === 'Method_Interrupted'
+        )
+            return;
 
         // This code is OK, but the eslint plugin crashes on recursive calls
         // eslint-disable-next-line react-hooks/immutability


### PR DESCRIPTION
## Description

Added other cancel code to prevent recovery loops.

## Notes for QA

**Affected areas:** Recovery flow on Android & iOS

## Related Issue

Resolve #21703

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/recovery-loop&lookback=7)