### PR TITLE
fix(suite): align support consent popover width with trigger button

### DIFF
--- a/packages/suite/src/components/guide/SupportConsentPopover.tsx
+++ b/packages/suite/src/components/guide/SupportConsentPopover.tsx
@@ -2,10 +2,13 @@ import { ReactNode, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { selectSupportChatUrl } from '@suite-common/support';
-import { Button, Card, Checkbox, Column, Paragraph, Popover } from '@trezor/components';
-import { zIndices } from '@trezor/theme';
+import { Button, Card, Checkbox, Column, Paragraph, Popover, variables } from '@trezor/components';
+import { spacingsPx, zIndices } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
+
+// To match the width of the trigger button in the SupportFeedbackSelection component.
+const POPOVER_WIDTH = `calc(${variables.LAYOUT_SIZE.GUIDE_PANEL_CONTENT_WIDTH} - 2 * ${spacingsPx.lg})`;
 
 type SupportConsentPopoverProps = {
     children: ReactNode;
@@ -21,7 +24,7 @@ export const SupportConsentPopover = ({ children }: SupportConsentPopoverProps) 
             popoverOffset={-5}
             placement={{ position: 'bottom', alignment: 'start' }}
             content={
-                <Card paddingType="small" width="320px">
+                <Card paddingType="small" width={POPOVER_WIDTH}>
                     <Column gap={12}>
                         <Paragraph typographyStyle="body-md" intent="neutral">
                             <Translation id="TR_GUIDE_SUPPORT_CONSENT_TITLE" />


### PR DESCRIPTION
## Description

- fixes the width of Guide > Support popover


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/guide-support-popover-width&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/guide-support-popover-width&lookback=7)