### PR TITLE
fix(suite): lower ethereum staking reserve e2e test

### DIFF
--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -8,7 +8,7 @@ import { createTestAnnotation } from '../../support/reporters/annotations';
 
 let ethereumStakingBalance: string | null;
 const MOCKED_FEE_AMOUNT = 0.000290278609719;
-const WITHDRAWAL_BUFFER = 0.03;
+const WITHDRAWAL_BUFFER = 0.005;
 
 test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({


### PR DESCRIPTION
## Description

Lower Ethereum staking withdrawal reserve from `0.03` ETH to `0.005` ETH.
Update the ETH staking e2e expectation to match the new reserve.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25503


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/lower-eth-staking-reserve-test&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/lower-eth-staking-reserve-test&lookback=7)