### PR TITLE
feat(suite-sync): enable QM override

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -516,6 +516,7 @@ export const saveSuiteSyncQuotaManager = () => (_dispatch: Dispatch, getState: G
         'suiteSyncQuotaManager',
         {
             baseUrl: suiteSyncQuotaManager.baseUrl,
+            enforceQuotaManager: suiteSyncQuotaManager.enforceQuotaManager,
             registeredDevices: suiteSyncQuotaManager.registeredDevices,
             ownersAllowance: suiteSyncQuotaManager.ownersAllowance,
         },

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -205,7 +205,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 isAnyOf(
                     suiteSyncQuotaManagerActions.quotaManagerDeviceFetched,
                     suiteSyncQuotaManagerActions.updateQuotaManagerBaseUrl,
-                )
+                    suiteSyncQuotaManagerActions.enforceQuotaManagerUpdated,
+                )(action)
             ) {
                 api.dispatch(storageActions.saveSuiteSyncQuotaManager());
             }

--- a/packages/suite/src/storage/migrations/versions/26.1.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.1.0.ts
@@ -15,6 +15,7 @@ export default createMigration<SuiteDBSchema>('26.1.0', async (db, tx) => {
             baseUrl: null,
             registeredDevices: [],
             ownersAllowance: [],
+            enforceQuotaManager: false,
         },
         'suiteSyncQuotaManager',
     );

--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 
 import {
+    enforceQuotaManagerUpdated,
     eraseFetchedDataDebug,
+    selectEnforceQuotaManager,
     selectOwnersAllowance,
     selectQuotaManagerBaseUrl,
     selectRegisteredDevices,
     updateQuotaManagerBaseUrl,
 } from '@suite-common/suite-sync-quota-manager';
-import { Button, Column, Input } from '@trezor/components';
+import { Button, Checkbox, Column, Input } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { SettingsSection } from 'src/components/settings/SettingsSection';
@@ -19,6 +21,7 @@ export const QuotaManagerSettings = () => {
     const quotaManagerBaseUrl = useSelector(selectQuotaManagerBaseUrl);
     const registeredDevices = useSelector(selectRegisteredDevices);
     const ownersAllowance = useSelector(selectOwnersAllowance);
+    const enforceQuotaManager = useSelector(selectEnforceQuotaManager);
     const [quotaManagerUrl, setQuotaManagerUrl] = useState(quotaManagerBaseUrl ?? '');
 
     const [isUpdateUrlLoading, setIsUpdateUrlLoading] = useState(false);
@@ -38,6 +41,13 @@ export const QuotaManagerSettings = () => {
     };
 
     const onEraseFetchedData = () => dispatch(eraseFetchedDataDebug());
+
+    const onToggleEnforceQuotaManager = () =>
+        dispatch(
+            enforceQuotaManagerUpdated({
+                enforce: !enforceQuotaManager,
+            }),
+        );
 
     return (
         <SettingsSection title="Quota Manager">
@@ -101,6 +111,16 @@ export const QuotaManagerSettings = () => {
                             ))
                         )}
                     </Column>
