### PR TITLE
refactor(components): update Checkbox and Radio components

### DIFF
--- a/packages/analytics-docs/src/components/AddEventModal/AttributeEditor.tsx
+++ b/packages/analytics-docs/src/components/AddEventModal/AttributeEditor.tsx
@@ -88,7 +88,7 @@ export const AttributeEditor = ({
 
                     <Checkbox
                         isChecked={attr.isOptional}
-                        onClick={() => onChange({ ...attr, isOptional: !attr.isOptional })}
+                        onChange={() => onChange({ ...attr, isOptional: !attr.isOptional })}
                     >
                         <Row gap={4} alignItems="center">
                             <Text>optional</Text>

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -54,7 +54,7 @@ const Container = styled.div<
     border: 0 solid
         ${({ $borderColor, $elevation, theme }) =>
             $borderColor ? theme[$borderColor] : mapElevationToBorder({ theme, $elevation })};
-    transition: background 0.3s ease;
+    transition: 0.2s ease;
 
     ${({ $borderWidth }) => {
         if ($borderWidth == null || $borderWidth === 0) return null;
@@ -92,6 +92,11 @@ const Container = styled.div<
         css`
             box-shadow: ${$shadow};
         `}
+
+    &:focus-visible {
+        outline: 4px solid ${({ theme }) => theme.stateBorderElementFocused};
+        outline-offset: 2px;
+    }
 
     ${withFrameProps};
 `;

--- a/packages/components/src/components/buttons/utils.ts
+++ b/packages/components/src/components/buttons/utils.ts
@@ -3,6 +3,7 @@ import { DefaultTheme, RuleSet, css } from 'styled-components';
 import { BorderRadii, Color, TypographyStyle } from '@trezor/theme';
 
 import { ButtonIntent, ButtonPriority, ButtonSize, CommonButtonProps, InverseKey } from './types';
+import { commonFocusStyles } from '../../utils/utils';
 
 export const pickButtonProps = ({
     href,
@@ -49,8 +50,7 @@ export const commonButtonStyles = css`
     transition: 0.1s ease-in-out;
 
     &:focus-visible {
-        outline: 4px solid ${({ theme }) => theme.stateBorderElementFocused};
-        outline-offset: 2px;
+        ${commonFocusStyles}
     }
 
     &:disabled {

--- a/packages/components/src/components/colors.stories.tsx
+++ b/packages/components/src/components/colors.stories.tsx
@@ -152,13 +152,13 @@ const Header = () => {
                     />
                 </Box>
                 <Row gap={20}>
-                    <Checkbox onClick={toggleV1} isChecked={isV1Visible}>
+                    <Checkbox onChange={toggleV1} isChecked={isV1Visible}>
                         <BadgeV1 />
                     </Checkbox>
-                    <Checkbox onClick={toggleV2} isChecked={isV2Visible}>
+                    <Checkbox onChange={toggleV2} isChecked={isV2Visible}>
                         <BadgeV2 />
                     </Checkbox>
-                    <Checkbox onClick={toggleColorCode} isChecked={isColorCodeVisible}>
+                    <Checkbox onChange={toggleColorCode} isChecked={isColorCodeVisible}>
                         #
                     </Checkbox>
                 </Row>

--- a/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,13 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from 'storybook/preview-api';
 
-import {
-    Checkbox as CheckboxComponent,
-    allowedCheckboxFrameProps,
-    checkboxVariants,
-    labelAlignments,
-    verticalAlignments,
-} from './Checkbox';
+import { Checkbox as CheckboxComponent, allowedCheckboxFrameProps } from './Checkbox';
+import { labelAlignments, verticalAlignments } from './types';
 import { getFramePropsStory } from '../../../utils/frameProps';
 
 const meta: Meta<typeof CheckboxComponent> = {
@@ -23,19 +18,13 @@ export const Checkbox: StoryObj<typeof meta> = {
         const handleIsChecked = () => updateArgs({ isChecked: !isChecked });
 
         return (
-            <CheckboxComponent
-                variant="primary"
-                isChecked={isChecked}
-                {...args}
-                onClick={handleIsChecked}
-            >
+            <CheckboxComponent isChecked={isChecked} {...args} onChange={handleIsChecked}>
                 {args.children}
             </CheckboxComponent>
         );
     },
     args: {
-        children: 'Checkbox',
-        variant: 'primary',
+        children: 'Label',
         isChecked: false,
         isDisabled: false,
         labelAlignment: 'end',
@@ -44,11 +33,11 @@ export const Checkbox: StoryObj<typeof meta> = {
     },
 
     argTypes: {
-        variant: {
-            control: {
-                type: 'radio',
-            },
-            options: checkboxVariants,
+        isChecked: {
+            control: 'boolean',
+        },
+        isDisabled: {
+            control: 'boolean',
         },
         labelAlignment: {
             control: {

--- a/packages/components/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/form/Checkbox/Checkbox.tsx
@@ -1,20 +1,15 @@
-import { EventHandler, KeyboardEvent, ReactNode, SyntheticEvent } from 'react';
+import { EventHandler, MouseEventHandler, ReactNode, SyntheticEvent } from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { Color, borders, spacingsPx, typography } from '@trezor/theme';
+import { borders } from '@trezor/theme';
 
-import { UIAlignment, UIVariant } from '../../../config/types';
-import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
-import {
-    FrameProps,
-    FramePropsKeys,
-    pickAndPrepareFrameProps,
-    withFrameProps,
-} from '../../../utils/frameProps';
-import { TransientProps } from '../../../utils/transientProps';
-import { getFocusShadowStyle } from '../../../utils/utils';
+import { LabelAlignment, VerticalAlignment } from './types';
+import { FrameProps, FramePropsKeys, pickAndPrepareFrameProps } from '../../../utils/frameProps';
+import { Row } from '../../Flex/Flex';
 import { Icon } from '../../Icon/Icon';
+import { Text } from '../../typography/Text/Text';
+import { commonCheckInputStyles } from '../utils';
 
 export const allowedCheckboxFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 export type AllowedCheckboxFrameProps = Pick<
@@ -22,220 +17,86 @@ export type AllowedCheckboxFrameProps = Pick<
     (typeof allowedCheckboxFrameProps)[number]
 >;
 
-interface VariantStyles {
-    background: Color;
-    border: Color;
-    backgroundHover: Color;
-    borderHover: Color;
-    backgroundChecked: Color;
-    borderChecked: Color;
-    backgroundDisabled: Color;
-    borderDisabled: Color;
-    backgroundDisabledChecked: Color;
-    borderDisabledChecked: Color;
-}
-
-export const variantStyles: Record<CheckboxVariant, VariantStyles> = {
-    primary: {
-        background: 'backgroundSurfaceElevation1',
-        border: 'iconSubdued',
-        backgroundHover: 'backgroundSurfaceElevation0',
-        borderHover: 'borderFocus',
-        backgroundChecked: 'backgroundPrimaryDefault',
-        borderChecked: 'backgroundPrimaryDefault',
-        backgroundDisabled: 'backgroundSurfaceElevationNegative',
-        borderDisabled: 'borderElevation1',
-        backgroundDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
-        borderDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
-    },
-    destructive: {
-        background: 'backgroundAlertRedSubtleOnElevation0',
-        border: 'borderAlertRed',
-        backgroundHover: 'backgroundSurfaceElevation0',
-        borderHover: 'borderAlertRed',
-        backgroundChecked: 'borderAlertRed',
-        borderChecked: 'borderAlertRed',
-        backgroundDisabled: 'backgroundSurfaceElevationNegative',
-        borderDisabled: 'backgroundAlertRedSubtleOnElevation0',
-        backgroundDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
-        borderDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
-    },
-    warning: {
-        background: 'backgroundAlertYellowSubtleOnElevation0',
-        border: 'backgroundAlertYellowBold',
-        backgroundHover: 'backgroundSurfaceElevation0',
-        borderHover: 'backgroundAlertYellowBold',
-        backgroundChecked: 'backgroundAlertYellowBold',
-        borderChecked: 'backgroundAlertYellowBold',
-        backgroundDisabled: 'backgroundSurfaceElevationNegative',
-        borderDisabled: 'backgroundAlertYellowSubtleOnElevation0',
-        backgroundDisabledChecked: 'backgroundAlertYellowSubtleOnElevation1',
-        borderDisabledChecked: 'backgroundAlertYellowSubtleOnElevation1',
-    },
-};
-
-type ContainerProps = TransientProps<AllowedCheckboxFrameProps> & {
-    $isDisabled?: boolean;
-    $labelAlignment?: LabelAlignment;
-    $verticalAlignment?: VerticalAlignment;
-};
-
-export const Container = styled.div<ContainerProps>`
-    display: flex;
-    align-items: ${({ $verticalAlignment }) =>
-        $verticalAlignment === 'start' ? 'flex-start' : 'center'};
-    gap: ${spacingsPx.sm};
-    flex-direction: ${({ $labelAlignment }) => $labelAlignment === 'start' && 'row-reverse'};
-    pointer-events: ${({ $isDisabled }) => $isDisabled && 'none'};
-    cursor: ${({ $isDisabled }) => ($isDisabled ? 'default' : 'pointer')};
-    ${withFrameProps}
-`;
-
-export const CheckContainer = styled.div<{ $variant: CheckboxVariant }>`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: ${spacingsPx.xl};
-    height: ${spacingsPx.xl};
-    min-width: ${spacingsPx.xl};
-    min-height: ${spacingsPx.xl};
-    border-radius: ${borders.radii.xxs};
-    background: ${({ theme, $variant }) => theme[variantStyles[$variant].background]};
-    border: 2px solid ${({ theme, $variant }) => theme[variantStyles[$variant].border]};
-    transition:
-        border 0.1s,
-        background 0.1s,
-        box-shadow 0.1s ease-out;
-
-    input:checked + & {
-        background: ${({ theme, $variant }) => theme[variantStyles[$variant].backgroundChecked]};
-        border-color: ${({ theme, $variant }) => theme[variantStyles[$variant].borderChecked]};
-    }
-
-    input:disabled + & {
-        cursor: not-allowed;
-        pointer-events: auto;
-    }
-
-    input:disabled:not(:checked) + & {
-        background: ${({ theme, $variant }) => theme[variantStyles[$variant].backgroundDisabled]};
-        border-color: ${({ theme, $variant }) => theme[variantStyles[$variant].borderDisabled]};
-    }
-
-    input:disabled:checked + & {
-        background: ${({ theme, $variant }) =>
-            theme[variantStyles[$variant].backgroundDisabledChecked]};
-        border-color: ${({ theme, $variant }) =>
-            theme[variantStyles[$variant].backgroundDisabledChecked]};
-    }
-
-    ${/* sc-selector */ Container}:hover input:not(:disabled):not(:checked) + && {
-        background: ${({ theme, $variant }) => theme[variantStyles[$variant].backgroundHover]};
-        border-color: ${({ theme, $variant }) => theme[variantStyles[$variant].borderHover]};
-    }
-
-    ${getFocusShadowStyle()}
-`;
-
-const CheckIcon = styled(Icon)<{ $isVisible: boolean }>`
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: opacity 0.1s;
-`;
-
-export const Label = styled.div<{ $isRed: boolean }>`
-    display: flex;
-    flex: 1;
-    text-align: left;
-    user-select: none;
-    color: ${({ theme, $isRed }) => $isRed && theme.textAlertRed};
-    ${typography['body-md']}
-    transition: color 0.1s;
-
-    input:disabled ~ & {
-        color: ${({ theme }) => theme.textDisabled};
-    }
-`;
-
-export const HiddenInput = styled.input`
+const HiddenInput = styled.input`
     position: absolute;
     opacity: 0;
     width: 0;
     height: 0;
 `;
 
-export const checkboxVariants = ['primary', 'destructive', 'warning'] as const;
-export type CheckboxVariant = Extract<UIVariant, (typeof checkboxVariants)[number]>;
+const FakeInput = styled.div`
+    ${commonCheckInputStyles}
 
-export const labelAlignments = ['start', 'end'] as const;
-export type LabelAlignment = Extract<UIAlignment, (typeof labelAlignments)[number]>;
+    border-radius: ${borders.radii.xxs};
 
-export const verticalAlignments = ['start', 'center'] as const;
-export type VerticalAlignment = Extract<UIAlignment, (typeof verticalAlignments)[number]>;
+    ${({ theme }) => css`
+        input:checked + & {
+            background-color: ${theme.backgroundPrimaryDefault};
+        }
 
-// export type LabelAlignment = Alignment;
-// export type VerticalAlignment = Alignment;
+        input:not(:checked) + & > * {
+            opacity: 0;
+        }
+
+        input:checked:disabled + & {
+            border-color: ${theme.backgroundPrimarySubtleOnElevation0};
+            background-color: ${theme.backgroundPrimarySubtleOnElevation0};
+        }
+    `}
+`;
 
 export type CheckboxProps = AllowedCheckboxFrameProps & {
-    variant?: CheckboxVariant;
     isChecked?: boolean;
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     verticalAlignment?: VerticalAlignment;
-    onClick: EventHandler<SyntheticEvent>;
+    onChange: EventHandler<SyntheticEvent>;
+    onClick?: MouseEventHandler<HTMLLabelElement>;
     'data-testid'?: string;
-    className?: string;
     children?: ReactNode;
 };
 
 export const Checkbox = ({
-    variant = 'primary',
     isChecked,
     isDisabled = false,
     labelAlignment = 'end',
     verticalAlignment = 'start',
+    onChange,
     onClick,
     'data-testid': dataTest,
-    className,
     children,
     ...rest
 }: CheckboxProps) => {
-    const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
-        if (
-            !isDisabled &&
-            (event.code === KEYBOARD_CODE.SPACE || event.code === KEYBOARD_CODE.ENTER)
-        ) {
-            onClick(event);
-        }
-    };
-
-    const frameProps = pickAndPrepareFrameProps(rest, allowedCheckboxFrameProps);
+    const frameProps = pickAndPrepareFrameProps(rest, allowedCheckboxFrameProps, false);
 
     return (
-        <Container
-            // @ts-expect-error - needed for playwright retry-ability
-            disabled={isDisabled}
+        <Row
+            gap={12}
+            alignItems={verticalAlignment === 'start' ? 'flex-start' : 'center'}
             data-testid={dataTest}
-            $isDisabled={isDisabled}
-            $labelAlignment={labelAlignment}
-            $verticalAlignment={verticalAlignment}
-            onClick={isDisabled ? undefined : onClick}
-            onKeyUp={handleKeyUp}
-            className={className}
+            isReversed={labelAlignment === 'start'}
+            cursor={isDisabled ? 'not-allowed' : 'pointer'}
+            as="label"
+            onClick={onClick}
             {...frameProps}
         >
             <HiddenInput
                 checked={isChecked}
                 disabled={isDisabled}
-                readOnly
+                onChange={onChange}
                 type="checkbox"
-                tabIndex={-1}
+                tabIndex={0}
             />
 
-            <CheckContainer tabIndex={0} $variant={variant}>
-                <CheckIcon $isVisible={!!isChecked} size={16} color="iconOnPrimary" name="check" />
-            </CheckContainer>
+            <FakeInput>
+                <Icon size={16} color="iconOnPrimary" name="check" />
+            </FakeInput>
 
-            {children && <Label $isRed={variant === 'destructive'}>{children}</Label>}
-        </Container>
+            {children && (
+                <Text typographyStyle="body-md" flex="1" isDisabled={isDisabled} as="div">
+                    {children}
+                </Text>
+            )}
+        </Row>
     );
 };

--- a/packages/components/src/components/form/Checkbox/types.ts
+++ b/packages/components/src/components/form/Checkbox/types.ts
@@ -1,0 +1,7 @@
+import { UIAlignment } from '../../../config/types';
+
+export const labelAlignments = ['start', 'end'] as const;
+export type LabelAlignment = Extract<UIAlignment, (typeof labelAlignments)[number]>;
+
+export const verticalAlignments = ['start', 'center'] as const;
+export type VerticalAlignment = Extract<UIAlignment, (typeof verticalAlignments)[number]>;

--- a/packages/components/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/components/src/components/form/Radio/Radio.stories.tsx
@@ -1,24 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { useArgs } from 'storybook/preview-api';
-import styled from 'styled-components';
 
-import { Radio as RadioComponent, RadioProps, radioVariants } from './Radio';
+import { Radio as RadioComponent } from './Radio';
 import { getFramePropsStory } from '../../../utils/frameProps';
-import { H2 } from '../../typography/Heading/Heading';
-import {
-    allowedCheckboxFrameProps,
-    labelAlignments,
-    verticalAlignments,
-} from '../Checkbox/Checkbox';
-
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-
-    & > * {
-        padding: 10px;
-    }
-`;
+import { allowedCheckboxFrameProps } from '../Checkbox/Checkbox';
+import { labelAlignments, verticalAlignments } from '../Checkbox/types';
 
 const meta: Meta<typeof RadioComponent> = {
     title: '✏️ Form',
@@ -26,33 +12,33 @@ const meta: Meta<typeof RadioComponent> = {
 };
 export default meta;
 
-export const RadioButton: StoryObj<RadioProps> = {
+export const Radio: StoryObj<typeof meta> = {
     render: ({ ...args }) => {
         // eslint-disable-next-line
         const [{ isChecked }, updateArgs] = useArgs();
         const handleIsChecked = () => updateArgs({ isChecked: !isChecked });
 
         return (
-            <RadioComponent {...args} onClick={handleIsChecked} isChecked={isChecked}>
+            <RadioComponent {...args} onChange={handleIsChecked} isChecked={isChecked}>
                 {args.children}
             </RadioComponent>
         );
     },
     args: {
-        children: 'RadioButton',
-        variant: 'primary',
+        children: 'Label',
         isChecked: false,
         isDisabled: false,
         labelAlignment: 'end',
         verticalAlignment: 'start',
         ...getFramePropsStory(allowedCheckboxFrameProps).args,
     },
+
     argTypes: {
-        variant: {
-            control: {
-                type: 'radio',
-            },
-            options: radioVariants,
+        isChecked: {
+            control: 'boolean',
+        },
+        isDisabled: {
+            control: 'boolean',
         },
         labelAlignment: {
             control: {
@@ -68,40 +54,4 @@ export const RadioButton: StoryObj<RadioProps> = {
         },
         ...getFramePropsStory(allowedCheckboxFrameProps).argTypes,
     },
-};
-
-export const RadioButtonGroup: StoryObj = {
-    render: () => {
-        // eslint-disable-next-line
-        const [{ option }, updateArgs] = useArgs();
-
-        const setOption = (option2: string) => updateArgs({ option: option2 });
-
-        return (
-            <Wrapper>
-                <RadioComponent
-                    onClick={() => setOption('option1')}
-                    isChecked={option === 'option1'}
-                >
-                    <div>
-                        <H2>Some heading</H2>
-                        First option (example of custom content)
-                    </div>
-                </RadioComponent>
-                <RadioComponent
-                    onClick={() => setOption('option2')}
-                    isChecked={option === 'option2'}
-                >
-                    Second option
-                </RadioComponent>
-                <RadioComponent
-                    onClick={() => setOption('option3')}
-                    isChecked={option === 'option3'}
-                >
-                    Third option
-                </RadioComponent>
-            </Wrapper>
-        );
-    },
-    args: { option: 'option1' },
 };

--- a/packages/components/src/components/form/Radio/Radio.tsx
+++ b/packages/components/src/components/form/Radio/Radio.tsx
@@ -1,166 +1,117 @@
-import { EventHandler, KeyboardEvent, ReactNode, SyntheticEvent } from 'react';
+import { EventHandler, MouseEventHandler, ReactNode, SyntheticEvent } from 'react';
 
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-import { Color, borders } from '@trezor/theme';
+import { borders } from '@trezor/theme';
 
-import { UIVariant } from '../../../config/types';
-import { KEYBOARD_CODE } from '../../../constants/keyboardEvents';
 import { pickAndPrepareFrameProps } from '../../../utils/frameProps';
-import { getFocusShadowStyle } from '../../../utils/utils';
-import {
-    AllowedCheckboxFrameProps,
-    CheckContainer,
-    Container,
-    HiddenInput,
-    Label,
-    LabelAlignment,
-    VerticalAlignment,
-    allowedCheckboxFrameProps,
-    variantStyles,
-} from '../Checkbox/Checkbox';
+import { Row } from '../../Flex/Flex';
+import { Text } from '../../typography/Text/Text';
+import { AllowedCheckboxFrameProps, allowedCheckboxFrameProps } from '../Checkbox/Checkbox';
+import { LabelAlignment, VerticalAlignment } from '../Checkbox/types';
+import { commonCheckInputStyles } from '../utils';
 
-interface VariantStyles {
-    borderChecked: Color;
-    dotDisabledChecked: Color;
-    borderDisabledChecked: Color;
-}
+const HiddenInput = styled.input`
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+`;
 
-export const radioVariants = ['primary', 'destructive', 'warning'] as const;
-export type RadioVariant = Extract<UIVariant, (typeof radioVariants)[number]>;
+const FakeInput = styled.div`
+    ${commonCheckInputStyles}
 
-const radioVariantStyles: Record<RadioVariant, VariantStyles> = {
-    primary: {
-        borderChecked: 'backgroundSecondaryDefault',
-        dotDisabledChecked: 'backgroundPrimarySubtleOnElevation0',
-        borderDisabledChecked: 'backgroundPrimarySubtleOnElevation1',
-    },
-    destructive: {
-        borderChecked: 'backgroundAlertRedSubtleOnElevation0',
-        dotDisabledChecked: 'backgroundAlertRedSubtleOnElevation0',
-        borderDisabledChecked: 'backgroundAlertRedSubtleOnElevation1',
-    },
-    warning: {
-        borderChecked: 'backgroundAlertYellowSubtleOnElevation0',
-        dotDisabledChecked: 'backgroundAlertYellowSubtleOnElevation0',
-        borderDisabledChecked: 'backgroundAlertYellowSubtleOnElevation1',
-    },
-};
-
-const RadioIcon = styled(CheckContainer)`
     position: relative;
     border-radius: ${borders.radii.full};
 
     &::after {
         content: '';
-        position: absolute;
-        top: 3px;
-        left: 3px;
         width: 14px;
         height: 14px;
         border-radius: 50%;
-        background: ${({ theme, $variant }) => theme[variantStyles[$variant].background]};
-        transition: background 0.1s;
+        opacity: 0;
+        transition: 0.1s ease-in-out;
     }
 
-    input:checked + & {
-        background: ${({ theme }) => theme.backgroundSurfaceElevation0};
-        border-color: ${({ theme, $variant }) => theme[radioVariantStyles[$variant].borderChecked]};
-
+    ${({ theme }) => css`
         &::after {
-            background: ${({ theme, $variant }) =>
-                theme[variantStyles[$variant].backgroundChecked]};
+            background-color: ${theme.backgroundPrimaryDefault};
         }
-    }
 
-    input:disabled + & {
-        cursor: not-allowed;
-    }
+        input:checked + & {
+            background-color: ${theme.backgroundSurfaceElevation0};
 
-    input:disabled:not(:checked) + & {
-        background: ${({ theme }) => theme.backgroundSurfaceElevation0};
-        border-color: ${({ theme, $variant }) => theme[variantStyles[$variant].borderDisabled]};
-
-        &::after {
-            background: transparent;
+            &::after {
+                opacity: 1;
+            }
         }
-    }
 
-    input:disabled:checked + & {
-        background: transparent;
-        border-color: ${({ theme, $variant }) =>
-            theme[radioVariantStyles[$variant].borderDisabledChecked]};
-
-        &::after {
-            background: ${({ theme, $variant }) =>
-                theme[radioVariantStyles[$variant].dotDisabledChecked]};
+        input:disabled:not(:checked) + &::after {
+            background-color: transparent;
         }
-    }
 
-    ${/* sc-selector */ Container}:hover input:not(:disabled):not(:checked) + & {
-        &::after {
-            background: ${({ theme, $variant }) => theme[variantStyles[$variant].backgroundHover]};
+        input:checked:disabled + & {
+            border-color: ${theme.backgroundPrimarySubtleOnElevation1};
+            background-color: transparent;
+
+            &::after {
+                background-color: ${theme.backgroundPrimarySubtleOnElevation0};
+            }
         }
-    }
-
-    ${getFocusShadowStyle()}
+    `}
 `;
 
 export type RadioProps = AllowedCheckboxFrameProps & {
-    variant?: RadioVariant;
     isChecked?: boolean;
     isDisabled?: boolean;
     labelAlignment?: LabelAlignment;
     verticalAlignment?: VerticalAlignment;
-    onClick: EventHandler<SyntheticEvent>;
+    onChange: EventHandler<SyntheticEvent>;
+    onClick?: MouseEventHandler<HTMLLabelElement>;
     'data-testid'?: string;
     children?: ReactNode;
 };
 
 export const Radio = ({
-    variant = 'primary',
     isChecked,
     labelAlignment = 'end',
     verticalAlignment = 'start',
     isDisabled = false,
+    onChange,
     onClick,
     'data-testid': dataTest,
     children,
     ...rest
 }: RadioProps) => {
-    const handleKeyUp = (event: KeyboardEvent<HTMLElement>) => {
-        if (
-            !isDisabled &&
-            (event.code === KEYBOARD_CODE.SPACE || event.code === KEYBOARD_CODE.ENTER)
-        ) {
-            onClick(event);
-        }
-    };
-
-    const frameProps = pickAndPrepareFrameProps(rest, allowedCheckboxFrameProps);
+    const frameProps = pickAndPrepareFrameProps(rest, allowedCheckboxFrameProps, false);
 
     return (
-        <Container
-            onClick={isDisabled ? undefined : onClick}
-            onKeyUp={handleKeyUp}
-            $isDisabled={isDisabled}
-            $labelAlignment={labelAlignment}
-            $verticalAlignment={verticalAlignment}
-            data-checked={isChecked}
+        <Row
+            gap={12}
+            alignItems={verticalAlignment === 'start' ? 'flex-start' : 'center'}
             data-testid={dataTest}
+            data-checked={isChecked}
+            isReversed={labelAlignment === 'start'}
+            cursor={isDisabled ? 'not-allowed' : 'pointer'}
+            as="label"
+            onClick={onClick}
             {...frameProps}
         >
             <HiddenInput
-                type="radio"
                 checked={isChecked}
                 disabled={isDisabled}
-                readOnly
-                tabIndex={-1}
+                onChange={onChange}
+                type="radio"
+                tabIndex={0}
             />
 
-            <RadioIcon $variant={variant} tabIndex={0} />
+            <FakeInput />
 
-            {children && <Label $isRed={variant === 'destructive'}>{children}</Label>}
-        </Container>
+            {children && (
+                <Text typographyStyle="body-md" flex="1" isDisabled={isDisabled} as="div">
+                    {children}
+                </Text>
+            )}
+        </Row>
     );
 };

--- a/packages/components/src/components/form/utils.ts
+++ b/packages/components/src/components/form/utils.ts
@@ -1,8 +1,9 @@
 import { css } from 'styled-components';
 
-import { SpacingValuesNew, TypographyStyle } from '@trezor/theme';
+import { SpacingValuesNew, TypographyStyle, borders } from '@trezor/theme';
 
 import { InputSize } from './types';
+import { commonFocusStyles } from '../../utils/utils';
 
 const heightMap: Record<InputSize, number> = {
     small: 36,
@@ -48,3 +49,37 @@ export const commonInputStyles = css`
 `;
 
 export const INPUT_PADDING: SpacingValuesNew = 16;
+
+export const commonCheckInputStyles = css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: ${borders.widths.large} solid;
+    transition: 0.1s ease-in-out;
+
+    ${({ theme }) => css`
+        border-color: ${theme.iconSubdued};
+        background-color: ${theme.backgroundSurfaceElevation1};
+
+        input:checked + & {
+            border-color: ${theme.backgroundPrimaryDefault};
+        }
+
+        input:disabled:not(:checked) + & {
+            border-color: ${theme.borderElevation1};
+            background-color: ${theme.backgroundSurfaceElevationNegative};
+        }
+
+        label:hover > input:not(:disabled, :checked) + & {
+            border-color: ${theme.borderFocus};
+            background-color: ${theme.backgroundSurfaceElevation0};
+        }
+
+        input:focus-visible + & {
+            ${commonFocusStyles}
+        }
+    `}
+`;

--- a/packages/components/src/utils/utils.ts
+++ b/packages/components/src/utils/utils.ts
@@ -11,6 +11,11 @@ export const getFocusShadowStyle = (selector = '&:focus-visible') => css`
     }
 `;
 
+export const commonFocusStyles = css`
+    outline: 4px solid ${({ theme }) => theme.stateBorderElementFocused};
+    outline-offset: 2px;
+`;
+
 export const addAlphaToHex = (hex: CSSColor, percent: number): CSSColor => {
     const cleanHex = hex.replace(/^#/, '');
     const clampedPercent = Math.min(1, Math.max(0, percent));

--- a/packages/connect-explorer/src/components/fields/Checkbox.tsx
+++ b/packages/connect-explorer/src/components/fields/Checkbox.tsx
@@ -12,7 +12,7 @@ interface CheckboxProps {
 const Checkbox = ({ field, onChange, ...rest }: CheckboxProps) => (
     <Row>
         <Card paddingType="small" onClick={() => onChange(field, !field.value)}>
-            <CheckboxComponent onClick={() => {}} isChecked={field.value} {...rest}>
+            <CheckboxComponent onChange={() => {}} isChecked={field.value} {...rest}>
                 {field.name}
             </CheckboxComponent>
         </Card>

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -77,7 +77,7 @@ export const Available = ({ onCancel, latest }: AvailableProps) => {
             <Card margin={{ top: spacings.xxl }}>
                 <Checkbox
                     isChecked={enableAutoupdateOnNextRun}
-                    onClick={handleToggleAutoUpdateClick}
+                    onChange={handleToggleAutoUpdateClick}
                 >
                     <Translation id="TR_UPDATE_MODAL_ENABLE_AUTO_UPDATES" />
                 </Checkbox>

--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -52,7 +52,7 @@ export const BackupSeedCards = () => {
                                 <Icon name={item.icon} intent="neutral" priority="secondary" />
                                 <Checkbox
                                     isChecked={isChecked(item.key)}
-                                    onClick={event => {
+                                    onChange={event => {
                                         event.preventDefault();
                                     }}
                                 />

--- a/packages/suite/src/components/earn/VotingDelegations/VotingDelegationsOptions.tsx
+++ b/packages/suite/src/components/earn/VotingDelegations/VotingDelegationsOptions.tsx
@@ -86,7 +86,7 @@ export const VotingDelegationsOptions = ({
                         <Radio
                             key={key}
                             isChecked={selectedVotingDelegation.type === key}
-                            onClick={() => handleOptionSelect(key)}
+                            onChange={() => handleOptionSelect(key)}
                         >
                             <Translation id={translationId} />
                         </Radio>

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/EarnProviderConsentModalLayout.tsx
@@ -71,7 +71,7 @@ export const EarnProviderConsentModalLayout = ({
                     <Checkbox
                         data-testid="@staking/provider-acknowledge-checkbox"
                         verticalAlignment="center"
-                        onClick={() => setHasAgreed(!hasAgreed)}
+                        onChange={() => setHasAgreed(!hasAgreed)}
                         isChecked={hasAgreed}
                     >
                         {consentText}

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -142,7 +142,7 @@ export const ConfirmStakeModal = ({
             <Card>
                 <Checkbox
                     data-testid="@staking/acknowledge-checkbox"
-                    onClick={() => setHasAgreed(!hasAgreed)}
+                    onChange={() => setHasAgreed(!hasAgreed)}
                     isChecked={hasAgreed}
                 >
                     <Translation id="TR_STAKE_ACKNOWLEDGE_ENTRY_PERIOD" />

--- a/packages/suite/src/components/guide/SupportConsentPopover.tsx
+++ b/packages/suite/src/components/guide/SupportConsentPopover.tsx
@@ -33,7 +33,7 @@ export const SupportConsentPopover = ({ children }: SupportConsentPopoverProps) 
                             <Card paddingType="small">
                                 <Checkbox
                                     isChecked={isSystemInfoShared}
-                                    onClick={() => setIsSystemInfoShared(prev => !prev)}
+                                    onChange={() => setIsSystemInfoShared(prev => !prev)}
                                     data-testid="@guide/support/share-system-info"
                                 >
                                     <Translation id="TR_GUIDE_SUPPORT_CONSENT_TOGGLE" />

--- a/packages/suite/src/components/suite/CheckItem.tsx
+++ b/packages/suite/src/components/suite/CheckItem.tsx
@@ -19,7 +19,7 @@ export const CheckItem = ({
     onClick,
     ...rest
 }: CheckItemProps) => (
-    <Checkbox isChecked={isChecked} onClick={onClick} {...rest}>
+    <Checkbox isChecked={isChecked} onChange={onClick} {...rest}>
         <Column alignItems="flex-start" gap={spacings.xs}>
             <Paragraph>{title}</Paragraph>
             {description && (

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -67,7 +67,7 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
                 <Translation id={getAddressTypeText(addressType)} />
             </Paragraph>
             <Card margin={{ top: spacings.xl }}>
-                <Checkbox isChecked={checked} onClick={() => setChecked(!checked)}>
+                <Checkbox isChecked={checked} onChange={() => setChecked(!checked)}>
                     <Translation id="TR_DO_NOT_SHOW_AGAIN" />
                 </Checkbox>
             </Card>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -65,7 +65,7 @@ export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) =
                 <Translation id="TR_UNHIDE_TOKEN_TEXT" />
             </Paragraph>
             <Card margin={{ top: spacings.xl }}>
-                <Checkbox isChecked={checked} onClick={() => setChecked(!checked)}>
+                <Checkbox isChecked={checked} onChange={() => setChecked(!checked)}>
                     <Translation id="TR_DO_NOT_SHOW_AGAIN" />
                 </Checkbox>
             </Card>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AutoStartBeforeQuitModal.tsx
@@ -72,7 +72,7 @@ export const AutoStartBeforeQuitModal = () => {
                     <Checkbox
                         data-testid="auto-start-before-quit/dont-ask-again-checkbox"
                         isChecked={dontAskAgain}
-                        onClick={() => setDontAskAgain(!dontAskAgain)}
+                        onChange={() => setDontAskAgain(!dontAskAgain)}
                     >
                         <Translation id="TR_DONT_ASK_AGAIN" />
                     </Checkbox>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -151,7 +151,7 @@ export const ConnectPermissionsModal = () => {
                                 <Checkbox
                                     data-testid="@connect-permissions-modal/remember-checkbox"
                                     isChecked={isRemembered}
-                                    onClick={() => setIsRemembered(!isRemembered)}
+                                    onChange={() => setIsRemembered(!isRemembered)}
                                 >
                                     <Translation id="TR_CONNECT_MODAL_REMEMBER" />
                                 </Checkbox>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/CriticalCoinjoinPhaseModal/AutoStopButton.tsx
@@ -20,7 +20,7 @@ export const AutoStopButton = ({ relatedAccountKey }: AutoStopButtonProps) => {
     };
 
     return (
-        <Checkbox isChecked={isActivated} onClick={handleClick} verticalAlignment="center">
+        <Checkbox isChecked={isActivated} onChange={handleClick} verticalAlignment="center">
             <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
                 <Translation id="TR_ENABLE_AUTOSTOP_COINJOIN" />
             </Text>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -41,7 +41,6 @@ export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) 
 
     const [isChecked1, setIsChecked1] = useState(false);
     const [isChecked2, setIsChecked2] = useState(false);
-    const [isSubmitted, setIsSubmitted] = useState(false);
 
     const learnMoreClicked = () => {
         analytics.report({
@@ -73,12 +72,7 @@ export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) 
     const getStepConfig = (): StepConfig => {
         switch (step) {
             case 'first-info': {
-                const goToStepNextStep = () => {
-                    setIsSubmitted(true);
-                    if (isChecked1 && isChecked2) {
-                        setStep('second-info');
-                    }
-                };
+                const goToStepNextStep = () => setStep('second-info');
 
                 return {
                     width: 600,
@@ -86,7 +80,6 @@ export const MultiShareBackupModal = ({ onCancel }: MultiShareBackupModalProps) 
                         <MultiShareBackupStep1
                             isChecked1={isChecked1}
                             isChecked2={isChecked2}
-                            isSubmitted={isSubmitted}
                             setIsChecked1={setIsChecked1}
                             setIsChecked2={setIsChecked2}
                         />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupStep1.tsx
@@ -7,7 +7,6 @@ import { spacings } from '@trezor/theme';
 type MultiShareBackupStep1Props = {
     isChecked1: boolean;
     isChecked2: boolean;
-    isSubmitted: boolean;
     setIsChecked1: Dispatch<SetStateAction<boolean>>;
     setIsChecked2: Dispatch<SetStateAction<boolean>>;
 };
@@ -15,16 +14,9 @@ type MultiShareBackupStep1Props = {
 export const MultiShareBackupStep1 = ({
     isChecked1,
     isChecked2,
-    isSubmitted,
     setIsChecked1,
     setIsChecked2,
 }: MultiShareBackupStep1Props) => {
-    const getCheckboxVariant = (isChecked: boolean) =>
-        isSubmitted && !isChecked ? 'destructive' : undefined;
-
-    const checkboxVariant1 = getCheckboxVariant(isChecked1);
-    const checkboxVariant2 = getCheckboxVariant(isChecked2);
-
     const toggleCheckbox1 = () => setIsChecked1(prev => !prev);
     const toggleCheckbox2 = () => setIsChecked2(prev => !prev);
 
@@ -50,16 +42,14 @@ export const MultiShareBackupStep1 = ({
                 <Column gap={spacings.sm}>
                     <Checkbox
                         isChecked={isChecked1}
-                        onClick={toggleCheckbox1}
-                        variant={checkboxVariant1}
+                        onChange={toggleCheckbox1}
                         data-testid="@multi-share-backup/checkbox/1"
                     >
                         <Translation id="TR_MULTI_SHARE_BACKUP_CHECKBOX_1" />
                     </Checkbox>
                     <Checkbox
                         isChecked={isChecked2}
-                        onClick={toggleCheckbox2}
-                        variant={checkboxVariant2}
+                        onChange={toggleCheckbox2}
                         data-testid="@multi-share-backup/checkbox/2"
                     >
                         <Translation id="TR_MULTI_SHARE_BACKUP_CHECKBOX_2" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SafetyChecksModal.tsx
@@ -56,7 +56,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                 <Column gap={spacings.xl} alignItems="flex-start">
                     <Radio
                         isChecked={level === 'Strict'}
-                        onClick={() => setLevel('Strict')}
+                        onChange={() => setLevel('Strict')}
                         data-testid="@radio-button-strict"
                         verticalAlignment="center"
                     >
@@ -72,7 +72,7 @@ export const SafetyChecksModal = ({ onCancel }: ModalProps) => {
                     <Radio
                         // For the purpose of this modal consider `PromptAlways` as identical to `PromptTemporarily`.
                         isChecked={level === 'PromptTemporarily' || level === 'PromptAlways'}
-                        onClick={() => setLevel('PromptTemporarily')}
+                        onChange={() => setLevel('PromptTemporarily')}
                         data-testid="@radio-button-prompt"
                         verticalAlignment="center"
                     >

--- a/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepCheckSeed.tsx
@@ -147,7 +147,7 @@ export const StepCheckSeed = ({
                 <Card>
                     <Checkbox
                         isChecked={isChecked}
-                        onClick={() => setIsChecked(!isChecked)}
+                        onChange={() => setIsChecked(!isChecked)}
                         data-testid="@firmware/confirm-seed-checkbox"
                     >
                         {checkbox}

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/OptionWithContent.tsx
@@ -112,7 +112,7 @@ const Option = ({
     >
         <Radio
             isChecked={isChecked}
-            onClick={onSelect}
+            onChange={onSelect}
             data-testid={dataTest}
             isDisabled={disabled}
         />

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentFilters.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemExperiment/MessageSystemExperimentFilters.tsx
@@ -11,7 +11,7 @@ export const MessageSystemExperimentFilters = ({
     onToggleActive,
 }: MessageSystemExperimentFiltersProps) => (
     <Row alignItems="center" justifyContent="flex-end" gap={spacings.sm}>
-        <Checkbox onClick={onToggleActive} isChecked={showActive}>
+        <Checkbox onChange={onToggleActive} isChecked={showActive}>
             Show only active
         </Checkbox>
     </Row>

--- a/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerFilters.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/MessageSystem/MessageSystemManager/MessageSystemManagerFilters.tsx
@@ -24,7 +24,7 @@ export const MessageSystemManagerFilters = ({
             size="small"
             onChange={onCategoryChange}
         />
-        <Checkbox onClick={onToggleActive} isChecked={showActive}>
+        <Checkbox onChange={onToggleActive} isChecked={showActive}>
             Show only active
         </Checkbox>
     </Row>

--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -119,7 +119,7 @@ export const QuotaManagerSettings = () => {
                     <Checkbox
                         data-testid="@settings/debug/quota-manager-enforce-for-custom-relay-checkbox"
                         isChecked={enforceQuotaManager}
-                        onClick={onToggleEnforceQuotaManager}
+                        onChange={onToggleEnforceQuotaManager}
                     />
                 </ActionColumn>
             </SectionItem>

--- a/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
@@ -18,7 +18,7 @@ export const ShowBluetoothDebugInfo = () => {
         <SectionItem>
             <TextColumn title="Show Bluetooth Debug Info" />
             <ActionColumn>
-                <Checkbox isChecked={showBluetoothDebugInfo} onClick={handleOnClick} />
+                <Checkbox isChecked={showBluetoothDebugInfo} onChange={handleOnClick} />
             </ActionColumn>
         </SectionItem>
     );

--- a/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
@@ -88,7 +88,7 @@ export const SuiteSyncSettings = () => {
                 <ActionColumn>
                     <Checkbox
                         isChecked={isSuiteSyncDebugEnabled}
-                        onClick={handleToggleSuiteSyncDebug}
+                        onChange={handleToggleSuiteSyncDebug}
                     />
                 </ActionColumn>
             </SectionItem>

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -73,7 +73,7 @@ export const Transport = () => {
                     <ActionColumn>
                         <Checkbox
                             isChecked={transport.checked}
-                            onClick={() => {
+                            onChange={() => {
                                 const nextTransports = items
                                     .filter(t => (t.name === transport.name) !== t.checked)
                                     .map(t => t.name);

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -37,7 +37,7 @@ export const TransportBackends = () => {
                 <ActionColumn>
                     <Checkbox
                         isChecked={bridgeProcess.process}
-                        onClick={() => {
+                        onChange={() => {
                             toggleBridge();
                         }}
                     />
@@ -51,7 +51,7 @@ export const TransportBackends = () => {
                 <ActionColumn>
                     <Checkbox
                         isChecked={!bridgeSettings.doNotStartOnStartup}
-                        onClick={() => {
+                        onChange={() => {
                             changeBridgeSettings({
                                 ...bridgeSettings,
                                 doNotStartOnStartup: !bridgeSettings.doNotStartOnStartup,

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -73,7 +73,7 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
                 ) : (
                     <Checkbox
                         isChecked={checked}
-                        onClick={onChangeFeature}
+                        onChange={onChangeFeature}
                         data-testid={`@settings/experimental-features/${feature}-checkbox`}
                     />
                 )}

--- a/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
+++ b/packages/suite/src/views/wallet/details/CoinjoinSetup/CoinjoinSetup.tsx
@@ -78,14 +78,14 @@ export const CoinjoinSetup = ({ accountKey }: CoinjoinSetupProps) => {
                 <SetupOptions>
                     <Radio
                         isChecked={!coinjoinAccount.setup}
-                        onClick={setRecommendedSetup}
+                        onChange={setRecommendedSetup}
                         isDisabled={hasSession}
                     >
                         <Translation id="TR_RECOMMENDED" />
                     </Radio>
                     <Radio
                         isChecked={!!coinjoinAccount.setup}
-                        onClick={setCustomSetup}
+                        onChange={setCustomSetup}
                         isDisabled={hasSession}
                     >
                         <Translation id="TR_CUSTOM" />

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -176,7 +176,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
                     <Checkbox
                         isChecked={allUtxosSelected}
                         isDisabled={!hasEligibleUtxos}
-                        onClick={handleAllUtxosSelected}
+                        onChange={handleAllUtxosSelected}
                     >
                         <Text intent="neutral" priority="secondary">
                             <Translation id="TR_SELECTED" values={{ amount: inputs.length }} />

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -129,19 +129,14 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
             ?.label ?? outputLabels?.[utxo.txid]?.[utxo.vout];
 
     return (
-        <GhostContainer
-            onClick={handleCheckbox}
-            isActive={isChecked}
-            padding={12}
-            margin={{ horizontal: -12 }}
-            as="div"
-        >
+        <GhostContainer onClick={handleCheckbox} padding={12} margin={{ horizontal: -12 }} as="div">
             <Row gap={24} width="100%">
                 <Tooltip content={unspendableTooltip}>
                     <Checkbox
                         isChecked={isChecked}
                         isDisabled={isDisabled}
-                        onClick={handleCheckbox}
+                        onChange={handleCheckbox}
+                        onClick={e => e.stopPropagation()}
                     />
                 </Tooltip>
                 <Column flex="1" gap={0}>

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -158,9 +158,8 @@ export const ReviewButton = () => {
                     intent="critical"
                     description={
                         <Checkbox
-                            variant="destructive"
                             isChecked={anonymityWarningChecked}
-                            onClick={toggleAnonymityWarning}
+                            onChange={toggleAnonymityWarning}
                         >
                             <Translation id="TR_BREAKING_ANONYMITY_CHECKBOX" />
                         </Checkbox>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -93,7 +93,7 @@ export const FilterAction = () => {
                                 isChecked={
                                     Boolean(suspiciousTransactionsHidden) === Boolean(option.id)
                                 }
-                                onClick={() => {
+                                onChange={() => {
                                     handleToggleSuspiciousTransactionsRequest(Boolean(option.id));
                                 }}
                                 data-testid={dataTest}

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -90,7 +90,9 @@ export class SettingsPage {
             ? this.page.locator('[data-testid*="@radio-button"]')
             : this.page.getByTestId(`@radio-button-${level}`);
     readonly safetyChecksRadioButtonCheck = (check: boolean): Locator =>
-        this.page.locator(`[data-testid*="@radio-button"][data-checked="${check}"]`);
+        this.page.locator(
+            `[data-testid*="@radio-button"]:has(input${check ? ':checked' : ':not(:checked)'})`,
+        );
     readonly settingsLoader: Locator;
     readonly experimentalFeaturesSwitch: Locator;
     readonly suiteSyncCheckbox: Locator;

--- a/suite/e2e/tests/settings/safety-checks.test.ts
+++ b/suite/e2e/tests/settings/safety-checks.test.ts
@@ -70,7 +70,7 @@ test.describe('Safety Checks Settings', { tag: ['@T3W1', '@T3T1'] }, () => {
         });
         await test.step('Reopen the modal and verify the change', async () => {
             await settingsPage.safetyChecksButton.click();
-            await expect(page.getByTestId(targetTestId)).toHaveAttribute('data-checked', 'true');
+            await expect(page.getByTestId(targetTestId).locator('input')).toBeChecked();
         });
     });
 });

--- a/suite/metadata/src/password-manager/EntryForm.tsx
+++ b/suite/metadata/src/password-manager/EntryForm.tsx
@@ -143,7 +143,7 @@ export const EntryForm = ({ onEncrypted, entry, cancel }: Props) => {
                             <Checkbox
                                 key={key} // key should be unique
                                 isChecked={selectedTags.includes(keyInt)}
-                                onClick={() => {
+                                onChange={() => {
                                     setSelectedTags(
                                         selectedTags.includes(keyInt)
                                             ? selectedTags.filter(tag => tag !== keyInt)

--- a/suite/tx-simulation/src/components/TxSimulationBanner.tsx
+++ b/suite/tx-simulation/src/components/TxSimulationBanner.tsx
@@ -32,7 +32,7 @@ export const TxSimulationBanner = ({
                     <Checkbox
                         data-testid="@tx-simulation-modal/disclaimer-checkbox"
                         isChecked={disclaimerAccepted}
-                        onClick={() => setDisclaimerAccepted(!disclaimerAccepted)}
+                        onChange={() => setDisclaimerAccepted(!disclaimerAccepted)}
                         verticalAlignment="center"
                     >
                         <Text intent="neutral" typographyStyle="body-sm">


### PR DESCRIPTION
## Notes for QA

Removed variants from Radio and Checkbox components

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/radio-and-checkbox-components&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/radio-and-checkbox-components&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Send form for bitcoin > switch display units to satoshis, fill a form in satoshis and send | 🤖 auto |
| ETH staking form > Staking form % inputs and limits | 🤖 auto |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-07T20:53:30.329Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T08:46:02.640Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->