### PR TITLE
chore(suite-common): remove unused device action setThpCredentials

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -289,7 +289,6 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             }
 
             if (
-                deviceActions.setThpCredentials.match(action) ||
                 thpActions.removeCredentials.match(action) ||
                 action.type === 'device-thp_credentials_changed' ||
                 (action.type === 'device-thp_pairing_status_changed' &&

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -5,7 +5,6 @@ import type {
     ButtonRequest,
     PersistentDeviceData,
     StoredAuthenticateDeviceResult,
-    ThpSuiteCredentials,
     TrezorDevice,
 } from '@suite-common/suite-types';
 import {
@@ -135,13 +134,6 @@ const setEntropyCheckResult = createAction(
     (payload: SetEntropyCheckResultParams) => ({ payload }),
 );
 
-const setThpCredentials = createAction(
-    `${DEVICE_MODULE_PREFIX}/setThpCredentials`,
-    ({ credentials }: { credentials: ThpSuiteCredentials[] }) => ({
-        payload: { credentials },
-    }),
-);
-
 type SetDelegatedIdentityKeyParams = {
     deviceId: string;
     delegatedKey: PersistentDeviceData['delegatedIdentityKey'];
@@ -194,7 +186,6 @@ export const deviceActions = {
     updateSelectedDevice,
     removeButtonRequests,
     setEntropyCheckResult,
-    setThpCredentials,
     setDelegatedIdentityKey,
     setDiscovered,
     devicePushNotification,


### PR DESCRIPTION


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/common/set-thp-credentials&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/common/set-thp-credentials&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T12:12:55.121Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T12:11:39.170Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->