### PR TITLE
fix(suite-native): storybook autogenerated file

### DIFF
--- a/suite-native/storybook/.rnstorybook/storybook.requires.ts
+++ b/suite-native/storybook/.rnstorybook/storybook.requires.ts
@@ -22,6 +22,7 @@ const normalizedStories = [
 declare global {
   var view: View;
   var STORIES: typeof normalizedStories;
+  var STORYBOOK_WEBSOCKET: { host: string; port: number } | undefined;
 }
 
 
@@ -30,21 +31,22 @@ const annotations = [
   require("@storybook/react-native/preview")
 ];
 
-global.STORIES = normalizedStories;
+globalThis.STORIES = normalizedStories;
+
 
 // @ts-ignore
 module?.hot?.accept?.();
 
 
 
-if (!global.view) {
-  global.view = start({
+if (!globalThis.view) {
+  globalThis.view = start({
     annotations,
     storyEntries: normalizedStories,
 
   });
 } else {
-  updateView(global.view, annotations, normalizedStories);
+  updateView(globalThis.view, annotations, normalizedStories);
 }
 
-export const view: View = global.view;
+export const view: View = globalThis.view;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update of storybook regenerates this file upon `yarn start` so I'm commiting the newer version. Let's consider adding check for this in CI  or maybe include it in precommit hook.

## Notes for QA
Nothing to test. 


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/storybook-requires-update&lookback=7)