### PR TITLE
XRP - dynamic reserve error message

### DIFF
--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -9,7 +9,7 @@ import { isFulfilled } from '@reduxjs/toolkit';
 
 import { selectDeviceUnavailableCapabilities } from '@suite-common/device';
 import { getExcludedUtxos } from '@suite-common/transaction-search';
-import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
+import { NetworkType, getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
 import {
     AccountsRootState,
     FeesRootState,
@@ -24,8 +24,12 @@ import {
     sendFormActions,
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
-import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import { convertAmountUnitsToSubunits, getNetworkReserve } from '@suite-common/wallet-utils';
+import { Account, AccountKey, TokenAddress } from '@suite-common/wallet-types';
+import {
+    convertAmountUnitsToSubunits,
+    formatNetworkAmount,
+    getNetworkReserve,
+} from '@suite-common/wallet-utils';
 import { useForm } from '@suite-native/forms';
 import {
     SendStackParamList,
@@ -41,9 +45,9 @@ import {
 } from '@suite-native/transaction-management';
 import { useDebounce } from '@trezor/react-utils';
 
-import { useUtxoSelection } from './useUtxoSelection';
 import { SendOutputsFormValues, sendOutputsFormValidationSchema } from '../sendOutputsFormSchema';
 import { constructFormDraft } from '../utils';
+import { useUtxoSelection } from './useUtxoSelection';
 
 const getDefaultValues = ({
     tokenContract,
@@ -63,6 +67,17 @@ const getDefaultValues = ({
             },
         ],
     }) as const;
+
+const getRippleReserve = (account: Account, networkType: NetworkType) => {
+    const reserve =
+        account.misc && 'reserve' in account.misc && account.misc.reserve
+            ? account.misc.reserve
+            : undefined;
+
+    if (networkType !== 'ripple' || !reserve) return undefined;
+
+    return formatNetworkAmount(reserve, account.symbol);
+};
 
 export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress) => {
     const dispatch = useDispatch();
@@ -119,6 +134,9 @@ export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress
           })
         : undefined;
 
+    const rippleReserve =
+        account && network ? getRippleReserve(account, network.networkType) : undefined;
+
     const form = useForm<SendOutputsFormValues>({
         validation: sendOutputsFormValidationSchema,
         // If the form is prefilled with the draft values, we want to revalidate the draft on every change.
@@ -135,6 +153,7 @@ export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress
             isTaprootAvailable: !deviceUnavailableCapabilities?.taproot,
             accountNativeAvailableBalance: account?.availableBalance,
             networkReserve,
+            rippleReserve,
         },
         defaultValues: getDefaultValues({
             tokenContract,

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -1,5 +1,5 @@
 import { formInputsMaxLength, yup } from '@suite-common/validators';
-import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getDisplaySymbol, getNetworkType } from '@suite-common/wallet-config';
 import { U_INT_32 } from '@suite-common/wallet-constants';
 import { FeeInfo, Output } from '@suite-common/wallet-types';
 import {
@@ -26,6 +26,7 @@ export type SendFormFormContext = {
     isTaprootAvailable?: boolean;
     accountNativeAvailableBalance?: string;
     networkReserve?: string;
+    rippleReserve?: string;
 };
 
 const isAmountDust = (amount: string, context?: SendFormFormContext) => {
@@ -153,9 +154,9 @@ const outputSchema = yup.object({
         )
         .test(
             'ripple-higher-than-reserve',
-            'Amount is above the required unspendable reserve (1 XRP)',
+            'Amount is above the required unspendable reserve',
             function (value, { options: { context } }: yup.TestContext<SendFormFormContext>) {
-                const { symbol, availableBalance, feeLevelsMaxAmount } = context!;
+                const { symbol, availableBalance, feeLevelsMaxAmount, rippleReserve } = context!;
 
                 if (!availableBalance || !symbol || getNetworkType(symbol) !== 'ripple')
                     return true;
@@ -172,7 +173,11 @@ const outputSchema = yup.object({
                         ),
                     )
                 ) {
-                    return false;
+                    const displaySymbol = getDisplaySymbol(symbol);
+
+                    return this.createError({
+                        message: `Amount is above the required unspendable reserve${rippleReserve ? ` (${rippleReserve} ${displaySymbol})` : ''}`,
+                    });
                 }
 
                 return true;


### PR DESCRIPTION
## Description

In send form validation, provide dynamic XRP reserve message to the user. The reserve is taken from `account.misc.reserve` is injected into the schema validation.

> [!IMPORTANT]
> This PR does NOT handle translations for yup schema validation, as a separate issue exists for this. (https://github.com/trezor/trezor-suite/issues/11004)

## Related Issue

Resolve #15894 

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="simulator_screenshot_A64A2AD0-8A86-43A3-A4B4-FDF93781B0BE" src="https://github.com/user-attachments/assets/be66531c-c88f-473f-8d47-ce0aaac978db" />
</td>
<td>
<img width="1206" height="2622" alt="simulator_screenshot_AEEF704A-ADA4-4665-BE04-7FC231798C05" src="https://github.com/user-attachments/assets/0aca6e17-d2db-491a-beb6-4b02049319a4" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/xrp-dynamic-reserve-message&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->