### PR TITLE
refactor(e2e-utils): rework Slack messaging and its format

### DIFF
--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -44,5 +44,6 @@ jobs:
         env:
           CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
           E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           npx tsx packages/e2e-utils/src/quarantineBot/index.ts

--- a/packages/e2e-utils/src/quarantineBot/config.ts
+++ b/packages/e2e-utils/src/quarantineBot/config.ts
@@ -15,6 +15,7 @@ export const EXPLORER_LOOKBACK_DAYS = 2; // window used by Tests Explorer to dis
 export const PRE_FILTER_FAILURE_RATE = 0.02; // inspect anything that isn't close to 100% passing
 export const TEST_RESULTS_PAGE_SIZE = 10; // default page size of the test-results API endpoint
 export const DEVELOP_BRANCH = 'develop';
+export const SLACK_TITLE_MAX_LENGTH = 50;
 
 export const PROJECTS: Array<{ id: string; label: string }> = [
     { id: 'Og0NOQ', label: 'Trezor Suite (web)' },

--- a/packages/e2e-utils/src/quarantineBot/index.ts
+++ b/packages/e2e-utils/src/quarantineBot/index.ts
@@ -8,6 +8,8 @@ import {
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
 import { quarantineFailingTests, unquarantinePassingTests } from './quarantine';
+import { buildSlackSummary, sendSlackNotification } from './slack';
+import type { SlackEvent } from './types';
 import { wipeAllAutoQuarantineActions } from './wipe';
 
 async function main(): Promise<void> {
@@ -29,6 +31,7 @@ async function main(): Promise<void> {
     console.log('');
 
     let hasError = false;
+    const slackEvents: SlackEvent[] = [];
 
     for (const project of PROJECTS) {
         try {
@@ -36,8 +39,20 @@ async function main(): Promise<void> {
                 getAutoQuarantineActions(project.id),
                 getActiveTests(project.id),
             ]);
-            await quarantineFailingTests(project.id, project.label, existingActions, activeTests);
-            await unquarantinePassingTests(project.id, project.label, existingActions, activeTests);
+            await quarantineFailingTests(
+                project.id,
+                project.label,
+                existingActions,
+                activeTests,
+                slackEvents,
+            );
+            await unquarantinePassingTests(
+                project.id,
+                project.label,
+                existingActions,
+                activeTests,
+                slackEvents,
+            );
         } catch (err) {
             console.error(
                 `\n[ERROR] Failed processing project ${project.label} (${project.id}):`,
@@ -45,6 +60,11 @@ async function main(): Promise<void> {
             );
             hasError = true;
         }
+    }
+
+    const summary = buildSlackSummary(PROJECTS, slackEvents);
+    if (summary) {
+        await sendSlackNotification(summary);
     }
 
     console.log('\n=== Done ===');

--- a/packages/e2e-utils/src/quarantineBot/quarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/quarantine.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { computeStats, extractKeyFromAction, getTestKey } from './actions';
+import { computeStats, extractKeyFromAction, getTestKey, normalizeTitlePath } from './actions';
 import {
     createQuarantineAction,
     deleteAction,
@@ -14,14 +14,14 @@ import {
     UNQUARANTINE_FAILURE_RATE,
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
-import { sendSlackNotification } from './slack';
-import type { Action, TestExplorerItem } from './types';
+import type { Action, SlackEvent, TestExplorerItem } from './types';
 
 export async function quarantineFailingTests(
     projectId: string,
     projectLabel: string,
     existingActions: Action[],
     activeTests: TestExplorerItem[],
+    slackEvents: SlackEvent[],
 ): Promise<void> {
     console.log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
 
@@ -41,8 +41,6 @@ export async function quarantineFailingTests(
             `${candidateTests.length} candidate(s) have ≥${Math.round(PRE_FILTER_FAILURE_RATE * 100)}% failure rate in the explorer window. ` +
             `Fetching last ${QUARANTINE_LAST_N_EXECUTIONS} individual results for each candidate...`,
     );
-
-    let newQuarantineCount = 0;
 
     for (const test of candidateTests) {
         if (!test.signature) {
@@ -75,22 +73,21 @@ export async function quarantineFailingTests(
                 `(${failurePercent}% fail rate, ${stats.failures}/${stats.executions} latest runs)`,
         );
 
-        await createQuarantineAction(projectId, test, stats);
-        newQuarantineCount++;
+        const action = await createQuarantineAction(projectId, test, stats);
+        slackEvents.push({
+            kind: 'quarantined',
+            projectId,
 
-        const slackMsg =
-            `:warning: *[${projectLabel}] Test auto-quarantined* :warning:\n` +
-            `> *Test:* \`${test.title}\`\n` +
-            `> *Spec:* \`${test.spec}\`\n` +
-            `> *Failure rate:* ${failurePercent}% (${stats.failures}/${stats.executions} latest executions)\n` +
-            `> *Action:* Test has been quarantined in Currents — its failures will no longer block CI.\n` +
-            `> _Investigate and fix the issue, then the test will be automatically unquarantined once it stabilises._\n` +
-            `> <https://app.currents.dev/projects/${projectId}|View in Currents Dashboard>`;
-
-        await sendSlackNotification(slackMsg);
+            titlePath: normalizeTitlePath(test),
+            signature: test.signature,
+            actionId: action.actionId,
+            failures: stats.failures,
+            executions: stats.executions,
+        });
     }
 
-    if (newQuarantineCount === 0) {
+    const quarantinedCount = slackEvents.filter(e => e.kind === 'quarantined').length;
+    if (quarantinedCount === 0) {
         console.log('  ✓ No new tests to quarantine.');
     }
 }
@@ -100,6 +97,7 @@ export async function unquarantinePassingTests(
     projectLabel: string,
     existingActions: Action[],
     activeTests: TestExplorerItem[],
+    slackEvents: SlackEvent[],
 ): Promise<void> {
     console.log(`\n── [${projectLabel}] Checking quarantined tests for recovery ──`);
 
@@ -153,16 +151,15 @@ export async function unquarantinePassingTests(
             );
 
             await deleteAction(action.actionId);
+            slackEvents.push({
+                kind: 'unquarantined',
+                projectId,
 
-            const slackMsg =
-                `:white_check_mark: *[${projectLabel}] Quarantined test is now healthy* :white_check_mark:\n` +
-                `> *Test:* \`${testTitle}\`\n` +
-                `> *Spec:* \`${test.spec}\`\n` +
-                `> *Pass rate:* ${passPercent}% (${stats.passes}/${stats.executions} latest executions)\n` +
-                `> *Action:* Test has been removed from quarantine — it will now contribute to CI results as normal.\n` +
-                `> <https://app.currents.dev/projects/${projectId}|View in Currents Dashboard>`;
-
-            await sendSlackNotification(slackMsg);
+                titlePath: JSON.parse(testKey) as string[],
+                signature: test.signature,
+                passes: stats.passes,
+                executions: stats.executions,
+            });
         } else {
             console.log(
                 `  ↳ Still failing: "${testTitle.slice(0, 80)}" ` +

--- a/packages/e2e-utils/src/quarantineBot/slack.ts
+++ b/packages/e2e-utils/src/quarantineBot/slack.ts
@@ -1,7 +1,97 @@
 /* eslint-disable no-console */
+import { SLACK_TITLE_MAX_LENGTH } from './config';
+import type { SlackEvent } from './types';
 
 export function getSlackWebhook(): string | undefined {
     return process.env.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK;
+}
+
+function truncateTitle(titlePath: string[]): string {
+    const joined = titlePath.join(' > ');
+
+    return joined.length > SLACK_TITLE_MAX_LENGTH
+        ? `${joined.slice(0, SLACK_TITLE_MAX_LENGTH)}…`
+        : joined;
+}
+
+function currentsTestUrl(projectId: string, signature: string): string {
+    return `https://app.currents.dev/projects/${projectId}/insights/tests/${signature}`;
+}
+
+function currentsActionUrl(projectId: string, actionId: string): string {
+    return `https://app.currents.dev/projects/${projectId}/actions/${actionId}`;
+}
+
+/**
+ * Build a single batched Slack message summarising all quarantine/unquarantine
+ * events across all projects. Returns null if there is nothing to report.
+ *
+ * *Trezor Suite (web)*
+ * :warning: *Quarantined (2)*
+ * • Staking - Cardano > Stake Cardano — 3/5 fail · action · currents
+ * • Dashboard > Send flow > Send BTC — 2/5 fail · action · currents
+ * :white_check_mark: *Restored (1)*
+ * • Settings > Change passphrase — 25/25 pass · currents
+ *
+ * *Trezor Suite (desktop)*
+ * :warning: *Quarantined (1)*
+ * • Onboarding > Create new wallet — 4/5 fail · action · currents
+ *
+ * CI run
+ */
+export function buildSlackSummary(
+    projects: Array<{ id: string; label: string }>,
+    events: SlackEvent[],
+): string | null {
+    if (events.length === 0) {
+        return null;
+    }
+
+    const sections: string[] = [];
+
+    for (const { id: projectId, label: projectLabel } of projects) {
+        const projectEvents = events.filter(e => e.projectId === projectId);
+        if (projectEvents.length === 0) {
+            continue;
+        }
+
+        const quarantinedEvents = projectEvents.filter(e => e.kind === 'quarantined');
+        const unquarantinedEvents = projectEvents.filter(e => e.kind === 'unquarantined');
+
+        const lines: string[] = [`*${projectLabel}*`];
+
+        if (quarantinedEvents.length > 0) {
+            lines.push(`:warning: *Quarantined (${quarantinedEvents.length})*`);
+            for (const event of quarantinedEvents) {
+                const testUrl = currentsTestUrl(projectId, event.signature);
+                const actionUrl = currentsActionUrl(projectId, event.actionId);
+                lines.push(
+                    `• ${truncateTitle(event.titlePath)} — ${event.failures}/${event.executions} failed · <${actionUrl}|action> · <${testUrl}|results>`,
+                );
+            }
+        }
+
+        if (unquarantinedEvents.length > 0) {
+            lines.push(`:white_check_mark: *Restored (${unquarantinedEvents.length})*`);
+            for (const event of unquarantinedEvents) {
+                const testUrl = currentsTestUrl(projectId, event.signature);
+                lines.push(
+                    `• ${truncateTitle(event.titlePath)} — ${event.passes}/${event.executions} passed · <${testUrl}|results>`,
+                );
+            }
+        }
+
+        sections.push(lines.join('\n'));
+    }
+
+    if (sections.length === 0) {
+        return null;
+    }
+
+    const ciRunUrl = `https://github.com/trezor/trezor-suite/actions/runs/${process.env.GITHUB_RUN_ID}`;
+    const footer = `<${ciRunUrl}|CI run>`;
+
+    return [...sections, footer].join('\n\n');
 }
 
 export async function sendSlackNotification(message: string): Promise<void> {

--- a/packages/e2e-utils/src/quarantineBot/types.ts
+++ b/packages/e2e-utils/src/quarantineBot/types.ts
@@ -90,3 +90,22 @@ export interface TestResultsResponse {
     has_more: boolean;
     data: TestResultItem[];
 }
+
+export type SlackEvent =
+    | {
+          kind: 'quarantined';
+          projectId: string;
+          titlePath: string[];
+          signature: string;
+          actionId: string;
+          failures: number;
+          executions: number;
+      }
+    | {
+          kind: 'unquarantined';
+          projectId: string;
+          titlePath: string[];
+          signature: string;
+          passes: number;
+          executions: number;
+      };


### PR DESCRIPTION
Changes how Slack message are sent and their format
They are now aggregated per CI run
The Slack message is a bit more concise and contains links to actions, test details and the CI run of check test health 

Trezor Suite (web)
:warning: Quarantined (2)
• Staking - Cardano > Stake Cardano — 3/5 fail · [action](https://app.currents.dev/projects/4ytF0E/actions/69aa90a25d6161f7e816c2df) · [results](https://app.currents.dev/projects/Og0NOQ/insights/tests/c93d297eba8a706da6dd587e62d8a177)
• Dashboard > Send flow > Send BTC — 2/5 fail · [action](https://app.currents.dev/projects/4ytF0E/actions/69aa90a25d6161f7e816c2df) · [results](https://app.currents.dev/projects/Og0NOQ/insights/tests/c93d297eba8a706da6dd587e62d8a177)
:white_check_mark: Restored (1)
• Settings > Change passphrase — 25/25 pass · [results](https://app.currents.dev/projects/Og0NOQ/insights/tests/c93d297eba8a706da6dd587e62d8a177)

Trezor Suite (desktop)
:warning: Quarantined (1)
• Onboarding > Create new wallet — 4/5 fail · [action](https://app.currents.dev/projects/4ytF0E/actions/69aa90a25d6161f7e816c2df) · [results](https://app.currents.dev/projects/Og0NOQ/insights/tests/c93d297eba8a706da6dd587e62d8a177)

[CI run](https://github.com/trezor/trezor-suite/actions/runs/22758809189)

🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-better-slack-msg-for-bot&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-better-slack-msg-for-bot&lookback=7)