### PR TITLE
feat(suite): hide empty yield accounts and show inactive vault opportunities

### DIFF
--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCell.tsx
@@ -13,6 +13,7 @@ type EarnAccountCellProps = {
     iconToken?: TokenDto;
     showAssetNetworkIcon?: boolean;
     tokenBalance?: EarnTokenBalance;
+    subtitle?: string;
 };
 
 export const EarnAccountCell = ({
@@ -21,6 +22,7 @@ export const EarnAccountCell = ({
     iconToken,
     showAssetNetworkIcon = false,
     tokenBalance,
+    subtitle,
 }: EarnAccountCellProps) => {
     const networkSymbol = account?.symbol ?? symbol;
     const assetLogo =
@@ -57,6 +59,7 @@ export const EarnAccountCell = ({
                     account={account}
                     networkSymbol={networkSymbol}
                     tokenBalance={tokenBalance}
+                    subtitle={subtitle}
                 />
             </Column>
         </Row>

--- a/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/common/EarnAccountCellDetails.tsx
@@ -10,24 +10,34 @@ type EarnAccountCellDetailsProps = {
     account?: Account;
     networkSymbol: NetworkSymbol;
     tokenBalance?: EarnTokenBalance;
+    subtitle?: string;
 };
 
 export const EarnAccountCellDetails = ({
     account,
     networkSymbol,
     tokenBalance,
+    subtitle,
 }: EarnAccountCellDetailsProps) => {
     if (!account) {
         return (
-            <Text
-                typographyStyle="body-sm"
-                intent="neutral"
-                priority="primary"
-                ellipsisLineCount={1}
-                maxWidth="100%"
-            >
-                {getNetwork(networkSymbol).name}
-            </Text>
+            <>
+                <Text
+                    typographyStyle="body-sm"
+                    intent="neutral"
+                    priority="primary"
+                    ellipsisLineCount={1}
+                    maxWidth="100%"
+                >
+                    {getNetwork(networkSymbol).name}
+                </Text>
+
+                {subtitle && (
+                    <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                        {subtitle}
+                    </Text>
+                )}
+            </>
         );
     }
 
@@ -42,22 +52,28 @@ export const EarnAccountCellDetails = ({
                 typographyStyle="body-sm"
             />
 
-            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
-                {tokenBalance ? (
-                    <FormattedCryptoAmount
-                        value={tokenBalance.value}
-                        symbol={tokenBalance.symbol}
-                        contractAddress={tokenBalance.contractAddress}
-                        isBalance
-                    />
-                ) : (
-                    <FormattedCryptoAmount
-                        value={account.formattedBalance}
-                        symbol={networkSymbol}
-                        isBalance
-                    />
-                )}
-            </Text>
+            {subtitle ? (
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                    {subtitle}
+                </Text>
+            ) : (
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                    {tokenBalance ? (
+                        <FormattedCryptoAmount
+                            value={tokenBalance.value}
+                            symbol={tokenBalance.symbol}
+                            contractAddress={tokenBalance.contractAddress}
+                            isBalance
+                        />
+                    ) : (
+                        <FormattedCryptoAmount
+                            value={account.formattedBalance}
+                            symbol={networkSymbol}
+                            isBalance
+                        />
+                    )}
+                </Text>
+            )}
         </>
     );
 };

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -109,6 +109,22 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
         );
     };
 
+    const navigateToYieldSupply = () => {
+        if (!opportunity.account) {
+            return;
+        }
+
+        dispatch(
+            goto('earn-supply', {
+                params: getEarnRouteParams({
+                    account: opportunity.account,
+                    yieldId: opportunity.vault.id,
+                    contractAddress: opportunity.vault.token.address ?? undefined,
+                }),
+            }),
+        );
+    };
+
     const navigateToYieldWithdraw = () => {
         if (!opportunity.account) {
             return;
@@ -133,6 +149,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                     symbol={opportunity.networkSymbol}
                     iconToken={opportunity.vault.token}
                     showAssetNetworkIcon
+                    subtitle={opportunity.vault.metadata.name}
                     tokenBalance={{
                         value: opportunity.additionalSupplyAmount,
                         symbol: opportunity.suppliedSymbol,
@@ -219,7 +236,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                 <Row justifyContent="flex-end" gap={8}>
                     {hasSuppliedBalance && (
                         <>
-                            <Button size="small" onClick={openYieldSupplyFlow}>
+                            <Button size="small" onClick={navigateToYieldSupply}>
                                 <Translation id="TR_EARN_YIELD_DASHBOARD_SUPPLY_MORE" />
                             </Button>
                             <Button

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldInactiveVaultOpportunity.tsx
@@ -1,0 +1,69 @@
+import { Translation } from '@suite/intl';
+import { getNetwork } from '@suite-common/wallet-config';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
+import { Button, Table } from '@trezor/components';
+
+import { openModal } from 'src/actions/suite/modalActions';
+import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+
+import { type YieldInactiveVaultOpportunity } from './types';
+import { EarnAccountCell } from '../common/EarnAccountCell';
+
+type EarnYieldInactiveVaultOpportunityProps = {
+    opportunity: YieldInactiveVaultOpportunity;
+};
+
+export const EarnYieldInactiveVaultOpportunity = ({
+    opportunity,
+}: EarnYieldInactiveVaultOpportunityProps) => {
+    const dispatch = useDispatch();
+    const { device } = useDevice();
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+    const { name } = getNetwork(opportunity.networkSymbol);
+
+    const openAddAccountModal = () => {
+        if (!device) {
+            return;
+        }
+
+        dispatch(
+            openModal({
+                type: 'add-account',
+                device,
+                symbol: opportunity.networkSymbol,
+                noRedirect: true,
+                isCoinjoinDisabled: true,
+                isBackClickDisabled: true,
+            }),
+        );
+    };
+
+    return (
+        <Table.Row>
+            <Table.Cell>
+                <EarnAccountCell
+                    symbol={opportunity.networkSymbol}
+                    iconToken={opportunity.vault.token}
+                    showAssetNetworkIcon
+                    subtitle={opportunity.vault.metadata.name}
+                />
+            </Table.Cell>
+
+            <Table.Cell>
+                <ApyValue apy={opportunity.apyPercentage} />
+            </Table.Cell>
+
+            <Table.Cell colSpan={2} />
+
+            <Table.Cell align="end">
+                <Button size="small" onClick={openAddAccountModal} isDisabled={isDiscoveryRunning}>
+                    <Translation
+                        id="TR_EARN_STAKING_DASHBOARD_ACTIVATE"
+                        values={{ networkName: name }}
+                    />
+                </Button>
+            </Table.Cell>
+        </Table.Row>
+    );
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTable.tsx
@@ -1,18 +1,20 @@
 import { useMemo } from 'react';
 
+import { Translation } from '@suite/intl';
 import { YieldDto } from '@suite-common/earn-api';
 import { NORMAL_ACCOUNT_TYPE } from '@suite-common/wallet-config';
 import {
     selectDeviceSupportedNetworks,
     selectVisibleDeviceAccounts,
 } from '@suite-common/wallet-core';
-import { Card, Table } from '@trezor/components';
+import { Button, Card, Column, Table } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 
 import { EarnYieldTableBody } from './EarnYieldTableBody';
 import { useAllYieldOpportunities } from './hooks/useAllYieldOpportunities';
 import { useBalances } from './hooks/useBalances';
+import { useYieldAccountsVisibility } from './hooks/useYieldAccountsVisibility';
 import { useYieldTableData } from './hooks/useYieldTableData';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
@@ -29,7 +31,6 @@ export const EarnYieldTable = () => {
     );
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
     const { yieldOpportunities, isYieldOpportunitiesLoading } = useAllYieldOpportunities();
-
     const availableVaults = useMemo(
         () => yieldOpportunities.filter(isYieldOpportunityAvailable),
         [yieldOpportunities],
@@ -39,11 +40,13 @@ export const EarnYieldTable = () => {
         () => new Set(normalAccounts.map(account => account.symbol)),
         [normalAccounts],
     );
+
     const { suppliedBalancesByYieldAndAddress } = useBalances({
         vaults: availableVaults,
         accounts: normalAccounts,
     });
-    const { yieldAccountOpportunities, yieldNetworksNotActivated, isYieldActive } =
+
+    const { yieldAccountOpportunities, yieldInactiveVaultOpportunities, isYieldActive } =
         useYieldTableData({
             availableVaults,
             deviceSupportedNetworkSymbols,
@@ -51,6 +54,13 @@ export const EarnYieldTable = () => {
             visibleAccounts: normalAccounts,
             visibleAccountSymbols,
         });
+
+    const {
+        displayedYieldAccountOpportunities,
+        hasHiddenYieldAccountOpportunities,
+        isExpanded,
+        toggleIsExpanded,
+    } = useYieldAccountsVisibility({ yieldAccountOpportunities });
 
     const badge = getEarnDashboardBadgeState({
         isSectionActive: isYieldActive,
@@ -65,16 +75,24 @@ export const EarnYieldTable = () => {
             provider="morpho"
             statusBadge={badge}
         >
-            <Card paddingType="none">
-                <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                    <EarnDashboardTableHeader />
-                    <EarnYieldTableBody
-                        isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
-                        yieldAccountOpportunities={yieldAccountOpportunities}
-                        yieldNetworksNotActivated={yieldNetworksNotActivated}
-                    />
-                </Table>
-            </Card>
+            <Column gap={16} alignItems="center">
+                <Card paddingType="none">
+                    <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                        <EarnDashboardTableHeader />
+                        <EarnYieldTableBody
+                            isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                            yieldAccountOpportunities={displayedYieldAccountOpportunities}
+                            yieldInactiveVaultOpportunities={yieldInactiveVaultOpportunities}
+                        />
+                    </Table>
+                </Card>
+
+                {hasHiddenYieldAccountOpportunities && (
+                    <Button intent="neutral" priority="secondary" onClick={toggleIsExpanded}>
+                        <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
+                    </Button>
+                )}
+            </Column>
         </EarnDashboardSection>
     );
 };

--- a/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTableBody.tsx
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/EarnYieldTableBody.tsx
@@ -2,19 +2,19 @@ import { Translation } from '@suite/intl';
 import { Paragraph, Row, Spinner, Table } from '@trezor/components';
 
 import { EarnYieldAccountOpportunity } from './EarnYieldAccountOpportunity';
-import { type YieldAccountOpportunity, type YieldNetworkNotActivated } from './types';
-import { EarnInactiveNetworkOpportunity } from '../common/EarnInactiveNetworkOpportunity';
+import { EarnYieldInactiveVaultOpportunity } from './EarnYieldInactiveVaultOpportunity';
+import { type YieldAccountOpportunity, type YieldInactiveVaultOpportunity } from './types';
 
 type EarnYieldTableBodyProps = {
     isYieldOpportunitiesLoading: boolean;
     yieldAccountOpportunities: YieldAccountOpportunity[];
-    yieldNetworksNotActivated: YieldNetworkNotActivated[];
+    yieldInactiveVaultOpportunities: YieldInactiveVaultOpportunity[];
 };
 
 export const EarnYieldTableBody = ({
     isYieldOpportunitiesLoading,
     yieldAccountOpportunities,
-    yieldNetworksNotActivated,
+    yieldInactiveVaultOpportunities,
 }: EarnYieldTableBodyProps) => {
     if (isYieldOpportunitiesLoading) {
         return (
@@ -30,7 +30,7 @@ export const EarnYieldTableBody = ({
         );
     }
 
-    if (yieldAccountOpportunities.length === 0 && yieldNetworksNotActivated.length === 0) {
+    if (yieldAccountOpportunities.length === 0 && yieldInactiveVaultOpportunities.length === 0) {
         return (
             <Table.Body>
                 <Table.Row>
@@ -50,11 +50,10 @@ export const EarnYieldTableBody = ({
                 <EarnYieldAccountOpportunity key={opportunity.key} opportunity={opportunity} />
             ))}
 
-            {yieldNetworksNotActivated.map(network => (
-                <EarnInactiveNetworkOpportunity
-                    key={network.symbol}
-                    symbol={network.symbol}
-                    apy={network.apyPercentage}
+            {yieldInactiveVaultOpportunities.map(opportunity => (
+                <EarnYieldInactiveVaultOpportunity
+                    key={opportunity.key}
+                    opportunity={opportunity}
                 />
             ))}
         </Table.Body>

--- a/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { BigNumber } from '@trezor/utils';
+
+import { type YieldAccountOpportunity } from '../types';
+
+type UseYieldAccountsVisibilityProps = {
+    yieldAccountOpportunities: YieldAccountOpportunity[];
+};
+
+const isOpportunityVisible = (opportunity: YieldAccountOpportunity) =>
+    new BigNumber(opportunity.suppliedAmount).gt(0) ||
+    new BigNumber(opportunity.additionalSupplyAmount).gt(0);
+
+export const useYieldAccountsVisibility = ({
+    yieldAccountOpportunities,
+}: UseYieldAccountsVisibilityProps) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const { collapsedYieldAccountOpportunities, hiddenYieldAccountOpportunities } = useMemo(() => {
+        const visibleOpportunityKeys = new Set(
+            yieldAccountOpportunities
+                .filter(opportunity => isOpportunityVisible(opportunity))
+                .map(opportunity => opportunity.key),
+        );
+        const networkSymbols = new Set(
+            yieldAccountOpportunities.map(opportunity => opportunity.networkSymbol),
+        );
+
+        networkSymbols.forEach(networkSymbol => {
+            const hasVisibleOpportunity = yieldAccountOpportunities.some(
+                opportunity =>
+                    opportunity.networkSymbol === networkSymbol &&
+                    visibleOpportunityKeys.has(opportunity.key),
+            );
+
+            if (hasVisibleOpportunity) {
+                return;
+            }
+
+            const fallbackOpportunity = yieldAccountOpportunities.find(
+                opportunity => opportunity.networkSymbol === networkSymbol,
+            );
+
+            if (fallbackOpportunity) {
+                visibleOpportunityKeys.add(fallbackOpportunity.key);
+            }
+        });
+
+        return {
+            collapsedYieldAccountOpportunities: yieldAccountOpportunities.filter(opportunity =>
+                visibleOpportunityKeys.has(opportunity.key),
+            ),
+            hiddenYieldAccountOpportunities: yieldAccountOpportunities.filter(
+                opportunity => !visibleOpportunityKeys.has(opportunity.key),
+            ),
+        };
+    }, [yieldAccountOpportunities]);
+
+    const displayedYieldAccountOpportunities = useMemo(
+        () => (isExpanded ? yieldAccountOpportunities : collapsedYieldAccountOpportunities),
+        [collapsedYieldAccountOpportunities, isExpanded, yieldAccountOpportunities],
+    );
+
+    const hasHiddenYieldAccountOpportunities = hiddenYieldAccountOpportunities.length > 0;
+
+    const toggleIsExpanded = useCallback(() => {
+        setIsExpanded(prev => !prev);
+    }, []);
+
+    return {
+        displayedYieldAccountOpportunities,
+        hasHiddenYieldAccountOpportunities,
+        isExpanded,
+        toggleIsExpanded,
+    };
+};

--- a/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/hooks/useYieldTableData.ts
@@ -9,13 +9,13 @@ import {
 import { Account, TokenInfoBranded, toTokenSymbol } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
-import { getApyPercent, getApyRate } from '../../../utils/earnApyUtils';
+import { getApyPercent } from '../../../utils/earnApyUtils';
 import {
     compareYieldRowsByAvailableBalanceDesc,
     compareYieldRowsBySuppliedAmountDesc,
     getYieldAddressKey,
 } from '../../utils/earnYieldUtils';
-import { type YieldAccountOpportunity, type YieldNetworkNotActivated } from '../types';
+import { type YieldAccountOpportunity, type YieldInactiveVaultOpportunity } from '../types';
 
 const getMatchedTokenForVault = (
     account: Account,
@@ -60,12 +60,7 @@ export const useYieldTableData = ({
         const allOpportunities = availableVaults.flatMap(vault => {
             const network = getNetworkByYieldXyzId(vault.network);
 
-            if (!network) {
-                return [];
-            }
-            const isNetworkActivated = visibleAccountSymbols.has(network.symbol);
-
-            if (!isNetworkActivated) {
+            if (!network || !visibleAccountSymbols.has(network.symbol)) {
                 return [];
             }
 
@@ -99,7 +94,7 @@ export const useYieldTableData = ({
 
         const activeOpportunities: YieldAccountOpportunity[] = [];
         const supplyableOpportunities: YieldAccountOpportunity[] = [];
-        const opportunitiesWithoutSupplyableBalance: YieldAccountOpportunity[] = [];
+        const buyOnlyOpportunities: YieldAccountOpportunity[] = [];
 
         allOpportunities.forEach(opportunity => {
             const hasSuppliedBalance = new BigNumber(opportunity.suppliedAmount).gt(0);
@@ -118,15 +113,13 @@ export const useYieldTableData = ({
                 return;
             }
 
-            opportunitiesWithoutSupplyableBalance.push(opportunity);
+            buyOnlyOpportunities.push(opportunity);
         });
 
         return [
             ...activeOpportunities.toSorted(compareYieldRowsBySuppliedAmountDesc),
             ...supplyableOpportunities.toSorted(compareYieldRowsByAvailableBalanceDesc),
-            ...opportunitiesWithoutSupplyableBalance.toSorted(
-                compareYieldRowsByAvailableBalanceDesc,
-            ),
+            ...buyOnlyOpportunities.toSorted(compareYieldRowsByAvailableBalanceDesc),
         ];
     }, [
         availableVaults,
@@ -135,39 +128,32 @@ export const useYieldTableData = ({
         visibleAccountSymbols,
     ]);
 
-    const yieldNetworksNotActivated = useMemo<YieldNetworkNotActivated[]>(() => {
-        const networkRowsBySymbol = availableVaults.reduce((map, vault) => {
+    const yieldInactiveVaultOpportunities = useMemo<YieldInactiveVaultOpportunity[]>(() => {
+        const opportunities = availableVaults.flatMap(vault => {
             const network = getNetworkByYieldXyzId(vault.network);
 
             if (!network) {
-                return map;
+                return [];
             }
 
             const isNetworkActivated = visibleAccountSymbols.has(network.symbol);
             const isNetworkSupported = deviceSupportedNetworkSymbols.includes(network.symbol);
 
             if (isNetworkActivated || !isNetworkSupported) {
-                return map;
+                return [];
             }
 
-            const currentApyRate = getApyRate(vault.rewardRate.total);
-            const currentNetworkRow = map.get(network.symbol);
-
-            if (!currentNetworkRow || currentApyRate > currentNetworkRow.apyRate) {
-                map.set(network.symbol, {
-                    symbol: network.symbol,
+            return [
+                {
+                    key: `${vault.id}:${network.symbol}:inactive`,
+                    networkSymbol: network.symbol,
+                    vault,
                     apyPercentage: getApyPercent(vault.rewardRate.total),
-                    apyRate: currentApyRate,
-                });
-            }
+                },
+            ];
+        });
 
-            return map;
-        }, new Map<NetworkSymbol, YieldNetworkNotActivated & { apyRate: number }>());
-
-        return Array.from(networkRowsBySymbol.values()).map(({ symbol, apyPercentage }) => ({
-            symbol,
-            apyPercentage,
-        }));
+        return opportunities;
     }, [availableVaults, deviceSupportedNetworkSymbols, visibleAccountSymbols]);
 
     const isYieldActive = useMemo(
@@ -181,6 +167,6 @@ export const useYieldTableData = ({
     return {
         isYieldActive,
         yieldAccountOpportunities,
-        yieldNetworksNotActivated,
+        yieldInactiveVaultOpportunities,
     };
 };

--- a/packages/suite/src/components/earn/EarnDashboard/yield/types.ts
+++ b/packages/suite/src/components/earn/EarnDashboard/yield/types.ts
@@ -15,7 +15,7 @@ export type YieldAccountOpportunity = {
     apyPercentage: number | null;
 };
 
-export type YieldNetworkNotActivated = {
-    symbol: NetworkSymbol;
-    apyPercentage: number | null;
-};
+export type YieldInactiveVaultOpportunity = Pick<
+    YieldAccountOpportunity,
+    'key' | 'networkSymbol' | 'vault' | 'apyPercentage'
+>;


### PR DESCRIPTION
## Description

Shows only relevant yield rows by default, adds Show more/less, and displays inactive vault opportunities with activation CTA.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25632

## Screenshots:

<img width="1210" height="712" alt="image" src="https://github.com/user-attachments/assets/d371d6b5-f237-466e-a2bf-8ece62b912fc" />

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-yield-hide-empty-opportunities&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-yield-hide-empty-opportunities&lookback=7)