### PR TITLE
fix(trading): update TradingOfferExchange button size

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -107,6 +107,8 @@ export const TradingOfferExchange = ({
                 isLoading={isFormLoading || disabled}
                 isDisabled={!device?.connected || disabled}
                 onClick={() => handleClick(() => onConfirmAndSendClick())}
+                size="large"
+                width="100%"
             >
                 <Translation id="TR_EXCHANGE_CONFIRM_ON_TREZOR_SEND" />
             </Button>


### PR DESCRIPTION
### Updated PR Description

## Description

Adjust SWAP review screen layout according to Figma: add `Confirm & Send` headline, make the review container full width, and make the `Confirm on Trezor & send` button large and full width.

## Notes for QA

- **Flow**: SWAP → select offer → proceed to review step.  
- **Verify**:
  - `Confirm & Send` headline is visible above the review content.
  - Review container spans full available width as per design.
  - `Confirm on Trezor & send` button is rendered in the large variant and spans the full width of the container.
- **Regression**:
  - Check that other trading flows (sell/exchange) are unaffected in their review steps.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24525

## Screenshots:
<img width="1202" height="688" alt="image" src="https://github.com/user-attachments/assets/345038f2-bd24-4baa-bd79-3c965e16b5b9" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/24525/swap-review-step&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/24525/swap-review-step&lookback=7)