### PR TITLE
feat(ci): Post info about quarantined tests to PR desc

### DIFF
--- a/.github/actions/post-quarantine-list/action.yml
+++ b/.github/actions/post-quarantine-list/action.yml
@@ -1,0 +1,110 @@
+name: "Post quarantine list"
+description: "Posts the current list of quarantined E2E tests to the pull request description"
+inputs:
+  github_token:
+    description: "GitHub token for accessing the API"
+    required: true
+  currents_api_key:
+    description: "Currents API key used to fetch quarantine actions"
+    required: true
+  project_name:
+    description: "Project name to filter results to a single project (e.g. 'web', 'desktop'). Omit to list all projects."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Fetch quarantined tests
+      shell: bash
+      env:
+        CURRENTS_API_KEY: ${{ inputs.currents_api_key }}
+      run: |
+        PROJECT_ARG=""
+        if [ -n "${{ inputs.project_name }}" ]; then
+          PROJECT_ARG="--project ${{ inputs.project_name }}"
+        fi
+        node --experimental-strip-types \
+          "${{ github.workspace }}/scripts/ci/quarantineBot/index.ts" \
+          --list $PROJECT_ARG > "${{ runner.temp }}/quarantine.json"
+
+    - name: Update PR description with quarantine list
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          const fs = require('fs');
+          const raw = fs.readFileSync('${{ runner.temp }}/quarantine.json', 'utf8');
+          const report = JSON.parse(raw);
+
+          const projectName = '${{ inputs.project_name }}';
+          const suffix = projectName ? `:${projectName}` : '';
+          const START_MARKER = `<!-- QUARANTINE-LIST${suffix}:START -->`;
+          const END_MARKER   = `<!-- QUARANTINE-LIST${suffix}:END -->`;
+
+          // Build the markdown section
+          const lines = [];
+          lines.push('## 🔒 Quarantined E2E Tests');
+          lines.push('');
+
+          let totalTests = 0;
+          for (const project of report) {
+            totalTests += project.tests.length;
+            const summary = `${project.projectLabel} — ${project.tests.length} test(s)`;
+            if (project.tests.length === 0) {
+              lines.push(`<details><summary>${summary}</summary>`);
+              lines.push('');
+              lines.push('_No quarantined tests_ ✅');
+              lines.push('');
+              lines.push('</details>');
+            } else {
+              lines.push(`<details><summary>${summary}</summary>`);
+              lines.push('');
+              lines.push('| Test | Type |');
+              lines.push('|------|------|');
+              for (const t of project.tests) {
+                const type = t.isAutoQuarantine ? '🤖 auto' : '🙋 manual';
+                const name = t.name.replace(/\|/g, '\\|');
+                lines.push(`| ${name} | ${type} |`);
+              }
+              lines.push('');
+              lines.push('</details>');
+            }
+            lines.push('');
+          }
+
+          lines.push(`_Updated: ${new Date().toISOString()} • ${totalTests} test(s) total_`);
+
+          const newSection =
+            START_MARKER + '\n' + lines.join('\n') + '\n' + END_MARKER;
+
+          // Fetch current PR description
+          const pr = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+          });
+
+          const existingBody = pr.data.body || '';
+
+          let newBody;
+          if (existingBody.includes(START_MARKER) && existingBody.includes(END_MARKER)) {
+            // Replace the existing section in-place
+            const before = existingBody.slice(0, existingBody.indexOf(START_MARKER));
+            const after  = existingBody.slice(existingBody.indexOf(END_MARKER) + END_MARKER.length);
+            newBody = before + newSection + after;
+          } else {
+            // Append the section for the first time, separated by a blank line
+            const separator = existingBody.endsWith('\n\n') ? '' :
+                              existingBody.endsWith('\n')   ? '\n' : '\n\n';
+            newBody = existingBody + separator + newSection;
+          }
+
+          await github.rest.pulls.update({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            body: newBody,
+          });
+
+          console.log(`Quarantine list updated (${totalTests} test(s) across ${report.length} project(s)).`);

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -61,7 +61,7 @@ jobs:
     if: github.repository == 'trezor/trezor-suite' && needs.check-previous-runs.outputs.skip_tests != 'true'
     uses: ./.github/workflows/build-suite-desktop-e2e.yml
 
-  post-currents-link:
+  post-currents-pr-info:
     if: github.repository == 'trezor/trezor-suite' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs:
@@ -69,6 +69,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
       - name: Generate GitHub App token
         id: trezor-bot-token
         uses: actions/create-github-app-token@v1
@@ -81,6 +85,12 @@ jobs:
           github_token: ${{ steps.trezor-bot-token.outputs.token }}
           project: "desktop"
           currents-project-id: "4ytF0E"
+      - name: Post quarantine list
+        uses: ./.github/actions/post-quarantine-list
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          currents_api_key: ${{ secrets.CURRENTS_API_KEY }}
+          project_name: "desktop"
 
   run-e2e-suite-desktop-tests:
     if: github.repository == 'trezor/trezor-suite'

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -101,7 +101,7 @@ jobs:
           nodeEnv: "development"
           connectPopupUrl: "https://dev.suite.sldev.cz/suite-web/${{ needs.extract-branch.outputs.branch }}/web/connect-popup"
 
