### PR TITLE
fix(trading): fix provider visibility logic

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingSelectedOfferProvider.tsx
@@ -44,12 +44,14 @@ export const TradingSelectedOfferProvider = () => {
         await goToOffers();
     };
 
-    const needsReceiveAddress = type !== 'sell';
     const isReceiveAddressSelected =
         (isTradingExchangeContext(context) || isTradingBuyContext(context)) &&
         !!context.tradingReceiveAddress.receiveAddress;
 
-    if (quote == null || isAmountEmpty || (needsReceiveAddress && !isReceiveAddressSelected)) {
+    const shouldHideProvider = isTradingBuyContext(context) && !isReceiveAddressSelected;
+    const hasNoQuoteOrAmount = quote == null || isAmountEmpty;
+
+    if (hasNoQuoteOrAmount || shouldHideProvider) {
         return;
     }
 

--- a/suite/e2e/fixtures/invity/index.ts
+++ b/suite/e2e/fixtures/invity/index.ts
@@ -34,6 +34,7 @@ import swapQuotesSolanaBTC from './swap/quotes-solana-btc.json';
 import swapQuotesSolanaTokens from './swap/quotes-solana-tokens.json';
 import swapQuotesSolanaUSDC from './swap/quotes-solana-usdc.json';
 import swapQuotesTetherBTC from './swap/quotes-tether-btc.json';
+import swapQuotesTetherStellar from './swap/quotes-tether-stellar.json';
 import swapTradeBTCEthereum from './swap/trade-btc-eth.json';
 import swapTradeEthereumBTC from './swap/trade-eth-btc.json';
 import swapTradeSolanaBTC from './swap/trade-solana-btc.json';
@@ -128,6 +129,7 @@ export {
     swapQuotesSolanaTokens,
     swapQuotesSolanaUSDC,
     swapQuotesTetherBTC,
+    swapQuotesTetherStellar,
     swapTradeBTCEthereum,
     swapTradeEthereumBTC,
     swapTradeSolanaBTC,

--- a/suite/e2e/fixtures/invity/swap/quotes-tether-stellar.json
+++ b/suite/e2e/fixtures/invity/swap/quotes-tether-stellar.json
@@ -1,0 +1,90 @@
+[
+    {
+        "exchange": "changeherofr",
+        "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        "receive": "stellar",
+        "exp": "NtgbqCtOJS4h7K7RCcxFP5yuVhgTKZVmVlUNlKrRehk=",
+        "sendStringAmount": "9",
+        "receiveStringAmount": "54.79560126",
+        "fee": "INCLUDED",
+        "min": 287.9135997120864,
+        "max": 79975.999920024,
+        "rate": 6.0884001404,
+        "extraFieldDescription": {
+            "name": "Memo ID",
+            "description": "Memo ID is another way to identify the transaction you'll receive. It may consist of numbers and letters.",
+            "required": false,
+            "type": "text"
+        },
+        "rateIdentificator": "3476e713-bc72-4c71-a3d0-38970312939f"
+    },
+    {
+        "exchange": "changenow",
+        "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        "receive": "stellar",
+        "exp": "NtgbqCtOJS4h7K7RCcxFP5yuVhgTKZVmVlUNlKrRehk=",
+        "sendStringAmount": "9",
+        "receiveStringAmount": "53.5316498",
+        "fee": "UNKNOWN",
+        "min": 1.638,
+        "max": "NONE",
+        "rate": 5.9479610888888885,
+        "extraFieldDescription": {
+            "name": "Memo ID",
+            "description": "Memo ID is another way to identify the transaction you'll receive. It may consist of numbers and letters.",
+            "required": false,
+            "type": "text"
+        }
+    },
+    {
+        "exchange": "changenowfr",
+        "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+        "receive": "stellar",
+        "exp": "NtgbqCtOJS4h7K7RCcxFP5yuVhgTKZVmVlUNlKrRehk=",
+        "sendStringAmount": "9",
+        "receiveStringAmount": "53.0138377",
+        "fee": "INCLUDED",
+        "min": 9.26527896,
+        "max": 33651.635786,
+        "rate": 5.890426411111111,
+        "extraFieldDescription": {
+            "name": "Memo ID",
+            "description": "Memo ID is another way to identify the transaction you'll receive. It may consist of numbers and letters.",
+            "required": false,
+            "type": "text"
+        },
+        "rateIdentificator": "lPHB+oCTOCyV/1/oLRdkLXr+2G+RpkdM0joKy5RCl8W2y6m6YR1ASUqtQRgIA1CkTzn5W2A5fAxgelFkRJ5l35FvGRbw2Y0rkMvbUhOG0DZI0DX5zbcz9pDSXxlyXtVObzJbg0lZvOkGpMpl2F/rWOOeel57qcV8XUcgqrlCYVXhOveqBT7Rjwpvv26dUnT6PlBvFrK1m0C3TJjGlgqs0g=="
+    },
+    {
+        "error": "Amount is less than minimal: 9.9969999900030011 usdtsol",
+        "exchange": "changehero"
+    },
+    {
+        "error": "No response from exchange.",
+        "exchange": "changelly",
+        "errorDetails": {
+            "origin": "internal",
+            "code": "no_response"
+        }
+    },
+    {
+        "error": "No response from exchange.",
+        "exchange": "changellyfr",
+        "errorDetails": {
+            "origin": "internal",
+            "code": "no_response"
+        }
+    },
+    {
+        "error": "Cannot trade pair solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB-stellar.",
+        "exchange": "godexexchange",
+        "errorDetails": {
+            "origin": "internal",
+            "code": "invalid_pair",
+            "pair": {
+                "send": "solana--Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+                "receive": "stellar"
+            }
+        }
+    }
+]

--- a/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
@@ -1,0 +1,55 @@
+import { getCryptoId } from '@suite-common/trading';
+
+import { invityEndpoint, swapQuotesTetherStellar } from '../../fixtures/invity';
+import { expect, test } from '../../support/fixtures';
+
+const sendAmount = swapQuotesTetherStellar[0].sendStringAmount!;
+
+test.describe(
+    'Trading - Swap token to disabled network asset',
+    {
+        tag: ['@webOnly', '@T3W1', '@T3T1'],
+    },
+    () => {
+        test.use({
+            deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
+        });
+
+        test.beforeEach(
+            async ({ page, onboardingPage, dashboardPage, walletPage, settingsPage }) => {
+                await test.step('Mocking responses', async () => {
+                    await page.route(invityEndpoint.swapQuotes, async route => {
+                        await route.fulfill({ json: swapQuotesTetherStellar });
+                    });
+                });
+
+                await onboardingPage.completeOnboarding();
+                await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+                await dashboardPage.openDeviceSwitcher();
+                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+                await walletPage.openSwapTrading({ symbol: 'sol' });
+            },
+        );
+
+        test('Show provider info for disabled network asset XLM', async ({ tradingPage }) => {
+            await test.step('Fill in a Swap form with Stellar buy asset', async () => {
+                await tradingPage.fillSwapForm({
+                    amount: sendAmount,
+                    sellAsset: {
+                        networkSymbol: 'sol',
+                        tokenSymbol: 'USDT',
+                    },
+                    buyAsset: {
+                        searchFilter: 'XLM',
+                        networkFilter: 'xlm',
+                        assetCryptoId: getCryptoId('xlm'),
+                    },
+                });
+            });
+
+            await test.step('Verify provider info is visible in quotes', async () => {
+                await expect(tradingPage.quotes.selectedProvider).toBeVisible();
+            });
+        });
+    },
+);


### PR DESCRIPTION
## Description

- Ensure swap provider is visible even when no receive account is selected, as long as quotes are loaded.
- Keep the stricter behavior only for Buy flow, where provider still hides until a valid receive address is chosen.
- Add regression coverage to the swap coin→token e2e test to verify provider visibility without a selected receive account.

## Notes for QA

- Go to **Swap**.
- Choose a **sell asset** you have (e.g. SOL or token) and a **buy asset/token** you do *not* yet have an account for.
- **Do not** select any receive account, enter a valid amount so quotes load.
- Verify:
  - Best offer loads and a **Provider** row is visible with the expected provider name.
  - You can click the provider row to open the offers list.
  - Buy flow behavior is unchanged: provider is still hidden until a valid receive address is set.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24194

## Screenshots:
<img width="1097" height="752" alt="image" src="https://github.com/user-attachments/assets/f59ca5eb-9897-4fc8-be6f-3923558546c0" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/24194/provider-visible-receive-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/24194/provider-visible-receive-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-11T15:37:11.569Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-09T13:59:30.008Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->