### PR TITLE
Enable  SLIP-24 also on solana and stellar

### DIFF
--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -70,6 +70,7 @@ export type CardanoSignTransactionParams = {
     unsignedTx?: { body: string; hash: string };
     testnet?: boolean;
     chunkify?: boolean;
+    payment_req?: PROTO.PaymentRequest;
 };
 
 export default class CardanoSignTransaction extends AbstractMethod<
@@ -232,6 +233,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
             unsignedTx: 'unsignedTx' in payload ? payload.unsignedTx : undefined,
             testnet: 'testnet' in payload ? payload.testnet : undefined,
             chunkify: typeof payload.chunkify === 'boolean' ? payload.chunkify : false,
+            payment_req: payload.payment_req,
         };
     }
 
@@ -299,6 +301,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
             include_network_id: this.params.includeNetworkId,
             chunkify: this.params.chunkify,
             tag_cbor_sets: this.params.tagCborSets,
+            payment_req: this.params.payment_req,
         };
 
         // init

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -47,6 +47,7 @@ export default class RippleSignTransaction extends AbstractMethod<
                 destination: transaction.payment.destination,
                 destination_tag: transaction.payment.destinationTag,
             },
+            payment_req: payload.payment_req,
             chunkify: typeof chunkify === 'boolean' ? chunkify : false,
         };
     }

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -71,6 +71,7 @@ export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTra
             address_n: path,
             serialized_tx: payload.serializedTx,
             additional_info: transformAdditionalInfo(payload.additionalInfo),
+            payment_req: payload.payment_req,
             serialize: !!payload.serialize,
         };
     }

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -3,6 +3,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
+import type { PROTO } from '../../../constants';
 import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
@@ -16,6 +17,7 @@ type Params = {
     path: number[];
     networkPassphrase: string;
     transaction: StellarTransaction;
+    payment_req?: PROTO.PaymentRequest;
 };
 
 const StellarSignTransactionFeatures = Object.freeze({
@@ -53,6 +55,7 @@ export default class StellarSignTransaction extends AbstractMethod<
             path,
             networkPassphrase: payload.networkPassphrase,
             transaction,
+            payment_req: payload.payment_req,
         };
     }
 
@@ -98,6 +101,7 @@ export default class StellarSignTransaction extends AbstractMethod<
             this.params.path,
             this.params.networkPassphrase,
             this.params.transaction,
