### PR TITLE
fix(suite): Center an arrow

### DIFF
--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -56,7 +56,6 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                     {currentVersion ? ` ${currentVersion}` : ''}
                 </Text>
             </Column>
-            <Icon name="arrowRight" size={16} />
         </>
     );
 
@@ -81,6 +80,7 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                 ) : (
                     <CurrentVersion />
                 ))}
+            {currentVersion && <Icon name="arrowRight" size={16} />}
             <Column alignItems="center" gap={spacings.xxs}>
                 <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
                     <Translation id="TR_ONBOARDING_NEW_VERSION" />


### PR DESCRIPTION
Moved arrow in Firmware offer so it is centered. 

## Notes for QA

There really isn't much to test here.

## Related Issue

Resolve #25544

## Screenshots:

<img width="766" height="517" alt="image" src="https://github.com/user-attachments/assets/797a6fd9-43ef-4ead-8a22-70f9dd2f6ead" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/center-arrow&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/center-arrow&lookback=7)