### PR TITLE
24612 price quote for each payment mobile

### DIFF
--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
@@ -1,39 +1,99 @@
 import { Pressable } from 'react-native';
 
-import { Card, HStack, Radio, Text } from '@suite-native/atoms';
+import type { BuyTrade, SellFiatTrade } from 'invity-api';
+
+import { HStack, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
-export type PaymentMethodListItemProps = {
-    orderId: string;
-    paymentMethodName: string;
-    isSelected: boolean;
+import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
+
+export type PaymentMethodListItemProps<T extends BuyTrade | SellFiatTrade> = {
+    quote: T;
     onPress: () => void;
+    isFirst?: boolean;
+    isLast?: boolean;
 };
 
-export const PAYMENT_METHOD_LIST_ITEM_HEIGHT = 66 as const;
+export const PAYMENT_METHOD_LIST_ITEM_HEIGHT = 74 as const;
 
-const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
-    marginVertical: spacings.sp4,
-}));
+const itemStyle = prepareNativeStyle<{ isFirst: boolean; isLast: boolean }>(
+    (
+        {
+            spacings: { sp1, sp12, sp20 },
+            colors: { backgroundSurfaceElevation1 },
+            borders: {
+                radii: { r20 },
+            },
+        },
+        { isFirst, isLast },
+    ) => ({
+        paddingHorizontal: sp20,
+        paddingVertical: sp12,
+        backgroundColor: backgroundSurfaceElevation1,
+        marginBottom: sp1,
+        extend: [
+            {
+                condition: isFirst,
+                style: {
+                    borderTopLeftRadius: r20,
+                    borderTopRightRadius: r20,
+                },
+            },
+            {
+                condition: isLast,
+                style: {
+                    borderBottomLeftRadius: r20,
+                    borderBottomRightRadius: r20,
+                },
+            },
+        ],
+    }),
+);
 
