### PR TITLE
feat: add debug setting to clear persistentDeviceData

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -302,6 +302,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     deviceActions.connectDevice,
                     deviceActions.deviceChanged,
                     deviceActions.setEntropyCheckResult,
+                    deviceActions.clearDevicePersistentData,
                 )(action)
             ) {
                 api.dispatch(storageActions.savePersistentDeviceData());

--- a/packages/suite/src/views/settings/SettingsDebug/ClearDevicePersistentData.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ClearDevicePersistentData.tsx
@@ -1,0 +1,29 @@
+import { deviceActions } from '@suite-common/device';
+import { notificationsActions } from '@suite-common/toast-notifications';
+
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { useDispatch } from 'src/hooks/suite';
+
+export const ClearDevicePersistentData = () => {
+    const dispatch = useDispatch();
+
+    const handleClick = () => {
+        dispatch(deviceActions.clearDevicePersistentData());
+        // technically just part of the storage was cleared, but it's just dev util, so close enough to let you know it is finished
+        dispatch(notificationsActions.addToast({ type: 'clear-storage' }));
+    };
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Clear app's device persistent data"
+                description="Clears Suite's stored per-device persistent data (mostly security checks). Does not affect Bluetooth or THP."
+            />
+            <ActionColumn>
+                <ActionButton onClick={handleClick} size="small" intent="critical">
+                    Clear
+                </ActionButton>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -11,6 +11,7 @@ import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { AnalyticsLogging } from './AnalyticsLogging';
 import { Backends } from './Backends';
 import { CheckFirmwareAuthenticity } from './CheckFirmwareAuthenticity';
+import { ClearDevicePersistentData } from './ClearDevicePersistentData';
 import { CoinjoinApi } from './CoinjoinApi';
 import { ConnectPopup } from './ConnectPopup';
 import { DeviceAuthenticity } from './DeviceAuthenticity';
@@ -67,6 +68,7 @@ export const SettingsDebug = () => {
                 <DeviceAuthenticity />
                 <Devkit />
                 <CheckFirmwareAuthenticity />
+                <ClearDevicePersistentData />
             </SettingsSection>
             <SettingsSection title="Testing">
                 <ThrowTestingError />

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -94,6 +94,8 @@ const forgetDevicePersistentData = createAction(
     (payload: { deviceId: AcquiredDevice['id'] }) => ({ payload }),
 );
 
+const clearDevicePersistentData = createAction(`${DEVICE_MODULE_PREFIX}/clearDevicePersistentData`);
+
 const addButtonRequest = createAction(
     `${DEVICE_MODULE_PREFIX}/addButtonRequest`,
     (payload: { device?: TrezorDevice; buttonRequest: ButtonRequest }) => ({ payload }),
@@ -183,6 +185,7 @@ export const deviceActions = {
     setTemporaryRememberedDevice,
     forgetDevice,
     forgetDevicePersistentData,
+    clearDevicePersistentData,
     addButtonRequest,
     requestDeviceReconnect,
     selectDevice,

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -636,6 +636,9 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                     d => d.device_id !== payload.deviceId,
                 );
             })
+            .addCase(deviceActions.clearDevicePersistentData, state => {
+                state.persistentDeviceData = [];
+            })
             .addCase(deviceActions.addButtonRequest, (state, { payload }) => {
                 addButtonRequest(state, payload.device, payload.buttonRequest);
             })

--- a/suite-native/module-dev-utils/package.json
+++ b/suite-native/module-dev-utils/package.json
@@ -15,6 +15,7 @@
         "@react-navigation/native-stack": "7.9.0",
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/analytics-redux": "workspace:*",
+        "@suite-common/device": "workspace:*",
         "@suite-common/firmware": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",

--- a/suite-native/module-dev-utils/src/components/DangerZoneCard.tsx
+++ b/suite-native/module-dev-utils/src/components/DangerZoneCard.tsx
@@ -1,8 +1,12 @@
+import { useDispatch } from 'react-redux';
+
+import { deviceActions } from '@suite-common/device';
 import { Button, Card, Text, VStack } from '@suite-native/atoms';
 import { useNativeServices } from '@suite-native/services';
 import { clearStorage } from '@suite-native/storage';
 
 export const DangerZoneCard = () => {
+    const dispatch = useDispatch();
     const { getMMKVStorage } = useNativeServices();
 
     return (
@@ -19,6 +23,14 @@ export const DangerZoneCard = () => {
                         }}
                     >
                         💥 Wipe all data
+                    </Button>
+                </VStack>
+                <VStack>
+                    <Button
+                        colorScheme="redBold"
+                        onPress={() => dispatch(deviceActions.clearDevicePersistentData())}
+                    >
+                        Clear app&apos;s device persistent data
                     </Button>
                 </VStack>
             </VStack>

--- a/suite-native/module-dev-utils/tsconfig.json
+++ b/suite-native/module-dev-utils/tsconfig.json
@@ -5,6 +5,7 @@
         {
             "path": "../../suite-common/analytics-redux"
         },
+        { "path": "../../suite-common/device" },
         { "path": "../../suite-common/firmware" },
         {
             "path": "../../suite-common/message-system"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13158,6 +13158,7 @@ __metadata:
     "@react-navigation/native-stack": "npm:7.9.0"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/analytics-redux": "workspace:*"
+    "@suite-common/device": "workspace:*"
     "@suite-common/firmware": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"


### PR DESCRIPTION
## Description

Add debug setting to clear persistent device data, which is useful for development – when you keep connecting many new devices, the list just keeps growing and resetting app is an impractical way to clear it. 

## Notes for QA

N/A, debug only

## Screenshots:

<img width="630" height="813" alt="image" src="https://github.com/user-attachments/assets/b6db7e59-283e-4c3c-ab7b-0b8d273b2860" />

<img width="407" height="920" alt="image" src="https://github.com/user-attachments/assets/0d1e835d-c97c-4f86-95c9-f1b42f033bf7" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/debug-clear-persistent-device-data&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/debug-clear-persistent-device-data&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/debug-clear-persistent-device-data&lookback=7)