### PR TITLE
Better event emitter typing

### DIFF
--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -1,5 +1,3 @@
-import EventEmitter from 'events';
-
 import { corsValidator, parseConnectSettings } from '@trezor/connect/src/data/connectSettings';
 import { createErrorMessage } from '@trezor/connect/src/events';
 import type { CallMethodPayload } from '@trezor/connect/src/events/call';
@@ -7,6 +5,7 @@ import { ConnectFactoryDependencies, factory } from '@trezor/connect/src/factory
 import type { ConnectSettings, ConnectSettingsMobile } from '@trezor/connect/src/types';
 import { InitFullSettings } from '@trezor/connect/src/types/api/init';
 import type { UpdateConnectSettings } from '@trezor/connect/src/types/api/updateConnectSettings';
+import { ConnectEmitter } from '@trezor/connect/src/types/emitter';
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import {
     DEEPLINK_VERSION,
@@ -15,7 +14,7 @@ import {
 import { Deferred, createDeferred, removeTrailingSlashes } from '@trezor/utils';
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
-    public eventEmitter = new EventEmitter();
+    public eventEmitter = new ConnectEmitter();
     private _settings: ConnectSettings;
     private messagePromises: Record<number, Deferred<any>> = {};
     private messageID = 0;

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -1,5 +1,3 @@
-import EventEmitter from 'events';
-
 import {
     CORE_CALL,
     CallMethodAnyResponse,
@@ -19,7 +17,6 @@ import { PopupManager } from '../popup';
  * This implementation is directly used here in connect-web, but it is also extended in connect-webextension.
  */
 export class CoreInSuiteWeb implements ConnectImpl {
-    public eventEmitter = new EventEmitter();
     private _popupManager?: PopupManager;
 
     protected logger: Log;

--- a/packages/connect-webextension/src/proxy/index.ts
+++ b/packages/connect-webextension/src/proxy/index.ts
@@ -1,14 +1,13 @@
-import EventEmitter from 'events';
-
 // NOTE: @trezor/connect part is intentionally not imported from the index
 import { CORE_CALL, CallMethod, POPUP, createErrorMessage } from '@trezor/connect/src/exports';
 import { factory } from '@trezor/connect/src/factory';
 import { ConnectDynamicSettings } from '@trezor/connect/src/impl/dynamic';
 import type { UpdateConnectSettings } from '@trezor/connect/src/types/api/updateConnectSettings';
+import { ConnectEmitter } from '@trezor/connect/src/types/emitter';
 import { ERRORS, WEBEXTENSION } from '@trezor/connect-common/src/constants';
 import { WindowServiceWorkerChannel } from '@trezor/connect-common/src/messageChannel/window-serviceworker';
 
-const eventEmitter = new EventEmitter();
+const eventEmitter = new ConnectEmitter();
 let _channel: any;
 
 const dispose = () => {
@@ -36,6 +35,7 @@ const init = (settings: ConnectDynamicSettings): Promise<void> => {
 
     _channel.port.onMessage.addListener((message: any) => {
         if (message.type === WEBEXTENSION.CHANNEL_HANDSHAKE_CONFIRM) {
+            // @ts-expect-error
             eventEmitter.emit(WEBEXTENSION.CHANNEL_HANDSHAKE_CONFIRM, message);
         }
     });

--- a/packages/connect/e2e/tests/device/discoverAccounts.test.ts
+++ b/packages/connect/e2e/tests/device/discoverAccounts.test.ts
@@ -67,7 +67,7 @@ describe(`TrezorConnect.discoverAccounts`, () => {
             */
         };
 
-        TrezorConnect.on<DiscoverAccountsProgress>(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
         /*
         new Promise(resolve => setTimeout(resolve, 600)).then(() =>
             TrezorConnect.cancel('CANCELLED'),

--- a/packages/connect/src/events/blockchain.ts
+++ b/packages/connect/src/events/blockchain.ts
@@ -81,11 +81,6 @@ export type BlockchainEvent =
 
 export type BlockchainEventMessage = BlockchainEvent & { event: typeof BLOCKCHAIN_EVENT };
 
-export type BlockchainEventListenerFn = (
-    type: typeof BLOCKCHAIN_EVENT,
-    cb: (event: BlockchainEventMessage) => void,
-) => void;
-
 export const createBlockchainMessage: MessageFactoryFn<typeof BLOCKCHAIN_EVENT, BlockchainEvent> = (
     type,
     payload,

--- a/packages/connect/src/events/device.ts
+++ b/packages/connect/src/events/device.ts
@@ -121,11 +121,6 @@ export type DeviceEvent =
 
 export type DeviceEventMessage = DeviceEvent & { event: typeof DEVICE_EVENT };
 
-export type DeviceEventListenerFn = (
-    type: typeof DEVICE_EVENT,
-    cb: (event: DeviceEventMessage) => void,
-) => void;
-
 export const createDeviceMessage: MessageFactoryFn<typeof DEVICE_EVENT, DeviceEvent> = (
     type,
     payload,

--- a/packages/connect/src/events/transport.ts
+++ b/packages/connect/src/events/transport.ts
@@ -49,11 +49,6 @@ export interface TransportGetInfo {
 
 export type TransportEventMessage = TransportEvent & { event: typeof TRANSPORT_EVENT };
 
-export type TransportEventListenerFn = (
-    type: typeof TRANSPORT_EVENT,
-    cb: (event: TransportEventMessage) => void,
-) => void;
-
 export const createTransportMessage: MessageFactoryFn<typeof TRANSPORT_EVENT, TransportEvent> = (
     type,
     payload,

--- a/packages/connect/src/events/ui-request.ts
+++ b/packages/connect/src/events/ui-request.ts
@@ -299,16 +299,6 @@ export type UiEvent =
 
 export type UiEventMessage = UiEvent & { event: typeof UI_EVENT };
 
-export type ProgressEventListenerFn = <R>(
-    type: typeof UI_REQUEST.BUNDLE_PROGRESS,
-    cb: (event: BundleProgress<R>['payload']) => void,
-) => void;
-
-export type UiEventListenerFn = (
-    type: typeof UI_EVENT,
-    cb: (event: UiEventMessage) => void,
-) => void;
-
 export const createUiMessage: MessageFactoryFn<typeof UI_EVENT, UiEvent> = (type, payload) =>
     ({
         event: UI_EVENT,

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -1,14 +1,13 @@
-import type { EventEmitter } from 'events';
-
 import { UI_REQUEST } from './events';
 import type { CallMethod, CallMethodKeys } from './events/call';
 import type { TrezorConnect } from './types';
 import type { InitType } from './types/api/init';
+import type { ConnectEmitter } from './types/emitter';
 
 export interface ConnectFactoryDependencies<SettingsType extends Record<string, any>> {
     init: InitType<SettingsType>;
     call: CallMethod;
-    eventEmitter: EventEmitter;
+    eventEmitter: ConnectEmitter;
     updateConnectSettings: TrezorConnect['updateConnectSettings'];
     uiResponse: TrezorConnect['uiResponse'];
     cancel: TrezorConnect['cancel'];
@@ -142,21 +141,11 @@ export const factory = <
         init,
         updateConnectSettings,
 
-        on: <T extends string, P extends (...args: any[]) => any>(type: T, fn: P) => {
-            eventEmitter.on(type, fn);
-        },
+        on: eventEmitter.on.bind(eventEmitter),
 
-        off: (type, fn) => {
-            eventEmitter.removeListener(type, fn);
-        },
+        off: eventEmitter.removeListener.bind(eventEmitter),
 
-        removeAllListeners: type => {
-            if (typeof type === 'string') {
-                eventEmitter.removeAllListeners(type);
-            } else {
-                eventEmitter.removeAllListeners();
-            }
-        },
+        removeAllListeners: eventEmitter.removeAllListeners.bind(eventEmitter),
 
         uiResponse,
 

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,5 +1,3 @@
-import EventEmitter from 'events';
-
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { DeferredManager, cloneObject, createDeferredManager } from '@trezor/utils';
 
@@ -23,10 +21,11 @@ import {
 import { ConnectFactoryDependencies } from '../factory';
 import type { ConnectSettings, ConnectSettingsPublic, Manifest } from '../types';
 import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
+import { ConnectEmitter } from '../types/emitter';
 import { Log, initLog } from '../utils/debug';
 
 export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
-    public eventEmitter = new EventEmitter();
+    public eventEmitter = new ConnectEmitter();
     public _settings: ConnectSettings;
 
     private _coreManager?: any;

--- a/packages/connect/src/impl/dynamic.ts
+++ b/packages/connect/src/impl/dynamic.ts
@@ -1,5 +1,3 @@
-import EventEmitter from 'events';
-
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { getSynchronize } from '@trezor/utils';
 
@@ -8,6 +6,7 @@ import { CallMethodPayload, createErrorMessage } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
 import { ConnectSettings } from '../types';
 import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
+import { ConnectEmitter } from '../types/emitter';
 
 export type ConnectImplSettings = {
     manifest: NonNullable<ConnectSettings['manifest']>;
@@ -40,7 +39,7 @@ type TrezorConnectDynamicParams = {
  *
  */
 export class TrezorConnectDynamic implements ConnectFactoryDependencies<{}> {
-    public readonly eventEmitter = new EventEmitter();
+    public readonly eventEmitter = new ConnectEmitter();
 
     private currentTarget: ImplType;
     private readonly implementations: Record<ImplType, ConnectImpl>;

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,5 +1,5 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { TypedEmitter, createDeferredManager, deepEqual } from '@trezor/utils';
+import { createDeferredManager, deepEqual } from '@trezor/utils';
 
 import { reconnectAllBackends } from './backend/BlockchainLink';
 import { initCoreState } from './core';
@@ -22,10 +22,10 @@ import {
 import { factory } from './factory';
 import type { ConnectSettings } from './types';
 import type { UpdateConnectSettings } from './types/api/updateConnectSettings';
-import { ConnectEvents } from './types/emitter';
+import { ConnectEmitter } from './types/emitter';
 import { initLog } from './utils/debug';
 
-export const eventEmitter = new TypedEmitter<ConnectEvents>();
+const eventEmitter = new ConnectEmitter();
 const _log = initLog('@trezor/connect');
 
 let _settings = parseConnectSettings();

--- a/packages/connect/src/types/api/__tests__/events.ts
+++ b/packages/connect/src/types/api/__tests__/events.ts
@@ -1,6 +1,4 @@
 import {
-    AccountInfo,
-    Address,
     BLOCKCHAIN,
     BLOCKCHAIN_EVENT,
     DEVICE_EVENT,
@@ -185,7 +183,7 @@ export const events = (api: TrezorConnect) => {
     api.on(UI_REQUEST.REQUEST_BUTTON, () => {});
     api.on(UI_REQUEST.REQUEST_BUTTON, _payload => {});
 
-    api.on<AccountInfo | null>(UI_REQUEST.BUNDLE_PROGRESS, event => {
+    api.on(UI_REQUEST.BUNDLE_PROGRESS, event => {
         // event.progress as number;
         event.error?.toLowerCase();
         if (event.response?.empty === false) {
@@ -193,7 +191,7 @@ export const events = (api: TrezorConnect) => {
         }
     });
 
-    api.on<Address>(UI_REQUEST.BUNDLE_PROGRESS, event => {
+    api.on(UI_REQUEST.BUNDLE_PROGRESS, event => {
         // event.progress as number;
         event.error?.toLowerCase();
         event.response.serializedPath.toLowerCase();

--- a/packages/connect/src/types/api/off.ts
+++ b/packages/connect/src/types/api/off.ts
@@ -1,17 +1,3 @@
-import { BLOCKCHAIN_EVENT, BlockchainEvent } from '../../events/blockchain';
-import { DEVICE_EVENT, DeviceEvent } from '../../events/device';
-import { TRANSPORT_EVENT, TransportEvent } from '../../events/transport';
-import { UI_EVENT, UiEvent } from '../../events/ui-request';
+import type { ConnectEventCallbacks } from '../emitter';
 
-type EventType<Event> = Event extends { type: string } ? Event['type'] : never;
-export type EventListenerType =
-    | typeof BLOCKCHAIN_EVENT
-    | typeof DEVICE_EVENT
-    | typeof TRANSPORT_EVENT
-    | typeof UI_EVENT
-    | EventType<TransportEvent>
-    | EventType<UiEvent>
-    | EventType<DeviceEvent>
-    | EventType<BlockchainEvent>;
-
-export declare function off(type: EventListenerType, cb: (...args: any[]) => any): void;
+export declare const off: ConnectEventCallbacks;

--- a/packages/connect/src/types/api/on.ts
+++ b/packages/connect/src/types/api/on.ts
@@ -1,24 +1,3 @@
-import type { BlockchainEvent, BlockchainEventListenerFn } from '../../events/blockchain';
-import type { DeviceEvent, DeviceEventListenerFn } from '../../events/device';
-import type { TransportEvent, TransportEventListenerFn } from '../../events/transport';
-import type { ProgressEventListenerFn, UiEvent, UiEventListenerFn } from '../../events/ui-request';
-import type { UnionToIntersection } from '../utils';
+import type { ConnectEventCallbacks } from '../emitter';
 
-type DetailedEvent<Event> = Event extends { type: string }
-    ? Event extends { payload: any }
-        ? (type: Event['type'], cb: (event: Event['payload']) => any) => void
-        : (type: Event['type'], cb: () => any) => void
-    : never;
-
-type EventsUnion =
-    | BlockchainEventListenerFn
-    | DetailedEvent<BlockchainEvent>
-    | DeviceEventListenerFn
-    | DetailedEvent<DeviceEvent>
-    | TransportEventListenerFn
-    | DetailedEvent<TransportEvent>
-    | UiEventListenerFn
-    | DetailedEvent<UiEvent>
-    | ProgressEventListenerFn;
-
-export declare const on: UnionToIntersection<EventsUnion>;
+export declare const on: ConnectEventCallbacks;

--- a/packages/connect/src/types/api/removeAllListeners.ts
+++ b/packages/connect/src/types/api/removeAllListeners.ts
@@ -1,3 +1,3 @@
-import type { EventListenerType } from './off';
+import type { ConnectEvents } from '../emitter';
 
-export declare function removeAllListeners(type?: EventListenerType): void;
+export declare const removeAllListeners: (type?: ConnectEvents) => void;

--- a/packages/connect/src/types/emitter.ts
+++ b/packages/connect/src/types/emitter.ts
@@ -1,25 +1,17 @@
-import {
-    BLOCKCHAIN_EVENT,
-    BlockchainEvent,
-    BlockchainEventMessage,
-    DEVICE_EVENT,
-    DeviceEvent,
-    DeviceEventMessage,
-    PopupEvent,
-    PopupEventMessage,
-    TRANSPORT_EVENT,
-    TransportEvent,
-    TransportEventMessage,
-    UI_EVENT,
-    UiEvent,
-    UiEventMessage,
-} from '../events';
+import { TypedEmitter } from '@trezor/utils';
+
+import type { UnionToIntersection } from './utils';
+import { BLOCKCHAIN_EVENT, BlockchainEvent, BlockchainEventMessage } from '../events/blockchain';
+import { DEVICE_EVENT, DeviceEvent, DeviceEventMessage } from '../events/device';
+import { PopupEvent, PopupEventMessage } from '../events/popup';
+import { TRANSPORT_EVENT, TransportEvent, TransportEventMessage } from '../events/transport';
+import { UI_EVENT, UiEvent, UiEventMessage } from '../events/ui-request';
 
 type EventPayloadMap<T extends { type: string; payload?: any }> = {
     [E in T as E['type']]: E extends { payload: infer P } ? P : undefined;
 };
 
-export type ConnectEvents = {
+type ConnectEventMap = {
     [DEVICE_EVENT]: DeviceEventMessage;
     [TRANSPORT_EVENT]: TransportEventMessage;
     [BLOCKCHAIN_EVENT]: BlockchainEventMessage;
@@ -29,3 +21,18 @@ export type ConnectEvents = {
     EventPayloadMap<BlockchainEvent> &
     EventPayloadMap<UiEvent> &
     EventPayloadMap<PopupEvent>;
+
+export type ConnectEvents = keyof ConnectEventMap;
+
+export type ConnectEventCallbacks = UnionToIntersection<
+    {
+        [K in ConnectEvents]: (
+            type: K,
+            cb: ConnectEventMap[K] extends undefined
+                ? () => void
+                : (event: ConnectEventMap[K]) => void,
+        ) => void;
+    }[ConnectEvents]
+>;
+
+export class ConnectEmitter extends TypedEmitter<ConnectEventMap> {}

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -508,10 +508,7 @@ export const runDiscoveryThunk = createThunk(
                 dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
             };
 
-            TrezorConnect.on<DiscoverAccountsProgress>(
-                UI_REQUEST.BUNDLE_PROGRESS,
-                onBundleProgress,
-            );
+            TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
 
             // NOTE: sync set discovery status to progress to make sure that there aren't some hanging states
             // before asnyc onBundleProgress is called which sets progress
@@ -768,7 +765,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
             dispatch(discoveryActions.updateDiscovery(discoveryPayload, device.path));
         };
 
-        TrezorConnect.on<DiscoverAccountsProgress>(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
+        TrezorConnect.on(UI_REQUEST.BUNDLE_PROGRESS, onBundleProgress);
 
         const result = await TrezorConnect.discoverAccounts({
             device: updatedDevice,


### PR DESCRIPTION
## Description

Connect's public event emitter typing is now based on real internal typed event emitter.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-emitter-type&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-emitter-type&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/connect-emitter-type&lookback=7)