### PR TITLE
fix(suite-native): handle THP correctly for auto-connect in device settings

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -77,11 +77,6 @@ export const selectIsPendingTransportEvent = createMemoizedSelector(
     devices => devices.length < 1,
 );
 
-export const selectDeviceAutoconnectCredentials = createMemoizedSelector(
-    [selectSelectedDevice],
-    device => device?.thp?.credentials.filter(cred => cred.autoconnect) ?? [],
-);
-
 export const selectIsDeviceUnlocked = createMemoizedSelector(
     [selectSelectedDevice],
     device => !!device?.features?.unlocked,

--- a/suite-native/device-authorization/src/hooks/useOnThpPairingCanceled.ts
+++ b/suite-native/device-authorization/src/hooks/useOnThpPairingCanceled.ts
@@ -1,6 +1,4 @@
-import { useCallback } from 'react';
-
-import { useFocusEffect } from '@react-navigation/native';
+import { useCallback, useEffect } from 'react';
 
 import TrezorConnect, { DEVICE, DeviceThpPairingStatus } from '@trezor/connect';
 
@@ -14,13 +12,12 @@ export const useOnThpPairingCanceled = (callback: () => void) => {
         [callback],
     );
 
-    useFocusEffect(
-        useCallback(() => {
-            TrezorConnect.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPairingStatusChange);
+    // We cannot use useFocusEffect here since a THP confirmation screen might be shown above.
+    useEffect(() => {
+        TrezorConnect.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPairingStatusChange);
 
-            return () => {
-                TrezorConnect.off(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPairingStatusChange);
-            };
-        }, [onThpPairingStatusChange]),
-    );
+        return () => {
+            TrezorConnect.off(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPairingStatusChange);
+        };
+    }, [onThpPairingStatusChange]);
 };

--- a/suite-native/module-device-settings/package.json
+++ b/suite-native/module-device-settings/package.json
@@ -16,6 +16,7 @@
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/device": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/validators": "workspace:*",

--- a/suite-native/module-device-settings/src/hooks/useDeviceAutoConnect.ts
+++ b/suite-native/module-device-settings/src/hooks/useDeviceAutoConnect.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { isRejected } from '@reduxjs/toolkit';
 