+                </ActionColumn>
+            </SectionItem>
+            <SectionItem>
+                <TextColumn title="Enforce Quota Manager for custom relay" />
+                <ActionColumn>
+                    <Checkbox
+                        data-testid="@settings/debug/quota-manager-enforce-for-custom-relay-checkbox"
+                        isChecked={enforceQuotaManager}
+                        onClick={onToggleEnforceQuotaManager}
+                    />
                 </ActionColumn>
             </SectionItem>
             <SectionItem>

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -22,6 +22,7 @@ export {
     suiteSyncQuotaManagerActions,
     eraseFetchedData as eraseFetchedDataDebug,
     noQuotaLeftWarningDismissed,
+    enforceQuotaManagerUpdated,
 } from './quotaManagerActions';
 
 /**
@@ -37,6 +38,7 @@ export {
     selectLeftDeviceQuota,
     selectDeviceDismissedNoQuotaLeftWarning,
     selectShouldDisplayOutOfQuotaAlert,
+    selectEnforceQuotaManager,
 } from './quotaManagerSelectors';
 export type { WithSuiteSyncQuotaManagerState } from './quotaManagerSelectors';
 

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerActions.ts
@@ -50,6 +50,11 @@ export const noQuotaLeftWarningDismissed = createAction(
     }),
 );
 
+export const enforceQuotaManagerUpdated = createAction(
+    `${QUOTA_MANAGER_PREFIX}/enforceQuotaManagerUpdated`,
+    (payload: { enforce: boolean }) => ({ payload }),
+);
+
 export const suiteSyncQuotaManagerActions = {
     updateQuotaManagerBaseUrl,
     quotaManagerFetchError,
@@ -57,4 +62,5 @@ export const suiteSyncQuotaManagerActions = {
     quotaManagerOwnerFetched,
     eraseFetchedData,
     noQuotaLeftWarningDismissed,
+    enforceQuotaManagerUpdated,
 };

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerReducer.ts
@@ -1,6 +1,7 @@
 import { createReducer } from '@reduxjs/toolkit';
 
 import {
+    enforceQuotaManagerUpdated,
     eraseFetchedData,
     noQuotaLeftWarningDismissed,
     quotaManagerDeviceFetched,
@@ -12,6 +13,7 @@ import { type OwnerAllowance, type RegisteredDevice } from './types';
 
 export type SuiteSyncQuotaManagerState = {
     baseUrl: string | null;
+    enforceQuotaManager: boolean;
 
     registeredDevices: RegisteredDevice[];
     ownersAllowance: OwnerAllowance[];
@@ -19,6 +21,7 @@ export type SuiteSyncQuotaManagerState = {
 
 export const quotaManagerInitialState: SuiteSyncQuotaManagerState = {
     baseUrl: null,
+    enforceQuotaManager: false,
     registeredDevices: [],
     ownersAllowance: [],
 };
@@ -84,5 +87,8 @@ export const suiteSyncQuotaManagerReducer = createReducer<SuiteSyncQuotaManagerS
                 if (existingDevice) {
                     existingDevice.dismissedNoQuotaLeftWarning = true;
                 }
+            })
+            .addCase(enforceQuotaManagerUpdated, (state, { payload }) => {
+                state.enforceQuotaManager = payload.enforce;
             }),
 );

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerSelectors.ts
@@ -44,6 +44,9 @@ export const selectDeviceDismissedNoQuotaLeftWarning = (
     state.suiteSyncQuotaManager.registeredDevices.find(d => d.deviceId === deviceId)
         ?.dismissedNoQuotaLeftWarning;
 
+export const selectEnforceQuotaManager = (state: WithSuiteSyncQuotaManagerState) =>
+    state.suiteSyncQuotaManager.enforceQuotaManager;
+
 export const selectHasDeviceAllowance = (
     state: WithSuiteSyncQuotaManagerState,
     deviceId: string,

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -106,8 +106,8 @@ export const createSuiteSyncCompositionRoot = (
         getDeviceForStaticSessionId,
         hasAllowance: ({ walletDescriptor, deviceId }) =>
             selectHasDeviceAllowance(deps.getState(), deviceId ?? null, walletDescriptor),
-        defaultRelayUrl: DEFAULT_SUITE_SYNC_RELAY_URL,
-        getRelayUrl: toGetter(deps.getState, selectSuiteSyncRelayUrl),
+        getIsDefaultRelayUrlSet: () =>
+            selectSuiteSyncRelayUrl(deps.getState()) === DEFAULT_SUITE_SYNC_RELAY_URL,
         getEnforceQuotaManager: toGetter(deps.getState, selectEnforceQuotaManager),
     });
 

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -4,7 +4,10 @@ import { EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-
 import { toGetter } from '@suite-common/dependency-injection';
 import { selectAllDeviceStaticIds, selectDeviceByStaticSessionId } from '@suite-common/device';
 import { PlatformEncryptionDep } from '@suite-common/platform-encryption';
-import { selectHasDeviceAllowance } from '@suite-common/suite-sync-quota-manager';
+import {
+    selectEnforceQuotaManager,
+    selectHasDeviceAllowance,
+} from '@suite-common/suite-sync-quota-manager';
 import { CreateSuiteStorage, CreateSuiteSyncOwnerDep } from '@suite-common/suite-sync-storage';
 import {
     SuiteSync,
@@ -105,6 +108,7 @@ export const createSuiteSyncCompositionRoot = (
             selectHasDeviceAllowance(deps.getState(), deviceId ?? null, walletDescriptor),
         defaultRelayUrl: DEFAULT_SUITE_SYNC_RELAY_URL,
         getRelayUrl: toGetter(deps.getState, selectSuiteSyncRelayUrl),
+        getEnforceQuotaManager: toGetter(deps.getState, selectEnforceQuotaManager),
     });
 
     const suiteSyncErrorHandler: SuiteSyncErrorHandler = createSuiteSyncErrorHandler({

--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -19,8 +19,7 @@ import { GetDeviceHasAllowance } from '../getDeviceHasAllowance';
 export type EnsureQuotaDeps = {
     dispatch: Dispatch;
     hasAllowance: GetDeviceHasAllowance;
-    defaultRelayUrl: string;
-    getRelayUrl: () => string;
+    getIsDefaultRelayUrlSet: () => boolean;
     getEnforceQuotaManager: () => boolean;
 } & GetDeviceForStaticSessionIdDep;
 
@@ -53,7 +52,7 @@ export const createEnsureQuota =
         // We only want to use QM for our own relay servers. In case custom URL has been set, QM is ignored,
         // unless enforceQuotaManager is set (used for e2e tests with a local relay).
         const isQuotaManagerEnabled =
-            deps.getRelayUrl() === deps.defaultRelayUrl || deps.getEnforceQuotaManager();
+            deps.getIsDefaultRelayUrlSet() || deps.getEnforceQuotaManager();
 
         if (
             deps.hasAllowance({ walletDescriptor, deviceId: device.id }) ||

--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -21,6 +21,7 @@ export type EnsureQuotaDeps = {
     hasAllowance: GetDeviceHasAllowance;
     defaultRelayUrl: string;
     getRelayUrl: () => string;
+    getEnforceQuotaManager: () => boolean;
 } & GetDeviceForStaticSessionIdDep;
 
 export type EnsureQuotaParams = {
@@ -49,8 +50,10 @@ export const createEnsureQuota =
             return ok();
         }
 
-        // We only want to use QM for our own relay servers. In case custom URL has been set, QM is ignored.
-        const isQuotaManagerEnabled = deps.getRelayUrl() === deps.defaultRelayUrl;
+        // We only want to use QM for our own relay servers. In case custom URL has been set, QM is ignored,
+        // unless enforceQuotaManager is set (used for e2e tests with a local relay).
+        const isQuotaManagerEnabled =
+            deps.getRelayUrl() === deps.defaultRelayUrl || deps.getEnforceQuotaManager();
 
         if (
             deps.hasAllowance({ walletDescriptor, deviceId: device.id }) ||

--- a/suite-common/suite-sync/src/storage/tests/createEnsureQuota.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureQuota.test.ts
@@ -20,8 +20,6 @@ const DELEGATED_KEY = asDelegatedIdentityKey('delegated-key-abcd');
 
 const deviceStaticSessionId: StaticSessionId = '1@device-id:3';
 
-const DEFAULT_RELAY_URL = 'wss://default-relay.example.com';
-
 const DEFAULT_PARAMS = {
     deviceStaticSessionId,
     delegatedKey: DELEGATED_KEY,
@@ -43,8 +41,7 @@ describe(createEnsureQuota.name, () => {
         const deps = createMockDeps<EnsureQuotaDeps>({
             dispatch: null,
             hasAllowance: null,
-            defaultRelayUrl: DEFAULT_RELAY_URL,
-            getRelayUrl: () => DEFAULT_RELAY_URL,
+            getIsDefaultRelayUrlSet: () => true,
             getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => getDevice(),
         });
@@ -59,21 +56,18 @@ describe(createEnsureQuota.name, () => {
         {
             description: 'device has allowance',
             hasAllowance: () => true,
-            relayUrl: DEFAULT_RELAY_URL,
         },
         {
             description: 'quota manager is disabled (custom relay URL)',
             hasAllowance: () => false,
-            relayUrl: 'wss://custom-relay.example.com',
         },
-    ])('returns ok without dispatching when $description', async ({ hasAllowance, relayUrl }) => {
+    ])('returns ok without dispatching when $description', async ({ hasAllowance }) => {
         const device = mockSuiteDevice();
 
         const deps = createMockDeps<EnsureQuotaDeps>({
             dispatch: null,
             hasAllowance,
-            defaultRelayUrl: DEFAULT_RELAY_URL,
-            getRelayUrl: () => relayUrl,
+            getIsDefaultRelayUrlSet: () => false,
             getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
@@ -90,8 +84,7 @@ describe(createEnsureQuota.name, () => {
         const deps = createMockDeps<EnsureQuotaDeps>({
             dispatch: () => Promise.resolve({ success: true }),
             hasAllowance: () => false,
-            defaultRelayUrl: DEFAULT_RELAY_URL,
-            getRelayUrl: () => 'wss://custom-relay.example.com',
+            getIsDefaultRelayUrlSet: () => false,
             getEnforceQuotaManager: () => true,
             getDeviceForStaticSessionId: () => device,
         });
@@ -112,8 +105,7 @@ describe(createEnsureQuota.name, () => {
                     error: { type: 'WriteModeRequiredForAllocation' },
                 }),
             hasAllowance: () => false,
-            defaultRelayUrl: DEFAULT_RELAY_URL,
-            getRelayUrl: () => DEFAULT_RELAY_URL,
+            getIsDefaultRelayUrlSet: () => true,
             getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
@@ -134,8 +126,7 @@ describe(createEnsureQuota.name, () => {
                     error: { type: 'HttpError' },
                 }),
             hasAllowance: () => false,
-            defaultRelayUrl: DEFAULT_RELAY_URL,
-            getRelayUrl: () => DEFAULT_RELAY_URL,
+            getIsDefaultRelayUrlSet: () => true,
             getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
@@ -143,5 +134,25 @@ describe(createEnsureQuota.name, () => {
         const result = await createEnsureQuota(deps)(DEFAULT_PARAMS);
 
         expect(result).toEqual(ok(undefined));
+    });
+
+    it('checks the current relay URL state when deciding whether quota manager is enabled', async () => {
+        const device = mockSuiteDevice();
+        let isDefaultRelayUrlSet = true;
+
+        const deps = createMockDeps<EnsureQuotaDeps>({
+            dispatch: null,
+            hasAllowance: () => false,
+            getIsDefaultRelayUrlSet: () => isDefaultRelayUrlSet,
+            getEnforceQuotaManager: () => false,
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        isDefaultRelayUrlSet = false;
+
+        const result = await createEnsureQuota(deps)(DEFAULT_PARAMS);
+
+        expect(result).toEqual(ok(undefined));
+        expect(deps.dispatch).not.toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync/src/storage/tests/createEnsureQuota.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureQuota.test.ts
@@ -45,6 +45,7 @@ describe(createEnsureQuota.name, () => {
             hasAllowance: null,
             defaultRelayUrl: DEFAULT_RELAY_URL,
             getRelayUrl: () => DEFAULT_RELAY_URL,
+            getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => getDevice(),
         });
 
@@ -73,6 +74,7 @@ describe(createEnsureQuota.name, () => {
             hasAllowance,
             defaultRelayUrl: DEFAULT_RELAY_URL,
             getRelayUrl: () => relayUrl,
+            getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
 
@@ -80,6 +82,24 @@ describe(createEnsureQuota.name, () => {
 
         expect(result).toEqual(ok(undefined));
         expect(deps.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches when enforceQuotaManager is set with custom relay URL', async () => {
+        const device = mockSuiteDevice();
+
+        const deps = createMockDeps<EnsureQuotaDeps>({
+            dispatch: () => Promise.resolve({ success: true }),
+            hasAllowance: () => false,
+            defaultRelayUrl: DEFAULT_RELAY_URL,
+            getRelayUrl: () => 'wss://custom-relay.example.com',
+            getEnforceQuotaManager: () => true,
+            getDeviceForStaticSessionId: () => device,
+        });
+
+        const result = await createEnsureQuota(deps)(DEFAULT_PARAMS);
+
+        expect(result).toEqual(ok(undefined));
+        expect(deps.dispatch).toHaveBeenCalled();
     });
 
     it('returns WriteModeRequiredForAllocation error when allocation fails with that error', async () => {
@@ -94,6 +114,7 @@ describe(createEnsureQuota.name, () => {
             hasAllowance: () => false,
             defaultRelayUrl: DEFAULT_RELAY_URL,
             getRelayUrl: () => DEFAULT_RELAY_URL,
+            getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
 
@@ -115,6 +136,7 @@ describe(createEnsureQuota.name, () => {
             hasAllowance: () => false,
             defaultRelayUrl: DEFAULT_RELAY_URL,
             getRelayUrl: () => DEFAULT_RELAY_URL,
+            getEnforceQuotaManager: () => false,
             getDeviceForStaticSessionId: () => device,
         });
 

--- a/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
@@ -1,14 +1,16 @@
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+    enforceQuotaManagerUpdated,
     eraseFetchedDataDebug,
+    selectEnforceQuotaManager,
     selectOwnersAllowance,
     selectQuotaManagerBaseUrl,
     selectRegisteredDevices,
     updateQuotaManagerBaseUrl,
 } from '@suite-common/suite-sync-quota-manager';
 import { yup } from '@suite-common/validators';
-import { Button, Card, Text, VStack } from '@suite-native/atoms';
+import { Box, Button, Card, HStack, Switch, Text, VStack } from '@suite-native/atoms';
 import { Form, TextInputField, useForm } from '@suite-native/forms';
 import { useToast } from '@suite-native/toasts';
 
@@ -19,8 +21,16 @@ export const SuiteSyncQuotaManager = () => {
     const quotaManagerBaseUrl = useSelector(selectQuotaManagerBaseUrl);
     const registeredDevices = useSelector(selectRegisteredDevices);
     const ownersAllowance = useSelector(selectOwnersAllowance);
+    const enforceQuotaManager = useSelector(selectEnforceQuotaManager);
 
     const onEraseFetchedData = () => dispatch(eraseFetchedDataDebug());
+
+    const onToggleEnforceQuotaManager = () =>
+        dispatch(
+            enforceQuotaManagerUpdated({
+                enforce: !enforceQuotaManager,
+            }),
+        );
 
     const form = useForm<{ suiteSyncQuotaManagerUrl: string }>({
         defaultValues: {
@@ -87,6 +97,17 @@ export const SuiteSyncQuotaManager = () => {
                         ))
                     )}
                 </VStack>
+                <HStack justifyContent="space-between">
+                    <Box flexShrink={1}>
+                        <Text variant="body-sm" color="textSubdued">
+                            Enforce Quota Manager for custom relay
+                        </Text>
+                    </Box>
+                    <Switch
+                        isChecked={enforceQuotaManager}
+                        onChange={onToggleEnforceQuotaManager}
+                    />
+                </HStack>
                 <Button colorScheme="redBold" onPress={onEraseFetchedData}>
                     Erase fetched data
                 </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reintroduces a debug-only `enforceQuotaManagerForCustomRelay` flag so Quota Manager can be enabled even when Suite Sync uses a custom relay URL.

This is mainly for e2e tests with local dockerized relay + quota server, while keeping the default production behavior unchanged.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25285

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/suite-sync/quota-manager-override&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/suite-sync/quota-manager-override&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/suite-sync/quota-manager-override&lookback=7)