### PR TITLE
fix(suite-native): display network reserve button only if relevant

### DIFF
--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -187,7 +187,7 @@ const outputSchema = yup.object({
         )
         .test(
             'network-reserve',
-            'Not enough funds left after we reserve for network fees.',
+            'Not enough funds remaining after reserving network fees',
             function (value, { options: { context } }: yup.TestContext<SendFormFormContext>) {
                 if (!value || !context) return true;
 

--- a/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsAdvancedScreen.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
+import { selectIsNetworkReserveSettingsVisible } from '@suite-common/wallet-core';
 import { VStack } from '@suite-native/atoms';
 import { ExperimentalFeaturesSettingsCard } from '@suite-native/experimental-features';
 import { Translation } from '@suite-native/intl';
@@ -16,6 +17,7 @@ import { selectIsBitcoinBackendsConfigVisible } from '../selectors';
 export const SettingsAdvancedScreen = () => {
     const isMevProtectionSettingsVisible = useSelector(selectIsMevProtectionSettingsVisible);
     const isBitcoinBackendsConfigVisible = useSelector(selectIsBitcoinBackendsConfigVisible);
+    const isNetworkReserveSettingsVisible = useSelector(selectIsNetworkReserveSettingsVisible);
 
     return (
         <Screen
@@ -29,7 +31,7 @@ export const SettingsAdvancedScreen = () => {
                 {isMevProtectionSettingsVisible && <ToggleMevProtectionCard />}
                 <ToggleFirmwareAuthenticityCheckCard />
                 <ToggleDeviceAuthenticityCheckCard />
-                <ToggleNetworkReserveCheckCard />
+                {isNetworkReserveSettingsVisible && <ToggleNetworkReserveCheckCard />}
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25770

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/network-reserve-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->