### PR TITLE
fix(trading): handle empty amount in isAmountWithinNetworkReserve

### DIFF
--- a/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/sendFormUtils.test.ts
@@ -19,6 +19,7 @@ import {
     getCryptoMaxAmountWithReserve,
     getExternalComposeOutput,
     getLowestFeeFromLevels,
+    isAmountWithinNetworkReserve,
     prepareEthereumTransaction,
     restoreOrigOutputsOrder,
 } from '../sendFormUtils';
@@ -760,5 +761,29 @@ describe('sendForm utils', () => {
                 );
             },
         );
+    });
+
+    describe('isAmountWithinNetworkReserve', () => {
+        it('should treat empty amount as zero', () => {
+            expect(
+                isAmountWithinNetworkReserve({
+                    reserve: '1',
+                    balance: '10',
+                    fee: '2',
+                    amount: '',
+                }),
+            ).toBe(true);
+        });
+
+        it('should return false when amount exceeds maximum spendable amount', () => {
+            expect(
+                isAmountWithinNetworkReserve({
+                    reserve: '1',
+                    balance: '10',
+                    fee: '2',
+                    amount: '8.00000001',
+                }),
+            ).toBe(false);
+        });
     });
 });

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -771,7 +771,7 @@ export const isAmountWithinNetworkReserve = ({
     fee = '0',
     amount,
 }: IsAmountWithinNetworkReserveProps): boolean => {
-    if (!reserve || !balance) return true;
+    if (!reserve || !balance || !amount) return true;
 
     const sendAmount = new BigNumber(amount);
     const accountBalance = new BigNumber(balance);


### PR DESCRIPTION
## Description

Fix send/swap validation so that the “insufficient funds / reserved for network fees” error is **not** shown when no amount is entered, for all networks that use a native token reserve, while preserving the reserve check for non‑empty amounts.


## Notes for QA

- Open Swap directly from the account. 
- Leave amount empty and check if `Not enough funds remaining after reserving network fees` error is not shown


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25744

## Screenshot
<img width="1217" height="530" alt="image" src="https://github.com/user-attachments/assets/67aa9832-996b-4cc6-83f0-079b2a231c0e" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25744/solana-swap-reserve-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25744/solana-swap-reserve-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/25744/solana-swap-reserve-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T12:11:17.689Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-09T12:10:11.178Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->