### PR TITLE
feat(trading): enhance country selection with svg flag 

### DIFF
--- a/packages/components/src/components/Flag/types.ts
+++ b/packages/components/src/components/Flag/types.ts
@@ -4,3 +4,9 @@ export type FlagType = keyof typeof FLAGS;
 
 export const flagSizes = [16, 20, 24, 32, 40, 48] as const;
 export type FlagSize = (typeof flagSizes)[number];
+
+export const isFlagType = (value?: string): value is FlagType => {
+    if (!value) return false;
+
+    return Object.hasOwn(FLAGS, value);
+};

--- a/packages/components/src/components/Flag/utils.ts
+++ b/packages/components/src/components/Flag/utils.ts
@@ -1,4 +1,4 @@
-import { FlagSize } from './types';
+import { FlagSize, FlagType, isFlagType } from './types';
 
 export const mapSizeToOutlineWidth = (size: FlagSize): number => {
     const outlineWidthMap: Record<FlagSize, number> = {
@@ -24,4 +24,16 @@ export const mapSizeToBorderRadius = (size: FlagSize): number => {
     };
 
     return borderRadiusMap[size];
+};
+
+export const getCountryFlag = (countryCode: string): FlagType | undefined => {
+    if (['unknown', 'XX', 'T1'].includes(countryCode)) {
+        return 'UNKNOWN';
+    }
+
+    if (isFlagType(countryCode)) {
+        return countryCode;
+    }
+
+    return undefined;
 };

--- a/packages/components/src/components/Flag/utils.ts
+++ b/packages/components/src/components/Flag/utils.ts
@@ -26,7 +26,11 @@ export const mapSizeToBorderRadius = (size: FlagSize): number => {
     return borderRadiusMap[size];
 };
 
-export const getCountryFlag = (countryCode: string): FlagType | undefined => {
+export const getCountryFlag = (countryCode?: string): FlagType | undefined => {
+    if (!countryCode) {
+        return undefined;
+    }
+
     if (['unknown', 'XX', 'T1'].includes(countryCode)) {
         return 'UNKNOWN';
     }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,6 +13,7 @@ export { Checkbox, type CheckboxProps } from './components/form/Checkbox/Checkbo
 export * from './components/animations/LottieAnimation';
 export { recolorLottieAnimation } from './components/animations/recolorLottieAnimation';
 export * from './components/Flag/Flag';
+export { getCountryFlag } from './components/Flag/utils';
 export { Badge, type BadgeProps, type BadgeSize, type BadgeIntent } from './components/Badge/Badge';
 export * from './components/buttons/ButtonGroup/ButtonGroup';
 export { Button, type ButtonProps, type ButtonIntent } from './components/buttons/Button/Button';

--- a/packages/suite/src/components/suite/FakeSelect.tsx
+++ b/packages/suite/src/components/suite/FakeSelect.tsx
@@ -23,7 +23,7 @@ const FakeSelectContainer = styled.button`
 `;
 
 export type FakeSelectProps = Omit<FormCellProps, 'children'> &
-    Pick<InputProps, 'value' | 'placeholder' | 'size'> & {
+    Pick<InputProps, 'value' | 'placeholder' | 'size' | 'leftContent'> & {
         isLoading?: boolean;
         onClick: () => void;
     };
@@ -37,11 +37,13 @@ export const FakeSelect = (props: FakeSelectProps) => {
         size = 'large',
         onClick,
         'data-testid': dataTestId,
+        leftContent,
         ...rest
     } = props;
 
     const formCellProps = pickFormCellProps(rest);
-    const leftContent = isLoading ? <Spinner size={20} /> : undefined;
+
+    const leftContentComponent = leftContent ?? (isLoading ? <Spinner size={20} /> : undefined);
 
     return (
         <FakeSelectContainer type="button" onClick={onClick} disabled={isDisabled}>
@@ -50,7 +52,7 @@ export const FakeSelect = (props: FakeSelectProps) => {
                 value={value}
                 placeholder={placeholder}
                 size={size}
-                leftContent={leftContent}
+                leftContent={leftContentComponent}
                 disabled={isDisabled}
                 rightContent={
                     <Icon name="caretDown" size={20} intent="neutral" priority="secondary" />

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useRef } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TradingBuyFormProps,
     buyThunks,
     getTradingPaymentMethods,
+    isCountrySubdivisionEmpty,
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';
 import { Timer } from '@trezor/react-utils';

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -4,7 +4,6 @@ import { useDebounce } from 'react-use';
 
 import { FiatCurrencyCode } from 'invity-api';
 
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_CRYPTO_TOKEN,
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -15,6 +14,7 @@ import {
     TradingAssetSellOption,
     type TradingExchangeFormProps,
     type TradingSellFormProps,
+    isCountrySubdivisionEmpty,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TradingSellFormProps,
     getTradingPaymentMethods,
+    isCountrySubdivisionEmpty,
     sellThunks,
 } from '@suite-common/trading';
 import { Network } from '@suite-common/wallet-config';

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -5,7 +5,6 @@ import type { BuyTrade, BuyTradeResponse, FiatCurrencyCode } from 'invity-api';
 import useDebounce from 'react-use/lib/useDebounce';
 
 import { events } from '@suite/analytics';
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_FORM_CRYPTO_INPUT,
@@ -17,6 +16,7 @@ import {
     type TradingBuyType,
     buyThunks,
     getTradingQuotesByPaymentMethod,
+    isCountrySubdivisionEmpty,
     selectTradingBuy,
     selectTradingPaymentMethods,
     selectTradingVerifiedAddress,

--- a/packages/suite/src/hooks/wallet/trading/useGetCountryName.ts
+++ b/packages/suite/src/hooks/wallet/trading/useGetCountryName.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+
+import { useTranslation } from '@suite/intl';
+import { TradingCountryOption, regional } from '@suite-common/trading';
+
+export const useGetCountryName = () => {
+    const { translationString } = useTranslation();
+
+    const getCountryName = useCallback(
+        (country: TradingCountryOption, fullName = false) => {
+            if ([regional.UNKNOWN_COUNTRY, 'XX', 'T1'].includes(country.value)) {
+                return translationString('TR_TRADING_COUNTRY_WORLD');
+            }
+
+            return fullName ? country.name : country.codeAlpha3;
+        },
+        [translationString],
+    );
+
+    return getCountryName;
+};

--- a/packages/suite/src/hooks/wallet/trading/useGetCountryName.ts
+++ b/packages/suite/src/hooks/wallet/trading/useGetCountryName.ts
@@ -8,7 +8,7 @@ export const useGetCountryName = () => {
 
     const getCountryName = useCallback(
         (country: TradingCountryOption, fullName = false) => {
-            if ([regional.UNKNOWN_COUNTRY, 'XX', 'T1'].includes(country.value)) {
+            if (regional.isWorldwideRegion(country.value)) {
                 return translationString('TR_TRADING_COUNTRY_WORLD');
             }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
 
-import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
     TradingBuyType,
+    isCountrySubdivisionRequired,
     selectTradingBuySupportedCryptoIds,
     selectTradingLoadingAndTimestamp,
     tradingActions,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySelectModal.tsx
@@ -7,10 +7,11 @@ import {
     TradingCountryOption,
     useCountryFilteredData,
 } from '@suite-common/trading';
-import { Column, Flag, Input, Modal, Paragraph, Row } from '@trezor/components';
+import { Column, Flag, Input, Modal, Paragraph, Row, getCountryFlag } from '@trezor/components';
 import { CardList } from '@trezor/product-components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useGetCountryName } from 'src/hooks/wallet/trading/useGetCountryName';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import { TradingBuySellFormProps } from 'src/types/trading/tradingForm';
 
@@ -23,6 +24,7 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
     const { translationString } = useTranslation();
     const { setValue, clearQuotesAndParams } = useTradingFormContext<TradingTradeBuySellType>();
     const { filteredData, setFilterValue, filterValue } = useCountryFilteredData();
+    const getCountryName = useGetCountryName();
 
     const selectCountry = (country: TradingCountryOption) => {
         const setValueTyped = setValue as UseFormSetValue<TradingBuySellFormProps>;
@@ -31,11 +33,6 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
         clearQuotesAndParams();
         onClose();
     };
-
-    const getCountryFlag = (country: TradingCountryOption) =>
-        country.value === 'unknown' || country.value === 'XX' || country.value === 'T1'
-            ? 'UNKNOWN'
-            : country.value;
 
     return (
         <Modal
@@ -54,18 +51,23 @@ export const CountrySelectModal = ({ heading, onClose }: CountrySelectModalProps
                 />
                 {filteredData.length > 0 && (
                     <CardList>
-                        {filteredData.map(country => (
-                            <CardList.Item
-                                key={country.value}
-                                onClick={() => selectCountry(country)}
-                                data-testid={`@trading/form/country-select/option/${country.value}`}
-                            >
-                                <Row gap={16}>
-                                    <Flag country={getCountryFlag(country)} size={24} />
-                                    {country.name}
-                                </Row>
-                            </CardList.Item>
-                        ))}
+                        {filteredData.map(country => {
+                            const countryFlag = getCountryFlag(country.value);
+                            const countryName = getCountryName(country, true);
+
+                            return (
+                                <CardList.Item
+                                    key={country.value}
+                                    onClick={() => selectCountry(country)}
+                                    data-testid={`@trading/form/country-select/option/${country.value}`}
+                                >
+                                    <Row gap={12}>
+                                        {countryFlag && <Flag country={countryFlag} size={24} />}
+                                        {countryName}
+                                    </Row>
+                                </CardList.Item>
+                            );
+                        })}
                     </CardList>
                 )}
                 {!filteredData.length && (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -34,9 +34,9 @@ export const TradingFormInputCountry = ({
         name: TRADING_FORM_COUNTRY_SELECT,
     });
 
-    const countryCode = countryValue?.value ?? defaultCountry?.value ?? '';
-    const countryFlag = getCountryFlag(countryCode);
-    const countryName = getCountryName(countryValue ?? defaultCountry);
+    const country = countryValue ?? defaultCountry;
+    const countryFlag = getCountryFlag(country?.value);
+    const countryName = getCountryName(country);
 
     return (
         <>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/TradingFormInputCountry.tsx
@@ -3,10 +3,11 @@ import { Control, useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { TRADING_FORM_COUNTRY_SELECT } from '@suite-common/trading';
-import { GhostContainer, Icon, Row, Text } from '@trezor/components';
+import { Flag, GhostContainer, Icon, Row, Text, getCountryFlag } from '@trezor/components';
 
 import { FakeSelect } from 'src/components/suite';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useGetCountryName } from 'src/hooks/wallet/trading/useGetCountryName';
 import { TradingTradeBuySellType } from 'src/types/trading/trading';
 import {
     TradingBuySellFormProps,
@@ -26,18 +27,24 @@ export const TradingFormInputCountry = ({
     const { translationString } = useTranslation();
     const [isModalOpen, setIsModalOpen] = useState(false);
     const { control, defaultCountry } = useTradingFormContext<TradingTradeBuySellType>();
+    const getCountryName = useGetCountryName();
 
     const countryValue = useWatch({
         control: control as Control<TradingBuySellFormProps>,
         name: TRADING_FORM_COUNTRY_SELECT,
     });
 
+    const countryCode = countryValue?.value ?? defaultCountry?.value ?? '';
+    const countryFlag = getCountryFlag(countryCode);
+    const countryName = getCountryName(countryValue ?? defaultCountry);
+
     return (
         <>
             {renderInput && (
                 <FakeSelect
-                    value={countryValue?.shortLabel ?? defaultCountry?.shortLabel ?? ''}
+                    value={countryName}
                     placeholder={label ? translationString(label) : undefined}
+                    leftContent={countryFlag && <Flag country={countryFlag} size={24} />}
                     onClick={() => setIsModalOpen(true)}
                     data-testid="@trading/form/country-select"
                 />
@@ -52,12 +59,13 @@ export const TradingFormInputCountry = ({
                         <Text typographyStyle="body-md" align="start">
                             {label && <Translation id={label} />}
                         </Text>
-                        <Row gap={16}>
+                        <Row gap={4}>
+                            {countryFlag && <Flag country={countryFlag} size={24} />}
                             <Text
                                 typographyStyle="body-md"
                                 data-testid="@trading/form/country-select/value"
                             >
-                                {countryValue?.shortLabel ?? defaultCountry?.shortLabel ?? ''}
+                                {countryName}
                             </Text>
                             <Icon
                                 name="caretRight"

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -3,10 +3,10 @@ import { useEffect, useMemo } from 'react';
 import type { BuyTrade, CryptoId, ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import {
     TRADING_EXCHANGE_FORM_DEX,
     type TradingType,
+    isCountrySubdivisionEmpty,
     isSendingEvmNativeToken,
     tradingExchangeActions,
     tradingSellActions,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -2,13 +2,13 @@ import { useCallback, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { events } from '@suite/analytics';
-import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingSellFormProps,
     TradingSellType,
+    isCountrySubdivisionRequired,
     selectTradingSellSupportedCryptoIds,
 } from '@suite-common/trading';
 import { TokenAddress } from '@suite-common/wallet-types';

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter.tsx
@@ -2,7 +2,6 @@ import { Control, useWatch } from 'react-hook-form';
 
 import styled from 'styled-components';
 
-import { isCountrySubdivisionRequired } from '@suite-common/geolocation';
 import {
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
@@ -12,6 +11,7 @@ import {
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     TradingTradeBuySellType,
+    isCountrySubdivisionRequired,
 } from '@suite-common/trading';
 import { Row } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';

--- a/suite-common/geolocation/package.json
+++ b/suite-common/geolocation/package.json
@@ -8,8 +8,8 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest",
-        "test-unit:watch": "yarn g:jest -o --watch"
+        "test:unit": "yarn g:jest --passWithNoTests",
+        "test-unit:watch": "yarn g:jest -o --watch --passWithNoTests"
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",

--- a/suite-common/geolocation/src/index.ts
+++ b/suite-common/geolocation/src/index.ts
@@ -2,4 +2,3 @@ export * from './geolocationThunks';
 export * from './geolocationReducer';
 export * from './geolocationSelectors';
 export * from './countries';
-export * from './utils';

--- a/suite-common/geolocation/src/utils/index.ts
+++ b/suite-common/geolocation/src/utils/index.ts
@@ -1,8 +1,0 @@
-export {
-    isCountryCode,
-    hasCountrySubdivisions,
-    isCountrySubdivisionRequired,
-    isCountrySubdivisionEmpty,
-    getCountrySubdivisions,
-    getCountrySubdivisionByCode,
-} from './countryUtils';

--- a/suite-common/trading/jest.config.js
+++ b/suite-common/trading/jest.config.js
@@ -3,7 +3,11 @@ const baseConfig = require('../../jest.config.base');
 module.exports = {
     ...baseConfig,
     testEnvironment: 'jsdom',
+
     setupFilesAfterEnv: [require('path').resolve(__dirname, '../../packages/suite/jest.setup.js')],
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+    },
     coverageThreshold: {
         global: {
             statements: 80,

--- a/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.ts
+++ b/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.ts
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 
-import { getCountrySubdivisions, isCountryCode } from '@suite-common/geolocation';
 import { normalizeForSearch } from '@suite-common/suite-utils';
 
 import type { TradingCountrySubdivisionOption } from '../types';
 import { useListDataFilter } from './useListDataFilter';
+import { getCountrySubdivisions, isCountryCode } from '../utils/countryUtils';
 
 const toSubdivisionOptions = (
     subdivisions: ReadonlyArray<{ code: string; name: string }>,

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -31,3 +31,4 @@ export * from './utils/buy/buyUtils';
 export * from './utils/exchange/exchangeUtils';
 export * from './utils/sell/sellUtils';
 export * from './utils/signature/signatureUtils';
+export * from './utils/countryUtils';

--- a/suite-common/trading/src/regional.ts
+++ b/suite-common/trading/src/regional.ts
@@ -64,6 +64,10 @@ class Regional {
 
         return this.countriesOptionsMap.get(this.UNKNOWN_COUNTRY)!;
     }
+
+    isWorldwideRegion(country: string): boolean {
+        return [this.UNKNOWN_COUNTRY, 'XX', 'T1'].includes(country);
+    }
 }
 
 export const regional = new Regional(() => true);

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -1,6 +1,5 @@
 import { BuyTrade, BuyTradeQuoteRequest } from 'invity-api';
 
-import { isCountrySubdivisionEmpty } from '@suite-common/geolocation';
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -22,6 +21,7 @@ import {
     tradingGetSuccessQuotes,
 } from '../../utils';
 import { buyUtils } from '../../utils/buy/buyUtils';
+import { isCountrySubdivisionEmpty } from '../../utils/countryUtils';
 
 type GetQuotesRequest = {
     requestData: BuyTradeQuoteRequest;

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -1,6 +1,5 @@
 import { SellFiatTrade, SellFiatTradeQuoteRequest } from 'invity-api';
 
-import { hasCountrySubdivisions, isCountryCode } from '@suite-common/geolocation';
 import { createThunk } from '@suite-common/redux-utils';
 import { Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
@@ -18,6 +17,7 @@ import {
     getTradingPaymentMethods,
     tradingGetSuccessQuotes,
 } from '../../utils';
+import { hasCountrySubdivisions, isCountryCode } from '../../utils/countryUtils';
 import { sellUtils } from '../../utils/sell/sellUtils';
 
 type GetQuotesRequest = {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -11,7 +11,6 @@ import {
 } from 'invity-api';
 import { v4 as uuidv4 } from 'uuid';
 
-import { getCountrySubdivisionByCode } from '@suite-common/geolocation';
 import {
     type Network,
     type NetworkSymbol,
@@ -49,6 +48,7 @@ import {
     TradingTradeType,
     TradingType,
 } from './types';
+import { getCountrySubdivisionByCode } from './utils/countryUtils';
 
 type NetworkAndContractAddress = {
     network: Network | undefined;

--- a/suite-common/trading/src/utils/__tests__/countryUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/countryUtils.test.ts
@@ -1,4 +1,5 @@
-import { usSubdivisions } from '../../countries';
+import { usSubdivisions } from '@suite-common/geolocation';
+
 import {
     getCountrySubdivisionByCode,
     getCountrySubdivisions,

--- a/suite-common/trading/src/utils/countryUtils.ts
+++ b/suite-common/trading/src/utils/countryUtils.ts
@@ -4,7 +4,7 @@ import {
     CountrySubdivision,
     countries,
     subdivisionsByCountry,
-} from '../countries';
+} from '@suite-common/geolocation';
 
 export const isCountryCode = (countryCode: string): countryCode is CountryCode =>
     countryCode in countries || countryCode === 'XX' || countryCode === 'T1';

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -996,6 +996,10 @@ export const messages = defineMessages({
         defaultMessage: 'Not selected',
         id: 'TR_TRADING_COUNTRY_SUBDIVISION_NOT_SELECTED',
     },
+    TR_TRADING_COUNTRY_WORLD: {
+        defaultMessage: 'Worldwide',
+        id: 'TR_TRADING_COUNTRY_WORLD',
+    },
     TR_TRADING_SUBDIVISION_REQUIRED_FOR_OFFERS: {
         defaultMessage: 'To see available offers, choose your state of residence.',
         id: 'TR_TRADING_SUBDIVISION_REQUIRED_FOR_OFFERS',


### PR DESCRIPTION
## Description

Replace emoji flags in Trading country picker with shared `Flag` component, updating trading country types/regional config and wiring the new component into `TradingFormInputCountry` and `CountrySelectModal`.

## Notes for QA

Country selection is UI-affected: please verify the country picker in Trading forms shows correct flags for all listed countries, selecting a country updates the input as expected, and no layout regressions appear on small and large viewports.

## Related Issue

Resolve [#25600](https://github.com/trezor/trezor-suite/issues/25600)

## Screenshots:
<img width="782" height="427" alt="image" src="https://github.com/user-attachments/assets/2cc37b65-44b4-4914-a123-5bc5c194510c" />
<img width="1231" height="409" alt="image" src="https://github.com/user-attachments/assets/4d66d7b1-d3a7-4975-acaf-5f382a266c15" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/25600/flag-country-select&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/25600/flag-country-select&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/25600/flag-country-select&lookback=7)