### PR TITLE
fix(suite-native): don't fetch keys for portfolio tracker

### DIFF
--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -1,5 +1,6 @@
 import { Dispatch } from '@reduxjs/toolkit';
 
+import { PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
 import { EnsureWalletSuiteSyncOnDep, TurnOnSuiteSync } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
 
@@ -21,7 +22,10 @@ export const createTurnOnSuiteSync =
 
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: true }));
 
-        if (deviceStaticSessionId !== undefined) {
+        if (
+            deviceStaticSessionId !== undefined &&
+            deviceStaticSessionId !== PORTFOLIO_TRACKER_DEVICE_STATE
+        ) {
             const result = await deps.ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
                 isWriteMode: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When turning suite sync, if portfolio device static session id is used, do not continue to key retrieval after enabling suite sync. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25696


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/portfolio-tracker-suite-sync-error&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/portfolio-tracker-suite-sync-error&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/portfolio-tracker-suite-sync-error&lookback=7)