-  post-currents-link:
+  post-currents-pr-info:
     if: github.repository == 'trezor/trezor-suite' && github.event_name == 'pull_request' && needs.check-previous-runs.outputs.skip_tests != 'true'
     runs-on: ubuntu-latest
     needs:
@@ -111,6 +111,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
       - name: Generate GitHub App token
         id: trezor-bot-token
         uses: actions/create-github-app-token@v1
@@ -123,6 +127,12 @@ jobs:
           github_token: ${{ steps.trezor-bot-token.outputs.token }}
           project: "web"
           currents-project-id: "Og0NOQ"
+      - name: Post quarantine list
+        uses: ./.github/actions/post-quarantine-list
+        with:
+          github_token: ${{ steps.trezor-bot-token.outputs.token }}
+          currents_api_key: ${{ secrets.CURRENTS_API_KEY }}
+          project_name: "web"
 
   run-e2e-suite-web-tests:
     if: github.repository == 'trezor/trezor-suite' && needs.check-previous-runs.outputs.skip_tests != 'true'

--- a/scripts/ci/quarantineBot/index.ts
+++ b/scripts/ci/quarantineBot/index.ts
@@ -32,10 +32,10 @@ const PRE_FILTER_FAILURE_RATE = 0.02; // inspect anything that isn't close to 10
 const TEST_RESULTS_PAGE_SIZE = 10; // default page size of the test-results API endpoint
 const DEVELOP_BRANCH = 'develop';
 
