### PR TITLE
fix(suite): fix analytics traking fo the start of the onbaording

### DIFF
--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceInitialize.tsx
@@ -1,7 +1,10 @@
 import { MouseEvent } from 'react';
 
+import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { selectSelectedDevice } from '@suite-common/device';
 import { Banner } from '@trezor/components';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import {
     enableOnboardingReducer,
@@ -11,9 +14,13 @@ import {
 import { goto } from 'src/actions/suite/routerActions';
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
+import { useStore } from 'src/hooks/suite/useStore';
+import { useAnalytics } from 'src/support/useAnalytics';
 
 export const DeviceInitialize = () => {
     const dispatch = useDispatch();
+    const analytics = useAnalytics();
+    const { getState } = useStore();
 
     const handleCtaClick = (e: MouseEvent) => {
         e.stopPropagation();
@@ -24,6 +31,14 @@ export const DeviceInitialize = () => {
 
         dispatch(updateAnalytics({ startTime: Date.now() }));
 
+        const device = selectSelectedDevice(getState());
+
+        analytics.report({
+            type: events.deviceSetupStartedEvent.name,
+            payload: {
+                deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+            },
+        });
         dispatch(goto('onboarding-index'));
     };
 

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceNoFirmware.tsx
@@ -1,17 +1,32 @@
 import { MouseEventHandler } from 'react';
 
+import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { selectSelectedDevice } from '@suite-common/device';
 import { Banner } from '@trezor/components';
+import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { goto } from 'src/actions/suite/routerActions';
 import { TroubleshootingTips } from 'src/components/suite/troubleshooting/TroubleshootingTips';
 import { useDispatch } from 'src/hooks/suite';
+import { useStore } from 'src/hooks/suite/useStore';
+import { useAnalytics } from 'src/support/useAnalytics';
 
 export const DeviceNoFirmware = () => {
     const dispatch = useDispatch();
+    const analytics = useAnalytics();
+    const { getState } = useStore();
 
     const handleClick: MouseEventHandler = e => {
         e.stopPropagation();
+        const device = selectSelectedDevice(getState());
+
+        analytics.report({
+            type: events.deviceSetupStartedEvent.name,
+            payload: {
+                deviceModel: device?.features?.internal_model || DeviceModelInternal.UNKNOWN,
+            },
+        });
         dispatch(goto('onboarding-index'));
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is lacking tracking for the onboarding started at some spots causing discrepancies between onboarding started and finished events.

## Notes for QA

This is for the data guys. They'll see it over time.

## Related Issue

Resolve #24542 24542

## Screenshots:


🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24542-wrong-tracking-device-setup-started&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24542-wrong-tracking-device-setup-started&lookback=7)