### PR TITLE
feat(suite): update Suite Sync init through label interaction

### DIFF
--- a/packages/product-components/src/components/EditableText/EditableText.tsx
+++ b/packages/product-components/src/components/EditableText/EditableText.tsx
@@ -263,7 +263,12 @@ export const EditableText = ({
     }, [onCancel, isDirty]);
 
     const handleEdit = useCallback(async () => {
-        await onEdit?.();
+        const result = await onEdit?.();
+
+        // Needed in case onEdit is undefined
+        if (result === false) {
+            return;
+        }
 
         setIsEditable(true);
         focus();

--- a/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback } from 'react';
+import { type ReactNode, useCallback, useRef, useState } from 'react';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
@@ -12,16 +12,14 @@ import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { type StaticSessionId } from '@trezor/connect';
 import { EditableText, type EditableTextProps } from '@trezor/product-components';
 
-import {
-    selectDesktopSuiteSyncInteraction,
-    updateShowEnableSuiteSyncModal,
-} from 'src/actions/suiteSync/suiteSyncSlice';
+import { selectDesktopSuiteSyncInteraction } from 'src/actions/suiteSync/suiteSyncSlice';
 import { processLegacyMetadataIntoSuiteSyncThunk } from 'src/actions/wallet/processLegacyMetadataIntoSuiteSyncThunk';
 import { useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 import { SuiteSyncInteractionsTooltip } from './SuiteSyncInteractionsTooltip';
 import { selectIsLabelActionEnabled } from './selectIsLabelActionEnabled';
+import { TurnOnSuiteSyncModals } from '../TurnOnSuiteSync/TurnOnSuiteSyncModals';
 import { suiteSyncErrorHandler } from '../suiteSyncErrorHandler';
 
 type LabelingProps = {
@@ -41,6 +39,8 @@ export const Labeling = ({
     ...rest
 }: LabelingProps) => {
     const dispatch = useDispatch();
+    const [showEnableSuiteSyncModal, setShowEnableSuiteSyncModal] = useState(false);
+    const suiteSyncTurnOnEditResolveRef = useRef<((value: boolean) => void) | null>(null);
     const { isDiscoveryRunning } = useDiscovery();
     const { suiteSync } = useSuiteServices();
     const legacyMetadataState = useSelector(selectMetadata);
@@ -61,7 +61,7 @@ export const Labeling = ({
 
     const handleEdit = useCallback(async () => {
         if (isSuiteSyncEnabled && suiteSyncInteraction === null) {
-            return;
+            return true;
         }
 
         // When clicking on inline input edit, ensure that everything needed is already ready.
@@ -88,13 +88,14 @@ export const Labeling = ({
                         });
                     }
 
-                    return;
+                    return result.success;
                 } else {
-                    dispatch(updateShowEnableSuiteSyncModal({ deviceStaticSessionId }));
-                }
+                    setShowEnableSuiteSyncModal(true);
 
-                // user can decide if they want to enable suite sync or not, so we do not set editing state yet
-                return;
+                    return new Promise<boolean>(resolve => {
+                        suiteSyncTurnOnEditResolveRef.current = resolve;
+                    });
+                }
             } else {
                 return await dispatch(
                     metadataLabelingActions.init(
@@ -106,6 +107,8 @@ export const Labeling = ({
                 );
             }
         }
+
+        return true;
     }, [
         isSuiteSyncEnabled,
         suiteSync,
@@ -116,6 +119,14 @@ export const Labeling = ({
         deviceStaticSessionId,
         deviceState,
     ]);
+
+    const handleSuiteSyncTurnOnModalComplete = useCallback((success: boolean) => {
+        setShowEnableSuiteSyncModal(false);
+        setTimeout(() => {
+            suiteSyncTurnOnEditResolveRef.current?.(success);
+            suiteSyncTurnOnEditResolveRef.current = null;
+        }, 100);
+    }, []);
 
     const handleSubmit = useCallback(
         async (value: string | undefined) => {
@@ -149,20 +160,29 @@ export const Labeling = ({
     );
 
     return (
-        <SuiteSyncInteractionsTooltip
-            suiteSyncInteraction={suiteSyncInteraction}
-            deviceStaticSessionId={deviceStaticSessionId}
-        >
-            <EditableText
-                onSubmit={onSubmit ?? handleSubmit}
-                onEdit={handleEdit}
-                isDisabled={isDisabled || !isLabelActionEnabled}
-                isLoading={legacyMetadataState.initiating || isDiscoveryRunning}
-                data-testid={`@metadata/${payload.type}/${payload.defaultValue}/hover-container`}
-                {...rest}
+        <>
+            {showEnableSuiteSyncModal && (
+                <TurnOnSuiteSyncModals
+                    onClose={() => handleSuiteSyncTurnOnModalComplete(false)}
+                    onSuccess={() => handleSuiteSyncTurnOnModalComplete(true)}
+                    deviceStaticSessionId={deviceStaticSessionId}
+                />
+            )}
+            <SuiteSyncInteractionsTooltip
+                suiteSyncInteraction={suiteSyncInteraction}
+                deviceStaticSessionId={deviceStaticSessionId}
             >
-                {children}
-            </EditableText>
-        </SuiteSyncInteractionsTooltip>
+                <EditableText
+                    onSubmit={onSubmit ?? handleSubmit}
+                    onEdit={handleEdit}
+                    isDisabled={isDisabled || !isLabelActionEnabled}
+                    isLoading={legacyMetadataState.initiating || isDiscoveryRunning}
+                    data-testid={`@metadata/${payload.type}/${payload.defaultValue}/hover-container`}
+                    {...rest}
+                >
+                    {children}
+                </EditableText>
+            </SuiteSyncInteractionsTooltip>
+        </>
     );
 };

--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
@@ -12,11 +12,13 @@ import { suiteSyncErrorTranslationKeyMap } from '../suiteSyncErrorTranslationKey
 type SuiteSyncTurnOnAndFwUpgradeModalProps = {
     deviceStaticSessionId: StaticSessionId;
     onClose: () => void;
+    onSuccess?: () => void;
 };
 
 export const SuiteSyncTurnOnModal = ({
     deviceStaticSessionId,
     onClose,
+    onSuccess,
 }: SuiteSyncTurnOnAndFwUpgradeModalProps) => {
     const dispatch = useDispatch();
     const { suiteSync } = useSuiteServices();
@@ -46,6 +48,8 @@ export const SuiteSyncTurnOnModal = ({
 
                 case 'WriteModeRequiredForAllocation':
                     // Do nothing, this is expected control flow error when we want allocate on-demand.
+                    onSuccess?.();
+
                     return;
 
                 case 'SuiteSyncUnavailableOnDeviceError':
@@ -63,6 +67,8 @@ export const SuiteSyncTurnOnModal = ({
                     return exhaustive(type);
             }
         }
+
+        onSuccess?.();
     };
 
     return (

--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals.tsx
@@ -1,20 +1,24 @@
+import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
-import {
-    selectDesktopSuiteSyncInteraction,
-    selectShowEnableSuiteSyncModal,
-} from 'src/actions/suiteSync/suiteSyncSlice';
-import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectDesktopSuiteSyncInteraction } from 'src/actions/suiteSync/suiteSyncSlice';
+import { useSelector } from 'src/hooks/suite';
 
 import { SuiteSyncFirmwareUpgradeNeededModal } from './SuiteSyncFirmwareUpgradeNeededModal';
 import { SuiteSyncTurnOnModal } from './SuiteSyncTurnOnModal';
 import { SuiteSyncTurnOnUnsupportedModal } from './SuiteSyncTurnOnUnsupportedModal';
-import { updateShowEnableSuiteSyncModal } from '../../../../actions/suiteSync/suiteSyncSlice';
 
-export const TurnOnSuiteSyncModalManager = () => {
-    const dispatch = useDispatch();
-    const deviceStaticSessionId = useSelector(selectShowEnableSuiteSyncModal);
+type TurnOnSuiteSyncModalsProps = {
+    onClose: () => void;
+    onSuccess?: () => void;
+    deviceStaticSessionId: StaticSessionId | null;
+};
 
+export const TurnOnSuiteSyncModals = ({
+    onClose,
+    onSuccess,
+    deviceStaticSessionId,
+}: TurnOnSuiteSyncModalsProps) => {
     const suiteSyncInteraction = useSelector(state =>
         selectDesktopSuiteSyncInteraction(state, deviceStaticSessionId),
     );
@@ -22,10 +26,6 @@ export const TurnOnSuiteSyncModalManager = () => {
     if (deviceStaticSessionId === null || suiteSyncInteraction === null) {
         return null;
     }
-
-    const onClose = () => {
-        dispatch(updateShowEnableSuiteSyncModal({ deviceStaticSessionId: null }));
-    };
 
     switch (suiteSyncInteraction) {
         case 'keys-needed':
@@ -37,6 +37,7 @@ export const TurnOnSuiteSyncModalManager = () => {
             return (
                 <SuiteSyncTurnOnModal
                     onClose={onClose}
+                    onSuccess={onSuccess}
                     deviceStaticSessionId={deviceStaticSessionId}
                 />
             );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
@@ -3,11 +3,16 @@ import { closeModalApp } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { UI_REQUEST } from '@trezor/connect';
 
+import {
+    selectShowEnableSuiteSyncModal,
+    updateShowEnableSuiteSyncModal,
+} from 'src/actions/suiteSync/suiteSyncSlice';
+
 import { useDispatch, usePreferredModal, useSelector } from '../../../../hooks/suite';
 import type { AppState, ForegroundAppRoute } from '../../../../types/suite';
 import { SwitchDevice } from '../../../../views/suite/SwitchDevice/SwitchDevice';
 import { ThpGlobalModalManager } from '../../../connection/thp/ThpGlobalModalManager';
-import { TurnOnSuiteSyncModalManager } from '../../labeling/TurnOnSuiteSync/TurnOnSuiteSyncModalManager';
+import { TurnOnSuiteSyncModals } from '../../labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals';
 import { ConfirmPassphraseBeforeAction } from '../../modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction';
 import { PassphraseModal } from '../../modals/ReduxModal/DeviceContextModal/PassphraseModal';
 import { PassphraseOnDeviceModal } from '../../modals/ReduxModal/DeviceContextModal/PassphraseOnDeviceModal';
@@ -54,6 +59,7 @@ type ForegroundAppModalProps = {
 
 const ForegroundAppModal = ({ app, cancelable }: ForegroundAppModalProps) => {
     const dispatch = useDispatch();
+    const deviceStaticSessionId = useSelector(selectShowEnableSuiteSyncModal);
 
     const onCancel = () => dispatch(closeModalApp());
 
@@ -63,7 +69,12 @@ const ForegroundAppModal = ({ app, cancelable }: ForegroundAppModalProps) => {
         return (
             <>
                 <SwitchDevice cancelable={cancelable} onCancel={onCancel} />
-                <TurnOnSuiteSyncModalManager />
+                <TurnOnSuiteSyncModals
+                    deviceStaticSessionId={deviceStaticSessionId}
+                    onClose={() => {
+                        dispatch(updateShowEnableSuiteSyncModal({ deviceStaticSessionId: null }));
+                    }}
+                />
                 {/* THP flow can be triggered by auto-connect and that will open THP modals.
                  *  However, this ForegroundApp takes precedes and prevents ALL other modals
                  *  to render. So we have to render it here as well.*/}

--- a/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
+++ b/packages/suite/src/components/suite/modals/ModalSwitcher/ModalSwitcher.tsx
@@ -1,10 +1,15 @@
+import {
+    selectShowEnableSuiteSyncModal,
+    updateShowEnableSuiteSyncModal,
+} from 'src/actions/suiteSync/suiteSyncSlice';
 import { ConnectionGlobalModalManager } from 'src/components/connection/ConnectionGlobalModalManager';
 import { ThpGlobalModalManager } from 'src/components/connection/thp/ThpGlobalModalManager';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { usePreferredModal } from 'src/hooks/suite/usePreferredModal';
 
 import { ForegroundAppModal } from './ForegroundAppModal';
 import { WipedBleDeviceNeedsManualOsRemovalModalManager } from '../../bluetooth/WipedBleDeviceNeedsManualOsRemovalModalManager';
-import { TurnOnSuiteSyncModalManager } from '../../labeling/TurnOnSuiteSync/TurnOnSuiteSyncModalManager';
+import { TurnOnSuiteSyncModals } from '../../labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals';
 import { ReduxModal } from '../ReduxModal/ReduxModal';
 
 type ModalParams = ReturnType<typeof usePreferredModal>;
@@ -21,6 +26,8 @@ const Inner = ({ modal }: { modal: ModalParams }) => {
 /** Displays whichever redux modal or foreground app should be displayed */
 export const ModalSwitcher = () => {
     const modal = usePreferredModal();
+    const dispatch = useDispatch();
+    const deviceStaticSessionId = useSelector(selectShowEnableSuiteSyncModal);
 
     // For foreground apps, we have to NOT render the other modals.
     // There may be conflicts: for example, Firmware Install / Upgrade flow
@@ -33,7 +40,12 @@ export const ModalSwitcher = () => {
         <>
             <WipedBleDeviceNeedsManualOsRemovalModalManager />
             <ThpGlobalModalManager />
-            <TurnOnSuiteSyncModalManager />
+            <TurnOnSuiteSyncModals
+                deviceStaticSessionId={deviceStaticSessionId}
+                onClose={() => {
+                    dispatch(updateShowEnableSuiteSyncModal({ deviceStaticSessionId: null }));
+                }}
+            />
             <ConnectionGlobalModalManager />
             <Inner modal={modal} />
         </>


### PR DESCRIPTION
## Notes for QA

When enabling Suite Sync labeling via clicking on a label, it should make the label editable after successfully going through the activation flow


https://github.com/user-attachments/assets/ecb2a080-54ca-49ec-8a82-d8f800bdbaa4



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/labeling-init&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/labeling-init&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/labeling-init&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/labeling-init&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-25T15:14:23.032Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T15:12:44.769Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->