### PR TITLE
FIX useBrowserAuth handling of redirect to buy trade detail

### DIFF
--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/TradeDetailAlert.tsx
@@ -114,11 +114,7 @@ export const TradeDetailAlert = ({
 
     const alertConfig = getAlertConfig(alertType);
 
-    const { openBrowser } = useBrowserAuth(
-        trade?.tradeType === 'buy'
-            ? { tradingType: trade.tradeType, orderId: trade.data.orderId }
-            : { tradingType: trade?.tradeType },
-    );
+    const { openBrowser } = useBrowserAuth(trade?.tradeType);
 
     // If no config found for this alert type, return null
     if (!alertConfig) {
@@ -146,7 +142,7 @@ export const TradeDetailAlert = ({
                 orderId,
             });
             onOpenedBrowser?.();
-            openBrowser(trade.data.partnerData, callbackUrl);
+            openBrowser(trade.data.partnerData, callbackUrl, orderId);
         }
     };
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -61,10 +61,7 @@ export const useBuyFlow = (form: BuyFormType) => {
         coinInfo,
     });
 
-    const { openBrowserForFormData } = useBrowserAuth({
-        tradingType: 'buy',
-        orderId: candidateQuote?.orderId,
-    });
+    const { openBrowserForFormData } = useBrowserAuth('buy');
 
     const reportTradeConfirmation = () => {
         analytics.report({
@@ -91,7 +88,7 @@ export const useBuyFlow = (form: BuyFormType) => {
         }
 
         if (response.tradeForm) {
-            openBrowserForFormData(response.tradeForm.form, returnUrl);
+            openBrowserForFormData(response.tradeForm.form, returnUrl, response.trade.orderId);
         }
 
         clearBuyFormQuoteData(form);
@@ -162,7 +159,8 @@ export const useBuyFlow = (form: BuyFormType) => {
                 quote: candidateQuote,
                 timer,
                 returnUrl,
-                loginRequest: formResponse => openBrowserForFormData(formResponse, returnUrl),
+                loginRequest: formResponse =>
+                    openBrowserForFormData(formResponse, returnUrl, candidateQuote.orderId),
                 nextStep: () => {
                     confirmTrade(candidateQuote, addressText);
                 },

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeFlow.tsx
@@ -38,9 +38,7 @@ export const useExchangeFlow = () => {
 
     const sendAccount = useSelector(selectExchangeSelectedSendAccount);
 
-    const { openBrowserForFormData } = useBrowserAuth({
-        tradingType: 'exchange',
-    });
+    const { openBrowserForFormData } = useBrowserAuth('exchange');
 
     const getCommonFunctions = useCallback(
         (trade?: ExchangeTrade) => {

--- a/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellFlow.ts
@@ -22,9 +22,7 @@ export const useSellFlow = () => {
 
     const sendAccount = useSelector(selectSellSelectedSendAccount);
 
-    const { openBrowserForFormData } = useBrowserAuth({
-        tradingType: 'sell',
-    });
+    const { openBrowserForFormData } = useBrowserAuth('sell');
 
     const getCommonFunctions = useCallback(
         (trade?: SellFiatTrade) => {

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
@@ -50,18 +50,7 @@ describe('useBrowserAuth', () => {
     let store: TestStore;
 
     const renderUseBrowserAuth = (tradingType: TradingType = 'sell') =>
-        renderHookWithStoreProvider(
-            () =>
-                useBrowserAuth(
-                    tradingType === 'buy'
-                        ? {
-                              orderId: 'trade-order-id-1',
-                              tradingType,
-                          }
-                        : { tradingType },
-                ),
-            { store },
-        );
+        renderHookWithStoreProvider(() => useBrowserAuth(tradingType), { store });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -80,10 +69,9 @@ describe('useBrowserAuth', () => {
         it('should log error to sentry and return early when called with undefined tradingType', async () => {
             const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
-            const { result } = renderHookWithStoreProvider(
-                () => useBrowserAuth({ tradingType: undefined }),
-                { store },
-            );
+            const { result } = renderHookWithStoreProvider(() => useBrowserAuth(undefined), {
+                store,
+            });
 
             await act(async () => {
                 await result.current.openBrowser('URL', 'CALLBACK_URL');
@@ -227,7 +215,7 @@ describe('useBrowserAuth', () => {
             const { result } = renderUseBrowserAuth('buy');
 
             act(() => {
-                result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK);
+                result.current.openBrowser('URL', TRADING_URL_DEFAULT_BACK, 'trade-order-id-1');
             });
 
             expect(selectTradeToBeOpened(store.getState())).toEqual(
@@ -302,6 +290,31 @@ describe('useBrowserAuth', () => {
             expect(selectTradingSellLastErrorMessage(store.getState())).toBe(
                 getTranslation('moduleTrading.browser.noURL'),
             );
+        });
+
+        it('should call handleBrowserSuccess and set tradeToBeOpened for buy ', () => {
+            mockLinkingURL = TRADING_URL_DEFAULT_BACK;
+            mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.CANCEL });
+            const { result } = renderUseBrowserAuth('buy');
+
+            act(() => {
+                result.current.openBrowserForFormData(
+                    {
+                        formMethod: 'GET',
+                        formAction: 'URL',
+                        fields: {},
+                    },
+                    TRADING_URL_DEFAULT_BACK,
+                    'trade-order-id-1',
+                );
+            });
+
+            expect(selectTradeToBeOpened(store.getState())).toEqual(
+                expect.objectContaining({
+                    data: expect.objectContaining({ orderId: 'trade-order-id-1' }),
+                }),
+            );
+            expect(mockDismissBrowser).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.e2e.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.e2e.ts
@@ -2,16 +2,16 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { invariant } from '@suite-common/suite-utils';
-import { tradingThunks } from '@suite-common/trading';
+import { type TradingType, tradingThunks } from '@suite-common/trading';
 
-import { BrowserAuthProps, BrowserAuthRet } from './useBrowserAuthTypes';
+import type { BrowserAuthRet } from './useBrowserAuthTypes';
 import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
 
 // NOTE this is file is for E2E testing purposes only.
 // It simulates the browser auth flow without actually opening a browser or listening for deep links.
-// We do this because Detox does not support interaction with Web browser.
+// We do this because Detox does not support interaction with a Web browser.
 
-export const useBrowserAuth = ({ tradingType }: BrowserAuthProps): BrowserAuthRet => {
+export const useBrowserAuth = (tradingType: TradingType | undefined): BrowserAuthRet => {
     const dispatch = useDispatch();
     const { handleBrowserClosed, handleBrowserOpened } =
         useBrowserStateChangeCallbacks(tradingType);

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.ts
@@ -10,13 +10,13 @@ import {
 } from 'expo-web-browser';
 
 import { invariant } from '@suite-common/suite-utils';
-import { TradingType, tradingThunks } from '@suite-common/trading';
+import { type TradingType, tradingThunks } from '@suite-common/trading';
 import { useTranslate } from '@suite-native/intl';
 import { captureSentryException } from '@suite-native/sentry';
 import { tradingActions } from '@suite-native/trading-state';
 import { exhaustive } from '@trezor/type-utils';
 
-import { BrowserAuthProps, BrowserAuthRet } from './useBrowserAuthTypes';
+import type { BrowserAuthRet } from './useBrowserAuthTypes';
 import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
 import { useOnForegroundCallback } from './useOnForegroundCallback';
 import { getSourceForForm } from '../utils/formUtils';
@@ -53,11 +53,13 @@ const useLastErrorMessageDispatcher = (tradingType: TradingType | undefined) => 
     return tradingType ? dispatchLastErrorMessage : noop;
 };
 
-export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): BrowserAuthRet => {
+export const useBrowserAuth = (tradingType: TradingType | undefined): BrowserAuthRet => {
     const dispatch = useDispatch();
     const { translate } = useTranslate();
 
-    const [lastCallbackUrl, setLastCallbackUrl] = useState<string | undefined>(undefined);
+    const [lastCallbackData, setLastCallbackData] = useState<
+        { callbackUrl: string; orderId: string | undefined } | undefined
+    >(undefined);
 
     const receivedDeeplinkUrl = useLinkingURL();
     const dispatchLastErrorMessage = useLastErrorMessageDispatcher(tradingType);
@@ -65,12 +67,14 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
         useBrowserStateChangeCallbacks(tradingType);
     const { setShouldWatchForForeground } = useOnForegroundCallback(handleBrowserClosed);
 
-    // when url contains lastCallbackUrl, dismissBrowser and mark the trade to be opened for buy
+    // when the url contains lastCallbackUrl, dismissBrowser and mark the trade to be opened for buy
     useEffect(() => {
-        if (
-            !lastCallbackUrl ||
-            !doesUrlContainCloseCallbackUrl(receivedDeeplinkUrl ?? '', lastCallbackUrl)
-        ) {
+        if (!lastCallbackData || !receivedDeeplinkUrl) {
+            return;
+        }
+
+        const { callbackUrl, orderId } = lastCallbackData;
+        if (!callbackUrl || !doesUrlContainCloseCallbackUrl(receivedDeeplinkUrl, callbackUrl)) {
             return;
         }
 
@@ -78,22 +82,16 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
             dispatch(tradingActions.setTradeOrderIdToBeOpened(orderId));
         }
 
+        setLastCallbackData(undefined);
         handleBrowserSuccess();
         dismissBrowser()?.catch(_ => {
             // Ignore the error, the browser might have been already closed.
             // (And in fact it most probably already is.)
         });
-    }, [
-        lastCallbackUrl,
-        orderId,
-        tradingType,
-        dispatch,
-        handleBrowserSuccess,
-        receivedDeeplinkUrl,
-    ]);
+    }, [lastCallbackData, tradingType, dispatch, handleBrowserSuccess, receivedDeeplinkUrl]);
 
     const openBrowser = useCallback(
-        async (url: string, callbackUrl: string) => {
+        async (url: string, callbackUrl: string, orderId?: string) => {
             if (!tradingType) {
                 const msg = 'Attempted to openBrowser without a tradingType provided.';
                 console.warn(msg);
@@ -102,11 +100,11 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
                 return;
             }
 
-            setLastCallbackUrl(callbackUrl);
+            setLastCallbackData({ callbackUrl, orderId });
 
             // Note that provider confirmation status is set "window_opened" even when `openBrowserAsync` fails (error is thrown / browser is locked).
-            // There is no need to set it back to "inactive" in that case, because user has no other option than
-            // read the error message and close the preview screen to try again.
+            // There is no need to set it back to "inactive" in that case, because a user has no other option than
+            // to read the error message and close the preview screen to try again.
             handleBrowserOpened();
 
             try {
@@ -114,8 +112,8 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
                     presentationStyle: WebBrowserPresentationStyle.OVER_FULL_SCREEN,
                     dismissButtonStyle: 'close',
                     enableBarCollapsing: false,
-                    // this allows to keep the browser open in the background on android, so user can switch
-                    // from and back to it (e.g. to copy the 2FA code from authenticator app)
+                    // this allows keeping the browser open in the background on android, so user can switch
+                    // from and back to it (e.g., to copy the 2FA code from an authenticator app)
                     // without it being killed by the system
                     showInRecents: true,
                 });
@@ -153,7 +151,7 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
     );
 
     const openBrowserForFormData = useCallback<BrowserAuthRet['openBrowserForFormData']>(
-        async (formData, returnUrl) => {
+        async (formData, returnUrl, orderId?: string) => {
             const source = getSourceForForm(formData);
             if (!source?.uri) {
                 const msg = 'Unable to open browser, no URI provided.';
@@ -164,7 +162,7 @@ export const useBrowserAuth = ({ tradingType, orderId }: BrowserAuthProps): Brow
                 return;
             }
 
-            await openBrowser(source.uri, returnUrl);
+            await openBrowser(source.uri, returnUrl, orderId);
         },
         [openBrowser, dispatchLastErrorMessage, translate],
     );

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuthTypes.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuthTypes.ts
@@ -1,19 +1,10 @@
 import type { FormResponse } from 'invity-api';
 
-import { TradingBuyType, TradingType } from '@suite-common/trading';
-
-export type BrowserAuthProps =
-    | {
-          tradingType: TradingType | undefined;
-          orderId?: undefined;
-      }
-    // We need orderId for buy flow only. It is used to open trade in history after successful provider confirmation.
-    | {
-          tradingType: TradingBuyType;
-          orderId: string;
-      };
-
 export type BrowserAuthRet = {
-    openBrowser: (url: string, callbackUrl: string) => Promise<void> | void;
-    openBrowserForFormData: (formData: FormResponse['form'], returnUrl: string) => void;
+    openBrowser: (url: string, callbackUrl: string, orderId?: string) => Promise<void> | void;
+    openBrowserForFormData: (
+        formData: FormResponse['form'],
+        returnUrl: string,
+        orderId?: string,
+    ) => void;
 };

--- a/suite-native/trading-browser-auth/src/index.ts
+++ b/suite-native/trading-browser-auth/src/index.ts
@@ -1,6 +1,6 @@
 export { ProviderConfirmationStatusInfo } from './components/ProviderConfirmationStatusInfo';
 export { ProviderStatusDevButtons } from './components/ProviderStatusDevButtons';
 
-export { useBrowserAuth, type BrowserAuthProps, type BrowserAuthRet } from './hooks/useBrowserAuth';
+export { useBrowserAuth, type BrowserAuthRet } from './hooks/useBrowserAuth';
 
 export { buildTradingUrl } from './utils/formUtils';


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- `orderId` was cleared before deeplink can be checked
- `orderId` is now saved to state alongside the `callbackUrl`

<!--- Describe your changes in detail -->

## Notes for QA
This should affect only buy trades.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-buy-trade-redirect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->