### PR TITLE
Pass route name to trading navigation

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.tsx
@@ -2,11 +2,17 @@ import { PropsWithChildren } from 'react';
 
 import { Column } from '@trezor/components';
 
+import { useSelector } from 'src/hooks/suite';
+import { selectRouteName } from 'src/reducers/suite/routerReducer';
 import { TradingLayoutNavigation } from 'src/views/wallet/trading/common/TradingLayout/TradingLayoutNavigation';
 
-export const TradingLayout = ({ children }: PropsWithChildren) => (
-    <Column data-testid="@trading" gap={24}>
-        <TradingLayoutNavigation />
-        {children}
-    </Column>
-);
+export const TradingLayout = ({ children }: PropsWithChildren) => {
+    const routeName = useSelector(selectRouteName);
+
+    return (
+        <Column data-testid="@trading" gap={24}>
+            <TradingLayoutNavigation route={routeName} />
+            {children}
+        </Column>
+    );
+};


### PR DESCRIPTION
## Notes to QA
Fix active tab state in trading navigation 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-navigation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-navigation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T08:15:53.242Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T08:13:56.511Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->