### PR TITLE
fix(connect): ensure thpRemoveCredentials is successful when called without device

### DIFF
--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -17,7 +17,7 @@ export default class ThpRemoveCredentials extends AbstractMethod<'thpRemoveCrede
 
     run() {
         const requestedCredentials = this.payload.credentials || [];
-        if (this.getDevice()) {
+        if (this.useDevice) {
             const thpState = this.getDevice().getThpState();
             if (thpState) {
                 requestedCredentials.push(...thpState.pairingCredentials);


### PR DESCRIPTION
Introduced by #25689. In case a `device` is not provided, the call incorrectly ends with `Device_NotFound`.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect/thp-remove-credentials&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect/thp-remove-credentials&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-09T19:07:20.501Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->