### PR TITLE
Mobile Trade: Fix failing test due the translation change

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListFooter.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListFooter.test.tsx
@@ -1,3 +1,4 @@
+import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { AccountListFooter, AccountsListFooterProps } from '../AccountListFooter';
@@ -11,13 +12,13 @@ describe('AccountListFooter', () => {
     it('should not render "OR" when hasTextualDivider props is false', () => {
         const { queryByText } = renderAccountsListFooter({ hasTextualDivider: false });
 
-        expect(queryByText('OR')).toBeNull();
+        expect(queryByText(getTranslation('generic.orSeparator'))).toBeNull();
     });
 
     it('should render "OR" when hasTextualDivider props is true', () => {
         const { getByText } = renderAccountsListFooter({ hasTextualDivider: true });
 
-        expect(getByText('OR')).toBeTruthy();
+        expect(getByText(getTranslation('generic.orSeparator'))).toBeTruthy();
     });
 
     it('should call onAddAccountTap callback on "Add new" button press', () => {
@@ -25,7 +26,11 @@ describe('AccountListFooter', () => {
         const { getByText } = renderAccountsListFooter({ onAddAccountTap });
 
         act(() => {
-            fireEvent.press(getByText('Add new'));
+            fireEvent.press(
+                getByText(
+                    getTranslation('moduleAddAccounts.coinDiscoveryFinishedScreen.addButton'),
+                ),
+            );
         });
 
         expect(onAddAccountTap).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`generic.orSeparator` changed from "OR" to "or" and was causing tests fails.

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-failing-native-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->