### PR TITLE
fix(node-utils): mismatch in http url sanitization due to trailing slash

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -417,7 +417,8 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                     query[key] = allParamsOfSameKey.map(singleParam => {
                         const decoded = this.getSafeDecodedURI(singleParam);
                         const sanitized = sanitizeUrl(decoded);
-                        if (sanitized !== decoded) isParamInvalid = true;
+                        // remove trailing slash from sanitized URL
+                        if (sanitized.replace(/\/$/, '') !== decoded) isParamInvalid = true;
 
                         return sanitized;
                     });


### PR DESCRIPTION
## Description

Trim trailling slash when checking sanitized URL parameters in HTTP server. 
This solves an issue with OAuth callback for Google Drive labeling on desktop. 

## Notes for QA

Try enabling Google Drive labeling on desktop

## Related Issue

Resolve #25751

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25751-http-url-sanitization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25751-http-url-sanitization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T10:18:49.025Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-09T10:17:28.615Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->