### PR TITLE
fix(trading): Fix trading payment method amount consistency 

### DIFF
--- a/suite-common/trading/src/__tests__/utils.test.ts
+++ b/suite-common/trading/src/__tests__/utils.test.ts
@@ -175,9 +175,13 @@ describe('isCryptoIdForNativeToken', () => {
 });
 
 describe('getTradingPaymentMethods', () => {
+    const duplicateApplePayQuoteWithWorseAmount = {
+        ...BUY_FIXTURE.MIN_MAX_QUOTES_OK[1],
+        receiveStringAmount: '0.00000001',
+    };
     const paymentMethods = getTradingPaymentMethods([
         ...BUY_FIXTURE.MIN_MAX_QUOTES_OK,
-        BUY_FIXTURE.MIN_MAX_QUOTES_OK[1], // duplicate applePay
+        duplicateApplePayQuoteWithWorseAmount, // duplicate applePay
     ]);
 
     it('should get payment methods from quotes', () => {
@@ -196,6 +200,14 @@ describe('getTradingPaymentMethods', () => {
 
         expect(amounts.map(amount => amount.toString())).toEqual(
             sortedAmounts.map(amount => amount.toString()),
+        );
+    });
+
+    it('should keep first quote amount for duplicate payment method', () => {
+        const applePayMethod = paymentMethods.find(method => method.value === 'applePay');
+
+        expect(applePayMethod?.receiveAmount).toBe(
+            BUY_FIXTURE.MIN_MAX_QUOTES_OK[1].receiveStringAmount,
         );
     });
 });

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -296,6 +296,7 @@ export const getTradingPaymentMethods = (
 
     quotes.forEach(quote => {
         if (!quote.paymentMethod) return;
+        if (uniqueMethods.has(quote.paymentMethod)) return;
         const amount = isBuyTrade(quote) ? quote.receiveStringAmount : quote.fiatStringAmount;
         uniqueMethods.set(quote.paymentMethod, {
             value: quote.paymentMethod,


### PR DESCRIPTION
## Description

Fix trading payment method amount consistency by keeping the first quote per payment method in `getTradingPaymentMethods` (instead of overwriting with later duplicates).  
This ensures the amount shown in the payment method modal matches the amount shown in the Buy offer after selecting that method.

Also adds a regression test covering duplicate payment methods with different amounts.

## Notes for QA

- In Buy flow, enter an amount and open Payment method modal.
- Pick a non-default method (e.g. Apple Pay), then change amount and reopen modal.
- Verify modal amount and `You get` amount match for the selected payment method.
- Focus on cases where multiple providers share the same payment method.

## Related Issue

Resolve [#25613](https://github.com/trezor/trezor-suite/issues/25613)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25613/buy-payment-method-amount-mismatch&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25613/buy-payment-method-amount-mismatch&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/25613/buy-payment-method-amount-mismatch&lookback=7)