### PR TITLE
Staking - include Cardano staking history in tx export

### DIFF
--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -20,6 +20,7 @@ import {
     isNftTokenTransfer,
     localizeNumber,
     roundTimestampToNearestPastHour,
+    subtypeToStakeTypeMap,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { TransactionTarget } from '@trezor/connect';
@@ -164,6 +165,7 @@ const prepareContent = (
                 type: t.type.toUpperCase(),
                 txid: t.txid,
             };
+            const symbol = getNetworkDisplaySymbol(data.symbol);
             const fiatRateKey = getFiatRateKey(t.symbol, baseCurrencyCode);
             const roundedTimestamp = roundTimestampToNearestPastHour(t.blockTime as Timestamp);
             const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
@@ -172,6 +174,17 @@ const prepareContent = (
             let tokens: Array<Fields | null> = [];
             let internalTransfers: Array<Fields | null> = [];
             let targets: Array<Fields | null> = [];
+            let cardanoStaking: Array<Fields | null> = [];
+
+            const getFiatAmount = (amount?: string, historicRate?: number) =>
+                amount && historicRate
+                    ? localizeNumber(
+                          new BigNumber(amount).multipliedBy(historicRate).toNumber(),
+                          undefined,
+                          2,
+                          2,
+                      ).toString()
+                    : '';
 
             if (t.targets.length > 0) {
                 targets = t.targets.map(target => {
@@ -181,24 +194,12 @@ const prepareContent = (
                     const targetData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed
-                            ? getNetworkDisplaySymbol(data.symbol)
-                            : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol : '',
                         address: target.isAddress ? target.addresses[0] : '', // SENT - it is destination address, RECV - it is MY address
                         label: target.isAddress && target.metadataLabel ? target.metadataLabel : '',
                         amount: target.isAddress ? target.amount : '',
-                        symbol: target.isAddress ? getNetworkDisplaySymbol(data.symbol) : '',
-                        fiat:
-                            target.isAddress && target.amount && historicRate
-                                ? localizeNumber(
-                                      new BigNumber(target.amount)
-                                          .multipliedBy(historicRate)
-                                          .toNumber(),
-                                      undefined,
-                                      2,
-                                      2,
-                                  ).toString()
-                                : '',
+                        symbol: target.isAddress ? symbol : '',
+                        fiat: target.isAddress ? getFiatAmount(target.amount, historicRate) : '',
                         other: !target.isAddress ? target.addresses[0] : '', // e.g. OP_RETURN
                     };
                     hasFeeBeenAlreadyUsed = true;
@@ -224,24 +225,12 @@ const prepareContent = (
                     const tokenData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed
-                            ? getNetworkDisplaySymbol(data.symbol)
-                            : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol : '',
                         address: token.to || '', // SENT - it is destination address, RECV - it is MY address
                         label: '', // token transactions do not have labels
                         amount: token.amount, // TODO: what to show if token.decimals missing so amount is not formatted correctly?
                         symbol: token.symbol || token.contract, // if symbol not available, use contract address
-                        fiat:
-                            historicTokenRate && token.amount
-                                ? localizeNumber(
-                                      new BigNumber(token.amount)
-                                          .multipliedBy(historicTokenRate)
-                                          .toNumber(),
-                                      undefined,
-                                      2,
-                                      2,
-                                  ).toString()
-                                : '',
+                        fiat: getFiatAmount(token.amount, historicTokenRate),
                         other: '',
                     };
                     hasFeeBeenAlreadyUsed = true;
@@ -255,24 +244,12 @@ const prepareContent = (
                     const internalTransferData = {
                         ...sharedData,
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
-                        feeSymbol: !hasFeeBeenAlreadyUsed
-                            ? getNetworkDisplaySymbol(data.symbol)
-                            : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol : '',
                         address: internal.to || '', // SENT - it is destination address, RECV - it is MY address
                         label: '', // internal transactions do not have labels
                         amount: internal.amount,
-                        symbol: getNetworkDisplaySymbol(data.symbol), // if symbol not available, use contract address
-                        fiat:
-                            internal.amount && historicRate
-                                ? localizeNumber(
-                                      new BigNumber(internal.amount)
-                                          .multipliedBy(historicRate)
-                                          .toNumber(),
-                                      undefined,
-                                      2,
-                                      2,
-                                  ).toString()
-                                : '',
+                        symbol, // if symbol not available, use contract address
+                        fiat: getFiatAmount(internal.amount, historicRate),
                         other: '',
                     };
                     hasFeeBeenAlreadyUsed = true;
@@ -281,7 +258,55 @@ const prepareContent = (
                 });
             }
 
-            return [...targets, ...tokens, ...internalTransfers];
+            if (t.cardanoSpecific && t.cardanoSpecific.subtype) {
+                const { subtype, withdrawal = '0', deposit = '0' } = t.cardanoSpecific;
+
+                const amount = (() => {
+                    switch (subtype) {
+                        case 'withdrawal':
+                            return withdrawal;
+                        case 'stake_registration':
+                        case 'stake_deregistration':
+                        case 'stake_delegation':
+                            return deposit;
+                        default:
+                            return '0';
+                    }
+                })();
+
+                const stakeTypeLabel = (() => {
+                    switch (subtypeToStakeTypeMap[subtype]) {
+                        case 'stake':
+                            return 'Stake';
+                        case 'unstake':
+                            return 'Unstake';
+                        case 'claim':
+                            return 'Claim rewards';
+                        case 'change-delegate':
+                            return 'Change delegate';
+                        default:
+                            return '';
+                    }
+                })();
+
+                cardanoStaking = [
+                    {
+                        ...sharedData,
+                        symbol,
+                        amount,
+                        fee: !hasFeeBeenAlreadyUsed ? t.fee : '',
+                        feeSymbol: !hasFeeBeenAlreadyUsed ? symbol : '',
+                        address: stakeTypeLabel,
+                        label: '',
+                        fiat: getFiatAmount(amount, historicRate),
+                        other: '',
+                    },
+                ];
+
+                hasFeeBeenAlreadyUsed = true;
+            }
+
+            return [...targets, ...tokens, ...internalTransfers, ...cardanoStaking];
         })
         .filter(record => record !== null) as Fields[];
 };


### PR DESCRIPTION
## Description

Include Cardano stake/unstake/claim transactions in export.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/18815

## Screenshots:

<img width="100%" alt="Screenshot 2026-03-05 at 16 26 03" src="https://github.com/user-attachments/assets/69bb8a46-d9c9-49ca-ab9e-e2dd7a7a9025" />

<img width="100%" alt="Screenshot 2026-03-05 at 16 23 03" src="https://github.com/user-attachments/assets/451140fb-efd7-43cd-b5b4-23ae3386d39c" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-stake-history-export&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-stake-history-export&lookback=7)