### PR TITLE
feat(trading): Show quote amount in payment method modal

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/PaymentMethodModal.tsx
@@ -8,9 +8,10 @@ import {
     TRADING_FORM_PROVIDER_SELECT,
     TradingPaymentMethodListProps,
 } from '@suite-common/trading';
-import { Modal, Row } from '@trezor/components';
+import { Modal, Row, Text } from '@trezor/components';
 import { CardList } from '@trezor/product-components';
 
+import { FormattedCryptoAmount } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import { TradingBuySellFormProps } from 'src/types/trading/tradingForm';
@@ -36,7 +37,7 @@ export const PaymentMethodModal = ({ onClose, heading }: PaymentMethodModalProps
 
     return (
         <Modal
-            width={400}
+            width={480}
             onCancel={onClose}
             heading={heading ? <Translation id={heading} /> : undefined}
         >
@@ -51,6 +52,17 @@ export const PaymentMethodModal = ({ onClose, heading }: PaymentMethodModalProps
                             <PaymentMethodIcon paymentMethod={item.value} />
                             {item.label}
                         </Row>
+                        {item.receiveAmount && item.symbol && (
+                            <Row>
+                                <Text typographyStyle="body-sm">
+                                    {'≈ '}
+                                    <FormattedCryptoAmount
+                                        value={item.receiveAmount}
+                                        symbol={item.symbol}
+                                    />
+                                </Text>
+                            </Row>
+                        )}
                     </CardList.Item>
                 ))}
             </CardList>

--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import { CryptoId, ExchangeProviderInfo, ExchangeTrade, SellFiatTrade } from 'in
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account, AccountKey } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
 
 import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
 import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
