### PR TITLE
chore(suite): remove unused suite sync string

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -2102,7 +2102,6 @@
   "TR_SUITE_META_DESCRIPTION": "New desktop & browser app for Trezor hardware wallets. Trezor Suite brings significant improvements across our three key pillars of usability, security, and privacy.",
   "TR_SUITE_STORAGE": "Reset app to default",
   "TR_SUITE_SYNC_CONNECT_AND_GET_KEYS": "Connect & allow",
-  "TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP": "Connect your Trezor to continue.",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE": "Update",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE_NEEDED_BANNER": "Firmware update required. Update firmware on your Trezor to use Suite Sync.",
   "TR_SUITE_SYNC_GET_KEYS": "Allow",

--- a/packages/suite-data/files/translations/uk-UA.json
+++ b/packages/suite-data/files/translations/uk-UA.json
@@ -2089,7 +2089,6 @@
   "TR_SUGGESTION": "Зворотній зв’язок",
   "TR_SUITE_META_DESCRIPTION": "Новий застосунок для робочого столу та браузера для апаратних гаманців Trezor. У Trezor Suite реалізовано значні поліпшення за трьома основними напрямами: зручність використання, безпека та конфіденційність.",
   "TR_SUITE_STORAGE": "Сховище застосунку",
-  "TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP": "Підключіть пристрій, щоб продовжити.",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE": "Оновити",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE_NEEDED_BANNER": "Потрібне оновлення прошивки. Оновіть прошивку пристрою, щоб використовувати Suite Sync.",
   "TR_SUITE_SYNC_GET_KEYS": "Дозволити",

--- a/packages/suite-data/files/translations/zh-CN.json
+++ b/packages/suite-data/files/translations/zh-CN.json
@@ -2102,7 +2102,6 @@
   "TR_SUITE_META_DESCRIPTION": "用于 Trezor 硬件钱包的全新桌面版和浏览器应用程序。Trezor Suite 在可用性、安全性和私密性三大支柱方面都有重大改进。",
   "TR_SUITE_STORAGE": "将应用程序重置为默认设置",
   "TR_SUITE_SYNC_CONNECT_AND_GET_KEYS": "连接并允许",
-  "TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP": "请连接您的 Trezor 设备以继续操作。",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE": "更新",
   "TR_SUITE_SYNC_FIRMWARE_UPDATE_NEEDED_BANNER": "需要固件更新。请更新您的 Trezor 设备固件以使用 Suite Sync 功能。",
   "TR_SUITE_SYNC_GET_KEYS": "允许",

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3178,10 +3178,6 @@ export const messages = defineMessages({
             'Firmware update required. Update firmware on your Trezor to use Suite Sync.',
         id: 'TR_SUITE_SYNC_FIRMWARE_UPDATE_NEEDED_BANNER',
     },
-    TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP: {
-        defaultMessage: 'Connect your Trezor to continue.',
-        id: 'TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP',
-    },
     TR_SUITE_SYNC_KEYS_NEEDED_BANNER: {
         defaultMessage:
             'Allow Suite Sync to view and edit your labels, wallet names, and account names.',


### PR DESCRIPTION
## Description

Removing unused string `TR_SUITE_SYNC_CONNECT_DEVICE_TOOLTIP`.

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-suite-sync-string&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-suite-sync-string&lookback=7)