### PR TITLE
feat(connect):  new method call cancel API

### DIFF
--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -104,6 +104,69 @@ describe('TrezorConnect.cancel', () => {
         //   }
     });
 
+    it(`GetAddress - New cancel API`, async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: false,
+        });
+        await initTrezorConnect(controller);
+
+        TrezorConnect.removeAllListeners();
+        const getAddressCall = getAddress(true);
+        await new Promise<void>(resolve => {
+            TrezorConnect.on('button', event => {
+                if (event.code === 'ButtonRequest_Address') {
+                    resolve();
+                }
+            });
+        });
+
+        getAddressCall.cancel('Cancel reason');
+
+        const response = await getAddressCall;
+
+        expect(response).toMatchObject({
+            success: false,
+            error: {
+                message: 'Cancel reason',
+                code: 'Method_Cancel',
+            },
+        });
+    });
+
+    it(`GetAddress - AbortController API`, async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: false,
+        });
+        await initTrezorConnect(controller);
+
+        const abortController = new AbortController();
+
+        TrezorConnect.removeAllListeners();
+        const getAddressCall = getAddress(true);
+        getAddressCall.setAbortSignal(abortController.signal);
+
+        await new Promise<void>(resolve => {
+            TrezorConnect.on('button', event => {
+                if (event.code === 'ButtonRequest_Address') {
+                    resolve();
+                }
+            });
+        });
+        abortController.abort('Cancel reason');
+
+        const response = await getAddressCall;
+
+        expect(response).toMatchObject({
+            success: false,
+            error: {
+                message: 'Cancel reason',
+                code: 'Method_Cancel',
+            },
+        });
+    });
+
     it('Synchronous Cancel', async () => {
         await setup(controller, {
             mnemonic: 'mnemonic_all',

--- a/packages/connect/src/factory.ts
+++ b/packages/connect/src/factory.ts
@@ -1,8 +1,9 @@
 import { Type } from '@trezor/schema-utils';
 
 import { UI_REQUEST } from './events';
-import type { CallMethod, CallMethodKeys } from './events/call';
+import type { CallMethod, CallMethodKeys, CallMethodPayload } from './events/call';
 import {
+    CancelablePromise,
     type Manifest,
     type TrezorConnect,
     TrezorConnectAccount,
@@ -72,16 +73,36 @@ export const factory = <
     init: InitType<SettingsType>;
     call: CallMethod;
 } & ExtraMethodsType => {
+    const wrappedCall = (params: CallMethodPayload) => {
+        const { method } = params;
+        const useEventListener = method?.toLowerCase()?.endsWith('getaddress')
+            ? eventEmitter.listenerCount(UI_REQUEST.ADDRESS_VALIDATION) > 0
+            : undefined;
+
+        const result = call({
+            ...params,
+            useEventListener,
+        }) as CancelablePromise<any>;
+        result.cancel = (reason?: string) => cancel(reason);
+        result.setAbortSignal = (signal: AbortSignal) => {
+            const handleAbort = () => {
+                cancel(signal.reason.toString());
+            };
+            signal.addEventListener('abort', handleAbort);
+
+            return () => signal.removeEventListener('abort', handleAbort);
+        };
+
+        return result;
+    };
+
     const callableMethods = Object.fromEntries(
         connectCallableMethods.map(method => [
             method,
             (params: any) =>
-                call({
+                wrappedCall({
                     ...params,
                     method,
-                    useEventListener: method.toLowerCase().endsWith('getaddress')
-                        ? eventEmitter.listenerCount(UI_REQUEST.ADDRESS_VALIDATION) > 0
-                        : undefined,
                 }),
         ]),
     ) as Pick<TrezorConnect, (typeof connectCallableMethods)[number]>;
@@ -98,7 +119,7 @@ export const factory = <
 
         uiResponse,
 
-        call,
+        call: wrappedCall,
 
         dispose,
 

--- a/packages/connect/src/types/api/updateConnectSettings.ts
+++ b/packages/connect/src/types/api/updateConnectSettings.ts
@@ -2,7 +2,9 @@
  * Update Connect settings such as proxy and transports configuration.
  */
 
-import type { Response } from '../params';
+import type { SerializedError } from '@trezor/connect-common/src/constants/errors';
+import type { Err, Ok } from '@trezor/type-utils';
+
 import type { ConnectSettingsTransport, Proxy } from '../settings';
 
 export type UpdateConnectSettings = {
@@ -12,4 +14,4 @@ export type UpdateConnectSettings = {
 
 export declare function updateConnectSettings(
     params: UpdateConnectSettings,
-): Response<{ message: 'success' }>;
+): Promise<Ok<{ message: 'success' }> | Err<SerializedError>>;

--- a/packages/connect/src/types/index.ts
+++ b/packages/connect/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './fees';
 export * from './firmware';
 export * from './params';
 export * from './settings';
+export { CancelablePromise } from './utils';
 
 // altcoin related types. these exports should satisfy needs of 3rd party apps
 export * from './api/cardano';

--- a/packages/connect/src/types/params.ts
+++ b/packages/connect/src/types/params.ts
@@ -5,6 +5,7 @@ import { Static, TSchema, Type } from '@trezor/schema-utils';
 import { Err, Ok } from '@trezor/type-utils';
 
 import { DeviceState, DeviceUniquePath } from './device';
+import { CancelablePromise } from './utils';
 
 export interface DeviceIdentity {
     path?: DeviceUniquePath;
@@ -47,7 +48,7 @@ export interface OkWithDevice<T> extends Ok<T> {
     device?: DeviceIdentity;
 }
 
-export type Response<T> = Promise<OkWithDevice<T> | Err<SerializedError>>;
+export type Response<T> = CancelablePromise<OkWithDevice<T> | Err<SerializedError>>;
 
 export type DerivationPath = string | number[];
 export const DerivationPath = Type.Union([Type.String(), Type.Array(Type.Number())], {

--- a/packages/connect/src/types/utils.ts
+++ b/packages/connect/src/types/utils.ts
@@ -18,3 +18,25 @@ export type MessageFactoryFn<Group, Event> = UnionToIntersection<
               ) => { event: Group; type: Event['type']; payload: undefined }
         : never
 >;
+
+export type CancelablePromise<T> = Promise<T> & {
+    cancel: (reason?: string) => void;
+    setAbortSignal: (signal: AbortSignal) => void;
+};
+
+export const CancelablePromise = {
+    resolve: <T>(value: T): CancelablePromise<T> => {
+        const promise = Promise.resolve(value) as CancelablePromise<T>;
+        promise.cancel = () => {};
+        promise.setAbortSignal = () => {};
+
+        return promise;
+    },
+    reject: <T = never>(reason?: string): CancelablePromise<T> => {
+        const promise = Promise.reject(reason) as CancelablePromise<T>;
+        promise.cancel = () => {};
+        promise.setAbortSignal = () => {};
+
+        return promise;
+    },
+};

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -5,7 +5,7 @@ import { screen } from '@testing-library/react';
 import { configureMockStore, initPreloadedState } from '@suite-common/test-utils';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { ServerInfo } from '@trezor/blockchain-link-types';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { CancelablePromise } from '@trezor/connect';
 
 import { ChangeFee } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee';
 import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton';
@@ -195,7 +195,7 @@ describe('useRbfForm hook', () => {
             const signTransactionMock = jest
                 .spyOn(TrezorConnect, 'signTransaction')
                 .mockImplementation(() =>
-                    Promise.resolve({
+                    CancelablePromise.resolve({
                         success: false,
                         error: { message: 'error', code: 'Failure_UnknownCode' },
                     }),

--- a/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
+++ b/suite-common/delegated-identity-key/src/tests/retrieveDelegatedIdentityKeyFromDevice.test.ts
@@ -1,4 +1,4 @@
-import { DeviceIdentity, asDeviceUniquePath } from '@trezor/connect';
+import { CancelablePromise, DeviceIdentity, asDeviceUniquePath } from '@trezor/connect';
 
 import {
     RetrieveDelegatedIdentityKeyFromDeviceDeps,
@@ -13,7 +13,7 @@ const device123: RetrieveDelegatedIdentityKeyParams['device'] = {
 
 const connectSimple: RetrieveDelegatedIdentityKeyFromDeviceDeps['trezorConnect'] = {
     evoluGetDelegatedIdentityKey: device =>
-        Promise.resolve({
+        CancelablePromise.resolve({
             device: device as DeviceIdentity,
             success: true,
             payload: { private_key: 'delegated-key-123' },

--- a/suite-common/staking/src/__tests__/ethereumStaking.test.ts
+++ b/suite-common/staking/src/__tests__/ethereumStaking.test.ts
@@ -1,5 +1,10 @@
 import { ValidatorsQueue, WalletAccountTransaction } from '@suite-common/wallet-types';
-import TrezorConnect, { AccountInfo, InternalTransfer, OkWithDevice } from '@trezor/connect';
+import TrezorConnect, {
+    AccountInfo,
+    CancelablePromise,
+    InternalTransfer,
+    OkWithDevice,
+} from '@trezor/connect';
 import {
     BlockchainEstimatedFee,
     BlockchainEstimatedFeeLevel,
@@ -66,12 +71,12 @@ const mockTrezorConnect = (test: Record<string, any>) => {
     if (!accountInfo && !estimatedFee) return null;
     if (accountInfo) {
         jest.spyOn(TrezorConnect, 'getAccountInfo').mockImplementation(() =>
-            Promise.resolve(accountInfo as AccountInfoResult),
+            CancelablePromise.resolve(accountInfo as AccountInfoResult),
         );
     }
     if (estimatedFee) {
         jest.spyOn(TrezorConnect, 'blockchainEstimateFee').mockImplementation(() =>
-            Promise.resolve(estimatedFee as EstimateFeeResult),
+            CancelablePromise.resolve(estimatedFee as EstimateFeeResult),
         );
     }
 };
@@ -264,7 +269,9 @@ describe('simulateUnstake', () => {
     simulateUnstakeFixture.forEach(test => {
         it(test.description, async () => {
             jest.spyOn(TrezorConnect, 'blockchainEvmRpcCall').mockImplementation(() =>
-                Promise.resolve(test.blockchainEvmRpcCallResult as BlockchainEvmRpcCallResult),
+                CancelablePromise.resolve(
+                    test.blockchainEvmRpcCallResult as BlockchainEvmRpcCallResult,
+                ),
             );
             const result = await simulateUnstake(test.args as SimulateUnstakeArgs);
             expect(result).toEqual(test.result);

--- a/suite-common/suite-sync/src/owner/tests/createRetrieveSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/tests/createRetrieveSuiteSyncOwner.test.ts
@@ -5,7 +5,7 @@ import {
     asSuiteSyncOwnerSecretHex,
 } from '@suite-common/suite-sync-storage';
 import { asDelegatedIdentityKey } from '@suite-common/suite-types';
-import { asDeviceUniquePath } from '@trezor/connect';
+import { CancelablePromise, asDeviceUniquePath } from '@trezor/connect';
 import { ok } from '@trezor/type-utils';
 
 import {
@@ -30,7 +30,7 @@ const owner1: SuiteSyncOwner = {
 
 const trezorConnect: RetrieveSuiteSyncOwnerDeps['trezorConnect'] = {
     evoluGetNode: () =>
-        Promise.resolve({
+        CancelablePromise.resolve({
             payload: { data: 'evoluNodeData' },
             success: true,
         }),

--- a/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
+++ b/suite-common/wallet-core/tests/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
@@ -1,6 +1,6 @@
 import { configureMockStore } from '@suite-common/test-utils';
 import { WalletAccountTransaction } from '@suite-common/wallet-types';
-import TrezorConnect, { PrecomposeResultFinal } from '@trezor/connect';
+import TrezorConnect, { CancelablePromise, PrecomposeResultFinal } from '@trezor/connect';
 
 import { chainedTxsFixture } from './chainedTransactions.fixture';
 import {
@@ -120,12 +120,12 @@ const createComposeTransactionMock = () =>
 
         // First `composeTransaction` call is just to get size of the transaction
         .mockImplementation(() =>
-            Promise.resolve({ success: true, payload: [createComposeTsResult()] }),
+            CancelablePromise.resolve({ success: true, payload: [createComposeTsResult()] }),
         )
 
         // Second `composeTransaction` call calculates the fee
         .mockImplementation(() =>
-            Promise.resolve({
+            CancelablePromise.resolve({
                 success: true,
                 // 1520 + 1410 = 2930, responsibility of `composeTransaction` so not tested
                 payload: [createComposeTsResult({ fee: '2930' })],

--- a/suite/metadata/src/__tests__/metadataActions.test.ts
+++ b/suite/metadata/src/__tests__/metadataActions.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { prepareDeviceReducer } from '@suite-common/device';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState, prepareAccountsReducer } from '@suite-common/wallet-core';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { CancelablePromise } from '@trezor/connect';
 
 import * as fixtures from '../__fixtures__/metadataActions';
 import * as metadataActions from '../metadataActions';
@@ -18,7 +18,7 @@ const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
 
 jest.spyOn(TrezorConnect, 'cipherKeyValue').mockImplementation(() =>
-    Promise.resolve({
+    CancelablePromise.resolve({
         success: true,
         payload: {
             value: '20c8bf0701213cdcf4c2f56fd0096c1772322d42fb9c4d0ddf6bb122d713d2f3',


### PR DESCRIPTION
## Description

Experimentation with method call cancel API. 

Adds 2 new methods directly on the promise returned by every TrezorConnect method call. First a simple `cancel` function for direct cancellation

```js
const call = TrezorConnect.getAddress({ path: "m/44'/0'/0'/0/0", coin: 'btc' });

// cancel when needed
call.cancel();

const result = await call;
// { success: false, error: { code: 'Method_Cancel' } }
```

And AbortController integration using `setAbortSignal`

```js
const abortController = new AbortController();
const call = TrezorConnect.getAddress({ path: "m/44'/0'/0'/0/0", coin: 'btc' });
call.setAbortSignal(abortController.signal);

// cancel via AbortController
abortController.abort();

const result = await call;
```

After this we could kill global `TrezorConnect.cancel()`

Related issue #23788 and partly #23785

## Notes for QA

Nothing to test

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/call-api-experimentation&lookback=7)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/call-api-experimentation&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/call-api-experimentation&lookback=7)