### PR TITLE
fix: remove '@trezor/connect' from optimizeDeps to prevent pre-bundling issues

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -579,12 +579,13 @@ export default defineConfig({
         ENABLE_REDUX_LOGGER: true,
     },
     optimizeDeps: {
-        include: ['@trezor/connect', '@trezor/suite', 'buffer'],
+        include: ['@trezor/suite', 'buffer'],
         exclude: [
             // Exclude WebAssembly modules
             '@trezor/crypto-utils',
             '@trezor/utxo-lib',
-            // Exclude transport to prevent pre-bundling issues with bridge URL construction
+            // Exclude connect and transport to prevent pre-bundling issues with bridge URL construction and exports
+            '@trezor/connect',
             '@trezor/transport',
         ],
     },


### PR DESCRIPTION
## Description

Fix Vite dev white‑screen caused by `@trezor/connect` being pre‑bundled without the `PAGING` export. Vite config now excludes `@trezor/connect` from `optimizeDeps`, and `getTxsPerPage` continues to consume `PAGING` from the library correctly.

## Notes for QA

Just dev thing, no need QA.

## Related Issue

Broken here: https://github.com/trezor/trezor-suite/pull/25397

## Screenshot
<img width="496" height="82" alt="image" src="https://github.com/user-attachments/assets/d18f0ade-e4d2-4c84-befd-3317b6f17465" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/vite-connect-paging&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/vite-connect-paging&lookback=7)