### PR TITLE
fix(trading): swap fixed and dex offer sections in TradingOffersExchange

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/TradingOffersExchange.tsx
@@ -63,13 +63,11 @@ export const TradingOffersExchange = () => {
     return (
         <>
             <TradingUtilsTorWarning tradingType="exchange" noOffer={false} />
-
-            {(showAll ||
-                exchangeTypeFilter === TRADING_EXCHANGE_COMPARATOR_RATE_FILTER_FIXED_CEX) && (
+            {(showAll || exchangeTypeFilter === TRADING_EXCHANGE_COMPARATOR_RATE_FILTER_DEX) && (
                 <TradingOffersExchangeQuotesByTypeSection
-                    quotes={fixed}
-                    heading="TR_TRADING_EXCHANGE_FIXED_OFFERS_HEADING"
-                    tooltip="TR_TRADING_FIX_RATE_DESCRIPTION"
+                    quotes={dex}
+                    heading="TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING"
+                    tooltip="TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING_TOOLTIP"
                 />
             )}
             {(showAll ||
@@ -80,11 +78,12 @@ export const TradingOffersExchange = () => {
                     tooltip="TR_TRADING_FLOATING_RATE_DESCRIPTION"
                 />
             )}
-            {(showAll || exchangeTypeFilter === TRADING_EXCHANGE_COMPARATOR_RATE_FILTER_DEX) && (
+            {(showAll ||
+                exchangeTypeFilter === TRADING_EXCHANGE_COMPARATOR_RATE_FILTER_FIXED_CEX) && (
                 <TradingOffersExchangeQuotesByTypeSection
-                    quotes={dex}
-                    heading="TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING"
-                    tooltip="TR_TRADING_EXCHANGE_DEX_OFFERS_HEADING_TOOLTIP"
+                    quotes={fixed}
+                    heading="TR_TRADING_EXCHANGE_FIXED_OFFERS_HEADING"
+                    tooltip="TR_TRADING_FIX_RATE_DESCRIPTION"
                 />
             )}
         </>


### PR DESCRIPTION
## Description

Change the order of sections on the Compare offers page to `DEX → Floating CEX → Fixed CEX` to match the new trading priorities.

## Notes for QA

Verify on the Compare offers page (desktop) that the sections are ordered as `DEX → Floating CEX → Fixed CEX`, and that offers and interactions within each section still work as before.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23906

## Screenshots:
<img width="1194" height="1279" alt="image" src="https://github.com/user-attachments/assets/fba33654-a223-4d62-a811-87dcc766332e" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/23906/compare-offers-order&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/23906/compare-offers-order&lookback=7)