-export const PaymentMethodListItem = ({
+export const PaymentMethodListItem = <T extends BuyTrade | SellFiatTrade>({
     onPress,
-    orderId,
-    paymentMethodName,
-    isSelected,
-}: PaymentMethodListItemProps) => {
+    quote,
+    isFirst = false,
+    isLast = false,
+}: PaymentMethodListItemProps<T>) => {
     const { applyStyle } = useNativeStyles();
+    const { formattedRate } = useChangeStringsExtractor(quote);
 
     return (
-        <Pressable onPress={onPress} style={applyStyle(wrapperStyle)}>
-            <Card>
+        <Pressable onPress={onPress} style={applyStyle(itemStyle, { isFirst, isLast })}>
+            <VStack spacing="sp4">
                 <HStack alignItems="center" justifyContent="space-between">
-                    <Text variant="body-md" color="textDefault">
-                        {paymentMethodName}
+                    <Text
+                        variant="body-md"
+                        color="textDefault"
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                    >
+                        {quote.paymentMethodName ?? ''}
                     </Text>
-                    <Radio value={orderId} onPress={onPress} isChecked={isSelected} />
                 </HStack>
-            </Card>
+                {!!formattedRate && (
+                    <HStack alignItems="center" justifyContent="space-between">
+                        <Text
+                            variant="body-sm"
+                            color="textSubdued"
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                        >
+                            <Translation id="moduleTrading.providerListItem.rate" />
+                        </Text>
+                        <Text
+                            variant="body-sm"
+                            color="textSubdued"
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                        >
+                            {formattedRate}
+                        </Text>
+                    </HStack>
+                )}
+            </VStack>
         </Pressable>
     );
 };

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodSheet.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodSheet.tsx
@@ -41,12 +41,12 @@ export const PaymentMethodSheet = <T extends BuyTrade | SellFiatTrade>({
         <BottomSheetFlashList<T>
             isVisible={isVisible}
             onClose={onClose}
-            renderItem={({ item }) => (
+            renderItem={({ item, index }) => (
                 <PaymentMethodListItem
-                    orderId={item.orderId ?? ''}
-                    paymentMethodName={item.paymentMethodName ?? ''}
+                    quote={item}
                     onPress={() => onQuoteSelectCallback(item)}
-                    isSelected={item.orderId === selectedQuote?.orderId}
+                    isFirst={index === 0}
+                    isLast={index === quotes.length - 1}
                 />
             )}
             handleComponent={() => <SimpleSheetHeader onClose={onClose} title={title} />}

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/__tests__/PaymentMethodListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/__tests__/PaymentMethodListItem.test.tsx
@@ -1,25 +1,23 @@
-import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
+import { buyQuotes, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { PaymentMethodListItem, type PaymentMethodListItemProps } from '../PaymentMethodListItem';
 
 describe('PaymentMethodListItem', () => {
-    const renderPaymentMethodListItem = (props: Partial<PaymentMethodListItemProps>) =>
-        renderWithBasicProvider(
-            <PaymentMethodListItem
-                paymentMethodName="Credit card"
-                orderId="orderId"
-                isSelected={false}
-                onPress={jest.fn()}
-                {...props}
-            />,
+    const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });
+
+    const renderPaymentMethodListItem = (props: Partial<PaymentMethodListItemProps<any>>) =>
+        renderWithStoreProvider(
+            <PaymentMethodListItem quote={buyQuotes[0]} onPress={jest.fn()} {...props} />,
+            { preloadedState: getPreloadedState() },
         );
 
-    it('should render given name', () => {
-        const { getByText } = renderPaymentMethodListItem({
-            paymentMethodName: 'Debit card',
-        });
+    it('should render given name and rate', () => {
+        const { getByText } = renderPaymentMethodListItem({});
 
-        expect(getByText('Debit card')).toBeTruthy();
+        expect(getByText('Apple Pay')).toBeOnTheScreen();
+        expect(getByText('Rate')).toBeOnTheScreen();
+        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
     });
 
     it('should call onPress callback on item press', () => {
@@ -27,9 +25,18 @@ describe('PaymentMethodListItem', () => {
         const { getByText } = renderPaymentMethodListItem({ onPress });
 
         act(() => {
-            fireEvent.press(getByText('Credit card'));
+            fireEvent.press(getByText('Apple Pay'));
         });
 
         expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not render rate row when rate is unknown', () => {
+        const { getByText, queryByText } = renderPaymentMethodListItem({
+            quote: { ...buyQuotes[0], rate: undefined, receiveStringAmount: undefined },
+        });
+
+        expect(getByText('Apple Pay')).toBeOnTheScreen();
+        expect(queryByText('Rate')).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.tsx
@@ -2,7 +2,6 @@ import type { TradingTradeType } from '@suite-common/trading';
 import { HStack, Text } from '@suite-native/atoms';
 
 import { useChangeStringsExtractor } from '../../../hooks/history/useChangeStringsExtractor';
-import { CryptoToFiatValueBadge } from '../CryptoToFiatValueBadge';
 
 export type ProviderListItemValueRowProps<T extends TradingTradeType> = {
     quote: T;
@@ -11,20 +10,17 @@ export type ProviderListItemValueRowProps<T extends TradingTradeType> = {
 export const ProviderListItemValueRow = <T extends TradingTradeType>({
     quote,
 }: ProviderListItemValueRowProps<T>) => {
-    const { toStringValue, isToCrypto, toValue, toCurrency } = useChangeStringsExtractor(quote);
+    const { formattedRate } = useChangeStringsExtractor(quote);
+
+    if (!formattedRate) {
+        return null;
+    }
 
     return (
         <HStack justifyContent="space-between" alignItems="center" paddingTop="sp8">
             <Text variant="body-md" color="textDefault">
-                {toStringValue}
+                {formattedRate}
             </Text>
-            {isToCrypto && (
-                <CryptoToFiatValueBadge
-                    amount={toValue}
-                    cryptoId={toCurrency}
-                    color="textSubdued"
-                />
-            )}
         </HStack>
     );
 };

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -47,9 +47,8 @@ describe('ProviderListItem', () => {
 
         const { getByText } = renderProviderListItem(quote, preloadedState, {});
 
-        // estimated rate in base currency (component is mocked)
-        expect(getByText(/^0.001[0-9]+-bitcoin$/)).toBeOnTheScreen();
         expect(getByText('Centralized exchange')).toBeOnTheScreen();
+        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
     });
 
     it('should render KYC information when provider has KYC policy', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItemValueRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItemValueRow.test.tsx
@@ -1,0 +1,49 @@
+import type { TradingTradeType } from '@suite-common/trading';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
+import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
+
+import { ProviderListItemValueRow } from '../ProviderListItemValueRow';
+
+describe('ProviderListItemValueRow', () => {
+    const getPreloadedState = () => ({
+        wallet: {
+            trading: getInitializedTradingStateWithQuotes(),
+        },
+    });
+
+    const renderProviderListItemValueRow = (
+        quote: TradingTradeType,
+        preloadedState: PreloadedState = {},
+    ) =>
+        renderWithStoreProvider(<ProviderListItemValueRow quote={quote} />, {
+            preloadedState,
+        });
+
+    it('should render formatted rate for a buy quote', () => {
+        const preloadedState = getPreloadedState();
+        const quote = preloadedState.wallet.trading.buy.quotes[0];
+
+        const { getByText } = renderProviderListItemValueRow(quote, preloadedState);
+
+        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
+    });
+
+    it('should render formatted rate for a sell quote', () => {
+        const preloadedState = getPreloadedState();
+        const quote = preloadedState.wallet.trading.sell.quotes[0];
+
+        const { getByText } = renderProviderListItemValueRow(quote, preloadedState);
+
+        expect(getByText('0.000258400798491738 ETH / $1')).toBeOnTheScreen();
+    });
+
+    it('should render nothing when buy quote has zero receiveStringAmount', () => {
+        const preloadedState = getPreloadedState();
+        // The third buy quote has receiveStringAmount: '0' which results in no formattedRate
+        const quote = preloadedState.wallet.trading.buy.quotes[2];
+
+        const { toJSON } = renderProviderListItemValueRow(quote, preloadedState);
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -1,3 +1,4 @@
+import type { TradingTradeType } from '@suite-common/trading';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     getBuyTrade,
@@ -9,12 +10,16 @@ import {
 import { useChangeStringsExtractor } from '../useChangeStringsExtractor';
 
 describe('useChangeStringsExtractor', () => {
+    const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });
+
+    const renderUseChangeStringsExtractor = (data: TradingTradeType | undefined) =>
+        renderHookWithStoreProvider(() => useChangeStringsExtractor(data), {
+            preloadedState: getPreloadedState(),
+        });
+
     it('should extract strings for buy trade', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const { result } = renderHookWithStoreProvider(
-            () => useChangeStringsExtractor(buyTrade.data),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+        const { result } = renderUseChangeStringsExtractor(buyTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'USD',
@@ -25,15 +30,13 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: false,
             isToCrypto: true,
+            formattedRate: '$2,667.61 / 1 ETH',
         });
     });
 
     it('should extract strings for sell trade', () => {
         const sellTrade = getSellTrade({ status: 'SUBMITTED' });
-        const { result } = renderHookWithStoreProvider(
-            () => useChangeStringsExtractor(sellTrade.data),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+        const { result } = renderUseChangeStringsExtractor(sellTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'bitcoin',
@@ -44,15 +47,13 @@ describe('useChangeStringsExtractor', () => {
             toValue: '100',
             isFromCrypto: true,
             isToCrypto: false,
+            formattedRate: '0.0122 BTC / $1.00',
         });
     });
 
     it('should extract strings for exchange trade', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONFIRM' });
-        const { result } = renderHookWithStoreProvider(
-            () => useChangeStringsExtractor(exchangeTrade.data),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+        const { result } = renderUseChangeStringsExtractor(exchangeTrade.data);
 
         expect(result.current).toEqual({
             fromCurrency: 'solana--jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL',
@@ -63,13 +64,12 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: true,
             isToCrypto: true,
+            formattedRate: '21.883930771791626 JTO / 1 SOL',
         });
     });
 
     it('should handle undefined trade', () => {
-        const { result } = renderHookWithStoreProvider(() => useChangeStringsExtractor(undefined), {
-            preloadedState: { wallet: { trading: getInitializedTradingState() } },
-        });
+        const { result } = renderUseChangeStringsExtractor(undefined);
 
         expect(result.current).toEqual({
             fromCurrency: undefined,
@@ -80,6 +80,7 @@ describe('useChangeStringsExtractor', () => {
             toValue: undefined,
             isFromCrypto: undefined,
             isToCrypto: undefined,
+            formattedRate: undefined,
         });
     });
 
@@ -91,10 +92,7 @@ describe('useChangeStringsExtractor', () => {
             receiveStringAmount: undefined,
         };
 
-        const { result } = renderHookWithStoreProvider(
-            () => useChangeStringsExtractor(tradeWithMissingValues),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+        const { result } = renderUseChangeStringsExtractor(tradeWithMissingValues);
 
         expect(result.current).toEqual({
             fromCurrency: 'USD',
@@ -105,6 +103,7 @@ describe('useChangeStringsExtractor', () => {
             toValue: undefined,
             isFromCrypto: false,
             isToCrypto: true,
+            formattedRate: undefined,
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -47,7 +47,7 @@ describe('useChangeStringsExtractor', () => {
             toValue: '100',
             isFromCrypto: true,
             isToCrypto: false,
-            formattedRate: '0.0122 BTC / $1.00',
+            formattedRate: '0.0122 BTC / $1',
         });
     });
 
@@ -64,7 +64,7 @@ describe('useChangeStringsExtractor', () => {
             toValue: '0.462586',
             isFromCrypto: true,
             isToCrypto: true,
-            formattedRate: '21.883930771791626 JTO / 1 SOL',
+            formattedRate: '21.883930771791622 JTO / 1 SOL',
         });
     });
 

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -15,6 +15,7 @@ export const useChangeStringsExtractor = (
 ): TradeOperationData & {
     fromStringValue: string | undefined;
     toStringValue: string | undefined;
+    formattedRate?: string | undefined;
 } => {
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { cryptoIdToCoinSymbol } = useTradingUtils();
@@ -58,6 +59,35 @@ export const useChangeStringsExtractor = (
         );
     };
 
+    const formatExchangeRate = () => {
+        if (!fromValue || !toValue || !fromCurrency || !toCurrency) {
+            return undefined;
+        }
+
+        const fromNumericValue = parseFloat(fromValue);
+        const toNumericValue = parseFloat(toValue);
+
+        if (isNaN(fromNumericValue) || isNaN(toNumericValue) || toNumericValue === 0) {
+            return undefined;
+        }
+
+        const rate = fromNumericValue / toNumericValue;
+
+        const rateFormatted = isFromCrypto
+            ? formatCryptoValue(rate.toString(), fromCurrency, false)
+            : formatFiatValue(asBaseCurrencyAmount(new BigNumber(rate)), fromCurrency);
+
+        const targetCurrencyFormatted = isToCrypto
+            ? formatCryptoValue('1', toCurrency, false)
+            : formatFiatValue(asBaseCurrencyAmount(new BigNumber('1')), toCurrency);
+
+        if (!rateFormatted || !targetCurrencyFormatted) {
+            return undefined;
+        }
+
+        return `${rateFormatted} / ${targetCurrencyFormatted}`;
+    };
+
     const fromStringValue = isFromCrypto
         ? formatCryptoValue(fromValue, fromCurrency)
         : formatFiatValue(
@@ -76,5 +106,6 @@ export const useChangeStringsExtractor = (
         ...tradeOperationData,
         fromStringValue,
         toStringValue,
+        formattedRate: formatExchangeRate(),
     };
 };

--- a/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
+++ b/suite-native/module-trading/src/hooks/history/useChangeStringsExtractor.ts
@@ -47,6 +47,7 @@ export const useChangeStringsExtractor = (
     const formatFiatValue = (
         value: BaseCurrencyAmount | undefined,
         currency: string | undefined,
+        fractionDigits?: number,
     ) => {
         if (value === undefined) {
             return undefined;
@@ -55,6 +56,8 @@ export const useChangeStringsExtractor = (
         return (
             BaseCurrencyAmountFormatter.format(value, {
                 currency,
+                minimumFractionDigits: fractionDigits,
+                maximumFractionDigits: fractionDigits,
             }) ?? undefined
         );
     };
@@ -64,22 +67,22 @@ export const useChangeStringsExtractor = (
             return undefined;
         }
 
-        const fromNumericValue = parseFloat(fromValue);
-        const toNumericValue = parseFloat(toValue);
+        const fromBigNumber = new BigNumber(fromValue);
+        const toBigNumber = new BigNumber(toValue);
 
-        if (isNaN(fromNumericValue) || isNaN(toNumericValue) || toNumericValue === 0) {
+        if (fromBigNumber.isNaN() || toBigNumber.isNaN() || toBigNumber.isZero()) {
             return undefined;
         }
 
-        const rate = fromNumericValue / toNumericValue;
+        const rate = fromBigNumber.div(toBigNumber);
 
         const rateFormatted = isFromCrypto
             ? formatCryptoValue(rate.toString(), fromCurrency, false)
-            : formatFiatValue(asBaseCurrencyAmount(new BigNumber(rate)), fromCurrency);
+            : formatFiatValue(asBaseCurrencyAmount(rate), fromCurrency);
 
         const targetCurrencyFormatted = isToCrypto
             ? formatCryptoValue('1', toCurrency, false)
-            : formatFiatValue(asBaseCurrencyAmount(new BigNumber('1')), toCurrency);
+            : formatFiatValue(asBaseCurrencyAmount(new BigNumber('1')), toCurrency, 0);
 
         if (!rateFormatted || !targetCurrencyFormatted) {
             return undefined;

--- a/suite-native/trading-state/package.json
+++ b/suite-native/trading-state/package.json
@@ -10,7 +10,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
         "lint:js:fix": "yarn lint:js --fix",
         "type-check": "yarn g:tsc --build",
-        "test:unit": "yarn g:jest --coverage",
+        "test:unit": "yarn g:jest --coverage --maxWorkers=2",
         "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {

--- a/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/buySelectors.test.ts
@@ -290,16 +290,16 @@ describe('buySelectors', () => {
         it('should return only first quote for each payment method', () => {
             expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([
                 expect.objectContaining({
+                    paymentMethod: 'googlePay',
+                    rate: 9991.316675433,
+                }),
+                expect.objectContaining({
                     paymentMethod: 'applePay',
                     rate: 9998.316675433,
                 }),
                 expect.objectContaining({
                     paymentMethod: 'creditCard',
                     rate: 20000,
-                }),
-                expect.objectContaining({
-                    paymentMethod: 'googlePay',
-                    rate: 9991.316675433,
                 }),
             ]);
         });
@@ -330,6 +330,23 @@ describe('buySelectors', () => {
             state.wallet.trading.buy.quotes = [quote];
 
             expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
+        });
+
+        it('should sort quotes by rate', () => {
+            const quote1 = {
+                ...buyQuotes[0],
+                paymentMethod: 'creditCard',
+                rate: 20000,
+            } as BuyTrade;
+            const quote2 = {
+                ...buyQuotes[0],
+                paymentMethod: 'applePay',
+                rate: 10000,
+            } as BuyTrade;
+
+            state.wallet.trading.buy.quotes = [quote1, quote2];
+
+            expect(selectBuyBestQuotesForAvailablePaymentMethods(state)).toEqual([quote2, quote1]);
         });
     });
 

--- a/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/sellSelectors.test.ts
@@ -274,12 +274,12 @@ describe('sellSelectors', () => {
         it('should return only first quote for each payment method', () => {
             expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([
                 expect.objectContaining({
-                    paymentMethod: 'creditCard',
-                    rate: 3869.9570815450643,
-                }),
-                expect.objectContaining({
                     paymentMethod: 'bankTransfer',
                     rate: 3937.6279729091198,
+                }),
+                expect.objectContaining({
+                    paymentMethod: 'creditCard',
+                    rate: 3869.9570815450643,
                 }),
             ]);
         });
@@ -310,6 +310,22 @@ describe('sellSelectors', () => {
             state.wallet.trading.sell.quotes = [quote];
 
             expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([]);
+        });
+
+        it('should sort quotes by rates', () => {
+            const quote1 = {
+                ...sellQuotes[0],
+                paymentMethod: 'creditCard',
+                rate: 10000,
+            } as SellFiatTrade;
+            const quote2 = {
+                ...sellQuotes[0],
+                paymentMethod: 'bankTransfer',
+                rate: 20000,
+            } as SellFiatTrade;
+            state.wallet.trading.sell.quotes = [quote1, quote2];
+
+            expect(selectSellBestQuotesForAvailablePaymentMethods(state)).toEqual([quote2, quote1]);
         });
     });
 

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -150,7 +150,15 @@ export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelec
             return quotesByPaymentMethodMap;
         }, new Map<BuyCryptoPaymentMethod, BuyTrade>());
 
-        return [...bestQuoteByPaymentMethodMap.values()];
+        return [...bestQuoteByPaymentMethodMap.values()].sort(
+            ({ rate: aRate }, { rate: bRate }) => {
+                // note that quotes without a valid rate should be filtered out by selectValidTradingBuyQuotesNative -> selectValidTradingBuyQuotes
+                invariant(aRate, 'rate in object "a" is required for sorting');
+                invariant(bRate, 'rate in object "b" is required for sorting');
+
+                return aRate - bRate;
+            },
+        );
     },
 );
 

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -1,6 +1,7 @@
 import type { FiatCurrencyCode, SellCryptoPaymentMethod, SellFiatTrade } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingCountryCode,
     type TradingPaymentMethodProps,
@@ -88,7 +89,15 @@ export const selectSellBestQuotesForAvailablePaymentMethods = createMemoizedSele
             return quotesByPaymentMethodMap;
         }, new Map<SellCryptoPaymentMethod, SellFiatTrade>());
 
-        return [...bestQuoteByPaymentMethodMap.values()];
+        return [...bestQuoteByPaymentMethodMap.values()].sort(
+            ({ rate: aRate }, { rate: bRate }) => {
+                // note that quotes without a valid rate should be filtered out by selectValidTradingSellQuotes
+                invariant(aRate, 'rate in object "a" is required for sorting');
+                invariant(bRate, 'rate in object "b" is required for sorting');
+
+                return bRate - aRate;
+            },
+        );
     },
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- displays rates on sheet with payment methods
- displays rates on sheet with providers
- sorts payment methods by rate

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #24612


## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-10 at 12 22 15" src="https://github.com/user-attachments/assets/c9f69520-a972-47d0-8c2c-27a940322f36" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-10 at 12 22 21" src="https://github.com/user-attachments/assets/b882fc1d-4920-41e9-947e-8d85b8ac09e7" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-10 at 12 22 38" src="https://github.com/user-attachments/assets/aa97d6d9-ab71-4457-a045-244ae5de4a16" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-10 at 12 22 47" src="https://github.com/user-attachments/assets/8debe610-b5ae-40cc-b0be-957714f0d66f" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24612-price-quote-for-each-payment-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24612-price-quote-for-each-payment-mobile&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24612-price-quote-for-each-payment-mobile&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T15:17:42.075Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T14:55:24.580Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->