### PR TITLE
fix(suite): staking form test - max of ETH balance

### DIFF
--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -7,7 +7,6 @@ import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 let ethereumStakingBalance: string | null;
-const MOCKED_FEE_AMOUNT = 0.000290278609719;
 const WITHDRAWAL_BUFFER = 0.005;
 
 test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
@@ -124,12 +123,10 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
                         .toHaveTranslation('TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL', {
                             values: { amount: '0.005', networkDisplaySymbol: 'ETH' },
                         });
-                    const expectedMax = new BigNumber(ethereumStakingBalance!)
-                        .minus(WITHDRAWAL_BUFFER)
-                        .minus(MOCKED_FEE_AMOUNT);
-                    const formattedExpectedMax = localizeNumber(
-                        expectedMax.decimalPlaces(2, BigNumber.ROUND_UP),
+                    const expectedMax = new BigNumber(ethereumStakingBalance!).minus(
+                        WITHDRAWAL_BUFFER,
                     );
+                    const formattedExpectedMax = localizeNumber(expectedMax);
                     await expect.soft(stakingSection.cryptoInput).toHaveValue(formattedExpectedMax);
                 });
             });


### PR DESCRIPTION
## Description

Fixed ETH staking e2e Max assertion to expect full precision with only the 0.005 ETH withdrawal buffer.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25503


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/eth-staking-form-test&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eth-staking-form-test&lookback=7)