### PR TITLE
 fix(connect): fix undefined device bug in bitcoin payloadToPrecomposed

### DIFF
--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -193,14 +193,20 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
         return getLabel('Sign #NETWORK transaction', coinInfo);
     }
 
-    async payloadToPrecomposed() {
+    payloadToPrecomposed() {
         try {
             const { inputs, outputs, coinInfo } = this.params;
-            const refTxs = this.params.refTxs ?? (await this.fetchRefTxs(false));
+            const { refTxs } = this.params;
             const inputsTotal: BigNumber = inputs.reduce((bn, input) => {
                 if (typeof input.amount === 'string') {
                     return bn.plus(input.amount);
                 } else {
+                    if (!refTxs) {
+                        throw ERRORS.TypedError(
+                            'Runtime',
+                            'refTxs are required for precomposed transaction info when input amount is not provided',
+                        );
+                    }
                     const refTx = refTxs.find(tx => tx.hash === input.prev_hash);
                     const refOutput =
                         refTx?.outputs?.[input.prev_index] ??
@@ -222,7 +228,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
             }
             const feePerByte = fee.dividedBy(bytes);
 
-            return {
+            return Promise.resolve({
                 type: 'final' as const,
                 inputs,
                 outputs,
@@ -231,12 +237,12 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
                 fee: fee.toString(),
                 feePerByte: feePerByte.toString(),
                 bytes,
-            };
+            });
         } catch (e) {
             // Don't throw errors from this method
             console.error('Error in payloadToPrecomposed', e);
 
-            return undefined;
+            return Promise.resolve(undefined);
         }
     }
 


### PR DESCRIPTION
Second attempt after this one #25580 got reverted 

the key part is that this.device is needed only for one execution branch which is not covered by tests.

one commit to be dropped and solved separately in #25611 it is here just to run CI. It proves that now the sign tx test passed https://app.currents.dev/instance/7aae730fa3b087ce/test/4f8df46e2b5918569eab-a8f5cfca12fdc78453a8

now proper flow is tested, previously it the missing device would get caught and connect-popup would fallback to a generic flow 
<img width="1111" height="590" alt="image" src="https://github.com/user-attachments/assets/5ad3ce61-114f-469a-8597-08ad5f1ff790" />

The "device might be undefined" bug only applies to a specific sub-path inside `fetchRefTxs`  when `origTxsIds` AND `addresses` is missing → `fetchAddresses` is called → `this.device` is accessed. That path is not hit by this test.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=revert-revert&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=revert-revert&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=revert-revert&lookback=7)