### PR TITLE
fix(suite-native): fix broken bottom sheet offset caused by nested BottomSheetModalProvider

### DIFF
--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -11,7 +11,6 @@
         "test:unit": "yarn g:jest"
     },
     "dependencies": {
-        "@gorhom/bottom-sheet": "5.2.8",
         "@mobily/ts-belt": "^3.13.1",
         "@react-navigation/native": "7.1.26",
         "@react-navigation/native-stack": "7.9.0",

--- a/suite-native/module-send/src/components/SendFeesForm.tsx
+++ b/suite-native/module-send/src/components/SendFeesForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useNavigation } from '@react-navigation/native';
 
 import { SendRootState, selectSendFormDraftByKey } from '@suite-common/wallet-core';
@@ -132,43 +131,40 @@ export const SendFeesForm = ({ accountKey, tokenContract }: SendFormProps) => {
 
     return (
         <Form form={form}>
-            {/*// BottomSheetModalProvider must be inside FormProvider to keep context available for sheets rendered via portal*/}
-            <BottomSheetModalProvider>
-                <VStack spacing="sp32" flex={1}>
-                    {!!selectedFeeLevelTransaction && (
-                        <RecipientsSummary
+            <VStack spacing="sp32" flex={1}>
+                {!!selectedFeeLevelTransaction && (
+                    <RecipientsSummary
+                        accountKey={accountKey}
+                        tokenContract={tokenContract}
+                        selectedFeeLevel={selectedFeeLevelTransaction}
+                    />
+                )}
+                <VStack flex={1} justifyContent="space-between" spacing="sp24">
+                    <FeesContent
+                        selectedFeeLevel={selectedFeeLevel}
+                        feeLevels={feeLevels}
+                        symbol={symbol}
+                        networkType={account.networkType}
+                        accountKey={accountKey}
+                        areFeesLoading={areFeesLoading}
+                        onSelectedFeeLevel={handleFeeLevelChange}
+                        onCustomFeeSet={handleCustomFeeSet}
+                        formDraft={formDraft}
+                    />
+                    {!!totalAmount && !!fee && (
+                        <FeesFooter
                             accountKey={accountKey}
+                            isSubmittable={isSubmittable}
+                            onSubmit={handleNavigateToReviewScreen}
+                            totalAmount={totalAmount}
+                            fee={fee}
+                            symbol={symbol}
                             tokenContract={tokenContract}
-                            selectedFeeLevel={selectedFeeLevelTransaction}
+                            withSubmitButton={true}
                         />
                     )}
-                    <VStack flex={1} justifyContent="space-between" spacing="sp24">
-                        <FeesContent
-                            selectedFeeLevel={selectedFeeLevel}
-                            feeLevels={feeLevels}
-                            symbol={symbol}
-                            networkType={account.networkType}
-                            accountKey={accountKey}
-                            areFeesLoading={areFeesLoading}
-                            onSelectedFeeLevel={handleFeeLevelChange}
-                            onCustomFeeSet={handleCustomFeeSet}
-                            formDraft={formDraft}
-                        />
-                        {!!totalAmount && !!fee && (
-                            <FeesFooter
-                                accountKey={accountKey}
-                                isSubmittable={isSubmittable}
-                                onSubmit={handleNavigateToReviewScreen}
-                                totalAmount={totalAmount}
-                                fee={fee}
-                                symbol={symbol}
-                                tokenContract={tokenContract}
-                                withSubmitButton={true}
-                            />
-                        )}
-                    </VStack>
                 </VStack>
-            </BottomSheetModalProvider>
+            </VStack>
         </Form>
     );
 };

--- a/suite-native/module-stellar-token-management/src/screens/ActivationFeeScreen.tsx
+++ b/suite-native/module-stellar-token-management/src/screens/ActivationFeeScreen.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { activateStellarTokenThunk } from '@suite-common/wallet-core';
@@ -90,116 +89,110 @@ export const ActivationFeeScreen = () => {
 
     return (
         <Form form={form}>
-            <BottomSheetModalProvider>
-                <ConfirmOnTrezorWrapper
-                    isManualControlEnabled
-                    controlRef={confirmOnTrezorRef}
-                    closeActionType="back"
-                    closeAction={handleCancel}
-                    defaultHeader={
-                        <ScreenHeader
-                            title={
-                                <Translation id="moduleStellarToken.screenTitle.activateToken" />
-                            }
-                            closeActionType="back"
-                        />
-                    }
-                >
-                    <Box flex={1} justifyContent="space-between">
-                        <VStack spacing="sp16">
-                            <TokenInfoCard
-                                tokenName={tokenName}
-                                issuerDomain={issuerDomain}
-                                iconContractAddress={iconContractAddress}
-                                onPress={openTokenDetail}
-                            />
-
-                            {/* Reserve Info */}
-                            <Text variant="body-md" color="textSubdued">
-                                <Translation
-                                    id="moduleStellarToken.networkFee.reserveInfo"
-                                    values={{
-                                        reserve: formatNetworkAmount(
-                                            BASE_INFO.BASE_RESERVE.toString(),
-                                            account.symbol,
-                                            true,
-                                        ),
-                                        link: chunks => (
-                                            <Link
-                                                href={HELP_CENTER_XLM_URL}
-                                                label={chunks}
-                                                isUnderlined
-                                                textColor="textSubdued"
-                                                textPressedColor="textSubdued"
-                                                textVariant="body-md"
-                                            />
-                                        ),
-                                    }}
-                                />
-                            </Text>
-
-                            {/* Insufficient Balance Warning */}
-                            {insufficientBalanceInfo && (
-                                <InlineAlertBox
-                                    variant="warning"
-                                    title={
-                                        <Translation
-                                            id="moduleStellarToken.networkFee.insufficientBalance"
-                                            values={{
-                                                required: formatNetworkAmount(
-                                                    insufficientBalanceInfo.required,
-                                                    account.symbol,
-                                                    true,
-                                                ),
-                                                available: formatNetworkAmount(
-                                                    insufficientBalanceInfo.available,
-                                                    account.symbol,
-                                                    true,
-                                                ),
-                                            }}
-                                        />
-                                    }
-                                />
-                            )}
-
-                            <FeeOptionsSection
-                                accountKey={accountKey}
-                                feeLevels={feeLevels}
-                                symbol={account.symbol}
-                                areFeesLoading={areFeesLoading}
-                                selectedFeeLevel={selectedFeeLevel}
-                                onSelectedFeeLevel={handleFeeLevelChange}
-                                onCustomFeeSet={handleCustomFeeSet}
-                                formDraft={formDraft}
-                            />
-                        </VStack>
-
-                        {/* Footer Button */}
-                        <Box paddingBottom="sp16">
-                            <Button
-                                onPress={handleReviewAndSign}
-                                isLoading={isSubmitting}
-                                isDisabled={
-                                    isSubmitting || !isSubmittable || !!insufficientBalanceInfo
-                                }
-                                testID="@stellar-token/review-and-sign-button"
-                            >
-                                <Translation id="moduleStellarToken.networkFee.reviewAndSign" />
-                            </Button>
-                        </Box>
-                    </Box>
-
-                    <TokenDetailBottomSheet
-                        bottomSheetRef={tokenDetailRef}
-                        tokenName={tokenName}
-                        assetCode={assetCode}
-                        issuerDomain={issuerDomain}
-                        issuerAddress={issuerAddress}
-                        iconContractAddress={iconContractAddress}
-                        onClose={closeTokenDetail}
+            <ConfirmOnTrezorWrapper
+                isManualControlEnabled
+                controlRef={confirmOnTrezorRef}
+                closeActionType="back"
+                closeAction={handleCancel}
+                defaultHeader={
+                    <ScreenHeader
+                        title={<Translation id="moduleStellarToken.screenTitle.activateToken" />}
+                        closeActionType="back"
                     />
-                </ConfirmOnTrezorWrapper>
-            </BottomSheetModalProvider>
+                }
+            >
+                <Box flex={1} justifyContent="space-between">
+                    <VStack spacing="sp16">
+                        <TokenInfoCard
+                            tokenName={tokenName}
+                            issuerDomain={issuerDomain}
+                            iconContractAddress={iconContractAddress}
+                            onPress={openTokenDetail}
+                        />
+
+                        {/* Reserve Info */}
+                        <Text variant="body-md" color="textSubdued">
+                            <Translation
+                                id="moduleStellarToken.networkFee.reserveInfo"
+                                values={{
+                                    reserve: formatNetworkAmount(
+                                        BASE_INFO.BASE_RESERVE.toString(),
+                                        account.symbol,
+                                        true,
+                                    ),
+                                    link: chunks => (
+                                        <Link
+                                            href={HELP_CENTER_XLM_URL}
+                                            label={chunks}
+                                            isUnderlined
+                                            textColor="textSubdued"
+                                            textPressedColor="textSubdued"
+                                            textVariant="body-md"
+                                        />
+                                    ),
+                                }}
+                            />
+                        </Text>
+
+                        {/* Insufficient Balance Warning */}
+                        {insufficientBalanceInfo && (
+                            <InlineAlertBox
+                                variant="warning"
+                                title={
+                                    <Translation
+                                        id="moduleStellarToken.networkFee.insufficientBalance"
+                                        values={{
+                                            required: formatNetworkAmount(
+                                                insufficientBalanceInfo.required,
+                                                account.symbol,
+                                                true,
+                                            ),
+                                            available: formatNetworkAmount(
+                                                insufficientBalanceInfo.available,
+                                                account.symbol,
+                                                true,
+                                            ),
+                                        }}
+                                    />
+                                }
+                            />
+                        )}
+
+                        <FeeOptionsSection
+                            accountKey={accountKey}
+                            feeLevels={feeLevels}
+                            symbol={account.symbol}
+                            areFeesLoading={areFeesLoading}
+                            selectedFeeLevel={selectedFeeLevel}
+                            onSelectedFeeLevel={handleFeeLevelChange}
+                            onCustomFeeSet={handleCustomFeeSet}
+                            formDraft={formDraft}
+                        />
+                    </VStack>
+
+                    {/* Footer Button */}
+                    <Box paddingBottom="sp16">
+                        <Button
+                            onPress={handleReviewAndSign}
+                            isLoading={isSubmitting}
+                            isDisabled={isSubmitting || !isSubmittable || !!insufficientBalanceInfo}
+                            testID="@stellar-token/review-and-sign-button"
+                        >
+                            <Translation id="moduleStellarToken.networkFee.reviewAndSign" />
+                        </Button>
+                    </Box>
+                </Box>
+
+                <TokenDetailBottomSheet
+                    bottomSheetRef={tokenDetailRef}
+                    tokenName={tokenName}
+                    assetCode={assetCode}
+                    issuerDomain={issuerDomain}
+                    issuerAddress={issuerAddress}
+                    iconContractAddress={iconContractAddress}
+                    onClose={closeTokenDetail}
+                />
+            </ConfirmOnTrezorWrapper>
         </Form>
     );
 };

--- a/suite-native/module-stellar-token-management/src/screens/DeactivationFeeScreen.tsx
+++ b/suite-native/module-stellar-token-management/src/screens/DeactivationFeeScreen.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { useNavigation, useRoute } from '@react-navigation/native';
 
 import { deactivateStellarTokenThunk } from '@suite-common/wallet-core';
@@ -88,87 +87,83 @@ export const DeactivationFeeScreen = () => {
 
     return (
         <Form form={form}>
-            <BottomSheetModalProvider>
-                <ConfirmOnTrezorWrapper
-                    isManualControlEnabled
-                    controlRef={confirmOnTrezorRef}
-                    closeActionType="back"
-                    closeAction={handleCancel}
-                    defaultHeader={
-                        <ScreenHeader
-                            title={
-                                <Translation id="moduleStellarToken.screenTitle.deactivateToken" />
-                            }
-                            closeActionType="back"
-                        />
-                    }
-                >
-                    <Box flex={1} justifyContent="space-between">
-                        <VStack spacing="sp16">
-                            <TokenInfoCard
-                                tokenName={tokenName}
-                                issuerDomain={issuerDomain}
-                                iconContractAddress={iconContractAddress}
-                                onPress={openTokenDetail}
-                            />
-
-                            {/* Warning Info */}
-                            <Card>
-                                <HStack alignItems="center" spacing="sp12">
-                                    <Icon name="info" color="iconSubdued" />
-                                    <Box flex={1}>
-                                        <Text variant="body-md">
-                                            <Translation
-                                                id="moduleStellarToken.deactivationFee.warningText"
-                                                values={{
-                                                    reserve: formatNetworkAmount(
-                                                        BASE_INFO.BASE_RESERVE.toString(),
-                                                        account.symbol,
-                                                        true,
-                                                    ),
-                                                }}
-                                            />
-                                        </Text>
-                                    </Box>
-                                </HStack>
-                            </Card>
-
-                            <FeeOptionsSection
-                                accountKey={accountKey}
-                                feeLevels={feeLevels}
-                                symbol={account.symbol}
-                                areFeesLoading={areFeesLoading}
-                                selectedFeeLevel={selectedFeeLevel}
-                                onSelectedFeeLevel={handleFeeLevelChange}
-                                onCustomFeeSet={handleCustomFeeSet}
-                                formDraft={formDraft}
-                            />
-                        </VStack>
-
-                        {/* Footer Button */}
-                        <Box paddingBottom="sp16">
-                            <Button
-                                onPress={handleReviewAndSign}
-                                isLoading={isSubmitting}
-                                isDisabled={isSubmitting || !isSubmittable}
-                                testID="@stellar-token/review-and-sign-button"
-                            >
-                                <Translation id="moduleStellarToken.networkFee.reviewAndSign" />
-                            </Button>
-                        </Box>
-                    </Box>
-
-                    <TokenDetailBottomSheet
-                        bottomSheetRef={tokenDetailRef}
-                        tokenName={tokenName}
-                        assetCode={assetCode}
-                        issuerDomain={issuerDomain}
-                        issuerAddress={issuerAddress}
-                        iconContractAddress={iconContractAddress}
-                        onClose={closeTokenDetail}
+            <ConfirmOnTrezorWrapper
+                isManualControlEnabled
+                controlRef={confirmOnTrezorRef}
+                closeActionType="back"
+                closeAction={handleCancel}
+                defaultHeader={
+                    <ScreenHeader
+                        title={<Translation id="moduleStellarToken.screenTitle.deactivateToken" />}
+                        closeActionType="back"
                     />
-                </ConfirmOnTrezorWrapper>
-            </BottomSheetModalProvider>
+                }
+            >
+                <Box flex={1} justifyContent="space-between">
+                    <VStack spacing="sp16">
+                        <TokenInfoCard
+                            tokenName={tokenName}
+                            issuerDomain={issuerDomain}
+                            iconContractAddress={iconContractAddress}
+                            onPress={openTokenDetail}
+                        />
+
+                        {/* Warning Info */}
+                        <Card>
+                            <HStack alignItems="center" spacing="sp12">
+                                <Icon name="info" color="iconSubdued" />
+                                <Box flex={1}>
+                                    <Text variant="body-md">
+                                        <Translation
+                                            id="moduleStellarToken.deactivationFee.warningText"
+                                            values={{
+                                                reserve: formatNetworkAmount(
+                                                    BASE_INFO.BASE_RESERVE.toString(),
+                                                    account.symbol,
+                                                    true,
+                                                ),
+                                            }}
+                                        />
+                                    </Text>
+                                </Box>
+                            </HStack>
+                        </Card>
+
+                        <FeeOptionsSection
+                            accountKey={accountKey}
+                            feeLevels={feeLevels}
+                            symbol={account.symbol}
+                            areFeesLoading={areFeesLoading}
+                            selectedFeeLevel={selectedFeeLevel}
+                            onSelectedFeeLevel={handleFeeLevelChange}
+                            onCustomFeeSet={handleCustomFeeSet}
+                            formDraft={formDraft}
+                        />
+                    </VStack>
+
+                    {/* Footer Button */}
+                    <Box paddingBottom="sp16">
+                        <Button
+                            onPress={handleReviewAndSign}
+                            isLoading={isSubmitting}
+                            isDisabled={isSubmitting || !isSubmittable}
+                            testID="@stellar-token/review-and-sign-button"
+                        >
+                            <Translation id="moduleStellarToken.networkFee.reviewAndSign" />
+                        </Button>
+                    </Box>
+                </Box>
+
+                <TokenDetailBottomSheet
+                    bottomSheetRef={tokenDetailRef}
+                    tokenName={tokenName}
+                    assetCode={assetCode}
+                    issuerDomain={issuerDomain}
+                    issuerAddress={issuerAddress}
+                    iconContractAddress={iconContractAddress}
+                    onClose={closeTokenDetail}
+                />
+            </ConfirmOnTrezorWrapper>
         </Form>
     );
 };

--- a/suite-native/module-trading/src/components/fees/TradingFeesForm.tsx
+++ b/suite-native/module-trading/src/components/fees/TradingFeesForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { RouteProp, useRoute } from '@react-navigation/native';
 
 import { FormDraftRootState, selectDeepCopyOfFormDraft } from '@suite-common/wallet-core';
@@ -61,33 +60,30 @@ export const TradingFeesForm = ({ accountKey, tokenContract }: TradingFeesFormPr
 
     return (
         <Form form={form}>
-            {/*// BottomSheetModalProvider must be inside FormProvider to keep context available for sheets rendered via portal*/}
-            <BottomSheetModalProvider>
-                <VStack flex={1} justifyContent="space-between" spacing="sp24">
-                    <FeesContent
-                        selectedFeeLevel={selectedFeeLevel}
-                        feeLevels={feeLevels}
-                        symbol={symbol}
+            <VStack flex={1} justifyContent="space-between" spacing="sp24">
+                <FeesContent
+                    selectedFeeLevel={selectedFeeLevel}
+                    feeLevels={feeLevels}
+                    symbol={symbol}
+                    accountKey={accountKey}
+                    areFeesLoading={areFeesLoading}
+                    onSelectedFeeLevel={handleFeeLevelChange}
+                    onCustomFeeSet={handleCustomFeeSet}
+                    formDraft={formDraft}
+                    networkType={account.networkType}
+                />
+                {!!totalAmount && !!fee && (
+                    <FeesFooter
                         accountKey={accountKey}
-                        areFeesLoading={areFeesLoading}
-                        onSelectedFeeLevel={handleFeeLevelChange}
-                        onCustomFeeSet={handleCustomFeeSet}
-                        formDraft={formDraft}
-                        networkType={account.networkType}
+                        isSubmittable={isSubmittable}
+                        totalAmount={totalAmount}
+                        fee={fee}
+                        symbol={symbol}
+                        tokenContract={tokenContract}
+                        withSubmitButton={false}
                     />
-                    {!!totalAmount && !!fee && (
-                        <FeesFooter
-                            accountKey={accountKey}
-                            isSubmittable={isSubmittable}
-                            totalAmount={totalAmount}
-                            fee={fee}
-                            symbol={symbol}
-                            tokenContract={tokenContract}
-                            withSubmitButton={false}
-                        />
-                    )}
-                </VStack>
-            </BottomSheetModalProvider>
+                )}
+            </VStack>
         </Form>
     );
 };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
@@ -14,7 +14,7 @@ import {
     VStack,
 } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
-import { FormSubmitButton, useFormContext } from '@suite-native/forms';
+import { Form, FormSubmitButton, useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { CustomFeeInputs } from './CustomFeeInputs';
@@ -48,6 +48,7 @@ export const CustomFeeBottomSheet = ({
         selectAccountNetworkSymbol(state, accountKey),
     );
 
+    const form = useFormContext<FeesFormValues>();
     const {
         setValue,
         handleSubmit,
@@ -55,7 +56,7 @@ export const CustomFeeBottomSheet = ({
         formState: { isDirty },
         watch,
         getValues,
-    } = useFormContext<FeesFormValues>();
+    } = form;
 
     const feeLevelValue = watch('feeLevel');
 
@@ -102,50 +103,52 @@ export const CustomFeeBottomSheet = ({
                 snapPoints: ['95%'],
             }}
         >
-            <VStack marginTop="sp24" spacing="sp24" justifyContent="space-between" flex={1}>
-                <CustomFeeInputs symbol={symbol} />
-                <HStack
-                    flex={1}
-                    justifyContent="space-between"
-                    alignItems="center"
-                    paddingHorizontal="sp1"
-                >
-                    <Text variant="body-md-strong">
-                        <Translation id="transactionManagement.fees.custom.bottomSheet.total" />
-                    </Text>
-                    <VStack alignItems="flex-end">
-                        <CryptoToFiatAmountFormatter
-                            value={feeValue}
-                            isLoading={isFeeLoading}
-                            symbol={symbol}
-                        />
-                        <CryptoAmountFormatter
-                            value={feeValue}
-                            symbol={symbol}
-                            variant="body-md"
-                            isLoading={isFeeLoading}
-                            isBalance={false}
-                        />
-                    </VStack>
-                </HStack>
-                {isErrorBoxVisible && (
-                    <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
-                        <InlineAlertBox
-                            variant="critical"
-                            title={<Translation id="transactionManagement.fees.error" />}
-                        />
-                    </Animated.View>
-                )}
-            </VStack>
-            <Box marginTop="sp16">
-                <FormSubmitButton
-                    onPress={handleSetCustomFee}
-                    isVisible={isButtonVisible}
-                    testID="@transactionManagement/custom-fee-submit-button"
-                >
-                    <Translation id="transactionManagement.fees.custom.bottomSheet.confirmButton" />
-                </FormSubmitButton>
-            </Box>
+            <Form form={form}>
+                <VStack marginTop="sp24" spacing="sp24" justifyContent="space-between" flex={1}>
+                    <CustomFeeInputs symbol={symbol} />
+                    <HStack
+                        flex={1}
+                        justifyContent="space-between"
+                        alignItems="center"
+                        paddingHorizontal="sp1"
+                    >
+                        <Text variant="body-md-strong">
+                            <Translation id="transactionManagement.fees.custom.bottomSheet.total" />
+                        </Text>
+                        <VStack alignItems="flex-end">
+                            <CryptoToFiatAmountFormatter
+                                value={feeValue}
+                                isLoading={isFeeLoading}
+                                symbol={symbol}
+                            />
+                            <CryptoAmountFormatter
+                                value={feeValue}
+                                symbol={symbol}
+                                variant="body-md"
+                                isLoading={isFeeLoading}
+                                isBalance={false}
+                            />
+                        </VStack>
+                    </HStack>
+                    {isErrorBoxVisible && (
+                        <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
+                            <InlineAlertBox
+                                variant="critical"
+                                title={<Translation id="transactionManagement.fees.error" />}
+                            />
+                        </Animated.View>
+                    )}
+                </VStack>
+                <Box marginTop="sp16">
+                    <FormSubmitButton
+                        onPress={handleSetCustomFee}
+                        isVisible={isButtonVisible}
+                        testID="@transactionManagement/custom-fee-submit-button"
+                    >
+                        <Translation id="transactionManagement.fees.custom.bottomSheet.confirmButton" />
+                    </FormSubmitButton>
+                </Box>
+            </Form>
         </BottomSheetModal>
     );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13438,7 +13438,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/module-send@workspace:suite-native/module-send"
   dependencies:
-    "@gorhom/bottom-sheet": "npm:5.2.8"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@react-navigation/native": "npm:7.1.26"
     "@react-navigation/native-stack": "npm:7.9.0"


### PR DESCRIPTION
## Description

Fee form screens had wrapped `<FeesContent>` in a nested `<BottomSheetModalProvider>` inside `<Form>` so that portaled content could access `FormContext`. Having two providers in the tree created competing portal hierarchies, breaking the bottom inset of other bottom sheets (e.g. Account List overlapping tab navigation).

Fix: re-provide `FormContext` at the portal boundary inside `CustomFeeBottomSheet` via `<Form form={form}>` around the `BottomSheetModal` children — removing the need for the nested bottom sheet provider in all four affected screens.

## Notes for QA

- Send flow → Fees → tap "Custom fee": sheet should open, inputs and validation should work
- After closing, open the Account List bottom sheet from the dashboard: it should sit correctly at the bottom with no overlap on the tab navigation
- Same check for Trading fees and Stellar token activation/deactivation screens

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24263

## Screenshots:
https://github.com/user-attachments/assets/20592b72-912c-457a-96ad-efa986141468


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-native/nested-bottom-sheet-modal-provider&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-native/nested-bottom-sheet-modal-provider&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/nested-bottom-sheet-modal-provider&lookback=7)