### PR TITLE
feat(trading): extend trade support banner and simplify status and support url logic

### DIFF
--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -1,11 +1,9 @@
 import {
-    BuyProviderInfo,
     BuyTrade,
     CryptoId,
     ExchangeProviderInfo,
     FiatCurrencyCode,
     SellFiatTrade,
-    SellProviderInfo,
 } from 'invity-api';
 
 import { ExtendedMessageDescriptor } from '@suite/intl';
@@ -15,6 +13,7 @@ import type {
     TradingExchangeInfoSelector,
     TradingExchangeType,
     TradingPaymentMethodType,
+    TradingProviderInfo,
     TradingSelectAssetOptionGroupProps,
     TradingSellInfoSelector,
     TradingSellType,
@@ -114,7 +113,7 @@ export interface TradingGetAmountLabelsReturnProps {
 
 export type TradingGetProvidersInfoProps =
     | {
-          [name: string]: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
+          [name: string]: TradingProviderInfo;
       }
     | undefined;
 

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -1,7 +1,5 @@
-import { BuyTrade, ExchangeTrade, SellFiatTrade } from 'invity-api';
-
 import { ExtendedMessageDescriptor } from '@suite/intl';
-import { type TradingType } from '@suite-common/trading';
+import type { TradingTradeType, TradingType } from '@suite-common/trading';
 import { Network, NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import { PrecomposedLevels, PrecomposedLevelsCardano } from '@suite-common/wallet-types';
 import { asAmountSubunit, substituteBip43Path, subunitsToUnits } from '@suite-common/wallet-utils';
@@ -213,7 +211,7 @@ export const getTradeTypeByRoute = (
 };
 
 interface GetTradeProviderProps {
-    trade: BuyTrade | ExchangeTrade | SellFiatTrade | undefined;
+    trade: TradingTradeType | undefined;
     providerInfo: TradingGetProvidersInfoProps;
 }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingContainer.tsx
@@ -1,7 +1,6 @@
 import { ElementType } from 'react';
 
-import { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
-
+import type { TradingProviderInfo } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -13,7 +12,7 @@ import { TradingLayoutHeader } from 'src/views/wallet/trading/common/TradingLayo
 
 export interface TradingContainerProps {
     SectionComponent: ElementType;
-    provider?: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
+    provider?: TradingProviderInfo;
 }
 
 export const TradingContainer = ({ SectionComponent, provider }: TradingContainerProps) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentFailed.tsx
@@ -45,7 +45,7 @@ export const TradingDetailBuyPaymentFailed = ({
                             trade={trade}
                         />
                     )}
-                    <TradingDetailSupportBanner provider={provider} orderId={trade.paymentId} />
+                    <TradingDetailSupportBanner provider={provider} trade={trade} />
                 </Column>
             </Card>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentProcessingStep.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailBuy/TradingDetailBuyPaymentProcessingStep.tsx
@@ -53,7 +53,7 @@ export const TradingDetailBuyPaymentProcessingStep = ({
                             trade={trade}
                         />
                     )}
-                    <TradingDetailSupportBanner provider={provider} orderId={trade.paymentId} />
+                    <TradingDetailSupportBanner provider={provider} trade={trade} />
                 </Column>
             </Card>
         </TradingDetailStep>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -69,8 +69,6 @@ export const TradingDetailExchange = () => {
     const exchange = trade?.data?.exchange;
     const provider =
         info && info.providerInfos && exchange ? info.providerInfos[exchange] : undefined;
-    const supportUrlTemplate = provider?.statusUrl || provider?.supportUrl;
-    const supportUrl = supportUrlTemplate?.replace('{{orderId}}', trade?.data?.orderId || '');
 
     const quoteAmounts: TradingGetCryptoQuoteAmountProps = {
         sendAmount: trade?.data?.sendStringAmount ?? '',
@@ -131,7 +129,7 @@ export const TradingDetailExchange = () => {
                         trade={trade.data}
                         account={sendAccount}
                         provider={provider}
-                        supportUrl={supportUrl}
+                        supportUrl={provider?.supportUrl}
                     />
                 );
             default:

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting.tsx
@@ -54,7 +54,7 @@ export const TradingDetailExchangePaymentConverting = ({
                             txId={trade.receiveTxHash}
                         />
                     )}
-                    <TradingDetailSupportBanner provider={provider} orderId={trade.orderId} />
+                    <TradingDetailSupportBanner provider={provider} trade={trade} />
                 </Column>
             </Card>
         </TradingDetailStep>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentFailed.tsx
@@ -50,7 +50,7 @@ export const TradingDetailExchangePaymentFailed = ({
                             txId={trade.receiveTxHash}
                         />
                     )}
-                    <TradingDetailSupportBanner provider={provider} orderId={trade.orderId} />
+                    <TradingDetailSupportBanner provider={provider} trade={trade} />
                 </Column>
             </Card>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
@@ -1,14 +1,9 @@
-import {
-    BuyProviderInfo,
-    BuyTrade,
-    ExchangeProviderInfo,
-    ExchangeTrade,
-    SellFiatTrade,
-    SellProviderInfo,
-} from 'invity-api';
-
 import { Translation } from '@suite/intl';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import type {
+    TradingProviderInfo as TradingProviderInfoType,
+    TradingTradeType,
+} from '@suite-common/trading';
 import { Button, Column, InfoItem, Row, Text } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 
@@ -22,8 +17,8 @@ type TradingDetailProviderInfoProps = {
     account?: Account;
     estimatedTime?: string;
     orderId?: string;
-    provider: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
-    trade: BuyTrade | ExchangeTrade | SellFiatTrade;
+    provider: TradingProviderInfoType;
+    trade: TradingTradeType;
     txId?: string;
 };
 

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentFailed.tsx
@@ -50,7 +50,7 @@ export const TradingDetailSellPaymentFailed = ({
                             txId={trade.txid}
                         />
                     )}
-                    <TradingDetailSupportBanner provider={provider} orderId={trade.orderId} />
+                    <TradingDetailSupportBanner provider={provider} trade={trade} />
                 </Column>
             </Card>
         </Column>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSell/TradingDetailSellPaymentSuccessful.tsx
@@ -55,10 +55,7 @@ export const TradingDetailSellPaymentSuccessful = ({
                                 provider={provider}
                                 trade={trade}
                             />
-                            <TradingDetailSupportBanner
-                                provider={provider}
-                                orderId={trade.orderId}
-                            />
+                            <TradingDetailSupportBanner provider={provider} trade={trade} />
                         </Column>
                     </Card>
                 )}

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
@@ -1,17 +1,24 @@
 import { Translation } from '@suite/intl';
-import { type TradingProviderInfo, isBuyProviderInfo } from '@suite-common/trading';
-import { Banner, Link, Paragraph } from '@trezor/components';
+import {
+    type TradingProviderInfo,
+    type TradingTradeType,
+    getStatusUrl,
+    isBuyProviderInfo,
+} from '@suite-common/trading';
+import { Banner, Link } from '@trezor/components';
+
+import { BannerPoints } from 'src/components/wallet/WalletLayout/AccountBanners/BannerPoints';
 
 type TradingDetailSupportBannerProps = {
     provider?: TradingProviderInfo;
-    orderId?: string;
+    trade?: TradingTradeType;
 };
 
 export const TradingDetailSupportBanner = ({
     provider,
-    orderId,
+    trade,
 }: TradingDetailSupportBannerProps) => {
-    if (!provider || !orderId) {
+    if (!provider || !trade) {
         return null;
     }
 
@@ -19,29 +26,39 @@ export const TradingDetailSupportBanner = ({
         ? (provider.brandName ?? provider.companyName)
         : (provider.companyName ?? provider.name);
 
-    const supportUrlTemplate = provider.statusUrl || provider.supportUrl;
-    const supportUrl = supportUrlTemplate
-        ?.replace('{{orderId}}', orderId)
-        ?.replace('{{paymentId}}', orderId);
+    const { supportUrl } = provider;
+    const statusUrl = getStatusUrl(provider, trade);
 
-    if (!supportUrl) {
+    if (!supportUrl && !statusUrl) {
         return null;
     }
 
     return (
         <Banner
             intent="neutral"
-            icon="question"
             description={
-                <Paragraph typographyStyle="body-sm">
-                    <Translation
-                        id="TR_TRADING_PROCESSING_SUPPORT"
-                        values={{
-                            providerName,
-                            link: chunks => <Link href={supportUrl}>{chunks}</Link>,
-                        }}
-                    />
-                </Paragraph>
+                <BannerPoints
+                    points={[
+                        statusUrl && (
+                            <Translation
+                                id="TR_TRADING_PROCESSING_STATUS"
+                                values={{
+                                    providerName,
+                                    link: chunks => <Link href={statusUrl}>{chunks}</Link>,
+                                }}
+                            />
+                        ),
+                        supportUrl && (
+                            <Translation
+                                id="TR_TRADING_PROCESSING_SUPPORT"
+                                values={{
+                                    providerName,
+                                    link: chunks => <Link href={supportUrl}>{chunks}</Link>,
+                                }}
+                            />
+                        ),
+                    ].filter(Boolean)}
+                />
             }
         />
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSupportBanner.tsx
@@ -1,16 +1,11 @@
-import { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
-
 import { Translation } from '@suite/intl';
+import { type TradingProviderInfo, isBuyProviderInfo } from '@suite-common/trading';
 import { Banner, Link, Paragraph } from '@trezor/components';
 
 type TradingDetailSupportBannerProps = {
-    provider?: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
+    provider?: TradingProviderInfo;
     orderId?: string;
 };
-
-const isBuyProviderInfo = (
-    provider: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo,
-): provider is BuyProviderInfo => 'brandName' in provider;
 
 export const TradingDetailSupportBanner = ({
     provider,

--- a/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFooter/TradingFooter.tsx
@@ -1,15 +1,13 @@
 import { useSelector } from 'react-redux';
 
-import { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
-
 import { Translation } from '@suite/intl';
-import { selectTradingProviderMetadata } from '@suite-common/trading';
+import { type TradingProviderInfo, selectTradingProviderMetadata } from '@suite-common/trading';
 import { Column, Link, Text } from '@trezor/components';
 
 import { TradingFormFeesDisclaimer } from '../TradingFormFeesDisclaimer/TradingFormFeesDisclaimer';
 
 type TradingFooterProps = {
-    provider?: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
+    provider?: TradingProviderInfo;
 };
 
 export const TradingFooter = ({ provider }: TradingFooterProps) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingProviderInfo.tsx
@@ -1,6 +1,7 @@
-import { BuyProviderInfo, ExchangeProviderInfo, SellProviderInfo } from 'invity-api';
-
-import { invityAPI } from '@suite-common/trading';
+import {
+    type TradingProviderInfo as TradingProviderInfoType,
+    invityAPI,
+} from '@suite-common/trading';
 import { Row } from '@trezor/components';
 
 import { TradingGetProvidersInfoProps } from 'src/types/trading/trading';
@@ -9,7 +10,7 @@ import { TradingIcon } from 'src/views/wallet/trading/common/TradingIcon';
 export type TradingProviderInfoProps = {
     exchange?: string;
     providers?: TradingGetProvidersInfoProps;
-    provider?: BuyProviderInfo | SellProviderInfo | ExchangeProviderInfo;
+    provider?: TradingProviderInfoType;
 };
 
 export const TradingProviderInfo = ({

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -1,4 +1,5 @@
 import {
+    BuyProviderInfo,
     BuyTrade,
     BuyTradeFinalStatus,
     CryptoId,
@@ -476,3 +477,6 @@ export const getTradingPrefilledFromAccountData = (
         key,
     };
 };
+
+export const isBuyProviderInfo = (provider: TradingProviderInfo): provider is BuyProviderInfo =>
+    'brandName' in provider;

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -480,3 +480,13 @@ export const getTradingPrefilledFromAccountData = (
 
 export const isBuyProviderInfo = (provider: TradingProviderInfo): provider is BuyProviderInfo =>
     'brandName' in provider;
+
+export const getStatusUrl = (provider?: TradingProviderInfo, trade?: TradingTradeType) => {
+    const tradeStatusUrl = trade?.statusUrl;
+
+    if (tradeStatusUrl === null) {
+        return undefined;
+    }
+
+    return tradeStatusUrl || provider?.statusUrl;
+};

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -1,13 +1,12 @@
 import { useSelector } from 'react-redux';
 
-import type { BuyTrade } from 'invity-api';
-
 import {
     TradingRootState,
     TradingTransaction,
     TradingTransactionBuy,
     TradingTransactionSell,
     TradingType,
+    getStatusUrl,
     selectTradingProviderByNameAndTradeType,
     selectTradingTradeByOrderId,
 } from '@suite-common/trading';
@@ -123,16 +122,10 @@ export const TradeDetailAlert = ({
 
     const { iconName, variant, titleKey, descriptionKey, buttonKey } = alertConfig;
 
-    const supportUrlTemplate = providerInfo?.statusUrl || providerInfo?.supportUrl;
-    let supportUrl: string | undefined;
-    if (tradeType === 'buy') {
-        supportUrl = supportUrlTemplate?.replace(
-            '{{originalPaymentId}}',
-            (trade?.data as BuyTrade)?.paymentId || '',
-        );
-    } else {
-        supportUrl = supportUrlTemplate?.replace('{{orderId}}', trade?.data?.orderId || '');
-    }
+    // todo: separate status url and support url just like on web and desktop
+    const supportUrl = providerInfo?.supportUrl;
+    const statusOrSupportUrl =
+        alertType === 'kyc' ? supportUrl : getStatusUrl(providerInfo, trade?.data) || supportUrl;
 
     const navigateToBrowser = () => {
         if (trade && isBuyOrSell(trade) && trade.data.partnerData) {
@@ -153,8 +146,8 @@ export const TradeDetailAlert = ({
         handleButtonPress = () => navigateToBrowser();
     }
 
-    if (supportUrl) {
-        handleButtonPress = () => openLink(supportUrl);
+    if (statusOrSupportUrl) {
+        handleButtonPress = () => openLink(statusOrSupportUrl);
     }
 
     const buttonLabel = handleButtonPress ? translate(buttonKey) : undefined;

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
@@ -14,15 +14,14 @@ import {
     getExchangeTrade,
     getInitializedTradingStateWithQuotes,
     getSellTrade,
+    sellMercuryo,
 } from '@suite-native/trading-fixtures';
 
 import { getTradeStatusStep } from '../../../../utils/general/utils';
 import { TradeDetailAlert } from '../TradeDetailAlert';
 
 const TEST_PROVIDER = 'mercuryo';
-const TEST_BUY_STATUS_URL = 'https://checkout.mercuryo.io/status/{{originalPaymentId}}';
-const TEST_EXCHANGE_STATUS_URL = 'https://checkout.mercuryo.io/status/{{orderId}}';
-const TEST_SELL_STATUS_URL = 'https://checkout.mercuryo.io/sell/status/{{orderId}}';
+const TEST_PROVIDER_STATUS_URL = 'https://checkout.mercuryo.io/trade-history';
 
 const mockOpenLink = jest.fn();
 const mockOnOpenedBrowser = jest.fn();
@@ -41,25 +40,36 @@ jest.mock('@react-navigation/native', () => ({
 
 const createPreloadedState = (
     trades: TradingTransaction[],
-    supportUrl?: string,
+    statusUrl?: string | null,
 ): PreloadedState => {
     const tradingState = getInitializedTradingStateWithQuotes();
     tradingState.trades = trades;
 
-    // Only add provider info if supportUrl is provided
-    if (supportUrl !== undefined) {
+    // Only add provider info if statusUrl is provided
+    if (statusUrl !== undefined) {
+        // null used to exclude statusUrl from provider info for testing fallback behavior
+        if (statusUrl === null) {
+            statusUrl = undefined;
+        }
+
         const buyProviderInfo = {
             ...buyMercuryo,
-            supportUrl,
+            statusUrl,
         };
-
+        const sellProviderInfo = {
+            ...sellMercuryo,
+            statusUrl,
+        };
         const exchangeProviderInfo = {
             ...exchangeMercuryo,
-            supportUrl,
+            statusUrl,
         };
 
         if (tradingState.buy.buyInfo?.providerInfos) {
             tradingState.buy.buyInfo.providerInfos[TEST_PROVIDER] = buyProviderInfo;
+        }
+        if (tradingState.sell.sellInfo?.providerInfos) {
+            tradingState.sell.sellInfo.providerInfos[TEST_PROVIDER] = sellProviderInfo;
         }
         if (tradingState.exchange.exchangeInfo?.providerInfos) {
             tradingState.exchange.exchangeInfo.providerInfos[TEST_PROVIDER] = exchangeProviderInfo;
@@ -81,7 +91,7 @@ describe('TradeDetailAlert', () => {
     const renderAlert = (
         tradeStatus: BuyTradeStatus | ExchangeTradeStatus | SellTradeStatus,
         tradeType: 'buy' | 'exchange' | 'sell' = 'buy',
-        supportUrl?: string,
+        statusUrl?: string,
         orderId?: string,
     ) => {
         let trade;
@@ -103,20 +113,20 @@ describe('TradeDetailAlert', () => {
                 orderId={orderId || trade.data.orderId}
                 onOpenedBrowser={mockOnOpenedBrowser}
             />,
-            { preloadedState: createPreloadedState([trade], supportUrl) },
+            { preloadedState: createPreloadedState([trade], statusUrl) },
         );
     };
 
     describe('Error Alert', () => {
         it('should render error alert with support button for buy trades', async () => {
-            const { getByText } = await renderAlert('ERROR', 'buy', TEST_BUY_STATUS_URL);
+            const { getByText } = await renderAlert('ERROR', 'buy', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Transaction failed')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
         });
 
         it('should render error alert with support button for sell trades', async () => {
-            const { getByText } = await renderAlert('ERROR', 'sell', TEST_SELL_STATUS_URL);
+            const { getByText } = await renderAlert('ERROR', 'sell', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Transaction failed')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
@@ -169,7 +179,7 @@ describe('TradeDetailAlert', () => {
             const { getByText } = await renderAlert(
                 'CONVERTING',
                 'exchange',
-                TEST_EXCHANGE_STATUS_URL,
+                TEST_PROVIDER_STATUS_URL,
             );
 
             expect(getByText('Converting your crypto...')).toBeTruthy();
@@ -182,7 +192,7 @@ describe('TradeDetailAlert', () => {
             const { getByText } = await renderAlert(
                 'SENDING',
                 'exchange',
-                TEST_EXCHANGE_STATUS_URL,
+                TEST_PROVIDER_STATUS_URL,
             );
 
             expect(getByText('Sending your crypto...')).toBeTruthy();
@@ -215,38 +225,14 @@ describe('TradeDetailAlert', () => {
 
     describe('Support Button Functionality', () => {
         it.each([
-            [
-                'ERROR',
-                'buy',
-                'https://checkout.mercuryo.io/#status/7546b3a9-ba27-4c9c-b3ae-45524fe63a97',
-            ],
-            [
-                'ERROR',
-                'exchange',
-                'https://checkout.mercuryo.io/#status/12ffba9e-7370-4a6e-87dc-aefd3851c735',
-            ],
-            [
-                'ERROR',
-                'sell',
-                'https://checkout.mercuryo.io/sell/status/d369ba9e-7370-4a6e-87dc-aefd3851c735',
-            ],
-            [
-                'KYC',
-                'exchange',
-                'https://checkout.mercuryo.io/#status/12ffba9e-7370-4a6e-87dc-aefd3851c735',
-            ],
-            [
-                'CONVERTING',
-                'exchange',
-                'https://checkout.mercuryo.io/#status/12ffba9e-7370-4a6e-87dc-aefd3851c735',
-            ],
-            [
-                'SENDING',
-                'exchange',
-                'https://checkout.mercuryo.io/#status/12ffba9e-7370-4a6e-87dc-aefd3851c735',
-            ],
+            ['ERROR', 'buy', TEST_PROVIDER_STATUS_URL],
+            ['ERROR', 'exchange', TEST_PROVIDER_STATUS_URL],
+            ['ERROR', 'sell', TEST_PROVIDER_STATUS_URL],
+            ['KYC', 'exchange', exchangeMercuryo.supportUrl],
+            ['CONVERTING', 'exchange', TEST_PROVIDER_STATUS_URL],
+            ['SENDING', 'exchange', TEST_PROVIDER_STATUS_URL],
         ])(
-            'should call openLink with support URL when support button is pressed for %s %s trades',
+            'should call openLink with status URL when support button is pressed for %s %s trades',
             async (status, tradeType, expectedUrl) => {
                 const { getByText } = await renderAlert(
                     status as any,
@@ -294,7 +280,7 @@ describe('TradeDetailAlert', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render error alert without button when provider info is missing', async () => {
+        it('should render error alert without button when trade and provider info is missing', async () => {
             const tradingState = getInitializedTradingStateWithQuotes();
             tradingState.trades = [];
             if (tradingState.buy.buyInfo?.providerInfos) {
@@ -316,7 +302,7 @@ describe('TradeDetailAlert', () => {
             expect(queryByText('Go to provider support')).toBeNull();
         });
 
-        it('should render waiting alert with support fallback when orderId is missing', async () => {
+        it('should render waiting alert with support fallback when statusUrl is missing', async () => {
             const { getByText } = await renderWithStoreProviderAsync(
                 <TradeDetailAlert
                     alertType="waiting"
@@ -325,14 +311,14 @@ describe('TradeDetailAlert', () => {
                     orderId={undefined}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: createPreloadedState([], TEST_BUY_STATUS_URL) },
+                { preloadedState: createPreloadedState([], null) },
             );
 
             act(() => {
                 fireEvent.press(getByText('Proceed to pay'));
             });
 
-            expect(mockOpenLink).toHaveBeenCalledWith('https://checkout.mercuryo.io/#status/');
+            expect(mockOpenLink).toHaveBeenCalledWith(buyMercuryo.supportUrl);
         });
 
         it('should render button but not navigate when partnerData is missing for buy trades', async () => {
@@ -372,7 +358,7 @@ describe('TradeDetailAlert', () => {
                     orderId={exchangeTrade.data.orderId!}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: createPreloadedState([exchangeTrade], TEST_EXCHANGE_STATUS_URL) },
+                { preloadedState: createPreloadedState([exchangeTrade], TEST_PROVIDER_STATUS_URL) },
             );
 
             act(() => {
@@ -380,9 +366,7 @@ describe('TradeDetailAlert', () => {
             });
 
             // Should fall back to support URL for exchange trades
-            expect(mockOpenLink).toHaveBeenCalledWith(
-                'https://checkout.mercuryo.io/#status/12ffba9e-7370-4a6e-87dc-aefd3851c735',
-            );
+            expect(mockOpenLink).toHaveBeenCalledWith(exchangeMercuryo.supportUrl);
             expect(mockNavigation.navigate).not.toHaveBeenCalled();
         });
 
@@ -433,17 +417,15 @@ describe('TradeDetailAlert', () => {
                     orderId={sellTrade.data.orderId!}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: createPreloadedState([sellTrade], TEST_SELL_STATUS_URL) },
+                { preloadedState: createPreloadedState([sellTrade], TEST_PROVIDER_STATUS_URL) },
             );
 
             act(() => {
                 fireEvent.press(getByText('Go to provider support'));
             });
 
-            // Should call support URL for sell trades (not browser auth navigation)
-            expect(mockOpenLink).toHaveBeenCalledWith(
-                'https://checkout.mercuryo.io/sell/status/d369ba9e-7370-4a6e-87dc-aefd3851c735',
-            );
+            // Should call status URL for sell trades (not browser auth navigation)
+            expect(mockOpenLink).toHaveBeenCalledWith(TEST_PROVIDER_STATUS_URL);
             expect(mockNavigation.navigate).not.toHaveBeenCalled();
         });
     });

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -858,6 +858,10 @@ export const messages = defineMessages({
         defaultMessage: 'Trade ID',
         id: 'TR_TRADE_ID',
     },
+    TR_TRADING_PROCESSING_STATUS: {
+        defaultMessage: '<link>Check your order status</link> on the {providerName}’s website.',
+        id: 'TR_TRADING_PROCESSING_STATUS',
+    },
     TR_TRADING_PROCESSING_SUPPORT: {
         defaultMessage: 'Need help? Reach out to <link>{providerName}’s support</link>.',
         id: 'TR_TRADING_PROCESSING_SUPPORT',


### PR DESCRIPTION
## Description

- consolidate trading types by utilizing existing `TradingProviderInfo` and `TradingTradeType`
- extract buy provider info utility function `isBuyProviderInfo()` to reduce duplication
- extend `TradingDetailSupportBanner` so it shows both `supportUrl` and `statusUrl` separately
- simplify `statusUrl` logic via new utility function `getStatusUrl()` based on [latest backend changes](https://github.com/trezor/trezor-trade-api/pull/486)
- ensure `TradingDetailExchangePaymentKYC` always shows only `supportUrl` for now
- adapt native `TradeDetailAlert` with updated `getStatusUrl()` logic (but still with only one button for now)

## Notes for QA

- instead of production backend, I recommend to test this feature with [related backend changes](https://github.com/trezor/trezor-trade-api/pull/486) on staging
- on desktop and web, we should go through most providers and make sure correct `statusUrl` and / or `supportUrl` is displayed based on [following partner integration notes](https://www.notion.so/satoshilabs/Partner-Integration-Status-309dc526060680f78b0ff8bd0ec2c86f) (e.g. `Topper` should only have `supportUrl` for now)
- on mobile, it is probably enough to pick a few providers with different `statusUrl` and `supportUrl` support (e.g. `Moonpay`, `Topper` and `Changelly`)

<img width="1440" height="944" alt="image" src="https://github.com/user-attachments/assets/cc2a0c05-8f88-451a-9fd6-9f67dd53cc68" />

<img width="1434" height="948" alt="image" src="https://github.com/user-attachments/assets/1a809ed0-8390-4d74-b160-1ee4be3b384e" />

<img width="713" height="179" alt="image" src="https://github.com/user-attachments/assets/91d6a2c9-dcb2-45db-a158-25cd9debc300" />

## Related Issue

Resolve [TTA-480](https://github.com/trezor/trezor-trade-api/issues/480)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/support-status-url&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/support-status-url&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/support-status-url&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/support-status-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T13:37:27.053Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->