### PR TITLE
fix(suite-native): revert coin visibility when passphrase fails or is cancelled

### DIFF
--- a/suite-native/discovery/package.json
+++ b/suite-native/discovery/package.json
@@ -26,6 +26,7 @@
         "@suite-native/feature-flags": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@suite-native/passphrase": "workspace:*",
         "@suite-native/settings": "workspace:*",
         "@suite-native/tokens": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-native/discovery/src/__tests__/pendingCoinVisibilitySlice.test.ts
+++ b/suite-native/discovery/src/__tests__/pendingCoinVisibilitySlice.test.ts
@@ -1,0 +1,60 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import {
+    addPendingCoinVisibility,
+    clearPendingCoinVisibility,
+    pendingCoinVisibilitySlice,
+    selectPendingCoinVisibilitySymbols,
+} from '../pendingCoinVisibilitySlice';
+
+describe('pendingCoinVisibilitySlice', () => {
+    const createStore = () =>
+        configureStore({
+            reducer: {
+                pendingCoinVisibility: pendingCoinVisibilitySlice.reducer,
+            },
+        });
+
+    it('should add symbol to pending when not already present', () => {
+        const store = createStore();
+
+        store.dispatch(addPendingCoinVisibility('btc'));
+
+        expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc']);
+    });
+
+    it('should not add duplicate symbols', () => {
+        const store = createStore();
+
+        store.dispatch(addPendingCoinVisibility('btc'));
+        store.dispatch(addPendingCoinVisibility('btc'));
+
+        expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc']);
+    });
+
+    it('should add multiple different symbols', () => {
+        const store = createStore();
+
+        store.dispatch(addPendingCoinVisibility('btc'));
+        store.dispatch(addPendingCoinVisibility('eth'));
+        store.dispatch(addPendingCoinVisibility('ltc'));
+
+        expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc', 'eth', 'ltc']);
+    });
+
+    it('should clear all pending symbols', () => {
+        const store = createStore();
+
+        store.dispatch(addPendingCoinVisibility('btc'));
+        store.dispatch(addPendingCoinVisibility('eth'));
+        store.dispatch(clearPendingCoinVisibility());
+
+        expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual([]);
+    });
+
+    it('should have empty symbols initially', () => {
+        const store = createStore();
+
+        expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual([]);
+    });
+});

