### PR TITLE
feat(suite): control device meta checks by FW auth checks settings

### DIFF
--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -26,6 +26,7 @@ export const TOGGLE_DEVICE_AUTHENTICITY_CHECK = '@suite/toggle-device-authentici
 export const TOGGLE_FIRMWARE_REVISION_CHECK = '@suite/toggle-firmware-revision-check';
 export const TOGGLE_FIRMWARE_HASH_CHECK = '@suite/toggle-firmware-hash-check';
 export const TOGGLE_ENTROPY_CHECK = '@suite/toggle-entropy-check';
+export const TOGGLE_DEVICE_META_CHECKS = '@suite/toggle-device-meta-checks';
 export const EVM_CONFIRM_EXPLANATION_MODAL = '@suite/evm-confirm-explanation-modal';
 export const EVM_CLOSE_EXPLANATION_BANNER = '@suite/evm-close-explanation-banner';
 export const LOCK_UI = '@suite/lock-ui';

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -46,6 +46,7 @@ export type SuiteAction =
     | { type: typeof SUITE.TOGGLE_FIRMWARE_REVISION_CHECK; payload: boolean }
     | { type: typeof SUITE.TOGGLE_FIRMWARE_HASH_CHECK; payload: boolean }
     | { type: typeof SUITE.TOGGLE_ENTROPY_CHECK; payload: boolean }
+    | { type: typeof SUITE.TOGGLE_DEVICE_META_CHECKS; payload: boolean }
     | { type: typeof SUITE.COINJOIN_RECEIVE_WARNING; payload: boolean }
     | { type: typeof SUITE.LOCK_UI; payload: boolean }
     | ReturnType<typeof lockDevice>
