### PR TITLE
chore(e2e): provide immutable commit to e2e test builds to not break fingerprint

### DIFF
--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -32,7 +32,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       EXPO_PUBLIC_ENVIRONMENT: preview
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      COMMIT_HASH: ${{ github.sha }}
+      COMMIT_HASH: "e2e-test" # it has to be hardcoded to avoid the fingerprint change
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -14,6 +14,7 @@ jobs:
       NODE_ENV: "test"
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       RN_SRC_EXT: "e2e.ts,e2e.tsx"
+      COMMIT_HASH: "e2e-test" # it has to be hardcoded to avoid the fingerprint change
     steps:
       - name: Checkout project
         uses: actions/checkout@v4

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -311,6 +311,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         },
         plugins: getPlugins(),
         extra: {
+            // FIXME: Fingerprint is always changed between commits because of this. We need to find a better solution.
             commitHash:
                 process.env.EAS_BUILD_GIT_COMMIT_HASH ||
                 process.env.COMMIT_HASH ||


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Right now, every mobile e2e pipeline build the app again, because the fingerprint depend on commit hash. This change should fix the caching so the app is rebuild only if there is a relevant native change.

- Any change in app.config.ts leads to fingerprint change, but then we can't rely on fingerprint for build cache if commit hash is changed everytime.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/e2e-android-builds-cache&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/e2e-android-builds-cache&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/e2e-android-builds-cache&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T14:20:48.028Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T14:19:12.981Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->