+            this.params.payment_req,
         );
 
         return {

--- a/packages/connect/src/api/stellar/stellarSignTx.ts
+++ b/packages/connect/src/api/stellar/stellarSignTx.ts
@@ -217,10 +217,12 @@ export const stellarSignTx = async (
     address_n: number[],
     networkPassphrase: string,
     tx: StellarTransaction,
+    payment_req?: PROTO.PaymentRequest,
 ) => {
     const message = transformSignMessage(tx);
     message.address_n = address_n;
     message.network_passphrase = networkPassphrase;
+    message.payment_req = payment_req;
 
     const operations: StellarOperationMessage[] = [];
     tx.operations.forEach(op => {

--- a/packages/connect/src/types/api/cardano/index.ts
+++ b/packages/connect/src/types/api/cardano/index.ts
@@ -267,6 +267,7 @@ export const CardanoSignTransaction = Type.Object({
     includeNetworkId: Type.Optional(Type.Boolean()),
     chunkify: Type.Optional(Type.Boolean()),
     tagCborSets: Type.Optional(Type.Boolean()),
+    payment_req: Type.Optional(PROTO.PaymentRequest),
 });
 
 export type CardanoSignTransactionExtended = Static<typeof CardanoSignTransactionExtended>;

--- a/packages/connect/src/types/api/ripple/index.ts
+++ b/packages/connect/src/types/api/ripple/index.ts
@@ -1,6 +1,7 @@
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { PROTO } from '../../../constants';
 import { DerivationPath } from '../../params';
 
 export type RipplePayment = Static<typeof RipplePayment>;
@@ -23,6 +24,7 @@ export type RippleSignTransaction = Static<typeof RippleSignTransaction>;
 export const RippleSignTransaction = Type.Object({
     path: DerivationPath,
     transaction: RippleTransaction,
+    payment_req: Type.Optional(PROTO.PaymentRequest),
     chunkify: Type.Optional(Type.Boolean()),
 });
 

--- a/packages/connect/src/types/api/solana/index.ts
+++ b/packages/connect/src/types/api/solana/index.ts
@@ -1,6 +1,7 @@
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
 
+import { PROTO } from '../../../constants';
 import { PublicKey } from '../../params';
 
 // solanaGetPublicKey
@@ -36,6 +37,7 @@ export const SolanaSignTransaction = Type.Object({
     path: Type.Union([Type.String(), Type.Array(Type.Number())]),
     serializedTx: Type.String(),
     additionalInfo: Type.Optional(SolanaTxAdditionalInfo),
+    payment_req: Type.Optional(PROTO.PaymentRequest),
     serialize: Type.Optional(Type.Boolean()),
     chunkify: Type.Optional(Type.Boolean()),
 });

--- a/packages/connect/src/types/api/stellar/index.ts
+++ b/packages/connect/src/types/api/stellar/index.ts
@@ -227,6 +227,7 @@ export const StellarSignTransaction = Type.Object({
     path: DerivationPath,
     networkPassphrase: Type.String(),
     transaction: StellarTransaction,
+    payment_req: Type.Optional(PROTO.PaymentRequest),
 });
 
 export type StellarSignedTx = Static<typeof StellarSignedTx>;

--- a/packages/protobuf/src/encode.ts
+++ b/packages/protobuf/src/encode.ts
@@ -11,9 +11,19 @@ const transform = (fieldType: string, value: any) => {
         // for example MultisigRedeemScriptType might have field signatures ['', '', ''] (check in TrezorConnect signTransactionMultisig test fixtures).
         // trezor needs to receive such field as signatures: [b'', b'', b'']. If we transfer this to empty buffer with protobufjs, this will be decoded by
         // trezor as signatures: [] (empty array)
-        if (typeof value === 'string' && !value) return value;
+        if (typeof value === 'string' && !value) {
+            return value;
+        }
 
-        // normal flow
+        // already binary: pass through (Buffer.from(buffer, 'hex') would misinterpret)
+        if (Buffer.isBuffer(value)) {
+            return value;
+        }
+
+        if (value instanceof Uint8Array) {
+            return Buffer.from(value);
+        }
+
         return Buffer.from(value, 'hex');
     }
     if (typeof value === 'number' && !Number.isSafeInteger(value)) {

--- a/packages/protobuf/tests/encode-decode-basic.test.ts
+++ b/packages/protobuf/tests/encode-decode-basic.test.ts
@@ -169,6 +169,11 @@ const basicFixtures = [
     },
 ];
 
+const bytesHex =
+    '851fc9542342321af63ecbba7d3ece545f2a42bad01ba32cff5535b18e54b6d3106e10b6a4525993d185a1443d9a125186960e028eabfdd8d76cf70a3a7e3100';
+const bytesEncoded =
+    '3a40851fc9542342321af63ecbba7d3ece545f2a42bad01ba32cff5535b18e54b6d3106e10b6a4525993d185a1443d9a125186960e028eabfdd8d76cf70a3a7e3100';
+
 // note: difference in bool encoding. if type === bool && field = optional && not message of only one field, bool is encoded as ""
 const advancedFixtures = [
     {
@@ -208,6 +213,22 @@ describe('basic concepts', () => {
                     const decoded = decode(Message, encoded);
                     expect(decoded).toEqual(f.params);
                 });
+            });
+        });
+
+        describe('bytes field accepts Buffer and Uint8Array', () => {
+            const Message = Messages.lookupType('messages.Bytes');
+
+            test('encoding with Buffer produces same output as hex string', () => {
+                const encoded = encode(Message, { field: Buffer.from(bytesHex, 'hex') });
+                expect(encoded.toString('hex')).toEqual(bytesEncoded);
+            });
+
+            test('encoding with Uint8Array produces same output as hex string', () => {
+                const encoded = encode(Message, {
+                    field: new Uint8Array(Buffer.from(bytesHex, 'hex')),
+                });
+                expect(encoded.toString('hex')).toEqual(bytesEncoded);
             });
         });
     });

