### PR TITLE
fix: webpack ProvidePlugin process

### DIFF
--- a/packages/blockchain-link/webpack/dev.js
+++ b/packages/blockchain-link/webpack/dev.js
@@ -63,7 +63,7 @@ module.exports = {
         // provide fallback plugins
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
-            process: 'process/browser',
+            process: 'process/browser.js',
         }),
         new HtmlWebpackPlugin({
             chunks: ['indexUI'],

--- a/packages/connect/e2e/karma.config.js
+++ b/packages/connect/e2e/karma.config.js
@@ -119,7 +119,7 @@ module.exports = config => {
                 // provide fallback plugins, Buffer and process are used in fixtures
                 new webpack.ProvidePlugin({
                     Buffer: ['buffer', 'Buffer'],
-                    process: 'process/browser',
+                    process: 'process/browser.js',
                 }),
                 new webpack.DefinePlugin({
                     // pass required process.env variables

--- a/packages/transport-bluetooth/webpack/webpack.build.js
+++ b/packages/transport-bluetooth/webpack/webpack.build.js
@@ -77,7 +77,6 @@ module.exports = {
         // provide fallback plugins
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
-            process: 'process/browser',
         }),
         new HtmlWebpackPlugin({
             template: `${SRC}ui/index.html`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cherrypicked from https://github.com/trezor/trezor-suite/pull/25585

Webpack 5 + strict ESM resolution issue which didnt cause any problems until now.

with new `@bufbuid` dependency it throws:

```
ERROR in ../../node_modules/@bufbuild/protobuf/dist/esm/proto-int64.js 28:19-26 Module not found: Error: 
Can't resolve 'process/browser' in 'node_modules/@bufbuild/protobuf/dist/esm' Did you mean 'browser.js'?
```

Following AI:

> Webpack 5 enforces fully-specified imports for ESM packages.
> That means if a package’s package.json contains: `"type": "module"`
> Then relative and bare imports must include file extensions (e.g. .js, .mjs) — otherwise Webpack will try to resolve the import literally and fail.

+ seems it was not used in transport-bridge, some copy/paste leftrovers


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/webpack-fallback&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/webpack-fallback&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/webpack-fallback&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/webpack-fallback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/webpack-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-11T16:20:26.071Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-11T08:31:06.330Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->