### PR TITLE
fix(suite-native): Fix cancelation on device during wallet creation / recovery

### DIFF
--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -17,6 +17,7 @@ import {
     RootStackParamList,
     RootStackRoutes,
     StackToStackCompositeNavigationProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
 import { ERRORS } from '@trezor/connect-common/src/constants';
@@ -46,6 +47,7 @@ export const WalletCreationScreen = () => {
     const { walletBackupType } = route.params;
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProp>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const { showToast } = useToast();
 
     const isEntropyCheckEnabled = useSelector((state: MessageSystemRootState) =>
@@ -75,12 +77,25 @@ export const WalletCreationScreen = () => {
                 return;
             }
 
-            // handle entropy check failure, otherwise continue with the flow
+            // handle entropy check failure
             if (isEntropyCheckEnabled && code === 'Failure_EntropyCheck') {
-                navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+                return navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
             }
+            // canceled on device -> cancel in suite
+            else if (code === 'Failure_ActionCancelled' || code === 'Method_Interrupted') {
+                return navigateToInitialScreen();
+            }
+
+            console.error(`Unknown definitive code: '${code}'`);
         }
-    }, [dispatch, walletBackupType, navigation, isEntropyCheckEnabled, showToast]);
+    }, [
+        dispatch,
+        walletBackupType,
+        navigation,
+        navigateToInitialScreen,
+        isEntropyCheckEnabled,
+        showToast,
+    ]);
 
     useEffect(() => {
         handleCreateAndBackupWallet();

--- a/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletRecoveryScreen.tsx
@@ -6,6 +6,7 @@ import {
     DeviceOnboardingStackParamList,
     DeviceOnboardingStackRoutes,
     StackProps,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 
 import { DeviceOnboardingScreenWithExitButton } from '../components/DeviceOnboardingScreenWithExitButton';
@@ -14,6 +15,7 @@ export const WalletRecoveryScreen = ({
     navigation,
 }: StackProps<DeviceOnboardingStackParamList, DeviceOnboardingStackRoutes.WalletRecovery>) => {
     const dispatch = useDispatch();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
 
     const handleRecoverWallet = useCallback(async () => {
         const response = await dispatch(recoverWalletThunk()).unwrap();
@@ -27,13 +29,14 @@ export const WalletRecoveryScreen = ({
         if (
             response.error.code === 'Failure_ActionCancelled' ||
             response.error.code === 'Method_Interrupted'
-        )
-            return;
+        ) {
+            return navigateToInitialScreen();
+        }
 
         // This code is OK, but the eslint plugin crashes on recursive calls
         // eslint-disable-next-line react-hooks/immutability
         handleRecoverWallet();
-    }, [dispatch, navigation]);
+    }, [dispatch, navigation, navigateToInitialScreen]);
 
     useEffect(() => {
         handleRecoverWallet();


### PR DESCRIPTION
Wallet creation / recovery now calls `navigateToInitialScreen` if the flow is canceled on device.

## Notes for QA

**Areas to test:** Cancelation during various times in onboarding on mobile.

## Related Issue

Resolve #25561

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/onboarding-cancel-on-device&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/onboarding-cancel-on-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->