### PR TITLE
chore: update @types/invity-api to version 1.1.14

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -144,7 +144,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@trezor/eslint": "workspace:*",
         "@types/file-saver": "^2.0.6",
-        "@types/invity-api": "^1.1.13",
+        "@types/invity-api": "^1.1.14",
         "@types/pako": "^2.0.4",
         "@types/pdfmake": "^0.2.11",
         "@types/react": "19.1.6",

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -40,6 +40,6 @@
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",
         "@testing-library/react": "^16.3.2",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-common/wallet-types/package.json
+++ b/suite-common/wallet-types/package.json
@@ -18,7 +18,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:^",
-        "@types/invity-api": "^1.1.13",
+        "@types/invity-api": "^1.1.14",
         "react": "19.1.0"
     }
 }

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -90,6 +90,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -35,7 +35,7 @@
         "@trezor/styles": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "@types/invity-api": "^1.1.13",
+        "@types/invity-api": "^1.1.14",
         "expo-system-ui": "~6.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",

--- a/suite-native/trading-analytics/package.json
+++ b/suite-native/trading-analytics/package.json
@@ -25,6 +25,6 @@
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -37,6 +37,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/trading-browser-auth/package.json
+++ b/suite-native/trading-browser-auth/package.json
@@ -41,6 +41,6 @@
         "@suite-native/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/trading-fixtures/package.json
+++ b/suite-native/trading-fixtures/package.json
@@ -23,6 +23,6 @@
     },
     "devDependencies": {
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -43,6 +43,6 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite-native/trading-fixtures": "workspace:*",
         "@suite-native/trading-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/suite-native/trading-types/package.json
+++ b/suite-native/trading-types/package.json
@@ -20,6 +20,6 @@
         "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
-        "@types/invity-api": "^1.1.13"
+        "@types/invity-api": "^1.1.14"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11583,7 +11583,7 @@ __metadata:
     "@trezor/react-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     react: "npm:19.1.0"
     react-redux: "npm:9.2.0"
     uuid: "npm:^13.0.0"
@@ -11700,7 +11700,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:^"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     react: "npm:19.1.0"
   languageName: unknown
   linkType: soft
@@ -13618,7 +13618,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     expo-linear-gradient: "npm:~15.0.8"
     react: "npm:19.1.0"
     react-intl: "npm:^8.1.3"
@@ -13695,7 +13695,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     expo-system-ui: "npm:~6.0.9"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
@@ -14177,7 +14177,7 @@ __metadata:
     "@suite-native/test-utils": "workspace:*"
     "@suite-native/trading-atoms": "workspace:*"
     "@suite-native/trading-fixtures": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     react: "npm:19.1.0"
     react-redux: "npm:9.2.0"
   languageName: unknown
@@ -14203,7 +14203,7 @@ __metadata:
     "@trezor/styles": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     react: "npm:19.1.0"
     react-native: "npm:0.81.5"
     react-native-gesture-handler: "npm:2.30.0"
@@ -14235,7 +14235,7 @@ __metadata:
     "@suite-native/trading-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     expo-linking: "npm:~8.0.11"
     expo-web-browser: "npm:~15.0.10"
     react: "npm:19.1.0"
@@ -14285,7 +14285,7 @@ __metadata:
     "@suite-native/trading-consts": "workspace:*"
     "@suite-native/trading-types": "workspace:*"
     "@trezor/connect": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
   languageName: unknown
   linkType: soft
 
@@ -14349,7 +14349,7 @@ __metadata:
     "@suite-native/trading-types": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     react-native: "npm:0.81.5"
   languageName: unknown
   linkType: soft
@@ -14366,7 +14366,7 @@ __metadata:
     "@suite-native/intl": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
   languageName: unknown
   linkType: soft
 
@@ -16014,7 +16014,7 @@ __metadata:
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@types/file-saver": "npm:^2.0.6"
-    "@types/invity-api": "npm:^1.1.13"
+    "@types/invity-api": "npm:^1.1.14"
     "@types/pako": "npm:^2.0.4"
     "@types/pdfmake": "npm:^0.2.11"
     "@types/react": "npm:19.1.6"
@@ -17076,10 +17076,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/invity-api@npm:^1.1.13":
-  version: 1.1.13
-  resolution: "@types/invity-api@npm:1.1.13"
-  checksum: 10/7f0b558bf92a51f3ca398386d9a46556352790354bafdfa01ad0c6d696c75977cd57ffa9734c7156045eab81984b9328dc993efb28bd95daecdf9b56824bac71
+"@types/invity-api@npm:^1.1.14":
+  version: 1.1.14
+  resolution: "@types/invity-api@npm:1.1.14"
+  checksum: 10/93c79ae99b3389d9a09cdc20c892e07ffaed96bb9d98a27eb82f34fedee844b06373b54bfe309206e7e367a6e8b2f1dd335855f65718a4ec30a248c362ed67b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update `@types/invity-api` to `^1.1.14` across Suite and native trading packages.

## Notes for QA

Just dev thing, no need QA.

## Related Issue


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-invity-api&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-invity-api&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/update-invity-api&lookback=7)