### PR TITLE
Earn - Hide Empty Accounts

### DIFF
--- a/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/staking/EarnStakingTable.tsx
@@ -1,21 +1,14 @@
-import { NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
+import { useMemo } from 'react';
+
+import { Translation } from '@suite/intl';
+import { StakingNetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectAccountIsStakingActive,
-    selectBaseCurrency,
     selectDeviceSupportedNetworks,
-    selectFiatRatesByFiatRateKey,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { Account } from '@suite-common/wallet-types';
-import {
-    getAccountTotalStakingBalance,
-    getFiatRateKey,
-    getStakingLimitsByNetworkSymbol,
-    isCardanoStakedWithFiveBinaries,
-    toFiatCurrency,
-} from '@suite-common/wallet-utils';
-import { Card, Table } from '@trezor/components';
-import { BigNumber, arrayPartition } from '@trezor/utils';
+import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
+import { Button, Card, Column, Table } from '@trezor/components';
 
 import { OutlineHighlight } from 'src/components/OutlineHighlight';
 import { DashboardAnchor } from 'src/constants/suite/anchors';
@@ -28,14 +21,8 @@ import { EarnStakingActivateRow } from './EarnStakingActivateRow';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
-
-const useCryptoCurrentRate = (symbol: NetworkSymbol) => {
-    const baseCurrency = useSelector(selectBaseCurrency);
-    const fiatRateKey = getFiatRateKey(symbol, baseCurrency);
-    const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
-
-    return currentRate?.rate;
-};
+import { useCryptoCurrentRate } from './hooks/useCryptoCurrencyRate';
+import { useStakingAccountsVisibility } from './hooks/useStakingAccountsVisibility';
 
 export const EarnStakingTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(DashboardAnchor.Staking);
@@ -44,13 +31,16 @@ export const EarnStakingTable = () => {
     const solCurrentRate = useCryptoCurrentRate('sol');
     const adaCurrentRate = useCryptoCurrentRate('ada');
 
-    const currentRates: Record<StakingNetworkSymbol, number | undefined> = {
-        eth: ethCurrentRate,
-        sol: solCurrentRate,
-        ada: adaCurrentRate,
-        thod: ethCurrentRate,
-        dsol: solCurrentRate,
-    };
+    const currentRates: Record<StakingNetworkSymbol, number | undefined> = useMemo(
+        () => ({
+            eth: ethCurrentRate,
+            sol: solCurrentRate,
+            ada: adaCurrentRate,
+            thod: ethCurrentRate,
+            dsol: solCurrentRate,
+        }),
+        [ethCurrentRate, solCurrentRate, adaCurrentRate],
+    );
 
     const ethStakingMessageSystem = useMessageSystemStaking('eth');
     const solStakingMessageSystem = useMessageSystemStaking('sol');
@@ -74,6 +64,32 @@ export const EarnStakingTable = () => {
     );
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
 
+    const ethNotActivated =
+        deviceSupportedNetworkSymbols.includes('eth') &&
+        !stakingAccounts.some(account => account.symbol === 'eth') &&
+        !isEthStakingDisabled;
+
+    const solNotActivated =
+        deviceSupportedNetworkSymbols.includes('sol') &&
+        !stakingAccounts.some(account => account.symbol === 'sol') &&
+        !isSolStakingDisabled;
+
+    const adaNotActivated =
+        deviceSupportedNetworkSymbols.includes('ada') &&
+        !stakingAccounts.some(account => account.symbol === 'ada') &&
+        !isAdaStakingDisabled;
+
+    const stakingAccountsNotActivated = ethNotActivated && solNotActivated && adaNotActivated;
+
+    const { displayedAccounts, isExpandable, isExpanded, toggleExpanded } =
+        useStakingAccountsVisibility({
+            stakingAccounts,
+            currentRates,
+            ethNotActivated,
+            solNotActivated,
+            adaNotActivated,
+        });
+
     if (!accounts.some(account => account.networkType !== 'bitcoin')) {
         return null;
     }
@@ -81,84 +97,6 @@ export const EarnStakingTable = () => {
     if (isEthStakingDisabled && isSolStakingDisabled && isAdaStakingDisabled) {
         return null;
     }
-
-    const [accountsStakingActive, accountsStakingNotActive] = arrayPartition(
-        stakingAccounts,
-        (account: Account) => {
-            const stakedAmount = getAccountTotalStakingBalance(account);
-
-            return stakedAmount !== null && stakedAmount !== '0';
-        },
-    );
-
-    const [accountsSufficientFunds, accountsInsufficientFunds] = arrayPartition(
-        accountsStakingNotActive,
-        (account: Account) => {
-            const minStakingAmount = getStakingLimitsByNetworkSymbol(
-                account.symbol,
-            )?.MIN_AMOUNT_FOR_STAKING;
-
-            return (
-                minStakingAmount !== undefined &&
-                new BigNumber(account.formattedBalance).gte(minStakingAmount)
-            );
-        },
-    );
-
-    const sortAccountsByStakedAmount = (a: Account, b: Account) => {
-        const getAccountStakedAmountInFiat = (account: Account) => {
-            const stakedAmountInCrypto = getAccountTotalStakingBalance(account) ?? '0';
-            const fiatCurrency = toFiatCurrency({
-                amount: stakedAmountInCrypto,
-                rate: currentRates[account.symbol as StakingNetworkSymbol],
-            });
-            const stakedAmountInFiat = new BigNumber(fiatCurrency ?? '0');
-
-            return stakedAmountInFiat;
-        };
-
-        const aStakedAmount = getAccountStakedAmountInFiat(a);
-        const bStakedAmount = getAccountStakedAmountInFiat(b);
-
-        return bStakedAmount.minus(aStakedAmount).toNumber();
-    };
-
-    const sortAccountsByBalance = (a: Account, b: Account) => {
-        const getAccountBalanceInFiat = (account: Account) => {
-            const fiatCurrency = toFiatCurrency({
-                amount: account.formattedBalance,
-                rate: currentRates[account.symbol as StakingNetworkSymbol],
-            });
-            const accountBalanceInFiat = new BigNumber(fiatCurrency ?? '0');
-
-            return accountBalanceInFiat;
-        };
-
-        const aAccountBalance = getAccountBalanceInFiat(a);
-        const bAccountBalance = getAccountBalanceInFiat(b);
-
-        return bAccountBalance.minus(aAccountBalance).toNumber();
-    };
-
-    const sortedAccounts = [
-        ...accountsStakingActive.toSorted(sortAccountsByStakedAmount),
-        ...accountsSufficientFunds.toSorted(sortAccountsByBalance),
-        ...accountsInsufficientFunds.toSorted(sortAccountsByBalance),
-    ];
-
-    const ethNotActivated =
-        deviceSupportedNetworkSymbols.includes('eth') &&
-        !stakingAccounts.some(account => account.symbol === 'eth') &&
-        !isEthStakingDisabled;
-    const solNotActivated =
-        deviceSupportedNetworkSymbols.includes('sol') &&
-        !stakingAccounts.some(account => account.symbol === 'sol') &&
-        !isSolStakingDisabled;
-    const adaNotActivated =
-        deviceSupportedNetworkSymbols.includes('ada') &&
-        !stakingAccounts.some(account => account.symbol === 'ada') &&
-        !isAdaStakingDisabled;
-    const stakingAccountsNotActivated = ethNotActivated && solNotActivated && adaNotActivated;
 
     const badge = getEarnDashboardBadgeState({
         isSectionActive: isStakingActive,
@@ -179,23 +117,31 @@ export const EarnStakingTable = () => {
                 statusBadge={badge}
                 sectionRef={anchorRef}
             >
-                <Card paddingType="none">
-                    <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                        <EarnDashboardTableHeader
-                            showRewardsColumns={!stakingAccountsNotActivated}
-                        />
+                <Column gap={16} alignItems="center">
+                    <Card paddingType="none">
+                        <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                            <EarnDashboardTableHeader
+                                showRewardsColumns={!stakingAccountsNotActivated}
+                            />
 
-                        <Table.Body>
-                            {sortedAccounts.map(account => (
-                                <EarnStakingAccountRow account={account} key={account.key} />
-                            ))}
+                            <Table.Body>
+                                {displayedAccounts.map(account => (
+                                    <EarnStakingAccountRow account={account} key={account.key} />
+                                ))}
 
-                            {ethNotActivated && <EarnStakingActivateRow symbol="eth" />}
-                            {adaNotActivated && <EarnStakingActivateRow symbol="ada" />}
-                            {solNotActivated && <EarnStakingActivateRow symbol="sol" />}
-                        </Table.Body>
-                    </Table>
-                </Card>
+                                {ethNotActivated && <EarnStakingActivateRow symbol="eth" />}
+                                {adaNotActivated && <EarnStakingActivateRow symbol="ada" />}
+                                {solNotActivated && <EarnStakingActivateRow symbol="sol" />}
+                            </Table.Body>
+                        </Table>
+                    </Card>
+
+                    {isExpandable && (
+                        <Button intent="neutral" priority="secondary" onClick={toggleExpanded}>
+                            <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
+                        </Button>
+                    )}
+                </Column>
             </EarnDashboardSection>
         </OutlineHighlight>
     );

--- a/packages/suite/src/components/earn/EarnDashboard/staking/hooks/useCryptoCurrencyRate.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/staking/hooks/useCryptoCurrencyRate.tsx
@@ -1,0 +1,13 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+export const useCryptoCurrentRate = (symbol: NetworkSymbol) => {
+    const baseCurrency = useSelector(selectBaseCurrency);
+    const fiatRateKey = getFiatRateKey(symbol, baseCurrency);
+    const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+
+    return currentRate?.rate;
+};

--- a/packages/suite/src/components/earn/EarnDashboard/staking/hooks/useStakingAccountsVisibility.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/staking/hooks/useStakingAccountsVisibility.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { StakingNetworkSymbol } from '@suite-common/wallet-config';
+import { Account } from '@suite-common/wallet-types';
+import {
+    getAccountTotalStakingBalance,
+    getStakingLimitsByNetworkSymbol,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
+import { BigNumber, arrayPartition } from '@trezor/utils';
+
+interface UseAccountVisibilityProps {
+    stakingAccounts: Account[];
+    currentRates: Record<StakingNetworkSymbol, number | undefined>;
+    ethNotActivated: boolean;
+    solNotActivated: boolean;
+    adaNotActivated: boolean;
+}
+
+export const useStakingAccountsVisibility = ({
+    stakingAccounts,
+    currentRates,
+    ethNotActivated,
+    solNotActivated,
+    adaNotActivated,
+}: UseAccountVisibilityProps) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const toggleExpanded = useCallback(() => {
+        setIsExpanded(prev => !prev);
+    }, []);
+
+    const sortAccountsByStakedAmount = useCallback(
+        (a: Account, b: Account) => {
+            const getAccountStakedAmountInFiat = (account: Account) => {
+                const stakedAmountInCrypto = getAccountTotalStakingBalance(account) ?? '0';
+                const fiatCurrency = toFiatCurrency({
+                    amount: stakedAmountInCrypto,
+                    rate: currentRates[account.symbol as StakingNetworkSymbol],
+                });
+
+                return new BigNumber(fiatCurrency ?? '0');
+            };
+
+            const aStakedAmount = getAccountStakedAmountInFiat(a);
+            const bStakedAmount = getAccountStakedAmountInFiat(b);
+
+            return bStakedAmount.minus(aStakedAmount).toNumber();
+        },
+        [currentRates],
+    );
+
+    const sortAccountsByBalance = useCallback(
+        (a: Account, b: Account) => {
+            const getAccountBalanceInFiat = (account: Account) => {
+                const fiatCurrency = toFiatCurrency({
+                    amount: account.formattedBalance,
+                    rate: currentRates[account.symbol as StakingNetworkSymbol],
+                });
+
+                return new BigNumber(fiatCurrency ?? '0');
+            };
+
+            const aAccountBalance = getAccountBalanceInFiat(a);
+            const bAccountBalance = getAccountBalanceInFiat(b);
+
+            return bAccountBalance.minus(aAccountBalance).toNumber();
+        },
+        [currentRates],
+    );
+
+    const [accountsStakingActive, accountsStakingNotActive] = arrayPartition(
+        stakingAccounts,
+        (account: Account) => {
+            const stakedAmount = getAccountTotalStakingBalance(account);
+
+            return stakedAmount !== null && stakedAmount !== '0';
+        },
+    );
+
+    const [accountsSufficientFunds, accountsInsufficientFunds] = arrayPartition(
+        accountsStakingNotActive,
+        (account: Account) => {
+            const minStakingAmount = getStakingLimitsByNetworkSymbol(
+                account.symbol,
+            )?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
+
+            return (
+                minStakingAmount !== undefined &&
+                new BigNumber(account.formattedBalance).gte(minStakingAmount)
+            );
+        },
+    );
+
+    const alwaysVisibleAccounts = useMemo(
+        () => [
+            ...accountsStakingActive.toSorted(sortAccountsByStakedAmount),
+            ...accountsSufficientFunds.toSorted(sortAccountsByBalance),
+        ],
+        [
+            accountsStakingActive,
+            accountsSufficientFunds,
+            sortAccountsByStakedAmount,
+            sortAccountsByBalance,
+        ],
+    );
+
+    const collapsedInsufficientFundsAccounts = useMemo(() => {
+        const hasEthBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'eth');
+        const hasSolBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'sol');
+        const hasAdaBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'ada');
+
+        const sortedInsufficientFundsAccounts =
+            accountsInsufficientFunds.toSorted(sortAccountsByBalance);
+
+        const additionalAccounts: Account[] = [];
+
+        if (!hasEthBaseAccount && !ethNotActivated) {
+            const account = sortedInsufficientFundsAccounts.find(
+                account => account.symbol === 'eth',
+            );
+
+            if (account) additionalAccounts.push(account);
+        }
+
+        if (!hasSolBaseAccount && !solNotActivated) {
+            const account = sortedInsufficientFundsAccounts.find(
+                account => account.symbol === 'sol',
+            );
+
+            if (account) additionalAccounts.push(account);
+        }
+
+        if (!hasAdaBaseAccount && !adaNotActivated) {
+            const account = sortedInsufficientFundsAccounts.find(
+                account => account.symbol === 'ada',
+            );
+
+            if (account) additionalAccounts.push(account);
+        }
+
+        return additionalAccounts.toSorted(sortAccountsByBalance);
+    }, [
+        alwaysVisibleAccounts,
+        accountsInsufficientFunds,
+        ethNotActivated,
+        solNotActivated,
+        adaNotActivated,
+        sortAccountsByBalance,
+    ]);
+
+    const collapsedAccounts = [...alwaysVisibleAccounts, ...collapsedInsufficientFundsAccounts];
+
+    const expandedAccounts = [
+        ...alwaysVisibleAccounts,
+        ...accountsInsufficientFunds.toSorted(sortAccountsByBalance),
+    ];
+
+    const displayedAccounts = isExpanded ? expandedAccounts : collapsedAccounts;
+    const isExpandable = collapsedAccounts.length !== expandedAccounts.length;
+
+    return { displayedAccounts, isExpanded, toggleExpanded, isExpandable };
+};


### PR DESCRIPTION
## Description

Hide empty/insufficient funds accounts in the Earn table. Only show at least one account per network.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25632

## Screenshots

<img width="100%" alt="Screenshot 2026-03-05 at 14 02 31" src="https://github.com/user-attachments/assets/d82c561f-e1f9-444d-bb88-6cbd42c62c05" />

<img width="100%" alt="Screenshot 2026-03-05 at 14 02 36" src="https://github.com/user-attachments/assets/35196047-8ec6-44e7-9dc8-cdec5f030851" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-hide-empty-accounts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-hide-empty-accounts&lookback=7)