### PR TITLE
Fix trading layout header

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
@@ -1,23 +1,12 @@
 import { PropsWithChildren } from 'react';
 
 import { Column } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
-import { useSelector } from 'src/hooks/suite';
-import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { TradingLayoutNavigation } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation';
 
-interface TradingLayoutProps extends PropsWithChildren {}
-
-export const TradingLayout = ({ children }: TradingLayoutProps) => {
-    const routeName = useSelector(selectRouteName);
-
-    return (
-        <Column data-testid="@trading" gap={spacings.xl}>
-            {!routeName?.includes(`wallet-trading-exchange`) && (
-                <TradingLayoutNavigation route={routeName} />
-            )}
-            {children}
-        </Column>
-    );
-};
+export const TradingLayout = ({ children }: PropsWithChildren) => (
+    <Column data-testid="@trading" gap={24}>
+        <TradingLayoutNavigation />
+        {children}
+    </Column>
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutHeader.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useMemo } from 'react';
+import { PropsWithChildren } from 'react';
 
 import { Translation, TranslationKey, useTranslation } from '@suite/intl';
 import { Route } from '@suite-common/suite-types';
@@ -69,12 +69,8 @@ const TradingPageHeader = ({ fallbackTitle }: TradingPageHeaderProps) => {
 };
 
 export const TradingLayoutHeader = ({ children }: PropsWithChildren) => {
-    const activeSection = useSelector(selectTradingActiveSection);
     const { translationString } = useTranslation();
-    const fallbackTitle = useMemo(
-        () => (activeSection === 'exchange' ? 'TR_TRADING_SWAP' : 'TR_TRADING_BUY_AND_SELL'),
-        [activeSection],
-    );
+    const fallbackTitle: TranslationKey = 'TR_NAV_TRADE';
 
     const translatedTitle = translationString(fallbackTitle);
     const pageTitle = `Trezor Suite | ${translatedTitle}`;

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation.tsx
@@ -28,6 +28,11 @@ const navigationItems: NavigationItem[] = [
         icon: 'minus',
         translationId: 'TR_NAV_SELL',
     },
+    {
+        id: 'wallet-trading-exchange',
+        icon: 'arrowsLeftRight',
+        translationId: 'TR_TRADING_SWAP',
+    },
 ];
 
 export const TradingLayoutNavigation = ({ route }: TradingLayoutNavigationProps) => {
@@ -52,6 +57,15 @@ export const TradingLayoutNavigation = ({ route }: TradingLayoutNavigationProps)
                     payload: {
                         action: 'navigate',
                         type: 'sell',
+                        from: 'buy/sell',
+                    },
+                });
+            case 'wallet-trading-exchange':
+                return analytics.report({
+                    type: events.tradeNavigateEvent.name,
+                    payload: {
+                        action: 'navigate',
+                        type: 'exchange',
                         from: 'buy/sell',
                     },
                 });

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -317,8 +317,10 @@ export class TradingPage {
 
     @step()
     async waitForRedirectCompletion() {
-        await expect(this.page.getByText('Buy & sell')).toBeHidden();
-        await expect(this.page.getByText('Buy & sell')).toBeVisible({ timeout: 30_000 });
+        const tradeHeading = this.page.getByRole('heading', { name: 'Trade' });
+
+        await expect(tradeHeading).toBeHidden();
+        await expect(tradeHeading).toBeVisible({ timeout: 30_000 });
     }
 
     @step()


### PR DESCRIPTION
# Notes for QA
Added Swap to the tab navigation in Buy & sell, renamed the whole section to Trade, instead of Buy & Sell and Swap.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/trade-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/trade-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T15:37:08.845Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-09T10:13:35.756Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->