### PR TITLE
feat(trading): Subdivision selector on compare page

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Control, useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { TRADING_FORM_COUNTRY_SELECT } from '@suite-common/trading';
@@ -7,7 +8,10 @@ import { GhostContainer, Icon, Row, Text } from '@trezor/components';
 import { FakeSelect } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
-import { TradingFormInputDefaultProps } from 'src/types/trading/tradingForm';
+import {
+    TradingBuySellFormProps,
+    TradingFormInputDefaultProps,
+} from 'src/types/trading/tradingForm';
 
 import { CountrySelectModal } from './CountrySelectModal';
 
@@ -21,9 +25,12 @@ export const TradingFormInputCountry = ({
 }: TradingFormInputCountryProps) => {
     const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
-    const { watch, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
+    const { control, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
 
-    const countryValue = watch()[TRADING_FORM_COUNTRY_SELECT];
+    const countryValue = useWatch({
+        control: control as Control<TradingBuySellFormProps>,
+        name: TRADING_FORM_COUNTRY_SELECT,
+    });
 
     return (
         <>

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
@@ -1,17 +1,23 @@
+import { Control, useWatch } from 'react-hook-form';
+
 import styled from 'styled-components';
 
+import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
+    TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
+    TradingTradeBuySellType,
 } from '@suite-common/trading';
 import { Row } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { TradingBuySellFormProps } from 'src/types/trading/tradingForm';
 import {
     isTradingBuyContext,
     isTradingExchangeContext,
@@ -21,14 +27,22 @@ import { TradingFormInputFiatCrypto } from 'src/views/wallet/trading/common/Trad
 import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod';
 import { TradingOffersExchangeFiltersPanel } from 'src/views/wallet/trading/common/TradingHeader/TradingOffersExchangeFiltersPanel';
 
+import { TradingFormInputCountrySubdivision } from '../TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
+
 const InputWrapper = styled.div`
-    width: 254px;
+    width: 200px;
     max-width: 100%;
     padding: ${spacingsPx.xxs} ${spacingsPx.md} ${spacingsPx.xxs} 0;
 `;
 
 export const TradingHeaderFilter = () => {
-    const context = useTradingFormContext();
+    const context = useTradingFormContext<TradingTradeBuySellType>();
+
+    const selectedCountry = useWatch({
+        control: context.control as Control<TradingBuySellFormProps>,
+        name: TRADING_FORM_COUNTRY_SELECT,
+    });
+    const countryRequiresSubdivision = isCountrySubdivisionRequired(selectedCountry?.value);
 
     if (isTradingExchangeContext(context)) {
         return (
@@ -65,6 +79,15 @@ export const TradingHeaderFilter = () => {
             <InputWrapper>
                 <TradingFormInputCountry renderInput label="TR_TRADING_COUNTRY" />
             </InputWrapper>
+            {countryRequiresSubdivision && (
+                <InputWrapper>
+                    <TradingFormInputCountrySubdivision
+                        renderInput
+                        label="TR_TRADING_COUNTRY_SUBDIVISION"
+                        country={selectedCountry}
+                    />
+                </InputWrapper>
+            )}
         </Row>
     );
 };


### PR DESCRIPTION
## Description

- Add country subdivision (state) selector support to trading buy/sell forms and compare offers page.
- Extend geolocation + trading utils/hooks/reducers to handle subdivisions, including filtering and redirects.
- Adjust trading header/filter layout to accommodate the new selector.

## Notes for QA

- Focus on Trading buy/sell flows and Compare offers page.
- Test countries that require subdivisions (e.g. US) vs. those that don’t:  
  - Verify subdivision selector appears only when required and is validated correctly.  
  - Confirm offers and redirects respect the selected subdivision (buy/sell, including re-opened forms).
- Smoke-test that existing trading flows still work for countries without subdivisions.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25330


## Screenshot
<img width="1231" height="373" alt="image" src="https://github.com/user-attachments/assets/442d9473-230a-41d1-b048-912b3495075f" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/25330/state-selector-compare-page&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/25330/state-selector-compare-page&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/25330/state-selector-compare-page&lookback=7)