### PR TITLE
feat(suite): lower ethereum staking reserve

### DIFF
--- a/suite-common/wallet-constants/src/ethereumStakingConstants.ts
+++ b/suite-common/wallet-constants/src/ethereumStakingConstants.ts
@@ -8,7 +8,7 @@ export const STAKE_GAS_LIMIT_RESERVE = 220_000;
 
 export const MIN_ETH_AMOUNT_FOR_STAKING = new BigNumber(0.1);
 export const MAX_ETH_AMOUNT_FOR_STAKING = new BigNumber(1_000_000);
-export const MIN_ETH_FOR_WITHDRAWALS = new BigNumber(0.03);
+export const MIN_ETH_FOR_WITHDRAWALS = new BigNumber(0.005);
 export const MIN_ETH_BALANCE_FOR_FEE_BUFFER = new BigNumber(0.005);
 export const MIN_ETH_BALANCE_FOR_STAKING = MIN_ETH_AMOUNT_FOR_STAKING.plus(MIN_ETH_FOR_WITHDRAWALS);
 export const UNSTAKE_INTERCHANGES = 5;

--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -122,7 +122,7 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
                     await expect
                         .soft(stakingSection.withdrawalWarning)
                         .toHaveTranslation('TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL', {
-                            values: { amount: '0.03', networkDisplaySymbol: 'ETH' },
+                            values: { amount: '0.005', networkDisplaySymbol: 'ETH' },
                         });
                     const expectedMax = new BigNumber(ethereumStakingBalance!)
                         .minus(WITHDRAWAL_BUFFER)


### PR DESCRIPTION
## Description

Lower Ethereum staking withdrawal reserve from `0.03` ETH to `0.005` ETH.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25503


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/lower-eth-staking-reserve&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/lower-eth-staking-reserve&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/lower-eth-staking-reserve&lookback=7)