### PR TITLE
fix(suite): broken select in walletconnect modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -240,6 +240,7 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                                     </Row>
                                 )}
                                 onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                                closeMenuOnScroll={false}
                             />
                         </ElevationUp>
                     </Card>


### PR DESCRIPTION
## Description

Select in WalletConnect modal broke after recent form components refactor #25141

## Notes for QA

Check that it opens and scrolls fine

## Screenshots:

Broken (before):

https://github.com/user-attachments/assets/6928cef2-9d69-414a-8ff1-cf3534506a01



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/walletconnect-modal-select-broken&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/walletconnect-modal-select-broken&lookback=7)