-import { selectDeviceAutoconnectCredentials, selectIsDeviceConnected } from '@suite-common/device';
+import { selectSelectedDevice } from '@suite-common/device';
 import { removeThpCredentialsThunk } from '@suite-common/thp';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -15,6 +15,8 @@ import {
 import { useThpAutoconnectActions } from '@suite-native/thp';
 import { useToast } from '@suite-native/toasts';
 import TrezorConnect from '@trezor/connect';
+
+import { selectDeviceAutoConnectCredentials } from '../selectors';
 
 type NavigationProp = StackNavigationProps<
     DeviceSettingsStackParamList,
@@ -30,12 +32,11 @@ export const useDeviceAutoConnect = () => {
 
     const { startThpAutoconnect } = useThpAutoconnectActions();
 
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
-    const autoconnectCredentials = useSelector(selectDeviceAutoconnectCredentials);
+    const device = useSelector(selectSelectedDevice);
+    const autoConnectCredentials = useSelector(selectDeviceAutoConnectCredentials);
+    const isAutoConnectEnabled = autoConnectCredentials.length > 0;
 
-    const turnAutoConnectOn = useCallback(async () => {
-        navigation.navigate(DeviceSettingsStackRoutes.DeviceAutoConnectStack);
-
+    const enableAutoConnect = useCallback(async () => {
         const result = await startThpAutoconnect();
 
         if (result && isRejected(result)) {
@@ -53,22 +54,26 @@ export const useDeviceAutoConnect = () => {
         navigation.goBack();
     }, [navigation, startThpAutoconnect, showToast, translate]);
 
-    const turnAutoConnectOff = useCallback(async () => {
-        if (!isDeviceConnected) {
-            // We cannot use AutoConnectStack since there's no progress screen once connected.
-            navigation.navigate(DeviceSettingsStackRoutes.DeviceAutoConnectGuard);
-        }
-
-        await dispatch(
+    const disableAutoConnect = useCallback(() => {
+        dispatch(
             removeThpCredentialsThunk({
-                credentials: autoconnectCredentials,
+                device,
+                credentials: autoConnectCredentials,
             }),
-        ).unwrap();
-    }, [isDeviceConnected, navigation, dispatch, autoconnectCredentials]);
+        );
+    }, [dispatch, device, autoConnectCredentials]);
+
+    const toggleAutoConnect = useCallback(() => {
+        if (!isAutoConnectEnabled) {
+            navigation.navigate(DeviceSettingsStackRoutes.DeviceAutoConnectStack);
+        } else {
+            disableAutoConnect();
+        }
+    }, [isAutoConnectEnabled, navigation, disableAutoConnect]);
 
     return {
-        isAutoconnectEnabled: autoconnectCredentials.length > 0,
-        turnAutoConnectOn,
-        turnAutoConnectOff,
+        isAutoConnectEnabled,
+        enableAutoConnect,
+        toggleAutoConnect,
     };
 };

--- a/suite-native/module-device-settings/src/navigation/DeviceAutoConnectStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceAutoConnectStackNavigator.tsx
@@ -1,36 +1,50 @@
-import { useSelector } from 'react-redux';
+import { useCallback, useState } from 'react';
 
+import { useFocusEffect } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectIsDeviceConnected } from '@suite-common/device';
-import { DeviceConnectionGuardScreenWithCancel } from '@suite-native/device-authorization';
+import {
+    DeviceConnectionGuardScreenWithCancel,
+    useDeviceConnectionGuard,
+} from '@suite-native/device-authorization';
 import {
     DeviceAutoConnectStackParamList,
     DeviceAutoConnectStackRoutes,
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { useDeviceAutoConnect } from '../hooks/useDeviceAutoConnect';
 import { ContinueOnTrezorScreen } from '../screens/ContinueOnTrezorScreen';
 
 const DeviceAutoConnectStack = createNativeStackNavigator<DeviceAutoConnectStackParamList>();
 
 export const DeviceAutoConnectStackNavigator = () => {
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const { isDeviceConnectionGuardVisible } = useDeviceConnectionGuard();
+    const [isEnableAutoconnectStarted, setIsEnableAutoconnectStarted] = useState(false);
+
+    const { enableAutoConnect } = useDeviceAutoConnect();
+
+    useFocusEffect(
+        useCallback(() => {
+            if (!isDeviceConnectionGuardVisible && !isEnableAutoconnectStarted) {
+                setIsEnableAutoconnectStarted(true);
+                enableAutoConnect();
+            }
+        }, [isDeviceConnectionGuardVisible, isEnableAutoconnectStarted, enableAutoConnect]),
+    );
 
     return (
         <DeviceAutoConnectStack.Navigator screenOptions={stackNavigationOptionsConfig}>
-            {!isDeviceConnected && (
+            {isDeviceConnectionGuardVisible && (
                 <DeviceAutoConnectStack.Screen
                     name={DeviceAutoConnectStackRoutes.DeviceConnectionGuard}
                     component={DeviceConnectionGuardScreenWithCancel}
                 />
             )}
-            {isDeviceConnected && (
-                <DeviceAutoConnectStack.Screen
-                    name={DeviceAutoConnectStackRoutes.ConfirmAutoConnect}
-                    component={ContinueOnTrezorScreen}
-                />
-            )}
+            <DeviceAutoConnectStack.Screen
+                name={DeviceAutoConnectStackRoutes.ConfirmAutoConnect}
+                component={ContinueOnTrezorScreen}
+            />
         </DeviceAutoConnectStack.Navigator>
     );
 };

--- a/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
+++ b/suite-native/module-device-settings/src/navigation/DeviceSettingsStackNavigator.tsx
@@ -1,11 +1,7 @@
-import { useSelector } from 'react-redux';
-
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
-import { selectIsDeviceConnected } from '@suite-common/device';
 // this import is against the rule of not importing from other modules. This specific case is OK, because the @suite-native/module-check-backup
 // is imported only here and nowhere else, so it is treated as a submodule of @suite-native/module-device-settings.
-import { DeviceConnectionGuardScreenWithCancel } from '@suite-native/device-authorization';
 import { DeviceCheckBackupStackNavigator } from '@suite-native/module-check-backup';
 import {
     DeviceSettingsStackParamList,
@@ -33,94 +29,84 @@ import { WipeDeviceScreen } from '../screens/WipeDeviceScreen';
 
 const DeviceSettingsStack = createNativeStackNavigator<DeviceSettingsStackParamList>();
 
-export const DeviceSettingsStackNavigator = () => {
-    const isDeviceConnected = useSelector(selectIsDeviceConnected);
-
-    return (
-        <DeviceSettingsStack.Navigator
-            initialRouteName={DeviceSettingsStackRoutes.DeviceSettings}
-            screenOptions={stackNavigationOptionsConfig}
-        >
+export const DeviceSettingsStackNavigator = () => (
+    <DeviceSettingsStack.Navigator
+        initialRouteName={DeviceSettingsStackRoutes.DeviceSettings}
+        screenOptions={stackNavigationOptionsConfig}
+    >
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DeviceSettings}
+            component={DeviceSettingsScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DeviceFirmware}
+            component={DeviceFirmwareScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DeviceAutoConnect}
+            component={DeviceAutoConnectScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.UnpairBluetoothDevice}
+            component={UnpairBluetoothDeviceScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DevicePinProtection}
+            component={PinProtectionScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DeviceBackupAndPassphrase}
+            component={BackupAndPassphraseScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.DeviceAuthenticity}
+            component={DeviceAuthenticityScreen}
+        />
+        <DeviceSettingsStack.Screen
+            name={DeviceSettingsStackRoutes.WipeDevice}
+            component={WipeDeviceScreen}
+        />
+        <DeviceSettingsStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceSettings}
-                component={DeviceSettingsScreen}
+                name={DeviceSettingsStackRoutes.DeviceNameStack}
+                component={DeviceNameStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceFirmware}
-                component={DeviceFirmwareScreen}
+                name={DeviceSettingsStackRoutes.FirmwareUpdateStack}
+                component={FirmwareUpdateStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceAutoConnect}
-                component={DeviceAutoConnectScreen}
+                name={DeviceSettingsStackRoutes.FirmwareLanguageStack}
+                component={FirmwareLanguageStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.UnpairBluetoothDevice}
-                component={UnpairBluetoothDeviceScreen}
+                name={DeviceSettingsStackRoutes.ContinueOnTrezor}
+                component={ContinueOnTrezorScreen}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DevicePinProtection}
-                component={PinProtectionScreen}
+                name={DeviceSettingsStackRoutes.DeviceAutoConnectStack}
+                component={DeviceAutoConnectStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceBackupAndPassphrase}
-                component={BackupAndPassphraseScreen}
+                name={DeviceSettingsStackRoutes.DevicePinProtectionStack}
+                component={DevicePinProtectionStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.DeviceAuthenticity}
-                component={DeviceAuthenticityScreen}
+                name={DeviceSettingsStackRoutes.DeviceCheckBackupStack}
+                component={DeviceCheckBackupStackNavigator}
             />
             <DeviceSettingsStack.Screen
-                name={DeviceSettingsStackRoutes.WipeDevice}
-                component={WipeDeviceScreen}
+                name={DeviceSettingsStackRoutes.DevicePassphraseStack}
+                component={DevicePassphraseStackNavigator}
             />
-            <DeviceSettingsStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DeviceNameStack}
-                    component={DeviceNameStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.FirmwareUpdateStack}
-                    component={FirmwareUpdateStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.FirmwareLanguageStack}
-                    component={FirmwareLanguageStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.ContinueOnTrezor}
-                    component={ContinueOnTrezorScreen}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DeviceAutoConnectStack}
-                    component={DeviceAutoConnectStackNavigator}
-                />
-                {!isDeviceConnected && (
-                    <DeviceSettingsStack.Screen
-                        name={DeviceSettingsStackRoutes.DeviceAutoConnectGuard}
-                        component={DeviceConnectionGuardScreenWithCancel}
-                    />
-                )}
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DevicePinProtectionStack}
-                    component={DevicePinProtectionStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DeviceCheckBackupStack}
-                    component={DeviceCheckBackupStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DevicePassphraseStack}
-                    component={DevicePassphraseStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
-                    component={DeviceAuthenticityStackNavigator}
-                />
-                <DeviceSettingsStack.Screen
-                    name={DeviceSettingsStackRoutes.WipeDeviceStack}
-                    component={WipeDeviceStackNavigator}
-                />
-            </DeviceSettingsStack.Group>
-        </DeviceSettingsStack.Navigator>
-    );
-};
+            <DeviceSettingsStack.Screen
+                name={DeviceSettingsStackRoutes.DeviceAuthenticityStack}
+                component={DeviceAuthenticityStackNavigator}
+            />
+            <DeviceSettingsStack.Screen
+                name={DeviceSettingsStackRoutes.WipeDeviceStack}
+                component={WipeDeviceStackNavigator}
+            />
+        </DeviceSettingsStack.Group>
+    </DeviceSettingsStack.Navigator>
+);

--- a/suite-native/module-device-settings/src/screens/DeviceAutoConnectScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/DeviceAutoConnectScreen.tsx
@@ -30,18 +30,10 @@ const configMap = {
 } as const satisfies Record<'enabled' | 'disabled', CardConfig>;
 
 export const DeviceAutoConnectScreen = () => {
-    const { isAutoconnectEnabled, turnAutoConnectOn, turnAutoConnectOff } = useDeviceAutoConnect();
-
-    const onPress = () => {
-        if (isAutoconnectEnabled) {
-            turnAutoConnectOff();
-        } else {
-            turnAutoConnectOn();
-        }
-    };
+    const { isAutoConnectEnabled, toggleAutoConnect } = useDeviceAutoConnect();
 
     const { pictogramVariant, pictogramIcon, titleId, subtitleId, buttonId } =
-        configMap[isAutoconnectEnabled ? 'enabled' : 'disabled'];
+        configMap[isAutoConnectEnabled ? 'enabled' : 'disabled'];
 
     return (
         <Screen
@@ -61,7 +53,7 @@ export const DeviceAutoConnectScreen = () => {
                         title={<Translation id={titleId} />}
                         subtitle={<Translation id={subtitleId} />}
                     />
-                    <Button onPress={onPress} colorScheme="primary" size="medium">
+                    <Button onPress={toggleAutoConnect} colorScheme="primary" size="medium">
                         <Translation id={buttonId} />
                     </Button>
                 </VStack>

--- a/suite-native/module-device-settings/src/selectors.ts
+++ b/suite-native/module-device-settings/src/selectors.ts
@@ -1,0 +1,14 @@
+import { DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { ThpRootState, selectThpCredentials } from '@suite-common/thp';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<DeviceRootState & ThpRootState>();
+
+// Deprecated: Temporary hack until THP credentials are migrated to THP reducer.
+export const selectDeviceAutoConnectCredentials = createMemoizedSelector(
+    [selectSelectedDevice, selectThpCredentials],
+    (device, thpCredentials) =>
+        device?.thp?.credentials.filter(
+            c => c.autoconnect && thpCredentials.some(tc => tc.credential === c.credential),
+        ) ?? [],
+);

--- a/suite-native/module-device-settings/tsconfig.json
+++ b/suite-native/module-device-settings/tsconfig.json
@@ -7,6 +7,9 @@
         },
         { "path": "../../suite-common/device" },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
             "path": "../../suite-common/suite-constants"
         },
         { "path": "../../suite-common/thp" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -248,7 +248,6 @@ export type DeviceSettingsStackParamList = {
     };
     [DeviceSettingsStackRoutes.DeviceAutoConnect]: undefined;
     [DeviceSettingsStackRoutes.DeviceAutoConnectStack]: undefined;
-    [DeviceSettingsStackRoutes.DeviceAutoConnectGuard]: undefined;
     [DeviceSettingsStackRoutes.UnpairBluetoothDevice]: undefined;
     [DeviceSettingsStackRoutes.DevicePinProtection]: undefined;
     [DeviceSettingsStackRoutes.DevicePinProtectionStack]: {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -87,7 +87,6 @@ export enum DeviceSettingsStackRoutes {
     ContinueOnTrezor = 'ContinueOnTrezor',
     DeviceAutoConnect = 'DeviceAutoConnect',
     DeviceAutoConnectStack = 'DeviceAutoConnectStack',
-    DeviceAutoConnectGuard = 'DeviceAutoConnectGuard',
     UnpairBluetoothDevice = 'UnpairBluetoothDevice',
     DevicePinProtection = 'DevicePinProtection',
     DevicePinProtectionStack = 'DevicePinProtectionStack',

--- a/yarn.lock
+++ b/yarn.lock
@@ -13229,6 +13229,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/device": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/validators": "workspace:*"


### PR DESCRIPTION
Similar fix as in #25528, this time for auto-connect.

### Implementation notes

Since `removeThpCredentialsThunk` works even for a disconnected device, we may discard `DeviceAutoConnectGuard` route. However, since it only removes THP credentials from the THP reducer, `selectDeviceAutoConnectCredentials` had to be tweaked. It's a temporary solution as we agreed with @Lemonexe that THP credentials shall only be present in THP reducer.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/device-settings-auto-connect-thp&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/device-settings-auto-connect-thp&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-settings-auto-connect-thp&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T10:49:20.217Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T13:19:44.645Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->