### PR TITLE
chore(ci): increase desktop test release build timeout

### DIFF
--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -216,7 +216,7 @@ jobs:
       - suite-desktop-autoupdate-release
       - build-web
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

The `create-test-releases` job in the staging release workflow was hitting the 40-minute timeout when building test versions of suite-desktop for autoupdate (linux/mac/win). Increases `timeout-minutes` from 40 → 60.

## Notes for QA

No functional changes — CI config only.