### PR TITLE
Dismiss keyboard on click to Add Label button

### DIFF
--- a/suite-native/labeling/package.json
+++ b/suite-native/labeling/package.json
@@ -33,6 +33,7 @@
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "react": "19.1.0",
+        "react-native": "0.81.5",
         "react-redux": "9.2.0"
     }
 }

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, Ref } from 'react';
+import { Keyboard } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import type { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
@@ -27,7 +28,10 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
     return (
         <>
             <TextButton
-                onPress={() => handleAddLabel(openModal)}
+                onPress={() => {
+                    Keyboard.dismiss();
+                    handleAddLabel(openModal);
+                }}
                 viewRight="pencil"
                 testID={testID}
             >

--- a/yarn.lock
+++ b/yarn.lock
@@ -12775,6 +12775,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     react: "npm:19.1.0"
+    react-native: "npm:0.81.5"
     react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- If there is some other active input in the app, the keyboard is not hidden automatically on click on Add label button, this would ensure the keyboard dismissed so Edit label bottom sheet is visible and not hidden behind the keyboard.

## Notes for QA

This change aplied on all places where this green Add label button is used on mobile (Send form, TX output, Address)

## Related Issue

Followup for https://github.com/trezor/trezor-suite/issues/23673

## Screenshots:
BEFORE:

https://github.com/user-attachments/assets/fcb177ef-2aa8-474b-8dea-7e84c3b033e3




AFTER:
https://github.com/user-attachments/assets/d29ed48d-d4c3-49e0-a3d6-3b3e0d3e1b08



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/keyboard-dismiss-add-label-in-send&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/keyboard-dismiss-add-label-in-send&lookback=7)

🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/keyboard-dismiss-add-label-in-send&lookback=7)