### PR TITLE
test(connect-web): call cancelled from the calling application

### DIFF
--- a/packages/connect-explorer/src/components/Method.tsx
+++ b/packages/connect-explorer/src/components/Method.tsx
@@ -335,6 +335,7 @@ export const Method = () => {
                                         icon="x"
                                         intent="neutral"
                                         priority="secondary"
+                                        data-testid="@cancel-button"
                                         onClick={() => actions.onCancelCall()}
                                     />
                                 )}

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -117,6 +117,51 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
     );
 
     test(
+        'call cancelled from calling application',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Web Connect: Call cancelled via TrezorConnect.cancel() from the calling app',
+            }),
+        },
+        async ({ page }) => {
+            await gotoConnectExplorer(page, 'bitcoin/getAddress');
+
+            // expand method tester
+            await page.getByTestId('@api-playground/collapsible-box').click();
+            await expect(page.getByTestId('@submit-button')).toBeVisible();
+            const [suite] = await Promise.all([
+                page.waitForEvent('popup', { timeout: 30_000 }),
+                page.getByTestId('@submit-button').click(),
+            ]);
+            const connectPermissionsModal = new ConnectPermissionsModal(suite);
+            await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
+                timeout: 15_000,
+            });
+            await connectPermissionsModal.confirmButton.click();
+
+            await expect(connectPermissionsModal.loadingHeader).toHaveText(
+                'Export Bitcoin address',
+            );
+
+            // Switch back to connect-explorer and click the cancel "x" button
+            // that appears next to the submit button while a call is in progress.
+            await page.bringToFront();
+            const cancelButton = page.getByTestId('@cancel-button');
+            await cancelButton.click();
+
+            const response = page.getByTestId('@response');
+            await expect(response).toHaveText(/success: false/);
+            await expect(response).toHaveText(/Method_Interrupted/);
+
+            // The popup (suite window) should show a cancellation message.
+            await expect(suite.getByText('Request was canceled by the user')).toBeVisible({
+                timeout: 15_000,
+            });
+        },
+    );
+
+    test(
         'closing popup window returns Method_Interrupted error',
         {
             annotation: createTestAnnotation({


### PR DESCRIPTION
one more missing test case, cherry-picked from #24471

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=one-more-connect-web-test&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=one-more-connect-web-test&lookback=7)