### PR TITLE
fix(suite-native): capture console.errors as Sentry events again

### DIFF
--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,3 +1,4 @@
+import { captureConsoleIntegration } from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
 
 import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
@@ -30,7 +31,12 @@ export const initSentry = () => {
         dsn: 'https://d473f56df60c4974ae3f3ce00547c2a9@o117836.ingest.sentry.io/4504214699245568',
         enableAutoSessionTracking: false,
         environment: isDetoxTestBuild() ? 'test' : getEnv(),
-        integrations: [Sentry.consoleLoggingIntegration({ levels: ['error'] })],
+        integrations: defaults => [
+            // remove consoleLoggingIntegration, which sends console.errors as logs
+            ...defaults.filter(i => i.name !== 'ConsoleLogs'),
+            // use this instead, which sends console.errors as error events
+            captureConsoleIntegration({ levels: ['error'] }),
+        ],
         enableLogs: true,
         beforeSend: redactSentryEvent,
         ignoreErrors,


### PR DESCRIPTION
## Description

Reintroduce `captureConsoleIntegration` to Suite Native after #22817,
which replaced it with `consoleLoggingIntegration`.

I checked the migration guides and current docs and there is no warning against using `captureConsoleIntegration` from `@sentry/core` in react-native environment, it worked before and it works now:
- [testing error event](https://satoshilabs.sentry.io/issues/7306327523/?project=4504214699245568&query=is%3Aunresolved&referrer=issue-stream)
- [is not in logs](https://satoshilabs.sentry.io/explore/logs/?environment=debug&logsFields=timestamp&logsFields=message&logsQuery=Testing%20console.error%20from%20native&logsSortBys=-timestamp&project=4504214699245568&statsPeriod=7d)
  - [this testing error from yesterday](https://satoshilabs.sentry.io/explore/logs/?environment=debug&logsFields=timestamp&logsFields=message&logsQuery=Testing%20error&logsSortBys=-timestamp&project=4504214699245568&statsPeriod=7d) was in logs, but we want events instead

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native-sentry-console-logs&lookback=7)