--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -58,6 +58,7 @@ import {
     selectTradingExchangeQuotesRequest,
     selectTradingExchangeSelectedQuote,
     selectTradingExchangeSellCryptoIds,
+    selectTradingIsSlip24Allowed,
     selectTradingLastErrorMessageByTradeType,
     selectTradingModalAccountKey,
     selectTradingNativeCoinSymbolByCryptoId,
@@ -1560,6 +1561,63 @@ describe('tradingSelectors', () => {
             const result = selectTradingProviderMetadata(state);
 
             expect(result).toBeUndefined();
+        });
+    });
+
+    describe(selectTradingIsSlip24Allowed.name, () => {
+        beforeEach(() => {
+            if (state.device.selectedDevice) {
+                state.device.selectedDevice.unavailableCapabilities = undefined;
+            }
+        });
+
+        it('should return false when account is undefined', () => {
+            expect(selectTradingIsSlip24Allowed(state, undefined, true)).toBe(false);
+        });
+
+        it('should return false when isSlip24Active is false', () => {
+            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, false)).toBe(false);
+        });
+
+        it('should return false when firmware has slip24 in unavailableCapabilities', () => {
+            if (state.device.selectedDevice) {
+                state.device.selectedDevice.unavailableCapabilities = { slip24: 'no-support' };
+            }
+            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(false);
+        });
+
+        it('should return true when account is set, isSlip24Active is true, and firmware supports slip24', () => {
+            expect(selectTradingIsSlip24Allowed(state, accountBtc as any, true)).toBe(true);
+        });
+
+        it('should return true for supported network when firmware supports slip24 (e.g. ethereum account)', () => {
+            expect(selectTradingIsSlip24Allowed(state, accountEth as any, true)).toBe(true);
+        });
+
+        it('should return true for solana network when firmware supports slip24', () => {
+            const solanaAccount = {
+                ...accountBtc,
+                networkType: 'solana',
+            };
+            expect(selectTradingIsSlip24Allowed(state, solanaAccount as any, true)).toBe(true);
+        });
+
+        it('should return true for stellar network when firmware supports slip24', () => {
+            const stellarAccount = {
+                ...accountBtc,
+                networkType: 'stellar',
+            };
+            expect(selectTradingIsSlip24Allowed(state, stellarAccount as any, true)).toBe(true);
+        });
+
+        it('should return false for unsupported network even when firmware supports slip24', () => {
+            const unsupportedNetworkAccount = {
+                ...accountBtc,
+                networkType: 'cardano',
+            };
+            expect(
+                selectTradingIsSlip24Allowed(state, unsupportedNetworkAccount as any, true),
+            ).toBe(false);
         });
     });
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -676,7 +676,7 @@ export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndA
 
         const isFirmwareVersionSlip24Compatible = !unavailableCapabilities?.['slip24'];
         // TODO: slip24 - can be removed when slip24 is enabled for all networks
-        const supportedNetworks: NetworkType[] = ['bitcoin', 'ethereum'];
+        const supportedNetworks: NetworkType[] = ['bitcoin', 'ethereum', 'solana', 'stellar'];
         const isNetworkSupported = supportedNetworks.includes(account.networkType);
 
         return isSlip24Active && isFirmwareVersionSlip24Compatible && isNetworkSupported;