-const PROJECTS: Array<{ id: string; label: string }> = [
-    { id: 'Og0NOQ', label: 'Trezor Suite (web)' },
-    { id: '4ytF0E', label: 'Trezor Suite (desktop)' },
-    //{ id: 'iBEsWE', label: 'Experimental Playground' },
+const PROJECTS: Array<{ id: string; name: string; label: string }> = [
+    { id: 'Og0NOQ', name: 'web', label: 'Trezor Suite (web)' },
+    { id: '4ytF0E', name: 'desktop', label: 'Trezor Suite (desktop)' },
+    //{ id: 'iBEsWE', name: 'playground', label: 'Experimental Playground' },
 ];
 
 // ---------------------------------------------------------------------------
@@ -325,6 +325,15 @@ async function getAutoQuarantineActions(projectId: string): Promise<Action[]> {
 }
 
 /**
+ * Fetch ALL quarantine actions for a project (both manual and auto-quarantined).
+ */
+async function getAllQuarantineActions(projectId: string): Promise<Action[]> {
+    const response = await currentsRequest<ActionsListResponse>(`/actions?projectId=${projectId}`);
+
+    return response.data.filter(a => a.action.some(r => r.op === 'quarantine'));
+}
+
+/**
  * Normalise a test's title path into individual parts.
  *
  * The Currents explorer returns `titlePath` as an array when populated, but
@@ -593,6 +602,96 @@ async function unquarantinePassingTests(
 }
 
 // ---------------------------------------------------------------------------
+// List mode
+// ---------------------------------------------------------------------------
+
+interface QuarantinedTestEntry {
+    name: string;
+    spec?: string;
+    isAutoQuarantine: boolean;
+}
+
+interface ProjectQuarantineReport {
+    projectId: string;
+    projectLabel: string;
+    tests: QuarantinedTestEntry[];
+}
+
+/**
+ * List all quarantined tests for every project and write a JSON report to stdout.
+ *
+ * Human-readable progress messages are written to stderr so that stdout contains
+ * only the JSON output, making it easy to capture with shell redirection:
+ *   node ... --list > quarantine.json
+ *   node ... --list --project web > quarantine-web.json
+ */
+async function listAllQuarantinedTests(projectNameFilter?: string): Promise<void> {
+    const projects = projectNameFilter
+        ? PROJECTS.filter(p => p.name === projectNameFilter)
+        : PROJECTS;
+
+    if (projectNameFilter && projects.length === 0) {
+        process.stderr.write(
+            `[ERROR] No project found with name "${projectNameFilter}". Known names: ${PROJECTS.map(p => p.name).join(', ')}\n`,
+        );
+        process.exit(1);
+    }
+
+    process.stderr.write(`=== Currents Quarantine List ===\n`);
+    process.stderr.write(`Timestamp: ${new Date().toISOString()}\n`);
+    process.stderr.write(`Projects: ${projects.map(p => `${p.label} (${p.id})`).join(', ')}\n\n`);
+
+    const report: ProjectQuarantineReport[] = [];
+    let hasError = false;
+
+    for (const project of projects) {
+        try {
+            const actions = await getAllQuarantineActions(project.id);
+
+            const tests: QuarantinedTestEntry[] = actions.map(action => {
+                const testKey = extractKeyFromAction(action);
+                const name = testKey ? (JSON.parse(testKey) as string[]).join(' > ') : action.name;
+
+                // Try to extract spec from a dedicated spec condition in the matcher.
+                const specCond = action.matcher?.cond?.find(c => c.type === 'spec');
+                const spec =
+                    specCond && typeof specCond.value === 'string' ? specCond.value : undefined;
+
+                return {
+                    name,
+                    spec,
+                    isAutoQuarantine: action.name.startsWith(AUTO_QUARANTINE_PREFIX),
+                };
+            });
+
+            report.push({
+                projectId: project.id,
+                projectLabel: project.label,
+                tests,
+            });
+
+            process.stderr.write(`[${project.label}] ${tests.length} quarantined test(s)\n`);
+            for (const t of tests) {
+                const tag = t.isAutoQuarantine ? ' [auto]' : ' [manual]';
+                process.stderr.write(`  - ${t.name}${tag}\n`);
+            }
+        } catch (err) {
+            process.stderr.write(
+                `[ERROR] Failed fetching quarantine actions for ${project.label}: ${err}\n`,
+            );
+            hasError = true;
+        }
+    }
+
+    // Emit the machine-readable JSON on stdout.
+    console.log(JSON.stringify(report, null, 2));
+
+    if (hasError) {
+        process.exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Wipe mode
 // ---------------------------------------------------------------------------
 
@@ -645,6 +744,45 @@ async function wipeAllAutoQuarantineActions(): Promise<void> {
 
 async function main(): Promise<void> {
     const args = process.argv.slice(2);
+
+    if (args.includes('--help') || args.includes('-h')) {
+        console.log(
+            [
+                'Usage: node index.ts [options]',
+                '',
+                'Options:',
+                '  (no args)                  Run the test health check: quarantine newly failing tests and',
+                '                             unquarantine tests that have recovered.',
+                '',
+                '  --list                     List all currently quarantined tests for every monitored project.',
+                '                             Outputs a JSON report to stdout; progress messages go to stderr.',
+                '                             Combine with --project to narrow to a single project.',
+                '',
+                '  --list --project <name>    Same as --list but limited to the specified project.',
+                `                             Known project names: ${PROJECTS.map(p => p.name).join(', ')}.`,
+                '',
+                '  --wipeAutoQuarantine       Delete ALL auto-quarantine actions (those created by this bot)',
+                '                             across every monitored project. Use with caution.',
+                '',
+                '  --help, -h                 Show this help message and exit.',
+                '',
+                'Environment variables:',
+                '  CURRENTS_API_KEY                          (required) API key for the Currents.dev API.',
+                '  E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK     (optional) Slack incoming-webhook URL for',
+                '                                            quarantine/unquarantine notifications.',
+            ].join('\n'),
+        );
+
+        return;
+    }
+
+    if (args.includes('--list')) {
+        const projectFlagIndex = args.indexOf('--project');
+        const projectNameFilter = projectFlagIndex !== -1 ? args[projectFlagIndex + 1] : undefined;
+        await listAllQuarantinedTests(projectNameFilter);
+
+        return;
+    }
 
     if (args.includes('--wipeAutoQuarantine')) {
         await wipeAllAutoQuarantineActions();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-quarantine-info&lookback=7)

<!-- QUARANTINE-LIST:START -->
## 🔒 Quarantined E2E Tests

<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Send form for bitcoin > switch display units to satoshis, fill a form in satoshis and send | 🤖 auto |
| ETH staking form > Staking form % inputs and limits | 🤖 auto |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| [auto-quarantine] ETH staking form > Staking form % inputs and limits | 🤖 auto |
| New Analytics Events > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| New Analytics Events > Should log staking/navigate - ADA from dashboard assets | 🤖 auto |
| New Analytics Events > Should log promo/dashboard-banner - TS7 from dashboard promo banner | 🤖 auto |
| New Analytics Events > Should log the event staking/navigate - ETH from account menu | 🤖 auto |
| New Analytics Events > Should log staking/navigate - ETH from dashboard assets | 🤖 auto |
| New Analytics Events > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-04T15:45:02.485Z • 15 test(s) total_
<!-- QUARANTINE-LIST:END -->

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-quarantine-info&lookback=7)

<!-- QUARANTINE-LIST:desktop:START -->
## 🔒 Quarantined E2E Tests

<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| ETH staking form > Staking form % inputs and limits | 🤖 auto |
| [auto-quarantine] ETH staking form > Staking form % inputs and limits | 🤖 auto |
| New Analytics Events > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| New Analytics Events > Should log staking/navigate - ADA from dashboard assets | 🤖 auto |
| New Analytics Events > Should log promo/dashboard-banner - TS7 from dashboard promo banner | 🤖 auto |
| New Analytics Events > Should log the event staking/navigate - ETH from account menu | 🤖 auto |
| New Analytics Events > Should log staking/navigate - ETH from dashboard assets | 🤖 auto |
| New Analytics Events > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-05T07:31:33.166Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->