### PR TITLE
fix(connect): de-noise version check debug

### DIFF
--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -941,12 +941,15 @@ export class Device extends TypedEmitter<DeviceEvents> {
         const newVersion = getFirmwareOrBootloaderVersionArray(feat); // guaranteed to be FW mode here
         // This should never happen, it's indicative of a transport-level bug, so log to Sentry via console.error
         if (feat.device_id !== oldId) {
-            // transport descriptors are useful debug info, but no need to await, the side-effect to log to Sentry can run async
-            this.transport.enumerate().then(res => {
-                const descriptors = res.success ? res.payload : undefined;
+            // during wipe device, the same device (same path) changes id. This also ignores rare transport-level errors of mismatched response
+            if (feat.initialized === this.features?.initialized) {
                 const oldDevice = this.toMessageObject();
-                console.error('getFeatures response mismatched', oldDevice, feat, descriptors);
-            });
+                // transport descriptors are useful debug info, but no need to await, the side-effect to log to Sentry can run async
+                this.transport.enumerate().then(res => {
+                    const descriptors = res.success ? res.payload : undefined;
+                    console.error('getFeatures device id mismatch', oldDevice, feat, descriptors);
+                });
+            }
 
             return;
         }


### PR DESCRIPTION
## Description

In #24548 I added a debug message to investigate why [we sometimes get mismatched features response](https://satoshilabs.sentry.io/issues/7204404766), but the debug did not take account that `device_id` routinely changes on the same device object when device is wiped.

## QA notes

Wipe device → no error in console `getFeatures response mismatched`

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/features-mismatch-debug-code&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/features-mismatch-debug-code&lookback=7)