### PR TITLE
fix(suite-native): remove @fixIos tag from appSettings e2e test

### DIFF
--- a/suite-native/app/e2e/tests/appSettings.test.ts
+++ b/suite-native/app/e2e/tests/appSettings.test.ts
@@ -17,7 +17,7 @@ const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
 );
 
-describe('App Settings - without device interactions [@noDevice @fixIos]', () => {
+describe('App Settings - without device interactions [@noDevice]', () => {
     beforeEach(async () => {
         await openApp({ args: { preloadedState } });
         await onHome.assertIsPortfolioGraphVisible();

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -75,6 +75,7 @@ export const CompactCardWithIconLayout = ({
     isDisabled = false,
     variant = 'normal',
     borderColor = 'borderElevation1',
+    testID,
     ...cardProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
@@ -105,7 +106,7 @@ export const CompactCardWithIconLayout = ({
 
     return (
         <GestureDetector gesture={tap}>
-            <View collapsable={false}>
+            <View collapsable={false} testID={testID}>
                 <AnimatedCard
                     noPadding
                     borderColor={borderColor ?? undefined}


### PR DESCRIPTION
## Description

- Added `testID` prop to `CompactCardWithIconLayout` so the component can be targeted in e2e tests on iOS.
- Removed the `@fixIos` skip tag from the `appSettings` e2e test now that the underlying issue is resolved.


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ios-e2e-app-settings-test&lookback=7)