### PR TITLE
Test /squash bot command

### DIFF
--- a/.github/workflows/bot-squash.yml
+++ b/.github/workflows/bot-squash.yml
@@ -1,0 +1,63 @@
+name: "[Bot] squash pull request"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  squash-pr:
+    name: Squash pull request
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && github.head_ref == 'add-squash-command-to-action-test') || (github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/squash') && github.repository == 'trezor/trezor-suite')
+    steps:
+      - name: Respond in pull request
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Start squashing: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            })
+      - name: Generate GitHub App token
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.trezor-bot-token.outputs.token }}
+      - name: Set test squash message
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "SQUASH_MESSAGE=test: verify squash action works" >> "$GITHUB_ENV"
+      - name: Auto squash pull request
+        env:
+          GITHUB_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: bash scripts/ci/bot-squash.sh
+      - name: Report failure
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Squashing failed, please squash manually."
+            })

--- a/scripts/ci/bot-squash.sh
+++ b/scripts/ci/bot-squash.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$PR_NUMBER" ]; then
+	PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		PR_NUMBER=$(jq -r ".issue.number" "$GITHUB_EVENT_PATH")
+	fi
+	if [[ "$PR_NUMBER" == "null" ]]; then
+		echo "Failed to determine PR Number."
+		exit 1
+	fi
+fi
+
+echo "Collecting information about PR #$PR_NUMBER of $GITHUB_REPOSITORY..."
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+	echo "Set the GITHUB_TOKEN env variable."
+	exit 1
+fi
+
+URI=https://api.github.com
+API_HEADER="Accept: application/vnd.github.v3+json"
+AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+
+pr_resp=$(curl -X GET -s -H "${AUTH_HEADER}" -H "${API_HEADER}" \
+	"${URI}/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+
+BASE_BRANCH=$(echo "$pr_resp" | jq -r .base.ref)
+HEAD_REPO=$(echo "$pr_resp" | jq -r .head.repo.full_name)
+HEAD_BRANCH=$(echo "$pr_resp" | jq -r .head.ref)
+
+if [[ -z "$BASE_BRANCH" || "$BASE_BRANCH" == "null" ]]; then
+	echo "Cannot get base branch information for PR #$PR_NUMBER!"
+	exit 1
+fi
+
+echo "Base branch for PR #$PR_NUMBER is $BASE_BRANCH"
+
+# Extract the squash message from the env (workflow_dispatch) or comment body
+if [[ -z "$SQUASH_MESSAGE" ]]; then
+	COMMENT_BODY=$(jq -r ".comment.body" "$GITHUB_EVENT_PATH")
+	SQUASH_MESSAGE="${COMMENT_BODY#/squash }"
+fi
+
+if [[ -z "$SQUASH_MESSAGE" || "$SQUASH_MESSAGE" == "/squash" ]]; then
+	echo "No commit message provided. Usage: /squash <commit message>"
+	exit 1
+fi
+
+if [[ -z "$USER_LOGIN" ]]; then
+	USER_LOGIN=$(jq -r ".comment.user.login" "$GITHUB_EVENT_PATH")
+fi
+
+if [[ "$USER_LOGIN" == "null" ]]; then
+	USER_LOGIN=$(jq -r ".pull_request.user.login" "$GITHUB_EVENT_PATH")
+fi
+
+user_resp=$(curl -X GET -s -H "${AUTH_HEADER}" -H "${API_HEADER}" \
+	"${URI}/users/${USER_LOGIN}")
+
+USER_NAME=$(echo "$user_resp" | jq -r ".name")
+if [[ "$USER_NAME" == "null" ]]; then
+	USER_NAME=$USER_LOGIN
+fi
+USER_NAME="${USER_NAME} (Squash PR Action)"
+
+USER_EMAIL=$(echo "$user_resp" | jq -r ".email")
+if [[ "$USER_EMAIL" == "null" ]]; then
+	USER_EMAIL="$USER_LOGIN@users.noreply.github.com"
+fi
+
+USER_TOKEN=${USER_LOGIN//-/_}_TOKEN
+UNTRIMMED_COMMITTER_TOKEN=${!USER_TOKEN:-$GITHUB_TOKEN}
+COMMITTER_TOKEN="$(echo -e "${UNTRIMMED_COMMITTER_TOKEN}" | tr -d '[:space:]')"
+
+# See https://github.com/actions/checkout/issues/766 for motivation.
+git config --global --add safe.directory /github/workspace
+
+git remote set-url origin "https://x-access-token:$COMMITTER_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+git config --global user.email "$USER_EMAIL"
+git config --global user.name "$USER_NAME"
+
+git remote add fork "https://x-access-token:$COMMITTER_TOKEN@github.com/$HEAD_REPO.git"
+
+set -o xtrace
+
+# make sure branches are up-to-date
+git fetch origin "$BASE_BRANCH"
+git fetch fork "$HEAD_BRANCH"
+
+# do the squash
+git checkout -b "fork/$HEAD_BRANCH" "fork/$HEAD_BRANCH"
+
+MERGE_BASE=$(git merge-base "fork/$HEAD_BRANCH" "origin/$BASE_BRANCH")
+git reset --soft "$MERGE_BASE"
+git commit -m "$SQUASH_MESSAGE"
+
+# push back
+git push --force-with-lease fork "fork/$HEAD_BRANCH:$HEAD_BRANCH"


### PR DESCRIPTION
## Description

Related to #25773

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-squash-command-to-action-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-squash-command-to-action-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T10:13:21.113Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T10:12:08.328Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->