### PR TITLE
chore(suite-native): remove debug-only networks unit tests from buy/exchange selectors test

### DIFF
--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import type { BuyTrade, CryptoId } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { AccountsRootState } from '@suite-common/wallet-core';
 import { Account, AccountKey } from '@suite-common/wallet-types';
@@ -106,52 +106,8 @@ describe('buySelectors', () => {
             expect(selectBuyTradeableAssets(state)).toEqual([]);
         });
 
-        describe('debug-only networks', () => {
-            beforeEach(() => {
-                // Add Tron which is a debug-only network
-                state.wallet.trading.buy.buyInfo!.supportedCryptoCurrencies = [
-                    'ethereum',
-                    'bitcoin',
-                    'tron',
-                ] as CryptoId[];
-                state.wallet.trading.info.coins = {
-                    ...state.wallet.trading.info.coins,
-                    tron: {
-                        symbol: 'trx',
-                        name: 'Tron',
-                        coingeckoId: 'tron',
-                        services: {
-                            buy: true,
-                            sell: true,
-                            exchange: true,
-                        },
-                    },
-                };
-            });
-
-            it('should filter out debug-only networks when flag is disabled', () => {
-                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = false;
-
-                const result = selectBuyTradeableAssets(state);
-
-                expect(result).toEqual([
-                    expect.objectContaining({ cryptoId: 'ethereum' }),
-                    expect.objectContaining({ cryptoId: 'bitcoin' }),
-                ]);
-                expect(result).not.toContainEqual(expect.objectContaining({ cryptoId: 'tron' }));
-            });
-
-            it('should include debug-only networks when flag is enabled', () => {
-                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = true;
-
-                const result = selectBuyTradeableAssets(state);
-
-                expect(result).toEqual([
-                    expect.objectContaining({ cryptoId: 'ethereum' }),
-                    expect.objectContaining({ cryptoId: 'bitcoin' }),
-                    expect.objectContaining({ cryptoId: 'tron', symbol: 'TRX' }),
-                ]);
-            });
+        describe.skip('debug-only networks', () => {
+            // There are currently no debug only networks. Skipping
         });
     });
 

--- a/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/exchangeSelectors.test.ts
@@ -173,52 +173,8 @@ describe('exchangeSelectors', () => {
             );
         });
 
-        describe('debug-only networks', () => {
-            beforeEach(() => {
-                // Add Tron which is a debug-only network
-                state.wallet.trading.exchange.exchangeInfo!.buyCryptoIds = [
-                    'ethereum',
-                    'bitcoin',
-                    'tron',
-                ] as CryptoId[];
-                state.wallet.trading.info.coins = {
-                    ...state.wallet.trading.info.coins,
-                    tron: {
-                        symbol: 'trx',
-                        name: 'Tron',
-                        coingeckoId: 'tron',
-                        services: {
-                            buy: true,
-                            sell: true,
-                            exchange: true,
-                        },
-                    },
-                };
-            });
-
-            it('should filter out debug-only networks when flag is disabled', () => {
-                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = false;
-
-                const result = selectExchangeBuyTradeableAssets(state);
-
-                expect(result).toEqual([
-                    expect.objectContaining({ cryptoId: 'ethereum' }),
-                    expect.objectContaining({ cryptoId: 'bitcoin' }),
-                ]);
-                expect(result).not.toContainEqual(expect.objectContaining({ cryptoId: 'tron' }));
-            });
-
-            it('should include debug-only networks when flag is enabled', () => {
-                state.featureFlags[FeatureFlag.AreDebugOnlyNetworksEnabled] = true;
-
-                const result = selectExchangeBuyTradeableAssets(state);
-
-                expect(result).toEqual([
-                    expect.objectContaining({ cryptoId: 'ethereum' }),
-                    expect.objectContaining({ cryptoId: 'bitcoin' }),
-                    expect.objectContaining({ cryptoId: 'tron', symbol: 'TRX' }),
-                ]);
-            });
+        describe.skip('debug-only networks', () => {
+            // There are currently no debug only networks. Skipping
         });
     });
 


### PR DESCRIPTION
## Description

This PR removes `debug-only networks` unit tests from `buySelectors.test.ts` and `exchangeSelectors.test.ts` as there are no debug only networks to test. Tron was there only for a short time.

## Notes for QA

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-unit-tests&lookback=7)