### PR TITLE
chore: in transport, use result type from type-utils

### DIFF
--- a/packages/connect-cli/src/transport.ts
+++ b/packages/connect-cli/src/transport.ts
@@ -34,7 +34,7 @@ export const initDebugLink = async () => {
 
     const enumerate = await debugTransport.enumerate();
     if (!enumerate.success) {
-        throw new Error(enumerate.error);
+        throw new Error(enumerate.error.code);
     }
 };
 
@@ -45,7 +45,7 @@ const waitForDebugDevice = async () => {
         const enumerate = await debugTransport.enumerate();
         console.log('DebugLink enumerate attempt', attempt);
         if (!enumerate.success) {
-            throw new Error(enumerate.error);
+            throw new Error(enumerate.error.code);
         }
         if (enumerate.payload.length > 0) {
             device = enumerate.payload[0];
@@ -64,7 +64,7 @@ export const debugLinkState = async (uiEvent: UiRequestThpPairing['payload']) =>
     const input = { ...descriptor, previous: descriptor.session };
     const acquire = await debugTransport.acquire({ input });
     if (!acquire.success) {
-        throw new Error(acquire.error);
+        throw new Error(acquire.error.code);
     }
 
     const { channel } = uiEvent.device.thp;
@@ -97,14 +97,14 @@ export const debugLinkDecision = async () => {
 
     const enumerate = await debugTransport.enumerate();
     if (!enumerate.success) {
-        throw new Error(enumerate.error);
+        throw new Error(enumerate.error.code);
     }
     const descriptor = enumerate.payload[0];
     const input = { ...descriptor, previous: descriptor.session };
 
     const acquire = await debugTransport.acquire({ input });
     if (!acquire.success) {
-        throw new Error(acquire.error);
+        throw new Error(acquire.error.code);
     }
 
     const session = acquire.payload;

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -231,13 +231,13 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
                 if ((await sessionPromise) !== response.payload) {
                     return {
                         success: false,
-                        error: TRANSPORT_ERROR.SESSION_WRONG_PREVIOUS,
+                        error: { code: TRANSPORT_ERROR.SESSION_WRONG_PREVIOUS },
                     } as const;
                 }
             } catch {
                 return {
                     success: false,
-                    error: TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION,
+                    error: { code: TRANSPORT_ERROR.DEVICE_DISCONNECTED_DURING_ACTION },
                 } as const;
             }
         }
@@ -264,7 +264,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
 
                     return result;
                 } else {
-                    throw new Error(result.error);
+                    throw new Error(result.error.code);
                 }
             })
             .finally(() => {

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -309,11 +309,13 @@ export class DeviceCurrentSession implements TypedCallProvider {
             const { type, message } = result.payload;
             logger.debug('Received', type, filterForLog(type, message));
         } else {
-            // res.message is not propagated to higher levels, only logged here. webusb/node-bridge may return message with additional information
-            logger.warn('Received transport error', result.error, result.message);
+            // result.error.message is not propagated to higher levels, only logged here. webusb/node-bridge may return message with additional information
+            logger.warn('Received transport error', result.error.code, result.error.message);
         }
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success
+            ? success(result.payload)
+            : fail(result.error.message || result.error.code);
     }
 
     async send(name: string, data: Record<string, unknown>, options: AbortableOptions = {}) {
@@ -328,7 +330,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
             ...options,
         });
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success
+            ? success(result.payload)
+            : fail(result.error.message || result.error.code);
     }
 
     async receive(options: AbortableOptions = {}) {
@@ -341,7 +345,9 @@ export class DeviceCurrentSession implements TypedCallProvider {
             ...options,
         });
 
