### PR TITLE
fix(trade): disable sell or swap unless fees are composed

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -32,6 +32,7 @@ import {
     selectTradingIsSlip24Allowed,
     selectTradingTrades,
     selectTradingVerifiedAddress,
+    tradingActions,
     tradingExchangeActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -241,6 +242,19 @@ export const useTradingExchangeForm = ({
         methods,
         setShowReserveBanner,
     });
+
+    useEffect(() => {
+        if (pageType !== 'form') return;
+
+        dispatch(tradingActions.saveComposedTransactionInfo({}));
+    }, [
+        dispatch,
+        pageType,
+        values?.sendCryptoSelect?.id,
+        values?.receiveCryptoSelect?.id,
+        output?.amount,
+        values?.provider,
+    ]);
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -208,6 +208,22 @@ export const useTradingSellForm = ({
         setShowReserveBanner,
     });
 
+    useEffect(() => {
+        if (pageType !== 'form') return;
+
+        dispatch(tradingActions.saveComposedTransactionInfo({}));
+    }, [
+        dispatch,
+        pageType,
+        values?.sendCryptoSelect?.id,
+        output?.amount,
+        output?.fiat,
+        values?.paymentMethod?.value,
+        values?.provider,
+        values?.countrySelect?.value,
+        values?.countrySubdivisionSelect?.value,
+    ]);
+
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
         account,
         methods,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -8,6 +8,7 @@ import {
     type TradingType,
     isCountrySubdivisionEmpty,
     isSendingEvmNativeToken,
+    selectTradingComposedTransactionInfo,
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
@@ -45,6 +46,9 @@ import { TradingRevokeModal } from './TradingRevokeModal';
 import { useIsContentBelowBreakpoint } from '../../../../../support/suite/ContentFlex';
 import { useReceiveAddressModalControls } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 import { TradingUtilsTorWarning } from '../TradingUtils/TradingUtilsTorWarning';
+
+const isFeeRequiredButMissing = (fee: string | undefined, type: TradingType) =>
+    (type === 'sell' || type === 'exchange') && (fee === undefined || fee === '');
 
 const getQuotesFilteredByPaymentMethod = (
     quotes: BuyTrade[] | SellFiatTrade[],
@@ -114,7 +118,11 @@ export const TradingFormOffer = () => {
     const quote = preselectedQuote ?? getSelectedQuote(context);
     const bestScoredQuoteAmounts = getCryptoQuoteAmountProps(quote, context);
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, account.symbol));
+    const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+
+    const fee = composedTransactionInfo?.composed?.fee;
+    const isFeeRequiredButMissingValue = isFeeRequiredButMissing(fee, type);
 
     const selectedCryptoId = getSelectedCryptoId(context);
     const receiveCurrency = bestScoredQuoteAmounts?.receiveCurrency;
@@ -241,7 +249,9 @@ export const TradingFormOffer = () => {
         tradingDeviceDisconnected ||
         state.isLoadingOrInvalid ||
         !quote ||
-        amountTooHigh;
+        amountTooHigh ||
+        areFeesLoading ||
+        isFeeRequiredButMissingValue;
 
     const isLoading = requiresTokenApproval
         ? state.isFormLoading || isLoadingQuote || isQuoteOutdated


### PR DESCRIPTION
When user got quote, the sell button got green before the transaction fees were precomposed. Now it waits for the fees and discards precomposed fees on changing erlevant params.

## Notes for QA
there should always be the fees visible when Swap/Sell button is enabled



🔍🖥️ **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trade/disable-sell-swap-while-loading-fees&lookback=7)

🔍🖥️ **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trade/disable-sell-swap-while-loading-fees&lookback=7)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trade/disable-sell-swap-while-loading-fees&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trade/disable-sell-swap-while-loading-fees&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-09T07:36:24.591Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T19:07:03.248Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->