### PR TITLE
fix(blockchain-link-utils): guard against missing gasLimit in Tron fee mapping

### DIFF
--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -269,7 +269,7 @@ export const transformTransaction = (
             : undefined;
 
     const fee =
-        tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed
+        tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed && tx.ethereumSpecific.gasLimit
             ? new BigNumber(
                   tx.ethereumSpecific?.maxFeePerGas ?? tx.ethereumSpecific?.gasPrice ?? '0',
               )


### PR DESCRIPTION
## Description

This PR fixes the app crash caused by wrongly calculated fee for Tron network.

## Notes for QA

List of transactions should be visible for Tron and app should not crash.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-tx-crash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-tx-crash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-10T16:38:26.361Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-10T16:36:41.512Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->