### PR TITLE
fix(connect): fix undefined device bug in bitcoin payloadToPrecomposed

### DIFF
--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -193,10 +193,16 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
         return getLabel('Sign #NETWORK transaction', coinInfo);
     }
 
-    async payloadToPrecomposed() {
+    payloadToPrecomposed() {
         try {
             const { inputs, outputs, coinInfo } = this.params;
-            const refTxs = this.params.refTxs ?? (await this.fetchRefTxs(false));
+            if (!this.params.refTxs) {
+                throw ERRORS.TypedError(
+                    'Runtime',
+                    'refTxs are required for precomposed transaction info',
+                );
+            }
+            const { refTxs } = this.params;
             const inputsTotal: BigNumber = inputs.reduce((bn, input) => {
                 if (typeof input.amount === 'string') {
                     return bn.plus(input.amount);
@@ -222,7 +228,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             }
             const feePerByte = fee.dividedBy(bytes);
 
-            return {
+            return Promise.resolve({
                 type: 'final' as const,
                 inputs,
                 outputs,
@@ -231,12 +237,12 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 fee: fee.toString(),
                 feePerByte: feePerByte.toString(),
                 bytes,
-            };
+            });
         } catch (e) {
             // Don't throw errors from this method
             console.error('Error in payloadToPrecomposed', e);
 
-            return undefined;
+            return Promise.resolve(undefined);
         }
     }
 


### PR DESCRIPTION
while looking into this task #5306 I bumped into this pre-existing error, so I am opening this fix as a prerequisite.

## Fix latent bug in `signTransaction.payloadToPrecomposed()`

### Bug

`payloadToPrecomposed()` is called from the `__info`/`__precomposed` path in `core/index.ts` **before device selection**. In `signTransaction.ts`, the override fell through to `this.fetchRefTxs()` when `refTxs` were not provided in params. `fetchRefTxs()` called `this.fetchAddresses()`, which accessed `this.device.getCommands()` — but `this.device` is `undefined` at that point in the lifecycle, causing a `TypeError` at runtime.

The bug was never hit in production because the only caller of `__precomposed` is Suite's `connectPopupCallThunkInner`, which always provides transaction data via `account.transactions` in the payload. This gets validated and stored as `this.params.refTxs` during `init()`, so the `fetchRefTxs()` fallback was never reached.

### Fix

- **`signTransaction.ts`**: `payloadToPrecomposed()` now checks for `this.params.refTxs` upfront and throws a clear `TypedError('Runtime', 'refTxs are required for precomposed transaction info')` if missing, instead of falling through to a device-dependent code path that crashes.


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-fix-missing-device-bug&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-fix-missing-device-bug&lookback=7)