### PR TITLE
Fix(native): device compromised navigation

### DIFF
--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.tsx
@@ -1,10 +1,5 @@
 import { TranslationKey } from '@suite/intl';
-import {
-    getIsDeviceIdValid,
-    selectIsDeviceInvariabilityCheckSuccess,
-    selectSelectedDevice,
-    selectWasFwHashCheckOtherErrorLastTime,
-} from '@suite-common/device';
+import { selectWasFwHashCheckOtherErrorLastTime } from '@suite-common/device';
 import { SkippedHashCheckError } from '@suite-common/firmware-authenticity';
 import { Card } from '@trezor/components';
 import { FirmwareHashCheckError } from '@trezor/connect';
@@ -13,6 +8,8 @@ import { useSelector } from 'src/hooks/suite';
 import {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
+    selectIsDeviceIdCheckEnabledAndFailed,
+    selectIsDeviceInvariabilityEnabledAndFailed,
     selectIsEntropyCheckEnabledAndFailed,
 } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 
@@ -36,15 +33,15 @@ const hashCheckSubtitleMap: Record<
 };
 
 const DeviceCompromisedContent = () => {
-    const isValidId = getIsDeviceIdValid(useSelector(selectSelectedDevice));
-    const isDeviceInvariabilityCheckSuccess = useSelector(selectIsDeviceInvariabilityCheckSuccess);
+    const isIdCheckFailure = useSelector(selectIsDeviceIdCheckEnabledAndFailed);
+    const isInvariabilityCheckFailure = useSelector(selectIsDeviceInvariabilityEnabledAndFailed);
     const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
     const hashCheckError = useSelector(selectFirmwareHashCheckErrorIfEnabled);
     const isEntropyCheckFailed = useSelector(selectIsEntropyCheckEnabledAndFailed);
     const wasHashCheckOtherErrorLastTime = useSelector(selectWasFwHashCheckOtherErrorLastTime);
 
     // this check is only a precaution, not expected to be seen often. This one cannot be dismissed (need id to register dismissal)
-    if (!isValidId) {
+    if (isIdCheckFailure) {
         return (
             <SecurityCheckFail
                 ctaSection={<FwAuthenticityCheckSupportButton />}
@@ -55,7 +52,7 @@ const DeviceCompromisedContent = () => {
         );
     }
     // this check is only a precaution, not expected to be seen often
-    if (!isDeviceInvariabilityCheckSuccess) {
+    if (isInvariabilityCheckFailure) {
         return (
             <SecurityCheckFail
                 ctaSection={<FwAuthencityChecksCtas />}

--- a/packages/suite/src/components/suite/SecurityCheck/useDeviceCompromisedNotification.ts
+++ b/packages/suite/src/components/suite/SecurityCheck/useDeviceCompromisedNotification.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { TranslationKey } from '@suite/intl';
 import {
     RevisionCheckErrorWithNotification,
-    isRevisionCheckErrorWithNotification,
+    getIsRevisionCheckErrorWithNotification,
 } from '@suite-common/firmware-authenticity';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -29,7 +29,7 @@ export const useDeviceCompromisedNotification = () => {
 
     useEffect(() => {
         if (errorType === null) return;
-        if (isRevisionCheckErrorWithNotification(errorType)) {
+        if (getIsRevisionCheckErrorWithNotification(errorType)) {
             dispatch(
                 notificationsActions.addToast({
                     type: 'firmware-authenticity-check-error',

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -22,7 +22,7 @@ import {
     updateSuiteSyncEnabled,
 } from '@suite-common/suite-sync';
 import { suiteSyncQuotaManagerActions } from '@suite-common/suite-sync-quota-manager';
-import { isDeviceRemembered } from '@suite-common/suite-utils';
+import { getIsDeviceRemembered } from '@suite-common/suite-utils';
 import { thpActions } from '@suite-common/thp';
 import { TokenManagementAction } from '@suite-common/token-definitions';
 import { tokenDefinitionsActions } from '@suite-common/token-definitions/src/tokenDefinitionsActions';
@@ -74,7 +74,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const device = findAccountDevice(newAccount, selectDevices(state));
 
                 // update only transactions for remembered device
-                if (isDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
+                if (getIsDeviceRemembered(device) && isAccountSuccessful(newAccount)) {
                     storageActions.saveAccounts([newAccount]);
                     api.dispatch(storageActions.saveCoinjoinAccount(newAccount.key));
                 }
@@ -86,7 +86,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 // When setDeviceState/addAuthorizedDevice is dispatched for passphrase wallet,
                 // it means that its device was just created, but already discovered accounts
                 // may have not been persisted, so try to do it now
-                if (device && !device.useEmptyPassphrase && isDeviceRemembered(device)) {
+                if (device && !device.useEmptyPassphrase && getIsDeviceRemembered(device)) {
                     const accounts = selectAccountsByDeviceState(
                         api.getState(),
                         action.payload.state,
@@ -103,7 +103,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             if (isAnyOf(metadataActions.setAccountAdd)(action)) {
                 const device = findAccountDevice(action.payload, selectDevices(api.getState()));
                 // if device is remembered, and there is a change in account.metadata (metadataActions.setAccountLoaded), update database
-                if (isDeviceRemembered(device) && isAccountSuccessful(action.payload)) {
+                if (getIsDeviceRemembered(device) && isAccountSuccessful(action.payload)) {
                     storageActions.saveAccounts([action.payload]);
                 }
             }
@@ -128,7 +128,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const { account } = action.payload;
                 const device = findAccountDevice(account, selectDevices(api.getState()));
                 // update only transactions for remembered device
-                if (isDeviceRemembered(device)) {
+                if (getIsDeviceRemembered(device)) {
                     storageActions.removeAccountTransactions(account);
                     api.dispatch(storageActions.saveAccountTransactions(account));
                 }
@@ -146,7 +146,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     const device = findAccountDevice(account, selectDevices(api.getState()));
                     const historicRates = selectHistoricFiatRates(api.getState());
                     // update only historic rates for remembered device
-                    if (isDeviceRemembered(device)) {
+                    if (getIsDeviceRemembered(device)) {
                         storageActions.removeAccountHistoricRates(account.key);
                         if (historicRates) {
                             api.dispatch(
@@ -246,7 +246,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 const isAutoEjectEnabled = selectIsDeviceAutoEjectEnabled(api.getState());
 
                 if (
-                    isDeviceRemembered(action.payload) &&
+                    getIsDeviceRemembered(action.payload) &&
                     action.payload?.mode === 'normal' &&
                     !isAutoEjectEnabled
                 ) {
@@ -355,7 +355,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     const device = devices.find(
                         d => d.state?.staticSessionId === action.payload.account.deviceState,
                     );
-                    if (isDeviceRemembered(device)) {
+                    if (getIsDeviceRemembered(device)) {
                         storageActions.saveGraph([action.payload]);
                     }
                     break;
@@ -376,7 +376,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                         api.getState(),
                         action.payload.deviceState,
                     );
-                    if (isDeviceRemembered(device) && device) {
+                    if (getIsDeviceRemembered(device) && device) {
                         api.dispatch(storageActions.saveDeviceMetadataError(device));
                     }
                     break;
@@ -388,7 +388,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                         api.getState(),
                         action.payload.deviceState,
                     );
-                    if (isDeviceRemembered(device) && device) {
+                    if (getIsDeviceRemembered(device) && device) {
                         storageActions.saveDevice({
                             ...device,
                             metadata: action.payload.metadata,
@@ -411,7 +411,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     );
                     const device =
                         account && findAccountDevice(account, selectDevices(api.getState()));
-                    if (device && isDeviceRemembered(device)) {
+                    if (device && getIsDeviceRemembered(device)) {
                         api.dispatch(
                             storageActions.saveCoinjoinAccount(
                                 action.payload.accountKey as AccountKey,
@@ -427,7 +427,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     affectedAccounts.forEach(key => {
                         const account = selectAccountByKey(state, key as AccountKey);
                         const device = account && findAccountDevice(account, devices);
-                        if (device && isDeviceRemembered(device)) {
+                        if (device && getIsDeviceRemembered(device)) {
                             api.dispatch(storageActions.saveCoinjoinAccount(key as AccountKey));
                         }
                     });

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -1,12 +1,12 @@
 import {
-    selectFirmwareHashCheckError,
-    selectFirmwareRevisionCheckError,
-    selectIsDeviceIdCheckSuccess,
+    getIsDeviceIdValid,
     selectIsDeviceInvariabilityCheckSuccess,
     selectIsEntropyCheckFailed,
     selectIsFirmwareAuthenticityCheckDismissed,
+    selectSelectedDevice,
 } from '@suite-common/device';
 import {
+    getFirmwareAuthenticityCheckErrors,
     isHardHashCheckError,
     isHardRevisionCheckError,
     isSkippedHashCheckError,
@@ -24,7 +24,8 @@ import {
 } from './suiteSelectors';
 
 export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
-    const revisionCheckError = selectFirmwareRevisionCheckError(state);
+    const device = selectSelectedDevice(state);
+    const { revisionCheckError } = getFirmwareAuthenticityCheckErrors(device);
     if (revisionCheckError === null) return null;
     if (isSkippedRevisionCheckError(revisionCheckError)) return null;
 
@@ -38,7 +39,8 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
 };
 
 export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
-    const hashCheckError = selectFirmwareHashCheckError(state);
+    const device = selectSelectedDevice(state);
+    const { hashCheckError } = getFirmwareAuthenticityCheckErrors(device);
     if (hashCheckError === null) return null;
     if (isSkippedHashCheckError(hashCheckError)) return null;
 
@@ -86,28 +88,34 @@ export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: App
  * Return true if entropy check has failed and is not disabled via settings nor message system.
  */
 export const selectIsEntropyCheckEnabledAndFailed = (state: AppState) => {
+    const device = selectSelectedDevice(state);
     const isEntropyCheckEnabled = selectIsEntropyCheckEnabled(state);
     const isEntropyCheckDisabledByMessageSystem = selectIsFeatureDisabled(
         state,
         Feature.entropyCheck,
     );
-    const isEntropyCheckFailed = selectIsEntropyCheckFailed(state);
+    const isEntropyCheckFailed = selectIsEntropyCheckFailed(state, device?.id);
 
     return isEntropyCheckEnabled && !isEntropyCheckDisabledByMessageSystem && isEntropyCheckFailed;
 };
 
 export const selectIsDeviceIdCheckEnabledAndFailed = (state: AppState) => {
+    const device = selectSelectedDevice(state);
     const areDeviceMetaChecksEnabled = selectAreDeviceMetaChecksEnabled(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.idCheck);
-    const isDeviceIdValid = selectIsDeviceIdCheckSuccess(state);
+    const isDeviceIdValid = getIsDeviceIdValid(device);
 
     return areDeviceMetaChecksEnabled && !isDisabledByMessageSystem && !isDeviceIdValid;
 };
 
 export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AppState) => {
+    const device = selectSelectedDevice(state);
     const areDeviceMetaChecksEnabled = selectAreDeviceMetaChecksEnabled(state);
     const isDisabledByMessageSystem = selectIsFeatureDisabled(state, Feature.invariabilityCheck);
-    const isDeviceInvariabilityCheckSuccess = selectIsDeviceInvariabilityCheckSuccess(state);
+    const isDeviceInvariabilityCheckSuccess = selectIsDeviceInvariabilityCheckSuccess(
+        state,
+        device,
+    );
 
     return (
         areDeviceMetaChecksEnabled &&
@@ -123,7 +131,11 @@ export const selectShouldDisplayDeviceCompromised = (state: AppState): boolean =
     if (isEntropyCheckEnabledAndFailed) return true;
 
     // All following checks are dismissable
-    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(state);
+    const device = selectSelectedDevice(state);
+    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(
+        state,
+        device?.id,
+    );
     if (isFirmwareAuthenticityCheckDismissed) return false;
 
     const isDeviceIdCheckFailed = selectIsDeviceIdCheckEnabledAndFailed(state);

--- a/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteAuthenticityChecksSelectors.ts
@@ -7,10 +7,10 @@ import {
 } from '@suite-common/device';
 import {
     getFirmwareAuthenticityCheckErrors,
-    isHardHashCheckError,
-    isHardRevisionCheckError,
-    isSkippedHashCheckError,
-    isSkippedRevisionCheckError,
+    getIsHardHashCheckError,
+    getIsHardRevisionCheckError,
+    getIsSkippedHashCheckError,
+    getIsSkippedRevisionCheckError,
 } from '@suite-common/firmware-authenticity';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 
@@ -27,7 +27,7 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: AppState) => {
     const device = selectSelectedDevice(state);
     const { revisionCheckError } = getFirmwareAuthenticityCheckErrors(device);
     if (revisionCheckError === null) return null;
-    if (isSkippedRevisionCheckError(revisionCheckError)) return null;
+    if (getIsSkippedRevisionCheckError(revisionCheckError)) return null;
 
     const isFirmwareRevisionCheckDisabled = !selectIsFirmwareRevisionCheckEnabled(state);
     if (isFirmwareRevisionCheckDisabled) return null;
@@ -42,7 +42,7 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AppState) => {
     const device = selectSelectedDevice(state);
     const { hashCheckError } = getFirmwareAuthenticityCheckErrors(device);
     if (hashCheckError === null) return null;
-    if (isSkippedHashCheckError(hashCheckError)) return null;
+    if (getIsSkippedHashCheckError(hashCheckError)) return null;
 
     const isFirmwareHashCheckDisabled = !selectIsFirmwareHashCheckEnabled(state);
     if (isFirmwareHashCheckDisabled) return null;
@@ -81,7 +81,7 @@ export const selectIsFirmwareAuthenticityCheckEnabledAndHardFailed = (state: App
     const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
     const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
 
-    return isHardRevisionCheckError(revisionError) || isHardHashCheckError(hashError);
+    return getIsHardRevisionCheckError(revisionError) || getIsHardHashCheckError(hashError);
 };
 
 /**

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { Translation, TranslationKey } from '@suite/intl';
-import { selectSelectedDevice, selectSelectedDeviceAuthenticity } from '@suite-common/device';
+import { selectDeviceAuthenticityByDeviceId, selectSelectedDevice } from '@suite-common/device';
 import { checkDeviceAuthenticityThunk } from '@suite-common/device-authenticity';
 import { Card, Column, Grid, Icon, IconName, Paragraph } from '@trezor/components';
 
@@ -23,7 +23,9 @@ type DeviceAuthenticityProps = {
 
 export const DeviceAuthenticityStep = ({ goToNext }: DeviceAuthenticityProps) => {
     const device = useSelector(selectSelectedDevice);
-    const selectedDeviceAuthenticity = useSelector(selectSelectedDeviceAuthenticity);
+    const selectedDeviceAuthenticity = useSelector(state =>
+        selectDeviceAuthenticityByDeviceId(state, device?.id),
+    );
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const dispatch = useDispatch();
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -2,7 +2,7 @@ import { Translation } from '@suite/intl';
 import { selectIsDeviceConnectedViaBluetooth } from '@suite-common/device';
 import { Context } from '@suite-common/message-system';
 import { SUPPORTS_DEVICE_AUTHENTICITY_CHECK } from '@suite-common/suite-constants';
-import { isDeviceRemembered } from '@suite-common/suite-utils';
+import { getIsDeviceRemembered } from '@suite-common/suite-utils';
 import { isBitcoinOnlyDevice } from '@trezor/device-utils';
 
 import { DeviceBanner } from 'src/components/settings/DeviceBanner';
@@ -60,7 +60,7 @@ export const SettingsDevice = () => {
     const bootloaderMode = device?.mode === 'bootloader';
     const initializeMode = device?.mode === 'initialize';
     const isNormalMode = !bootloaderMode && !initializeMode;
-    const deviceRemembered = isDeviceRemembered(device) && !device?.connected;
+    const deviceRemembered = getIsDeviceRemembered(device) && !device?.connected;
     const isDeviceConnectedViaBluetooth = useSelector(selectIsDeviceConnectedViaBluetooth);
     const bitcoinOnlyDevice = isBitcoinOnlyDevice(device);
 

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -20,7 +20,6 @@ import {
     getIsThpDevice,
     getSortedDevicesWithoutInstances,
     getStatus,
-    isDeviceAcquired,
 } from '@suite-common/suite-utils';
 import { Device, DeviceState, StaticSessionId, asBluetoothDeviceId } from '@trezor/connect';
 import {
@@ -44,7 +43,6 @@ import {
     deviceInvariabilityCheck,
     rawDataToDeviceInvariabilityCheckDTO,
 } from './services/deviceInvariabilityCheck';
-import { getIsDeviceIdValid } from './services/getIsDeviceIdValid';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 
@@ -333,25 +331,23 @@ export const selectDeviceById = createMemoizedSelector(
     (devices, deviceId) => devices.find(device => device.id === deviceId),
 );
 
-export const selectSelectedPersistentDeviceData = createMemoizedSelector(
-    [selectSelectedDevice, selectPersistentDeviceData],
-    (device, persistentDeviceData) => persistentDeviceData.find(d => d.device_id === device?.id),
-);
-
 export const selectDeviceAuthenticity = (state: DeviceRootState) => state.device.deviceAuthenticity;
 
-export const selectSelectedDeviceAuthenticity = createMemoizedSelector(
-    [selectSelectedDevice, selectDeviceAuthenticity],
-    (device, deviceAuthenticity) => (device?.id ? deviceAuthenticity?.[device.id] : undefined),
+export const selectDeviceAuthenticityByDeviceId = createMemoizedSelector(
+    [(_state, deviceId: TrezorDevice['id']) => deviceId, selectDeviceAuthenticity],
+    (deviceId, deviceAuthenticity) => (deviceId ? deviceAuthenticity?.[deviceId] : undefined),
 );
 
 export const selectIsFirmwareAuthenticityCheckDismissed = createMemoizedSelector(
-    [selectSelectedDevice, state => state.device.dismissedSecurityChecks?.firmwareAuthenticity],
-    (device, dismissedChecks) => !!(device?.id && dismissedChecks?.includes(device.id)),
+    [
+        (_state, deviceId: TrezorDevice['id']) => deviceId,
+        state => state.device.dismissedSecurityChecks?.firmwareAuthenticity,
+    ],
+    (deviceId, dismissedChecks) => !!(deviceId && dismissedChecks?.includes(deviceId)),
 );
 
 export const selectIsEntropyCheckFailed = createMemoizedSelector(
-    [selectSelectedPersistentDeviceData],
+    [selectPersistentDeviceDataById],
     persistentDeviceData => persistentDeviceData?.lastEntropyCheckResult?.success === false,
 );
 
@@ -365,20 +361,12 @@ export const selectWasFwHashCheckOtherErrorLastTime = createMemoizedSelector(
     },
 );
 
-export const selectIsDeviceIdCheckSuccess = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => getIsDeviceIdValid(device) === true,
-);
-
 export const selectIsDeviceInvariabilityCheckSuccess = createMemoizedSelector(
-    [selectSelectedDevice, selectSelectedPersistentDeviceData],
+    [
+        (_state, device) => device,
+        (state, device) => selectPersistentDeviceDataById(state, device?.id),
+    ],
     (device, previousData) => {
-        // just a failsafe in case memoization returned wrong results
-        if (device && previousData && device.id !== previousData.device_id) {
-            console.error('Device invariability check ID mismatch');
-
-            return true;
-        }
         const dto = rawDataToDeviceInvariabilityCheckDTO({ device, previousData });
 
         return deviceInvariabilityCheck(dto).success;
@@ -635,34 +623,6 @@ export const selectIsSameOrNewDevice = createMemoizedSelector(
 export const selectDeviceFirmwareRevision = createMemoizedSelector([selectSelectedDevice], device =>
     getFirmwareRevision(device),
 );
-
-/**
- * Get firmware revision check error, or null if check was successful / skipped.
- */
-export const selectFirmwareRevisionCheckError = (state: DeviceRootState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareRevision;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    return checkResult.error;
-};
-
-/**
- * Get firmware hash check error, or null if check was successful / skipped.
- */
-export const selectFirmwareHashCheckError = (state: DeviceRootState) => {
-    const device = selectSelectedDevice(state);
-    if (!isDeviceAcquired(device) || !device.authenticityChecks) return null;
-    const checkResult = device.authenticityChecks.firmwareHash;
-
-    // null means not performed, then don't consider it failed
-    if (!checkResult || checkResult.success) return null;
-
-    return checkResult.error;
-};
 
 export const selectIsDevicePinLocked = createMemoizedSelector(
     [selectSelectedDevice],

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -17,6 +17,7 @@ import {
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceConnectedViaBluetooth,
     getIsDeviceInitialized,
+    getIsDeviceRemembered,
     getIsThpDevice,
     getSortedDevicesWithoutInstances,
     getStatus,
@@ -470,7 +471,7 @@ export const selectHasDeviceFirmwareInstalled = createMemoizedSelector(
 
 export const selectIsDeviceRemembered = createMemoizedSelector(
     [selectSelectedDevice],
-    device => !!device?.remember,
+    getIsDeviceRemembered,
 );
 
 export const selectRememberedStandardWallets = createMemoizedSelector(

--- a/suite-common/firmware-authenticity/src/deviceUtils.ts
+++ b/suite-common/firmware-authenticity/src/deviceUtils.ts
@@ -1,0 +1,22 @@
+import { isDeviceKnown } from '@suite-common/suite-utils';
+import { Device, FirmwareHashCheckError, FirmwareRevisionCheckError } from '@trezor/connect';
+
+type FirmwareAuthenticityCheckErrors = {
+    revisionCheckError: FirmwareRevisionCheckError | null;
+    hashCheckError: FirmwareHashCheckError | null;
+};
+
+export const getFirmwareAuthenticityCheckErrors = (
+    device?: Device,
+): FirmwareAuthenticityCheckErrors => {
+    const checks = isDeviceKnown(device) ? device.authenticityChecks : null;
+
+    const revisionCheckResult = checks?.firmwareRevision;
+    const hashCheckResult = checks?.firmwareHash;
+
+    return {
+        revisionCheckError:
+            revisionCheckResult?.success === false ? revisionCheckResult.error : null,
+        hashCheckError: hashCheckResult?.success === false ? hashCheckResult.error : null,
+    };
+};

--- a/suite-common/firmware-authenticity/src/index.ts
+++ b/suite-common/firmware-authenticity/src/index.ts
@@ -2,3 +2,4 @@ export * from './reportSecurityCheckThunk';
 export * from './scenariosConfig';
 export * from './useReportDeviceCompromised';
 export * from './utils';
+export * from './deviceUtils';

--- a/suite-common/firmware-authenticity/src/utils.ts
+++ b/suite-common/firmware-authenticity/src/utils.ts
@@ -4,10 +4,10 @@ import type { FilterPropertiesByType } from '@trezor/type-utils';
 
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenariosConfig';
 
-export const isHardRevisionCheckError = (error: FirmwareRevisionCheckError | null) =>
+export const getIsHardRevisionCheckError = (error: FirmwareRevisionCheckError | null) =>
     error !== null && revisionCheckErrorScenarios[error].type === 'hardModal';
 
-export const isHardHashCheckError = (error: FirmwareHashCheckError | null) =>
+export const getIsHardHashCheckError = (error: FirmwareHashCheckError | null) =>
     error !== null && hashCheckErrorScenarios[error].type === 'hardModal';
 
 export type SkippedRevisionCheckError = keyof FilterPropertiesByType<
@@ -15,7 +15,7 @@ export type SkippedRevisionCheckError = keyof FilterPropertiesByType<
     { type: 'skipped' }
 >;
 
-export const isSkippedRevisionCheckError = (
+export const getIsSkippedRevisionCheckError = (
     error: FirmwareRevisionCheckError,
 ): error is SkippedRevisionCheckError => revisionCheckErrorScenarios[error].type === 'skipped';
 
@@ -24,7 +24,7 @@ export type SkippedHashCheckError = keyof FilterPropertiesByType<
     { type: 'skipped' }
 >;
 
-export const isSkippedHashCheckError = (
+export const getIsSkippedHashCheckError = (
     error: FirmwareHashCheckError,
 ): error is SkippedHashCheckError => hashCheckErrorScenarios[error].type === 'skipped';
 
@@ -33,7 +33,7 @@ export type RevisionCheckErrorWithNotification = keyof FilterPropertiesByType<
     { shouldNotify: true }
 >;
 
-export const isRevisionCheckErrorWithNotification = (
+export const getIsRevisionCheckErrorWithNotification = (
     error: FirmwareRevisionCheckError,
 ): error is RevisionCheckErrorWithNotification =>
     revisionCheckErrorScenarios[error].shouldNotify === true;
@@ -43,7 +43,7 @@ export type HashCheckErrorWithNotification = keyof FilterPropertiesByType<
     { shouldNotify: true }
 >;
 
-export const isHashCheckErrorWithNotification = (
+export const getIsHashCheckErrorWithNotification = (
     error: FirmwareHashCheckError,
 ): error is HashCheckErrorWithNotification =>
     // @ts-expect-error if this no longer gives error, then TODO hash check notifications must be implemented

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -10,12 +10,12 @@ import {
     getFirmwareDowngradeUrl,
     getFirstDeviceInstance,
     getIsDeviceConnectedViaBluetooth,
+    getIsDeviceRemembered,
     getNewInstanceNumber,
     getNewWalletNumber,
     getPackagingUrl,
     getSelectedDevice,
     getStatus,
-    isDeviceRemembered,
     isDeviceWithButtonOnlyNoTouchscreen,
     isSelectedDevice,
     isSelectedInstance,
@@ -118,10 +118,10 @@ describe(getDeviceInstances.name, () => {
     });
 });
 
-describe(isDeviceRemembered.name, () => {
+describe(getIsDeviceRemembered.name, () => {
     fixtures.isDeviceRemembered.forEach(f => {
         it(f.description, () => {
-            expect(isDeviceRemembered(f.device)).toEqual(f.result);
+            expect(getIsDeviceRemembered(f.device)).toEqual(f.result);
         });
     });
 });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -163,7 +163,7 @@ export const shouldDisplayInitialWarningIcon = (deviceStatus: DeviceStatus | nul
     }
 };
 
-export const isDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
+export const getIsDeviceRemembered = (device?: TrezorDevice): boolean => !!device?.remember;
 
 // Is a Suite extended device acquired (corresponds to Connect "known")
 export const isDeviceAcquired = (device?: TrezorDevice): device is AcquiredDevice =>

--- a/suite-native/connection-status/src/useIsFwRevisionCheckOfflineError.ts
+++ b/suite-native/connection-status/src/useIsFwRevisionCheckOfflineError.ts
@@ -1,10 +1,12 @@
 import { useSelector } from 'react-redux';
 
 import { revisionCheckErrorScenarios } from '@suite-common/firmware-authenticity';
-import { selectFirmwareRevisionCheckErrorIfEnabled } from '@suite-native/device';
+import { selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled } from '@suite-native/device';
 
 export const useIsFwRevisionCheckOfflineError = () => {
-    const firmwareRevisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const firmwareRevisionCheckError = useSelector(
+        selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled,
+    );
 
     return (
         firmwareRevisionCheckError === 'cannot-perform-check-offline' &&

--- a/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
+++ b/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import {
     RevisionCheckErrorWithNotification,
-    isRevisionCheckErrorWithNotification,
+    getIsRevisionCheckErrorWithNotification,
 } from '@suite-common/firmware-authenticity';
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
@@ -26,7 +26,7 @@ export const useDeviceCompromisedNotification = () => {
 
     useEffect(() => {
         if (revisionCheckError === null) return;
-        if (isRevisionCheckErrorWithNotification(revisionCheckError)) {
+        if (getIsRevisionCheckErrorWithNotification(revisionCheckError)) {
             showToast({
                 variant: 'error',
                 message: translate(revisionCheckNotifications[revisionCheckError]),

--- a/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
+++ b/suite-native/device/src/hooks/useDeviceCompromisedNotification.ts
@@ -8,7 +8,7 @@ import {
 import { TxKeyPath, useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 
-import { selectFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
+import { selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
 
 const revisionCheckNotifications: Record<RevisionCheckErrorWithNotification, TxKeyPath> = {
     'other-error': 'moduleDevice.toasts.firmwareRevisionCheckOtherError',
@@ -22,7 +22,7 @@ const revisionCheckNotifications: Record<RevisionCheckErrorWithNotification, TxK
 export const useDeviceCompromisedNotification = () => {
     const { translate } = useTranslate();
     const { showToast } = useToast();
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const revisionCheckError = useSelector(selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled);
 
     useEffect(() => {
         if (revisionCheckError === null) return;

--- a/suite-native/device/src/hooks/useRenderDeviceDangerBanner.ts
+++ b/suite-native/device/src/hooks/useRenderDeviceDangerBanner.ts
@@ -6,7 +6,7 @@ import { useSetAtom } from 'jotai';
 
 import { selectIsDeviceBackupRequired, selectIsDeviceBackupUnfinished } from '@suite-common/device';
 import {
-    isSkippedRevisionCheckError as getIsSkippedRevisionCheckError,
+    getIsSkippedRevisionCheckError,
     revisionCheckErrorScenarios,
 } from '@suite-common/firmware-authenticity';
 import {

--- a/suite-native/device/src/hooks/useRenderDeviceDangerBanner.ts
+++ b/suite-native/device/src/hooks/useRenderDeviceDangerBanner.ts
@@ -6,6 +6,10 @@ import { useSetAtom } from 'jotai';
 
 import { selectIsDeviceBackupRequired, selectIsDeviceBackupUnfinished } from '@suite-common/device';
 import {
+    isSkippedRevisionCheckError as getIsSkippedRevisionCheckError,
+    revisionCheckErrorScenarios,
+} from '@suite-common/firmware-authenticity';
+import {
     AppTabsRoutes,
     HomeStackRoutes,
     RootStackRoutes,
@@ -13,20 +17,36 @@ import {
     useNavigationRouteMatch,
 } from '@suite-native/navigation';
 import { selectIsOnboardingFinished } from '@suite-native/settings';
+import { FirmwareRevisionCheckError } from '@trezor/connect';
 
 import { DeviceDangerBannerCause, deviceDangerBannerAtom } from '../deviceAtoms';
-import {
-    selectFirmwareRevisionCheckErrorIfEnabled,
-    selectIsSkippedRevisionCheckError,
-} from '../selectors';
+import { selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
+
+/**
+ * On mobile, we should skip revision check errors that are defined as skipped, but also the offline error,
+ * because its banner is rendered separately in useIsOfflineBannerVisible.
+ * So consider it skipped when rendering the banner centrally.
+ */
+const getShouldSkipRevisionCheckError = (
+    revisionCheckError: FirmwareRevisionCheckError | null,
+): boolean => {
+    if (revisionCheckError === null) return false;
+    if (getIsSkippedRevisionCheckError(revisionCheckError)) return true;
+
+    return (
+        revisionCheckError === 'cannot-perform-check-offline' &&
+        // if TS throws error, it means that the aforementioned logic is no longer valid, and this function should be removed
+        revisionCheckErrorScenarios[revisionCheckError].type === 'softWarning'
+    );
+};
 
 export const useRenderDeviceDangerBanner = () => {
     const setBannerVariant = useSetAtom(deviceDangerBannerAtom);
     const navigation = useNavigation();
     const lastRoute = useLastRouteName();
     const isOnboardingFinished = useSelector(selectIsOnboardingFinished);
-    const revisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
-    const isSkippedRevisionCheckError = useSelector(selectIsSkippedRevisionCheckError);
+    const revisionCheckError = useSelector(selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled);
+    const isSkippedRevisionCheckError = getShouldSkipRevisionCheckError(revisionCheckError);
     const isDeviceBackupUnfinished = useSelector(selectIsDeviceBackupUnfinished);
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);
 

--- a/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
+++ b/suite-native/device/src/hooks/useRetryFwAuthenticityChecks.ts
@@ -6,12 +6,14 @@ import TrezorConnect, { FIRMWARE } from '@trezor/connect';
 import { TimerId } from '@trezor/type-utils';
 import { isArrayMember } from '@trezor/utils';
 
-import { selectFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
+import { selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled } from '../selectors';
 
 const REFRESH_INTERVAL = 3_000; // [ms]
 
 export const useRetryFwAuthenticityChecks = () => {
-    const firmwareRevisionCheckError = useSelector(selectFirmwareRevisionCheckErrorIfEnabled);
+    const firmwareRevisionCheckError = useSelector(
+        selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled,
+    );
 
     const isRetriableError =
         firmwareRevisionCheckError !== null &&

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -5,7 +5,12 @@ import {
     createListenerMiddleware,
 } from '@reduxjs/toolkit';
 
-import { deviceActions, selectDevices, selectIsDeviceRemembered } from '@suite-common/device';
+import {
+    deviceActions,
+    selectDevices,
+    selectIsDeviceRemembered,
+    selectSelectedDevice,
+} from '@suite-common/device';
 import {
     getDeviceInternalModel,
     getIsDeviceDescriptorApiTypeBluetooth,
@@ -139,7 +144,10 @@ deviceConnectionMiddleware.startListening({
         // Your decision logic should be derived from device passed from TrezorConnect in the action payload (not selectedDevice from the state).
         const { device } = action.payload;
 
-        const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(getState());
+        const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(
+            getState(),
+            device,
+        );
 
         if (checkIsActiveRouteAnyOf(DEVICE_CONNECTION_BLACKLISTED_ROUTES)) return;
 
@@ -190,7 +198,11 @@ deviceConnectionMiddleware.startListening({
         }
 
         const isDeviceRemembered = selectIsDeviceRemembered(getState());
-        const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(getState());
+        const device = selectSelectedDevice(getState()); // the device being disconnected is the one currently selected
+        const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(
+            getState(),
+            device?.id,
+        );
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
         const wasDeviceConnectedViaBluetooth = getIsDeviceDescriptorApiTypeBluetooth(
             action.payload,

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -5,16 +5,12 @@ import {
     createListenerMiddleware,
 } from '@reduxjs/toolkit';
 
-import {
-    deviceActions,
-    selectDevices,
-    selectIsDeviceRemembered,
-    selectSelectedDevice,
-} from '@suite-common/device';
+import { deviceActions, selectDevices } from '@suite-common/device';
 import {
     getDeviceInternalModel,
     getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
+    getIsDeviceRemembered,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction, selectThpAutoconnectStep } from '@suite-common/thp';
 import { selectIsAnyNetworkEnabled } from '@suite-common/wallet-core';
@@ -197,8 +193,8 @@ deviceConnectionMiddleware.startListening({
             throw new Error('This listener only handles deviceDisconnect action');
         }
 
-        const isDeviceRemembered = selectIsDeviceRemembered(getState());
-        const device = selectSelectedDevice(getState()); // the device being disconnected is the one currently selected
+        const device = action.payload;
+        const isDeviceRemembered = getIsDeviceRemembered(device);
         const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(
             getState(),
             device?.id,

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -3,11 +3,11 @@ import { A, pipe } from '@mobily/ts-belt';
 import {
     DeviceRootState,
     PORTFOLIO_TRACKER_DEVICE_ID,
+    selectDeviceAuthenticityByDeviceId,
     selectDeviceFirmwareVersionArray,
     selectDeviceInstances,
     selectDeviceModel,
     selectDevices,
-    selectFirmwareRevisionCheckError,
     selectHasDeviceFirmwareInstalled,
     selectIsConnectedDeviceUninitialized,
     selectIsDeviceConnected,
@@ -18,12 +18,10 @@ import {
     selectIsFirmwareAuthenticityCheckDismissed,
     selectIsUnacquiredDevice,
     selectSelectedDevice,
-    selectSelectedDeviceAuthenticity,
 } from '@suite-common/device';
 import {
+    getFirmwareAuthenticityCheckErrors,
     isHardRevisionCheckError,
-    isSkippedRevisionCheckError,
-    revisionCheckErrorScenarios,
 } from '@suite-common/firmware-authenticity';
 import {
     Feature,
@@ -62,6 +60,7 @@ import {
 } from '@suite-native/settings';
 import { doesCoinSupportStaking } from '@suite-native/staking';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { Device } from '@trezor/connect';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
 
 import { getIsDeviceSetupSupported, isFirmwareVersionSupported } from './utils';
@@ -193,8 +192,11 @@ type FwAuthenticityCheckState = NativeDeviceRootState &
 /**
  * Get firmware revision check error, or null if check was successful / skipped, if the check is enabled in settings and through message system.
  */
-export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityCheckState) => {
-    const revisionCheckError = selectFirmwareRevisionCheckError(state);
+export const selectFirmwareRevisionCheckErrorIfEnabled = (
+    state: FwAuthenticityCheckState,
+    device: Device,
+) => {
+    const { revisionCheckError } = getFirmwareAuthenticityCheckErrors(device);
     const { isFirmwareRevisionCheckEnabled } = state.appSettings;
     const isMessageSystemFeatureEnabled = selectIsFeatureEnabled(
         state,
@@ -205,20 +207,13 @@ export const selectFirmwareRevisionCheckErrorIfEnabled = (state: FwAuthenticityC
 
     return isCheckEnabled ? revisionCheckError : null;
 };
+export const selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled = (
+    state: FwAuthenticityCheckState,
+) => {
+    const device = selectSelectedDevice(state);
+    if (!device) return null;
 
-export const selectIsSkippedRevisionCheckError = (state: FwAuthenticityCheckState): boolean => {
-    const revisionCheckError = selectFirmwareRevisionCheckErrorIfEnabled(state);
-    if (revisionCheckError === null) return false;
-    if (isSkippedRevisionCheckError(revisionCheckError)) return true;
-
-    // Special handling for offline error, which is handled as softWarning (top-screen banner),
-    // but the banner is rendered separately in useIsOfflineBannerVisible.
-    // So consider it skipped when rendering the banner centrally.
-    return (
-        revisionCheckError === 'cannot-perform-check-offline' &&
-        // if TS throws error, it means that the aforementioned logic is no longer valid, and it should be reworked
-        revisionCheckErrorScenarios[revisionCheckError].type === 'softWarning'
-    );
+    return selectFirmwareRevisionCheckErrorIfEnabled(state, device);
 };
 
 /**
@@ -228,6 +223,15 @@ export const selectHasFirmwareAuthenticityCheckHardFailed = createMemoizedSelect
     [selectFirmwareRevisionCheckErrorIfEnabled],
     revisionError => isHardRevisionCheckError(revisionError), // FW hash check to be implemented
 );
+
+export const selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice = (
+    state: FwAuthenticityCheckState,
+) => {
+    const device = selectSelectedDevice(state);
+    if (!device) return false;
+
+    return selectHasFirmwareAuthenticityCheckHardFailed(state, device);
+};
 
 export const selectIsEntropyCheckEnabledAndFailed = createMemoizedSelector(
     [
@@ -239,8 +243,8 @@ export const selectIsEntropyCheckEnabledAndFailed = createMemoizedSelector(
 );
 
 export const selectIsDeviceAuthenticityCheckFailed = createMemoizedSelector(
-    [selectSelectedDeviceAuthenticity],
-    selectedDeviceAuthenticity => selectedDeviceAuthenticity?.valid === false,
+    [selectDeviceAuthenticityByDeviceId],
+    authenticityCheckResult => authenticityCheckResult?.valid === false,
 );
 
 export const selectIsDeviceSetupSupported = createMemoizedSelector(
@@ -257,10 +261,14 @@ export const selectShouldFactoryResetBeVisible = createMemoizedSelector(
 export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
     [
         selectIsDeviceAuthenticityCheckEnabled,
-        selectIsDeviceAuthenticityCheckFailed,
-        selectIsEntropyCheckEnabledAndFailed,
-        selectIsFirmwareAuthenticityCheckDismissed,
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        (state: NativeDeviceRootState, device: Device) =>
+            selectIsDeviceAuthenticityCheckFailed(state, device?.id),
+        (state: NativeDeviceRootState, device: Device) =>
+            selectIsEntropyCheckEnabledAndFailed(state, device?.id),
+        (state: NativeDeviceRootState, device: Device) =>
+            selectIsFirmwareAuthenticityCheckDismissed(state, device?.id),
+        (state: NativeDeviceRootState, device: Device) =>
+            selectHasFirmwareAuthenticityCheckHardFailed(state, device),
     ],
     (
         isDeviceAuthenticityCheckEnabled,
@@ -288,6 +296,13 @@ export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
         return null;
     },
 );
+
+export const selectSelectedDeviceCompromisedDeviceFailedCheck = (state: NativeDeviceRootState) => {
+    const device = selectSelectedDevice(state);
+    if (!device) return null;
+
+    return selectCompromisedDeviceFailedCheck(state, device);
+};
 
 export const selectIsDeviceCompromised = createMemoizedSelector(
     [selectCompromisedDeviceFailedCheck],

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -254,7 +254,7 @@ export const selectShouldFactoryResetBeVisible = createMemoizedSelector(
         isDeviceInBootloader && hasDeviceFirmwareInstalled,
 );
 
-export const selectIsDeviceCompromised = createMemoizedSelector(
+export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
     [
         selectIsDeviceAuthenticityCheckEnabled,
         selectIsDeviceAuthenticityCheckFailed,
@@ -275,35 +275,21 @@ export const selectIsDeviceCompromised = createMemoizedSelector(
         const isFirmwareAuthenticityCheckHardFailedAndNotDismissed =
             hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
 
-        return (
-            isDeviceAuthenticityEnabledAndFailed ||
-            isEntropyCheckEnabledAndFailed ||
-            isFirmwareAuthenticityCheckHardFailedAndNotDismissed
-        );
-    },
-);
-
-export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
-    [
-        selectIsDeviceAuthenticityCheckEnabled,
-        selectIsDeviceAuthenticityCheckFailed,
-        selectIsEntropyCheckEnabledAndFailed,
-    ],
-    (
-        isDeviceAuthenticityCheckEnabled,
-        isDeviceAuthenticityCheckFailed,
-        isEntropyCheckEnabledAndFailed,
-    ) => {
-        const isDeviceAuthenticityEnabledAndFailed =
-            isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
-
         if (isDeviceAuthenticityEnabledAndFailed) {
             return 'device-authenticity';
         }
         if (isEntropyCheckEnabledAndFailed) {
             return 'entropy';
         }
+        if (isFirmwareAuthenticityCheckHardFailedAndNotDismissed) {
+            return 'firmware-authenticity';
+        }
 
-        return 'firmware-authenticity';
+        return null;
     },
+);
+
+export const selectIsDeviceCompromised = createMemoizedSelector(
+    [selectCompromisedDeviceFailedCheck],
+    failedCheck => failedCheck !== null,
 );

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -21,7 +21,7 @@ import {
 } from '@suite-common/device';
 import {
     getFirmwareAuthenticityCheckErrors,
-    isHardRevisionCheckError,
+    getIsHardRevisionCheckError,
 } from '@suite-common/firmware-authenticity';
 import {
     Feature,
@@ -221,7 +221,7 @@ export const selectSelectedDeviceFirmwareRevisionCheckErrorIfEnabled = (
  */
 export const selectHasFirmwareAuthenticityCheckHardFailed = createMemoizedSelector(
     [selectFirmwareRevisionCheckErrorIfEnabled],
-    revisionError => isHardRevisionCheckError(revisionError), // FW hash check to be implemented
+    revisionError => getIsHardRevisionCheckError(revisionError), // FW hash check to be implemented
 );
 
 export const selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice = (

--- a/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountSettingsShowXpubButton.tsx
@@ -7,7 +7,7 @@ import { AccountKey } from '@suite-common/wallet-types';
 import { isAddressBasedNetwork } from '@suite-common/wallet-utils';
 import { useAlert } from '@suite-native/alerts';
 import { Button, useBottomSheetModal } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { SUITE_MOBILE_SUPPORT_URL, useOpenLink } from '@suite-native/link';
 import { WalletBackupNotSetWarningBottomSheet } from '@suite-native/module-device-onboarding';
@@ -34,7 +34,7 @@ export const AccountSettingsShowXpubButton = ({ accountKey }: { accountKey: Acco
     } = useBottomSheetModal();
 
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
 
     const isDeviceBackupRequired = useSelector(selectIsDeviceBackupRequired);

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -14,7 +14,7 @@ import {
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { FeatureFlagsRootState } from '@suite-native/feature-flags';
 import { Translation } from '@suite-native/intl';
 import {
@@ -105,7 +105,7 @@ export const TransactionListHeader = memo(
         );
         const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
         const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-            selectHasFirmwareAuthenticityCheckHardFailed,
+            selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
         );
         const token = useSelector((state: TokensRootState) =>
             selectAccountTokenInfo(state, accountKey, tokenContract),

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { selectCompromisedDeviceFailedCheck } from '@suite-native/device';
+import { selectSelectedDeviceCompromisedDeviceFailedCheck } from '@suite-native/device';
 import { exhaustive } from '@trezor/type-utils';
 
 import { DeviceAuthenticityCheckFailModalContent } from '../components/DeviceAuthenticityCheckFailModalContent';
@@ -14,7 +14,7 @@ import { FirmwareAuthenticityCheckFailModalContent } from '../components/Firmwar
  * - device authenticity check failure
  */
 export const DeviceCompromisedModalScreen = () => {
-    const failedCheck = useSelector(selectCompromisedDeviceFailedCheck);
+    const failedCheck = useSelector(selectSelectedDeviceCompromisedDeviceFailedCheck);
 
     switch (failedCheck) {
         case 'device-authenticity':

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -22,6 +22,7 @@ export const DeviceCompromisedModalScreen = () => {
         case 'entropy':
             return <EntropyCheckFailModalContent />;
         case 'firmware-authenticity':
+        case null: // TODO fix entropy check screen persistence after disconnecting the device
             return <FirmwareAuthenticityCheckFailModalContent />;
         default:
             return exhaustive(failedCheck);

--- a/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/PortfolioContent.tsx
@@ -9,7 +9,7 @@ import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { selectHasDeviceAnySendAvailableAccount } from '@suite-native/accounts';
 import { Assets } from '@suite-native/assets';
 import { AnimatedVStack, Button, HStack, VStack } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
     ReceiveStackRoutes,
@@ -29,7 +29,7 @@ export const PortfolioContent = forwardRef<PortfolioGraphRef>((_props, ref) => {
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
     const hasDeviceAnySendAvailableAccount = useSelector(selectHasDeviceAnySendAvailableAccount);
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
 
     const isPortfolioTracker = useSelector(selectIsPortfolioTrackerDevice);

--- a/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAccountsScreen.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { AccountsList, AddAccountButton, OnSelectAccount } from '@suite-native/accounts';
 import { events } from '@suite-native/analytics';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
     ReceiveStackParamList,
@@ -26,7 +26,7 @@ export const ReceiveAccountsScreen = () => {
     const analytics = useAnalytics();
     const navigation = useNavigation<NavigationProp>();
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
     if (hasFirmwareAuthenticityCheckHardFailed) return <ReceiveBlockedDeviceCompromisedScreen />;
 

--- a/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
+++ b/suite-native/receive/src/screens/ReceiveAddressScreen.tsx
@@ -21,7 +21,7 @@ import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { useInAppRating } from '@suite-native/in-app-rating';
 import { Translation } from '@suite-native/intl';
 import { Link } from '@suite-native/link';
@@ -102,7 +102,7 @@ export const ReceiveAddressScreen = ({
     }, [closeModal]);
 
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
 
     if (hasFirmwareAuthenticityCheckHardFailed) return <ReceiveBlockedDeviceCompromisedScreen />;

--- a/suite-native/transactions/src/components/TransactionsEmptyState.tsx
+++ b/suite-native/transactions/src/components/TransactionsEmptyState.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { AccountKey } from '@suite-common/wallet-types';
 import { Box, Button, Text, VStack } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailed } from '@suite-native/device';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import {
     ReceiveStackRoutes,
@@ -20,7 +20,7 @@ type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.A
 export const TransactionsEmptyState = ({ accountKey }: { accountKey: AccountKey }) => {
     const navigation = useNavigation<NavigationProp>();
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailed,
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
     const showReceiveButton = !hasFirmwareAuthenticityCheckHardFailed;
 


### PR DESCRIPTION
## Description

In #20081 and subsequent works, device connection reactivity was rewritten in mobile.
At some point it caused some cases of Device Compromised navigation to break, see the issue.

The core problem: in mobile `deviceConnectionMiddleware`, we are working with `device` which is not yet selected, but all selectors pertaining security checks rely on selected device. 
Note that in Suite Web/Desktop, we will always work with selected device, and it'll stay that way due to the different architceture (React native navigation vs. Preloader wrapper component).

:point_right: 
- refactor Device compromised selectors to work with a given device or device id.
- to keep changes at minimum and at the same time for brevity: introduce selectors that supply selected device
- deduplicate some native selectors ()

## Notes for QA

Please test thoroughly Desktop & Mobile. Not everything can be tested on real setups, I have testing branch to simulate all kinds of security check failures, but that's not usable on mobile build.
So at least test this:
- Device Authenticity Check failure using a bootloader-unlocked device, or even better, a device provisioned with dev/staging keys if available
- Firmware Revision Check failure by changing your FW source to not production (e.g. Test Signed) and connecting a production device

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/197

## Screenshots:

Desktop/Web behavior is unchanged. 

Mobile: revision check now works, failed entropy check works on subsequent connection and other checks are unaffected:
[DAC and revision check.webm](https://github.com/user-attachments/assets/34d9ea09-8afd-4640-8388-54dff18a0306)
[entropy check failure.webm](https://github.com/user-attachments/assets/d85e7fb1-986b-4b01-86a9-1f49cdb34964)
[entropy check success.webm](https://github.com/user-attachments/assets/d6911063-9899-461b-b7eb-c80ced0dfab1)
[entropy failure reconnection.webm](https://github.com/user-attachments/assets/b2371096-2030-469d-b8ec-bfd3362540fc)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-compro-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-compro-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-compro-navigation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Send form for bitcoin > switch display units to satoshis, fill a form in satoshis and send | 🤖 auto |
| ETH staking form > Staking form % inputs and limits | 🤖 auto |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-08T09:43:11.163Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-08T09:41:44.502Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->