@@ -169,12 +170,12 @@ describe('isCryptoIdForNativeToken', () => {
 });
 
 describe('getTradingPaymentMethods', () => {
-    it('should get payment methods from quotes', () => {
-        const paymentMethods = getTradingPaymentMethods([
-            ...BUY_FIXTURE.MIN_MAX_QUOTES_OK,
-            BUY_FIXTURE.MIN_MAX_QUOTES_OK[1], // duplicate applePay
-        ]);
+    const paymentMethods = getTradingPaymentMethods([
+        ...BUY_FIXTURE.MIN_MAX_QUOTES_OK,
+        BUY_FIXTURE.MIN_MAX_QUOTES_OK[1], // duplicate applePay
+    ]);
 
+    it('should get payment methods from quotes', () => {
         const findApplePay = paymentMethods.find(
             paymentMethod =>
                 paymentMethod.value === 'applePay' && paymentMethod.label === 'Apple Pay',
@@ -182,6 +183,15 @@ describe('getTradingPaymentMethods', () => {
 
         expect(paymentMethods.length).toBe(2);
         expect(findApplePay).toBeDefined();
+    });
+
+    it('should sort payment methods by receive amount in descending order', () => {
+        const amounts = paymentMethods.map(method => new BigNumber(method.receiveAmount || '0'));
+        const sortedAmounts = [...amounts].sort((a, b) => b.minus(a).toNumber());
+
+        expect(amounts.map(amount => amount.toString())).toEqual(
+            sortedAmounts.map(amount => amount.toString()),
+        );
     });
 });
 

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -129,7 +129,7 @@ export const handleBuyRequestThunk = createThunk<
         );
         // without errors
         const quotesSuccess = tradingGetSuccessQuotes<TradingBuyType>(quotesDefault);
-        const paymentMethodsFromQuotes = getTradingPaymentMethods<TradingBuyType>(quotesSuccess);
+        const paymentMethodsFromQuotes = getTradingPaymentMethods(quotesSuccess);
 
         const symbol =
             selectTradingCoinSymbolByCryptoId(getState(), requestData.receiveCurrency) ??

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -137,7 +137,7 @@ export const handleSellRequestThunk = createThunk<
         // without errors
         const successQuotes = tradingGetSuccessQuotes<TradingSellType>(quotesDefault);
 
-        const paymentMethodsFromQuotes = getTradingPaymentMethods<TradingSellType>(successQuotes);
+        const paymentMethodsFromQuotes = getTradingPaymentMethods(successQuotes);
 
         dispatch(tradingSellActions.saveQuotes(successQuotes));
         dispatch(tradingSellActions.saveQuoteRequest(requestData));

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -93,6 +93,8 @@ export type TradingPaymentMethodProps = BuyCryptoPaymentMethod | '';
 export type TradingPaymentMethodListProps = {
     value: TradingPaymentMethodProps;
     label: string;
+    receiveAmount?: string;
+    symbol?: string;
 };
 
 type TradingCommonTransaction = {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -53,6 +53,46 @@ type NetworkAndContractAddress = {
     contractAddress: string | undefined;
 };
 
+type TradingGetFormStateSellProps = {
+    activeSection: TradingSellType;
+    trade: SellFiatTrade;
+};
+
+type TradingGetFormStateExchangeProps = {
+    activeSection: TradingExchangeType;
+    trade: ExchangeTrade;
+};
+
+type TradingGetFormStateProps = {
+    providers: Record<string, ExchangeProviderInfo | SellProviderInfo> | undefined;
+    isSlip24Active?: boolean;
+    sendAccountKey: AccountKey | undefined;
+    receiveAccountKey?: AccountKey | undefined;
+} & (TradingGetFormStateSellProps | TradingGetFormStateExchangeProps);
+
+export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
+    buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
+    sell: ['SUCCESS', 'ERROR', 'BLOCKED', 'CANCELLED', 'REFUNDED'] satisfies SellTradeFinalStatus[],
+    exchange: ['SUCCESS', 'ERROR', 'KYC'] satisfies ExchangeTradeFinalStatus[],
+};
+
+export const isFinalStatus = (
+    tradingType: TradingType,
+    tradeStatus: TradingTradeStatusType | undefined,
+) => (tradeStatus ? tradeFinalStatuses[tradingType].includes(tradeStatus) : false);
+
+export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
+    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
+
+export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
+    'cryptoStringAmount' in quote && 'fiatStringAmount' in quote;
+
+export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
+    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
+
+export const isExchangeProvider = (provider: TradingProviderInfo) =>
+    provider && 'kycPolicyType' in provider;
+
 export const parseCryptoId = (cryptoId: CryptoId): TradingParsedCryptoIdProps => {
     const parts = cryptoId.split(CRYPTO_PLATFORM_SEPARATOR);
 
@@ -233,29 +273,34 @@ export const addIdsToQuotes = <T extends TradingType>(
 export const getNetworkDecimalsWithFallback = (
     symbol: NetworkSymbol | undefined,
     fallback = getNetwork('btc').decimals,
-) => (symbol ? (getNetwork(symbol)?.decimals ?? fallback) : fallback);
+): number => (symbol ? (getNetwork(symbol).decimals ?? fallback) : fallback);
 
-export const getTradingPaymentMethods = <T extends TradingTradeBuySellType>(
-    quotes: TradingTradeMapProps[T][],
-) => {
-    const newPaymentMethods: TradingPaymentMethodListProps[] = [];
+export const getTradingPaymentMethods = (
+    quotes: BuyTrade[] | SellFiatTrade[],
+): TradingPaymentMethodListProps[] => {
+    const uniqueMethods = new Map<string, TradingPaymentMethodListProps>();
 
     quotes.forEach(quote => {
-        const { paymentMethod, paymentMethodName } = quote;
-
-        const shouldAddToPaymentMethods =
-            paymentMethod !== undefined &&
-            newPaymentMethods.every(item => item.value !== paymentMethod);
-
-        if (shouldAddToPaymentMethods) {
-            newPaymentMethods.push({
-                value: paymentMethod,
-                label: paymentMethodName ?? paymentMethod,
-            });
-        }
+        if (!quote.paymentMethod) return;
+        const amount = isBuyTrade(quote) ? quote.receiveStringAmount : quote.fiatStringAmount;
+        uniqueMethods.set(quote.paymentMethod, {
+            value: quote.paymentMethod,
+            label: quote.paymentMethodName ?? quote.paymentMethod,
+            receiveAmount: amount,
+            symbol: isBuyTrade(quote)
+                ? cryptoIdToSymbol(quote.receiveCurrency)
+                : (quote as SellFiatTrade).fiatCurrency,
+        });
     });
 
-    return newPaymentMethods;
+    const sortedMethods = Array.from(uniqueMethods.values()).sort((a, b) => {
+        const aAmount = new BigNumber(a.receiveAmount || '0');
+        const bAmount = new BigNumber(b.receiveAmount || '0');
+
+        return bAmount.minus(aAmount).toNumber();
+    });
+
+    return sortedMethods;
 };
 
 export const getTradingQuotesByPaymentMethod = <T extends TradingTradeBuySellType>(
@@ -291,46 +336,6 @@ export const getBestRatedQuote = <T extends TradingType>(
 
     return bestRatedQuotes[0];
 };
-
-export const tradeFinalStatuses: Record<TradingType, TradingTradeStatusType[]> = {
-    buy: ['SUCCESS', 'ERROR', 'BLOCKED'] satisfies BuyTradeFinalStatus[],
-    sell: ['SUCCESS', 'ERROR', 'BLOCKED', 'CANCELLED', 'REFUNDED'] satisfies SellTradeFinalStatus[],
-    exchange: ['SUCCESS', 'ERROR', 'KYC'] satisfies ExchangeTradeFinalStatus[],
-};
-
-export const isFinalStatus = (
-    tradingType: TradingType,
-    tradeStatus: TradingTradeStatusType | undefined,
-) => (tradeStatus ? tradeFinalStatuses[tradingType].includes(tradeStatus) : false);
-
-export const isBuyTrade = (quote: TradingTradeType): quote is BuyTrade =>
-    'fiatStringAmount' in quote && 'receiveStringAmount' in quote;
-
-export const isSellFiatTrade = (quote: TradingTradeType): quote is SellFiatTrade =>
-    'cryptoStringAmount' in quote && 'fiatStringAmount' in quote;
-
-export const isExchangeTrade = (quote: TradingTradeType): quote is ExchangeTrade =>
-    'sendStringAmount' in quote && 'receiveStringAmount' in quote;
-
-export const isExchangeProvider = (provider: TradingProviderInfo) =>
-    provider && 'kycPolicyType' in provider;
-
-type TradingGetFormStateSellProps = {
-    activeSection: TradingSellType;
-    trade: SellFiatTrade;
-};
-
-type TradingGetFormStateExchangeProps = {
-    activeSection: TradingExchangeType;
-    trade: ExchangeTrade;
-};
-
-type TradingGetFormStateProps = {
-    providers: Record<string, ExchangeProviderInfo | SellProviderInfo> | undefined;
-    isSlip24Active?: boolean;
-    sendAccountKey: AccountKey | undefined;
-    receiveAccountKey?: AccountKey | undefined;
-} & (TradingGetFormStateSellProps | TradingGetFormStateExchangeProps);
 
 export const getTradingFormState = ({
     activeSection,


### PR DESCRIPTION
## Description

- Sort methods by highest receive amount for buy/sell quotes.
- Adjust desktop payment method modal to display deduplicated, sorted methods with approximate receive amounts.
- Align trading types, thunks, and tests with the new payment method behavior.

## Notes for QA

- Focus on buy and sell trading flows on desktop where a payment method selection is available.
- Verify that the payment method list shows each method only once, ordered by the highest receive amount (top = best payout).
- Confirm that approximate receive amounts and symbols are shown correctly and that selecting a method updates the form as expected.
- Sanity-check that quote fetching and submission for both buy and sell are unaffected beyond the new ordering.

## Related Issue

Resolve #21680

## Screenshots:
<img width="557" height="410" alt="image" src="https://github.com/user-attachments/assets/c7fbe946-c48e-49d3-af45-97279f2272cd" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/21680/price-quote-payment-desktop&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/21680/price-quote-payment-desktop&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/21680/price-quote-payment-desktop&lookback=7)