### PR TITLE
feat(connect): allow signMessage using address on external api

### DIFF
--- a/packages/connect-explorer/next-env.d.ts
+++ b/packages/connect-explorer/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signMessage.mdx
@@ -13,7 +13,9 @@ import signMessage from '../../../data/methods/bitcoin/signMessage.ts';
 />
 
 export const paramDescriptions = {
-    path: 'minimum length is `3`. [read more](/details/path)',
+    path: 'minimum length is `3`. [read more](/details/path). Either `path` or `address` must be provided.',
+    address:
+        'address to sign with. When provided instead of `path`, the address is resolved to a derivation path using discovered accounts in Suite. Requires Suite as the connect-popup host.',
     message: '',
     coin: 'Determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut`, `name` or `label` can be used. If `coin` is not set API will try to get network definition from `path`.',
     hex: 'convert message from hex',
@@ -22,6 +24,8 @@ export const paramDescriptions = {
 ## Sign message
 
 Asks device to sign a message using the private key derived by given BIP32 path.
+
+You can provide either a `path` (BIP32 derivation path) or an `address`. When using `address`, the Suite connect-popup resolves it to the corresponding derivation path from discovered accounts.
 
 ```javascript
 const result = await TrezorConnect.signMessage(params);
@@ -38,8 +42,16 @@ const result = await TrezorConnect.signMessage(params);
 ### Example
 
 ```javascript
+// Using path
 TrezorConnect.signMessage({
     path: "m/44'/0'/0'",
+    message: 'example message',
+});
+
+// Using address (requires Suite as connect-popup host)
+TrezorConnect.signMessage({
+    address: 'bc1qexampleaddress',
+    coin: 'btc',
     message: 'example message',
 });
 ```

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignMessage.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignMessage.mdx
@@ -17,7 +17,9 @@ import signMessage from '../../../data/methods/ethereum/signMessage.ts';
 />
 
 export const paramDescriptions = {
-    path: 'minimum length is `3`. [read more](/details/path)',
+    path: 'minimum length is `3`. [read more](/details/path). Either `path` or `address` must be provided.',
+    address:
+        'Ethereum address to sign with. When provided instead of `path`, the address is resolved to a derivation path using discovered accounts in Suite. Requires Suite as the connect-popup host.',
     message: 'message to sign in plain text',
     hex: 'convert message from hex',
 };
@@ -25,6 +27,8 @@ export const paramDescriptions = {
 ## Ethereum: sign message
 
 Asks device to sign a message using the private key derived by given BIP32 path.
+
+You can provide either a `path` (BIP32 derivation path) or an `address`. When using `address`, the Suite connect-popup resolves it to the corresponding derivation path from discovered accounts.
 
 ```javascript
 const result = await TrezorConnect.ethereumSignMessage(params);
@@ -41,8 +45,15 @@ const result = await TrezorConnect.ethereumSignMessage(params);
 ### Example
 
 ```javascript
+// Using path
 TrezorConnect.ethereumSignMessage({
     path: "m/44'/60'/0'",
+    message: 'example message',
+});
+
+// Using address (requires Suite as connect-popup host)
+TrezorConnect.ethereumSignMessage({
+    address: '0x73d0385F4d8E00C5e6504C6030F47BF6212736A8',
     message: 'example message',
 });
 ```

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -37,6 +37,25 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
         // validate incoming parameters
         Assert(EthereumSignMessageSchema, payload);
 
+        if (!payload.path) {
+            if (!payload.address) {
+                throw new Error(
+                    "ethereumSignMessage: either 'path' or 'address' parameter is required",
+                );
+            }
+
+            // Address-only call: set up minimal state for getMethodInfo().
+            // The preCallHook will resolve address to path, and init() will run again
+            // with the resolved path on the actual device call.
+            this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
+            this.params = {
+                address_n: [],
+                message: '',
+            };
+
+            return;
+        }
+
         const path = validatePath(payload.path, 3);
         const network = getEthereumNetwork(path);
         this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -25,6 +25,29 @@ export default class SignMessage extends AbstractMethod<'signMessage', PROTO.Sig
         // validate incoming parameters
         Assert(SignMessageSchema, payload);
 
+        if (!payload.path) {
+            if (!payload.address) {
+                throw new Error("signMessage: either 'path' or 'address' parameter is required");
+            }
+
+            // Address-only call: set up minimal state for getMethodInfo().
+            // The preCallHook will resolve address to path, and init() will run again
+            // with the resolved path on the actual device call.
+            if (payload.coin) {
+                this.coinInfo = getBitcoinNetwork(payload.coin);
+            }
+            this.firmwareRange = getFirmwareRange(this.name, this.coinInfo, this.firmwareRange);
+            this.params = {
+                address_n: [],
+                message: '',
+                coin_name: this.coinInfo?.name,
+                script_type: 'SPENDADDRESS',
+                no_script_type: payload.no_script_type,
+            };
+
+            return;
+        }
+
         const path = validatePath(payload.path);
         if (payload.coin) {
             this.coinInfo = getBitcoinNetwork(payload.coin);

--- a/packages/connect/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect/src/types/api/__tests__/bitcoin.ts
@@ -660,6 +660,25 @@ export const signMessage = async (api: TrezorConnect) => {
         payload.address.toLowerCase();
         payload.signature.toLowerCase();
     }
+
+    // signMessage with address instead of path
+    const signByAddress = await api.signMessage({
+        address: 'bc1qexample',
+        coin: 'btc',
+        message: 'foo',
+    });
+    if (signByAddress.success) {
+        const { payload } = signByAddress;
+        payload.address.toLowerCase();
+        payload.signature.toLowerCase();
+    }
+
+    // signMessage with both path and address
+    api.signMessage({ path: 'm/44', address: 'bc1qexample', coin: 'btc', message: 'foo' });
+
+    // @ts-expect-error missing both "path" and "address"
+    api.signMessage({ coin: 'btc', message: 'foo' });
+
     const verify = await api.verifyMessage({
         address: 'a',
         signature: 'a',

--- a/packages/connect/src/types/api/__tests__/ethereum.ts
+++ b/packages/connect/src/types/api/__tests__/ethereum.ts
@@ -156,6 +156,24 @@ export const signVerifyMessage = async (api: TrezorConnect) => {
         payload.address.toLowerCase();
         payload.signature.toLowerCase();
     }
+
+    // ethereumSignMessage with address instead of path
+    const signByAddress = await api.ethereumSignMessage({
+        address: '0x1234567890abcdef',
+        message: 'foo',
+    });
+    if (signByAddress.success) {
+        const { payload } = signByAddress;
+        payload.address.toLowerCase();
+        payload.signature.toLowerCase();
+    }
+
+    // ethereumSignMessage with both path and address
+    api.ethereumSignMessage({ path: 'm/44', address: '0xabc', message: 'foo' });
+
+    // @ts-expect-error missing both "path" and "address"
+    api.ethereumSignMessage({ message: 'foo' });
+
     const verify = await api.ethereumVerifyMessage({
         address: 'a',
         signature: 'a',

--- a/packages/connect/src/types/api/bitcoin/index.ts
+++ b/packages/connect/src/types/api/bitcoin/index.ts
@@ -8,14 +8,27 @@ import { DerivationPath, ProtoWithDerivationPath } from '../../params';
 
 // signMessage
 
-export type SignMessage = Static<typeof SignMessage>;
-export const SignMessage = Type.Object({
-    path: DerivationPath,
+const SignMessageCommon = {
     coin: Type.Optional(Type.String()),
     message: Type.String(),
     hex: Type.Optional(Type.Boolean()),
     no_script_type: Type.Optional(Type.Boolean()),
+};
+
+const SignMessageWithPath = Type.Object({
+    path: DerivationPath,
+    address: Type.Optional(Type.String()),
+    ...SignMessageCommon,
 });
+
+const SignMessageWithAddress = Type.Object({
+    path: Type.Optional(DerivationPath),
+    address: Type.String(),
+    ...SignMessageCommon,
+});
+
+export type SignMessage = Static<typeof SignMessage>;
+export const SignMessage = Type.Union([SignMessageWithPath, SignMessageWithAddress]);
 
 // signTransaction
 

--- a/packages/connect/src/types/api/ethereum/index.ts
+++ b/packages/connect/src/types/api/ethereum/index.ts
@@ -5,12 +5,28 @@ import { DerivationPath } from '../../params';
 
 // ethereumSignMessage
 
-export type EthereumSignMessage = Static<typeof EthereumSignMessage>;
-export const EthereumSignMessage = Type.Object({
-    path: DerivationPath,
+const EthereumSignMessageCommon = {
     message: Type.String(),
     hex: Type.Optional(Type.Boolean()),
+};
+
+const EthereumSignMessageWithPath = Type.Object({
+    path: DerivationPath,
+    address: Type.Optional(Type.String()),
+    ...EthereumSignMessageCommon,
 });
+
+const EthereumSignMessageWithAddress = Type.Object({
+    path: Type.Optional(DerivationPath),
+    address: Type.String(),
+    ...EthereumSignMessageCommon,
+});
+
+export type EthereumSignMessage = Static<typeof EthereumSignMessage>;
+export const EthereumSignMessage = Type.Union([
+    EthereumSignMessageWithPath,
+    EthereumSignMessageWithAddress,
+]);
 
 // ethereumSignTransaction
 

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -4,12 +4,16 @@ import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
+import { signMessageHooks } from './signMessage';
 import { solanaSignTransaction } from './solanaSignTransaction';
 import { PostCallHookParams, PreCallHookParams } from './types';
 
 export const preCallHooks = async <M extends CallMethodKeys>(params: PreCallHookParams<M>) => {
     await bitcoinSignTransaction.preCallHook(params);
     await solanaSignTransaction.preCallHook(params);
+
+    const signMessagePayload = signMessageHooks.preCallHook(params);
+    if (signMessagePayload) return signMessagePayload;
 
     const ethereumPayload = await ethereumSignTransaction.preCallHook(params);
     if (ethereumPayload) return ethereumPayload;

--- a/suite-common/connect-popup/src/methodHooks/signMessage.ts
+++ b/suite-common/connect-popup/src/methodHooks/signMessage.ts
@@ -1,0 +1,78 @@
+import { selectDeviceAccounts } from '@suite-common/wallet-core';
+import type { CallMethodKeys } from '@trezor/connect';
+
+import { PreCallHookParams } from './types';
+
+/**
+ * Resolves `address` to `path` for signMessage and ethereumSignMessage methods.
+ *
+ * When the caller provides an `address` instead of a `path`, this hook looks up the address
+ * in Suite's discovered accounts (Redux store) and resolves it to the corresponding BIP-32 path.
+ */
+export const signMessageHooks = {
+    preCallHook: <M extends CallMethodKeys>(params: PreCallHookParams<M>) => {
+        const { method, payload, getState } = params;
+
+        if (method === 'signMessage') {
+            const typedPayload = payload as { address?: string; path?: string; coin?: string };
+            if (typedPayload.address && !typedPayload.path) {
+                const accounts = selectDeviceAccounts(getState());
+                for (const account of accounts) {
+                    if (account.addresses) {
+                        const allAddresses = [
+                            ...account.addresses.used,
+                            ...account.addresses.change,
+                            ...account.addresses.unused,
+                        ];
+                        const addressInfo = allAddresses.find(
+                            a => a.address === typedPayload.address,
+                        );
+                        if (addressInfo) {
+                            return {
+                                ...payload,
+                                path: addressInfo.path,
+                                coin: typedPayload.coin ?? account.symbol,
+                            };
+                        }
+                    }
+
+                    if (account.descriptor === typedPayload.address) {
+                        return {
+                            ...payload,
+                            path: account.path,
+                            coin: typedPayload.coin ?? account.symbol,
+                        };
+                    }
+                }
+
+                throw new Error(
+                    `signMessage: Address "${typedPayload.address}" not found in discovered accounts`,
+                );
+            }
+        }
+
+        if (method === 'ethereumSignMessage') {
+            const typedPayload = payload as { address?: string; path?: string };
+            if (typedPayload.address && !typedPayload.path) {
+                const accounts = selectDeviceAccounts(getState());
+                const account = accounts.find(
+                    a =>
+                        a.networkType === 'ethereum' &&
+                        a.descriptor.toLowerCase() === typedPayload.address!.toLowerCase(),
+                );
+                if (!account) {
+                    throw new Error(
+                        `ethereumSignMessage: Address "${typedPayload.address}" not found in discovered accounts`,
+                    );
+                }
+
+                return {
+                    ...payload,
+                    path: account.path,
+                };
+            }
+        }
+
+        return undefined;
+    },
+};

--- a/suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
+++ b/suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts
@@ -44,6 +44,38 @@ test.describe(
             expect(await res).toMatchObject({ success: true });
         });
 
+        test('TrezorConnect.ethereumSignMessage with address instead of path', async ({
+            connectPermissionsModal,
+            page,
+            device,
+        }) => {
+            // First, get the Ethereum address from the device to use it in signMessage
+            const getAddressRes = TrezorConnect.ethereumGetAddress({
+                path: "m/44'/60'/0'/0/0",
+                showOnTrezor: false,
+            });
+            await connectPermissionsModal.confirmButton.click();
+            const addressResult = await getAddressRes;
+            expect(addressResult.success).toBe(true);
+            if (!addressResult.success) return;
+            const { address } = addressResult.payload;
+
+            // Now sign a message using address instead of path
+            const res = TrezorConnect.ethereumSignMessage({
+                address,
+                message: 'example message',
+            });
+
+            const text = page.getByTestId('@sign-message-modal/message');
+            await expect(text).toHaveText('example message');
+
+            await device.pressContinue();
+            await device.pressContinue();
+
+            await device.pressYes();
+            expect(await res).toMatchObject({ success: true });
+        });
+
         // todo: use account not available in suite (weird derivation path)
     },
 );

--- a/suite/e2e/tests/trezor-connect/signMessage.test.ts
+++ b/suite/e2e/tests/trezor-connect/signMessage.test.ts
@@ -1,0 +1,78 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('TrezorConnect.signMessage', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
+    test.use({ electronConf: { exposeConnectWs: true } });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+        await test.step('Initialize TrezorConnect', async () => {
+            await TrezorConnect.init({
+                manifest: {
+                    appUrl: 'http://localhost:8080',
+                    email: '',
+                    appName: 'Tester',
+                },
+                coreMode: 'suite-desktop',
+                debug: true,
+            });
+        });
+    });
+
+    test('TrezorConnect.signMessage with path', async ({
+        connectPermissionsModal,
+        page,
+        device,
+    }) => {
+        const res = TrezorConnect.signMessage({
+            path: "m/84'/0'/0'/0/0",
+            coin: 'btc',
+            message: 'example message',
+        });
+
+        await connectPermissionsModal.confirmButton.click();
+
+        const text = page.getByTestId('@sign-message-modal/message');
+        await expect(text).toHaveText('example message');
+
+        await device.pressContinue();
+        await device.pressContinue();
+
+        await device.pressYes();
+        expect(await res).toMatchObject({ success: true });
+    });
+
+    test('TrezorConnect.signMessage with address instead of path', async ({
+        connectPermissionsModal,
+        page,
+        device,
+    }) => {
+        // First, get a Bitcoin address from the device to use it in signMessage
+        const getAddressRes = TrezorConnect.getAddress({
+            path: "m/84'/0'/0'/0/0",
+            coin: 'btc',
+            showOnTrezor: false,
+        });
+        await connectPermissionsModal.confirmButton.click();
+        const addressResult = await getAddressRes;
+        expect(addressResult.success).toBe(true);
+        if (!addressResult.success) return;
+        const { address } = addressResult.payload;
+
+        // Now sign a message using address instead of path
+        const res = TrezorConnect.signMessage({
+            address,
+            coin: 'btc',
+            message: 'example message',
+        });
+
+        const text = page.getByTestId('@sign-message-modal/message');
+        await expect(text).toHaveText('example message');
+
+        await device.pressContinue();
+        await device.pressContinue();
+
+        await device.pressYes();
+        expect(await res).toMatchObject({ success: true });
+    });
+});


### PR DESCRIPTION
will eventually resolve #24039

right now it only solves the happy path when discovery is finished and target address is known to suite

<img width="653" height="499" alt="image" src="https://github.com/user-attachments/assets/817fb309-fe83-4ba3-872a-4ca50d11a400" />

problems: 
- if discovery hasn't run yet, should we run it while popup is active?
- what about node implementation that does not have popup? should connect core run discovery as a fallback if path was not provided?

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sign-message-using-address&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sign-message-using-address&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/sign-message-using-address&lookback=7)