### PR TITLE
chore(suite-native): ignore all suite packages from eas builds

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -14,8 +14,7 @@ packages/suite-desktop-ui/
 packages/suite-storage/
 packages/suite-web/
 packages/transport-bluetooth/
-suite/e2e/
-suite/test-utils/
+suite/
 
 
 ### content of all .gitignore files is not applied if .easignore is present


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ignore all `suite/` packages in `.easignore` for native builds. This shouldn't affect anything and is just build time optimization to ignore some files we don't need in mobile. 

## Notes for QA
Nothing to test.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25462

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/ignore-suite-from-easbuild&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/ignore-suite-from-easbuild&lookback=7)