-        return result.success ? success(result.payload) : fail(result.message || result.error);
+        return result.success
+            ? success(result.payload)
+            : fail(result.error.message || result.error.code);
     }
 
     cancelCall() {

--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -279,7 +279,7 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
         const enumerateResult = await transport.enumerate({ signal });
 
         if (!enumerateResult.success) {
-            throw new Error(enumerateResult.message || enumerateResult.error);
+            throw new Error(enumerateResult.error.message || enumerateResult.error.code);
         }
 
         const descriptors = enumerateResult.payload;

--- a/packages/connect/src/device/TransportManager.ts
+++ b/packages/connect/src/device/TransportManager.ts
@@ -108,7 +108,7 @@ export class TransportManager extends TypedEmitter<TransportManagerEvents> {
         const result = await transport.init({ signal });
         if (result.success) return transport;
         else if (rest.length) return this.selectTransport(rest, signal);
-        else throw new Error(result.error);
+        else throw new Error(result.error.code);
     }
 
     private scheduleUpgradeCheck(pendingTransportEvent: boolean) {

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -123,7 +123,8 @@ describe('DeviceList', () => {
 
     it('.init() with pendingTransportEvent (unacquired device)', async () => {
         const transport = createTestTransport({
-            openDevice: () => Promise.resolve({ success: false, error: 'wrong previous session' }),
+            openDevice: () =>
+                Promise.resolve({ success: false, error: { code: 'wrong previous session' } }),
         });
 
         list.init({ transports: [transport], pendingTransportEvent: true });
@@ -135,7 +136,8 @@ describe('DeviceList', () => {
 
     it('.init() with pendingTransportEvent (disconnected device)', async () => {
         const transport = createTestTransport({
-            openDevice: () => Promise.resolve({ success: false, error: 'device not found' }),
+            openDevice: () =>
+                Promise.resolve({ success: false, error: { code: 'device not found' } }),
         });
 
         list.init({ transports: [transport], pendingTransportEvent: true });
@@ -198,7 +200,7 @@ describe('DeviceList', () => {
             }),
             openDevice: (path: string) =>
                 path === '2'
-                    ? Promise.resolve({ success: false, error: 'device not found' })
+                    ? Promise.resolve({ success: false, error: { code: 'device not found' } })
                     : Promise.resolve({ success: true, payload: [{ path }] }),
             type: 'usb2',
         });

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -47,7 +47,7 @@ export class BluetoothApi extends AbstractApi {
         try {
             await api.connect();
         } catch (err) {
-            return error({ error: ERRORS.UNEXPECTED_ERROR, message: err.message });
+            return error({ code: ERRORS.UNEXPECTED_ERROR, message: err.message });
         }
 
         return success(true);
@@ -110,7 +110,7 @@ export class BluetoothApi extends AbstractApi {
         return this.api
             .send('write', { id: path, data: Array.from(chunk) })
             .then(() => success(undefined))
-            .catch(e => error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
+            .catch(e => error({ code: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
     }
 
     openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
@@ -129,7 +129,7 @@ export class BluetoothApi extends AbstractApi {
             .send('open_device', { id: path, characteristic: options?.channel })
             .then(() => success(undefined))
             .catch(e =>
-                error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
+                error({ code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
             );
     }
 
@@ -146,7 +146,7 @@ export class BluetoothApi extends AbstractApi {
             .send('close_device', { id: path, characteristic: options?.channel })
             .then(() => success(undefined))
             .catch(e =>
-                error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),
+                error({ code: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),
             );
     }
 }

--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -8,6 +8,7 @@ import * as ERRORS from '@trezor/transport/src/errors';
 import { type PathInternal } from '@trezor/transport/src/types';
 import { getBLEDescriptorModel } from '@trezor/transport/src/utils/descriptor';
 import { readMessageBuffer } from '@trezor/transport/src/utils/readMessageBuffer';
+import { error, success } from '@trezor/transport/src/utils/result';
 
 import { TrezorBluetooth } from './trezor-bluetooth';
 import { type BluetoothDevice, type TrezorBluetoothSettings } from './types';
@@ -45,18 +46,18 @@ export class BluetoothApi extends AbstractApi {
         const { api } = this;
         try {
             await api.connect();
-        } catch (error) {
-            return this.error({ error: ERRORS.UNEXPECTED_ERROR, message: error.message });
+        } catch (err) {
+            return error({ error: ERRORS.UNEXPECTED_ERROR, message: err.message });
         }
 
-        return this.success(true);
+        return success(true);
     }
 
     enumerate() {
         return this.api
             .send('enumerate')
-            .then(({ devices }) => this.success(this.devicesToDescriptors(devices)))
-            .catch(() => this.success([]));
+            .then(({ devices }) => success(this.devicesToDescriptors(devices)))
+            .catch(() => success([]));
     }
 
     listen() {
@@ -108,8 +109,8 @@ export class BluetoothApi extends AbstractApi {
 
         return this.api
             .send('write', { id: path, data: Array.from(chunk) })
-            .then(() => this.success(undefined))
-            .catch(e => this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
+            .then(() => success(undefined))
+            .catch(e => error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: e.message }));
     }
 
     openDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
@@ -118,7 +119,7 @@ export class BluetoothApi extends AbstractApi {
             this.readBuffer.cancelRead(path);
             if (this.readSubscription[path]) {
                 // already subscribed to TX (read) characteristics
-                return Promise.resolve(this.success(undefined));
+                return Promise.resolve(success(undefined));
             } else {
                 this.readSubscription[path] = true;
             }
@@ -126,9 +127,9 @@ export class BluetoothApi extends AbstractApi {
 
         return this.api
             .send('open_device', { id: path, characteristic: options?.channel })
-            .then(() => this.success(undefined))
+            .then(() => success(undefined))
             .catch(e =>
-                this.error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
+                error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE, message: e.message }),
             );
     }
 
@@ -138,14 +139,14 @@ export class BluetoothApi extends AbstractApi {
             // do not close subscriptions to TX (read) characteristics
             this.readBuffer.cancelRead(path);
 
-            return Promise.resolve(this.success(undefined));
+            return Promise.resolve(success(undefined));
         }
 
         return this.api
             .send('close_device', { id: path, characteristic: options?.channel })
-            .then(() => this.success(undefined))
+            .then(() => success(undefined))
             .catch(e =>
-                this.error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),
+                error({ error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE, message: e.message }),
             );
     }
 }

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -248,7 +248,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
             if (protocol.name === 'v2') {
                 if (!thpState) {
-                    return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+                    return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
                 }
 
                 const state = new protocolThp.ThpState();
@@ -319,7 +319,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         const { path } = sessionsResult.payload;
         if (protocol.name === 'v2') {
             if (!thpState) {
-                return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+                return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
             }
 
             const state = new protocolThp.ThpState();
@@ -373,7 +373,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         return api.runInIsolation({ lock: { read: true, write: false }, path }, async () => {
             if (protocol.name === 'v2') {
                 if (!thpState) {
-                    return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+                    return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
                 }
 
                 const state = new protocolThp.ThpState();

--- a/packages/transport-bridge/src/http.ts
+++ b/packages/transport-bridge/src/http.ts
@@ -327,7 +327,7 @@ export class TrezordNode {
 
                             return this.handleResponse(
                                 res,
-                                str({ error: result.error, message: result.message }),
+                                str({ error: result.error.code, message: result.error.message }),
                             );
                         }
                         res.statusCode = 200;
@@ -370,7 +370,10 @@ export class TrezordNode {
 
                                 return this.handleResponse(
                                     res,
-                                    str({ error: result.error, message: result.message }),
+                                    str({
+                                        error: result.error.code,
+                                        message: result.error.message,
+                                    }),
                                 );
                             }
                             res.statusCode = 200;
@@ -393,7 +396,10 @@ export class TrezordNode {
 
                                 return this.handleResponse(
                                     res,
-                                    str({ error: result.error, message: result.message }),
+                                    str({
+                                        error: result.error.code,
+                                        message: result.error.message,
+                                    }),
                                 );
                             }
                             res.statusCode = 200;
@@ -445,7 +451,10 @@ export class TrezordNode {
 
                                 return this.handleResponse(
                                     res,
-                                    str({ error: result.error, message: result.message }),
+                                    str({
+                                        error: result.error.code,
+                                        message: result.error.message,
+                                    }),
                                 );
                             }
                             res.statusCode = 200;
@@ -475,7 +484,10 @@ export class TrezordNode {
 
                                 return this.handleResponse(
                                     res,
-                                    str({ error: result.error, message: result.message }),
+                                    str({
+                                        error: result.error.code,
+                                        message: result.error.message,
+                                    }),
                                 );
                             }
                             res.statusCode = 200;
@@ -505,7 +517,10 @@ export class TrezordNode {
 
                                 return this.handleResponse(
                                     res,
-                                    str({ error: result.error, message: result.message }),
+                                    str({
+                                        error: result.error.code,
+                                        message: result.error.message,
+                                    }),
                                 );
                             }
                             res.statusCode = 200;

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -308,8 +308,10 @@ describe('http', () => {
             });
             expect(res).toMatchObject({
                 success: false,
-                error: 'unexpected error',
-                message: 'Invalid BridgeProtocolMessage protocol',
+                error: {
+                    code: 'unexpected error',
+                    message: 'Invalid BridgeProtocolMessage protocol',
+                },
             });
 
             // invalid protocol message (not a hex)
@@ -320,7 +322,7 @@ describe('http', () => {
             });
             expect(res).toMatchObject({
                 success: false,
-                message: 'Invalid BridgeProtocolMessage data',
+                error: { message: 'Invalid BridgeProtocolMessage data' },
             });
 
             // invalid protocol message (malformed json)
@@ -331,7 +333,7 @@ describe('http', () => {
             });
             expect(res).toMatchObject({
                 success: false,
-                message: 'Invalid BridgeProtocolMessage body',
+                error: { message: 'Invalid BridgeProtocolMessage body' },
             });
             res = await bridgeApiCall({
                 url: `${url}post/1`,
@@ -339,7 +341,7 @@ describe('http', () => {
             });
             expect(res).toMatchObject({
                 success: false,
-                message: 'Invalid BridgeProtocolMessage body',
+                error: { message: 'Invalid BridgeProtocolMessage body' },
             });
             res = await bridgeApiCall({
                 url: `${url}post/1`,
@@ -349,7 +351,7 @@ describe('http', () => {
             });
             expect(res).toMatchObject({
                 success: false,
-                message: 'Invalid BridgeProtocolMessage body',
+                error: { message: 'Invalid BridgeProtocolMessage body' },
             });
 
             await trezordNode.stop();

--- a/packages/transport-bridge/tests/http.test.ts
+++ b/packages/transport-bridge/tests/http.test.ts
@@ -136,7 +136,7 @@ describe('http', () => {
                 method: 'POST',
             });
             if (!response.success) {
-                throw new Error(response.error + ' ' + response.message);
+                throw new Error(response.error.code + ' ' + response.error.message);
             }
             expect(response.payload).toMatchObject({
                 version: trezordNode.version,
@@ -152,7 +152,7 @@ describe('http', () => {
                 method: 'POST',
             });
             if (!response.success) {
-                throw new Error(response.error + ' ' + response.message);
+                throw new Error(response.error.code + ' ' + response.error.message);
             }
             expect(response.payload).toMatchObject({
                 version: trezordNode.version,
@@ -172,7 +172,7 @@ describe('http', () => {
                 body: GET_FEATURES,
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toBe(FEATURES);
             // invalid legacy message (not a hex)
@@ -190,7 +190,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'bridge', data: GET_FEATURES }),
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toEqual({
                 protocol: 'bridge',
@@ -204,7 +204,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'v1', data: '3f2323' + GET_FEATURES }),
             });
             if (!res.success) {
-                throw new Error(res.error);
+                throw new Error(res.error.code);
             }
             expect(res.payload).toEqual({
                 protocol: 'v1',
@@ -261,7 +261,7 @@ describe('http', () => {
                 body: GET_FEATURES,
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toBe('');
             // invalid legacy message (not a hex)
@@ -279,7 +279,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'bridge', data: GET_FEATURES }),
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toEqual({
                 protocol: 'bridge',
@@ -293,7 +293,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'v1', data: '3f2323' + GET_FEATURES }),
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toEqual({
                 protocol: 'v1',
@@ -365,7 +365,7 @@ describe('http', () => {
                 method: 'POST',
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toBe(FEATURES);
 
@@ -376,7 +376,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'bridge' }),
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toEqual({
                 protocol: 'bridge',
@@ -390,7 +390,7 @@ describe('http', () => {
                 body: JSON.stringify({ protocol: 'v1' }),
             });
             if (!res.success) {
-                throw new Error(res.error + ' ' + res.message);
+                throw new Error(res.error.code + ' ' + res.error.message);
             }
             expect(res.payload).toEqual({
                 protocol: 'v1',
@@ -428,7 +428,7 @@ describe('http', () => {
                     method: 'GET',
                 });
                 if (!response.success) {
-                    throw new Error(response.error);
+                    throw new Error(response.error.code);
                 }
                 expect(response.payload).toContain('<html');
 
@@ -488,7 +488,7 @@ describe('http', () => {
                 method: 'POST',
             });
             if (!response.success) {
-                throw new Error(response.error);
+                throw new Error(response.error.code);
             }
             expect(response.payload).toMatchObject({
                 version: trezordNode.version,
@@ -509,7 +509,7 @@ describe('http', () => {
                 method: 'POST',
             });
             if (!response.success) {
-                throw new Error(response.error);
+                throw new Error(response.error.code);
             }
             expect(response.payload).toEqual([{ path: '1', session: null, apiType: 'usb' }]);
             await trezordNode.stop();

--- a/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
+++ b/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
@@ -89,20 +89,20 @@ export class BluetoothApi extends AbstractApi {
         this.logger?.debug('read');
 
         if (!bluetoothManager.isDeviceConnected(path)) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
             const result = await bluetoothManager.read(path, signal);
             if (!result.success) {
-                return error({ error: ERRORS.INTERFACE_DATA_TRANSFER });
+                return error({ code: ERRORS.INTERFACE_DATA_TRANSFER });
             }
 
             return result;
         } catch (err) {
             this.logger?.error('read error', err);
 
-            return error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
+            return error({ code: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
         }
     }
 
@@ -110,7 +110,7 @@ export class BluetoothApi extends AbstractApi {
         this.logger?.debug('write', buffer);
 
         if (!bluetoothManager.isDeviceConnected(path)) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -123,7 +123,7 @@ export class BluetoothApi extends AbstractApi {
         } catch (err) {
             this.logger?.error('write error', err);
 
-            return error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
+            return error({ code: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
         }
     }
 

--- a/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
+++ b/packages/transport-native-bluetooth/src/api/BluetoothApi.ts
@@ -12,6 +12,7 @@ import {
     type DescriptorApiLevel,
     type PathInternal,
 } from '@trezor/transport/src/types';
+import { error, success } from '@trezor/transport/src/utils/result';
 
 import { bluetoothManager } from './bluetoothManager';
 
@@ -48,11 +49,11 @@ export class BluetoothApi extends AbstractApi {
     public async enumerate() {
         this.logger?.debug('enumerate');
         try {
-            return this.success(this.getDescriptors());
-        } catch (error) {
-            this.logger?.error('enumerate error', error);
+            return success(this.getDescriptors());
+        } catch (err) {
+            this.logger?.error('enumerate error', err);
 
-            return this.unknownError(error, []);
+            return this.unknownError(err, []);
         }
     }
 
@@ -88,20 +89,20 @@ export class BluetoothApi extends AbstractApi {
         this.logger?.debug('read');
 
         if (!bluetoothManager.isDeviceConnected(path)) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
             const result = await bluetoothManager.read(path, signal);
             if (!result.success) {
-                return this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER });
+                return error({ error: ERRORS.INTERFACE_DATA_TRANSFER });
             }
 
             return result;
-        } catch (error) {
-            this.logger?.error('read error', error);
+        } catch (err) {
+            this.logger?.error('read error', err);
 
-            return this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: error.message });
+            return error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
         }
     }
 
@@ -109,7 +110,7 @@ export class BluetoothApi extends AbstractApi {
         this.logger?.debug('write', buffer);
 
         if (!bluetoothManager.isDeviceConnected(path)) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -118,11 +119,11 @@ export class BluetoothApi extends AbstractApi {
 
             await bluetoothManager.write(path, chunk);
 
-            return this.success(undefined);
-        } catch (error) {
-            this.logger?.error('write error', error);
+            return success(undefined);
+        } catch (err) {
+            this.logger?.error('write error', err);
 
-            return this.error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: error.message });
+            return error({ error: ERRORS.INTERFACE_DATA_TRANSFER, message: err.message });
         }
     }
 
@@ -136,7 +137,7 @@ export class BluetoothApi extends AbstractApi {
         }
 
         // BT does not need to be opened, it is opened when connected
-        return this.success(undefined);
+        return success(undefined);
     }
 
     public async closeDevice(path: string, options?: { channel?: OpenDeviceChannel }) {
@@ -150,7 +151,7 @@ export class BluetoothApi extends AbstractApi {
             this.batteryLevelChangeSubscribedDevices.delete(path);
         }
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     public async dispose(): Promise<void> {

--- a/packages/transport-test/e2e/api/utils.ts
+++ b/packages/transport-test/e2e/api/utils.ts
@@ -25,7 +25,9 @@ export const assertMessage = (message: Buffer, expected: keyof typeof MESSAGES) 
 };
 export function assertSuccess(result: any): asserts result is { success: true; payload: any } {
     if (!result.success) {
-        throw new Error(error(`${result.error}${result.message ? `: ${result.message}` : ''}`));
+        throw new Error(
+            error(`${result.error.code}${result.error.message ? `: ${result.error.message}` : ''}`),
+        );
     }
 }
 export function assertFailure(result: any): asserts result is { success: false; error: any } {

--- a/packages/transport-test/e2e/bridge/bridge.test.ts
+++ b/packages/transport-test/e2e/bridge/bridge.test.ts
@@ -195,7 +195,7 @@ describe('bridge', () => {
         ]);
         expect(results).toIncludeAllPartialMembers([
             { success: true, payload: `${Number.parseInt(session) + 1}` },
-            { success: false, error: 'wrong previous session' },
+            { success: false, error: { code: 'wrong previous session' } },
         ]);
         assertSuccess(results[0]);
         session = results[0].payload;
@@ -213,7 +213,7 @@ describe('bridge', () => {
 
             expect(results).toIncludeAllPartialMembers([
                 { success: true, payload: { type: 'Features', message: expect.any(Object) } },
-                { success: false, error: 'other call in progress' },
+                { success: false, error: { code: 'other call in progress' } },
             ]);
         });
     }
@@ -225,7 +225,7 @@ describe('bridge', () => {
         ]);
         expect(results).toIncludeAllPartialMembers([
             { success: true, payload: { type: 'Features', message: expect.any(Object) } },
-            { success: false, error: 'other call in progress' },
+            { success: false, error: { code: 'other call in progress' } },
         ]);
     });
 
@@ -291,13 +291,12 @@ describe('bridge', () => {
 
             expect(results[0]).toMatchObject({
                 success: false,
-                error: 'session not found',
-                message: undefined,
+                error: { code: 'session not found' },
             });
 
             expect([results[1], results[2]]).toIncludeAllPartialMembers([
                 { success: true, payload: { type: 'Features', message: expect.any(Object) } },
-                { success: false, error: 'other call in progress' },
+                { success: false, error: { code: 'other call in progress' } },
             ]);
         });
     }

--- a/packages/transport-test/e2e/bridge/multi-client.test.ts
+++ b/packages/transport-test/e2e/bridge/multi-client.test.ts
@@ -205,7 +205,7 @@ describe('bridge', () => {
             await expect(receive1res).resolves.toMatchObject({
                 success: false,
                 // todo: this error is expected, fix errors. also emu error is weird
-                error: errorCase1,
+                error: { code: errorCase1 },
             });
 
             if (!session2.success) {

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -162,7 +162,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         }
         // check already existing lock
         if ((this.lock[path].read && lock.read) || (this.lock[path].write && lock.write)) {
-            return error({ error: ERRORS.OTHER_CALL_IN_PROGRESS });
+            return error({ code: ERRORS.OTHER_CALL_IN_PROGRESS });
         }
         // add to the current lock
         this.lock[path] = {

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,4 +1,3 @@
-import type { Ok } from '@trezor/type-utils';
 import { TypedEmitter, getSynchronize } from '@trezor/utils';
 
 import { type TRANSPORT } from '../constants';
@@ -146,14 +145,6 @@ export abstract class AbstractApi extends TypedEmitter<{
      */
     public nativeWriteChunking: boolean = false;
 
-    protected success<T>(payload: T): Ok<T> {
-        return success(payload);
-    }
-
-    protected error<E extends AnyError>(payload: { error: E; message?: string }) {
-        return error(payload);
-    }
-
     protected unknownError<E extends AnyError = never>(err: Error, expectedErrors: E[] = []) {
         this.logger?.error('transport: abstract api: unknown error', err);
 
@@ -171,7 +162,7 @@ export abstract class AbstractApi extends TypedEmitter<{
         }
         // check already existing lock
         if ((this.lock[path].read && lock.read) || (this.lock[path].write && lock.write)) {
-            return this.error({ error: ERRORS.OTHER_CALL_IN_PROGRESS });
+            return error({ error: ERRORS.OTHER_CALL_IN_PROGRESS });
         }
         // add to the current lock
         this.lock[path] = {
@@ -179,7 +170,7 @@ export abstract class AbstractApi extends TypedEmitter<{
             write: this.lock[path].write || lock.write,
         };
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     /**

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -1,3 +1,4 @@
+import type { Ok } from '@trezor/type-utils';
 import { TypedEmitter, getSynchronize } from '@trezor/utils';
 
 import { type TRANSPORT } from '../constants';
@@ -9,7 +10,6 @@ import type {
     DescriptorApiLevel,
     Logger,
     PathInternal,
-    Success,
 } from '../types';
 import { error, success, unknownError } from '../utils/result';
 
@@ -146,7 +146,7 @@ export abstract class AbstractApi extends TypedEmitter<{
      */
     public nativeWriteChunking: boolean = false;
 
-    protected success<T>(payload: T): Success<T> {
+    protected success<T>(payload: T): Ok<T> {
         return success(payload);
     }
 

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -11,6 +11,7 @@ import { DEVICE_TYPE } from '../constants';
 import * as ERRORS from '../errors';
 import { type DescriptorApiLevel, PathInternal } from '../types';
 import { readMessageBuffer } from '../utils/readMessageBuffer';
+import { error, success } from '../utils/result';
 
 const PING = Buffer.from('PINGPING');
 const PONG = Buffer.from('PONGPONG');
@@ -67,7 +68,7 @@ export class UdpApi extends AbstractApi {
         return new Promise<AbstractApiAwaitedResult<'write'>>(resolve => {
             const listener = () => {
                 resolve(
-                    this.error({
+                    error({
                         error: ERRORS.ABORTED_BY_SIGNAL,
                     }),
                 );
@@ -95,14 +96,14 @@ export class UdpApi extends AbstractApi {
                     this.logger?.error(err.message);
 
                     resolve(
-                        this.error({
+                        error({
                             error: ERRORS.INTERFACE_DATA_TRANSFER,
                             message: err.message,
                         }),
                     );
                 }
 
-                resolve(this.success(undefined));
+                resolve(success(undefined));
             });
         });
     }
@@ -173,11 +174,11 @@ export class UdpApi extends AbstractApi {
             ).then(res => res.filter(isNotUndefined));
             this.handleDevicesChange(enumerateResult);
 
-            return this.success(enumerateResult);
+            return success(enumerateResult);
         } catch {
             this.handleDevicesChange([]);
 
-            return this.error({ error: ERRORS.ABORTED_BY_SIGNAL });
+            return error({ error: ERRORS.ABORTED_BY_SIGNAL });
         }
     }
 
@@ -204,13 +205,13 @@ export class UdpApi extends AbstractApi {
 
     public openDevice(_path: string) {
         // todo: maybe ping?
-        return Promise.resolve(this.success(undefined));
+        return Promise.resolve(success(undefined));
     }
 
     public closeDevice(path: string) {
         this.readBuffer.cancelRead(path);
 
-        return Promise.resolve(this.success(undefined));
+        return Promise.resolve(success(undefined));
     }
 
     public dispose() {

--- a/packages/transport/src/api/udp.ts
+++ b/packages/transport/src/api/udp.ts
@@ -69,7 +69,7 @@ export class UdpApi extends AbstractApi {
             const listener = () => {
                 resolve(
                     error({
-                        error: ERRORS.ABORTED_BY_SIGNAL,
+                        code: ERRORS.ABORTED_BY_SIGNAL,
                     }),
                 );
             };
@@ -97,7 +97,7 @@ export class UdpApi extends AbstractApi {
 
                     resolve(
                         error({
-                            error: ERRORS.INTERFACE_DATA_TRANSFER,
+                            code: ERRORS.INTERFACE_DATA_TRANSFER,
                             message: err.message,
                         }),
                     );
@@ -178,7 +178,7 @@ export class UdpApi extends AbstractApi {
         } catch {
             this.handleDevicesChange([]);
 
-            return error({ error: ERRORS.ABORTED_BY_SIGNAL });
+            return error({ code: ERRORS.ABORTED_BY_SIGNAL });
         }
     }
 

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -16,6 +16,7 @@ import {
 import * as ERRORS from '../errors';
 import { type DescriptorApiLevel, PathInternal } from '../types';
 import { getUSBDescriptorModel } from '../utils/descriptor';
+import { error, success } from '../utils/result';
 
 interface ConstructorParams extends Omit<AbstractApiConstructorParams, 'type'> {
     usbInterface: USB;
@@ -199,7 +200,7 @@ export class UsbApi extends AbstractApi {
 
             this.devices = await this.createDevices(devices, signal);
 
-            return this.success(this.devicesToDescriptors());
+            return success(this.devicesToDescriptors());
         } catch (err) {
             // this shouldn't throw
             return this.unknownError(err);
@@ -221,7 +222,7 @@ export class UsbApi extends AbstractApi {
     public async read(path: string, signal?: AbortSignal) {
         const device = this.findDevice(path);
         if (!device) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -237,10 +238,10 @@ export class UsbApi extends AbstractApi {
             if (!res.data?.byteLength) {
                 this.logger?.warn(`usb: device.transferIn error: empty data buffer`);
 
-                return this.success(Buffer.alloc(0));
+                return success(Buffer.alloc(0));
             }
 
-            return this.success(Buffer.from(res.data.buffer));
+            return success(Buffer.from(res.data.buffer));
         } catch (err) {
             this.logger?.error(`usb: device.transferIn error ${err}`);
 
@@ -251,7 +252,7 @@ export class UsbApi extends AbstractApi {
     public async write(path: string, buffer: Buffer, signal?: AbortSignal) {
         const device = this.findDevice(path);
         if (!device) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         let newArray: Uint8Array<ArrayBuffer>;
@@ -286,7 +287,7 @@ export class UsbApi extends AbstractApi {
                 throw new Error('transfer out status not ok');
             }
 
-            return this.success(undefined);
+            return success(undefined);
         } catch (err) {
             return this.handleReadWriteError(err);
         } finally {
@@ -320,7 +321,7 @@ export class UsbApi extends AbstractApi {
     ) {
         const device = this.findDevice(path);
         if (!device) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -330,10 +331,10 @@ export class UsbApi extends AbstractApi {
         } catch (err) {
             this.logger?.error(`usb: device.open error ${err}`);
             if (err.message.includes('LIBUSB_ERROR_ACCESS')) {
-                return this.error({ error: ERRORS.LIBUSB_ERROR_ACCESS });
+                return error({ error: ERRORS.LIBUSB_ERROR_ACCESS });
             }
 
-            return this.error({
+            return error({
                 error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                 message: err.message,
             });
@@ -377,20 +378,20 @@ export class UsbApi extends AbstractApi {
             } catch (err) {
                 this.logger?.error(`usb: device.claimInterface error ${err}.`);
 
-                return this.error({
+                return error({
                     error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                     message: err.message,
                 });
             }
         }
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     public async closeDevice(path: string) {
         let device = this.findDevice(path);
         if (!device) {
-            return this.error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         this.logger?.debug(`usb: closeDevice. device.opened: ${device.opened}`);
@@ -430,14 +431,14 @@ export class UsbApi extends AbstractApi {
             } catch (err) {
                 this.logger?.debug(`usb: device.close error ${err}.`);
 
-                return this.error({
+                return error({
                     error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE,
                     message: err.message,
                 });
             }
         }
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     private findDevice(path: string) {
@@ -586,7 +587,7 @@ export class UsbApi extends AbstractApi {
                 'The device was disconnected.',
             ].some(disconnectedErr => err.message.includes(disconnectedErr))
         ) {
-            return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
+            return error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
         }
 
         return this.unknownError(err, [

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -222,7 +222,7 @@ export class UsbApi extends AbstractApi {
     public async read(path: string, signal?: AbortSignal) {
         const device = this.findDevice(path);
         if (!device) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -252,7 +252,7 @@ export class UsbApi extends AbstractApi {
     public async write(path: string, buffer: Buffer, signal?: AbortSignal) {
         const device = this.findDevice(path);
         if (!device) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         let newArray: Uint8Array<ArrayBuffer>;
@@ -321,7 +321,7 @@ export class UsbApi extends AbstractApi {
     ) {
         const device = this.findDevice(path);
         if (!device) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         try {
@@ -331,11 +331,11 @@ export class UsbApi extends AbstractApi {
         } catch (err) {
             this.logger?.error(`usb: device.open error ${err}`);
             if (err.message.includes('LIBUSB_ERROR_ACCESS')) {
-                return error({ error: ERRORS.LIBUSB_ERROR_ACCESS });
+                return error({ code: ERRORS.LIBUSB_ERROR_ACCESS });
             }
 
             return error({
-                error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
+                code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                 message: err.message,
             });
         }
@@ -379,7 +379,7 @@ export class UsbApi extends AbstractApi {
                 this.logger?.error(`usb: device.claimInterface error ${err}.`);
 
                 return error({
-                    error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
+                    code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
                     message: err.message,
                 });
             }
@@ -391,7 +391,7 @@ export class UsbApi extends AbstractApi {
     public async closeDevice(path: string) {
         let device = this.findDevice(path);
         if (!device) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         this.logger?.debug(`usb: closeDevice. device.opened: ${device.opened}`);
@@ -432,7 +432,7 @@ export class UsbApi extends AbstractApi {
                 this.logger?.debug(`usb: device.close error ${err}.`);
 
                 return error({
-                    error: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE,
+                    code: ERRORS.INTERFACE_UNABLE_TO_CLOSE_DEVICE,
                     message: err.message,
                 });
             }
@@ -514,7 +514,7 @@ export class UsbApi extends AbstractApi {
             await this.abortableMethod(
                 () =>
                     device
-                        // @ts-expect-error: this is not part of common types between webusb and usb.
+                        // @ts-expect-error:  this is not part of common types between webusb and usb.
                         .getStringDescriptor(device.device.deviceDescriptor.iSerialNumber),
                 { signal },
             );
@@ -587,7 +587,7 @@ export class UsbApi extends AbstractApi {
                 'The device was disconnected.',
             ].some(disconnectedErr => err.message.includes(disconnectedErr))
         ) {
-            return error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
+            return error({ code: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
         }
 
         return this.unknownError(err, [

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -11,7 +11,6 @@
 
 import { type TimerId } from '@trezor/type-utils';
 import { type Deferred, TypedEmitter, createDeferred, typedObjectKeys } from '@trezor/utils';
-import type { Ok } from '@trezor/type-utils';
 
 import type {
     AcquireDoneRequest,
@@ -27,6 +26,7 @@ import type {
 import * as ERRORS from '../errors';
 import type { Descriptor, PathInternal } from '../types';
 import { PathPublic, Session } from '../types';
+import { error, success } from '../utils/result';
 
 type DescriptorsDict = Record<PathInternal, Descriptor>;
 
@@ -109,7 +109,7 @@ export class SessionsBackground
             // catch unexpected errors and notify client.
             // background should never stay in "hanged" state
             return {
-                ...this.error(ERRORS.UNEXPECTED_ERROR),
+                ...error({ error: ERRORS.UNEXPECTED_ERROR }),
                 id: message.type,
             } as HandleMessageResponse<M>;
         } finally {
@@ -127,7 +127,7 @@ export class SessionsBackground
     }
 
     private handshake() {
-        return this.success(undefined);
+        return success(undefined);
     }
 
     /**
@@ -158,7 +158,7 @@ export class SessionsBackground
             }
         });
 
-        return Promise.resolve(this.success({ descriptors: Object.values(this.descriptors) }));
+        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }
 
     /**
@@ -168,17 +168,17 @@ export class SessionsBackground
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal) {
-            return this.error(ERRORS.DEVICE_NOT_FOUND);
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         const previous = this.descriptors[pathInternal];
 
         if (!previous) {
-            return this.error(ERRORS.DEVICE_NOT_FOUND);
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
 
         if (payload.previous !== previous.session) {
-            return this.error(ERRORS.SESSION_WRONG_PREVIOUS);
+            return error({ error: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
         await this.waitInQueue();
@@ -187,7 +187,7 @@ export class SessionsBackground
         if (previous.session !== this.descriptors[pathInternal]?.session) {
             this.clearLock();
 
-            return this.error(ERRORS.SESSION_WRONG_PREVIOUS);
+            return error({ error: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
         this.lastSessionId++;
@@ -195,7 +195,7 @@ export class SessionsBackground
         const releaseRequest =
             previous.session !== null ? this.descriptors[pathInternal] : undefined;
 
-        return this.success({ session, path: pathInternal, releaseRequest });
+        return success({ session, path: pathInternal, releaseRequest });
     }
 
     /**
@@ -207,12 +207,12 @@ export class SessionsBackground
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal || !this.descriptors[pathInternal]) {
-            return this.error(ERRORS.DEVICE_NOT_FOUND);
+            return error({ error: ERRORS.DEVICE_NOT_FOUND });
         }
         this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
         this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
 
-        return Promise.resolve(this.success({ descriptors: Object.values(this.descriptors) }));
+        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }
 
     private async releaseIntent(payload: ReleaseIntentRequest) {
@@ -225,7 +225,7 @@ export class SessionsBackground
 
         await this.waitInQueue();
 
-        return this.success({ path });
+        return success({ path });
     }
 
     private releaseDone(payload: ReleaseDoneRequest) {
@@ -234,11 +234,11 @@ export class SessionsBackground
 
         this.clearLock();
 
-        return Promise.resolve(this.success({ descriptors: Object.values(this.descriptors) }));
+        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }
 
     private getSessions() {
-        return Promise.resolve(this.success({ descriptors: Object.values(this.descriptors) }));
+        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }
 
     private getPathBySession({ session }: GetPathBySessionRequest) {
@@ -247,10 +247,10 @@ export class SessionsBackground
         );
 
         if (!path) {
-            return this.error(ERRORS.SESSION_NOT_FOUND);
+            return error({ error: ERRORS.SESSION_NOT_FOUND });
         }
 
-        return this.success({ path });
+        return success({ path });
     }
 
     private startLock() {
@@ -293,20 +293,6 @@ export class SessionsBackground
     private async waitInQueue() {
         const myIndex = this.startLock();
         await this.waitForUnlocked(myIndex);
-    }
-
-    private success<T>(payload: T): Ok<T> {
-        return {
-            success: true as const,
-            payload,
-        };
-    }
-
-    private error<E extends string>(error: E) {
-        return {
-            success: false as const,
-            error: { code: error } as const,
-        };
     }
 
     private getInternal(pathPublic: PathPublic): PathInternal | undefined {

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -11,6 +11,7 @@
 
 import { type TimerId } from '@trezor/type-utils';
 import { type Deferred, TypedEmitter, createDeferred, typedObjectKeys } from '@trezor/utils';
+import type { Ok } from '@trezor/type-utils';
 
 import type {
     AcquireDoneRequest,
@@ -24,7 +25,7 @@ import type {
     SessionsBackgroundInterface,
 } from './types';
 import * as ERRORS from '../errors';
-import type { Descriptor, PathInternal, Success } from '../types';
+import type { Descriptor, PathInternal } from '../types';
 import { PathPublic, Session } from '../types';
 
 type DescriptorsDict = Record<PathInternal, Descriptor>;
@@ -294,17 +295,17 @@ export class SessionsBackground
         await this.waitForUnlocked(myIndex);
     }
 
-    private success<T>(payload: T): Success<T> {
+    private success<T>(payload: T): Ok<T> {
         return {
             success: true as const,
             payload,
         };
     }
 
-    private error<E>(error: E) {
+    private error<E extends string>(error: E) {
         return {
             success: false as const,
-            error,
+            error: { code: error } as const,
         };
     }
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -109,7 +109,7 @@ export class SessionsBackground
             // catch unexpected errors and notify client.
             // background should never stay in "hanged" state
             return {
-                ...error({ error: ERRORS.UNEXPECTED_ERROR }),
+                ...error({ code: ERRORS.UNEXPECTED_ERROR }),
                 id: message.type,
             } as HandleMessageResponse<M>;
         } finally {
@@ -168,17 +168,17 @@ export class SessionsBackground
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         const previous = this.descriptors[pathInternal];
 
         if (!previous) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
         if (payload.previous !== previous.session) {
-            return error({ error: ERRORS.SESSION_WRONG_PREVIOUS });
+            return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
         await this.waitInQueue();
@@ -187,7 +187,7 @@ export class SessionsBackground
         if (previous.session !== this.descriptors[pathInternal]?.session) {
             this.clearLock();
 
-            return error({ error: ERRORS.SESSION_WRONG_PREVIOUS });
+            return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
         this.lastSessionId++;
@@ -207,7 +207,7 @@ export class SessionsBackground
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal || !this.descriptors[pathInternal]) {
-            return error({ error: ERRORS.DEVICE_NOT_FOUND });
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
         this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
         this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
@@ -247,7 +247,7 @@ export class SessionsBackground
         );
 
         if (!path) {
-            return error({ error: ERRORS.SESSION_NOT_FOUND });
+            return error({ code: ERRORS.SESSION_NOT_FOUND });
         }
 
         return success({ path });

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -1,3 +1,5 @@
+import type { Ok } from '@trezor/type-utils';
+
 import type * as ERRORS from '../errors';
 import type { AcquireInput } from '../transports/abstract';
 import type {
@@ -7,11 +9,12 @@ import type {
     PathPublic,
     ResultWithTypedError,
     Session,
-    Success,
 } from '../types';
 
-type BackgroundResponseWithError<T, E> = ResultWithTypedError<T, E> & { id: number };
-type BackgroundResponse<T> = Success<T> & { id: number };
+type BackgroundResponseWithError<T, E extends string> = ResultWithTypedError<T, E> & {
+    id: number;
+};
+type BackgroundResponse<T> = Ok<T> & { id: number };
 
 export type HandshakeRequest = Record<string, never>;
 export type HandshakeResponse = BackgroundResponse<undefined>;

--- a/packages/transport/src/thp/call.ts
+++ b/packages/transport/src/thp/call.ts
@@ -12,11 +12,11 @@ export const callThpMessage = async ({
     logger,
 }: CommonProps) => {
     if (!thpState) {
-        return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+        return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
     }
 
     const result = await thpLoop({ chunks, thpState, apiWrite, apiRead, signal, logger });
 
     // NOTE: result should never be empty
-    return result ?? error({ error: THP_STATE_ERROR, message: 'MissingResponse' });
+    return result ?? error({ code: THP_STATE_ERROR, message: 'MissingResponse' });
 };

--- a/packages/transport/src/thp/loop.ts
+++ b/packages/transport/src/thp/loop.ts
@@ -48,7 +48,7 @@ export const thpLoop = async ({
     let readAttempt = 0;
     const deadline = Date.now() + THP_ACK_DEADLINE;
     const isDeadlineReached = () => Date.now() >= deadline;
-    const thpStateError = (message: string) => error({ error: THP_STATE_ERROR, message });
+    const thpStateError = (message: string) => error({ code: THP_STATE_ERROR, message });
     let result;
 
     while (phase !== ThpLoopState.DONE) {

--- a/packages/transport/src/thp/loop.ts
+++ b/packages/transport/src/thp/loop.ts
@@ -101,11 +101,11 @@ export const thpLoop = async ({
                     THP_ACK_TIMEOUT,
                 );
                 if (!ackResult.success) {
-                    switch (ackResult.error) {
+                    switch (ackResult.error.code) {
                         case 'UnexpectedChunk':
                             break; // keep reading
                         case 'UnexpectedCRC':
-                            return thpStateError(ackResult.error);
+                            return thpStateError(ackResult.error.code);
                         case 'UnexpectedChannel':
                             break; // keep reading. TODO: try to close unknown channel
                         case 'UnexpectedRecentMessage':
@@ -163,11 +163,11 @@ export const thpLoop = async ({
 
                 const receiveResult = await receiveExpectedMessage(apiRead, thpState, signal);
                 if (!receiveResult.success) {
-                    switch (receiveResult.error) {
+                    switch (receiveResult.error.code) {
                         case 'UnexpectedChunk':
                             break; // keep reading
                         case 'UnexpectedCRC':
-                            return thpStateError(receiveResult.error);
+                            return thpStateError(receiveResult.error.code);
                         case 'UnexpectedChannel':
                             break; // keep reading. TODO: try to close unknown channel
                         case 'UnexpectedRecentMessage':
@@ -175,12 +175,12 @@ export const thpLoop = async ({
                                 phase = ThpLoopState.SEND_RECENT_ACK;
                                 break;
                             } else {
-                                return thpStateError(receiveResult.error);
+                                return thpStateError(receiveResult.error.code);
                             }
                         case 'Timeout': // NOTE: timeout should never happen here as receiveExpectedMessage doesn't use it
                         case 'UnexpectedMessage':
                         case 'UnexpectedRecvBit':
-                            return thpStateError(receiveResult.error);
+                            return thpStateError(receiveResult.error.code);
                         default:
                             return receiveResult;
                     }

--- a/packages/transport/src/thp/receive.ts
+++ b/packages/transport/src/thp/receive.ts
@@ -18,7 +18,7 @@ export const receiveThpMessage = async ({
     skipAck,
 }: Omit<CommonProps, 'chunks'>) => {
     if (!thpState) {
-        return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+        return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
     }
 
     const result = await thpLoop({
@@ -33,7 +33,7 @@ export const receiveThpMessage = async ({
     });
 
     // NOTE: result should never be empty
-    return result ?? error({ error: THP_STATE_ERROR, message: 'MissingResponse' });
+    return result ?? error({ code: THP_STATE_ERROR, message: 'MissingResponse' });
 };
 
 export type ParseThpMessageProps = {

--- a/packages/transport/src/thp/receiveExpectedMessage.ts
+++ b/packages/transport/src/thp/receiveExpectedMessage.ts
@@ -68,18 +68,18 @@ export const receiveExpectedMessage = async (
         },
     ).catch(e =>
         error({
-            error: e.message as ScheduleActionError,
+            code: e.message as ScheduleActionError,
         }),
     );
 
     if (!receiveResult.success) {
         // apiRead received gibberish for example continuation packet or empty data
         if (receiveResult.error.code === PROTOCOL_MALFORMED) {
-            return error({ error: 'UnexpectedChunk' });
+            return error({ code: 'UnexpectedChunk' });
         }
 
         if (receiveResult.error.code === SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE) {
-            return error({ error: 'Timeout' });
+            return error({ code: 'Timeout' });
         }
 
         return receiveResult as ReceiveError;
@@ -90,13 +90,13 @@ export const receiveExpectedMessage = async (
 
     const isExpectedChannel = thpHeader.channel.compare(thpState.channel) === 0;
     if (!isExpectedChannel) {
-        return error({ error: 'UnexpectedChannel' });
+        return error({ code: 'UnexpectedChannel' });
     }
 
     try {
         protocolThp.validateCrc(encodedMessage);
     } catch {
-        return error({ error: 'UnexpectedCRC' });
+        return error({ code: 'UnexpectedCRC' });
     }
 
     if (encodedMessage.messageType === THP_CONTROL_BYTE.ERROR) {
@@ -113,18 +113,18 @@ export const receiveExpectedMessage = async (
 
     if (!isExpectedCtrlByte) {
         if (isRecentMessage(receiveResult, thpState)) {
-            return error({ error: 'UnexpectedRecentMessage' });
+            return error({ code: 'UnexpectedRecentMessage' });
         }
 
-        return error({ error: 'UnexpectedMessage' });
+        return error({ code: 'UnexpectedMessage' });
     }
 
     if (thpHeader.sequenceBit !== thpState.recvBit) {
         if (isRecentMessage(receiveResult, thpState)) {
-            return error({ error: 'UnexpectedRecentMessage' });
+            return error({ code: 'UnexpectedRecentMessage' });
         }
 
-        return error({ error: 'UnexpectedRecvBit' });
+        return error({ code: 'UnexpectedRecvBit' });
     }
 
     return receiveResult;

--- a/packages/transport/src/thp/receiveExpectedMessage.ts
+++ b/packages/transport/src/thp/receiveExpectedMessage.ts
@@ -74,11 +74,11 @@ export const receiveExpectedMessage = async (
 
     if (!receiveResult.success) {
         // apiRead received gibberish for example continuation packet or empty data
-        if (receiveResult.error === PROTOCOL_MALFORMED) {
+        if (receiveResult.error.code === PROTOCOL_MALFORMED) {
             return error({ error: 'UnexpectedChunk' });
         }
 
-        if (receiveResult.error === SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE) {
+        if (receiveResult.error.code === SCHEDULE_ACTION_TIMEOUT_ERROR_MESSAGE) {
             return error({ error: 'Timeout' });
         }
 

--- a/packages/transport/src/thp/send.ts
+++ b/packages/transport/src/thp/send.ts
@@ -13,7 +13,7 @@ export const sendThpMessage = async ({
     skipAck,
 }: CommonProps) => {
     if (!thpState) {
-        return error({ error: THP_STATE_ERROR, message: 'ThpStateMissing' });
+        return error({ code: THP_STATE_ERROR, message: 'ThpStateMissing' });
     }
 
     const result = await thpLoop({

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -6,6 +6,7 @@ import {
     TypedEmitter,
     scheduleAction,
 } from '@trezor/utils';
+import type { Ok } from '@trezor/type-utils';
 
 import { type OpenDeviceChannel } from '../api/abstract';
 import { ACTION_TIMEOUT, TRANSPORT } from '../constants';
@@ -21,7 +22,6 @@ import type {
     PathPublic,
     ResultWithTypedError,
     Session,
-    Success,
 } from '../types';
 import { error, success, unknownError } from '../utils/result';
 
@@ -77,7 +77,14 @@ export type ReadWriteError =
     | typeof ERRORS.DEVICE_NOT_FOUND
     | typeof ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE
     | typeof ERRORS.INTERFACE_DATA_TRANSFER
-    | typeof ERRORS.THP_STATE_ERROR;
+    | typeof ERRORS.THP_STATE_ERROR
+    | 'UnexpectedChunk'
+    | 'UnexpectedChannel'
+    | 'UnexpectedCRC'
+    | 'UnexpectedRecvBit'
+    | 'UnexpectedRecentMessage'
+    | 'UnexpectedMessage'
+    | 'Timeout';
 
 type TransportEvents = {
     [TRANSPORT.DEVICE_CONNECTED]: Descriptor;
@@ -389,7 +396,7 @@ export abstract class AbstractTransport extends TypedEmitter<TransportEvents> {
         return loadDefinitions(this.messages, packageName, packageLoader);
     }
 
-    protected success<T>(payload: T): Success<T> {
+    protected success<T>(payload: T): Ok<T> {
         return success(payload);
     }
 

--- a/packages/transport/src/transports/abstract.ts
+++ b/packages/transport/src/transports/abstract.ts
@@ -6,7 +6,6 @@ import {
     TypedEmitter,
     scheduleAction,
 } from '@trezor/utils';
-import type { Ok } from '@trezor/type-utils';
 
 import { type OpenDeviceChannel } from '../api/abstract';
 import { ACTION_TIMEOUT, TRANSPORT } from '../constants';
@@ -23,7 +22,7 @@ import type {
     ResultWithTypedError,
     Session,
 } from '../types';
-import { error, success, unknownError } from '../utils/result';
+import { unknownError } from '../utils/result';
 
 export type AcquireInput = {
     path: PathPublic;
@@ -394,14 +393,6 @@ export abstract class AbstractTransport extends TypedEmitter<TransportEvents> {
 
     public loadMessages(packageName: string, packageLoader: Parameters<typeof loadDefinitions>[2]) {
         return loadDefinitions(this.messages, packageName, packageLoader);
-    }
-
-    protected success<T>(payload: T): Ok<T> {
-        return success(payload);
-    }
-
-    protected error<E extends AnyError>(payload: { error: E; message?: string }) {
-        return error<E>(payload);
     }
 
     protected unknownError = <E extends AnyError = never>(

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -14,6 +14,7 @@ import { type SessionsBackgroundInterface } from '../sessions/types';
 import { callThpMessage, parseThpMessage, receiveThpMessage, sendThpMessage } from '../thp';
 import { type Session } from '../types';
 import { receiveAndParse } from '../utils/receive';
+import { error, success } from '../utils/result';
 import { buildMessage, createChunks, sendChunks } from '../utils/send';
 
 interface ConstructorParams extends AbstractTransportParams {
@@ -57,7 +58,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
     public listen() {
         if (this.listening) {
-            return this.error({ error: ERRORS.ALREADY_LISTENING });
+            return error({ error: ERRORS.ALREADY_LISTENING });
         }
 
         this.api.listen();
@@ -83,7 +84,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
             this.deviceEvents.emit(descriptor.path, { type: TRANSPORT.DEVICE_REQUEST_RELEASE });
         });
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     public enumerate({ signal }: AbstractTransportMethodParams<'enumerate'> = {}) {
@@ -103,7 +104,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     descriptors,
                 });
 
-                return this.success(enumerateDoneResponse.payload.descriptors);
+                return success(enumerateDoneResponse.payload.descriptors);
             },
             { signal },
         );
@@ -117,7 +118,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const acquireIntentResponse = await this.sessionsClient.acquireIntent(input);
 
                 if (!acquireIntentResponse.success) {
-                    return this.error({ error: acquireIntentResponse.error.code });
+                    return error({ error: acquireIntentResponse.error.code });
                 }
 
                 const reset = !!input.previous;
@@ -136,7 +137,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
 
-                return this.success(acquireIntentResponse.payload.session);
+                return success(acquireIntentResponse.payload.session);
             },
             { signal },
             [ERRORS.DEVICE_DISCONNECTED_DURING_ACTION, ERRORS.SESSION_WRONG_PREVIOUS],
@@ -172,7 +173,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 const map = Object.fromEntries(entries);
 
-                return this.success(map as Record<OpenDeviceChannel, boolean>);
+                return success(map as Record<OpenDeviceChannel, boolean>);
             },
             { signal },
         );
@@ -186,7 +187,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
 
                 if (!releaseIntentResponse.success) {
-                    return this.error({ error: releaseIntentResponse.error.code });
+                    return error({ error: releaseIntentResponse.error.code });
                 }
 
                 await this.api.closeDevice(releaseIntentResponse.payload.path, { channel: 'read' });
@@ -195,7 +196,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     path: releaseIntentResponse.payload.path,
                 });
 
-                return this.success(null);
+                return success(null);
             },
             { signal },
         );
@@ -231,10 +232,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 if (!getPathBySessionResponse.success) {
                     // session not found means that device was disconnected
                     if (getPathBySessionResponse.error.code === 'session not found') {
-                        return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
+                        return error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
                     }
 
-                    return this.error({ error: ERRORS.UNEXPECTED_ERROR });
+                    return error({ error: ERRORS.UNEXPECTED_ERROR });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -292,7 +293,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     });
                     thpState?.sync('recv', message.type);
 
-                    return this.success(message);
+                    return success(message);
                 }
                 const sendResult = await sendChunks(chunks, apiWrite);
 
@@ -331,7 +332,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return this.error({ error: getPathBySessionResponse.error.code });
+                    return error({ error: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -400,7 +401,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return this.error({ error: getPathBySessionResponse.error.code });
+                    return error({ error: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -429,7 +430,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         thpState,
                     });
 
-                    return this.success(message);
+                    return success(message);
                 }
 
                 const message = await receiveAndParse(this.messages, apiRead, protocol);
@@ -456,7 +457,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     return this.api.closeDevice(response.payload.path, { channel: 'read' });
                 }
 
-                return this.success(undefined);
+                return success(undefined);
             });
     }
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -58,7 +58,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
     public listen() {
         if (this.listening) {
-            return error({ error: ERRORS.ALREADY_LISTENING });
+            return error({ code: ERRORS.ALREADY_LISTENING });
         }
 
         this.api.listen();
@@ -118,7 +118,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const acquireIntentResponse = await this.sessionsClient.acquireIntent(input);
 
                 if (!acquireIntentResponse.success) {
-                    return error({ error: acquireIntentResponse.error.code });
+                    return error({ code: acquireIntentResponse.error.code });
                 }
 
                 const reset = !!input.previous;
@@ -187,7 +187,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
 
                 if (!releaseIntentResponse.success) {
-                    return error({ error: releaseIntentResponse.error.code });
+                    return error({ code: releaseIntentResponse.error.code });
                 }
 
                 await this.api.closeDevice(releaseIntentResponse.payload.path, { channel: 'read' });
@@ -232,10 +232,10 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 if (!getPathBySessionResponse.success) {
                     // session not found means that device was disconnected
                     if (getPathBySessionResponse.error.code === 'session not found') {
-                        return error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
+                        return error({ code: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
                     }
 
-                    return error({ error: ERRORS.UNEXPECTED_ERROR });
+                    return error({ code: ERRORS.UNEXPECTED_ERROR });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -332,7 +332,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return error({ error: getPathBySessionResponse.error.code });
+                    return error({ code: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -401,7 +401,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return error({ error: getPathBySessionResponse.error.code });
+                    return error({ code: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -117,7 +117,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const acquireIntentResponse = await this.sessionsClient.acquireIntent(input);
 
                 if (!acquireIntentResponse.success) {
-                    return this.error({ error: acquireIntentResponse.error });
+                    return this.error({ error: acquireIntentResponse.error.code });
                 }
 
                 const reset = !!input.previous;
@@ -186,7 +186,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
 
                 if (!releaseIntentResponse.success) {
-                    return this.error({ error: releaseIntentResponse.error });
+                    return this.error({ error: releaseIntentResponse.error.code });
                 }
 
                 await this.api.closeDevice(releaseIntentResponse.payload.path, { channel: 'read' });
@@ -230,7 +230,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 });
                 if (!getPathBySessionResponse.success) {
                     // session not found means that device was disconnected
-                    if (getPathBySessionResponse.error === 'session not found') {
+                    if (getPathBySessionResponse.error.code === 'session not found') {
                         return this.error({ error: ERRORS.DEVICE_DISCONNECTED_DURING_ACTION });
                     }
 
@@ -276,7 +276,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                         logger: this.logger,
                     });
                     if (!callResult.success) {
-                        handleError(callResult.error);
+                        handleError(callResult.error.code);
 
                         return callResult;
                     }
@@ -297,7 +297,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const sendResult = await sendChunks(chunks, apiWrite);
 
                 if (!sendResult.success) {
-                    handleError(sendResult.error);
+                    handleError(sendResult.error.code);
 
                     return sendResult;
                 }
@@ -305,7 +305,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const readResult = await receiveAndParse(this.messages, apiRead, protocol);
 
                 if (!readResult.success) {
-                    handleError(readResult.error);
+                    handleError(readResult.error.code);
 
                     return readResult;
                 }
@@ -331,7 +331,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return this.error({ error: getPathBySessionResponse.error });
+                    return this.error({ error: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -376,7 +376,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
 
                 if (!sendResult.success) {
-                    if (sendResult.error === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
+                    if (sendResult.error.code === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
                         this.enumerate();
                     }
                 }
@@ -400,7 +400,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                     session,
                 });
                 if (!getPathBySessionResponse.success) {
-                    return this.error({ error: getPathBySessionResponse.error });
+                    return this.error({ error: getPathBySessionResponse.error.code });
                 }
                 const { path } = getPathBySessionResponse.payload;
 
@@ -435,7 +435,7 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 const message = await receiveAndParse(this.messages, apiRead, protocol);
 
                 if (!message.success) {
-                    if (message.error === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
+                    if (message.error.code === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
                         this.enumerate();
                     }
                 }

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -131,7 +131,7 @@ export class BridgeTransport extends AbstractTransport {
             });
 
             if (!response.success) {
-                this.emit(TRANSPORT.ERROR, response.error);
+                this.emit(TRANSPORT.ERROR, response.error.code);
             } else {
                 this.handleDescriptorsChange(response.payload);
             }
@@ -431,18 +431,18 @@ export class BridgeTransport extends AbstractTransport {
         });
 
         if (!response.success) {
-            if (response.error === ERRORS.UNEXPECTED_ERROR) {
-                return this.unknownError(response.error);
+            if (response.error.code === ERRORS.UNEXPECTED_ERROR) {
+                return this.unknownError(response.error.code);
             }
-            if (response.error === ERRORS.HTTP_ERROR) {
-                return this.error({ error: response.error });
+            if (response.error.code === ERRORS.HTTP_ERROR) {
+                return this.error({ error: response.error.code });
             }
 
             switch (endpoint) {
                 case '/':
-                    return this.unknownError(response.error);
+                    return this.unknownError(response.error.code);
                 case '/acquire':
-                    return this.unknownError(response.error, [
+                    return this.unknownError(response.error.code, [
                         ERRORS.SESSION_WRONG_PREVIOUS,
                         ERRORS.DEVICE_NOT_FOUND,
                         ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE,
@@ -452,7 +452,7 @@ export class BridgeTransport extends AbstractTransport {
                 case '/call':
                 case '/read':
                 case '/post':
-                    return this.unknownError(response.error, [
+                    return this.unknownError(response.error.code, [
                         ERRORS.SESSION_NOT_FOUND,
                         ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
                         ERRORS.OTHER_CALL_IN_PROGRESS,
@@ -460,12 +460,12 @@ export class BridgeTransport extends AbstractTransport {
                         PROTOCOL_MALFORMED,
                     ]);
                 case '/abort':
-                    return this.unknownError(response.error, [ERRORS.SESSION_NOT_FOUND]);
+                    return this.unknownError(response.error.code, [ERRORS.SESSION_NOT_FOUND]);
                 case '/enumerate':
                 case '/listen':
-                    return this.unknownError(response.error);
+                    return this.unknownError(response.error.code);
                 case '/release':
-                    return this.unknownError(response.error, [
+                    return this.unknownError(response.error.code, [
                         ERRORS.SESSION_NOT_FOUND,
                         ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
                     ]);

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -115,7 +115,7 @@ export class BridgeTransport extends AbstractTransport {
     // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L373
     public listen() {
         if (this.listening) {
-            return error({ error: ERRORS.ALREADY_LISTENING });
+            return error({ code: ERRORS.ALREADY_LISTENING });
         }
 
         this.listening = true;
@@ -436,7 +436,7 @@ export class BridgeTransport extends AbstractTransport {
                 return this.unknownError(response.error.code);
             }
             if (response.error.code === ERRORS.HTTP_ERROR) {
-                return error({ error: response.error.code });
+                return error({ code: response.error.code });
             }
 
             switch (endpoint) {
@@ -472,7 +472,7 @@ export class BridgeTransport extends AbstractTransport {
                     ]);
                 default:
                     return error({
-                        error: ERRORS.WRONG_RESULT_TYPE,
+                        code: ERRORS.WRONG_RESULT_TYPE,
                         message: 'just for type safety, should never happen',
                     });
                 // should never get here
@@ -498,7 +498,7 @@ export class BridgeTransport extends AbstractTransport {
                 return bridgeApiResult.empty(response.payload);
             default:
                 return error({
-                    error: ERRORS.WRONG_RESULT_TYPE,
+                    code: ERRORS.WRONG_RESULT_TYPE,
                     message: 'just for type safety, should never happen',
                 });
             // should never get here

--- a/packages/transport/src/transports/bridge.ts
+++ b/packages/transport/src/transports/bridge.ts
@@ -28,6 +28,7 @@ import { bridgeApiCall } from '../utils/bridgeApiCall';
 import * as bridgeApiResult from '../utils/bridgeApiResult';
 import { createProtocolMessage } from '../utils/bridgeProtocolMessage';
 import { receiveAndParse } from '../utils/receive';
+import { error, success } from '../utils/result';
 import { buildMessage } from '../utils/send';
 
 const DEFAULT_URL = 'http://127.0.0.1';
@@ -105,7 +106,7 @@ export class BridgeTransport extends AbstractTransport {
 
                 this.stopped = false;
 
-                return this.success(undefined);
+                return success(undefined);
             },
             { signal },
         );
@@ -114,13 +115,13 @@ export class BridgeTransport extends AbstractTransport {
     // https://github.com/trezor/trezord-go/blob/f559ee5079679aeb5f897c65318d3310f78223ca/core/core.go#L373
     public listen() {
         if (this.listening) {
-            return this.error({ error: ERRORS.ALREADY_LISTENING });
+            return error({ error: ERRORS.ALREADY_LISTENING });
         }
 
         this.listening = true;
         this.listenLoop();
 
-        return this.success(undefined);
+        return success(undefined);
     }
 
     private async listenLoop() {
@@ -171,7 +172,7 @@ export class BridgeTransport extends AbstractTransport {
                     signal,
                 });
 
-                return response.success ? this.success(null) : response;
+                return response.success ? success(null) : response;
             },
             { signal },
         );
@@ -186,7 +187,7 @@ export class BridgeTransport extends AbstractTransport {
     }
 
     public releaseDevice() {
-        return Promise.resolve(this.success(undefined));
+        return Promise.resolve(success(undefined));
     }
 
     private getProtocol(customProtocol?: TransportProtocol) {
@@ -278,12 +279,12 @@ export class BridgeTransport extends AbstractTransport {
                         );
                     }
 
-                    return this.success(message);
+                    return success(message);
                 }
 
                 return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(this.success(respBytes)),
+                    () => Promise.resolve(success(respBytes)),
                     protocol,
                 );
             },
@@ -323,7 +324,7 @@ export class BridgeTransport extends AbstractTransport {
                     thpState?.sync('send', name);
                 }
 
-                return this.success(undefined);
+                return success(undefined);
             },
             { signal, timeout },
         );
@@ -359,12 +360,12 @@ export class BridgeTransport extends AbstractTransport {
                     });
                     thpState?.sync('recv', message.type);
 
-                    return this.success(message);
+                    return success(message);
                 }
 
                 return receiveAndParse(
                     this.messages,
-                    () => Promise.resolve(this.success(respBytes)),
+                    () => Promise.resolve(success(respBytes)),
                     protocol,
                 );
             },
@@ -435,7 +436,7 @@ export class BridgeTransport extends AbstractTransport {
                 return this.unknownError(response.error.code);
             }
             if (response.error.code === ERRORS.HTTP_ERROR) {
-                return this.error({ error: response.error.code });
+                return error({ error: response.error.code });
             }
 
             switch (endpoint) {
@@ -470,7 +471,7 @@ export class BridgeTransport extends AbstractTransport {
                         ERRORS.DEVICE_DISCONNECTED_DURING_ACTION,
                     ]);
                 default:
-                    return this.error({
+                    return error({
                         error: ERRORS.WRONG_RESULT_TYPE,
                         message: 'just for type safety, should never happen',
                     });
@@ -496,7 +497,7 @@ export class BridgeTransport extends AbstractTransport {
             case '/abort':
                 return bridgeApiResult.empty(response.payload);
             default:
-                return this.error({
+                return error({
                     error: ERRORS.WRONG_RESULT_TYPE,
                     message: 'just for type safety, should never happen',
                 });

--- a/packages/transport/src/transports/udp.browser.ts
+++ b/packages/transport/src/transports/udp.browser.ts
@@ -2,9 +2,9 @@ import { AbstractTransport } from './abstract';
 import { WRONG_ENVIRONMENT } from '../errors';
 import { error } from '../utils/result';
 
-const empty = () => Promise.resolve(error({ error: WRONG_ENVIRONMENT }));
+const empty = () => Promise.resolve(error({ code: WRONG_ENVIRONMENT }));
 
-const emptySync = () => error({ error: WRONG_ENVIRONMENT });
+const emptySync = () => error({ code: WRONG_ENVIRONMENT });
 
 export class UdpTransport extends AbstractTransport {
     public name = 'UdpTransport' as const;

--- a/packages/transport/src/types/apiCall.ts
+++ b/packages/transport/src/types/apiCall.ts
@@ -5,25 +5,19 @@ import {
     type TransportProtocol,
     type thp as protocolThp,
 } from '@trezor/protocol';
+import { type Result } from '@trezor/type-utils';
 
 import type * as ERRORS from '../errors';
 
 export type AnyError = (typeof ERRORS)[keyof typeof ERRORS] | typeof PROTOCOL_MALFORMED;
 
-export interface Success<T> {
-    success: true;
-    payload: T;
-}
-
-type ErrorGeneric<ErrorType> = {
-    success: false;
-    error: ErrorType;
-    message?: string;
+export type TransportError<E extends string = AnyError> = {
+    readonly code: E;
+    readonly message?: string;
 };
 
-// Todo: consider using Result from `@trezor/type-utils`
-export type ResultWithTypedError<T, E> = Success<T> | ErrorGeneric<E>;
-export type AsyncResultWithTypedError<T, E> = Promise<Success<T> | ErrorGeneric<E>>;
+export type ResultWithTypedError<T, E extends string> = Result<T, TransportError<E>>;
+export type AsyncResultWithTypedError<T, E extends string> = Promise<Result<T, TransportError<E>>>;
 
 export type AbortableParam = { signal?: AbortSignal; timeout?: number };
 

--- a/packages/transport/src/utils/bridgeApiCall.ts
+++ b/packages/transport/src/utils/bridgeApiCall.ts
@@ -63,7 +63,7 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
     try {
         res = await fetch(options.url, fetchOptions);
     } catch (err) {
-        return error({ error: ERRORS.HTTP_ERROR, message: err.message });
+        return error({ code: ERRORS.HTTP_ERROR, message: err.message });
     }
 
     let resParsed: Record<string, unknown> | string;
@@ -71,7 +71,7 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
         resParsed = await res.text();
         resParsed = parseResult(resParsed);
     } catch (err) {
-        return error({ error: ERRORS.HTTP_ERROR, message: err.message });
+        return error({ code: ERRORS.HTTP_ERROR, message: err.message });
     }
 
     const getErrorStr = (err: typeof resParsed) => {
@@ -99,13 +99,13 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
         // this block only changes error messages from old bridge to the same messages returned by new bridge / connect usb stack
         const errStr = getErrorStr(resParsed);
         if (errStr === BRIDGE_ERROR_DEVICE_CLOSED) {
-            return error({ error: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE });
+            return error({ code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE });
         }
         if (errStr === BRIDGE_MALFORMED_PROTOBUF || errStr === PROTOCOL_MALFORMED) {
-            return error({ error: PROTOCOL_MALFORMED });
+            return error({ code: PROTOCOL_MALFORMED });
         }
         if (errStr === BRIDGE_MALFORMED_WIRE_FORMAT) {
-            return error({ error: PROTOCOL_MALFORMED });
+            return error({ code: PROTOCOL_MALFORMED });
         }
 
         if (
@@ -114,7 +114,7 @@ export async function bridgeApiCall(options: HttpRequestOptions) {
             typeof resParsed.error === 'string'
         ) {
             return error({
-                error: resParsed.error,
+                code: resParsed.error,
                 message:
                     'message' in resParsed && typeof resParsed.message === 'string'
                         ? resParsed.message

--- a/packages/transport/src/utils/bridgeApiResult.ts
+++ b/packages/transport/src/utils/bridgeApiResult.ts
@@ -13,11 +13,11 @@ function isString(payload: UnknownPayload): payload is string {
 
 export function info(res: UnknownPayload) {
     if (isString(res)) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
     const { version } = res;
     if (typeof version !== 'string') {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
     const configured = !!res.configured;
     const protocolMessages = !!res.protocolMessages;
@@ -27,7 +27,7 @@ export function info(res: UnknownPayload) {
 
 export function version(res: UnknownPayload) {
     if (!isString(res)) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
 
     return success(res.trim());
@@ -35,10 +35,10 @@ export function version(res: UnknownPayload) {
 
 export function devices(res: UnknownPayload) {
     if (isString(res)) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
     if (!(res instanceof Array)) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
     if (
         res.some(
@@ -49,7 +49,7 @@ export function devices(res: UnknownPayload) {
                 (typeof o.session !== 'string' && o.session !== null),
         )
     ) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
 
     return success(
@@ -73,11 +73,11 @@ export function devices(res: UnknownPayload) {
 
 export function acquire(res: UnknownPayload) {
     if (isString(res)) {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
     const { session } = res;
     if (typeof session !== 'string') {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
 
     return success(session as Session);
@@ -87,7 +87,7 @@ export function call(res: UnknownPayload) {
     try {
         return success(validateProtocolMessage(res, true));
     } catch {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
 }
 
@@ -95,12 +95,12 @@ export function post(res: UnknownPayload) {
     try {
         return success(validateProtocolMessage(res, false));
     } catch {
-        return error({ error: ERRORS.WRONG_RESULT_TYPE });
+        return error({ code: ERRORS.WRONG_RESULT_TYPE });
     }
 }
 
 export function empty(res: UnknownPayload) {
     return res != null && JSON.stringify(res) === '{}'
-        ? error({ error: ERRORS.WRONG_RESULT_TYPE })
+        ? error({ code: ERRORS.WRONG_RESULT_TYPE })
         : success(undefined);
 }

--- a/packages/transport/src/utils/readMessageBuffer.ts
+++ b/packages/transport/src/utils/readMessageBuffer.ts
@@ -41,7 +41,7 @@ export const readMessageBuffer = () => {
         readRequests[path] = dfd;
 
         const abortListener = () => {
-            dfd.resolve(error({ error: ABORTED_BY_SIGNAL }));
+            dfd.resolve(error({ code: ABORTED_BY_SIGNAL }));
         };
         signal?.addEventListener('abort', abortListener);
 
@@ -53,7 +53,7 @@ export const readMessageBuffer = () => {
 
     const cancelRead = (path: string) => {
         if (readRequests[path]) {
-            readRequests[path].resolve(error({ error: INTERFACE_DATA_TRANSFER }));
+            readRequests[path].resolve(error({ code: INTERFACE_DATA_TRANSFER }));
         }
         delete readRequests[path];
         delete readBuffer[path];

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -43,7 +43,7 @@ export async function receive<T extends Receiver>(receiver: T, protocol: Transpo
             payload: readResult.payload.toString('hex'),
         });
 
-        return error({ error: PROTOCOL_MALFORMED, message: e.message });
+        return error({ code: PROTOCOL_MALFORMED, message: e.message });
     }
 }
 

--- a/packages/transport/src/utils/result.ts
+++ b/packages/transport/src/utils/result.ts
@@ -8,10 +8,10 @@ import type { TransportError } from '../types';
 export const success = <T>(payload: T): Ok<T> => ok(payload) as Ok<T>;
 
 export const error = <E extends string>({
-    error: code,
+    code,
     message,
 }: {
-    error: E;
+    code: E;
     message?: string;
 }): Result<never, TransportError<E>> => err({ code, message });
 
@@ -21,8 +21,8 @@ export const unknownError = <E extends string = never>(
 ) => {
     const expectedErr = expectedErrors.find(eE => eE === thrownError.message);
     if (expectedErr) {
-        return error({ error: expectedErr });
+        return error({ code: expectedErr });
     }
 
-    return error({ error: UNEXPECTED_ERROR, message: thrownError.message });
+    return error({ code: UNEXPECTED_ERROR, message: thrownError.message });
 };

--- a/packages/transport/src/utils/result.ts
+++ b/packages/transport/src/utils/result.ts
@@ -1,26 +1,28 @@
+import { type Ok, type Result, err, ok } from '@trezor/type-utils';
+
 import { UNEXPECTED_ERROR } from '../errors';
-import type { Success } from '../types';
+import type { TransportError } from '../types';
 
-export const success = <T>(payload: T): Success<T> => ({
-    success: true as const,
-    payload,
-});
+// The ok() factory returns Result<T, never> which is structurally Ok<T> but TS
+// does not narrow the union automatically, so we assert.
+export const success = <T>(payload: T): Ok<T> => ok(payload) as Ok<T>;
 
-export const error = <E>({ error, message }: { error: E; message?: string }) => ({
-    success: false as const,
-    error,
+export const error = <E extends string>({
+    error: code,
     message,
-});
+}: {
+    error: E;
+    message?: string;
+}): Result<never, TransportError<E>> => err({ code, message });
 
-export const unknownError = <E = never>(err: Error, expectedErrors: E[] = []) => {
-    const expectedErr = expectedErrors.find(eE => eE === err.message);
+export const unknownError = <E extends string = never>(
+    thrownError: Error,
+    expectedErrors: E[] = [],
+) => {
+    const expectedErr = expectedErrors.find(eE => eE === thrownError.message);
     if (expectedErr) {
         return error({ error: expectedErr });
     }
 
-    return {
-        success: false as const,
-        error: UNEXPECTED_ERROR,
-        message: err.message,
-    };
+    return error({ error: UNEXPECTED_ERROR, message: thrownError.message });
 };

--- a/packages/transport/src/utils/resultEmpty.ts
+++ b/packages/transport/src/utils/resultEmpty.ts
@@ -1,6 +1,6 @@
 import { WRONG_ENVIRONMENT } from '../errors';
 import { error } from './result';
 
-export const empty = () => Promise.resolve(error({ error: WRONG_ENVIRONMENT }));
+export const empty = () => Promise.resolve(error({ code: WRONG_ENVIRONMENT }));
 
-export const emptySync = () => error({ error: WRONG_ENVIRONMENT });
+export const emptySync = () => error({ code: WRONG_ENVIRONMENT });

--- a/packages/transport/src/utils/send.ts
+++ b/packages/transport/src/utils/send.ts
@@ -55,7 +55,7 @@ export const buildMessage = ({ messages, name, data, protocol, thpState }: Build
     return protobufEncoder(name, data);
 };
 
-export const sendChunks = async <T, E>(
+export const sendChunks = async <T, E extends string>(
     chunks: Buffer[],
     apiWrite: (chunk: Buffer) => AsyncResultWithTypedError<T, E>,
 ) => {

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -95,8 +95,7 @@ describe('Usb', () => {
 
             expect(res).toEqual({
                 success: false,
-                error: 'unexpected error',
-                message: 'crazy error nobody expects',
+                error: { code: 'unexpected error', message: 'crazy error nobody expects' },
             });
         });
     });
@@ -187,7 +186,10 @@ describe('Usb', () => {
                 session: Session('1'),
                 protocol: v1Protocol,
             });
-            expect(res).toEqual({ success: false, error: 'device disconnected during action' });
+            expect(res).toEqual({
+                success: false,
+                error: { code: 'device disconnected during action' },
+            });
         });
 
         it('call - with valid and invalid message.', async () => {
@@ -228,8 +230,7 @@ describe('Usb', () => {
             });
             expect(res2).toEqual({
                 success: false,
-                error: 'unexpected error',
-                message: 'no such type: Foo-bar message',
+                error: { code: 'unexpected error', message: 'no such type: Foo-bar message' },
             });
         });
 
@@ -351,7 +352,7 @@ describe('Usb', () => {
 
             await expect(promise).resolves.toMatchObject({
                 success: false,
-                error: 'Aborted by signal',
+                error: { code: 'Aborted by signal' },
             });
 
             const promise2 = transport.call({

--- a/packages/transport/tests/apiUdp.test.ts
+++ b/packages/transport/tests/apiUdp.test.ts
@@ -37,7 +37,7 @@ describe('api/udp', () => {
         abortController.abort();
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('Aborted by signal');
+        expect(result.error.code).toContain('Aborted by signal');
     });
 
     it('write aborted', async () => {
@@ -65,7 +65,7 @@ describe('api/udp', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('Aborted by signal');
+        expect(result.error.code).toContain('Aborted by signal');
         expect(listeners).toBe(1); // only the global listener is present
     });
 
@@ -86,6 +86,6 @@ describe('api/udp', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('Aborted by signal');
+        expect(result.error.code).toContain('Aborted by signal');
     });
 });

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -78,7 +78,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('Aborted by signal');
+        expect(result.error.code).toContain('Aborted by signal');
         expect(reset).toHaveBeenCalledTimes(1);
     });
 
@@ -106,7 +106,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toContain('Aborted by signal');
+        expect(result.error.code).toContain('Aborted by signal');
         expect(reset).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -123,7 +123,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.message).toContain('Aborted by signal');
+        expect(result.error.message).toContain('Aborted by signal');
     });
 
     it('openDevice aborted', async () => {
@@ -146,7 +146,7 @@ describe('api/usb', () => {
 
         const result = await promise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.message).toContain('Aborted by signal');
+        expect(result.error.message).toContain('Aborted by signal');
     });
 
     it('device connection event induced chain of calls aborted', async () => {

--- a/packages/transport/tests/readMessageBuffer.test.ts
+++ b/packages/transport/tests/readMessageBuffer.test.ts
@@ -10,11 +10,11 @@ describe('readMessageBuffer', () => {
         r.onMessage('1', Buffer.alloc(2).fill(2));
 
         let result = await r.read('1');
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0101');
 
         result = await r.read('1');
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0202');
     });
 
@@ -29,15 +29,15 @@ describe('readMessageBuffer', () => {
         r.onMessage('1', Buffer.alloc(2).fill(2));
 
         let result = await readPromise1;
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0101');
 
         result = await readPromise2;
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0101');
 
         result = await r.read('1');
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0202');
     });
 
@@ -52,11 +52,11 @@ describe('readMessageBuffer', () => {
 
         let result = await readPromise;
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toEqual(ABORTED_BY_SIGNAL);
+        expect(result.error.code).toEqual(ABORTED_BY_SIGNAL);
 
         r.onMessage('1', Buffer.alloc(2).fill(1));
         result = await r.read('1');
-        if (!result.success) throw new Error(result.error);
+        if (!result.success) throw new Error(result.error.code);
         expect(result.payload.toString('hex')).toEqual('0101');
     });
 
@@ -68,6 +68,6 @@ describe('readMessageBuffer', () => {
         const result = await readPromise;
 
         if (result.success) throw new Error('Unexpected success');
-        expect(result.error).toEqual(INTERFACE_DATA_TRANSFER);
+        expect(result.error.code).toEqual(INTERFACE_DATA_TRANSFER);
     });
 });

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -21,7 +21,7 @@ describe('sessions', () => {
         expect(acquireIntent).toEqual({
             success: false,
             id: 1,
-            error: 'device not found',
+            error: { code: 'device not found' },
         });
     });
 
@@ -93,7 +93,7 @@ describe('sessions', () => {
         });
         expect(acquire2).toMatchObject({
             success: false,
-            error: 'wrong previous session',
+            error: { code: 'wrong previous session' },
         });
 
         await client1.acquireDone({ path: PathPublic('1') });

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -80,10 +80,11 @@ describe('thp', () => {
             const result = await receiveThpMessage({
                 thpState,
                 apiRead: () => Promise.resolve({ success: true, payload: HANDSHAKE_COMP_RES }),
-                apiWrite: () => Promise.resolve({ success: false, error: 'unexpected error' }),
+                apiWrite: () =>
+                    Promise.resolve({ success: false, error: { code: 'unexpected error' } }),
             });
 
-            expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+            expect(result).toMatchObject({ success: false, error: { code: 'unexpected error' } });
         });
 
         it('success', async () => {

--- a/packages/transport/tests/thp.test.ts
+++ b/packages/transport/tests/thp.test.ts
@@ -52,7 +52,10 @@ describe('thp', () => {
                             resolve({ success: true, payload: Buffer.alloc(32) });
                         } else {
                             signal?.addEventListener('abort', () => {
-                                resolve({ success: false, message: 'Aborted by signal in API' });
+                                resolve({
+                                    success: false,
+                                    error: { code: 'Aborted by signal in API' },
+                                });
                             });
                             abortController.abort();
                         }
@@ -69,7 +72,10 @@ describe('thp', () => {
             });
 
             expect(apiRead).toHaveBeenCalledTimes(5);
-            expect(result).toMatchObject({ success: false, message: 'Aborted by signal in API' });
+            expect(result).toMatchObject({
+                success: false,
+                error: { code: 'Aborted by signal in API' },
+            });
         });
 
         it('write ThpAck error', async () => {
@@ -175,7 +181,7 @@ describe('thp', () => {
             await jest.advanceTimersByTimeAsync((ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE);
             const result = await sendPromise;
 
-            expect(result).toMatchObject({ success: false, message: 'RetriesExceeded' });
+            expect(result).toMatchObject({ success: false, error: { message: 'RetriesExceeded' } });
             expect(apiWrite).toHaveBeenCalledTimes(10);
         });
 
@@ -208,7 +214,10 @@ describe('thp', () => {
             await jest.advanceTimersByTimeAsync(THP_ACK_TIMEOUT + THP_ACK_DEADLINE); // (ATTEMPTS_LIMIT + 1) * THP_ACK_DEADLINE
             const result = await sendPromise;
 
-            expect(result).toMatchObject({ success: false, message: 'Aborted by deadline' });
+            expect(result).toMatchObject({
+                success: false,
+                error: { message: 'Aborted by deadline' },
+            });
             expect(apiWrite).toHaveBeenCalledTimes(3);
         });
 
@@ -218,7 +227,7 @@ describe('thp', () => {
             const apiRead = jest.fn(
                 () =>
                     new Promise<any>(resolve => {
-                        resolve({ success: false, message: 'API read error' });
+                        resolve({ success: false, error: { code: 'API read error' } });
                     }),
             );
 
@@ -246,7 +255,7 @@ describe('thp', () => {
             const apiWrite = jest.fn(
                 () =>
                     new Promise<any>(resolve => {
-                        resolve({ success: false, error: 'unexpected error' });
+                        resolve({ success: false, error: { code: 'unexpected error' } });
                     }),
             );
 
@@ -262,7 +271,7 @@ describe('thp', () => {
                 apiRead,
             });
 
-            expect(result).toMatchObject({ success: false, error: 'unexpected error' });
+            expect(result).toMatchObject({ success: false, error: { code: 'unexpected error' } });
             expect(apiRead).toHaveBeenCalledTimes(0);
         });
 
@@ -295,7 +304,7 @@ describe('thp', () => {
             abortController.abort();
 
             const result = await sendPromise;
-            expect(result).toMatchObject({ success: false, error: 'Aborted in api' });
+            expect(result).toMatchObject({ success: false, error: { code: 'Aborted in api' } });
         });
 
         it('success. ThpAck not required', async () => {


### PR DESCRIPTION
## Description

Migrates `@trezor/transport` to `@trezor/type-utils` Result type.

Replaces the transport-specific `Success`/`ErrorGeneric`/`ResultWithTypedError` types with the shared `Ok`/`Err`/`Result` from `@trezor/type-utils`.

### Key changes

- **`TransportError<E>`** — new structured error type `{ code: E; message?: string }` absorbs the old top-level `message` field into the error object
- **`ResultWithTypedError<T, E>`** is now an alias for `Result<T, TransportError<E>>`
- **Factory functions** (`success`, `error`, `unknownError`) keep the same call-site API but internally delegate to `ok()`/`err()` from type-utils
- **`Success<T>` type alias removed** — replaced with `Ok<T>` everywhere
- **`error()` utility** now accepts `{ code, message? }` directly (no longer `{ error, message? }`), eliminating internal parameter renaming

### Migration pattern

All error consumers change from:
```ts
result.error === ERRORS.SOMETHING   →  result.error.code === ERRORS.SOMETHING
result.message                      →  result.error.message
```

All `error()` call sites change from:
```ts
error({ error: ERRORS.SOMETHING })  →  error({ code: ERRORS.SOMETHING })
```

follows up after #24948

## Notes for QA

No functional behaviour changes — this is a refactor of internal transport result types and the `error()` utility signature. Affected packages: `@trezor/transport`, `@trezor/transport-bridge`, `@trezor/transport-native-bluetooth`, `@trezor/transport-bluetooth`.

Log statement strings (e.g. in `usb.ts`) and their corresponding logger spy assertions in tests are unchanged — only result shape fields were renamed, not log message text.

## Related Issue

## Screenshots:

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=transport-use-type-utils&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=transport-use-type-utils&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=transport-use-type-utils&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T13:14:49.120Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T12:27:59.256Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->