### PR TITLE
feat(suite): add tooltip to changing delegate button

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -11,7 +11,7 @@ import {
 } from '@suite-common/wallet-core';
 import { SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { validateCardanoDrep } from '@suite-common/wallet-utils';
-import { Card, Column, Modal } from '@trezor/components';
+import { Card, Column, Modal, Tooltip } from '@trezor/components';
 
 import { VotingDelegationsOptions } from 'src/components/earn';
 import { Fees } from 'src/components/wallet/Fees/Fees';
@@ -62,20 +62,31 @@ export const StakeChangeDelegateModalLoaded = ({
         onCancel?.();
     };
 
-    const isDisabled = useMemo(() => {
+    const { isDisabled, errorType } = useMemo(() => {
         switch (selectedVotingDelegation.type) {
-            case 'everstake':
-                return isEverstake;
+            case 'everstake': {
+                if (isEverstake) {
+                    return { isDisabled: true, errorType: 'current_delegate' as const };
+                }
 
+                break;
+            }
             case 'another_drep': {
                 const { drepId } = selectedVotingDelegation;
 
-                return drepId === currentDrepId || !validateCardanoDrep(drepId);
-            }
+                if (drepId === currentDrepId) {
+                    return { isDisabled: true, errorType: 'current_delegate' as const };
+                }
 
-            default:
-                return false;
+                if (!validateCardanoDrep(drepId)) {
+                    return { isDisabled: true, errorType: 'invalid_drep' as const };
+                }
+
+                break;
+            }
         }
+
+        return { isDisabled: false };
     }, [selectedVotingDelegation, currentDrepId, isEverstake]);
 
     return (
@@ -85,12 +96,17 @@ export const StakeChangeDelegateModalLoaded = ({
                     heading={<Translation id="TR_STAKE_CHANGE_DELEGATE" />}
                     onCancel={handleCancel}
                     bottomContent={
-                        <Modal.Button
-                            isDisabled={isDisabled}
-                            onClick={() => handleSubmit(signTx)()}
+                        <Tooltip
+                            isActive={isDisabled && errorType === 'current_delegate'}
+                            content={<Translation id="TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP" />}
                         >
-                            <Translation id="TR_CONTINUE" />
-                        </Modal.Button>
+                            <Modal.Button
+                                isDisabled={isDisabled}
+                                onClick={() => handleSubmit(signTx)()}
+                            >
+                                <Translation id="TR_CONTINUE" />
+                            </Modal.Button>
+                        </Tooltip>
                     }
                 >
                     <Card>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9574,6 +9574,11 @@ export const messages = defineMessages({
         id: 'TR_STAKE_CURRENT_DELEGATE',
         defaultMessage: 'Current delegate',
     },
+    TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP: {
+        id: 'TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP',
+        defaultMessage:
+            'You cannot select your current delegate. Please select a different delegate.',
+    },
     TR_STAKE_PROVIDER_UNKNOWN: {
         id: 'TR_STAKE_PROVIDER_UNKNOWN',
         defaultMessage: 'Unknown provider',


### PR DESCRIPTION
## Description

Add tooltip to disabled button when the same delegate as current delegate is selected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25485

## Screenshots:

<img width="100%" alt="Screenshot 2026-03-05 at 15 10 44" src="https://github.com/user-attachments/assets/ea55bab6-4bb8-4873-b2c6-608c369058bd" />

<img width="100%" alt="Screenshot 2026-03-05 at 15 10 52" src="https://github.com/user-attachments/assets/aa87436e-8575-40ea-aca6-ade27d2fd76b" />


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/staking-delegate-tooltip&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/staking-delegate-tooltip&lookback=7)