### PR TITLE
fix(suite): improve crypto decimal amounts formatting

### DIFF
--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -98,7 +98,7 @@ export const FormattedCryptoAmount = ({
     if (isBalance && !isAmountLow) {
         formattedValue = formatCoinBalance(String(formattedValue), locale);
     } else {
-        formattedValue = localizeNumber(formattedValue, locale);
+        formattedValue = localizeNumber(formattedValue, locale, 0, undefined, true);
     }
 
     // prefix balance with < if it's below threshold

--- a/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/balanceUtils.test.ts
@@ -21,8 +21,8 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('2000000')).toEqual('2,000,000');
     expect(formatCoinBalance('2900000')).toEqual('2,900,000');
     expect(formatCoinBalance('0099999999.999999999999')).toEqual('99,999,999.9…');
-    expect(formatCoinBalance('0.12345678')).toEqual('0.12345678');
-    expect(formatCoinBalance('10.12345678')).toEqual('10.1234567…');
+    expect(formatCoinBalance('0.12345678')).toEqual('0.123,456,78');
+    expect(formatCoinBalance('10.12345678')).toEqual('10.123,456,7…');
     expect(formatCoinBalance('10000.123', 'cs-CZ')).toEqual('10\xa0000,123');
     expect(formatCoinBalance('10000.123', 'es-ES')).toEqual('10.000,123');
     expect(formatCoinBalance('10000.123', 'ru-RU')).toEqual('10\xa0000,123');

--- a/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/localizeNumber.test.ts
@@ -13,6 +13,23 @@ describe('localizeNumber', () => {
         expect(localizeNumber(1.234832924423748, 'cs-CZ')).toStrictEqual('1,234832924423748');
     });
 
+    it('groups fractional part when enabled', () => {
+        expect(localizeNumber('0.023324534', 'cs-CZ', 0, undefined, true)).toStrictEqual(
+            '0,023 324 534',
+        );
+        expect(localizeNumber('10.023324534', 'cs-CZ', 0, undefined, true)).toStrictEqual(
+            '10,023 324 534',
+        );
+        expect(localizeNumber('0.42', 'cs-CZ', 0, undefined, true)).toStrictEqual('0,42');
+
+        expect(localizeNumber('0.023324534', 'en-US', 0, undefined, true)).toStrictEqual(
+            '0.023,324,534',
+        );
+        expect(localizeNumber('1234.0000001', 'en-US', 0, undefined, true)).toStrictEqual(
+            '1,234.000,000,1',
+        );
+    });
+
     it('errors with wrong values', () => {
         expect(localizeNumber(NaN)).toStrictEqual('');
         expect(localizeNumber(Infinity)).toStrictEqual('');

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -31,13 +31,13 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
         // indicate the dust
         const noDecimalsLeft = fixedBalanceBig.modulo(2).toFixed() === '0';
         if (noDecimalsLeft) {
-            return localizeNumber(fixedBalanceBig, locale, 2);
+            return localizeNumber(fixedBalanceBig, locale, 2, undefined, true);
         }
 
-        const localizedBalance = localizeNumber(fixedBalanceBig, locale);
+        const localizedBalance = localizeNumber(fixedBalanceBig, locale, 0, undefined, true);
 
         return isTruncated ? `${localizedBalance}…` : localizedBalance;
     }
 
-    return localizeNumber(balanceBig, locale);
+    return localizeNumber(balanceBig, locale, 0, undefined, true);
 };

--- a/suite-common/wallet-utils/src/localizeNumberUtils.ts
+++ b/suite-common/wallet-utils/src/localizeNumberUtils.ts
@@ -6,6 +6,7 @@ export const localizeNumber = (
     locale: Locale = 'en-US',
     minDecimals = 0,
     maxDecimals?: number,
+    groupFractionalPart = false,
 ) => {
     if (maxDecimals !== undefined && maxDecimals < minDecimals) {
         throw Error(
@@ -43,9 +44,30 @@ export const localizeNumber = (
             ? 4
             : 3;
 
-    return amount.toFormat(getDecimalsLength(), {
+    const localized = amount.toFormat(getDecimalsLength(), {
         decimalSeparator,
         groupSize,
         groupSeparator: thousandsSeparator,
     });
+
+    if (!groupFractionalPart) {
+        return localized;
+    }
+
+    const decimalIndex = localized.indexOf(decimalSeparator);
+    if (decimalIndex === -1) {
+        return localized;
+    }
+
+    const whole = localized.slice(0, decimalIndex);
+    const fractional = localized.slice(decimalIndex + decimalSeparator.length);
+
+    // Keep shorter fractions readable (e.g. 0.42, 0.0001). Add grouping only for long fractions.
+    if (fractional.length <= 6) {
+        return localized;
+    }
+
+    const groupedFractional = fractional.replace(/(\d{3})(?=\d)/g, `$1${thousandsSeparator}`);
+
+    return `${whole}${decimalSeparator}${groupedFractional}`;
 };


### PR DESCRIPTION
- added dividers according to language in case of having decimal number with more than 6 digits 

<!--- Provide a general summary of your changes in the Title above -->

## Description

related discussion: https://satoshilabs.slack.com/archives/CKZHV2G13/p1772014716269699

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

after

<img width="1742" height="1092" alt="image" src="https://github.com/user-attachments/assets/0e74ff4d-c827-4e41-ae5c-778ec205bad0" />


<img width="1742" height="1092" alt="image" src="https://github.com/user-attachments/assets/71978551-63d4-41a6-b3d0-c3118f29315d" />



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=dividers-for-crypto-amounts&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=dividers-for-crypto-amounts&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=dividers-for-crypto-amounts&lookback=7)