### PR TITLE
fix: fix the correct versioning of the coin_discovery event

### DIFF
--- a/suite-common/analytics/src/events/coinDiscoveryEvent.ts
+++ b/suite-common/analytics/src/events/coinDiscoveryEvent.ts
@@ -17,35 +17,59 @@ type Attributes = {
 export const coinDiscoveryEvent: EventDef<Attributes, EventType.CoinDiscovery> = {
     name: EventType.CoinDiscovery,
     descriptionTrigger: 'Coin discovery - when wallet is discovered',
-    changelog: [{ version: '26.2.0', notes: 'added' }],
+    changelog: [
+        { version: '26.3.1', notes: 'added on desktop' },
+        { version: '26.2.3', notes: 'added on mobile' },
+    ],
 
     attributes: {
         discoveryId: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Discovery id (device.path)',
         },
         symbol: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Coin symbol',
         },
         numberOfAccounts: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Number of accounts',
         },
         numberOfNonZeroAccounts: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Number of non zero accounts',
         },
         tokenAddresses: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Token addresses',
         },
         tokenSymbols: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Token symbols',
         },
         numberOfStakedAccounts: {
-            changelog: [{ version: '26.2.0', notes: 'added' }],
+            changelog: [
+                { version: '26.3.1', notes: 'added on desktop' },
+                { version: '26.2.3', notes: 'added on mobile' },
+            ],
             description: 'Number of staked accounts',
         },
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I filled earlier a wrong version of this event. As it has been released alredy on the mobil, it makes mess in the analytics. So the correct version will the one released now. Where the events on both platforms will be correct.

## Notes for QA

Just an internal analytics

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-analytics-versioning&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-analytics-versioning&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-analytics-versioning&lookback=7)