### PR TITLE
Analytics for staking after discovery

### DIFF
--- a/packages/blockchain-link-types/src/solana.ts
+++ b/packages/blockchain-link-types/src/solana.ts
@@ -8,6 +8,7 @@ export type SolanaStakingAccount = {
     status: string;
     stake?: string;
     rentExemptReserve: string;
+    voterPubkey?: string;
 };
 
 export const StakeState = {

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -113,6 +113,7 @@ export const getSolanaStakingData = async (
                     stake: fields[1]?.delegation?.stake.toString(),
                     status: stakeState,
                     isEverStake,
+                    voterPubkey,
                 };
             }
         })

--- a/suite-common/analytics/src/events/coinDiscoveryEvent.ts
+++ b/suite-common/analytics/src/events/coinDiscoveryEvent.ts
@@ -12,6 +12,7 @@ type Attributes = {
     tokenSymbols: AttributeDef<TokenSymbol[]>;
     tokenAddresses: AttributeDef<TokenAddress[]>;
     numberOfStakedAccounts: AttributeDef<number>;
+    stakingProviders: AttributeDef<string[]>;
 };
 
 export const coinDiscoveryEvent: EventDef<Attributes, EventType.CoinDiscovery> = {
@@ -71,6 +72,13 @@ export const coinDiscoveryEvent: EventDef<Attributes, EventType.CoinDiscovery> =
                 { version: '26.2.3', notes: 'added on mobile' },
             ],
             description: 'Number of staked accounts',
+        },
+        stakingProviders: {
+            changelog: [
+                { version: '26.4.1', notes: 'added on desktop' },
+                { version: '26.4.1', notes: 'added on mobile' },
+            ],
+            description: 'Staking providers detected for the coin',
         },
     },
 };

--- a/suite-common/staking-solana/src/constants.ts
+++ b/suite-common/staking-solana/src/constants.ts
@@ -1,7 +1,12 @@
 import { address } from '@solana/kit';
 
-export const MAINNET_VALIDATOR_ADDRESS = address('9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF');
-export const DEVNET_VALIDATOR_ADDRESS = address('GkqYQysEGmuL6V2AJoNnWZUz2ZBGWhzQXsJiXm2CLKAN');
+import {
+    EVERSTAKE_SOLANA_DEVNET_VALIDATOR,
+    EVERSTAKE_SOLANA_MAINNET_VALIDATOR,
+} from '@suite-common/wallet-config';
+
+export const MAINNET_VALIDATOR_ADDRESS = address(EVERSTAKE_SOLANA_MAINNET_VALIDATOR);
+export const DEVNET_VALIDATOR_ADDRESS = address(EVERSTAKE_SOLANA_DEVNET_VALIDATOR);
 
 export const STAKE_HISTORY_ACCOUNT = address('SysvarStakeHistory1111111111111111111111111');
 export const STAKE_CONFIG_ACCOUNT = address('StakeConfig11111111111111111111111111111111');

--- a/suite-common/wallet-config/package.json
+++ b/suite-common/wallet-config/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@suite-common/earn-api": "workspace:*",
+        "@suite-common/wallet-constants": "workspace:*",
         "@trezor/device-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"

--- a/suite-common/wallet-config/src/index.ts
+++ b/suite-common/wallet-config/src/index.ts
@@ -1,4 +1,5 @@
 export * from './networksConfig';
+export * from './stakingProviders';
 export * from './types';
 export * from './utils';
 export * from './getExplorerUrls';