--- a/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
+++ b/suite-common/trading/src/thunks/common/getPaymentRequestOutputs.ts
@@ -4,6 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import type { Network } from '@suite-common/wallet-config';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
+import { getAssociatedTokenAccountAddress } from '@trezor/connect/src/api/solana/solanaUtils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { type TradingSendRejectedProps } from '../../types';
@@ -19,10 +20,35 @@ export const getPaymentRequestOutputs = createThunk<
         const outputs: PaymentRequestOutput[] = [];
 
         for (const output of composedLevels.outputs) {
+            const amount = formatSlip24SendAmountByNetwork({ value: output.amount, network });
             if ('address' in output && output.address) {
+                let sendAddress = output.address;
+
+                // solana sends tokens to associated token accounts not to base account
+                if (network.networkType === 'solana' && composedLevels?.token?.contract) {
+                    try {
+                        const { contract, standard } = composedLevels.token;
+                        const associatedTokenAccountAddress =
+                            await getAssociatedTokenAccountAddress(
+                                output.address,
+                                contract,
+                                standard === 'SPL' ? 'spl-token' : 'spl-token-2022',
+                            );
+
+                        sendAddress = associatedTokenAccountAddress.toString();
+                    } catch {
+                        return rejectWithValue({
+                            type: 'sign-tx-error',
+                            error: {
+                                id: 'TR_PAYMENT_REQUESTS_ERROR',
+                            },
+                        });
+                    }
+                }
+
                 outputs.push({
-                    amount: formatSlip24SendAmountByNetwork({ value: output.amount, network }),
-                    address: output.address,
+                    amount,
+                    address: sendAddress,
                 });
             }
 

--- a/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormCardanoThunks.ts
@@ -145,7 +145,10 @@ export const signCardanoSendFormTransactionThunk = createThunk<
     { rejectValue: SignTransactionError }
 >(
     `${SEND_MODULE_PREFIX}/signCardanoSendFormTransactionThunk`,
-    async ({ precomposedTransaction, selectedAccount, device }, { rejectWithValue }) => {
+    async (
+        { precomposedTransaction, selectedAccount, device, paymentRequests },
+        { rejectWithValue },
+    ) => {
         const { symbol, accountType } = selectedAccount;
 
         if (selectedAccount.networkType !== 'cardano')
@@ -153,6 +156,8 @@ export const signCardanoSendFormTransactionThunk = createThunk<
                 error: 'sign-transaction-failed',
                 message: 'Account network type is not Cardano.',
             });
+
+        const payment_req = paymentRequests?.[0] ?? undefined;
 
         // todo: add chunkify once we allow it for Cardano
         const response = await TrezorConnect.cardanoSignTransaction({
@@ -173,6 +178,7 @@ export const signCardanoSendFormTransactionThunk = createThunk<
             fee: precomposedTransaction.fee,
             ttl: precomposedTransaction.ttl?.toString(),
             derivationType: getDerivationType(accountType),
+            payment_req,
         });
 
         if (!response.success) {

--- a/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormRippleStellarThunks.ts
@@ -230,7 +230,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
 >(
     `${SEND_MODULE_PREFIX}/signRippleStellarSendFormTransactionThunk`,
     async (
-        { formState, precomposedTransaction, selectedAccount, device },
+        { formState, precomposedTransaction, selectedAccount, device, paymentRequests },
         { getState, extra, rejectWithValue },
     ) => {
         const {
@@ -268,6 +268,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     sequence: selectedAccount.misc.sequence,
                     payment,
                 },
+                payment_req: paymentRequests?.[0] ?? undefined,
                 chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
             });
             if (response.success) {
@@ -347,6 +348,7 @@ export const signRippleStellarSendFormTransactionThunk = createThunk<
                     },
                     operations: [operation],
                 },
+                payment_req: paymentRequests?.[0] ?? undefined,
                 chunkify: addressDisplayType === AddressDisplayOptions.CHUNKED,
             };
             response = await TrezorConnect.stellarSignTransaction(transformedTransaction);

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -320,7 +320,10 @@ export const signSolanaSendFormTransactionThunk = createThunk<
     { rejectValue: SignTransactionError }
 >(
     `${SEND_MODULE_PREFIX}/signSolanaSendFormTransactionThunk`,
-    async ({ formState, precomposedTransaction, selectedAccount, device }, { rejectWithValue }) => {
+    async (
+        { formState, precomposedTransaction, selectedAccount, device, paymentRequests },
+        { rejectWithValue },
+    ) => {
         if (precomposedTransaction.feeLimit == null)
             return rejectWithValue({
                 error: 'sign-transaction-failed',
@@ -382,6 +385,8 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             });
         }
 
+        const payment_req = paymentRequests?.[0] ?? undefined;
+
         const response = await TrezorConnect.solanaSignTransaction({
             device: {
                 path: device.path,
@@ -391,6 +396,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
             },
             path: selectedAccount.path,
             serializedTx: transaction.payload.serializedTx,
+            payment_req,
             serialize: true,
             additionalInfo: transaction.payload.additionalInfo.tokenAccountInfo
                 ? {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -535,6 +535,7 @@ export const signTransactionThunk = createThunk<
                     precomposedTransaction,
                     device,
                     selectedAccount,
+                    paymentRequests,
                 }),
             );
         } else {

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -544,20 +544,13 @@ export const signTransactionThunk = createThunk<
                 precomposedTransaction,
                 selectedAccount,
                 device,
-            };
-            // TODO: slip24 - can be moved into thinkArguments when slip24 is enabled for all networks
-            const thunkArgumentsWithPaymentRequests = {
-                ...thunkArguments,
                 paymentRequests,
             };
+
             if (networkType === 'bitcoin') {
-                response = await dispatch(
-                    signBitcoinSendFormTransactionThunk(thunkArgumentsWithPaymentRequests),
-                );
+                response = await dispatch(signBitcoinSendFormTransactionThunk(thunkArguments));
             } else if (networkType === 'ethereum') {
-                response = await dispatch(
-                    signEthereumSendFormTransactionThunk(thunkArgumentsWithPaymentRequests),
-                );
+                response = await dispatch(signEthereumSendFormTransactionThunk(thunkArguments));
             } else if (networkType === 'solana') {
                 response = await dispatch(signSolanaSendFormTransactionThunk(thunkArguments));
             } else if (['ripple', 'stellar'].includes(networkType)) {


### PR DESCRIPTION
- **Connect:** Add `payment_req` to sign-transaction flows for Cardano, Solana, Ripple, and Stellar (params + API wiring).
- **Wallet-core:** Pass `paymentRequests` through send/sign for Ada, Solana, XRP, and XLM so trading can attach a payment request when signing.
- **Protobuf:** In `bytes` encoding, pass through `Buffer` and `Uint8Array` instead of treating them as hex (fixes payment-request binary payloads).
- **Trading:** Allow Slip24 for networks with `bitcoin`, `ethereum`, `solana` and `stellar` network types when firmware supports it;

## Notes for QA
Sending and swapping should work with SLIP24 disabled as before. Might return errors with SLIP24 enabled due to some other issues e.g. https://github.com/trezor/trezor-suite/issues/24120

Also when sending native SOL it will not go via SLIP24 unless [this firmware PR](https://github.com/trezor/trezor-firmware/pull/6595) is merged in firmware main.

## Related Issue

Part of #21897



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/slip24/enable-on-all-networks&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/slip24/enable-on-all-networks&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/slip24/enable-on-all-networks&lookback=7)