### PR TITLE
fix(suite-native): handle THP correctly for firmware language in device settings

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -237,6 +237,7 @@ deviceConnectionMiddleware.startListening({
             checkIsActiveRouteAnyOf([
                 DeviceSettingsStackRoutes.DeviceNameStack,
                 DeviceSettingsStackRoutes.FirmwareUpdateStack,
+                DeviceSettingsStackRoutes.FirmwareLanguageStack,
                 DeviceSettingsStackRoutes.DevicePinProtectionStack,
                 DeviceSettingsStackRoutes.DeviceCheckBackupStack,
                 DeviceSettingsStackRoutes.DeviceAuthenticityStack,

--- a/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import {
     selectDeviceLanguage,
     selectIsDeviceLanguageConfigurable,
@@ -10,15 +12,23 @@ import { Locale } from '@suite-common/suite-types';
 import { Badge, Card, HStack, Select, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
+    StackNavigationProps,
+} from '@suite-native/navigation';
 
-import { useFirmwareLanguage } from '../hooks/useFirmwareLanguage';
+type NavigationProps = StackNavigationProps<
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes.DeviceFirmware
+>;
 
 const BetaBadge = () => (
     <Badge label={<Translation id="firmware.languageCard.betaBadge" />} variant="blue" />
 );
 
 export const FirmwareLanguageCard = () => {
-    const { changeFirmwareLanguage } = useFirmwareLanguage();
+    const navigation = useNavigation<NavigationProps>();
 
     const isDeviceLanguageConfigurable = useSelector(selectIsDeviceLanguageConfigurable);
     const supportedDeviceLanguages = useSelector(selectSupportedDeviceLanguages);
@@ -37,7 +47,7 @@ export const FirmwareLanguageCard = () => {
 
     const changeFirmwareLanguageIfDifferent = (language: Locale) => {
         if (language !== deviceLanguage) {
-            changeFirmwareLanguage(language);
+            navigation.navigate(DeviceSettingsStackRoutes.FirmwareLanguageStack, { language });
         }
     };
 

--- a/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
+++ b/suite-native/firmware/src/hooks/useFirmwareLanguage.ts
@@ -30,8 +30,6 @@ export const useFirmwareLanguage = () => {
 
     const changeFirmwareLanguage = useCallback(
         async (language: Locale) => {
-            navigation.navigate(DeviceSettingsStackRoutes.FirmwareLanguageStack);
-
             const result = await requestPrioritizedDeviceAccess(() =>
                 TrezorConnect.changeLanguage({ language }),
             );

--- a/suite-native/module-device-settings/src/navigation/FirmwareLanguageStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/FirmwareLanguageStackNavigator.tsx
@@ -1,12 +1,19 @@
-import { useSelector } from 'react-redux';
+import { useCallback } from 'react';
 
+import { useFocusEffect } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectIsDeviceConnected } from '@suite-common/device';
-import { DeviceConnectionGuardScreenWithCancel } from '@suite-native/device-authorization';
 import {
+    DeviceConnectionGuardScreenWithCancel,
+    useDeviceConnectionGuard,
+} from '@suite-native/device-authorization';
+import { useFirmwareLanguage } from '@suite-native/firmware';
+import {
+    DeviceSettingsStackParamList,
+    DeviceSettingsStackRoutes,
     FirmwareLanguageStackParamList,
     FirmwareLanguageStackRoutes,
+    StackProps,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
@@ -14,23 +21,34 @@ import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 
 const FirmwareLanguageStack = createNativeStackNavigator<FirmwareLanguageStackParamList>();
 
-export const FirmwareLanguageStackNavigator = () => {
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+export const FirmwareLanguageStackNavigator = ({
+    route,
+}: StackProps<DeviceSettingsStackParamList, DeviceSettingsStackRoutes.FirmwareLanguageStack>) => {
+    const { language } = route.params;
+
+    const { isDeviceConnectionGuardVisible } = useDeviceConnectionGuard();
+    const { changeFirmwareLanguage } = useFirmwareLanguage();
+
+    useFocusEffect(
+        useCallback(() => {
+            if (!isDeviceConnectionGuardVisible) {
+                changeFirmwareLanguage(language);
+            }
+        }, [isDeviceConnectionGuardVisible, changeFirmwareLanguage, language]),
+    );
 
     return (
         <FirmwareLanguageStack.Navigator screenOptions={stackNavigationOptionsConfig}>
-            {!isDeviceConnected && (
+            {isDeviceConnectionGuardVisible && (
                 <FirmwareLanguageStack.Screen
                     name={FirmwareLanguageStackRoutes.DeviceConnectionGuard}
                     component={DeviceConnectionGuardScreenWithCancel}
                 />
             )}
-            {isDeviceConnected && (
-                <FirmwareLanguageStack.Screen
-                    name={FirmwareLanguageStackRoutes.ConfirmLanguageChange}
-                    component={ContinueOnTrezorScreen}
-                />
-            )}
+            <FirmwareLanguageStack.Screen
+                name={FirmwareLanguageStackRoutes.ConfirmLanguageChange}
+                component={ContinueOnTrezorScreen}
+            />
         </FirmwareLanguageStack.Navigator>
     );
 };

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -2,7 +2,7 @@ import { NavigatorScreenParams } from '@react-navigation/native';
 import type { ExchangeTrade } from 'invity-api';
 import { RequireAllOrNone } from 'type-fest';
 
-import { BackupType } from '@suite-common/suite-types';
+import { BackupType, Locale } from '@suite-common/suite-types';
 import { TradingType } from '@suite-common/trading';
 import { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import {
@@ -243,7 +243,9 @@ export type DeviceSettingsStackParamList = {
         closeActionType: CloseActionType;
     };
     [DeviceSettingsStackRoutes.FirmwareUpdateStack]: undefined;
-    [DeviceSettingsStackRoutes.FirmwareLanguageStack]: undefined;
+    [DeviceSettingsStackRoutes.FirmwareLanguageStack]: {
+        language: Locale;
+    };
     [DeviceSettingsStackRoutes.DeviceAutoConnect]: undefined;
     [DeviceSettingsStackRoutes.DeviceAutoConnectStack]: undefined;
     [DeviceSettingsStackRoutes.DeviceAutoConnectGuard]: undefined;


### PR DESCRIPTION
Similar fix as in https://github.com/trezor/trezor-suite/pull/25528, this time for firmware language.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-settings-firmware-language-thp&lookback=7)