### PR TITLE
Refactor(native): device compromised navigation

### DIFF
--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -71,12 +71,10 @@ type ResetNavigationTarget = {
 };
 
 type NavigationTarget = {
-    route: RootStackRoutes;
-    params?: {
-        screen: string;
-        params?: Record<string, any>;
-    };
-};
+    [K in keyof RootStackParamList]: undefined extends RootStackParamList[K]
+        ? { route: K; params?: RootStackParamList[K] }
+        : { route: K; params: RootStackParamList[K] };
+}[keyof RootStackParamList];
 
 type NavigationFixture = {
     description: string;
@@ -377,6 +375,9 @@ export const deviceConnectCompromisedFixtures: NavigationFixture[] = [
         },
         expectedNavigation: {
             route: RootStackRoutes.DeviceCompromisedModal,
+            params: {
+                failedCheck: 'device-authenticity',
+            },
         },
     },
 ];

--- a/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionMiddleware.test.ts
@@ -99,10 +99,7 @@ describe('deviceConnectionMiddleware', () => {
 
                     expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
                         expectedNavigation.route,
-                        {
-                            screen: expectedNavigation.params?.screen,
-                            params: expectedNavigation.params?.params,
-                        },
+                        expectedNavigation.params,
                     );
                     expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(1);
                 },
