### PR TITLE
feat(suite-native): change send max button to switch

### DIFF
--- a/suite-native/module-send/src/components/SendMaxButton.tsx
+++ b/suite-native/module-send/src/components/SendMaxButton.tsx
@@ -13,10 +13,10 @@ import {
     selectBaseCurrency,
 } from '@suite-common/wallet-core';
 import { AccountKey, TokenAddress } from '@suite-common/wallet-types';
-import { getDecimalsForBaseCurrency, isAddressValid } from '@suite-common/wallet-utils';
-import { Button } from '@suite-native/atoms';
+import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
+import { HStack, Switch, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
-import { useField, useFormContext } from '@suite-native/forms';
+import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { TokensRootState, selectAccountTokenBalance } from '@suite-native/tokens';
 import { calculateFeeLevelsMaxAmountThunk } from '@suite-native/transaction-management';
@@ -54,10 +54,6 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
         selectAccountTokenBalance(state, accountKey, tokenContract),
     );
 
-    const { value: addressValue } = useField({
-        name: getOutputFieldName(outputIndex, 'address'),
-    });
-
     const [maxAmountValue, setMaxAmountValue] = useState<string | null>();
 
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
@@ -65,11 +61,10 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
 
     const formValues = watch();
 
-    const isAddressInputValid = symbol && isAddressValid(addressValue, symbol);
-
-    const isMainnetSendMaxAvailable =
-        !tokenContract && formValues.outputs.length === 1 && isAddressInputValid;
+    const isMainnetSendMaxAvailable = !tokenContract && formValues.outputs.length === 1;
     const isSendMaxAvailable = tokenContract || isMainnetSendMaxAvailable;
+
+    const isSendMaxEnabled = formValues.setMaxOutputId === outputIndex;
 
     const calculateFeeLevelsMaxAmount = useCallback(async () => {
         const response = await debounce(() =>
@@ -94,12 +89,11 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
         else setMaxAmountValue(undefined);
     }, [isMainnetSendMaxAvailable, calculateFeeLevelsMaxAmount, tokenBalance]);
 
-    const setOutputSendMax = () => {
+    const enableSendMax = () => {
         if (!maxAmountValue) return;
 
-        Keyboard.dismiss();
-
         setValue('setMaxOutputId', outputIndex);
+
         setValue(getOutputFieldName(outputIndex, 'amount'), maxAmountValue, {
             shouldValidate: true,
             shouldTouch: true,
@@ -114,13 +108,41 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
         }
     };
 
+    const disableSendMax = () => {
+        setValue('setMaxOutputId', undefined);
+
+        setValue(getOutputFieldName(outputIndex, 'amount'), '', {
+            shouldValidate: true,
+            shouldTouch: true,
+        });
+
+        setValue(getOutputFieldName(outputIndex, 'fiat'), '', {
+            shouldValidate: true,
+            shouldTouch: true,
+        });
+    };
+
+    const toggleSendMax = (isToggled: boolean) => {
+        Keyboard.dismiss();
+
+        if (isToggled) {
+            enableSendMax();
+        } else {
+            disableSendMax();
+        }
+    };
+
     return (
         isSendMaxAvailable &&
         maxAmountValue && (
             <Animated.View entering={FadeIn}>
-                <Button size="small" colorScheme="tertiaryElevation0" onPress={setOutputSendMax}>
-                    <Translation id="moduleSend.outputs.recipients.maxButton" />
-                </Button>
+                <HStack alignItems="center" spacing="sp8">
+                    <Text variant="body-sm">
+                        <Translation id="moduleSend.outputs.recipients.maxButton" />
+                    </Text>
+
+                    <Switch isChecked={isSendMaxEnabled} onChange={toggleSendMax} />
+                </HStack>
             </Animated.View>
         )
     );


### PR DESCRIPTION
## Description

Change the send max button in send form to a switch, just like on Desktop.

## Related Issue

Resolve #20346 

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-03-10 at 11 08 32" src="https://github.com/user-attachments/assets/f1926f31-98e1-4e48-8915-792915ce3248" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-03-10 at 11 08 38" src="https://github.com/user-attachments/assets/e0015b0e-c89c-4f70-a28b-0b03ff92856e" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/send-max-button-redesign&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->