### PR TITLE
feat(trading): implement country subdivision handling in trading forms

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TradingBuyFormProps,
@@ -42,6 +43,15 @@ export const useTradingBuyHandleChange = ({
     const previousPromise = useRef<PromiseType>(null);
     const analytics = useAnalytics();
     const handleChange = useCallback(async () => {
+        if (
+            isCountrySubdivisionEmpty(
+                formValues.countrySelect?.value,
+                formValues.countrySubdivisionSelect?.value,
+            )
+        ) {
+            return;
+        }
+
         if (previousPromise.current) {
             previousPromise.current.abort('Request was replaced by another one.');
         }

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -4,6 +4,7 @@ import { useDebounce } from 'react-use';
 
 import { FiatCurrencyCode } from 'invity-api';
 
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_CRYPTO_TOKEN,
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -298,10 +299,26 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
     useEffect(() => {
         if (type !== 'sell' || pageType === 'confirm' || pageType === 'retry') return;
 
+        const sellValues = values as TradingSellFormProps;
+
+        // do not dispatch form requests until subdivision is set when country has subdivisions
+        if (
+            isCountrySubdivisionEmpty(
+                sellValues.countrySelect?.value,
+                sellValues.countrySubdivisionSelect?.value,
+            )
+        ) {
+            return;
+        }
+
         if (
             isChanged(
                 (previousValues.current as TradingSellFormProps | null)?.countrySelect,
-                (values as TradingSellFormProps).countrySelect,
+                sellValues.countrySelect,
+            ) ||
+            isChanged(
+                (previousValues.current as TradingSellFormProps | null)?.countrySubdivisionSelect,
+                sellValues.countrySubdivisionSelect,
             ) ||
             isChanged(
                 previousValues.current?.outputs?.[0]?.currency?.value,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TradingSellFormProps,
@@ -44,6 +45,15 @@ export const useTradingSellHandleChange = ({
     const previousPromise = useRef<PromiseType>(null);
     const analytics = useAnalytics();
     const handleChange = useCallback(async () => {
+        if (
+            isCountrySubdivisionEmpty(
+                formValues.countrySelect?.value,
+                formValues.countrySubdivisionSelect?.value,
+            )
+        ) {
+            return;
+        }
+
         if (previousPromise.current) {
             previousPromise.current.abort('Request was replaced by another one.');
         }

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -5,6 +5,7 @@ import type { BuyTrade, BuyTradeResponse, FiatCurrencyCode } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import { events } from '@suite/analytics';
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_FORM_CRYPTO_INPUT,
@@ -19,6 +20,7 @@ import {
     selectTradingBuy,
     selectTradingPaymentMethods,
     selectTradingVerifiedAddress,
+    tradingActions,
     tradingBuyActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -57,7 +59,8 @@ export const useTradingBuyForm = ({
 }: UseTradingFormProps): TradingBuyFormContextProps => {
     const analytics = useAnalytics();
     const type = 'buy';
-    const isNotFormPage = pageType !== 'form';
+    const isFormPage = pageType === 'form';
+    const isOffersPage = pageType === 'offers';
     const dispatch = useDispatch();
     const {
         buyInfo,
@@ -98,8 +101,13 @@ export const useTradingBuyForm = ({
           };
     useTradingFiatValues(fiatTradingValuesParams);
 
-    const { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod } =
-        useTradingBuyFormDefaultValues(account.symbol, buyInfo);
+    const {
+        defaultValues,
+        defaultCountry,
+        defaultSubdivision,
+        defaultCurrency,
+        defaultPaymentMethod,
+    } = useTradingBuyFormDefaultValues(account.symbol, buyInfo);
     const redirectValues = useTradingBuyFormRedirectValues(isFromRedirect, quotesRequest);
     const { saveDraft, draft, removeDraft } = useFormDraft<TradingBuyFormProps>(
         'trading-buy',
@@ -116,7 +124,7 @@ export const useTradingBuyForm = ({
           }
         : null;
 
-    const isDraft = !!draftUpdated || isNotFormPage;
+    const isDraft = !!draftUpdated || !isFormPage;
     const methods = useForm<TradingBuyFormProps>({
         mode: 'onChange',
         defaultValues: redirectValues || (isDraft && draftUpdated ? draftUpdated : defaultValues),
@@ -125,7 +133,7 @@ export const useTradingBuyForm = ({
     const values = useWatch({ control }) as TradingBuyFormProps;
     const { paymentMethod, provider } = values;
     const previousValues = useRef<TradingBuyFormProps | null>(
-        !isFromRedirect && isNotFormPage ? draftUpdated : null,
+        !isFromRedirect && !isFormPage ? draftUpdated : null,
     );
 
     const isAmountEmpty = !values.fiatInput && !values.cryptoInput;
@@ -386,12 +394,26 @@ export const useTradingBuyForm = ({
             !values.countrySelect ||
             !values.receiveAddress ||
             !values.currencySelect
-        )
+        ) {
             return;
+        }
+
+        if (
+            isCountrySubdivisionEmpty(
+                values.countrySelect?.value,
+                values.countrySubdivisionSelect?.value,
+            )
+        ) {
+            return;
+        }
 
         if (
             isChanged(previousValues.current?.cryptoSelect, values.cryptoSelect) ||
             isChanged(previousValues.current?.countrySelect, values.countrySelect) ||
+            isChanged(
+                previousValues.current?.countrySubdivisionSelect,
+                values.countrySubdivisionSelect,
+            ) ||
             isChanged(previousValues.current?.currencySelect, values.currencySelect) ||
             isChanged(previousValues.current?.receiveAddress, values?.receiveAddress) ||
             isChanged(previousValues.current?.cryptoSelect.id, values?.cryptoSelect.id)
@@ -402,14 +424,18 @@ export const useTradingBuyForm = ({
 
             previousValues.current = values;
         }
-    }, [previousValues, values, isNotFormPage, pageType, handleChange, handleSubmit]);
+    }, [previousValues, values, isFormPage, pageType, handleChange, handleSubmit]);
 
     useEffect(() => {
         // when draft doesn't exist, we need to bind actual default values - that happens when we've got buyInfo from Invity API server
         if (!isDraft && buyInfo) {
-            reset(defaultValues);
+            const currentReceiveAddress = values.receiveAddress;
+            reset({
+                ...defaultValues,
+                receiveAddress: currentReceiveAddress,
+            });
         }
-    }, [reset, buyInfo, defaultValues, isDraft]);
+    }, [reset, buyInfo, defaultValues, isDraft, values.receiveAddress]);
 
     useEffect(() => {
         if (!isChanged(defaultValues, values)) {
@@ -424,12 +450,13 @@ export const useTradingBuyForm = ({
     }, [defaultValues, values, removeDraft]);
 
     useEffect(() => {
-        if (!quotesRequest && isNotFormPage) {
+        // We need to clear quotes on offers page without redirecting to form page
+        if (!quotesRequest && !isFormPage && !isOffersPage) {
             navigateToBuyForm();
 
             return;
         }
-    }, [quotesRequest, isNotFormPage, navigateToBuyForm]);
+    }, [quotesRequest, isFormPage, isOffersPage, navigateToBuyForm]);
 
     useEffect(() => {
         if (isFromRedirect && quotesRequest) {
@@ -470,6 +497,7 @@ export const useTradingBuyForm = ({
         methods,
         account,
         defaultCountry,
+        defaultSubdivision,
         defaultCurrency,
         defaultPaymentMethod,
         paymentMethods,
@@ -493,6 +521,10 @@ export const useTradingBuyForm = ({
         removeDraft,
         setAmountLimits: (limits: TradingAmountLimitProps | undefined) => {
             dispatch(tradingBuyActions.setAmountLimits(limits));
+        },
+        clearQuotesAndParams: () => {
+            dispatch(tradingBuyActions.clearQuotesAndParams());
+            dispatch(tradingActions.savePaymentMethods([]));
         },
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormDefaultValues.ts
@@ -10,6 +10,7 @@ import {
     type TradingPaymentMethodListProps,
     enabledTradingCurrencies,
     getDefaultCountry,
+    getDefaultCountrySubdivision,
     regional,
     selectTradingPrefilledFromAccount,
     useTradingAssets,
@@ -37,6 +38,11 @@ export const useTradingBuyFormDefaultValues = (
         ? (buyInfo?.buyInfo?.country as TradingCountryCode | undefined)
         : regional.UNKNOWN_COUNTRY;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
+
+    const defaultSubdivision = useMemo(
+        () => getDefaultCountrySubdivision(buyInfo?.buyInfo?.subdivision),
+        [buyInfo?.buyInfo?.subdivision],
+    );
 
     // For testnet accounts, use default currency instead of casting to mainnet-only type
     const isTestnetAccount = !!networks[accountSymbol]?.testnet;
@@ -75,17 +81,19 @@ export const useTradingBuyFormDefaultValues = (
             currencySelect: defaultCurrency,
             cryptoSelect: defaultCrypto,
             countrySelect: defaultCountry,
+            countrySubdivisionSelect: defaultSubdivision,
             paymentMethod: defaultPaymentMethod,
             provider: undefined,
             amountInCrypto: false,
             receiveAddress: undefined,
         }),
-        [defaultCountry, defaultCrypto, defaultCurrency, defaultPaymentMethod],
+        [defaultCountry, defaultCrypto, defaultCurrency, defaultPaymentMethod, defaultSubdivision],
     );
 
     return {
         defaultValues,
         defaultCountry,
+        defaultSubdivision,
         defaultCurrency,
         defaultPaymentMethod,
         suggestedFiatCurrency,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyFormRedirectValues.ts
@@ -4,6 +4,7 @@ import {
     TradingBuyFormProps,
     TradingCountryCode,
     getDefaultCountry,
+    getDefaultCountrySubdivision,
     useTradingAssets,
 } from '@suite-common/trading';
 
@@ -22,6 +23,7 @@ export const useTradingBuyFormRedirectValues = (
         cryptoSelect: createAssetOptionFromCryptoId(quotesRequest.receiveCurrency),
         currencySelect: buildTradingFiatOption(quotesRequest.fiatCurrency as FiatCurrencyCode),
         countrySelect: getDefaultCountry(quotesRequest.country as TradingCountryCode),
+        countrySubdivisionSelect: getDefaultCountrySubdivision(quotesRequest.subdivision),
 
         // fill the input that corresponds to the entered amount type
         ...(quotesRequest.wantCrypto

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -27,6 +27,7 @@ import {
     selectTradingTrades,
     sellThunks,
     sellUtils,
+    tradingActions,
     tradingSellActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -65,7 +66,8 @@ export const useTradingSellForm = ({
 }: UseTradingFormProps): TradingSellFormContextProps => {
     const analytics = useAnalytics();
     const type = 'sell';
-    const isNotFormPage = pageType !== 'form';
+    const isFormPage = pageType === 'form';
+    const isOffersPage = pageType === 'offers';
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const {
@@ -129,8 +131,17 @@ export const useTradingSellForm = ({
             trade.tradeType === 'sell' && trade.key === transactionId,
     );
 
-    const { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod } =
-        useTradingSellFormDefaultValues(accountKey, sellInfo?.country);
+    const {
+        defaultValues,
+        defaultCountry,
+        defaultSubdivision,
+        defaultCurrency,
+        defaultPaymentMethod,
+    } = useTradingSellFormDefaultValues(
+        accountKey,
+        sellInfo?.country,
+        sellInfo?.countrySubdivision,
+    );
     const redirectValues = useTradingSellFormRedirectValues(isFromRedirect, quotesRequest);
     const { saveDraft, draft, removeDraft } = useFormDraft<TradingSellFormProps>('trading-sell');
     const getDraftUpdated = (): TradingSellFormProps | null => {
@@ -151,6 +162,7 @@ export const useTradingSellForm = ({
             ...defaultValues,
             paymentMethod: draft.paymentMethod,
             countrySelect: draft.countrySelect,
+            countrySubdivisionSelect: draft.countrySubdivisionSelect,
             amountInCrypto: draft.amountInCrypto,
         };
     };
@@ -530,7 +542,7 @@ export const useTradingSellForm = ({
         if (!isDraft && sellInfo && isInitialDataLoading) {
             reset(defaultValues);
         }
-    }, [reset, sellInfo, defaultValues, isDraft, isNotFormPage, isInitialDataLoading]);
+    }, [reset, sellInfo, defaultValues, isDraft, isFormPage, isInitialDataLoading]);
 
     useDebounce(
         () => {
@@ -557,12 +569,13 @@ export const useTradingSellForm = ({
     );
 
     useEffect(() => {
-        if (!quotesRequest && isNotFormPage) {
+        // We need to clear quotes on offers page without redirecting to form page
+        if (!quotesRequest && !isFormPage && !isOffersPage) {
             navigateToSellForm();
 
             return;
         }
-    }, [quotesRequest, isNotFormPage, navigateToSellForm]);
+    }, [quotesRequest, isFormPage, isOffersPage, navigateToSellForm]);
 
     useEffect(() => {
         if (isFromRedirect) {
@@ -598,6 +611,7 @@ export const useTradingSellForm = ({
         methods,
         account,
         defaultCountry,
+        defaultSubdivision,
         defaultCurrency,
         defaultPaymentMethod,
         paymentMethods,
@@ -628,5 +642,9 @@ export const useTradingSellForm = ({
         sendTransaction,
         showReserveBanner,
         setShowReserveBanner,
+        clearQuotesAndParams: () => {
+            dispatch(tradingActions.savePaymentMethods([]));
+            dispatch(tradingSellActions.clearQuotesAndParams());
+        },
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormDefaultValues.ts
@@ -6,6 +6,7 @@ import {
     type TradingPaymentMethodListProps,
     enabledTradingCurrencies,
     getDefaultCountry,
+    getDefaultCountrySubdivision,
     regional,
 } from '@suite-common/trading';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
@@ -27,6 +28,7 @@ import { useTradingFormAccount } from './useTradingFormAccount';
 export const useTradingSellFormDefaultValues = (
     accountKey: AccountKey,
     sellInfoCountry: TradingCountryCode | undefined,
+    sellInfoCountrySubdivision?: string,
 ): TradingSellFormDefaultValuesProps => {
     const { cryptoId } = useTradingFormAccount('sell');
     const { isTorEnabled } = useSelector(selectTorState);
@@ -36,7 +38,13 @@ export const useTradingSellFormDefaultValues = (
         cryptoId,
     });
     const country = !isTorEnabled ? sellInfoCountry : regional.UNKNOWN_COUNTRY;
+    const countrySubdivision = !isTorEnabled ? sellInfoCountrySubdivision : undefined;
     const defaultCountry = useMemo(() => getDefaultCountry(country), [country]);
+
+    const defaultSubdivision = useMemo(
+        () => getDefaultCountrySubdivision(countrySubdivision),
+        [countrySubdivision],
+    );
 
     const { address, token } = resolveAddressAndToken(account, defaultAsset?.contractAddress);
 
@@ -80,11 +88,18 @@ export const useTradingSellFormDefaultValues = (
             ...defaultFormState,
             sendCryptoSelect: defaultAsset,
             countrySelect: defaultCountry,
+            countrySubdivisionSelect: defaultSubdivision,
             paymentMethod: defaultPaymentMethod,
             amountInCrypto: true,
         }),
-        [defaultFormState, defaultAsset, defaultCountry, defaultPaymentMethod],
+        [defaultFormState, defaultAsset, defaultCountry, defaultPaymentMethod, defaultSubdivision],
     );
 
-    return { defaultValues, defaultCountry, defaultCurrency, defaultPaymentMethod };
+    return {
+        defaultValues,
+        defaultCountry,
+        defaultSubdivision,
+        defaultCurrency,
+        defaultPaymentMethod,
+    };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellFormRedirectValues.ts
@@ -8,6 +8,7 @@ import {
     TradingCountryCode,
     type TradingSellFormProps,
     getDefaultCountry,
+    getDefaultCountrySubdivision,
     selectTradingComposedTransactionInfo,
     useTradingAssets,
 } from '@suite-common/trading';
@@ -78,6 +79,7 @@ export const useTradingSellFormRedirectValues = (
               amountInCrypto: quotesRequest.amountInCrypto,
               sendCryptoSelect: sendCrypto?.asset,
               countrySelect: getDefaultCountry(quotesRequest.country as TradingCountryCode),
+              countrySubdivisionSelect: getDefaultCountrySubdivision(quotesRequest.subdivision),
               paymentMethod: quotesRequest.paymentMethod && {
                   value: quotesRequest.paymentMethod,
                   label: quotesRequest.paymentMethod,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -27,6 +27,7 @@ import type {
     TradingBuyType,
     TradingComposedTransactionInfo,
     TradingCountryOption,
+    TradingCountrySubdivisionOption,
     TradingExchangeFormProps,
     TradingExchangeInfoSelector,
     TradingExchangeType,
@@ -68,6 +69,7 @@ export interface TradingBuyFormDefaultValuesProps {
     defaultCurrency: TradingFiatCurrencyOption;
     defaultPaymentMethod: TradingPaymentMethodListProps;
     suggestedFiatCurrency: FiatCurrencyCode;
+    defaultSubdivision: TradingCountrySubdivisionOption | undefined;
 }
 
 export type TradingBuySellFormProps = TradingBuyFormProps | TradingSellFormProps;
@@ -82,6 +84,7 @@ export interface TradingSellFormDefaultValuesProps {
     defaultCountry: TradingCountryOption;
     defaultCurrency: TradingFiatCurrencyOption;
     defaultPaymentMethod: TradingPaymentMethodListProps;
+    defaultSubdivision: TradingCountrySubdivisionOption | undefined;
 }
 
 export interface TradingExchangeFormDefaultValuesProps {
@@ -108,6 +111,7 @@ interface TradingCommonFormProps {
 
 interface TradingCommonFormBuySellProps {
     defaultCountry: TradingCountryOption;
+    defaultSubdivision: TradingCountrySubdivisionOption | undefined;
     defaultCurrency: TradingFiatCurrencyOption;
     defaultPaymentMethod: TradingPaymentMethodListProps;
     paymentMethods: TradingPaymentMethodListProps[];
@@ -154,6 +158,7 @@ export interface TradingBuyFormContextProps
     removeDraft: (key: string) => void;
     setAmountLimits: (limits?: AmountLimitProps) => void;
     methods: UseFormReturn<TradingBuyFormProps>;
+    clearQuotesAndParams: () => void;
 }
 
 export interface TradingSellFormContextProps
@@ -192,6 +197,7 @@ export interface TradingSellFormContextProps
     methods: UseFormReturn<TradingSellFormProps>;
     showReserveBanner: boolean;
     setShowReserveBanner: (showReserveBanner: boolean) => void;
+    clearQuotesAndParams: () => void;
 }
 
 export type TradingExchangeConfirmTradeProps = {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 
+import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
+    TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
@@ -29,9 +31,11 @@ import {
     TradingFormInputBuyAssetProps,
 } from './TradingFormInput/TradingFormInputBuyAsset/TradingFormInputBuyAsset';
 import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
+import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
 
 export const TradingBuyFormInputs = () => {
     const context = useTradingFormContext<TradingBuyType>();
+    const { defaultCountry } = context;
 
     const { isLoading } = useSelector(selectTradingLoadingAndTimestamp);
 
@@ -39,6 +43,7 @@ export const TradingBuyFormInputs = () => {
     const {
         [TRADING_FORM_CRYPTO_CURRENCY_SELECT]: cryptoSelect,
         [TRADING_FORM_CRYPTO_INPUT]: cryptoInput,
+        [TRADING_FORM_COUNTRY_SELECT]: countrySelect,
         amountInCrypto,
         currencySelect,
     } = getValues();
@@ -59,6 +64,9 @@ export const TradingBuyFormInputs = () => {
     );
 
     const buySupportedCryptoIds = useSelector(selectTradingBuySupportedCryptoIds);
+
+    const selectedCountry = countrySelect ?? defaultCountry;
+    const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
 
     return (
         <Column gap={20}>
@@ -105,6 +113,13 @@ export const TradingBuyFormInputs = () => {
                     <TradingFormInputPaymentMethod label="TR_TRADING_PAYMENT_METHOD" />
                 )}
                 <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
+
+                {selectedCountry && countryRequiresSubdivision && (
+                    <TradingFormInputCountrySubdivision
+                        label="TR_TRADING_COUNTRY_SUBDIVISION"
+                        country={selectedCountry}
+                    />
+                )}
                 <TradingSelectedOfferProvider />
             </TradingFormCard>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
@@ -3,6 +3,7 @@ import { UseFormSetValue } from 'react-hook-form';
 import { Translation, TranslationKey, useTranslation } from '@suite/intl';
 import {
     TRADING_FORM_COUNTRY_SELECT,
+    TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
     TradingCountryOption,
     useCountryFilteredData,
 } from '@suite-common/trading';
@@ -20,13 +21,14 @@ interface CountrySelectModalProps {
 
 export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps) => {
     const { translationString } = useTranslation();
-    const { setValue, setAmountLimits } = useTradingFormContext<TradingTradeBuySellType>();
+    const { setValue, clearQuotesAndParams } = useTradingFormContext<TradingTradeBuySellType>();
     const { filteredData, setFilterValue, filterValue } = useCountryFilteredData();
 
     const selectCountry = (country: TradingCountryOption) => {
         const setValueTyped = setValue as UseFormSetValue<TradingBuySellFormProps>;
-        setValueTyped(TRADING_FORM_COUNTRY_SELECT, country);
-        setAmountLimits(undefined);
+        setValueTyped(TRADING_FORM_COUNTRY_SELECT, country, { shouldDirty: true });
+        setValueTyped(TRADING_FORM_COUNTRY_SUBDIVISION_SELECT, undefined, { shouldDirty: true });
+        clearQuotesAndParams();
         onClose();
     };
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
@@ -1,0 +1,77 @@
+import { UseFormSetValue } from 'react-hook-form';
+
+import { Translation, useTranslation } from '@suite/intl';
+import {
+    TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
+    TradingCountryOption,
+    TradingCountrySubdivisionOption,
+    useCountrySubdivisionFilteredData,
+} from '@suite-common/trading';
+import { CardList, Column, Input, Modal, Paragraph, Text } from '@trezor/components';
+
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { TradingTradeBuySellType } from 'src/types/trading/trading';
+import { TradingBuySellFormProps } from 'src/types/trading/tradingForm';
+
+interface CountrySubdivisionSelectModalProps {
+    onClose: () => void;
+    country: TradingCountryOption;
+}
+
+export const CountrySubdivisionSelectModal = ({
+    onClose,
+    country,
+}: CountrySubdivisionSelectModalProps) => {
+    const { translationString } = useTranslation();
+    const { setValue, setAmountLimits } = useTradingFormContext<TradingTradeBuySellType>();
+    const { filteredData, setFilterValue, filterValue } = useCountrySubdivisionFilteredData(
+        country.value,
+    );
+
+    const selectSubdivision = (subdivision: TradingCountrySubdivisionOption) => {
+        const setValueTyped = setValue as UseFormSetValue<TradingBuySellFormProps>;
+        setValueTyped(TRADING_FORM_COUNTRY_SUBDIVISION_SELECT, subdivision, { shouldDirty: true });
+        setAmountLimits(undefined);
+        onClose();
+    };
+
+    return (
+        <Modal
+            heading={<Translation id="TR_TRADING_COUNTRY_SUBDIVISION" />}
+            onCancel={onClose}
+            height="85vh"
+            width={400}
+        >
+            <Column gap={12}>
+                <Input
+                    value={filterValue}
+                    onChange={event => setFilterValue(event.target.value)}
+                    placeholder={translationString('TR_SEARCH_COUNTRY_PLACEHOLDER')}
+                />
+                {filteredData.length > 0 && (
+                    <CardList>
+                        {filteredData.map(subdivision => (
+                            <CardList.Item
+                                key={subdivision.value}
+                                onClick={() => selectSubdivision(subdivision)}
+                                data-testid={`@trading/form/country-subdivision-select/option/${subdivision.value}`}
+                            >
+                                <Text>{subdivision.name}</Text>
+                            </CardList.Item>
+                        ))}
+                    </CardList>
+                )}
+                {!filteredData.length && (
+                    <Column justifyContent="center">
+                        <Paragraph align="center">
+                            <Translation id="TR_TRADING_COUNTRY_SUBDIVISION_NOT_FOUND" />
+                        </Paragraph>
+                        <Paragraph align="center" typographyStyle="body-sm" color="textSubdued">
+                            <Translation id="TR_TRADING_COUNTRY_NOT_FOUND_DESCRIPTION" />
+                        </Paragraph>
+                    </Column>
+                )}
+            </Column>
+        </Modal>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Control, useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { TRADING_FORM_COUNTRY_SELECT } from '@suite-common/trading';
@@ -7,7 +8,10 @@ import { GhostContainer, Icon, Row, Text } from '@trezor/components';
 import { FakeSelect } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
-import { TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
+import {
+    TradingBuySellFormProps,
+    TradingFormInputDefaultProps,
+} from 'src/types/trading/tradingForm';
 
 import { CountrySelectModal } from './CountrySelectModal';
 
@@ -21,9 +25,12 @@ export const TradingFormInputCountry = ({
 }: TradingFormInputCountryProps) => {
     const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const { watch, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
+    const { control, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const countryValue = watch()[TRADING_FORM_COUNTRY_SELECT];
+    const countryValue = useWatch({
+        control: control as Control<TradingBuySellFormProps>,
+        name: TRADING_FORM_COUNTRY_SELECT,
+    });
 
     return (
         <>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+
+import { Translation, useTranslation } from '@suite/intl';
+import {
+    TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
+    TradingCountryOption,
+} from '@suite-common/trading';
+import { GhostContainer, Icon, Row, Text } from '@trezor/components';
+
+import { FakeSelect } from 'src/components/suite';
+import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { TradingTradeBuySellType } from 'src/types/trading/trading';
+import { TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
+
+import { CountrySubdivisionSelectModal } from './CountrySubdivisionSelectModal';
+
+interface TradingFormInputCountrySubdivisionProps extends TradingFormInputDefaultProps {
+    renderInput?: boolean;
+    country: TradingCountryOption;
+}
+
+export const TradingFormInputCountrySubdivision = ({
+    label,
+    renderInput = false,
+    country,
+}: TradingFormInputCountrySubdivisionProps) => {
+    const { translationString } = useTranslation();
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const { watch, defaultSubdivision } = useTradingFormContext<TradingTradeBuySellType>();
+
+    const subdivisionValue = watch()[TRADING_FORM_COUNTRY_SUBDIVISION_SELECT];
+
+    const subdivisionLabel = useMemo(() => {
+        const resolvedLabel = subdivisionValue?.label ?? defaultSubdivision?.label;
+
+        return (
+            resolvedLabel ?? (
+                <Text color="textSubdued">
+                    <Translation id="TR_TRADING_COUNTRY_SUBDIVISION_NOT_SELECTED" />
+                </Text>
+            )
+        );
+    }, [subdivisionValue, defaultSubdivision]);
+
+    return (
+        <>
+            {renderInput && (
+                <FakeSelect
+                    value={subdivisionValue?.label ?? defaultSubdivision?.label ?? ''}
+                    placeholder={label ? translationString(label) : undefined}
+                    onClick={() => setIsModalOpen(true)}
+                    data-testid="@trading/form/country-subdivision-select"
+                />
+            )}
+            {!renderInput && (
+                <GhostContainer
+                    onClick={() => setIsModalOpen(true)}
+                    borderRadius={0}
+                    data-testid="@trading/form/country-subdivision-select"
+                >
+                    <Row justifyContent="space-between" padding={20}>
+                        <Text typographyStyle="body-md" align="start">
+                            <Translation id="TR_TRADING_COUNTRY_SUBDIVISION" />
+                        </Text>
+                        <Row gap={16}>
+                            <Text
+                                typographyStyle="body-md"
+                                data-testid="@trading/form/country-subdivision-select/value"
+                            >
+                                {subdivisionLabel}
+                            </Text>
+                            <Icon
+                                name="caretRight"
+                                size={20}
+                                intent="neutral"
+                                priority="secondary"
+                            />
+                        </Row>
+                    </Row>
+                </GhostContainer>
+            )}
+            {isModalOpen && (
+                <CountrySubdivisionSelectModal
+                    onClose={() => setIsModalOpen(false)}
+                    country={country}
+                />
+            )}
+        </>
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import type { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_EXCHANGE_FORM_DEX,
     type TradingType,
@@ -95,7 +96,6 @@ export const TradingFormOffer = () => {
         type,
         quotes,
         isAmountEmpty,
-
         getValues,
         form: { state },
     } = context;
@@ -141,6 +141,16 @@ export const TradingFormOffer = () => {
     const isQuoteOutdated =
         isTradingExchangeContext(context) &&
         (quote as ExchangeTrade)?.send !== context.getValues('sendCryptoSelect')?.id;
+
+    const isSubdivisionMissing = useMemo(() => {
+        if (isTradingSellContext(context) || isTradingBuyContext(context)) {
+            const { countrySelect, countrySubdivisionSelect } = context.getValues();
+
+            return isCountrySubdivisionEmpty(countrySelect?.value, countrySubdivisionSelect?.value);
+        }
+
+        return false;
+    }, [context]);
 
     useEffect(() => {
         // confirm the quote once it loads
@@ -271,7 +281,7 @@ export const TradingFormOffer = () => {
                 )}
             </Column>
 
-            {!quote && !state.isFormLoading && !state.isFormInvalid && (
+            {!isSubdivisionMissing && !quote && !state.isFormLoading && !state.isFormInvalid && (
                 <Card>
                     <Paragraph
                         typographyStyle="body-sm"
@@ -288,6 +298,21 @@ export const TradingFormOffer = () => {
                                     : 'TR_TRADING_NO_OFFER_BUY_OR_SELL'
                             }
                         />
+                    </Paragraph>
+                </Card>
+            )}
+
+            {isSubdivisionMissing && (
+                <Card>
+                    <Paragraph
+                        typographyStyle="body-sm"
+                        intent="neutral"
+                        priority="secondary"
+                        align="center"
+                        margin={{ vertical: 8 }}
+                        data-testid="trading-offer-subdivision-required"
+                    >
+                        <Translation id="TR_TRADING_SUBDIVISION_REQUIRED_FOR_OFFERS" />
                     </Paragraph>
                 </Card>
             )}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
+import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
@@ -28,6 +29,7 @@ import { TradingFormCard } from './TradingFormCard';
 import { TradingFormFees } from './TradingFormFees';
 import { TradingSelectedOfferProvider } from '../TradingSelectedOffer/TradingSelectedOfferProvider';
 import { AssetPickerInputBalance } from './TradingFormInput/TradingFormInputAssetPicker';
+import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
 import {
     TradingFormInputSellAsset,
     TradingFormInputSellAssetProps,
@@ -49,9 +51,10 @@ export const TradingSellFormInputs = () => {
         changeFeeLevel,
         showReserveBanner,
         quotes,
+        defaultCountry,
     } = context;
     const { getValues } = useFormContext<TradingSellFormProps>();
-    const { outputs, sendCryptoSelect, amountInCrypto } = getValues();
+    const { outputs, sendCryptoSelect, amountInCrypto, countrySelect } = getValues();
     const output = outputs[0];
     const currencySelect = output.currency;
     const tokenAddress = (output.token ?? undefined) as TokenAddress | undefined;
@@ -80,6 +83,9 @@ export const TradingSellFormInputs = () => {
     );
 
     const sellSupportedCryptoIds = useSelector(selectTradingSellSupportedCryptoIds);
+
+    const selectedCountry = countrySelect ?? defaultCountry;
+    const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
 
     return (
         <Column gap={20}>
@@ -159,9 +165,14 @@ export const TradingSellFormInputs = () => {
                 {!!quotes.length && (
                     <TradingFormInputPaymentMethod label="TR_TRADING_RECEIVE_METHOD" />
                 )}
-                <TradingFormSection>
-                    <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
-                </TradingFormSection>
+
+                <TradingFormInputCountry label="TR_TRADING_COUNTRY" />
+                {countryRequiresSubdivision && (
+                    <TradingFormInputCountrySubdivision
+                        label="TR_TRADING_COUNTRY_SUBDIVISION"
+                        country={selectedCountry}
+                    />
+                )}
                 <TradingSelectedOfferProvider />
             </TradingFormCard>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
@@ -1,17 +1,23 @@
+import { Control, useWatch } from 'react-hook-form';
+
 import styled from 'styled-components';
 
+import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
+    TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
+    TradingTradeBuySellType,
 } from '@suite-common/trading';
 import { Row } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { TradingBuySellFormProps } from 'src/types/trading/tradingForm';
 import {
     isTradingBuyContext,
     isTradingExchangeContext,
@@ -21,14 +27,22 @@ import { TradingFormInputFiatCrypto } from 'src/views/wallet/trading/common/Trad
 import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod';
 import { TradingOffersExchangeFiltersPanel } from 'src/views/wallet/trading/common/TradingHeader/TradingOffersExchangeFiltersPanel';
 
+import { TradingFormInputCountrySubdivision } from '../TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
+
 const InputWrapper = styled.div`
-    width: 254px;
+    width: 200px;
     max-width: 100%;
     padding: ${spacingsPx.xxs} ${spacingsPx.md} ${spacingsPx.xxs} 0;
 `;
 
 export const TradingHeaderFilter = () => {
-    const context = useTradingFormContext();
+    const context = useTradingFormContext<TradingTradeBuySellType>();
+
+    const selectedCountry = useWatch({
+        control: context.control as Control<TradingBuySellFormProps>,
+        name: TRADING_FORM_COUNTRY_SELECT,
+    });
+    const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
 
     if (isTradingExchangeContext(context)) {
         return (
@@ -65,6 +79,15 @@ export const TradingHeaderFilter = () => {
             <InputWrapper>
                 <TradingFormInputCountry renderInput label="TR_TRADING_COUNTRY" />
             </InputWrapper>
+            {countryRequiresSubdivision && (
+                <InputWrapper>
+                    <TradingFormInputCountrySubdivision
+                        renderInput
+                        label="TR_TRADING_COUNTRY_SUBDIVISION"
+                        country={selectedCountry}
+                    />
+                </InputWrapper>
+            )}
         </Row>
     );
 };

--- a/suite-common/geolocation/jest.config.js
+++ b/suite-common/geolocation/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/geolocation/package.json
+++ b/suite-common/geolocation/package.json
@@ -7,7 +7,9 @@
     "main": "src/index",
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
+        "test-unit:watch": "yarn g:jest -o --watch"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",

--- a/suite-common/geolocation/src/countries.ts
+++ b/suite-common/geolocation/src/countries.ts
@@ -5,6 +5,11 @@ type Country = {
     name: string;
 };
 
+export type CountrySubdivision = {
+    code: string;
+    name: string;
+};
+
 export const countries = {
     AD: { code: 'AD', codeAlpha3: 'AND', flag: '🇦🇩', name: 'Andorra' },
     AE: { code: 'AE', codeAlpha3: 'ARE', flag: '🇦🇪', name: 'United Arab Emirates' },
@@ -272,6 +277,72 @@ export const countries = {
     ZM: { code: 'ZM', codeAlpha3: 'ZMB', flag: '🇿🇲', name: 'Zambia' },
     ZW: { code: 'ZW', codeAlpha3: 'ZWE', flag: '🇿🇼', name: 'Zimbabwe' },
 } as const satisfies Record<`${Uppercase<string>}`, Country>;
+
+export const usSubdivisions = [
+    { code: 'AK', name: 'Alaska' },
+    { code: 'AL', name: 'Alabama' },
+    { code: 'AR', name: 'Arkansas' },
+    { code: 'AS', name: 'American Samoa' },
+    { code: 'AZ', name: 'Arizona' },
+    { code: 'CA', name: 'California' },
+    { code: 'CO', name: 'Colorado' },
+    { code: 'CT', name: 'Connecticut' },
+    { code: 'DC', name: 'District of Columbia' },
+    { code: 'DE', name: 'Delaware' },
+    { code: 'FL', name: 'Florida' },
+    { code: 'GA', name: 'Georgia' },
+    { code: 'GU', name: 'Guam' },
+    { code: 'HI', name: 'Hawaii' },
+    { code: 'IA', name: 'Iowa' },
+    { code: 'ID', name: 'Idaho' },
+    { code: 'IL', name: 'Illinois' },
+    { code: 'IN', name: 'Indiana' },
+    { code: 'KS', name: 'Kansas' },
+    { code: 'KY', name: 'Kentucky' },
+    { code: 'LA', name: 'Louisiana' },
+    { code: 'MA', name: 'Massachusetts' },
+    { code: 'MD', name: 'Maryland' },
+    { code: 'ME', name: 'Maine' },
+    { code: 'MI', name: 'Michigan' },
+    { code: 'MN', name: 'Minnesota' },
+    { code: 'MO', name: 'Missouri' },
+    { code: 'MP', name: 'Northern Mariana Islands' },
+    { code: 'MS', name: 'Mississippi' },
+    { code: 'MT', name: 'Montana' },
+    { code: 'NC', name: 'North Carolina' },
+    { code: 'ND', name: 'North Dakota' },
+    { code: 'NE', name: 'Nebraska' },
+    { code: 'NH', name: 'New Hampshire' },
+    { code: 'NJ', name: 'New Jersey' },
+    { code: 'NM', name: 'New Mexico' },
+    { code: 'NV', name: 'Nevada' },
+    { code: 'NY', name: 'New York' },
+    { code: 'OH', name: 'Ohio' },
+    { code: 'OK', name: 'Oklahoma' },
+    { code: 'OR', name: 'Oregon' },
+    { code: 'PA', name: 'Pennsylvania' },
+    { code: 'PR', name: 'Puerto Rico' },
+    { code: 'RI', name: 'Rhode Island' },
+    { code: 'SC', name: 'South Carolina' },
+    { code: 'SD', name: 'South Dakota' },
+    { code: 'TN', name: 'Tennessee' },
+    { code: 'TX', name: 'Texas' },
+    { code: 'UM', name: 'United States Minor Outlying Islands' },
+    { code: 'UT', name: 'Utah' },
+    { code: 'VA', name: 'Virginia' },
+    { code: 'VI', name: 'U.S. Virgin Islands' },
+    { code: 'VT', name: 'Vermont' },
+    { code: 'WA', name: 'Washington' },
+    { code: 'WI', name: 'Wisconsin' },
+    { code: 'WV', name: 'West Virginia' },
+    { code: 'WY', name: 'Wyoming' },
+] as const satisfies ReadonlyArray<CountrySubdivision>;
+
+export const subdivisionsByCountry = {
+    US: usSubdivisions,
+} as const satisfies Partial<Record<keyof typeof countries, ReadonlyArray<CountrySubdivision>>>;
+
+export type CountryCodeWithSubdivisions = keyof typeof subdivisionsByCountry;
 
 // European Economic Area (EEA) - https://en.wikipedia.org/wiki/European_Economic_Area
 export const EEACountryCodes = [

--- a/suite-common/geolocation/src/index.ts
+++ b/suite-common/geolocation/src/index.ts
@@ -2,3 +2,4 @@ export * from './geolocationThunks';
 export * from './geolocationReducer';
 export * from './geolocationSelectors';
 export * from './countries';
+export * from './utils';

--- a/suite-common/geolocation/src/utils/__tests__/countryUtils.test.ts
+++ b/suite-common/geolocation/src/utils/__tests__/countryUtils.test.ts
@@ -1,0 +1,85 @@
+import { usSubdivisions } from '../../countries';
+import {
+    getCountrySubdivisionByCode,
+    getCountrySubdivisions,
+    hasCountrySubdivisions,
+    isCountryCode,
+    isCountrySubdivisionEmpty,
+    isCountrySubdivisionRequired,
+} from '../countryUtils';
+
+describe('countryUtils', () => {
+    describe('isCountryCode', () => {
+        it('returns true for ISO country code and cloudflare specific codes', () => {
+            expect(isCountryCode('US')).toBe(true);
+            expect(isCountryCode('XX')).toBe(true);
+            expect(isCountryCode('T1')).toBe(true);
+        });
+
+        it('returns false for invalid country code', () => {
+            expect(isCountryCode('INVALID')).toBe(false);
+        });
+    });
+
+    describe('hasCountrySubdivisions', () => {
+        it('returns true only for countries with subdivisions', () => {
+            expect(hasCountrySubdivisions('US')).toBe(true);
+            expect(hasCountrySubdivisions('DE')).toBe(false);
+        });
+    });
+
+    describe('isCountrySubdivisionRequired', () => {
+        it('returns true only when country has subdivisions', () => {
+            expect(isCountrySubdivisionRequired('US')).toBe(true);
+            expect(isCountrySubdivisionRequired('DE')).toBe(false);
+            expect(isCountrySubdivisionRequired('XX')).toBe(false);
+            expect(isCountrySubdivisionRequired(undefined)).toBe(false);
+        });
+    });
+
+    describe('isCountrySubdivisionEmpty', () => {
+        it('returns true only when subdivision is required and missing', () => {
+            expect(isCountrySubdivisionEmpty('US')).toBe(true);
+            expect(isCountrySubdivisionEmpty('US', 'CA')).toBe(false);
+            expect(isCountrySubdivisionEmpty('DE')).toBe(false);
+        });
+    });
+
+    describe('getCountrySubdivisions', () => {
+        it('returns subdivisions for countries that support them', () => {
+            expect(getCountrySubdivisions('US')).toEqual(usSubdivisions);
+        });
+
+        it('returns undefined for countries without subdivisions', () => {
+            expect(getCountrySubdivisions('DE')).toBeUndefined();
+        });
+    });
+
+    describe('getCountrySubdivisionByCode', () => {
+        it('returns subdivision when country with subdivisions is provided', () => {
+            expect(getCountrySubdivisionByCode('CA', 'US')).toEqual({
+                code: 'CA',
+                name: 'California',
+            });
+        });
+
+        it('returns undefined for unknown subdivision in selected country', () => {
+            expect(getCountrySubdivisionByCode('ZZ', 'US')).toBeUndefined();
+        });
+
+        it('falls back to global search when country has no subdivisions', () => {
+            expect(getCountrySubdivisionByCode('TX', 'DE')).toEqual({
+                code: 'TX',
+                name: 'Texas',
+            });
+        });
+
+        it('searches globally when country is not provided', () => {
+            expect(getCountrySubdivisionByCode('NY')).toEqual({
+                code: 'NY',
+                name: 'New York',
+            });
+            expect(getCountrySubdivisionByCode('ZZ')).toBeUndefined();
+        });
+    });
+});

--- a/suite-common/geolocation/src/utils/countryUtils.ts
+++ b/suite-common/geolocation/src/utils/countryUtils.ts
@@ -1,0 +1,41 @@
+import {
+    CountryCode,
+    CountryCodeWithSubdivisions,
+    CountrySubdivision,
+    countries,
+    subdivisionsByCountry,
+} from '../countries';
+
+export const isCountryCode = (countryCode: string): countryCode is CountryCode =>
+    countryCode in countries || countryCode === 'XX' || countryCode === 'T1';
+
+export const hasCountrySubdivisions = (
+    countryCode: CountryCode,
+): countryCode is CountryCodeWithSubdivisions => countryCode in subdivisionsByCountry;
+
+export const isCountrySubdivisionRequired = (countryCode?: string) =>
+    !!countryCode && isCountryCode(countryCode) && hasCountrySubdivisions(countryCode);
+
+export const isCountrySubdivisionEmpty = (countryCode?: string, subdivisionCode?: string) =>
+    isCountrySubdivisionRequired(countryCode) && !subdivisionCode;
+
+export const getCountrySubdivisions = (
+    countryCode: CountryCode,
+): ReadonlyArray<CountrySubdivision> | undefined =>
+    hasCountrySubdivisions(countryCode) ? subdivisionsByCountry[countryCode] : undefined;
+
+export const getCountrySubdivisionByCode = (
+    subdivisionCode: string,
+    countryCode?: CountryCode,
+): CountrySubdivision | undefined => {
+    if (countryCode && hasCountrySubdivisions(countryCode)) {
+        return subdivisionsByCountry[countryCode].find(s => s.code === subdivisionCode);
+    }
+
+    for (const subdivisions of Object.values(subdivisionsByCountry)) {
+        const match = subdivisions.find(s => s.code === subdivisionCode);
+        if (match) return match;
+    }
+
+    return undefined;
+};

--- a/suite-common/geolocation/src/utils/index.ts
+++ b/suite-common/geolocation/src/utils/index.ts
@@ -1,0 +1,8 @@
+export {
+    isCountryCode,
+    hasCountrySubdivisions,
+    isCountrySubdivisionRequired,
+    isCountrySubdivisionEmpty,
+    getCountrySubdivisions,
+    getCountrySubdivisionByCode,
+} from './countryUtils';

--- a/suite-common/suite-utils/src/__tests__/listFilterUtils.test.ts
+++ b/suite-common/suite-utils/src/__tests__/listFilterUtils.test.ts
@@ -1,0 +1,18 @@
+import { normalizeForSearch } from '../listFilterUtils';
+
+describe('normalizeForSearch', () => {
+    it.each([
+        ['Hello World', 'hello world'], // Basic casing
+        ['  Trim Me  ', 'trim me'], // Whitespace handling
+        ['Crème Brûlée', 'creme brulee'], // Accents/Diacritics
+        ['München', 'munchen'], // Umlauts
+        ['ñandú', 'nandu'], // Tildes
+        ['   Pikachu   ', 'pikachu'], // Combined trim + case
+        ['123-ABC', '123-abc'], // Numbers and symbols (remain)
+        ['', ''], // Empty string
+        ['!@#$%^&*()', '!@#$%^&*()'], // Special characters
+        ['STRANGE CASE', 'strange case'], // All caps
+    ])('should transform "%s" into "%s"', (input, expected) => {
+        expect(normalizeForSearch(input)).toBe(expected);
+    });
+});

--- a/suite-common/suite-utils/src/index.ts
+++ b/suite-common/suite-utils/src/index.ts
@@ -11,3 +11,4 @@ export * from './pollingController';
 export * from './triggerWebDownloadFile';
 export * from './translations';
 export * from './userAgent';
+export * from './listFilterUtils';

--- a/suite-common/suite-utils/src/listFilterUtils.ts
+++ b/suite-common/suite-utils/src/listFilterUtils.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalizes a string for search by removing diacritics, converting to lowercase, and trimming whitespace.
+ * Used by list filter callbacks (e.g. country and subdivision search).
+ */
+export const normalizeForSearch = (str: string): string =>
+    str
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .trim();

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -17,6 +17,7 @@
         "@suite-common/geolocation": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -17,6 +17,7 @@ import {
     filterQuotesAccordingTags,
     getBestRatedQuote,
     getDefaultCountry,
+    getDefaultCountrySubdivision,
     getTagAndInfoNote,
     getTradingFormState,
     getTradingPaymentMethods,
@@ -118,12 +119,16 @@ describe('addIdsToQuotes', () => {
 
         expect(addIdsToQuotes([], 'buy')).toStrictEqual([]);
         expect(addIdsToQuotes(undefined, 'buy')).toStrictEqual([]);
-        expect(addIdsToQuotes(quotes, 'buy').length).toStrictEqual(
-            quotes.filter(q => q.orderId && q.paymentId).length,
-        );
-        expect(addIdsToQuotes(quotesExchange, 'exchange').length).toStrictEqual(
-            quotesExchange.filter(q => q.orderId).length,
-        );
+
+        const buyResult = addIdsToQuotes(quotes, 'buy');
+        expect(buyResult.length).toStrictEqual(quotes.length);
+        expect(
+            buyResult.filter(q => q.orderId && 'paymentId' in q && q.paymentId).length,
+        ).toStrictEqual(quotes.length);
+
+        const exchangeResult = addIdsToQuotes(quotesExchange, 'exchange');
+        expect(exchangeResult.length).toStrictEqual(quotesExchange.length);
+        expect(exchangeResult.filter(q => q.orderId).length).toStrictEqual(quotesExchange.length);
     });
 });
 
@@ -293,6 +298,24 @@ describe('getDefaultCountry', () => {
             name: 'Worldwide',
             shortLabel: '🌍 Worldwide',
             value: 'unknown',
+        });
+    });
+});
+
+describe('getDefaultCountrySubdivision', () => {
+    it('should return undefined when subdivision is undefined', () => {
+        expect(getDefaultCountrySubdivision(undefined)).toBeUndefined();
+    });
+
+    it('should return undefined when subdivision code is not in the list', () => {
+        expect(getDefaultCountrySubdivision('XX')).toBeUndefined();
+    });
+
+    it('should return correct option for a known subdivision code', () => {
+        expect(getDefaultCountrySubdivision('CA')).toEqual({
+            value: 'CA',
+            label: 'California',
+            name: 'California',
         });
     });
 });

--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -39,6 +39,7 @@ export const TRADING_FORM_FIAT_CURRENCY_SELECT = 'currencySelect';
 export const TRADING_FORM_CRYPTO_INPUT = 'cryptoInput';
 export const TRADING_FORM_CRYPTO_CURRENCY_SELECT = 'cryptoSelect';
 export const TRADING_FORM_COUNTRY_SELECT = 'countrySelect';
+export const TRADING_FORM_COUNTRY_SUBDIVISION_SELECT = 'countrySubdivisionSelect';
 export const TRADING_FORM_PAYMENT_METHOD_SELECT = 'paymentMethod';
 export const TRADING_FORM_PROVIDER_SELECT = 'provider';
 export const TRADING_FORM_AMOUNT_IN_CRYPTO = 'amountInCrypto';

--- a/suite-common/trading/src/hooks/__tests__/useCountrySubdivisionFilteredData.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useCountrySubdivisionFilteredData.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useCountrySubdivisionFilteredData } from '../useCountrySubdivisionFilteredData';
+
+describe('useCountrySubdivisionFilteredData', () => {
+    it('should return empty data when countryCode is undefined', () => {
+        const { result } = renderHook(() => useCountrySubdivisionFilteredData(undefined));
+
+        expect(result.current.filteredData).toEqual([]);
+    });
+
+    it('should return empty data when country has no subdivisions', () => {
+        const { result } = renderHook(() => useCountrySubdivisionFilteredData('CZ'));
+
+        expect(result.current.filteredData).toEqual([]);
+    });
+
+    it('should return subdivision options for US', () => {
+        const { result } = renderHook(() => useCountrySubdivisionFilteredData('US'));
+
+        expect(result.current.filteredData.length).toBeGreaterThan(0);
+        expect(result.current.filteredData).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ value: 'CA', label: 'California', name: 'California' }),
+            ]),
+        );
+    });
+
+    it('should filter by name case-insensitive', () => {
+        const { result } = renderHook(() => useCountrySubdivisionFilteredData('US'));
+
+        act(() => {
+            result.current.setFilterValue('calif');
+        });
+
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ value: 'CA', name: 'California' }),
+        ]);
+    });
+
+    it('should filter by value (code)', () => {
+        const { result } = renderHook(() => useCountrySubdivisionFilteredData('US'));
+
+        act(() => {
+            result.current.setFilterValue('NY');
+        });
+
+        expect(result.current.filteredData).toEqual([
+            expect.objectContaining({ value: 'NY', name: 'New York' }),
+        ]);
+    });
+});

--- a/suite-common/trading/src/hooks/useCountryFilteredData.ts
+++ b/suite-common/trading/src/hooks/useCountryFilteredData.ts
@@ -1,17 +1,8 @@
+import { normalizeForSearch } from '@suite-common/suite-utils';
+
 import { nonSanctionedRegional } from '../regional';
 import { TradingCountryOption } from '../types';
 import { useListDataFilter } from './useListDataFilter';
-
-/**
- * Normalizes a string for search by removing diacritics, converting to lowercase, and trimming whitespace.
- * Countries are currently without diacritics, but this is to future-proof the function.
- */
-const normalizeForSearch = (str: string) =>
-    str
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .trim();
 
 const filterCallback = (
     { label, value, codeAlpha3 }: TradingCountryOption,

--- a/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.ts
+++ b/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+
+import { getCountrySubdivisions, isCountryCode } from '@suite-common/geolocation';
+import { normalizeForSearch } from '@suite-common/suite-utils';
+
+import type { TradingCountrySubdivisionOption } from '../types';
+import { useListDataFilter } from './useListDataFilter';
+
+const toSubdivisionOptions = (
+    subdivisions: ReadonlyArray<{ code: string; name: string }>,
+): TradingCountrySubdivisionOption[] =>
+    subdivisions.map(s => ({ value: s.code, label: s.name, name: s.name }));
+
+const filterCallback = (
+    { label, value, name }: TradingCountrySubdivisionOption,
+    filterValue: string,
+): boolean => {
+    const normalizedFilterValue = normalizeForSearch(filterValue);
+
+    return (
+        normalizeForSearch(label).includes(normalizedFilterValue) ||
+        normalizeForSearch(name).includes(normalizedFilterValue) ||
+        normalizeForSearch(value).includes(normalizedFilterValue)
+    );
+};
+
+const sortCallback = (
+    a: TradingCountrySubdivisionOption,
+    b: TradingCountrySubdivisionOption,
+    filterValue: string,
+): number => {
+    const query = normalizeForSearch(filterValue);
+    if (!query) return a.name.localeCompare(b.name);
+
+    const getWeight = (item: TradingCountrySubdivisionOption): number => {
+        const name = normalizeForSearch(item.name);
+        const value = normalizeForSearch(item.value);
+
+        if (name === query) return 0; // Exact match on name
+        if (value === query) return 1; // Exact match on value (code)
+        if (name.startsWith(query)) return 2; // Starts with match on name
+
+        return 3; // Other matches
+    };
+
+    const weightA = getWeight(a);
+    const weightB = getWeight(b);
+
+    if (weightA !== weightB) return weightA - weightB;
+
+    return a.name.localeCompare(b.name);
+};
+
+/**
+ * Filtered and sorted list of country subdivisions for a given country.
+ * Returns empty data when countryCode is missing or the country has no subdivisions.
+ */
+export const useCountrySubdivisionFilteredData = (countryCode: string | undefined) => {
+    const subdivisionOptions = useMemo(() => {
+        if (!countryCode || !isCountryCode(countryCode)) return [];
+
+        const subdivisions = getCountrySubdivisions(countryCode);
+
+        return subdivisions ? toSubdivisionOptions(subdivisions) : [];
+    }, [countryCode]);
+
+    return useListDataFilter(subdivisionOptions, filterCallback, sortCallback);
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -6,6 +6,7 @@ export * from './hooks/useTradingAssets';
 export * from './hooks/useTradingUtils';
 export * from './hooks/useListDataFilter';
 export * from './hooks/useCountryFilteredData';
+export * from './hooks/useCountrySubdivisionFilteredData';
 export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
 export * from './invityAPI';

--- a/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/buyReducer.test.ts
@@ -48,4 +48,15 @@ describe('tradingBuyReducer', () => {
             expect(state.lastErrorMessage).toBe('Some error');
         });
     });
+    describe('clearQuotesAndParams', () => {
+        it('should clear quotes, quotesRequest, selectedQuote, preselectedQuote, and amountLimits', () => {
+            const state = tradingBuyReducer(undefined, tradingBuyActions.clearQuotesAndParams());
+
+            expect(state.quotes).toEqual([]);
+            expect(state.quotesRequest).toBeUndefined();
+            expect(state.selectedQuote).toBeUndefined();
+            expect(state.preselectedQuote).toBeUndefined();
+            expect(state.amountLimits).toBeUndefined();
+        });
+    });
 });

--- a/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/sellReducer.test.ts
@@ -48,4 +48,15 @@ describe('tradingSellReducer', () => {
             expect(state.lastErrorMessage).toBe('Some error');
         });
     });
+    describe('clearQuotesAndParams', () => {
+        it('should clear quotes, quotesRequest, selectedQuote, preselectedQuote, and amountLimits', () => {
+            const state = tradingSellReducer(undefined, tradingSellActions.clearQuotesAndParams());
+
+            expect(state.quotes).toEqual([]);
+            expect(state.quotesRequest).toBeUndefined();
+            expect(state.selectedQuote).toBeUndefined();
+            expect(state.preselectedQuote).toBeUndefined();
+            expect(state.amountLimits).toBeUndefined();
+        });
+    });
 });

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -92,6 +92,13 @@ const tradingBuySlice = createSlice({
         setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
             state.lastErrorMessage = action.payload;
         },
+        clearQuotesAndParams(state) {
+            state.quotes = [];
+            state.quotesRequest = undefined;
+            state.selectedQuote = undefined;
+            state.preselectedQuote = undefined;
+            state.amountLimits = undefined;
+        },
     },
 });
 

--- a/suite-common/trading/src/reducers/sellReducer.ts
+++ b/suite-common/trading/src/reducers/sellReducer.ts
@@ -11,6 +11,7 @@ export interface SellInfo {
     supportedFiatCurrencies: string[];
     supportedCryptoCurrencies: CryptoId[];
     country: TradingCountryCode;
+    countrySubdivision?: string;
 }
 
 export type TradingSellState = {
@@ -82,6 +83,13 @@ const tradingSellSlice = createSlice({
         },
         setLastErrorMessage(state, action: PayloadAction<string | undefined>) {
             state.lastErrorMessage = action.payload;
+        },
+        clearQuotesAndParams(state) {
+            state.quotes = [];
+            state.quotesRequest = undefined;
+            state.selectedQuote = undefined;
+            state.preselectedQuote = undefined;
+            state.amountLimits = undefined;
         },
     },
 });

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -17,6 +17,8 @@ import { MIN_MAX_QUOTES_OK } from '../../../utils/buy/__fixtures__/buyUtils';
 import { buyThunks } from '../index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const createMockQuotes = () =>
+    [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES].map(quote => ({ ...quote }));
 
 describe('handleBuyRequestThunk', () => {
     afterEach(() => {
@@ -119,7 +121,7 @@ describe('handleBuyRequestThunk', () => {
 
     it('should successfully request quotes and save them', async () => {
         const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
-        const mockQuotes = [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES];
+        const mockQuotes = createMockQuotes();
 
         invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
 
@@ -141,7 +143,10 @@ describe('handleBuyRequestThunk', () => {
         expect(state.info.paymentMethods.length).toEqual(1);
         expect(state.isLoading).toBe(false);
         expect(mockTimerReset).toHaveBeenCalledTimes(1);
-        expect(quotesResponse).toEqual([mockQuotes[1], mockQuotes[6]]);
+        expect(quotesResponse).toEqual([
+            expect.objectContaining(mockQuotes[1]),
+            expect.objectContaining(mockQuotes[6]),
+        ]);
     });
 
     it.each([
@@ -156,6 +161,20 @@ describe('handleBuyRequestThunk', () => {
             'incorrect cryptoSelect',
             {
                 cryptoSelect: undefined as unknown as TradingAssetOption,
+            },
+        ],
+        [
+            'country with subdivisions but no subdivision selected',
+            {
+                countrySelect: {
+                    value: 'US' as const,
+                    codeAlpha3: 'USA',
+                    flag: '🇺🇸',
+                    name: 'United States of America',
+                    label: '🇺🇸 United States',
+                    shortLabel: '🇺🇸 USA',
+                },
+                countrySubdivisionSelect: undefined,
             },
         ],
     ])('should not save quotes when %s', async (_, incorrectFormValues) => {
@@ -179,6 +198,57 @@ describe('handleBuyRequestThunk', () => {
         expect(state.buy.quotes?.length).toEqual(0);
         expect(state.isLoading).toBe(false);
         await expect(() => promise.unwrap()).rejects.toEqual('Invalid request data');
+    });
+
+    it('should request quotes and include subdivision when country has subdivisions and subdivision is selected', async () => {
+        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const mockQuotes = createMockQuotes();
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        const quotesResponse = await store
+            .dispatch(
+                buyThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        countrySelect: {
+                            value: 'US' as const,
+                            codeAlpha3: 'USA',
+                            flag: '🇺🇸',
+                            name: 'United States of America',
+                            label: '🇺🇸 United States',
+                            shortLabel: '🇺🇸 USA',
+                        },
+                        countrySubdivisionSelect: {
+                            value: 'CA',
+                            label: 'California',
+                            name: 'California',
+                        },
+                    },
+                }),
+            )
+            .unwrap();
+
+        const state = store.getState().wallet.trading;
+
+        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
+        expect(state.buy.amountLimits).toBeUndefined();
+        expect(state.buy.quotes?.length).toEqual(2);
+        expect(state.buy.quotesRequest).toEqual({
+            country: 'US',
+            subdivision: 'CA',
+            cryptoStringAmount: '0',
+            fiatCurrency: 'USD',
+            fiatStringAmount: '1000',
+            receiveCurrency: 'bitcoin',
+            wantCrypto: false,
+        });
+        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(quotesResponse).toEqual([
+            expect.objectContaining(mockQuotes[1]),
+            expect.objectContaining(mockQuotes[6]),
+        ]);
     });
 
     it('should save empty quotes when empty array is returned from in the response', async () => {

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -1,5 +1,6 @@
 import { BuyTrade, BuyTradeQuoteRequest } from 'invity-api';
 
+import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -68,7 +69,15 @@ const getQuoteRequestData = ({
         return undefined;
     }
 
-    return request;
+    // do not fetch quotes until subdivision is set when country has subdivisions
+    if (isCountrySubdivisionEmpty(request.country, formValues.countrySubdivisionSelect?.value)) {
+        return undefined;
+    }
+
+    return {
+        ...request,
+        subdivision: formValues.countrySubdivisionSelect?.value,
+    };
 };
 
 export const handleBuyRequestThunk = createThunk<

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -86,12 +86,12 @@ describe('handleSellRequestThunk', () => {
                 },
             ],
             countrySelect: {
-                codeAlpha3: 'USA',
-                flag: '🇺🇸',
-                name: 'United States of America',
-                value: 'US',
-                label: '🇺🇸 United States',
-                shortLabel: '🇺🇸 USA',
+                value: 'CZ' as const,
+                codeAlpha3: 'CZE',
+                flag: '🇨🇿',
+                name: 'Czechia',
+                label: '🇨🇿 Czechia',
+                shortLabel: '🇨🇿 CZE',
             },
             sendCryptoSelect: {
                 id: 'bitcoin' as CryptoId,
@@ -156,7 +156,7 @@ describe('handleSellRequestThunk', () => {
             amountInCrypto: true,
             cryptoCurrency: 'bitcoin',
             fiatCurrency: 'USD',
-            country: 'US',
+            country: 'CZ',
             cryptoStringAmount: '0.0015',
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
@@ -201,7 +201,7 @@ describe('handleSellRequestThunk', () => {
             amountInCrypto: true,
             cryptoCurrency: 'bitcoin',
             fiatCurrency: 'USD',
-            country: 'US',
+            country: 'CZ',
             cryptoStringAmount: '0.0015',
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
@@ -249,7 +249,7 @@ describe('handleSellRequestThunk', () => {
             amountInCrypto: true,
             cryptoCurrency: 'ethereum',
             fiatCurrency: 'USD',
-            country: 'US',
+            country: 'CZ',
             cryptoStringAmount: '0.0015',
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
@@ -257,6 +257,92 @@ describe('handleSellRequestThunk', () => {
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(1);
         expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
+    });
+
+    it('should request sell quotes and include subdivision when country has subdivisions and subdivision is selected', async () => {
+        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
+            ...quote,
+            orderId: undefined,
+        }));
+
+        invityAPI.getSellQuotes = () => Promise.resolve(mockQuotes);
+
+        const quotesResponse = await store
+            .dispatch(
+                sellThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        countrySelect: {
+                            value: 'US' as const,
+                            codeAlpha3: 'USA',
+                            flag: '🇺🇸',
+                            name: 'United States of America',
+                            label: '🇺🇸 United States',
+                            shortLabel: '🇺🇸 USA',
+                        },
+                        countrySubdivisionSelect: {
+                            value: 'CA',
+                            label: 'California',
+                            name: 'California',
+                        },
+                    },
+                }),
+            )
+            .unwrap();
+
+        const state = store.getState().wallet.trading;
+
+        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
+        expect(state.sell.quotes.length).toEqual(1);
+        expect(quotesResponse?.length).toEqual(1);
+        expect(state.sell.quotesRequest).toEqual({
+            amountInCrypto: true,
+            cryptoCurrency: 'bitcoin',
+            fiatCurrency: 'USD',
+            country: 'US',
+            subdivision: 'CA',
+            cryptoStringAmount: '0.0015',
+            fiatStringAmount: '50',
+            flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+        });
+        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(state.isLoading).toBe(false);
+    });
+
+    it('should not save quotes when country has subdivisions but no subdivision is selected', async () => {
+        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const incorrectData = {
+            ...input,
+            formValues: {
+                ...input.formValues,
+                countrySelect: {
+                    value: 'US' as const,
+                    codeAlpha3: 'USA',
+                    flag: '🇺🇸',
+                    name: 'United States of America',
+                    label: '🇺🇸 United States',
+                    shortLabel: '🇺🇸 USA',
+                },
+                countrySubdivisionSelect: undefined,
+            },
+        };
+
+        jest.spyOn(invityAPI, 'getSellQuotes');
+
+        const promise = store.dispatch(sellThunks.handleRequestThunk(incorrectData));
+        await promise;
+
+        const state = store.getState().wallet.trading;
+
+        expect(invityAPI.getSellQuotes).not.toHaveBeenCalled();
+        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
+        expect(mockTimerStop).toHaveBeenCalledTimes(1);
+        expect(state.sell.quotesRequest).toBeUndefined();
+        expect(state.sell.quotes.length).toEqual(0);
+        expect(state.isLoading).toBe(false);
+        await expect(() => promise.unwrap()).rejects.toEqual('Invalid request data');
     });
 
     it('should not save quotes when request is aborted', async () => {

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -1,5 +1,6 @@
 import { SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 
+import { hasCountrySubdivisions, isCountryCode } from '@suite-common/geolocation';
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -62,10 +63,21 @@ const getQuoteRequestData = ({
         cryptoCurrency: sendCryptoSelect.id,
         fiatCurrency: currencySelect.value.toUpperCase(),
         country: countrySelect.value,
+        subdivision: formValues.countrySubdivisionSelect?.value,
         cryptoStringAmount,
         fiatStringAmount,
         flows: TRADING_DEFAULT_SELL_FLOWS,
     };
+
+    // do not fetch quotes until subdivision is set when country has subdivisions
+    if (
+        request.country &&
+        isCountryCode(request.country) &&
+        hasCountrySubdivisions(request.country) &&
+        !formValues.countrySubdivisionSelect?.value
+    ) {
+        return null;
+    }
 
     return request;
 };

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -41,6 +41,7 @@ export const loadSellInfoThunk = createThunk<SellInfo>(
             supportedFiatCurrencies: [...new Set(supportedFiatCurrencies)],
             supportedCryptoCurrencies: [...new Set(supportedCryptoCurrencies)],
             country: sellList.country as TradingCountryCode,
+            countrySubdivision: sellList.subdivision,
         });
     },
 );

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -148,12 +148,19 @@ export type TradingCountryOption = {
     name: string;
 };
 
+export type TradingCountrySubdivisionOption = {
+    value: string;
+    label: string;
+    name: string;
+};
+
 export type TradingBuyFormProps = {
     [constants.TRADING_FORM_FIAT_INPUT]?: string;
     [constants.TRADING_FORM_CRYPTO_INPUT]?: string;
     [constants.TRADING_FORM_FIAT_CURRENCY_SELECT]: TradingFiatCurrencyOption;
     [constants.TRADING_FORM_CRYPTO_CURRENCY_SELECT]: TradingAssetOption;
     [constants.TRADING_FORM_COUNTRY_SELECT]: TradingCountryOption;
+    [constants.TRADING_FORM_COUNTRY_SUBDIVISION_SELECT]?: TradingCountrySubdivisionOption;
     [constants.TRADING_FORM_PAYMENT_METHOD_SELECT]?: TradingPaymentMethodListProps;
     [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
     [constants.TRADING_FORM_AMOUNT_IN_CRYPTO]: boolean;
@@ -262,6 +269,7 @@ export interface TradingSellFormProps extends FormState {
     [constants.TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT]: TradingAssetSellOption | undefined;
     [constants.TRADING_FORM_PAYMENT_METHOD_SELECT]?: TradingPaymentMethodListProps;
     [constants.TRADING_FORM_COUNTRY_SELECT]: TradingCountryOption;
+    [constants.TRADING_FORM_COUNTRY_SUBDIVISION_SELECT]?: TradingCountrySubdivisionOption;
     [constants.TRADING_FORM_AMOUNT_IN_CRYPTO]: boolean;
     [constants.TRADING_FORM_PROVIDER_SELECT]?: string;
 }
@@ -270,6 +278,7 @@ export type MinimalSellFormProps = {
     outputs: { amount?: string; fiat?: string; currency: Pick<BaseCurrencyOption, 'value'> }[];
     sendCryptoSelect: Pick<TradingAssetSellOption, 'id'> | undefined;
     countrySelect: TradingCountryOption;
+    countrySubdivisionSelect?: TradingCountrySubdivisionOption;
     amountInCrypto: boolean;
     setMaxOutputId?: number;
 };

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -11,6 +11,7 @@ import {
 } from 'invity-api';
 import { v4 as uuidv4 } from 'uuid';
 
+import { getCountrySubdivisionByCode } from '@suite-common/geolocation';
 import {
     type Network,
     type NetworkSymbol,
@@ -34,6 +35,7 @@ import {
 import { regional } from './regional';
 import {
     TradingCountryCode,
+    TradingCountrySubdivisionOption,
     TradingExchangeType,
     TradingParsedCryptoIdProps,
     TradingPaymentMethodListProps,
@@ -239,6 +241,18 @@ export const tradingGetSuccessQuotes = <T extends TradingType>(quotes: TradingTr
 
 export const getDefaultCountry = (country: TradingCountryCode = regional.UNKNOWN_COUNTRY) =>
     regional.getCountryOptionWithWorldwideFallback(country);
+
+export const getDefaultCountrySubdivision = (
+    subdivision: string | undefined,
+): TradingCountrySubdivisionOption | undefined => {
+    if (!subdivision) return undefined;
+
+    const found = getCountrySubdivisionByCode(subdivision);
+
+    if (!found) return undefined;
+
+    return { value: found.code, label: found.name, name: found.name };
+};
 
 export const filterQuotesAccordingTags = <T extends TradingTradeBuySellType>(
     quotes: TradingTradeBuySellMapProps[T][],

--- a/suite-common/trading/tsconfig.json
+++ b/suite-common/trading/tsconfig.json
@@ -6,6 +6,7 @@
         { "path": "../geolocation" },
         { "path": "../redux-utils" },
         { "path": "../suite-types" },
+        { "path": "../suite-utils" },
         { "path": "../toast-notifications" },
         { "path": "../wallet-config" },
         { "path": "../wallet-constants" },

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -976,6 +976,30 @@ export const messages = defineMessages({
         defaultMessage: 'Country not found',
         id: 'TR_TRADING_COUNTRY_NOT_FOUND',
     },
+    TR_TRADING_COUNTRY_NOT_FOUND_DESCRIPTION: {
+        defaultMessage: 'Check the spelling or browse the list to select an option.',
+        id: 'TR_TRADING_COUNTRY_NOT_FOUND_DESCRIPTION',
+    },
+    TR_TRADING_COUNTRY_SUBDIVISION: {
+        defaultMessage: 'State of residence',
+        id: 'TR_TRADING_COUNTRY_SUBDIVISION',
+    },
+    TR_SEARCH_COUNTRY_SUBDIVISION_PLACEHOLDER: {
+        defaultMessage: 'Search state',
+        id: 'TR_SEARCH_COUNTRY_SUBDIVISION_PLACEHOLDER',
+    },
+    TR_TRADING_COUNTRY_SUBDIVISION_NOT_FOUND: {
+        defaultMessage: 'State not found',
+        id: 'TR_TRADING_COUNTRY_SUBDIVISION_NOT_FOUND',
+    },
+    TR_TRADING_COUNTRY_SUBDIVISION_NOT_SELECTED: {
+        defaultMessage: 'Not selected',
+        id: 'TR_TRADING_COUNTRY_SUBDIVISION_NOT_SELECTED',
+    },
+    TR_TRADING_SUBDIVISION_REQUIRED_FOR_OFFERS: {
+        defaultMessage: 'To see available offers, choose your state of residence.',
+        id: 'TR_TRADING_SUBDIVISION_REQUIRED_FOR_OFFERS',
+    },
     TR_TRADING_OFFER_LOOKING: {
         defaultMessage: 'Searching for your best offer',
         id: 'TR_TRADING_OFFER_LOOKING',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11608,6 +11608,7 @@ __metadata:
     "@suite-common/geolocation": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
## Description

Add support for selecting and handling country subdivisions (states/regions) in trading buy/sell flows, including updated form inputs, geolocation data, and trading hooks with accompanying tests.

## Notes for QA

- **Area to test**: Trading buy/sell forms with the new country subdivision (state/region) field.
- **Scenarios**:
  - Verify subdivision selection is available only for countries that support it and works in both Buy and Sell flows.
  - Confirm the selected subdivision is persisted across form steps, correctly reflected in offers/quotes, and sent to backend as expected.
  - Check behavior when changing country after selecting a subdivision, and when no subdivision is required.
- **Regression**:
  - Existing trading flows without subdivision selection should behave exactly as before.
  - No impact on non-trading wallet views or other geolocation-dependent features.

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/21974
Resolve #25560

## Screenshots:
<img width="850" height="849" alt="image" src="https://github.com/user-attachments/assets/1734d733-cc08-4341-83e5-b6dfbc135475" />
<img width="1185" height="713" alt="image" src="https://github.com/user-attachments/assets/5fac857b-9ba7-4806-b5d6-b14bc7b7cda4" />




🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/country-subdivision&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/country-subdivision&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/country-subdivision&lookback=7)