--- a/suite-common/wallet-config/src/stakingProviders.ts
+++ b/suite-common/wallet-config/src/stakingProviders.ts
@@ -1,0 +1,48 @@
+import { EVERSTAKE_POOLS, FIVE_BINARIES_POOLS } from '@suite-common/wallet-constants';
+
+export type StakingProviderId = 'everstake' | 'fivebinaries';
+
+export type StakingProvider = {
+    id: StakingProviderId;
+    name: string;
+    solanaVoterPubkeys: string[];
+    cardanoPoolIds: string[];
+    ethereumPoolNames: string[];
+};
+
+export const EVERSTAKE_SOLANA_MAINNET_VALIDATOR = '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF';
+export const EVERSTAKE_SOLANA_DEVNET_VALIDATOR = 'GkqYQysEGmuL6V2AJoNnWZUz2ZBGWhzQXsJiXm2CLKAN';
+
+export const EVERSTAKE_PROVIDER: StakingProvider = {
+    id: 'everstake',
+    name: 'Everstake',
+    solanaVoterPubkeys: [EVERSTAKE_SOLANA_MAINNET_VALIDATOR, EVERSTAKE_SOLANA_DEVNET_VALIDATOR],
+    cardanoPoolIds: EVERSTAKE_POOLS,
+    ethereumPoolNames: ['Everstake'],
+};
+
+export const FIVEBINARIES_PROVIDER: StakingProvider = {
+    id: 'fivebinaries',
+    name: 'FiveBinaries',
+    solanaVoterPubkeys: [],
+    cardanoPoolIds: FIVE_BINARIES_POOLS,
+    ethereumPoolNames: [],
+};
+
+export const STAKING_PROVIDERS: readonly StakingProvider[] = [
+    EVERSTAKE_PROVIDER,
+    FIVEBINARIES_PROVIDER,
+];
+
+export const getStakingProviderBySolanaVoterPubkey = (
+    voterPubkey: string,
+): StakingProvider | undefined =>
+    STAKING_PROVIDERS.find(provider => provider.solanaVoterPubkeys.includes(voterPubkey));
+
+export const getStakingProviderByCardanoPoolId = (poolId: string): StakingProvider | undefined =>
+    STAKING_PROVIDERS.find(provider => provider.cardanoPoolIds.includes(poolId));
+
+export const getStakingProviderByEthereumPoolName = (
+    poolName: string,
+): StakingProvider | undefined =>
+    STAKING_PROVIDERS.find(provider => provider.ethereumPoolNames.includes(poolName));

--- a/suite-common/wallet-config/tsconfig.json
+++ b/suite-common/wallet-config/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../earn-api" },
+        { "path": "../wallet-constants" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -31,6 +31,7 @@ import { Account, DiscoveryStatus, TokenSymbol, toTokenAddress } from '@suite-co
 import {
     getAccountTotalStakingBalance,
     getAccountsWithSomeTransactionHistory,
+    getStakingProvidersForAnalytics,
 } from '@suite-common/wallet-utils';
 import TrezorConnect, {
     AccountInfo,
@@ -305,6 +306,7 @@ const trackCompleteDiscoveryResult = (
                     numberOfStakedAccounts: accounts.filter(account =>
                         new BigNumber(getAccountTotalStakingBalance(account) || 0).gt(0),
                     ).length,
+                    stakingProviders: getStakingProvidersForAnalytics(accounts),
                 },
             });
         }

--- a/suite-common/wallet-core/src/stake/stakeConstants.ts
+++ b/suite-common/wallet-core/src/stake/stakeConstants.ts
@@ -1,4 +1,5 @@
 import { SupportedSolanaNetworkSymbols } from '@suite-common/staking-solana-types';
