### PR TITLE
fix(suite): connect to relay even when read mode

### DIFF
--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -80,8 +80,8 @@ export const createEnsureStorage =
             isWriteMode,
         });
 
-        if (quotaResult.success) {
-            // Only set the relay URL for transport in case that quota manager is enabled or has quota for device.
+        // Set the relay URL if quota is allocated or if we are not in write mode.
+        if (quotaResult.success || quotaResult.error.type === 'WriteModeRequiredForAllocation') {
             await newStorage.updateRelayUrl(deps.getRelayUrl());
         }
 

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -139,7 +139,7 @@ describe(createEnsureStorage.name, () => {
         });
     });
 
-    it('does not update relay URL when ensureQuota fails', async () => {
+    it('does update relay URL when ensureQuota fails on WriteModeRequiredForAllocation', async () => {
         const device = mockSuiteDevice();
         const updateRelayUrl = mock(() => Promise.resolve());
         const newStorage = createSuiteSyncStorageMock({ updateRelayUrl });
@@ -166,7 +166,7 @@ describe(createEnsureStorage.name, () => {
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.createSuiteStorage).toHaveBeenCalled();
-        expect(updateRelayUrl).not.toHaveBeenCalled();
+        expect(updateRelayUrl).toHaveBeenCalled();
     });
 
     it('creates and stores new storage when all dependencies succeed', async () => {


### PR DESCRIPTION
We need to try to connect to the Evolu relay even tho we are not in write mode. 

Why? Because users might be trying to search for his lost passphrase and we don't want to let him waste quota on this. Thus, we are allocating quota on-demand, but we also need to try and connect to the relay to check if user has any data there.

## Notes for QA

- just a fix, now you should be able to connect to evolu relay in case of new wallet

## Related Issue

Resolve 



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ss/connect-relay-in-read-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ss/connect-relay-in-read-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/ss/connect-relay-in-read-mode&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T11:11:08.990Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T11:09:08.523Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->