### PR TITLE
fix(connect-web): proper matching of branch on sldev

### DIFF
--- a/packages/connect-web/jest.config.js
+++ b/packages/connect-web/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/packages/connect-web/src/impl/__tests__/getSuiteWebUrl.test.ts
+++ b/packages/connect-web/src/impl/__tests__/getSuiteWebUrl.test.ts
@@ -1,0 +1,69 @@
+import { extractBranch, getSuiteWebUrl } from '../getSuiteWebUrl';
+
+const DEV_ORIGIN = 'https://dev.suite.sldev.cz';
+
+describe('extractBranch', () => {
+    it('extracts single-segment branch from methods page', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/develop/methods/bitcoin/getAddress`)).toBe(
+            'develop',
+        );
+    });
+
+    it('extracts single-segment branch from settings page', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/develop/settings/`)).toBe('develop');
+    });
+
+    it('extracts multi-segment branch from methods page', () => {
+        expect(
+            extractBranch(`${DEV_ORIGIN}/connect/feat/xyz/phase-1/methods/bitcoin/getAddress`),
+        ).toBe('feat/xyz/phase-1');
+    });
+
+    it('extracts multi-segment branch from settings page', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/feat/xyz/settings/`)).toBe('feat/xyz');
+    });
+
+    it('extracts branch from root URL (no page segment)', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/develop`)).toBe('develop');
+    });
+
+    it('extracts multi-segment branch from root URL', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/feat/xyz`)).toBe('feat/xyz');
+    });
+
+    it('returns undefined for non-matching URL', () => {
+        expect(extractBranch('https://example.com/other/path')).toBeUndefined();
+    });
+});
+
+describe('getSuiteWebUrl', () => {
+    it('returns localhost popup URL for local dev', () => {
+        expect(getSuiteWebUrl('http://localhost:8088/settings/', 'http://localhost:8088')).toBe(
+            'http://localhost:8000/connect-popup',
+        );
+    });
+
+    it('returns dev popup URL for dev methods page', () => {
+        expect(
+            getSuiteWebUrl(`${DEV_ORIGIN}/connect/develop/methods/bitcoin/getAddress`, DEV_ORIGIN),
+        ).toBe(`${DEV_ORIGIN}/suite-web/develop/web/connect-popup`);
+    });
+
+    it('returns dev popup URL for dev settings page', () => {
+        expect(getSuiteWebUrl(`${DEV_ORIGIN}/connect/develop/settings/`, DEV_ORIGIN)).toBe(
+            `${DEV_ORIGIN}/suite-web/develop/web/connect-popup`,
+        );
+    });
+
+    it('returns dev popup URL with multi-segment branch', () => {
+        expect(
+            getSuiteWebUrl(`${DEV_ORIGIN}/connect/feat/xyz/methods/bitcoin/getAddress`, DEV_ORIGIN),
+        ).toBe(`${DEV_ORIGIN}/suite-web/feat/xyz/web/connect-popup`);
+    });
+
+    it('returns production URL for non-dev origin', () => {
+        expect(getSuiteWebUrl('https://example.com/', 'https://example.com')).toBe(
+            'https://suite.trezor.io/web/connect-popup',
+        );
+    });
+});

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -65,7 +65,9 @@ export class CoreInSuiteWeb implements ConnectImpl {
             typeof window !== 'undefined' &&
             window.location.href.startsWith('https://dev.suite.sldev.cz/connect/')
         ) {
-            const branch = window.location.href.match(/\/connect\/(.+?)(?:\/methods\/|$)/)?.[1];
+            const branch = window.location.href.match(
+                /\/connect\/(.+?)(?:\/methods\/|\/settings\/|$)/,
+            )?.[1];
             if (branch) {
                 return `https://dev.suite.sldev.cz/suite-web/${branch}/web/connect-popup`;
             }

--- a/packages/connect-web/src/impl/core-in-suite-web.ts
+++ b/packages/connect-web/src/impl/core-in-suite-web.ts
@@ -11,6 +11,7 @@ import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 
 import { getEnv } from '../connectSettings';
 import { PopupManager } from '../popup';
+import { getSuiteWebUrl } from './getSuiteWebUrl';
 
 /**
  * Base class for CoreInPopup methods for TrezorConnect factory.
@@ -55,22 +56,8 @@ export class CoreInSuiteWeb implements ConnectImpl {
     }
 
     private getSuiteUrl() {
-        // this is for web
-        // todo: the only problem I see here is that a 3rd party when developing locally
-        // on the http://localhost:8088 will not fallback to the the production version of connect-popup
-        if (typeof window !== 'undefined' && window.location.origin === 'http://localhost:8088') {
-            return 'http://localhost:8000/connect-popup';
-        }
-        if (
-            typeof window !== 'undefined' &&
-            window.location.href.startsWith('https://dev.suite.sldev.cz/connect/')
-        ) {
-            const branch = window.location.href.match(
-                /\/connect\/(.+?)(?:\/methods\/|\/settings\/|$)/,
-            )?.[1];
-            if (branch) {
-                return `https://dev.suite.sldev.cz/suite-web/${branch}/web/connect-popup`;
-            }
+        if (typeof window !== 'undefined') {
+            return getSuiteWebUrl(window.location.href, window.location.origin);
         }
 
         return 'https://suite.trezor.io/web/connect-popup';

--- a/packages/connect-web/src/impl/getSuiteWebUrl.ts
+++ b/packages/connect-web/src/impl/getSuiteWebUrl.ts
@@ -1,0 +1,37 @@
+const DEV_CONNECT_ORIGIN = 'https://dev.suite.sldev.cz';
+const DEV_CONNECT_PREFIX = `${DEV_CONNECT_ORIGIN}/connect/`;
+
+/**
+ * Extract branch name from a connect-explorer dev URL.
+ *
+ * Expected URL patterns (init can happen on methods or settings pages):
+ *   https://dev.suite.sldev.cz/connect/{branch}/methods/...
+ *   https://dev.suite.sldev.cz/connect/{branch}/settings/
+ *
+ * Branch names may contain slashes (e.g. "feat/xyz/phase-1").
+ * Returns undefined if the URL doesn't match the expected pattern.
+ */
+export const extractBranch = (href: string): string | undefined =>
+    href.match(/\/connect\/(.+?)(?:\/methods\/|\/settings\/|$)/)?.[1];
+
+/**
+ * Resolve the Suite Web popup URL based on the current window location.
+ *
+ * - localhost:8088 → localhost:8000/connect-popup (local dev)
+ * - dev.suite.sldev.cz/connect/{branch}/... → dev.suite.sldev.cz/suite-web/{branch}/web/connect-popup
+ * - everything else → production suite.trezor.io/web/connect-popup
+ */
+export const getSuiteWebUrl = (href: string, origin: string): string => {
+    if (origin === 'http://localhost:8088') {
+        return 'http://localhost:8000/connect-popup';
+    }
+
+    if (href.startsWith(DEV_CONNECT_PREFIX)) {
+        const branch = extractBranch(href);
+        if (branch) {
+            return `${DEV_CONNECT_ORIGIN}/suite-web/${branch}/web/connect-popup`;
+        }
+    }
+
+    return 'https://suite.trezor.io/web/connect-popup';
+};


### PR DESCRIPTION
should resolve #25690

@evgenysl pls test once it is deployed. Also test this #25748 which has the same fix but has a `/` in its branch name

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-connectsrc&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T09:31:27.796Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->