### PR TITLE
fix(ci): reintroduce "prod" Nx input config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,8 @@
             "{workspaceRoot}/patches/*.patch",
             "{workspaceRoot}/package.json"
         ],
-        "default": ["{projectRoot}/**/*", "sharedGlobals"]
+        "default": ["{projectRoot}/**/*", "sharedGlobals"],
+        "production": ["{projectRoot}/**/*", "!{projectRoot}/**/*.test.{ts,tsx}"]
     },
     "tui": {
         "autoExit": true
@@ -15,6 +16,7 @@
         "build:lib": {
             "dependsOn": [],
             "inputs": [
+                "^production",
                 "default",
                 "{workspaceRoot}/tsconfig.base.json",
                 "{workspaceRoot}/tsconfig.lib.json"
@@ -30,6 +32,7 @@
                 "@suite-common/message-system:build:lib"
             ],
             "inputs": [
+                "^production",
                 "default",
                 "{workspaceRoot}/tsconfig.base.json",
                 "{workspaceRoot}/tsconfig.lib.json"
@@ -40,6 +43,7 @@
         "test:unit": {
             "dependsOn": ["@suite-common/message-system:build:lib"],
             "inputs": [
+                "^production",
                 "default",
                 "{workspaceRoot}/jest.config.base.js",
                 "{workspaceRoot}/jest.config.native.js"


### PR DESCRIPTION
## Description

Effectively revert #24605 which was a bad decision. But now written more carefully 

Let's say we have workspaces `A,B,C`, and `A` imports `B`, which imports `C`, so `A` is downstream, `C` is upstream.

If you make change in `B`, then currently only `B` runs – bad, because change in `B` can break `A` :x:
After this PR, it should run `A, B` :heavy_check_mark: 

Will this work? I tested locally, but the cloud cache we can only know by trying it.

### How does it work

After change in `B`:
- nx affected forms graph of affected `A, B`
- for `A` and `B`, cache is evaluated:
  - currently `A` cache is used because it's only calculated from A, so still valid
    - so only `B` runs
  - after this PR, the A cache is invalidated because it points to `^production = B` 
    - so `A` and `B` runs

## QA

How I tested it:
```
git checkout fix/nx-unit-tests
git branch -f develop HEAD && git branch -f origin/develop HEAD # to make nx think that we are up-to-date with develop

yarn nx:show-affected
# → nothing

echo "// source code change" >> ./packages/suite-desktop-native/src/index.ts

yarn nx:show-affected
# @trezor/suite-desktop-native
# @trezor/suite-desktop-core

yarn nx:test-unit # cache miss, should run suite-desktop-core tests
yarn nx:test-unit # cache hit, nothing run

echo "// test file change" >> ./packages/suite-desktop-native/a.test.ts
yarn nx:show-affected # still both packages
yarn nx:test-unit # cache hit, nothing run
```


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nx-unit-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nx-unit-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-11T09:22:39.437Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-11T09:19:16.048Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->