### PR TITLE
chore(trade): rename trade debug settings

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -18,7 +18,6 @@ import { Devkit } from './Devkit';
 import { FirmwareUpdateEnvironmentSelect } from './FirmwareUpdateEnvironmentSelect';
 import { ForgetAllDevicesButton } from './ForgetBluetoothDevices';
 import { GithubIssue } from './GithubIssue';
-import { InvityApi } from './InvityApi';
 import { MessageSystemConfigSourceSelect } from './MessageSystem/MessageSystemConfigSourceSelect';
 import { MessageSystemDebug } from './MessageSystem/MessageSystemDebug';
 import { Metadata } from './Metadata';
@@ -31,6 +30,7 @@ import { ShowBluetoothDebugInfo } from './ShowBluetoothDebugInfo';
 import { SuiteSyncSettings } from './SuiteSyncSettings';
 import { ThrowTestingError } from './ThrowTestingError';
 import { Tor } from './Tor';
+import { TradeApi } from './TradeApi';
 import { Transport } from './Transport';
 import { TransportBackends } from './TransportBackends';
 import { TrezorConnectLogs } from './TrezorConnectLogs';
@@ -54,8 +54,8 @@ export const SettingsDebug = () => {
             <SettingsSection title="Analytics">
                 <AnalyticsLogging />
             </SettingsSection>
-            <SettingsSection title="Invity">
-                <InvityApi />
+            <SettingsSection title="Trade">
+                <TradeApi />
             </SettingsSection>
             <SettingsSection title="OAuth">
                 <OAuthApi />

--- a/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
@@ -11,7 +11,7 @@ const StyledActionSelect = styled(ActionSelect)`
     min-width: 256px;
 `;
 
-export const InvityApi = () => {
+export const TradeApi = () => {
     const debug = useSelector(state => state.suite.settings.debug);
     const dispatch = useDispatch();
 


### PR DESCRIPTION
Renaming `Invity` -> `Trade` debug settings to get rid of legacy naming

## Notes for QA

debug settings for trading should have different title


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rename-trade-debug-setting&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rename-trade-debug-setting&lookback=7)