### PR TITLE
feat(suite-native): add editable, elevation, keepPlaceholderOnFocus controls to TextInput story

### DIFF
--- a/suite-native/atoms/src/stories/Inputs/TextInput.stories.tsx
+++ b/suite-native/atoms/src/stories/Inputs/TextInput.stories.tsx
@@ -3,6 +3,7 @@ import { useArgs } from 'storybook/preview-api';
 
 import { Input as InputComponent, InputProps } from '../../Input/Input';
 import { InputWrapper } from '../../Input/InputWrapper';
+import { SURFACE_ELEVATIONS } from '../../types';
 
 type TextInputArgs = InputProps & { wrapperLabel: string; hint: string; error: string };
 
@@ -39,6 +40,8 @@ export const TextInput: TextInputStory = {
         wrapperLabel: 'Wrapper label',
         hint: 'This is a hint: always define only label or placeholder, never both',
         label: 'Label',
+        editable: true,
+        keepPlaceholderOnFocus: false,
     },
     argTypes: {
         label: {
@@ -50,11 +53,21 @@ export const TextInput: TextInputStory = {
         value: {
             control: { type: 'text' },
         },
+        editable: {
+            control: { type: 'boolean' },
+        },
         placeholder: {
             control: { type: 'text' },
         },
         error: {
             control: { type: 'text' },
+        },
+        elevation: {
+            control: { type: 'select' },
+            options: SURFACE_ELEVATIONS,
+        },
+        keepPlaceholderOnFocus: {
+            control: { type: 'boolean' },
         },
     },
 };


### PR DESCRIPTION
## Description

Adds `editable`, `elevation`, and `keepPlaceholderOnFocus` Storybook controls to the `TextInput` story.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-native-textinput-story-controls&lookback=7)