### PR TITLE
fix(connect-explorer): remove react error from console

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useId, useMemo, useRef } from 'react';
 import ReactSelect, {
     ControlProps,
     OptionProps,
@@ -67,6 +67,7 @@ export const Select = ({
     ...rest
 }: SelectProps) => {
     const selectRef = useRef<SelectInstance<OptionType, boolean>>(null);
+    const autoInstanceId = useId();
 
     const formCellProps = pickFormCellProps(rest);
     const { isDisabled, hasError } = formCellProps;
@@ -154,6 +155,7 @@ export const Select = ({
                 unstyled
                 styles={createSharedMenuStyles<OptionType>()}
                 components={memoizedComponents}
+                instanceId={autoInstanceId}
                 {...reactSelectProps}
             />
         </FormCell>


### PR DESCRIPTION
on develop 
1. yarn workspace @trezor/connect-explorer dev
2. Open http://localhost:8088 
3. Maybe navigate around a bit

you get this in console

<img width="617" height="548" alt="Screenshot 2026-03-01 at 14 23 27" src="https://github.com/user-attachments/assets/5b1d28ab-2c87-49ad-bd1f-e759e0d7baf8" />

Are you guys ok with solving it like this? Or should we plass this instance id from outside everywhere we use Select component? 

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-explorer-react-error&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-explorer-react-error&lookback=7)