### PR TITLE
fix(suite-native): handle THP correctly for passphrase protection in device settings

### DIFF
--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -240,6 +240,7 @@ deviceConnectionMiddleware.startListening({
                 DeviceSettingsStackRoutes.FirmwareLanguageStack,
                 DeviceSettingsStackRoutes.DevicePinProtectionStack,
                 DeviceSettingsStackRoutes.DeviceCheckBackupStack,
+                DeviceSettingsStackRoutes.DevicePassphraseStack,
                 DeviceSettingsStackRoutes.DeviceAuthenticityStack,
             ])
         ) {

--- a/suite-native/module-device-settings/src/components/PassphraseCard.tsx
+++ b/suite-native/module-device-settings/src/components/PassphraseCard.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectIsDeviceProtectedByPassphrase, selectSelectedDevice } from '@suite-common/device';
+import { selectIsDeviceProtectedByPassphrase } from '@suite-common/device';
 import { TouchableSwitchRow } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
@@ -10,42 +10,22 @@ import {
     DeviceSettingsStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
-import { useToast } from '@suite-native/toasts';
-import TrezorConnect from '@trezor/connect';
 
 type NavigationProp = StackNavigationProps<DeviceSettingsStackParamList, DeviceSettingsStackRoutes>;
 
 export const PassphraseCard = () => {
     const navigation = useNavigation<NavigationProp>();
-    const device = useSelector(selectSelectedDevice);
+
     const isPassphraseEnabled = useSelector(selectIsDeviceProtectedByPassphrase);
-    const { showToast } = useToast();
 
-    if (!device) return null;
-
-    const togglePassphrase = async () => {
+    const navigateToDevicePassphraseStack = () => {
         navigation.navigate(DeviceSettingsStackRoutes.DevicePassphraseStack);
-        const response = await TrezorConnect.applySettings({
-            device: {
-                path: device.path,
-            },
-            use_passphrase: !isPassphraseEnabled,
-        });
-        navigation.goBack();
-
-        if (!response.success) {
-            showToast({
-                variant: 'default',
-                message: response.error.message,
-                icon: 'check',
-            });
-        }
     };
 
     return (
         <TouchableSwitchRow
             isChecked={isPassphraseEnabled}
-            onChange={togglePassphrase}
+            onChange={navigateToDevicePassphraseStack}
             icon="password"
             accessibilityLabel="passphrase"
             text={<Translation id="moduleDeviceSettings.passphrase.title" />}

--- a/suite-native/module-device-settings/src/hooks/useTogglePassphrase.ts
+++ b/suite-native/module-device-settings/src/hooks/useTogglePassphrase.ts
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { selectIsDeviceProtectedByPassphrase, selectSelectedDevice } from '@suite-common/device';
+import { useToast } from '@suite-native/toasts';
+import TrezorConnect from '@trezor/connect';
+
+export const useTogglePassphrase = () => {
+    const navigation = useNavigation();
+    const { showToast } = useToast();
+
+    const device = useSelector(selectSelectedDevice);
+    const isPassphraseEnabled = useSelector(selectIsDeviceProtectedByPassphrase);
+
+    const togglePassphrase = async () => {
+        if (!device) {
+            return;
+        }
+
+        const response = await TrezorConnect.applySettings({
+            device: {
+                path: device.path,
+            },
+            use_passphrase: !isPassphraseEnabled,
+        });
+        navigation.goBack();
+
+        if (!response.success) {
+            showToast({
+                variant: 'default',
+                message: response.error.message,
+                icon: 'check',
+            });
+        }
+    };
+
+    return { togglePassphrase };
+};

--- a/suite-native/module-device-settings/src/navigation/DevicePassphraseStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DevicePassphraseStackNavigator.tsx
@@ -1,36 +1,50 @@
-import { useSelector } from 'react-redux';
+import { useCallback, useState } from 'react';
 
+import { useFocusEffect } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectIsDeviceConnected } from '@suite-common/device';
-import { DeviceConnectionGuardScreenWithCancel } from '@suite-native/device-authorization';
+import {
+    DeviceConnectionGuardScreenWithCancel,
+    useDeviceConnectionGuard,
+} from '@suite-native/device-authorization';
 import {
     DevicePassphraseStackParamList,
     DevicePassphraseStackRoutes,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { useTogglePassphrase } from '../hooks/useTogglePassphrase';
 import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 
 const BackupAndPassphraseStack = createNativeStackNavigator<DevicePassphraseStackParamList>();
 
 export const DevicePassphraseStackNavigator = () => {
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const { isDeviceConnectionGuardVisible } = useDeviceConnectionGuard();
+    const [isTogglePassphraseStarted, setIsTogglePassphraseStarted] = useState(false);
+
+    const { togglePassphrase } = useTogglePassphrase();
+
+    useFocusEffect(
+        useCallback(() => {
+            if (!isDeviceConnectionGuardVisible && !isTogglePassphraseStarted) {
+                setIsTogglePassphraseStarted(true);
+                togglePassphrase();
+            }
+        }, [isDeviceConnectionGuardVisible, isTogglePassphraseStarted, togglePassphrase]),
+    );
 
     return (
         <BackupAndPassphraseStack.Navigator screenOptions={stackNavigationOptionsConfig}>
-            {!isDeviceConnected && (
+            {isDeviceConnectionGuardVisible && (
                 <BackupAndPassphraseStack.Screen
                     name={DevicePassphraseStackRoutes.DeviceConnectionGuard}
                     component={DeviceConnectionGuardScreenWithCancel}
                 />
             )}
-            {isDeviceConnected && (
-                <BackupAndPassphraseStack.Screen
-                    name={DevicePassphraseStackRoutes.ContinueOnTrezor}
-                    component={ContinueOnTrezorScreen}
-                />
-            )}
+            <BackupAndPassphraseStack.Screen
+                name={DevicePassphraseStackRoutes.ContinueOnTrezor}
+                component={ContinueOnTrezorScreen}
+            />
         </BackupAndPassphraseStack.Navigator>
     );
 };


### PR DESCRIPTION
Similar fix as in https://github.com/trezor/trezor-suite/pull/25528, this time for the passphrase protection toggle.

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-settings-passphrase-thp&lookback=7)