### PR TITLE
fix(trading): fix subdivison modal placeholder and layout

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCountry/CountrySubdivisionSelectModal.tsx
@@ -42,11 +42,11 @@ export const CountrySubdivisionSelectModal = ({
             height="85vh"
             width={400}
         >
-            <Column gap={12}>
+            <Column gap={12} height="100%">
                 <Input
                     value={filterValue}
                     onChange={event => setFilterValue(event.target.value)}
-                    placeholder={translationString('TR_SEARCH_COUNTRY_PLACEHOLDER')}
+                    placeholder={translationString('TR_SEARCH_COUNTRY_SUBDIVISION_PLACEHOLDER')}
                 />
                 {filteredData.length > 0 && (
                     <CardList>
@@ -62,7 +62,7 @@ export const CountrySubdivisionSelectModal = ({
                     </CardList>
                 )}
                 {!filteredData.length && (
-                    <Column justifyContent="center">
+                    <Column justifyContent="center" flex="0.75">
                         <Paragraph align="center">
                             <Translation id="TR_TRADING_COUNTRY_SUBDIVISION_NOT_FOUND" />
                         </Paragraph>


### PR DESCRIPTION
## Description

- **Fix subdivision picker layout and copy**: make the subdivision select modal content fill the full height, adjust the empty state vertical alignment, and use a subdivision-specific search placeholder string.

## Notes for QA

- **Scope**: `Trading > Country subdivision select` modal.
- **Check**:
  - The modal stretches content to full height and looks correct on different window sizes.
  - The search input placeholder reads "search subdivision" (localized via `TR_SEARCH_COUNTRY_SUBDIVISION_PLACEHOLDER`).
  - Typing a query that yields results shows the list as expected.
  - Typing a query with no results shows the "not found" message, vertically centered in a visually balanced way, without layout jumps.

## Related Issue

Part of **https://github.com/trezor/trezor-suite/issues/21974**

## Screenshots:
<img width="416" height="645" alt="image" src="https://github.com/user-attachments/assets/94e0de82-73a0-4141-95b7-c54733318e1e" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/subdivision-modal&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/subdivision-modal&lookback=7)