### PR TITLE
fix(connect-examples): use prod webpack to measure bundle size

### DIFF
--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -97,7 +97,7 @@ runs:
       env:
         FULL_URL: ${{ inputs.connectPopupUrl || format('https://{0}/{1}', inputs.serverHostname, inputs.serverPath) }}
       run: |
-        yarn workspace @trezor/webextension-mv3-sw-ts build
+        NODE_ENV=production yarn workspace @trezor/webextension-mv3-sw-ts build
         echo "FULL_URL is set to ${FULL_URL}"
         node ./packages/connect-examples/update-webextensions-sw.js --trezor-connect-src "${FULL_URL}"
         ./packages/connect-examples/webextension/scripts/check-webextension-bundle-size.sh

--- a/packages/connect-examples/webextension/scripts/check-webextension-bundle-size.sh
+++ b/packages/connect-examples/webextension/scripts/check-webextension-bundle-size.sh
@@ -5,12 +5,12 @@ set -e
 echo "trezor-connect webextension bundle size check"
 
 # Configuration parameters
-# Baseline: 196 KB (measured on 2026-02-19, compressed)
-# MAX_KB: 216 KB (110% of baseline = max allowed growth)
+# Baseline: 24 KB (measured on 2026-03-02, prod, compressed)
+# MAX_KB: 29 KB (110% of baseline = max allowed growth)
 # To update baseline after legitimate changes: measure new compressed size and update both values
 
-BASELINE_KB=196
-MAX_KB=${MAX_KB:-216}
+BASELINE_KB=24
+MAX_KB=${MAX_KB:-29}
 
 # Get script directory and build folder
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/packages/connect-examples/webextension/webpack.config.js
+++ b/packages/connect-examples/webextension/webpack.config.js
@@ -49,6 +49,6 @@ module.exports = {
             patterns: [{ from: 'src/manifest.json', to: 'manifest.json' }],
         }),
     ],
-    mode: 'development',
-    devtool: 'inline-source-map',
+    mode: process.env.NODE_ENV || 'development',
+    devtool: process.env.NODE_ENV === 'production' ? undefined : 'inline-source-map',
 };


### PR DESCRIPTION
## Description

When measuring the bundle size of Connect webextension, we were using a development build with source maps, which results in much bigger files than reality. 
In production mode, Connect webextension is currently only about 16 KB. 

## Notes for QA

Nothing to test

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/webextension-prod-build-size&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/webextension-prod-build-size&lookback=7)