### PR TITLE
feat(ci): Auto-quarantine workflow

### DIFF
--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -1,0 +1,36 @@
+name: "[Check] Test Health"
+
+# Runs every 15 minutes during daytime hours (Central European Time).
+# GitHub Actions uses UTC; the schedule below covers 4:00–21:59 UTC, which
+# maps to 6:00–23:59 CEST (UTC+2, summer) and 5:00–22:59 CET (UTC+1, winter),
+# ensuring the 6 am–10 pm CET window is always covered.
+on:
+  schedule:
+    - cron: "*/15 4-21 * * *"
+  # Allow manual runs and easy one-off debugging.
+  workflow_dispatch:
+
+jobs:
+  check-test-health:
+    name: Check test health & manage quarantine
+    runs-on: ubuntu-latest
+    # Only run in the canonical repository, not forks.
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Uses the version from .nvmrc (Node 24+, which natively strips TypeScript types).
+          node-version-file: ".nvmrc"
+
+      - name: Check test health and manage quarantine
+        env:
+          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+          E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
+        run: |
+          node --experimental-strip-types scripts/ci/quarantineBot/index.ts

--- a/scripts/ci/quarantineBot/index.ts
+++ b/scripts/ci/quarantineBot/index.ts
@@ -1,0 +1,546 @@
+/* eslint-disable no-console */
+/**
+ * Currents.dev Test Health Check
+ *
+ * Periodically:
+ * 1. Enumerates recently-active tests via the Tests Explorer, then fetches the latest
+ *    LAST_N_EXECUTIONS individual results per test via the Test Results API and quarantines
+ *    any test with ≥80% failure rate in that window.
+ * 2. For already-quarantined tests, checks their latest LAST_N_EXECUTIONS results and
+ *    unquarantines any that now have ≤20% failure rate.
+ *
+ * Projects monitored:
+ *   Web E2E: Og0NOQ
+ *   Desktop E2E: 4ytF0E
+ */
+
+const CURRENTS_API_BASE = 'https://api.currents.dev/v1';
+const AUTO_QUARANTINE_PREFIX = '[auto-quarantine]';
+
+/**
+ * Heuristic thresholds
+ */
+const QUARANTINE_FAILURE_RATE = 0.8; // quarantine if ≥80% fails in the last N executions
+const UNQUARANTINE_FAILURE_RATE = 0.2; // unquarantine if ≤20% fails (i.e., ≥80% passes)
+const LAST_N_EXECUTIONS = 5; // number of individual executions to evaluate
+const EXPLORER_LOOKBACK_DAYS = 1; // window used by Tests Explorer to discover active tests
+// Pre-filter: skip only tests that are nearly perfect (>98% pass rate) in the explorer window.
+// Any test with ≥2% failure rate in the aggregate metrics is worth inspecting individually.
+// The exact quarantine decision is still made on the precise last-N execution results.
+const PRE_FILTER_RATE = 0.02; // inspect anything that isn't close to 100% passing
+
+const PROJECTS: Array<{ id: string; label: string }> = [
+    { id: 'Og0NOQ', label: 'Trezor Suite (web)' },
+    { id: '4ytF0E', label: 'Trezor Suite (desktop)' },
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TestExplorerMetrics {
+    executions: number;
+    failures: number;
+    passes: number;
+    failureRate: number;
+    flakinessRate: number;
+    flaky: number;
+    ignored: number;
+    avgDurationMs: number;
+    flakinessVolume: number;
+    failureVolume: number;
+    durationVolume: number;
+}
+
+interface TestExplorerItem {
+    title: string;
+    titlePath?: string[];
+    spec: string;
+    signature?: string;
+    latestTag?: string[];
+    lastSeen?: string;
+    metrics: TestExplorerMetrics;
+}
+
+interface TestsExplorerResponse {
+    status: string;
+    data: {
+        list: TestExplorerItem[];
+        count: number;
+        total: number;
+        nextPage: boolean;
+    };
+}
+
+interface RuleMatcherCondition {
+    type: string;
+    op: string;
+    value: string | string[];
+}
+
+interface RuleMatcher {
+    op: string;
+    cond: RuleMatcherCondition[];
+}
+
+interface RuleAction {
+    op: 'skip' | 'quarantine' | 'tag';
+    details?: { tags: string[] };
+}
+
+interface Action {
+    actionId: string;
+    name: string;
+    description: string;
+    action: RuleAction[];
+    matcher: RuleMatcher;
+    status: string;
+    createdAt: string;
+    expiresAfter?: string;
+}
+
+interface ActionsListResponse {
+    status: string;
+    data: Action[];
+}
+
+interface TestResultCommit {
+    branch: string;
+    sha: string;
+    authorName: string;
+    authorEmail: string;
+    message: string;
+}
+
+interface TestResultItem {
+    cursor: string;
+    signature: string;
+    createdAt: string;
+    runId: string;
+    instanceId: string;
+    spec: string;
+    status: 'passed' | 'failed' | 'pending' | 'skipped';
+    flaky: boolean;
+    commit: TestResultCommit;
+    duration: number;
+}
+
+interface TestResultsResponse {
+    status: string;
+    has_more: boolean;
+    data: TestResultItem[];
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+function getApiKey(): string {
+    const key = process.env.CURRENTS_API_KEY;
+    if (!key) throw new Error('CURRENTS_API_KEY env var is not set');
+
+    return key;
+}
+
+function getSlackWebhook(): string | undefined {
+    return process.env.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK;
+}
+
+async function currentsRequest<T>(
+    path: string,
+    options: RequestInit = {},
+    retries = 3,
+): Promise<T> {
+    const url = `${CURRENTS_API_BASE}${path}`;
+    const res = await fetch(url, {
+        ...options,
+        headers: {
+            Authorization: `Bearer ${getApiKey()}`,
+            'Content-Type': 'application/json',
+            ...(options.headers ?? {}),
+        },
+    });
+
+    // Handle rate limiting (HTTP 429) with exponential back-off
+    if (res.status === 429 && retries > 0) {
+        const retryAfter = res.headers.get('Retry-After');
+        const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : 10_000 * (4 - retries);
+        console.warn(
+            `  [rate-limit] 429 received for ${url}. Waiting ${waitMs}ms before retry (${retries} left)…`,
+        );
+        await new Promise(resolve => setTimeout(resolve, waitMs));
+
+        return currentsRequest<T>(path, options, retries - 1);
+    }
+
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Currents API ${options.method ?? 'GET'} ${url} → ${res.status}: ${body}`);
+    }
+
+    return res.json() as Promise<T>;
+}
+
+/**
+ * Fetch the latest N individual execution results for a specific test signature
+ * via the Test Results API. Results are returned newest-first.
+ */
+async function getLastNResults(
+    signature: string,
+    n = LAST_N_EXECUTIONS,
+): Promise<TestResultItem[]> {
+    const dateEnd = new Date();
+    const dateStart = new Date(dateEnd.getTime() - EXPLORER_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+
+    const queryString = [
+        `date_start=${dateStart.toISOString()}`,
+        `date_end=${dateEnd.toISOString()}`,
+        `limit=${n}`,
+    ].join('&');
+
+    const response = await currentsRequest<TestResultsResponse>(
+        `/test-results/${signature}?${queryString}`,
+    );
+
+    return response.data;
+}
+
+/**
+ * Compute failure stats from a list of individual execution results.
+ */
+function computeStats(results: TestResultItem[]): {
+    executions: number;
+    failures: number;
+    passes: number;
+    failureRate: number;
+} {
+    const executions = results.length;
+    const failures = results.filter(r => r.status === 'failed').length;
+    const passes = results.filter(r => r.status === 'passed').length;
+    const failureRate = executions > 0 ? failures / executions : 0;
+
+    return { executions, failures, passes, failureRate };
+}
+
+/**
+ * Fetch all pages from the Tests Explorer for a given project.
+ * Used only to enumerate active tests and obtain their signatures.
+ */
+async function getActiveTests(projectId: string): Promise<TestExplorerItem[]> {
+    const dateEnd = new Date();
+    const dateStart = new Date(dateEnd.getTime() - EXPLORER_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+
+    // The Currents API only accepts date-only strings (YYYY-MM-DD); time components are ignored/rejected
+    const toDateString = (d: Date) => d.toISOString().slice(0, 10);
+
+    const items: TestExplorerItem[] = [];
+    let page = 0;
+    const limit = 25;
+
+    while (true) {
+        const queryString = [
+            `date_start=${toDateString(dateStart)}`,
+            `date_end=${toDateString(dateEnd)}`,
+            `order=failRateXSamples`,
+            `dir=desc`,
+            `page=${page}`,
+            `limit=${limit}`,
+        ].join('&');
+
+        const response = await currentsRequest<TestsExplorerResponse>(
+            `/tests/${projectId}?${queryString}`,
+        );
+
+        items.push(...response.data.list);
+
+        if (!response.data.nextPage) break;
+        page++;
+    }
+
+    return items;
+}
+
+/**
+ * Fetch all auto-quarantine actions for a project.
+ */
+async function getAutoQuarantineActions(projectId: string): Promise<Action[]> {
+    const response = await currentsRequest<ActionsListResponse>(`/actions?projectId=${projectId}`);
+
+    return response.data.filter(
+        a => a.name.startsWith(AUTO_QUARANTINE_PREFIX) && a.action.some(r => r.op === 'quarantine'),
+    );
+}
+
+/**
+ * Extract the test title from an action's matcher conditions.
+ */
+function extractTitleFromAction(action: Action): string | undefined {
+    const conds = action.matcher?.cond ?? [];
+    const titleCond = conds.find(c => c.type === 'title' && c.op === 'eq');
+
+    return typeof titleCond?.value === 'string' ? titleCond.value : undefined;
+}
+
+/**
+ * Create a quarantine action for a failing test.
+ */
+function createQuarantineAction(
+    projectId: string,
+    test: TestExplorerItem,
+    stats: ReturnType<typeof computeStats>,
+): Promise<Action> {
+    const failurePercent = Math.round(stats.failureRate * 100);
+    const name = `${AUTO_QUARANTINE_PREFIX} ${test.title.slice(0, 80)}`;
+    const description =
+        `Automatically quarantined by test-health-check workflow.\n` +
+        `Reason: ${failurePercent}% failure rate (${stats.failures}/${stats.executions} latest executions).\n` +
+        `Spec: ${test.spec}\n` +
+        `Full title: ${test.title}`;
+
+    const body = {
+        name,
+        description,
+        action: [{ op: 'quarantine' }],
+        matcher: {
+            op: 'AND',
+            cond: [{ type: 'title', op: 'eq', value: test.title }],
+        },
+    };
+
+    return currentsRequest<Action>(`/actions?projectId=${projectId}`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+    });
+}
+
+/**
+ * Delete (remove) a quarantine action.
+ */
+async function deleteAction(actionId: string): Promise<void> {
+    await currentsRequest(`/actions/${actionId}`, { method: 'DELETE' });
+}
+
+// ---------------------------------------------------------------------------
+// Slack notification
+// ---------------------------------------------------------------------------
+
+async function sendSlackNotification(message: string): Promise<void> {
+    const webhook = getSlackWebhook();
+    if (!webhook) {
+        console.log(
+            '[slack] No E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK configured, skipping notification.',
+        );
+        console.log(`[slack] Message would have been:\n${message}`);
+
+        return;
+    }
+    const res = await fetch(webhook, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message }),
+    });
+    if (!res.ok) {
+        console.warn(`[slack] Failed to send Slack notification: ${res.status}`);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+async function quarantineFailingTests(
+    projectId: string,
+    projectLabel: string,
+    existingActions: Action[],
+    activeTests: TestExplorerItem[],
+): Promise<void> {
+    console.log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
+
+    const alreadyQuarantinedTitles = new Set(
+        existingActions.map(a => extractTitleFromAction(a)).filter(Boolean) as string[],
+    );
+
+    const candidateTests = activeTests.filter(
+        t =>
+            t.signature &&
+            t.metrics.executions >= LAST_N_EXECUTIONS &&
+            t.metrics.failureRate >= PRE_FILTER_RATE,
+    );
+
+    console.log(
+        `  Found ${activeTests.length} active test(s) in the last ${EXPLORER_LOOKBACK_DAYS} days. ` +
+            `${candidateTests.length} candidate(s) have ≥${Math.round(PRE_FILTER_RATE * 100)}% failure rate in the explorer window. ` +
+            `Fetching last ${LAST_N_EXECUTIONS} individual results for each candidate...`,
+    );
+
+    let newQuarantineCount = 0;
+
+    for (const test of candidateTests) {
+        if (!test.signature) {
+            continue;
+        }
+
+        if (alreadyQuarantinedTitles.has(test.title)) {
+            console.log(`  ↳ Already quarantined: "${test.title.slice(0, 80)}"`);
+            continue;
+        }
+
+        const results = await getLastNResults(test.signature);
+
+        if (results.length < LAST_N_EXECUTIONS) {
+            console.log(
+                `  ↳ Skipping "${test.title.slice(0, 80)}" — only ${results.length}/${LAST_N_EXECUTIONS} executions found.`,
+            );
+            continue;
+        }
+
+        const stats = computeStats(results);
+
+        if (stats.failureRate < QUARANTINE_FAILURE_RATE) {
+            continue;
+        }
+
+        const failurePercent = Math.round(stats.failureRate * 100);
+        console.log(
+            `  ↳ Quarantining: "${test.title.slice(0, 80)}" ` +
+                `(${failurePercent}% fail rate, ${stats.failures}/${stats.executions} latest runs)`,
+        );
+
+        await createQuarantineAction(projectId, test, stats);
+        newQuarantineCount++;
+
+        const slackMsg =
+            `:warning: *[${projectLabel}] Test auto-quarantined* :warning:\n` +
+            `> *Test:* \`${test.title}\`\n` +
+            `> *Spec:* \`${test.spec}\`\n` +
+            `> *Failure rate:* ${failurePercent}% (${stats.failures}/${stats.executions} latest executions)\n` +
+            `> *Action:* Test has been quarantined in Currents — its failures will no longer block CI.\n` +
+            `> _Investigate and fix the issue, then the test will be automatically unquarantined once it stabilises._\n` +
+            `> <https://app.currents.dev/projects/${projectId}|View in Currents Dashboard>`;
+
+        await sendSlackNotification(slackMsg);
+    }
+
+    if (newQuarantineCount === 0) {
+        console.log('  ✓ No new tests to quarantine.');
+    }
+}
+
+async function unquarantinePassingTests(
+    projectId: string,
+    projectLabel: string,
+    existingActions: Action[],
+    activeTests: TestExplorerItem[],
+): Promise<void> {
+    console.log(`\n── [${projectLabel}] Checking quarantined tests for recovery ──`);
+
+    if (existingActions.length === 0) {
+        console.log('  ✓ No auto-quarantined tests to check.');
+
+        return;
+    }
+
+    console.log(`  Found ${existingActions.length} auto-quarantined test(s).`);
+
+    const testsByTitle = new Map(activeTests.map(t => [t.title, t]));
+
+    for (const action of existingActions) {
+        const testTitle = extractTitleFromAction(action);
+        if (!testTitle) {
+            console.warn(`  ↳ Could not extract title from action "${action.name}", skipping.`);
+            continue;
+        }
+
+        // Look up the test signature from the pre-fetched explorer results.
+        const test = testsByTitle.get(testTitle);
+
+        if (!test?.signature) {
+            console.log(
+                `  ↳ "${testTitle.slice(0, 80)}" — not found in explorer (may not have run recently), keeping quarantine.`,
+            );
+            continue;
+        }
+
+        const results = await getLastNResults(test.signature);
+
+        if (results.length < LAST_N_EXECUTIONS) {
+            console.log(
+                `  ↳ "${testTitle.slice(0, 80)}" — only ${results.length}/${LAST_N_EXECUTIONS} executions found, keeping quarantine.`,
+            );
+            continue;
+        }
+
+        const stats = computeStats(results);
+        const failurePercent = Math.round(stats.failureRate * 100);
+        const passPercent = 100 - failurePercent;
+
+        if (stats.failureRate <= UNQUARANTINE_FAILURE_RATE) {
+            console.log(
+                `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" ` +
+                    `(${passPercent}% pass rate, ${stats.passes}/${stats.executions} latest runs) ✓`,
+            );
+
+            await deleteAction(action.actionId);
+
+            const slackMsg =
+                `:white_check_mark: *[${projectLabel}] Quarantined test is now healthy* :white_check_mark:\n` +
+                `> *Test:* \`${testTitle}\`\n` +
+                `> *Spec:* \`${test.spec}\`\n` +
+                `> *Pass rate:* ${passPercent}% (${stats.passes}/${stats.executions} latest executions)\n` +
+                `> *Action:* Test has been removed from quarantine — it will now contribute to CI results as normal.\n` +
+                `> <https://app.currents.dev/projects/${projectId}|View in Currents Dashboard>`;
+
+            await sendSlackNotification(slackMsg);
+        } else {
+            console.log(
+                `  ↳ Still failing: "${testTitle.slice(0, 80)}" ` +
+                    `(${failurePercent}% failure rate, ${stats.failures}/${stats.executions} latest runs) — keeping quarantine.`,
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+    console.log('=== Currents Test Health Check ===');
+    console.log(`Timestamp: ${new Date().toISOString()}`);
+    console.log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
+    console.log(
+        `Thresholds: quarantine ≥${QUARANTINE_FAILURE_RATE * 100}% failures, unquarantine ≤${UNQUARANTINE_FAILURE_RATE * 100}% failures, ` +
+            `evaluated over last ${LAST_N_EXECUTIONS} individual executions (using Test Results API)`,
+    );
+    console.log('');
+
+    let hasError = false;
+
+    for (const project of PROJECTS) {
+        try {
+            const [existingActions, activeTests] = await Promise.all([
+                getAutoQuarantineActions(project.id),
+                getActiveTests(project.id),
+            ]);
+            await quarantineFailingTests(project.id, project.label, existingActions, activeTests);
+            await unquarantinePassingTests(project.id, project.label, existingActions, activeTests);
+        } catch (err) {
+            console.error(
+                `\n[ERROR] Failed processing project ${project.label} (${project.id}):`,
+                err,
+            );
+            hasError = true;
+        }
+    }
+
+    console.log('\n=== Done ===');
+
+    if (hasError) {
+        process.exit(1);
+    }
+}
+
+main().catch(err => {
+    console.error('[FATAL]', err);
+    process.exit(1);
+});

--- a/scripts/ci/quarantineBot/seed/fake-tests.spec.ts
+++ b/scripts/ci/quarantineBot/seed/fake-tests.spec.ts
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * Seeder for Currents.dev test health-check.
+ *
+ * Contains ONE test with a stable name. Each invocation of this script is a
+ * separate Currents run, so running it N times gives that one test N data
+ * points in the Tests Explorer. That is the history the health-check uses to
+ * decide on quarantine/unquarantine.
+ *
+ * --- Environment variables ------------------------------------------------
+ *
+ *   SEED_FAIL            Set to "true" to make the test fail in this run.
+ *                        Default: false (test passes)
+ *
+ *   SEED_TEST_NAME       Override the stable test title.
+ *                        Default: "canary: health-check seed test"
+ *
+ * --- Workflow for triggering quarantine -----------------------------------
+ *
+ *   # Fail the test in 5 consecutive runs → 100% failure rate → quarantined:
+ *   for i in 1 2 3 4 5; do
+ *     SEED_FAIL=true CURRENTS_RECORD_KEY=xxx \
+ *       npx playwright test --config=playwright.config.ts
+ *   done
+ *
+ *   # Then pass in 5 runs → failure rate drops → unquarantined:
+ *   for i in 1 2 3 4 5; do
+ *     CURRENTS_RECORD_KEY=xxx \
+ *       npx playwright test --config=playwright.config.ts
+ *   done
+ */
+
+import { expect, test } from '@playwright/test';
+
+const SEED_FAIL = process.env.SEED_FAIL === 'true';
+const SEED_TEST_NAME = process.env.SEED_TEST_NAME ?? 'canary: health-check seed test';
+
+test(SEED_TEST_NAME, () => {
+    if (SEED_FAIL) {
+        expect(false, `[seed] Intentional failure: ${SEED_TEST_NAME}`).toBe(true);
+    } else {
+        expect(true).toBe(true);
+    }
+});

--- a/scripts/ci/quarantineBot/seed/playwright.config.ts
+++ b/scripts/ci/quarantineBot/seed/playwright.config.ts
@@ -1,0 +1,33 @@
+/* eslint-disable import/no-extraneous-dependencies, import/no-default-export */
+/**
+ * Playwright config for seeding fake test results into Currents.dev.
+ *
+ * Target project: Experimental Playground (iBEsWE)
+ *
+ * Required env vars:
+ *   CURRENTS_RECORD_KEY   – your Currents record key
+ *
+ * Optional env vars (see fake-tests.spec.ts for the full list):
+ *   CURRENTS_CI_BUILD_ID  – custom build ID (defaults to seed-<timestamp>)
+ *   CURRENTS_TAG          – comma-separated tags to attach to the run
+ */
+
+import { currentsReporter } from '@currents/playwright';
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+    testDir: '.',
+    testMatch: 'fake-tests.spec.ts',
+    fullyParallel: true,
+    workers: 4,
+    retries: 0,
+    reporter: [
+        ['list'],
+        currentsReporter({
+            ciBuildId: process.env.CURRENTS_CI_BUILD_ID ?? `seed-${Date.now()}`,
+            recordKey: process.env.CURRENTS_RECORD_KEY!,
+            projectId: 'iBEsWE', // Experimental Playground project ID
+            tag: process.env.CURRENTS_TAG?.split(',').filter(Boolean) ?? ['seed'],
+        }),
+    ],
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,9 @@
     },
     "devDependencies": {
         "@babel/cli": "7.28.6",
+        "@currents/playwright": "^1.19.0",
         "@mobily/ts-belt": "^3.13.1",
+        "@playwright/test": "^1.57.0",
         "@trezor/eslint": "workspace:*",
         "@types/semver": "^7.7.0",
         "chalk": "^5.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15656,7 +15656,9 @@ __metadata:
   resolution: "@trezor/scripts@workspace:scripts"
   dependencies:
     "@babel/cli": "npm:7.28.6"
+    "@currents/playwright": "npm:^1.19.0"
     "@mobily/ts-belt": "npm:^3.13.1"
+    "@playwright/test": "npm:^1.57.0"
     "@trezor/eslint": "workspace:*"
     "@types/semver": "npm:^7.7.0"
     chalk: "npm:^5.6.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

New workflow. Every 15 minutes check health of all e2e tests and quarantine the ones that failed 80% of the last 5 executions. Unquarantine when the inverse is true. We can tweak these numbers and heuristics as we want, but this should make our response time to catch tests that need to be quarantined much faster.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-autoquarantine&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-autoquarantine&lookback=7)