@@ -183,6 +180,7 @@ describe('deviceConnectionMiddleware', () => {
 
                     expect(navigationContainerRef.navigate).toHaveBeenCalledWith(
                         expectedNavigation.route,
+                        expectedNavigation.params,
                     );
                     expect(navigationContainerRef.navigate).toHaveBeenCalledTimes(1);
                 },

--- a/suite-native/device/src/deviceNavigationConfig.ts
+++ b/suite-native/device/src/deviceNavigationConfig.ts
@@ -8,6 +8,7 @@ import {
 // We should not redirect him away so he can read the screen content and decide what to do.
 // If the device is connected again, he still should stay on that screen.
 export const DEVICE_DISCONNECTION_BLACKLISTED_ROUTES = [
+    RootStackRoutes.DeviceCompromisedModal,
     DeviceOnboardingStackRoutes.SuspiciousDevice,
 ];
 
@@ -19,14 +20,8 @@ export const DEVICE_CONNECTION_BLACKLISTED_ROUTES = [
     ...SEND_STACK_ROUTES,
 ];
 
-export const buildDisconnectionBlacklist = (
-    isEntropyCheckEnabledAndFailed: boolean,
-    isDeviceRemembered: boolean,
-) => [
+export const buildDisconnectionBlacklist = (isDeviceRemembered: boolean) => [
     ...DEVICE_DISCONNECTION_BLACKLISTED_ROUTES,
-    // Device compromised modal is persistant and should not be interrupted by device disconnection,
-    // however Entropy check modal should be dismissed on disconnect because you cannot exit the modal via normal means
-    ...(!isEntropyCheckEnabledAndFailed ? [RootStackRoutes.DeviceCompromisedModal] : []),
     // Add SendStack only if device is remembered
     ...(isDeviceRemembered ? SEND_STACK_ROUTES : []),
 ];

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -33,11 +33,7 @@ import {
     DEVICE_CONNECTION_BLACKLISTED_ROUTES,
     buildDisconnectionBlacklist,
 } from '../deviceNavigationConfig';
-import {
-    NativeDeviceRootState,
-    selectCompromisedDeviceFailedCheck,
-    selectIsEntropyCheckEnabledAndFailed,
-} from '../selectors';
+import { NativeDeviceRootState, selectCompromisedDeviceFailedCheck } from '../selectors';
 import { getIsDeviceSetupSupported } from '../utils';
 
 export const deviceConnectionMiddleware = createListenerMiddleware<NativeDeviceRootState>();
@@ -194,19 +190,13 @@ deviceConnectionMiddleware.startListening({
 
         const device = action.payload;
         const isDeviceRemembered = getIsDeviceRemembered(device);
-        const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(
-            getState(),
-            device?.id,
-        );
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
         const wasDeviceConnectedViaBluetooth = getIsDeviceDescriptorApiTypeBluetooth(
             action.payload,
         );
 
         if (
-            checkIsActiveRouteAnyOf(
-                buildDisconnectionBlacklist(isEntropyCheckEnabledAndFailed, isDeviceRemembered),
-            ) ||
+            checkIsActiveRouteAnyOf(buildDisconnectionBlacklist(isDeviceRemembered)) ||
             isFirmwareInstallationRunning
         )
             return;

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -35,7 +35,7 @@ import {
 } from '../deviceNavigationConfig';
 import {
     NativeDeviceRootState,
-    selectIsDeviceCompromised,
+    selectCompromisedDeviceFailedCheck,
     selectIsEntropyCheckEnabledAndFailed,
 } from '../selectors';
 import { getIsDeviceSetupSupported } from '../utils';
@@ -140,20 +140,19 @@ deviceConnectionMiddleware.startListening({
         // Your decision logic should be derived from device passed from TrezorConnect in the action payload (not selectedDevice from the state).
         const { device } = action.payload;
 
-        const shouldNavigateToDeviceCompromisedModal = selectIsDeviceCompromised(
-            getState(),
-            device,
-        );
+        const failedCheck = selectCompromisedDeviceFailedCheck(getState(), device);
 
         if (checkIsActiveRouteAnyOf(DEVICE_CONNECTION_BLACKLISTED_ROUTES)) return;
 
         // During firmware installation, device restarts (disconnect + connect) and we want to ignore it.
         if (selectIsFirmwareInstallationRunning(getState())) return;
 
-        if (shouldNavigateToDeviceCompromisedModal) {
+        if (failedCheck) {
             // When the compromised modal is closed on first connection and no coins would be selected, we will need to redirect user
             // to coin enabling so he can continue to the app with running discovery.
-            navigationContainerRef.navigate(RootStackRoutes.DeviceCompromisedModal);
+            navigationContainerRef.navigate(RootStackRoutes.DeviceCompromisedModal, {
+                failedCheck,
+            });
 
             return;
         }

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -258,53 +258,31 @@ export const selectShouldFactoryResetBeVisible = createMemoizedSelector(
         isDeviceInBootloader && hasDeviceFirmwareInstalled,
 );
 
-export const selectCompromisedDeviceFailedCheck = createMemoizedSelector(
-    [
-        selectIsDeviceAuthenticityCheckEnabled,
-        (state: NativeDeviceRootState, device: Device) =>
-            selectIsDeviceAuthenticityCheckFailed(state, device?.id),
-        (state: NativeDeviceRootState, device: Device) =>
-            selectIsEntropyCheckEnabledAndFailed(state, device?.id),
-        (state: NativeDeviceRootState, device: Device) =>
-            selectIsFirmwareAuthenticityCheckDismissed(state, device?.id),
-        (state: NativeDeviceRootState, device: Device) =>
-            selectHasFirmwareAuthenticityCheckHardFailed(state, device),
-    ],
-    (
-        isDeviceAuthenticityCheckEnabled,
-        isDeviceAuthenticityCheckFailed,
-        isEntropyCheckEnabledAndFailed,
-        isFirmwareAuthenticityCheckDismissed,
-        hasFirmwareAuthenticityCheckHardFailed,
-    ) => {
-        const isDeviceAuthenticityEnabledAndFailed =
-            isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
+export const selectCompromisedDeviceFailedCheck = (
+    state: NativeDeviceRootState,
+    device: Device,
+) => {
+    const deviceId = device?.id;
+    const isDeviceAuthenticityCheckEnabled = selectIsDeviceAuthenticityCheckEnabled(state);
+    const isDeviceAuthenticityCheckFailed = selectIsDeviceAuthenticityCheckFailed(state, deviceId);
+    const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state, deviceId);
+    const isFirmwareAuthenticityCheckDismissed = selectIsFirmwareAuthenticityCheckDismissed(
+        state,
+        deviceId,
+    );
+    const hasFirmwareAuthenticityCheckHardFailed = selectHasFirmwareAuthenticityCheckHardFailed(
+        state,
+        device,
+    );
+    const isDeviceAuthenticityEnabledAndFailed =
+        isDeviceAuthenticityCheckEnabled && isDeviceAuthenticityCheckFailed;
 
-        const isFirmwareAuthenticityCheckHardFailedAndNotDismissed =
-            hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
+    const isFirmwareAuthenticityCheckHardFailedAndNotDismissed =
+        hasFirmwareAuthenticityCheckHardFailed && !isFirmwareAuthenticityCheckDismissed;
 
-        if (isDeviceAuthenticityEnabledAndFailed) {
-            return 'device-authenticity';
-        }
-        if (isEntropyCheckEnabledAndFailed) {
-            return 'entropy';
-        }
-        if (isFirmwareAuthenticityCheckHardFailedAndNotDismissed) {
-            return 'firmware-authenticity';
-        }
+    if (isDeviceAuthenticityEnabledAndFailed) return 'device-authenticity';
+    if (isEntropyCheckEnabledAndFailed) return 'entropy';
+    if (isFirmwareAuthenticityCheckHardFailedAndNotDismissed) return 'firmware-authenticity';
 
-        return null;
-    },
-);
-
-export const selectSelectedDeviceCompromisedDeviceFailedCheck = (state: NativeDeviceRootState) => {
-    const device = selectSelectedDevice(state);
-    if (!device) return null;
-
-    return selectCompromisedDeviceFailedCheck(state, device);
+    return null;
 };
-
-export const selectIsDeviceCompromised = createMemoizedSelector(
-    [selectCompromisedDeviceFailedCheck],
-    failedCheck => failedCheck !== null,
-);

--- a/suite-native/device/src/selectors.ts
+++ b/suite-native/device/src/selectors.ts
@@ -241,6 +241,14 @@ export const selectIsEntropyCheckEnabledAndFailed = createMemoizedSelector(
     ],
     (isFeatureEnabled, isEntropyCheckFailed) => isFeatureEnabled && isEntropyCheckFailed,
 );
+export const selectIsEntropyCheckEnabledAndFailedForSelectedDevice = (
+    state: FwAuthenticityCheckState,
+) => {
+    const device = selectSelectedDevice(state);
+    if (!device) return false;
+
+    return selectIsEntropyCheckEnabledAndFailed(state, device.id);
+};
 
 export const selectIsDeviceAuthenticityCheckFailed = createMemoizedSelector(
     [selectDeviceAuthenticityByDeviceId],

--- a/suite-native/module-authenticity-checks/src/components/CloseButton.tsx
+++ b/suite-native/module-authenticity-checks/src/components/CloseButton.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type CloseButtonProps = {
+    handleClose: () => void;
+};
+
+export const CloseButton = ({ handleClose }: CloseButtonProps) => (
+    <Button colorScheme="redElevation0" onPress={handleClose}>
+        <Translation id="generic.buttons.close" />
+    </Button>
+);

--- a/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/EntropyCheckFailModalContent.tsx
@@ -1,16 +1,35 @@
+import { useSelector } from 'react-redux';
+
+import { selectIsEntropyCheckEnabledAndFailedForSelectedDevice } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 import { ScreenHeader, useInterceptNativeNavigation } from '@suite-native/navigation';
 import { HELP_CENTER_ENTROPY_CHECK_URL } from '@trezor/urls';
 
+import { CloseButton } from './CloseButton';
 import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
+import { useCloseDeviceCompromisedScreen } from './useCloseDeviceCompromisedScreen';
 
 export const EntropyCheckFailModalContent = () => {
     useInterceptNativeNavigation();
 
+    const { handleClose } = useCloseDeviceCompromisedScreen();
+
+    const isEntropyCheckFailedForCurrentDevice = useSelector(
+        selectIsEntropyCheckEnabledAndFailedForSelectedDevice,
+    );
+    const canClose = !isEntropyCheckFailedForCurrentDevice;
+
     return (
         <DeviceCompromisedModalContent
             contactSupportUrl={HELP_CENTER_ENTROPY_CHECK_URL}
-            screenHeaderContent={<ScreenHeader leftIcon={null} />}
+            screenHeaderContent={
+                canClose ? (
+                    <ScreenHeader closeActionType="close" closeAction={handleClose} />
+                ) : (
+                    <ScreenHeader leftIcon={null} />
+                )
+            }
+            closeButtonContent={canClose ? <CloseButton handleClose={handleClose} /> : null}
             subtitleContent={
                 <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle.entropy" />
             }

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -1,79 +1,11 @@
-import { useDispatch, useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
-
-import {
-    deviceActions,
-    selectIsDeviceInitialized,
-    selectSelectedDevice,
-} from '@suite-common/device';
-import { getDeviceInternalModel } from '@suite-common/suite-utils';
-import { selectIsAnyNetworkEnabled } from '@suite-common/wallet-core';
-import { Button } from '@suite-native/atoms';
-import { selectIsDeviceSetupSupported } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
-import {
-    AuthorizeDeviceStackRoutes,
-    DeviceOnboardingStackRoutes,
-    RootStackParamList,
-    RootStackRoutes,
-    ScreenHeader,
-    StackToStackCompositeNavigationProps,
-    useNavigateToInitialScreen,
-} from '@suite-native/navigation';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
 import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
-
-type NavigationProps = StackToStackCompositeNavigationProps<
-    RootStackParamList,
-    RootStackRoutes.DeviceCompromisedModal,
-    RootStackParamList
->;
+import { useCloseDeviceCompromisedScreen } from './useCloseDeviceCompromisedScreen';
 
 export const FirmwareAuthenticityCheckFailModalContent = () => {
-    const dispatch = useDispatch();
-
-    const navigation = useNavigation<NavigationProps>();
-    const navigateToInitialScreen = useNavigateToInitialScreen();
-
-    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
-    const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
-    const isAnyNetworkEnabled = useSelector(selectIsAnyNetworkEnabled);
-    const device = useSelector(selectSelectedDevice);
-
-    const dismissCheck = () => {
-        if (device?.id) {
-            dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
-        }
-    };
-
-    const handleClose = () => {
-        dismissCheck();
-
-        if (!isDeviceInitialized && isDeviceSetupSupported) {
-            navigation.popTo(RootStackRoutes.DeviceOnboardingStack, {
-                screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
-                params: {
-                    deviceModel: getDeviceInternalModel(device),
-                },
-            });
-        } else if (!isAnyNetworkEnabled) {
-            navigation.popTo(RootStackRoutes.AuthorizeDeviceStack, {
-                screen: AuthorizeDeviceStackRoutes.CoinEnablingInit,
-            });
-        } else {
-            navigateToInitialScreen();
-        }
-    };
-
-    const screenHeaderContent = <ScreenHeader closeActionType="close" closeAction={handleClose} />;
-
-    const closeButtonContent = (
-        <Button colorScheme="redElevation0" onPress={handleClose}>
-            <Translation id="generic.buttons.close" />
-        </Button>
-    );
+    const { screenHeaderContent, closeButtonContent } = useCloseDeviceCompromisedScreen();
 
     return (
         <DeviceCompromisedModalContent

--- a/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
+++ b/suite-native/module-authenticity-checks/src/components/FirmwareAuthenticityCheckFailModalContent.tsx
@@ -1,17 +1,19 @@
 import { Translation } from '@suite-native/intl';
+import { ScreenHeader } from '@suite-native/navigation';
 import { TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL } from '@trezor/urls';
 
+import { CloseButton } from './CloseButton';
 import { DeviceCompromisedModalContent } from './DeviceCompromisedModalContent';
 import { useCloseDeviceCompromisedScreen } from './useCloseDeviceCompromisedScreen';
 
 export const FirmwareAuthenticityCheckFailModalContent = () => {
-    const { screenHeaderContent, closeButtonContent } = useCloseDeviceCompromisedScreen();
+    const { handleClose } = useCloseDeviceCompromisedScreen();
 
     return (
         <DeviceCompromisedModalContent
             contactSupportUrl={TREZOR_SUPPORT_FW_REVISION_CHECK_FAILED_MOBILE_URL}
-            screenHeaderContent={screenHeaderContent}
-            closeButtonContent={closeButtonContent}
+            screenHeaderContent={<ScreenHeader closeActionType="close" closeAction={handleClose} />}
+            closeButtonContent={<CloseButton handleClose={handleClose} />}
             subtitleContent={
                 <Translation id="moduleAuthenticityChecks.deviceCompromised.subtitle.fwRevision" />
             }

--- a/suite-native/module-authenticity-checks/src/components/useCloseDeviceCompromisedScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/components/useCloseDeviceCompromisedScreen.tsx
@@ -1,0 +1,84 @@
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import {
+    deviceActions,
+    selectIsDeviceInitialized,
+    selectSelectedDevice,
+} from '@suite-common/device';
+import { getDeviceInternalModel } from '@suite-common/suite-utils';
+import { selectIsAnyNetworkEnabled } from '@suite-common/wallet-core';
+import { Button } from '@suite-native/atoms';
+import { selectIsDeviceSetupSupported } from '@suite-native/device';
+import { Translation } from '@suite-native/intl';
+import {
+    AuthorizeDeviceStackRoutes,
+    DeviceOnboardingStackRoutes,
+    RootStackParamList,
+    RootStackRoutes,
+    ScreenHeader,
+    StackToStackCompositeNavigationProps,
+    useNavigateToInitialScreen,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.DeviceCompromisedModal,
+    RootStackParamList
+>;
+
+/**
+ * Functionality to navigate to the appropriate next screen based on the current state, because navigation
+ * to the Device Compromised screen can occur inbetween different flows.
+ */
+export const useCloseDeviceCompromisedScreen = () => {
+    const dispatch = useDispatch();
+
+    const navigation = useNavigation<NavigationProps>();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
+
+    const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
+    const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
+    const isAnyNetworkEnabled = useSelector(selectIsAnyNetworkEnabled);
+    const device = useSelector(selectSelectedDevice);
+
+    const dismissCheck = () => {
+        if (device?.id) {
+            dispatch(deviceActions.dismissFirmwareAuthenticityCheck(device.id));
+        }
+    };
+
+    const handleClose = () => {
+        dismissCheck();
+
+        if (!isDeviceInitialized && isDeviceSetupSupported) {
+            navigation.popTo(RootStackRoutes.DeviceOnboardingStack, {
+                screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
+                params: {
+                    deviceModel: getDeviceInternalModel(device),
+                },
+            });
+        } else if (!isAnyNetworkEnabled) {
+            navigation.popTo(RootStackRoutes.AuthorizeDeviceStack, {
+                screen: AuthorizeDeviceStackRoutes.CoinEnablingInit,
+            });
+        } else {
+            navigateToInitialScreen();
+        }
+    };
+
+    const screenHeaderContent = <ScreenHeader closeActionType="close" closeAction={handleClose} />;
+
+    const closeButtonContent = (
+        <Button colorScheme="redElevation0" onPress={handleClose}>
+            <Translation id="generic.buttons.close" />
+        </Button>
+    );
+
+    return {
+        handleClose,
+        screenHeaderContent,
+        closeButtonContent,
+    };
+};

--- a/suite-native/module-authenticity-checks/src/components/useCloseDeviceCompromisedScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/components/useCloseDeviceCompromisedScreen.tsx
@@ -9,15 +9,12 @@ import {
 } from '@suite-common/device';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { selectIsAnyNetworkEnabled } from '@suite-common/wallet-core';
-import { Button } from '@suite-native/atoms';
 import { selectIsDeviceSetupSupported } from '@suite-native/device';
-import { Translation } from '@suite-native/intl';
 import {
     AuthorizeDeviceStackRoutes,
     DeviceOnboardingStackRoutes,
     RootStackParamList,
     RootStackRoutes,
-    ScreenHeader,
     StackToStackCompositeNavigationProps,
     useNavigateToInitialScreen,
 } from '@suite-native/navigation';
@@ -68,17 +65,7 @@ export const useCloseDeviceCompromisedScreen = () => {
         }
     };
 
-    const screenHeaderContent = <ScreenHeader closeActionType="close" closeAction={handleClose} />;
-
-    const closeButtonContent = (
-        <Button colorScheme="redElevation0" onPress={handleClose}>
-            <Translation id="generic.buttons.close" />
-        </Button>
-    );
-
     return {
         handleClose,
-        screenHeaderContent,
-        closeButtonContent,
     };
 };

--- a/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
+++ b/suite-native/module-authenticity-checks/src/screens/DeviceCompromisedModalScreen.tsx
@@ -1,11 +1,12 @@
-import { useSelector } from 'react-redux';
+import { RouteProp, useRoute } from '@react-navigation/native';
 
-import { selectSelectedDeviceCompromisedDeviceFailedCheck } from '@suite-native/device';
+import { RootStackParamList, RootStackRoutes } from '@suite-native/navigation';
 import { exhaustive } from '@trezor/type-utils';
 
 import { DeviceAuthenticityCheckFailModalContent } from '../components/DeviceAuthenticityCheckFailModalContent';
 import { EntropyCheckFailModalContent } from '../components/EntropyCheckFailModalContent';
 import { FirmwareAuthenticityCheckFailModalContent } from '../components/FirmwareAuthenticityCheckFailModalContent';
+import { useCloseDeviceCompromisedScreen } from '../components/useCloseDeviceCompromisedScreen';
 
 /**
  * Modal can be displayed for:
@@ -14,7 +15,16 @@ import { FirmwareAuthenticityCheckFailModalContent } from '../components/Firmwar
  * - device authenticity check failure
  */
 export const DeviceCompromisedModalScreen = () => {
-    const failedCheck = useSelector(selectSelectedDeviceCompromisedDeviceFailedCheck);
+    const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.DeviceCompromisedModal>>();
+    const { failedCheck } = route.params;
+    const { handleClose } = useCloseDeviceCompromisedScreen();
+
+    if (!failedCheck) {
+        console.error('DeviceCompromisedModalScreen requires failedCheck param to be passed');
+        handleClose();
+
+        return null;
+    }
 
     switch (failedCheck) {
         case 'device-authenticity':
@@ -22,7 +32,6 @@ export const DeviceCompromisedModalScreen = () => {
         case 'entropy':
             return <EntropyCheckFailModalContent />;
         case 'firmware-authenticity':
-        case null: // TODO fix entropy check screen persistence after disconnecting the device
             return <FirmwareAuthenticityCheckFailModalContent />;
         default:
             return exhaustive(failedCheck);

--- a/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceAuthenticityScreen.tsx
@@ -26,7 +26,9 @@ export const DeviceAuthenticityScreen = ({ navigation }: { navigation: Navigatio
         navigation.navigate(DeviceOnboardingStackRoutes.DeviceAuthenticitySuccess);
     }, [navigation]);
     const handleFailure = useCallback(() => {
-        navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+        navigation.navigate(RootStackRoutes.DeviceCompromisedModal, {
+            failedCheck: 'device-authenticity',
+        });
     }, [navigation]);
 
     const startCheckDeviceAuthenticity = useCallback(() => {

--- a/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/WalletCreationScreen.tsx
@@ -79,7 +79,9 @@ export const WalletCreationScreen = () => {
 
             // handle entropy check failure
             if (isEntropyCheckEnabled && code === 'Failure_EntropyCheck') {
-                return navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+                return navigation.navigate(RootStackRoutes.DeviceCompromisedModal, {
+                    failedCheck: 'entropy',
+                });
             }
             // canceled on device -> cancel in suite
             else if (code === 'Failure_ActionCancelled' || code === 'Method_Interrupted') {

--- a/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceAuthenticityStackNavigator.tsx
@@ -44,7 +44,9 @@ export const DeviceAuthenticityStackNavigator = () => {
     }, [navigation]);
 
     const handleFailure = useCallback(() => {
-        navigation.navigate(RootStackRoutes.DeviceCompromisedModal);
+        navigation.navigate(RootStackRoutes.DeviceCompromisedModal, {
+            failedCheck: 'device-authenticity',
+        });
     }, [navigation]);
 
     useEffect(() => {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -60,6 +60,11 @@ export type DeviceSuspicionCause =
     | 'securitySeal'
     | 'packaging';
 
+export type DeviceCompromisedModalFailedCheck =
+    | 'device-authenticity'
+    | 'entropy'
+    | 'firmware-authenticity';
+
 type AccountDetailParams = {
     accountKey?: AccountKey;
     tokenContract?: TokenAddress;
@@ -387,7 +392,9 @@ export type RootStackParamList = {
     [RootStackRoutes.WalletConnectPair]: undefined;
     [RootStackRoutes.SettingsScreenStack]: NavigatorScreenParams<SettingsStackParamList>;
     [RootStackRoutes.BackupFailedModal]: undefined;
-    [RootStackRoutes.DeviceCompromisedModal]: undefined;
+    [RootStackRoutes.DeviceCompromisedModal]: {
+        failedCheck: DeviceCompromisedModalFailedCheck;
+    };
     [RootStackRoutes.BootloaderMode]: undefined;
     [RootStackRoutes.TradingLocationModal]: undefined;
     [RootStackRoutes.Storybook]: undefined;


### PR DESCRIPTION
## Description

Followup to #25736

- extract `useCloseDeviceCompromisedScreen` from FW Auth screen
- instead of navigation to DeviceCompromised, and then selecting which check is failed, pass the failed check as a navigation param
  - [fixes this problem](https://github.com/trezor/trezor-suite/pull/25736#discussion_r2901657550) from previous PR
- change behavior of entropy check screen: now persists after disconnecting the device, and becomes dismissable
  - this is better UX and it removes hack from code as well

## Notes for QA

Test together with #25736

## Screenshots:

Entropy check screen fixed bug, can be closed after disconnect
[entropy check closable after disconnect.webm](https://github.com/user-attachments/assets/0160e799-643c-4594-8c49-47e72f689f96)

Unchanged behavior: revision check screen closable always:
[rev check closable always.webm](https://github.com/user-attachments/assets/10d28197-de1a-469b-925e-dde565682500)


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-compro-navigation-followup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->