### PR TITLE
feat(suite-native): cancel send flow when device it disconnected

### DIFF
--- a/suite-native/device/src/deviceNavigationConfig.ts
+++ b/suite-native/device/src/deviceNavigationConfig.ts
@@ -19,9 +19,3 @@ export const DEVICE_CONNECTION_BLACKLISTED_ROUTES = [
     DeviceOnboardingStackRoutes.SuspiciousDevice,
     ...SEND_STACK_ROUTES,
 ];
-
-export const buildDisconnectionBlacklist = (isDeviceRemembered: boolean) => [
-    ...DEVICE_DISCONNECTION_BLACKLISTED_ROUTES,
-    // Add SendStack only if device is remembered
-    ...(isDeviceRemembered ? SEND_STACK_ROUTES : []),
-];

--- a/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
+++ b/suite-native/device/src/middlewares/deviceConnectionMiddleware.ts
@@ -10,7 +10,6 @@ import {
     getDeviceInternalModel,
     getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
-    getIsDeviceRemembered,
 } from '@suite-common/suite-utils';
 import { isThpPairingUIRequestButtonAction, selectThpAutoconnectStep } from '@suite-common/thp';
 import { selectIsAnyNetworkEnabled } from '@suite-common/wallet-core';
@@ -31,7 +30,7 @@ import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-util
 
 import {
     DEVICE_CONNECTION_BLACKLISTED_ROUTES,
-    buildDisconnectionBlacklist,
+    DEVICE_DISCONNECTION_BLACKLISTED_ROUTES,
 } from '../deviceNavigationConfig';
 import { NativeDeviceRootState, selectCompromisedDeviceFailedCheck } from '../selectors';
 import { getIsDeviceSetupSupported } from '../utils';
@@ -188,15 +187,13 @@ deviceConnectionMiddleware.startListening({
             throw new Error('This listener only handles deviceDisconnect action');
         }
 
-        const device = action.payload;
-        const isDeviceRemembered = getIsDeviceRemembered(device);
         const isFirmwareInstallationRunning = selectIsFirmwareInstallationRunning(getState());
         const wasDeviceConnectedViaBluetooth = getIsDeviceDescriptorApiTypeBluetooth(
             action.payload,
         );
 
         if (
-            checkIsActiveRouteAnyOf(buildDisconnectionBlacklist(isDeviceRemembered)) ||
+            checkIsActiveRouteAnyOf(DEVICE_DISCONNECTION_BLACKLISTED_ROUTES) ||
             isFirmwareInstallationRunning
         )
             return;


### PR DESCRIPTION
## Description

On mobile, when the device gets disconnected during the send flow, cancel the send flow and navigate back home.

## Notes for QA

Try disconnecting the device during any part of the send flow.

## Related Issue

Resolve #21270 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/send-device-disconnected&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/send-device-disconnected&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/send-device-disconnected&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T12:36:59.499Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T12:35:33.651Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->