+import { EVERSTAKE_SOLANA_MAINNET_VALIDATOR } from '@suite-common/wallet-config';
 import {
     SupportedCardanoNetworkSymbols,
     SupportedEthereumNetworkSymbol,
@@ -20,7 +21,7 @@ export const EVERSTAKE_ENDPOINT_PREFIX = {
 export const EVERSTAKE_REWARDS_SOLANA_ENPOINT =
     'https://stake-sync-api.everstake.one/v1/solana/rewards';
 
-export const EVERSTAKE_VALIDATOR = '9QU2QSxhb24FUX3Tu2FpczXjpK3VYrvRudywSZaM29mF';
+export const EVERSTAKE_VALIDATOR = EVERSTAKE_SOLANA_MAINNET_VALIDATOR;
 export const EVERSTAKE_API_KEY = '70ab9ee4-7699-47af-9f79-ad85aee1d490';
 
 export const DEFAULT_VOTING_OPTION: VotingDelegationOption = { type: 'everstake' };

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -5,6 +5,9 @@ import {
     STAKING_TYPES,
     StakingNetworkSymbol,
     StakingNetworkType,
+    getStakingProviderByCardanoPoolId,
+    getStakingProviderByEthereumPoolName,
+    getStakingProviderBySolanaVoterPubkey,
 } from '@suite-common/wallet-config';
 import {
     CARDANO_EPOCH_DAYS,
@@ -71,7 +74,7 @@ const STAKING_BALANCE_BY_TYPE = {
 
 export const getAccountTotalStakingBalance = (account: Account) =>
     isStakingNetworkType(account.networkType)
-        ? STAKING_BALANCE_BY_TYPE[account.networkType](account)
+        ? STAKING_BALANCE_BY_TYPE[account.networkType]?.(account)
         : null;
 
 export const isSupportedStakingNetworkSymbol = (symbol: NetworkSymbol) =>
@@ -230,6 +233,66 @@ export const calculateRewards = (amount: string, apyPercent: number | null, days
     const currentRewards = new BigNumber(amount).multipliedBy(factor).toString();
 
     return currentRewards;
+};
+
+export const getStakingProvidersForAnalytics = (accounts: Account[]): string[] => {
+    const providers = new Set<string>();
+
+    accounts.forEach(account => {
+        const stakingBalance = getAccountTotalStakingBalance(account);
+        if (!stakingBalance || new BigNumber(stakingBalance).lte(0)) {
+            return;
+        }
+
+        switch (account.networkType) {
+            case 'ethereum':
+                account.misc?.stakingPools?.forEach(pool => {
+                    const provider = getStakingProviderByEthereumPoolName(pool.name);
+                    if (provider) {
+                        providers.add(provider.id);
+                    } else {
+                        // Account is staked but provider is unknown
+                        providers.add('unknown');
+                    }
+                });
+                break;
+            case 'solana':
+                [
+                    ...(account.misc?.solStakingAccounts ?? []),
+                    ...(account.misc?.solExternalStakingAccounts ?? []),
+                ].forEach(stakingAccount => {
+                    if (stakingAccount.voterPubkey) {
+                        const provider = getStakingProviderBySolanaVoterPubkey(
+                            stakingAccount.voterPubkey,
+                        );
+                        if (provider) {
+                            providers.add(provider.id);
+                        } else {
+                            // Account is staked but provider is unknown
+                            providers.add('unknown');
+                        }
+                    }
+                });
+                break;
+            case 'cardano': {
+                const poolId = account.misc?.staking?.poolId;
+                if (!poolId) break;
+
+                const provider = getStakingProviderByCardanoPoolId(poolId);
+                if (provider) {
+                    providers.add(provider.id);
+                } else {
+                    // Account is staked but provider is unknown
+                    providers.add('unknown');
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    });
+
+    return Array.from(providers);
 };
 
 export const getTxStakeType = (tx: WalletAccountTransaction) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11642,6 +11642,7 @@ __metadata:
   resolution: "@suite-common/wallet-config@workspace:suite-common/wallet-config"
   dependencies:
     "@suite-common/earn-api": "workspace:*"
+    "@suite-common/wallet-constants": "workspace:*"
     "@trezor/device-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Attemps to add tracking for the staking providers in the `coin_discovery` event. The problem is that staking is wired in weridy and I want avoid import circles

## Notes for QA

If possible, test somehow if the FiveBinaries are displayed in the tracking for Cardano staking.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24846

## Screenshots:


🔍🖥️ **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24846-coin-discovery-staking&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24846-coin-discovery-staking&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24846-coin-discovery-staking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24846-coin-discovery-staking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-13T12:36:26.980Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T08:55:10.148Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->