### PR TITLE
fix(connect): init/call/dispose races

### DIFF
--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -146,6 +146,15 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
             if (!this.settings.manifest) {
                 throw ERRORS.TypedError('Init_ManifestMissing');
             }
+
+            // If init() is in progress but hasn't completed yet, wait for it.
+            if (!this.coreManager.get()) {
+                const pending = this.coreManager.getPending();
+                if (pending) {
+                    await pending;
+                }
+            }
+
             const { promiseId, promise } = this.messagePromises.create();
             const payload = cloneObject<any>(params);
             this.handleCoreMessage({ type: CORE_CALL, id: promiseId, payload });
@@ -170,6 +179,12 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
     public dispose() {
         this.eventEmitter.removeAllListeners();
         this.settings = parseConnectSettings();
-        this.coreManager.dispose();
+
+        // Only dispose coreManager if initialization has completed.
+        // If init is still pending (getPending() is truthy), disposing would reject
+        // the pending promise and cause an unhandled rejection in the init() caller.
+        if (this.coreManager.get()) {
+            this.coreManager.dispose();
+        }
     }
 }


### PR DESCRIPTION
on develop `yarn workspace @suite-common/connect-init test:unit` is now failing (if cache is not applied).  It looks like we broke tests after merging this #25589 probably and we also have some cache invalidation issue with nx

cc @juriczech 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-call-init-dispose-races&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-call-init-dispose-races&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T08:15:14.978Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->