@@ -321,6 +322,7 @@ export const toggleFirmwareAuthenticityChecks = (enable: boolean) => (dispatch: 
     const firmwareAuthenticityChecks = [
         SUITE.TOGGLE_FIRMWARE_REVISION_CHECK,
         SUITE.TOGGLE_FIRMWARE_HASH_CHECK,
+        SUITE.TOGGLE_DEVICE_META_CHECKS,
     ] as const;
 
     firmwareAuthenticityChecks.forEach(type => {

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -43,7 +43,7 @@ const DeviceCompromisedContent = () => {
     const isEntropyCheckFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
     const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
 
-    // this check is only a precaution, not expected to be seen often
+    // this check is only a precaution, not expected to be seen often. This one cannot be dismissed (need id to register dismissal)
     if (!isValidId) {
         return (
             <SecurityCheckFail
@@ -58,7 +58,7 @@ const DeviceCompromisedContent = () => {
     if (!isDeviceInvariabilityCheckSuccess) {
         return (
             <SecurityCheckFail
-                ctaSection={<FwAuthenticityCheckSupportButton />}
+                ctaSection={<FwAuthencityChecksCtas />}
                 heading="TR_DEVICE_COMPROMISED_HEADING"
                 text="TR_DEVICE_COMPROMISED_INVARIABILITY_CHECK_FAILED_TEXT"
                 checklistItems={hardFailureChecklistItems}

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -330,6 +330,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.TOGGLE_DEVICE_AUTHENTICITY_CHECK:
                 case SUITE.TOGGLE_FIRMWARE_REVISION_CHECK:
                 case SUITE.TOGGLE_FIRMWARE_HASH_CHECK:
+                case SUITE.TOGGLE_DEVICE_META_CHECKS:
                 case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:
                 case SUITE.EVM_CLOSE_EXPLANATION_BANNER:
                 case SUITE.SET_IS_COINS_FILTER_VISIBLE:

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -100,6 +100,7 @@ export interface SuiteSettings {
         entropy: boolean;
         firmwareRevision: boolean;
         firmwareHash: boolean;
+        deviceMeta: boolean;
     };
     addressDisplayType: AddressDisplayOptions;
     experimental?: ExperimentalFeature[];
@@ -190,6 +191,7 @@ const initialState: SuiteState = {
             entropy: true,
             firmwareRevision: true,
             firmwareHash: true,
+            deviceMeta: true,
         },
         debug: {
             invityServerEnvironment: undefined,
@@ -246,6 +248,10 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 draft.settings = {
                     ...draft.settings,
                     ...action.payload.suiteSettings?.settings,
+                    enabledSecurityChecks: {
+                        ...draft.settings.enabledSecurityChecks,
+                        ...action.payload.suiteSettings?.settings.enabledSecurityChecks,
+                    },
                 };
                 break;
             case STORAGE.ERROR:
@@ -390,6 +396,9 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
                 break;
             case SUITE.TOGGLE_FIRMWARE_REVISION_CHECK:
                 draft.settings.enabledSecurityChecks.firmwareRevision = action.payload;
+                break;
+            case SUITE.TOGGLE_DEVICE_META_CHECKS:
+                draft.settings.enabledSecurityChecks.deviceMeta = action.payload;
                 break;
             case SUITE.TOGGLE_FIRMWARE_HASH_CHECK:
                 draft.settings.enabledSecurityChecks.firmwareHash = action.payload;

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -17,7 +17,7 @@ import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { AppState } from 'src/types/suite';
 
 import {
-    selectIsDebugModeActive,
+    selectAreDeviceMetaChecksEnabled,
     selectIsEntropyCheckEnabled,
     selectIsFirmwareHashCheckEnabled,
     selectIsFirmwareRevisionCheckEnabled,
@@ -97,36 +97,41 @@ export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
 };
 
 export const selectIsDeviceIdCheckEnabledAndFailed = (state: AppState) => {
-    const isDebugMode = selectIsDebugModeActive(state);
+    const areDeviceMetaChecksEnabled = selectAreDeviceMetaChecksEnabled(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.idCheck);
     const isDeviceIdValid = selectIsDeviceIdCheckSuccess(state);
 
-    return !isDebugMode && !isDisabledByMessageSystem && !isDeviceIdValid;
+    return areDeviceMetaChecksEnabled && !isDisabledByMessageSystem && !isDeviceIdValid;
 };
 
 export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AppState) => {
-    const isDebugMode = selectIsDebugModeActive(state);
+    const areDeviceMetaChecksEnabled = selectAreDeviceMetaChecksEnabled(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.invariabilityCheck);
     const isDeviceInvariabilityCheckSuccess = selectIsDeviceInvariabilityCheckSuccess(state);
 
-    return !isDebugMode && !isDisabledByMessageSystem && !isDeviceInvariabilityCheckSuccess;
+    return (
+        areDeviceMetaChecksEnabled &&
+        !isDisabledByMessageSystem &&
+        !isDeviceInvariabilityCheckSuccess
+    );
 };
 
 export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean => {
-    const isDeviceIdCheckFailed = selectIsDeviceIdCheckEnabledAndFailed(state);
-    const isDeviceInvariabilityCheckFailed = selectIsDeviceInvariabilityEnabledAndFailed(state);
-
-    const isFirmwareCheckEnabledAndFailed =
-        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
-    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
-
     // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
     const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);
+    // Entropy check is not dismissable
+    if (isEntropyCheckEnabledAndFailed) return true;
+
+    // All following checks are dismissable
+    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
+    if (isFirmwareAuthenticityCheckDismissed) return false;
+
+    const isDeviceIdCheckFailed = selectIsDeviceIdCheckEnabledAndFailed(state);
+    const isDeviceInvariabilityCheckFailed = selectIsDeviceInvariabilityEnabledAndFailed(state);
+    const isFirmwareCheckEnabledAndFailed =
+        selectIsFirmwareAuthenticityCheckEnabledAndHardFailed(state);
 
     return (
-        isDeviceIdCheckFailed ||
-        isDeviceInvariabilityCheckFailed ||
-        (!isFirmwareAuthenticityCheckDismissed && isFirmwareCheckEnabledAndFailed) ||
-        isEntropyCheckEnabledAndFailed
+        isDeviceIdCheckFailed || isDeviceInvariabilityCheckFailed || isFirmwareCheckEnabledAndFailed
     );
 };

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -100,6 +100,8 @@ export const selectIsFirmwareHashCheckEnabled = (state: SuiteRootState) =>
     state.suite.settings.enabledSecurityChecks.firmwareHash;
 export const selectIsFirmwareRevisionCheckEnabled = (state: SuiteRootState) =>
     state.suite.settings.enabledSecurityChecks.firmwareRevision;
+export const selectAreDeviceMetaChecksEnabled = (state: SuiteRootState) =>
+    state.suite.settings.enabledSecurityChecks.deviceMeta;
 
 // TODO use selectDeviceByDeviceRef from wallet-core; currently WIP in https://github.com/trezor/trezor-suite/pull/20955
 export const selectRecentlyConnectedDevice = (state: AppState): TrezorDevice | undefined =>

--- a/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CheckFirmwareAuthenticity.tsx
@@ -4,6 +4,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import {
+    selectAreDeviceMetaChecksEnabled,
     selectIsEntropyCheckEnabled,
     selectIsFirmwareHashCheckEnabled,
     selectIsFirmwareRevisionCheckEnabled,
@@ -14,6 +15,7 @@ export const CheckFirmwareAuthenticity = () => {
     const isEntropyCheckEnabled = useSelector(selectIsEntropyCheckEnabled);
     const isFirmwareHashCheckEnabled = useSelector(selectIsFirmwareHashCheckEnabled);
     const isFirmwareRevisionCheckEnabled = useSelector(selectIsFirmwareRevisionCheckEnabled);
+    const areDeviceMetaChecksEnabled = useSelector(selectAreDeviceMetaChecksEnabled);
 
     const toggleEntropyCheck = (isChecked: boolean) =>
         dispatch({
@@ -28,6 +30,11 @@ export const CheckFirmwareAuthenticity = () => {
     const toggleFirmwareRevisionCheck = (isChecked: boolean) =>
         dispatch({
             type: SUITE.TOGGLE_FIRMWARE_REVISION_CHECK,
+            payload: isChecked,
+        });
+    const toggleDeviceMetaChecks = (isChecked: boolean) =>
+        dispatch({
+            type: SUITE.TOGGLE_DEVICE_META_CHECKS,
             payload: isChecked,
         });
 
@@ -63,6 +70,18 @@ export const CheckFirmwareAuthenticity = () => {
                     <Switch
                         onChange={toggleFirmwareRevisionCheck}
                         isChecked={isFirmwareRevisionCheckEnabled}
+                    />
+                </ActionColumn>
+            </SectionItem>
+            <SectionItem>
+                <TextColumn
+                    title="Perform device meta checks regularly"
+                    description="Carry out ID check & invariabilitiy check every time you authorize Trezor device."
+                />
+                <ActionColumn>
+                    <Switch
+                        onChange={toggleDeviceMetaChecks}
+                        isChecked={areDeviceMetaChecksEnabled}
                     />
                 </ActionColumn>
             </SectionItem>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Notes for QA

Should not ever occur, so N/A, just be vigilant that we do not receive false positives in normal situations

If you want there is a [testing branch deployed on web](https://dev.suite.sldev.cz/suite-web/feat/device-meta-checks-suite-UI-TESTING/web/) and you can replicate the errors as per instructions in https://github.com/trezor/trezor-suite/pull/25164

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25620

## Screenshots:

Id check: can only be turned off
[id settings.webm](https://github.com/user-attachments/assets/8f9220b3-996a-43f3-ab0f-a2f78205b5e3)

Invariability check: can be dismissed or turned off
[invariability dismissal and settings.webm](https://github.com/user-attachments/assets/a120ad72-21e5-4b38-b5cf-f913ce49a43f)


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dismissable-device-meta-checks&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dismissable-device-meta-checks&lookback=7)