### PR TITLE
feat(trading): add header to TradingOfferExchange

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -8,7 +8,7 @@ import {
     selectTradingExchangeReceiveAccountKey,
 } from '@suite-common/trading';
 import { selectAccountByKey } from '@suite-common/wallet-core';
-import { Button, Column } from '@trezor/components';
+import { Button, Column, H2 } from '@trezor/components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
 import { spacings } from '@trezor/theme';
 
@@ -76,6 +76,9 @@ export const TradingOfferExchange = ({
 
     return (
         <Column gap={spacings.lg}>
+            <H2 typographyStyle="headline-sm">
+                <Translation id="TR_SELL_CONFIRM_SEND_STEP" />
+            </H2>
             <TradingInfoItem
                 key={amountLabels.sendLabel}
                 account={sendAccount}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOffer.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import { Card, Column } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -38,7 +37,7 @@ export const TradingSelectedOffer = () => {
     if (isTradingExchangeContext(context)) {
         return (
             <Column width="100%" alignItems="center">
-                <Card width="100%" maxWidth="520px" data-testid="@trading/selected-offer">
+                <Card width="100%" maxWidth="440px" data-testid="@trading/selected-offer">
                     <TradingOfferExchange
                         account={account}
                         selectedQuote={selectedTrade as TradingOfferExchangeProps['selectedQuote']}
@@ -53,7 +52,7 @@ export const TradingSelectedOffer = () => {
 
     if (isTradingSellContext(context)) {
         return (
-            <Column gap={spacings.md}>
+            <Column gap={16}>
                 {tradingDeviceDisconnected && <ConnectDeviceGenericPromo />}
 
                 <Wrapper data-testid="@trading/selected-offer">


### PR DESCRIPTION
## Description

Add a clear send-review header to the trading exchange review step and slightly narrow the review card width for a tighter layout.

## Notes for QA

Focus on the trading sell/exchange review step: verify that a new send confirmation header is visible above the exchange details, text is correctly translated, and the card width change (520px → 440px) looks good on both desktop and smaller viewports. No changes to fee/amount/account calculations or trading behavior are expected.

## Related Issue

Resolve #24525

## Screenshots:
<img width="709" height="668" alt="image" src="https://github.com/user-attachments/assets/fe043665-6df0-424d-b762-ee86f159f7ae" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/24525/swap-review-step&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/24525/swap-review-step&lookback=7)