### PR TITLE
fix(suite): disconnected keys banner copy

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
@@ -7,7 +7,7 @@ import {
     selectHasDeviceSuiteSyncError,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
-import { Banner, Tooltip } from '@trezor/components';
+import { Banner } from '@trezor/components';
 import { StaticSessionId } from '@trezor/connect';
 
 import { goto } from 'src/actions/suite/routerActions';
@@ -40,6 +40,24 @@ const bannerConfigs: Record<SuiteSyncBannerInteraction, BannerConfig> = {
 const isBannerInteraction = (interaction: string): interaction is SuiteSyncBannerInteraction =>
     interaction in bannerConfigs;
 
+const getBannerConfig = ({
+    interaction,
+    isDeviceConnected,
+}: {
+    interaction: SuiteSyncBannerInteraction;
+    isDeviceConnected: boolean;
+}): BannerConfig => {
+    if (interaction === 'keys-needed' && !isDeviceConnected) {
+        return {
+            testId: '@notification/suite-sync-keys',
+            buttonLabel: 'TR_SUITE_SYNC_CONNECT_AND_GET_KEYS',
+            description: 'TR_SUITE_SYNC_KEYS_NEEDED_CONNECT_DEVICE_BANNER',
+        };
+    }
+
+    return bannerConfigs[interaction];
+};
+
 type SuiteSyncBannerProps = {
     deviceStaticSessionId: StaticSessionId;
 };
@@ -57,21 +75,11 @@ const SuiteSyncBannerContent = ({
         icon
         intent="info"
         rightContent={
-            <Tooltip
-                content={
-                    !isDeviceConnected ? (
-                        <Translation id="TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP" />
-                    ) : undefined
-                }
-            >
-                <Banner.Button
-                    isDisabled={!isDeviceConnected}
-                    onClick={onClick}
-                    data-testid={`${config.testId}/button`}
-                >
+            isDeviceConnected && (
+                <Banner.Button onClick={onClick} data-testid={`${config.testId}/button`}>
                     <Translation id={config.buttonLabel} />
                 </Banner.Button>
-            </Tooltip>
+            )
         }
         data-testid={config.testId}
         description={<Translation id={config.description} />}
@@ -94,7 +102,10 @@ export const SuiteSyncBanner = ({ deviceStaticSessionId }: SuiteSyncBannerProps)
         return null;
     }
 
-    const config = bannerConfigs[suiteSyncInteraction];
+    const config = getBannerConfig({
+        interaction: suiteSyncInteraction,
+        isDeviceConnected,
+    });
 
     const handlers: Record<SuiteSyncBannerInteraction, () => void | Promise<void>> = {
         'keys-needed': async () => {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -173,6 +173,9 @@ export const messages = {
             description:
                 'Allow Suite Sync to view and edit your labels, wallet names, and account names.',
             button: 'Allow',
+            connectDescription:
+                'Connect Trezor and allow Suite Sync to view and edit your labels, wallet names, and account names.',
+            connectButton: 'Connect & allow',
         },
         suiteSyncFirmwareUpdateAlert: {
             title: 'Firmware update required',

--- a/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/SuiteSyncKeysAlert.tsx
@@ -53,8 +53,24 @@ export const SuiteSyncKeysAlert = () => {
         <AnimatedFullAlertBox
             variant="info"
             title={<Translation id="moduleHome.suiteSyncAlert.title" />}
-            description={<Translation id="moduleHome.suiteSyncAlert.description" />}
-            primaryButtonLabel={<Translation id="moduleHome.suiteSyncAlert.button" />}
+            description={
+                <Translation
+                    id={
+                        isDeviceConnected
+                            ? 'moduleHome.suiteSyncAlert.description'
+                            : 'moduleHome.suiteSyncAlert.connectDescription'
+                    }
+                />
+            }
+            primaryButtonLabel={
+                <Translation
+                    id={
+                        isDeviceConnected
+                            ? 'moduleHome.suiteSyncAlert.button'
+                            : 'moduleHome.suiteSyncAlert.connectButton'
+                    }
+                />
+            }
             onPressPrimaryButton={allowSuiteSyncForWallet}
             marginHorizontal="sp16"
         />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3142,6 +3142,10 @@ export const messages = defineMessages({
         defaultMessage: 'Allow',
         id: 'TR_SUITE_SYNC_GET_KEYS',
     },
+    TR_SUITE_SYNC_CONNECT_AND_GET_KEYS: {
+        defaultMessage: 'Connect & allow',
+        id: 'TR_SUITE_SYNC_CONNECT_AND_GET_KEYS',
+    },
     TR_SUITE_SYNC_FIRMWARE_UPDATE: {
         defaultMessage: 'Update',
         id: 'TR_SUITE_SYNC_FIRMWARE_UPDATE',
@@ -3159,6 +3163,11 @@ export const messages = defineMessages({
         defaultMessage:
             'Allow Suite Sync to view and edit your labels, wallet names, and account names.',
         id: 'TR_SUITE_SYNC_KEYS_NEEDED_BANNER',
+    },
+    TR_SUITE_SYNC_KEYS_NEEDED_CONNECT_DEVICE_BANNER: {
+        defaultMessage:
+            'Connect Trezor and allow Suite Sync to view and edit your labels, wallet names, and account names.',
+        id: 'TR_SUITE_SYNC_KEYS_NEEDED_CONNECT_DEVICE_BANNER',
     },
     TR_SUITE_SYNC_OUT_OF_QUOTA_BANNER_DESCRIPTION: {
         defaultMessage:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update copy for suite sync banner if device is disconnected. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25535



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/banner-copy-disconnected&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/banner-copy-disconnected&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/banner-copy-disconnected&lookback=7)