--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -7,6 +7,7 @@ import {
     changeCoinVisibility,
     changeNetworks,
     discoveryActions,
+    selectDiscoveryForSelectedDevice,
     selectIsAnyNetworkEnabled,
     selectIsBitcoinEnabled,
     selectShouldRediscover,
@@ -17,8 +18,16 @@ import {
     recoverWalletThunk,
     selectIsDeviceFirmwareSupported,
 } from '@suite-native/device';
+import { isPassphraseDiscoveryFailure } from '@suite-native/passphrase';
 import { DEVICE } from '@trezor/connect';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
+
+import {
+    PendingCoinVisibilityRootState,
+    addPendingCoinVisibility,
+    clearPendingCoinVisibility,
+    selectPendingCoinVisibilitySymbols,
+} from './pendingCoinVisibilitySlice';
 
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, next, getState }) => {
@@ -36,6 +45,25 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         const isDeviceFirmwareVersionSupported = selectIsDeviceFirmwareSupported(getState());
         const isAnyNetworkEnabled = selectIsAnyNetworkEnabled(getState());
         const isBitcoinEnabled = selectIsBitcoinEnabled(getState());
+
+        // Clear pending coins on discovery success, revert on passphrase failure
+        if (discoveryActions.updateDiscovery.match(action)) {
+            const discoveryStatus = action.payload?.status;
+
+            if (discoveryStatus?.status === 'complete') {
+                dispatch(clearPendingCoinVisibility());
+            } else if (isPassphraseDiscoveryFailure(discoveryStatus)) {
+                const pendingSymbols = selectPendingCoinVisibilitySymbols(
+                    getState() as PendingCoinVisibilityRootState,
+                );
+
+                for (const symbol of pendingSymbols) {
+                    dispatch(changeCoinVisibility({ symbol, shouldBeVisible: false }));
+                }
+
+                dispatch(clearPendingCoinVisibility());
+            }
+        }
 
         // ensure that BTC is enabled when device with BTC-only firmware is connected
         // (it could have been disabled via some other device with universal firmware)
@@ -70,8 +98,23 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
                 device.connected &&
                 isDeviceAcquired(device)
             ) {
+                // Track every enabled coin for revert on passphrase failure
+                if (
+                    changeCoinVisibility.fulfilled.match(action) &&
+                    action.meta.arg?.shouldBeVisible === true
+                ) {
+                    dispatch(addPendingCoinVisibility(action.meta.arg.symbol));
+                }
+
+                // Don't restart discovery when reverting after passphrase failure (we dispatch
+                // changeCoinVisibility(false) for each pending coin, which would retrigger discovery).
+                const isRevertingAfterPassphraseFailure =
+                    changeCoinVisibility.fulfilled.match(action) &&
+                    action.meta.arg?.shouldBeVisible === false &&
+                    isPassphraseDiscoveryFailure(selectDiscoveryForSelectedDevice(getState()));
+
                 const shouldRediscover = selectShouldRediscover(getState(), device);
-                if (shouldRediscover) {
+                if (shouldRediscover && !isRevertingAfterPassphraseFailure) {
                     dispatch(startOrRestartDiscoveryThunk());
                 }
             }

--- a/suite-native/discovery/src/index.ts
+++ b/suite-native/discovery/src/index.ts
@@ -1,4 +1,5 @@
 export { prepareDiscoveryMiddleware } from './discoveryMiddleware';
 export * from './components/AccountsRediscoveryNeededWarning';
 export * from './discoverySelectors';
+export * from './pendingCoinVisibilitySlice';
 export * from './useIsDiscoveryDurationTooLong';

--- a/suite-native/discovery/src/pendingCoinVisibilitySlice.ts
+++ b/suite-native/discovery/src/pendingCoinVisibilitySlice.ts
@@ -1,0 +1,36 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+
+export type PendingCoinVisibilityState = {
+    symbols: NetworkSymbol[];
+};
+
+export type PendingCoinVisibilityRootState = {
+    pendingCoinVisibility: PendingCoinVisibilityState;
+};
+
+const initialState: PendingCoinVisibilityState = {
+    symbols: [],
+};
+
+export const pendingCoinVisibilitySlice = createSlice({
+    name: 'pendingCoinVisibility',
+    initialState,
+    reducers: {
+        addPendingCoinVisibility: (state, { payload }: PayloadAction<NetworkSymbol>) => {
+            if (!state.symbols.includes(payload)) {
+                state.symbols.push(payload);
+            }
+        },
+        clearPendingCoinVisibility: state => {
+            state.symbols = [];
+        },
+    },
+});
+
+export const { addPendingCoinVisibility, clearPendingCoinVisibility } =
+    pendingCoinVisibilitySlice.actions;
+
+export const selectPendingCoinVisibilitySymbols = (state: PendingCoinVisibilityRootState) =>
+    state.pendingCoinVisibility.symbols;

--- a/suite-native/discovery/tsconfig.json
+++ b/suite-native/discovery/tsconfig.json
@@ -27,6 +27,7 @@
         { "path": "../feature-flags" },
         { "path": "../icons" },
         { "path": "../intl" },
+        { "path": "../passphrase" },
         { "path": "../settings" },
         { "path": "../tokens" },
         { "path": "../../packages/connect" },

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -22,7 +22,7 @@ import {
     Screen,
     StackProps,
 } from '@suite-native/navigation';
-import { selectHasPassphraseIncorrectError } from '@suite-native/passphrase';
+import { isPassphraseDiscoveryFailure } from '@suite-native/passphrase';
 
 import { AddCoinAccountNavigationProps, useAddCoinAccount } from '../hooks/useAddCoinAccount';
 
@@ -36,9 +36,7 @@ export const AddCoinDiscoveryRunningScreen = ({
         selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
     );
     const discoveryInfo = useSelector(selectDiscoveryForSelectedDevice);
-    const passphraseModalCancelled =
-        discoveryInfo?.status === 'failed' && discoveryInfo?.errorCode === 'Method_Interrupted';
-    const hasPassphraseIncorrectError = useSelector(selectHasPassphraseIncorrectError);
+    const hasPassphraseFailure = isPassphraseDiscoveryFailure(discoveryInfo);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const enabledNetworkSymbols = useSelector(selectDeviceEnabledDiscoveryNetworkSymbols);
     const { navigateToSuccessorScreen, clearNetworkWithTypeToBeAdded } = useAddCoinAccount();
@@ -89,11 +87,13 @@ export const AddCoinDiscoveryRunningScreen = ({
     };
 
     useEffect(() => {
+        const isBlockedByPassphraseError = hasPassphraseFailure && loadingResult === 'error';
         if (
             networkSymbol &&
             !enabledNetworkSymbols.includes(networkSymbol) &&
             accounts.length === 0 &&
-            !hasDiscovery
+            !hasDiscovery &&
+            !isBlockedByPassphraseError
         ) {
             dispatch(
                 changeCoinVisibility({
@@ -105,7 +105,7 @@ export const AddCoinDiscoveryRunningScreen = ({
             return;
         }
 
-        if (!hasDiscovery && (hasPassphraseIncorrectError || passphraseModalCancelled)) {
+        if (!hasDiscovery && hasPassphraseFailure) {
             setLoadingResult('error');
         }
 
@@ -119,8 +119,7 @@ export const AddCoinDiscoveryRunningScreen = ({
         enabledNetworkSymbols,
         loadingResult,
         networkSymbol,
-        hasPassphraseIncorrectError,
-        passphraseModalCancelled,
+        hasPassphraseFailure,
     ]);
 
     return (

--- a/suite-native/passphrase/src/passphraseSelectors.ts
+++ b/suite-native/passphrase/src/passphraseSelectors.ts
@@ -1,6 +1,28 @@
 import type { DeviceRootState } from '@suite-common/device';
 import { DiscoveryRootState, selectDiscoveryByDevicePath } from '@suite-common/wallet-core';
 
+/**
+ * Returns true if discovery failed due to passphrase flow (cancelled, wrong passphrase, modal dismissed).
+ */
+export const isPassphraseDiscoveryFailure = (
+    status: { status: string; error?: string; errorCode?: string } | undefined,
+): boolean => {
+    if (!status) return false;
+
+    if (status.status === 'cancelled' || status.status === 'passphrase-mismatch') {
+        return true;
+    }
+
+    if (
+        status.status === 'failed' &&
+        (status.errorCode === 'Method_Interrupted' || status.error === 'Passphrase is incorrect')
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
 export const selectHasPassphraseMismatchError = (state: DiscoveryRootState & DeviceRootState) => {
     const discovery = selectDiscoveryByDevicePath(state, state.device.selectedDevice?.path);
 

--- a/suite-native/state/mocks/mockInitialAppState.ts
+++ b/suite-native/state/mocks/mockInitialAppState.ts
@@ -27,6 +27,7 @@ import { bannerFlagsInitialState } from '@suite-native/banner-flags';
 import { bluetoothInitialState } from '@suite-native/bluetooth';
 import { deviceAuthorizationInitialState } from '@suite-native/device-authorization';
 import { deviceOnboardingSliceInitialState } from '@suite-native/device-onboarding';
+import { pendingCoinVisibilitySlice } from '@suite-native/discovery';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { nativeFirmwareInitialState } from '@suite-native/firmware';
 import { graphInitialState } from '@suite-native/graph';
@@ -61,6 +62,7 @@ export const mockInitialAppState = (partialState?: Partial<FullAppState>): FullA
     messageSystem: messageSystemInitialState,
     nativeFirmware: nativeFirmwareInitialState,
     notifications: createNotificationsReducer<TxKeyPath>().initialState,
+    pendingCoinVisibility: pendingCoinVisibilitySlice.getInitialState(),
     suiteSync: initialSuiteSyncState,
     suiteSyncData: initialSuiteSyncDataState,
     thp: initialThpState,

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -37,6 +37,7 @@ import { bannerFlagsPersistWhitelist, bannerFlagsReducer } from '@suite-native/b
 import { bluetoothSlice } from '@suite-native/bluetooth';
 import { deviceAuthorizationReducer } from '@suite-native/device-authorization';
 import { deviceOnboardingReducer } from '@suite-native/device-onboarding';
+import { pendingCoinVisibilitySlice } from '@suite-native/discovery';
 import { featureFlagsPersistedKeys, featureFlagsReducer } from '@suite-native/feature-flags';
 import { nativeFirmwareReducer } from '@suite-native/firmware';
 import { graphPersistTransform, graphReducer } from '@suite-native/graph';
@@ -351,6 +352,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
             messageSystem: messageSystemPersistedReducer,
             nativeFirmware: nativeFirmwareReducer,
             notifications: createNotificationsReducer<TxKeyPath>().reducer,
+            pendingCoinVisibility: pendingCoinVisibilitySlice.reducer,
             suiteSync: suiteSyncPersistedReducer,
             suiteSyncData: suiteSyncDataReducer,
             thp: thpPersistedReducer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12484,6 +12484,7 @@ __metadata:
     "@suite-native/feature-flags": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@suite-native/passphrase": "workspace:*"
     "@suite-native/settings": "workspace:*"
     "@suite-native/test-utils": "workspace:*"
     "@suite-native/tokens": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When adding or enabling a coin and discovery prompts for passphrase, dismissing the modal or entering the wrong passphrase left the coin enabled although discovery failed.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25479

## Screenshots:

https://github.com/user-attachments/assets/37acd3c1-59ea-45db-aecd-0f8cb78f8501



🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/passphrase-coin-enable&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/passphrase-coin-enable&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/passphrase-coin-enable&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/passphrase-coin-enable&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->