### PR TITLE
Unify connect indexes

### DIFF
--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -25,7 +25,7 @@ import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
 import { ConnectEmitter } from '../types/emitter';
 import { initLog } from '../utils/debug';
 
-export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
+export abstract class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
     public readonly eventEmitter = new ConnectEmitter();
 
     private settings;
@@ -35,9 +35,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
     private readonly boundOnCoreEvent = this.onCoreEvent.bind(this);
 
-    protected get defaultTransports(): ConnectSettingsTransport[] {
-        return ['BridgeTransport', 'WebUsbTransport'];
-    }
+    protected abstract get defaultTransports(): ConnectSettingsTransport[];
 
     public constructor() {
         this.settings = parseConnectSettings();
@@ -59,8 +57,6 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
     // handle message received from Core
     private onCoreEvent(rawMessage: CoreEventMessage) {
-        this.log.debug('handleMessage', rawMessage.type);
-
         const message = cloneObject(rawMessage);
 
         const { event, type, payload } = message;
@@ -124,16 +120,7 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
         await this.coreManager.getOrInit(this.settings, this.boundOnCoreEvent);
     }
 
-    protected updateProxy(proxy: UpdateConnectSettings['proxy']) {
-        if (proxy !== undefined) {
-            throw ERRORS.TypedError(
-                'Method_InvalidPackage',
-                'proxy setting is not supported in web environment',
-            );
-        }
-
-        return Promise.resolve();
-    }
+    protected abstract updateProxy(proxy: UpdateConnectSettings['proxy']): Promise<void>;
 
     public async updateConnectSettings(params: UpdateConnectSettings) {
         const { proxy, transports: newTransports } = params;
@@ -156,6 +143,9 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
     public async call(params: CallMethodPayload) {
         try {
+            if (!this.settings.manifest) {
+                throw ERRORS.TypedError('Init_ManifestMissing');
+            }
             const { promiseId, promise } = this.messagePromises.create();
             const payload = cloneObject<any>(params);
             this.handleCoreMessage({ type: CORE_CALL, id: promiseId, payload });

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -1,6 +1,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { DeferredManager, cloneObject, createDeferredManager } from '@trezor/utils';
+import { cloneObject, createDeferredManager } from '@trezor/utils';
 
+import { initCoreState } from '../core';
 import { parseConnectSettings } from '../data/connectSettings';
 import {
     BLOCKCHAIN_EVENT,
@@ -19,81 +20,37 @@ import {
     createErrorMessage,
 } from '../events';
 import { ConnectFactoryDependencies } from '../factory';
-import type { ConnectSettings, ConnectSettingsPublic, Manifest } from '../types';
+import type { ConnectSettings, ConnectSettingsPublic, ConnectSettingsTransport } from '../types';
 import type { UpdateConnectSettings } from '../types/api/updateConnectSettings';
 import { ConnectEmitter } from '../types/emitter';
-import { Log, initLog } from '../utils/debug';
+import { initLog } from '../utils/debug';
 
 export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsPublic> {
-    public eventEmitter = new ConnectEmitter();
-    public _settings: ConnectSettings;
+    public readonly eventEmitter = new ConnectEmitter();
 
-    private _coreManager?: any;
-    private _log: Log;
-    private _messagePromises: DeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>;
+    private settings;
+    private coreManager;
+    private log;
+    private messagePromises;
 
     private readonly boundOnCoreEvent = this.onCoreEvent.bind(this);
 
+    protected get defaultTransports(): ConnectSettingsTransport[] {
+        return ['BridgeTransport', 'WebUsbTransport'];
+    }
+
     public constructor() {
-        this._settings = parseConnectSettings();
-        this._log = initLog('@trezor/connect-web');
-        this._messagePromises = createDeferredManager({ initialId: 1 });
-    }
-
-    private async initCoreManager() {
-        const importResult = await import('@trezor/connect/src/core/index').catch(_err => {
-            this._log.error(`_err: Cannot load connect core`, _err);
-        });
-
-        if (!importResult) {
-            this._log.error(`importResult is empty! Cannot load connect core`);
-            throw new Error(`importResult is empty! Cannot load connect core`);
-        }
-
-        const { initCoreState } = importResult;
-
-        if (!initCoreState) return;
-
-        this._coreManager = initCoreState();
-
-        return this._coreManager;
-    }
-
-    public manifest(data: Manifest) {
-        this._settings = parseConnectSettings({
-            ...this._settings,
-            manifest: data,
-        });
-    }
-
-    public dispose() {
-        this.eventEmitter.removeAllListeners();
-        this._settings = parseConnectSettings();
-        if (this._coreManager) {
-            this._coreManager.dispose();
-        }
-        this._coreManager = undefined;
-
-        return Promise.resolve(undefined);
-    }
-
-    public cancel(error?: string) {
-        if (this._coreManager) {
-            const core = this._coreManager.get();
-            if (!core) {
-                throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
-            }
-
-            this.handleCoreMessage({
-                type: POPUP.CLOSED,
-                payload: error ? { error } : null,
-            });
-        }
+        this.settings = parseConnectSettings();
+        this.log = initLog('@trezor/connect');
+        this.coreManager = initCoreState();
+        this.messagePromises = createDeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>(
+            { initialId: 1 },
+        );
     }
 
     // handle messages to core
     public handleCoreMessage(message: CoreRequestMessage) {
-        const core = this._coreManager.get();
+        const core = this.coreManager.get();
         if (!core) {
             throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
         }
@@ -102,21 +59,22 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
 
     // handle message received from Core
     private onCoreEvent(rawMessage: CoreEventMessage) {
+        this.log.debug('handleMessage', rawMessage.type);
+
         const message = cloneObject(rawMessage);
 
         const { event, type, payload } = message;
 
         switch (event) {
             case RESPONSE_EVENT: {
-                const { id = 0, success, error, device } = message;
-                const resolved = this._messagePromises.resolve(id, {
+                const { id = 0, success, device } = message;
+                const resolved = this.messagePromises.resolve(
                     id,
-                    success,
-                    payload,
-                    error,
-                    device,
-                });
-                if (!resolved) this._log.warn(`Unknown message id ${id}`);
+                    success
+                        ? { id, success, payload: message.payload, device }
+                        : { id, success, error: message.error, device },
+                );
+                if (!resolved) this.log.warn(`Unknown message id ${id}`);
                 break;
             }
             case DEVICE_EVENT:
@@ -142,97 +100,86 @@ export class CoreInModule implements ConnectFactoryDependencies<ConnectSettingsP
                 break;
 
             default:
-                this._log.warn('Undefined message', event, message);
+                this.log.warn('Undefined message', event, message);
         }
     }
 
     public async init(settings: Partial<ConnectSettings>) {
-        if (this._coreManager && (this._coreManager.get() || this._coreManager.getPending())) {
+        if (this.coreManager.get() || this.coreManager.getPending()) {
             throw ERRORS.TypedError('Init_AlreadyInitialized');
         }
 
-        this._settings = parseConnectSettings({ ...this._settings, ...settings });
+        this.settings = parseConnectSettings({ ...this.settings, ...settings });
 
-        if (!this._settings.manifest) {
+        if (!this.settings.manifest) {
             throw ERRORS.TypedError('Init_ManifestMissing');
         }
 
-        // defaults for connect-web
-        if (!this._settings.transports?.length) {
-            this._settings.transports = ['BridgeTransport', 'WebUsbTransport'];
+        if (!this.settings.transports?.length) {
+            this.settings.transports = this.defaultTransports;
         }
 
-        if (!this._coreManager) {
-            this._coreManager = await this.initCoreManager();
-            await this._coreManager.getOrInit(this._settings, this.boundOnCoreEvent);
-        }
+        this.log.enabled = !!this.settings.debug;
 
-        this._log.enabled = !!this._settings.debug;
+        await this.coreManager.getOrInit(this.settings, this.boundOnCoreEvent);
     }
 
-    public updateConnectSettings(params: UpdateConnectSettings) {
-        const { proxy, transports } = params;
-
+    protected updateProxy(proxy: UpdateConnectSettings['proxy']) {
         if (proxy !== undefined) {
-            return Promise.resolve(
-                createErrorMessage(
-                    ERRORS.TypedError(
-                        'Method_InvalidPackage',
-                        'proxy setting is not supported in web environment',
-                    ),
-                ),
+            throw ERRORS.TypedError(
+                'Method_InvalidPackage',
+                'proxy setting is not supported in web environment',
             );
         }
 
-        if (transports !== undefined) {
-            let newTransports = transports;
-            if (!transports?.length) {
-                newTransports = ['BridgeTransport', 'WebUsbTransport'];
-            }
-            this._settings = parseConnectSettings({ ...this._settings, transports: newTransports });
-            this.handleCoreMessage({
-                type: TRANSPORT.SET_TRANSPORTS,
-                payload: { transports: newTransports },
-            });
+        return Promise.resolve();
+    }
+
+    public async updateConnectSettings(params: UpdateConnectSettings) {
+        const { proxy, transports: newTransports } = params;
+
+        try {
+            await this.updateProxy(proxy);
+        } catch (err) {
+            return Promise.resolve(createErrorMessage(err));
         }
 
-        return Promise.resolve({
-            success: true as const,
-            payload: { message: 'success' },
-        } as const);
+        if (newTransports !== undefined) {
+            const transports = newTransports?.length ? newTransports : this.defaultTransports;
+
+            this.settings = parseConnectSettings({ ...this.settings, transports });
+            this.handleCoreMessage({ type: TRANSPORT.SET_TRANSPORTS, payload: { transports } });
+        }
+
+        return { success: true as const, payload: { message: 'success' } } as const;
     }
 
     public async call(params: CallMethodPayload) {
-        if (!this._coreManager) {
-            try {
-                await this.init({});
-            } catch (err) {
-                return createErrorMessage(err);
-            }
-        }
         try {
-            const { promiseId, promise } = this._messagePromises.create();
+            const { promiseId, promise } = this.messagePromises.create();
             const payload = cloneObject<any>(params);
-            this.handleCoreMessage({
-                type: CORE_CALL,
-                id: promiseId,
-                payload,
-            });
+            this.handleCoreMessage({ type: CORE_CALL, id: promiseId, payload });
             const response = cloneObject(await promise);
 
             return response ?? createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
         } catch (error) {
-            this._log.error('call', error);
+            this.log.error('call', error);
 
             return createErrorMessage(error);
         }
     }
 
     public uiResponse(response: UiResponseEvent) {
-        const core = this._coreManager.get();
-        if (!core) {
-            throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
-        }
         this.handleCoreMessage(response);
+    }
+
+    public cancel(error?: string) {
+        this.handleCoreMessage({ type: POPUP.CLOSED, payload: error ? { error } : null });
+    }
+
+    public dispose() {
+        this.eventEmitter.removeAllListeners();
+        this.settings = parseConnectSettings();
+        this.coreManager.dispose();
     }
 }

--- a/packages/connect/src/index-browser.ts
+++ b/packages/connect/src/index-browser.ts
@@ -1,22 +1,42 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
 import { config } from './data/config';
 import { TRANSPORT } from './events';
 import { factory } from './factory';
 import { CoreInModule } from './impl/core-in-module';
+import { UpdateConnectSettings } from './types/api/updateConnectSettings';
 
-const impl = new CoreInModule();
-
-const disableWebUSB = () => {
-    impl.handleCoreMessage({ type: TRANSPORT.DISABLE_WEBUSB });
-};
-
-const requestWebUSBDevice = async () => {
-    try {
-        await window.navigator.usb.requestDevice({ filters: config.webusb });
-        impl.handleCoreMessage({ type: TRANSPORT.REQUEST_DEVICE });
-    } catch {
-        // empty
+class CoreInModuleWeb extends CoreInModule {
+    protected get defaultTransports() {
+        return ['BridgeTransport' as const, 'WebUsbTransport' as const];
     }
-};
+
+    updateProxy(proxy: UpdateConnectSettings['proxy']) {
+        if (proxy !== undefined) {
+            throw ERRORS.TypedError(
+                'Method_InvalidPackage',
+                'proxy setting is not supported in web environment',
+            );
+        }
+
+        return Promise.resolve();
+    }
+
+    disableWebUSB() {
+        this.handleCoreMessage({ type: TRANSPORT.DISABLE_WEBUSB });
+    }
+
+    async requestWebUSBDevice() {
+        try {
+            await window.navigator.usb.requestDevice({ filters: config.webusb });
+            this.handleCoreMessage({ type: TRANSPORT.REQUEST_DEVICE });
+        } catch {
+            // empty
+        }
+    }
+}
+
+const impl = new CoreInModuleWeb();
 
 // Exported to enable using directly
 const TrezorConnect = factory(
@@ -30,8 +50,8 @@ const TrezorConnect = factory(
         dispose: impl.dispose.bind(impl),
     },
     {
-        disableWebUSB,
-        requestWebUSBDevice,
+        disableWebUSB: impl.disableWebUSB.bind(impl),
+        requestWebUSBDevice: impl.requestWebUSBDevice.bind(impl),
     },
 );
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,191 +1,36 @@
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { createDeferredManager, deepEqual } from '@trezor/utils';
+import { deepEqual } from '@trezor/utils';
 
 import { reconnectAllBackends } from './backend/BlockchainLink';
-import { initCoreState } from './core';
 import { DataManager } from './data/DataManager';
-import { parseConnectSettings } from './data/connectSettings';
-import {
-    BLOCKCHAIN_EVENT,
-    CORE_CALL,
-    CallMethod,
-    CoreEventMessage,
-    DEVICE_EVENT,
-    POPUP,
-    RESPONSE_EVENT,
-    TRANSPORT,
-    TRANSPORT_EVENT,
-    UI_EVENT,
-    UiResponseEvent,
-    createErrorMessage,
-} from './events';
 import { factory } from './factory';
-import type { ConnectSettings } from './types';
+import { CoreInModule } from './impl/core-in-module';
 import type { UpdateConnectSettings } from './types/api/updateConnectSettings';
-import { ConnectEmitter } from './types/emitter';
-import { initLog } from './utils/debug';
 
-const eventEmitter = new ConnectEmitter();
-const _log = initLog('@trezor/connect');
+class CoreInModuleNode extends CoreInModule {
+    protected get defaultTransports() {
+        return ['BridgeTransport' as const];
+    }
 
-let _settings = parseConnectSettings();
-
-const coreManager = initCoreState();
-const messagePromises = createDeferredManager({ initialId: 1 });
-
-const dispose = () => {
-    eventEmitter.removeAllListeners();
-    _settings = parseConnectSettings();
-    coreManager.dispose();
-};
-
-// handle message received from Core
-const onCoreEvent = (message: CoreEventMessage) => {
-    _log.debug('handleMessage', message.type);
-
-    switch (message.event) {
-        case RESPONSE_EVENT: {
-            const { id = 0, success, device } = message;
-            const resolved = messagePromises.resolve(
-                id,
-                success
-                    ? { id, success, payload: message.payload, device }
-                    : { id, success, error: message.error, device },
-            );
-            if (!resolved) _log.warn(`Unknown message id ${id}`);
-            break;
+    protected async updateProxy(proxy: UpdateConnectSettings['proxy']) {
+        const settings = DataManager.getSettings();
+        if (proxy !== undefined && !deepEqual(settings.proxy, proxy)) {
+            DataManager.updateSettings({ proxy });
+            await reconnectAllBackends();
         }
-        case DEVICE_EVENT:
-            // pass DEVICE event up to html
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload); // DEVICE_EVENT also emit single events (connect/disconnect...)
-            break;
-
-        case TRANSPORT_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        case BLOCKCHAIN_EVENT:
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        case UI_EVENT:
-            // pass UI event up
-            eventEmitter.emit(message.event, message);
-            eventEmitter.emit(message.type, message.payload);
-            break;
-
-        default:
-            _log.warn('Undefined message', message);
     }
-};
+}
 
-const initSettings = (settings: Partial<ConnectSettings> = {}) => {
-    _settings = parseConnectSettings({ ..._settings, ...settings });
-
-    if (!_settings.manifest) {
-        throw ERRORS.TypedError('Init_ManifestMissing');
-    }
-
-    if (!_settings.transports?.length) {
-        // default fallback for node
-        _settings.transports = ['BridgeTransport'];
-    }
-};
-
-const init = async (settings: Partial<ConnectSettings>) => {
-    if (coreManager.get() || coreManager.getPending()) {
-        throw ERRORS.TypedError('Init_AlreadyInitialized');
-    }
-
-    initSettings(settings);
-
-    await coreManager.getOrInit(_settings, onCoreEvent);
-};
-
-const initCore = () => {
-    // todo: only to keep manifest validation during 'lazyload' call, will be reworked
-    initSettings({});
-
-    return coreManager.getOrInit(_settings, onCoreEvent);
-};
-
-const call: CallMethod = async params => {
-    let core;
-    try {
-        core = coreManager.get() ?? (await coreManager.getPending()) ?? (await initCore());
-    } catch (error) {
-        return createErrorMessage(error);
-    }
-
-    try {
-        const { promiseId, promise } = messagePromises.create();
-        core.handleMessage({
-            type: CORE_CALL,
-            payload: params,
-            id: promiseId,
-        });
-        const response = await promise;
-
-        return response ?? createErrorMessage(ERRORS.TypedError('Method_NoResponse'));
-    } catch (error) {
-        _log.error('call', error);
-
-        return createErrorMessage(error);
-    }
-};
-
-const updateConnectSettings = async (params: UpdateConnectSettings) => {
-    const { proxy, transports } = params;
-
-    const settings = DataManager.getSettings();
-    if (proxy !== undefined && !deepEqual(settings.proxy, proxy)) {
-        DataManager.updateSettings({ proxy });
-        await reconnectAllBackends();
-    }
-
-    if (transports !== undefined) {
-        const core = coreManager.get();
-        if (!core) {
-            return createErrorMessage(ERRORS.TypedError('Init_NotInitialized'));
-        }
-        core.handleMessage({ type: TRANSPORT.SET_TRANSPORTS, payload: { transports } });
-    }
-
-    return { success: true as const, payload: { message: 'success' } } as const;
-};
-
-const uiResponse = (response: UiResponseEvent) => {
-    const core = coreManager.get();
-    if (!core) {
-        throw ERRORS.TypedError('Init_NotInitialized');
-    }
-    core.handleMessage(response);
-};
-
-const cancel = (error?: string) => {
-    const core = coreManager.get();
-    if (!core) {
-        throw ERRORS.TypedError('Runtime', 'postMessage: _core not found');
-    }
-
-    core.handleMessage({
-        type: POPUP.CLOSED,
-        payload: error ? { error } : null,
-    });
-};
+const impl = new CoreInModuleNode();
 
 const TrezorConnect = factory(
     {
-        eventEmitter,
-        init,
-        call,
-        updateConnectSettings,
-        uiResponse,
-        cancel,
-        dispose,
+        eventEmitter: impl.eventEmitter,
+        init: impl.init.bind(impl),
+        call: impl.call.bind(impl),
+        updateConnectSettings: impl.updateConnectSettings.bind(impl),
+        uiResponse: impl.uiResponse.bind(impl),
+        cancel: impl.cancel.bind(impl),
+        dispose: impl.dispose.bind(impl),
     },
     {},
 );


### PR DESCRIPTION
## Description

Remove duplicated code of desktop and web connect entry point:

- removed `lazyLoad` Connect option; was used only in desktop to initialize connect on first `call` rather than `init` and I believe it's useless
- removed dynamic core/index import in web Connect; I believe it's useless as well as the created bundle is rather small.
- use CoreInModule for both desktop and web Connect


🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/unify-connect-indexes&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/unify-connect-indexes&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/unify-connect-indexes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->