### PR TITLE
test(e2e): minor fixes

### DIFF
--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -46,4 +46,4 @@ jobs:
           E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          npx tsx packages/e2e-utils/src/quarantineBot/index.ts
+          yarn workspace @trezor/e2e-utils test-health

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -34,11 +34,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Uses the version from .nvmrc (Node 24+, which natively strips TypeScript types).
           node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install dependencies
+        shell: bash
+        run: yarn workspaces focus @trezor/e2e-utils
 
       - name: Check test health and manage quarantine
         env:

--- a/packages/e2e-utils/src/quarantineBot/index.ts
+++ b/packages/e2e-utils/src/quarantineBot/index.ts
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
     if (args.includes('--help') || args.includes('-h')) {
         console.log(
             [
-                'Usage: node index.ts [options]',
+                'Usage: yarn workspace @trezor/e2e-utils test-health [options]',
                 '',
                 'Options:',
                 '  (no args)                  Run the test health check: quarantine newly failing tests and',

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -53,13 +53,27 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
-            await test.step('Reload inactive suite session to take Bridge session back', async () => {
-                await stealBridgeSession();
-                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
-                await page.reload();
-                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
+            // Possible change of behaviour to this instead of rest of the test.
+            // ATM discussed with Varmuza
+            // await test.step('Reload inactive suite session to take Bridge session back', async () => {
+            //     await stealBridgeSession();
+            //     await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
+            //     await page.reload();
+            //     await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
+            //         timeout: 30_000,
+            //     });
+            // });
+
+            await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
                     timeout: 30_000,
                 });
+            });
+
+            await test.step('Take Bridge session back', async () => {
+                await dashboardPage.deviceSwitchingOpenButton.click();
+                await dashboardPage.solveIssuesButton.click();
+                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -22,8 +22,7 @@ const stealBridgeSession = async () => {
 
 test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { passphrase_protection: true } });
-    // Skipped, because it started failing after PW update. Needs to be investigated.
-    test.skip(
+    test(
         'Session overtaken by another',
         {
             annotation: createTestAnnotation({
@@ -41,7 +40,7 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatusOnSwitchDevice).toHaveTranslation(
                     'TR_USE_HERE',
                 );
-                await expect(dashboardPage.walletAtIndex(0)).toBeHidden();
+                await expect(dashboardPage.walletAtIndex(0)).toBeVisible();
             });
 
             await test.step('Take Bridge session back', async () => {
@@ -54,22 +53,13 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
-            await test.step('Reload inactive suite session', async () => {
+            await test.step('Reload inactive suite session to take Bridge session back', async () => {
                 await stealBridgeSession();
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
                 await page.reload();
-            });
-
-            await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
+                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
                     timeout: 30_000,
                 });
-            });
-
-            await test.step('Take Bridge session back', async () => {
-                await dashboardPage.deviceSwitchingOpenButton.click();
-                await dashboardPage.solveIssuesButton.click();
-                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );
@@ -106,7 +96,4 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
             await pageTwo.close();
         },
     );
-
-    // todo: test what happens if you steal session and navigate directly to device settings (web)
-    // todo: test the same for other routes as well (/recovery, /backup, etc..)
 });

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -219,7 +219,7 @@ test.describe(
                     errorMessageMaxCalculation,
                 ).toHaveText(ethereumMaximumFee);
                 const maxFeeWrapped = device.wrapText(`${ethereumMaximumFee} ETH`, {
-                    isAmount: true,
+                    wrapByWords: true,
                 });
                 await expect(device).toShowOnDisplay({
                     T3W1: {


### PR DESCRIPTION
correct calling and help of quarantine bot
fixes emulator assert in send-base test
adapts multiple-session to latest behaviour

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T11:13:13.091Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T08:48:38.273Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->