### PR TITLE
chore(suite): @suite/locks/ package

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -77,6 +77,7 @@
         "@suite/experimental-feedback": "workspace:*",
         "@suite/idb-migration-utils": "workspace:*",
         "@suite/intl": "workspace:*",
+        "@suite/locks": "workspace:*",
         "@suite/metadata": "workspace:*",
         "@suite/modal": "workspace:*",
         "@suite/platform-encryption-electron": "workspace:*",

--- a/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
+++ b/packages/suite/src/actions/backup/__tests__/backupActions.test.ts
@@ -1,3 +1,4 @@
+import { lockDevice } from '@suite/locks';
 import { connectInitThunk } from '@suite-common/connect-init';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { testMocks } from '@suite-common/test-utils';
@@ -8,13 +9,11 @@ import { mergeDeepObject } from '@trezor/utils';
 
 import * as backupActions from 'src/actions/backup/backupActions';
 import { BACKUP } from 'src/actions/backup/constants';
-import { SUITE } from 'src/actions/suite/constants';
 import { configureStore } from 'src/support/tests/configureStore';
 
 const getInitialState = (override: any) => {
     const defaults = {
         suite: {
-            locks: [3],
             settings: { debug: {} },
         },
         // doesnt affect anything, just needed for TrezorConnect.init action
@@ -79,8 +78,8 @@ describe('Backup Actions', () => {
             type: BACKUP.SET_IN_PROGRESS,
             payload: true,
         });
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: true });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: false });
         expect(store.getActions().shift()).toMatchObject({
             type: '@suite/device/removeButtonRequests',
         });
@@ -118,14 +117,14 @@ describe('Backup Actions', () => {
             type: BACKUP.SET_IN_PROGRESS,
             payload: true,
         });
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: true });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: false });
         expect(store.getActions().shift()).toMatchObject({
             type: '@suite/device/removeButtonRequests',
         });
 
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: true });
-        expect(store.getActions().shift()).toEqual({ type: SUITE.LOCK_DEVICE, payload: false });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: true });
+        expect(store.getActions().shift()).toEqual({ type: lockDevice.type, payload: false });
         expect(store.getActions().shift()).toMatchObject({
             type: '@suite/device/removeButtonRequests',
         });

--- a/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
+++ b/packages/suite/src/actions/firmware/__tests__/firmwareActions.test.ts
@@ -25,7 +25,6 @@ const getInitialState = (override?: InitialState): any => {
 
     return {
         suite: {
-            locks: [],
             flags: {},
             settings: {
                 language: 'en',

--- a/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/routerActions.ts
@@ -41,14 +41,14 @@ export const onBeforePopState = [
     {
         description: `router locked`,
         state: {
-            suite: { locks: { router: 1 } },
+            locks: { router: 1 },
         },
         result: false,
     },
     {
         description: `device locked`,
         state: {
-            suite: { locks: { ui: 1 } },
+            locks: { ui: 1 },
         },
         result: false,
     },
@@ -84,7 +84,7 @@ export const goto = [
     {
         description: `ui locked`,
         state: {
-            suite: { locks: { ui: 1 } },
+            locks: { ui: 1 },
         },
         url: 'wallet-index',
     },
@@ -112,7 +112,7 @@ export const initialRedirection = [
     {
         description: `router locked`,
         state: {
-            suite: { locks: { router: 1 } },
+            locks: { router: 1 },
         },
         app: 'start',
     },

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -67,21 +67,6 @@ const reducerActions = [
         ],
     },
     {
-        description: `lockUI (true/false)`,
-        actions: [suiteActions.lockUI(true), suiteActions.lockUI(false)],
-        result: [{ locks: { ui: 1 } }, { locks: { ui: 0 } }],
-    },
-    {
-        description: `lockDevice (true/false)`,
-        actions: [suiteActions.lockDevice(true), suiteActions.lockDevice(false)],
-        result: [{ locks: { device: 1 } }, { locks: { device: 0 } }],
-    },
-    {
-        description: `lockRouter (true/false)`,
-        actions: [suiteActions.lockRouter(true), suiteActions.lockRouter(false)],
-        result: [{ locks: { router: 1 } }, { locks: { router: 0 } }],
-    },
-    {
         description: `updateOnlineStatus (true/false)`,
         actions: [suiteActions.updateOnlineStatus(true), suiteActions.updateOnlineStatus(false)],
         result: [

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -1,5 +1,6 @@
 import { createMemoryHistory } from 'history';
 
+import { lockRouter, locksInitialState, locksReducer } from '@suite/locks';
 import { metadataReducer } from '@suite/metadata';
 import { modalReducer } from '@suite/modal';
 import type { PathString } from '@suite/router';
@@ -67,6 +68,7 @@ const getInitialState = (initialRun?: boolean) => ({
         ...suiteReducer(undefined, EMPTY_ACTION),
         ...(initialRun !== undefined ? ({ flags: { initialRun } } as any) : {}),
     },
+    locks: locksInitialState,
     router: routerReducer(undefined, EMPTY_ACTION),
     analytics: analyticsReducer(undefined, EMPTY_ACTION),
     modal: modalReducer(undefined, EMPTY_ACTION),
@@ -109,7 +111,7 @@ const fixtures: Fixture[] = [
             initialRedirection.pending.type,
             appChanged.type,
             ROUTER.LOCATION_CHANGE,
-            SUITE.LOCK_ROUTER,
+            lockRouter.type,
             connectInitThunk.pending.type,
             initialRedirection.fulfilled.type,
             connectInitThunk.fulfilled.type,
@@ -267,7 +269,7 @@ const fixtures: Fixture[] = [
             initialRedirection.pending.type,
             appChanged.type,
             ROUTER.LOCATION_CHANGE,
-            SUITE.LOCK_ROUTER,
+            lockRouter.type,
             connectInitThunk.pending.type,
             initialRedirection.fulfilled.type,
             connectInitThunk.rejected.type,
@@ -292,9 +294,10 @@ const initStore = (state: State) => {
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().slice(-1)[0];
-        const { suite, router } = store.getState();
+        const { suite, router, locks } = store.getState();
         store.getState().suite = suiteReducer(suite, action);
         store.getState().router = routerReducer(router, action);
+        store.getState().locks = locksReducer(locks, action);
     });
 
     return {

--- a/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/routerActions.test.ts
@@ -1,5 +1,6 @@
 import { createMemoryHistory } from 'history';
 
+import { LocksState, locksInitialState, locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
 import { routerReducer } from '@suite/router';
 
@@ -25,14 +26,16 @@ const defaultLocation = {
 interface InitialState {
     suite?: Partial<SuiteState>;
     router?: Exclude<RouterState, 'app|url|pathname'>;
+    locks?: Partial<LocksState>;
 }
 
 // some super long recursive type will make TSC to fail with export
 const getInitialState = (
     state: InitialState | undefined,
-): Pick<AppState, 'suite' | 'router' | 'modal' | 'analytics'> => {
+): Pick<AppState, 'suite' | 'router' | 'modal' | 'analytics' | 'locks'> => {
     const suite = state ? state.suite : undefined;
     const router = state ? state.router : undefined;
+    const locks = state ? state.locks : undefined;
 
     return {
         suite: {
@@ -47,6 +50,10 @@ const getInitialState = (
         analytics: {
             confirmed: false,
         },
+        locks: {
+            ...locksInitialState,
+            ...locks,
+        },
     };
 };
 
@@ -59,9 +66,10 @@ const initStore = (state: State) => {
     })(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
-        const { suite, router } = store.getState();
+        const { suite, router, locks } = store.getState();
         store.getState().suite = suiteReducer(suite, action);
         store.getState().router = routerReducer(router, action);
+        store.getState().locks = locksReducer(locks, action);
         // add action back to stack
         store.getActions().push(action);
     });
@@ -126,7 +134,7 @@ describe('Suite Actions', () => {
 
     it(`onLocationChange with lock`, () => {
         const state = getInitialState({
-            suite: { locks: { router: 1 } },
+            locks: { router: 1 },
             router: { loaded: true },
         } as InitialState);
         const { store } = initStore(state);

--- a/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/trezorConnectActions.test.ts
@@ -1,3 +1,4 @@
+import { lockDevice } from '@suite/locks';
 import { connectInitThunk } from '@suite-common/connect-init';
 import { deviceReducerInitialState } from '@suite-common/device';
 import { messageSystemInitialState } from '@suite-common/message-system';
@@ -5,7 +6,6 @@ import { testMocks } from '@suite-common/test-utils';
 import { BLOCKCHAIN_EVENT, DEVICE_EVENT, TRANSPORT_EVENT, UI_EVENT } from '@trezor/connect';
 
 import { deviceSlice } from 'src/actions/device/deviceSlice';
-import { SUITE } from 'src/actions/suite/constants';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { extraDependencies } from 'src/support/extraDependencies';
 import { configureStore } from 'src/support/tests/configureStore';
@@ -129,11 +129,11 @@ describe('TrezorConnect Actions', () => {
             type: '@suite/device/removeButtonRequests',
         });
         expect(actions.pop()).toEqual({
-            type: SUITE.LOCK_DEVICE,
+            type: lockDevice.type,
             payload: false,
         });
         expect(actions.pop()).toEqual({
-            type: SUITE.LOCK_DEVICE,
+            type: lockDevice.type,
             payload: true,
         });
     });

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -29,14 +29,6 @@ export const TOGGLE_ENTROPY_CHECK = '@suite/toggle-entropy-check';
 export const TOGGLE_DEVICE_META_CHECKS = '@suite/toggle-device-meta-checks';
 export const EVM_CONFIRM_EXPLANATION_MODAL = '@suite/evm-confirm-explanation-modal';
 export const EVM_CLOSE_EXPLANATION_BANNER = '@suite/evm-close-explanation-banner';
-export const LOCK_UI = '@suite/lock-ui';
-export const LOCK_DEVICE = '@suite/lock-device';
-export const LOCK_ROUTER = '@suite/lock-router';
-export const LOCK_TYPE = {
-    ROUTER: 'router', // restricted route changes, all other actions are possible
-    DEVICE: 'device', // restricted device call (TrezorConnect)
-    UI: 'ui', // restricted most of the UI actions (buttons, keyboard etc.)
-} as const;
 export const SET_EXPERIMENTAL_FEATURES = '@suite/set-experimental-features';
 export const SET_SIDEBAR_WIDTH = '@suite/set-sidebar-width';
 export const SET_IS_COINS_FILTER_VISIBLE = '@suite/set-is-coins-filter-visible';

--- a/packages/suite/src/actions/suite/routerActions.ts
+++ b/packages/suite/src/actions/suite/routerActions.ts
@@ -2,6 +2,7 @@
  * Use override for react-native (@suite-native/app/src/actions)
  */
 
+import { lockRouter, selectIsRouterLocked, selectIsRouterOrUiLocked } from '@suite/locks';
 import {
     type AnchorType,
     RouteParams,
@@ -23,8 +24,6 @@ import { ExtraDependencies, createThunk } from '@suite-common/redux-utils';
 import { Route } from '@suite-common/suite-types';
 
 import { ROUTER } from 'src/actions/suite/constants';
-import * as suiteActions from 'src/actions/suite/suiteActions';
-import { selectIsRouterLocked, selectIsRouterOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 import { asSuiteServices } from 'src/support/extraDependencies';
 import { Dispatch, GetState } from 'src/types/suite';
 
@@ -109,7 +108,7 @@ export const goto =
         const hasRouterLock = selectIsRouterLocked(state);
 
         if (hasRouterLock) {
-            dispatch(suiteActions.lockRouter(false));
+            dispatch(lockRouter(false));
         }
         const unlocked = dispatch(onBeforePopState());
 
@@ -132,7 +131,7 @@ export const goto =
 
         dispatch(onLocationChange({ pathname, hash, anchor }));
         if (route?.isForegroundApp) {
-            dispatch(suiteActions.lockRouter(true));
+            dispatch(lockRouter(true));
 
             // NOTE: this is useful eg. on welcome screen / logged out screen
             // where we want to have suite-start router clearing the URL to ensure
@@ -155,7 +154,7 @@ export const goto =
 export const closeModalApp =
     (preserveParams = true) =>
     (dispatch: Dispatch, _: GetState, extra: ExtraDependencies) => {
-        dispatch(suiteActions.lockRouter(false));
+        dispatch(lockRouter(false));
 
         const location = asSuiteServices(extra.services).suiteRouterHistory.getLocation();
         const route = findRoute(location.pathname);

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -48,9 +48,6 @@ export type SuiteAction =
     | { type: typeof SUITE.TOGGLE_ENTROPY_CHECK; payload: boolean }
     | { type: typeof SUITE.TOGGLE_DEVICE_META_CHECKS; payload: boolean }
     | { type: typeof SUITE.COINJOIN_RECEIVE_WARNING; payload: boolean }
-    | { type: typeof SUITE.LOCK_UI; payload: boolean }
-    | ReturnType<typeof lockDevice>
-    | { type: typeof SUITE.LOCK_ROUTER; payload: boolean }
     | {
           type: typeof SUITE.SET_FLAG;
           key: keyof AppState['suite']['flags'];
@@ -351,35 +348,5 @@ export const onSuiteReady = (): SuiteAction => ({
  */
 export const setDebugMode = (payload: Partial<DebugModeOptions>): SuiteAction => ({
     type: SUITE.SET_DEBUG_MODE,
-    payload,
-});
-
-/**
- * Called from multiple places before and after TrezorConnect call
- * Prevent from mad clicking
- * Set `lock` field in suite reducer
- * @returns {SuiteAction}
- */
-export const lockUI = (payload: boolean): SuiteAction => ({
-    type: SUITE.LOCK_UI,
-    payload,
-});
-
-/**
- * Prevent TrezorConnect multiple calls
- * Called before and after specific process, like onboarding
- * Set `lock` field in suite reducer
- * @returns {SuiteAction}
- */
-export const lockDevice = createAction(SUITE.LOCK_DEVICE, (payload: boolean) => ({ payload }));
-
-/**
- * Prevent route change and rendering
- * Called before and after specific process, like onboarding
- * Set `lock` field in suite reducer
- * @returns {SuiteAction}
- */
-export const lockRouter = (payload: boolean): SuiteAction => ({
-    type: SUITE.LOCK_ROUTER,
     payload,
 });

--- a/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/coinjoinClientActions.ts
@@ -465,9 +465,7 @@ export const getOwnershipProof = [
         description: 'getOwnershipProof unsuccessful with multiple unresolved inputs',
         connect: [],
         state: {
-            suite: {
-                locks: { device: 1 },
-            },
+            locks: { device: 1 },
             devices: [
                 DEVICE,
                 { ...DEVICE, state: { staticSessionId: 'device-state-2' } },

--- a/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/receiveActions.ts
@@ -1,3 +1,4 @@
+import { lockDevice } from '@suite/locks';
 import {
     MODAL_CLOSE,
     MODAL_OPEN_USER_CONTEXT,
@@ -9,7 +10,6 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { confirmAddressOnDeviceThunk } from '@suite-common/wallet-core';
 
-import { SUITE } from 'src/actions/suite/constants';
 import * as receiveActions from 'src/actions/wallet/receiveActions';
 
 import { RECEIVE } from '../constants';
@@ -46,8 +46,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL_PRESERVE },
                 { type: confirmAddressOnDeviceThunk.pending.type, payload: undefined },
-                { type: SUITE.LOCK_DEVICE, payload: true },
-                { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: lockDevice.type, payload: true },
+                { type: lockDevice.type, payload: false },
                 { type: '@suite/device/removeButtonRequests', payload: {} },
                 { type: confirmAddressOnDeviceThunk.fulfilled.type, payload: { success: true } },
                 { type: MODAL_REMOVE_PRESERVE },
@@ -80,8 +80,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL_PRESERVE },
                 { type: confirmAddressOnDeviceThunk.pending.type, payload: undefined },
-                { type: SUITE.LOCK_DEVICE, payload: true },
-                { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: lockDevice.type, payload: true },
+                { type: lockDevice.type, payload: false },
                 { type: '@suite/device/removeButtonRequests', payload: {} },
                 { type: confirmAddressOnDeviceThunk.fulfilled.type, payload: { success: true } },
                 { type: MODAL_REMOVE_PRESERVE },
@@ -114,8 +114,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL_PRESERVE },
                 { type: confirmAddressOnDeviceThunk.pending.type, payload: undefined },
-                { type: SUITE.LOCK_DEVICE, payload: true },
-                { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: lockDevice.type, payload: true },
+                { type: lockDevice.type, payload: false },
                 { type: '@suite/device/removeButtonRequests', payload: {} },
                 { type: confirmAddressOnDeviceThunk.fulfilled.type, payload: { success: true } },
                 { type: MODAL_REMOVE_PRESERVE },
@@ -195,8 +195,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL_PRESERVE },
                 { type: confirmAddressOnDeviceThunk.pending.type, payload: undefined },
-                { type: SUITE.LOCK_DEVICE, payload: true },
-                { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: lockDevice.type, payload: true },
+                { type: lockDevice.type, payload: false },
                 { type: '@suite/device/removeButtonRequests', payload: {} },
                 { type: confirmAddressOnDeviceThunk.fulfilled.type, payload: { success: false } },
                 { type: MODAL_REMOVE_PRESERVE },
@@ -224,8 +224,8 @@ export default [
                 { type: connectInitThunk.fulfilled.type, payload: undefined },
                 { type: MODAL_PRESERVE },
                 { type: confirmAddressOnDeviceThunk.pending.type, payload: undefined },
-                { type: SUITE.LOCK_DEVICE, payload: true },
-                { type: SUITE.LOCK_DEVICE, payload: false },
+                { type: lockDevice.type, payload: true },
+                { type: lockDevice.type, payload: false },
                 { type: '@suite/device/removeButtonRequests', payload: {} },
                 { type: confirmAddressOnDeviceThunk.fulfilled.type, payload: { success: false } },
                 { type: MODAL_REMOVE_PRESERVE },

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -57,7 +57,10 @@ const initStore = ({ accounts, coinjoin, devices }: Wallet = {}) =>
         reducer: rootReducer,
         preloadedState: initPreloadedState({
             rootReducer,
-            partialState: { device: { devices }, wallet: { accounts, coinjoin } },
+            partialState: {
+                ...(devices !== undefined ? { device: { devices } } : {}),
+                wallet: { accounts, coinjoin },
+            },
         }),
     });
 

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinAccountActions.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
+import { locksReducer } from '@suite/locks';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
@@ -28,13 +29,13 @@ const DEVICE = mockSuiteDevice({
 const rootReducer = combineReducers({
     suite: createReducer(
         {
-            locks: [],
             settings: {
                 debug: {},
             },
         },
         () => ({}),
     ),
+    locks: locksReducer,
     messageSystem: prepareMessageSystemReducer(extraDependencies),
     device: createReducer({ devices: [DEVICE], selectedDevice: DEVICE }, () => ({})),
     modal: () => ({}),

--- a/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/coinjoinClientActions.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
+import { locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { configureMockStore, initPreloadedState, testMocks } from '@suite-common/test-utils';
@@ -39,11 +40,11 @@ const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
 const rootReducer = combineReducers({
     suite: createReducer(
         {
-            locks: {},
             settings: { debug: {} },
         },
         () => ({}),
     ),
+    locks: locksReducer,
     device: createReducer(
         { devices: [fixtures.DEVICE], selectedDevice: fixtures.DEVICE },
         () => ({}),
@@ -61,9 +62,10 @@ type State = ReturnType<typeof rootReducer>;
 type Wallet = Partial<State['wallet']> & {
     device?: State['device'];
     suite?: State['suite'];
+    locks?: Partial<State['locks']>;
 };
 
-const initStore = ({ accounts, coinjoin, device, selectedAccount, suite }: Wallet = {}) => {
+const initStore = ({ accounts, coinjoin, device, selectedAccount, suite, locks }: Wallet = {}) => {
     // State != suite AppState, therefore <any>
     const store = configureMockStore<any>({
         reducer: rootReducer,
@@ -71,6 +73,7 @@ const initStore = ({ accounts, coinjoin, device, selectedAccount, suite }: Walle
             rootReducer,
             partialState: {
                 suite,
+                locks,
                 device,
                 wallet: {
                     accounts,

--- a/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinAccountActions.ts
@@ -1,3 +1,4 @@
+import { selectIsDeviceLocked } from '@suite/locks';
 import { openModal } from '@suite/modal';
 import { selectRouteName } from '@suite/router';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
@@ -31,7 +32,6 @@ import {
     selectSessionByAccountKey,
     selectWeightedAnonymityByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
-import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { COORDINATOR_FEE_RATE_MULTIPLIER, CoinjoinService } from 'src/services/coinjoin';
 import type { CoinjoinSymbol } from 'src/services/coinjoin';
 import { Dispatch, GetState } from 'src/types/suite';

--- a/packages/suite/src/actions/wallet/coinjoinClientActions.ts
+++ b/packages/suite/src/actions/wallet/coinjoinClientActions.ts
@@ -1,3 +1,4 @@
+import { selectIsDeviceLocked } from '@suite/locks';
 import { closeModal, openModal } from '@suite/modal';
 import { selectDevices } from '@suite-common/device';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
@@ -26,7 +27,7 @@ import {
     selectRoundsLeftByAccountKey,
     selectRoundsNeededByAccountKey,
 } from 'src/reducers/wallet/coinjoinReducer';
-import { selectAddressDisplayType, selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
+import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 import type { CoinjoinSymbol } from 'src/services/coinjoin';
 import { CoinjoinService, getCoinjoinConfig } from 'src/services/coinjoin';
 import { Dispatch, GetState } from 'src/types/suite';

--- a/packages/suite/src/hooks/suite/useDevice.ts
+++ b/packages/suite/src/hooks/suite/useDevice.ts
@@ -1,9 +1,8 @@
 import { useCallback } from 'react';
 
+import { selectIsDeviceOrUiLocked } from '@suite/locks';
 import { selectSelectedDevice } from '@suite-common/device';
 import { TrezorDevice } from '@suite-common/suite-types';
-
-import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 
 import { useSelector } from './useSelector';
 

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -1,5 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
+import { locksReducer } from '@suite/locks';
 import { SuiteSyncDataState, SuiteSyncState } from '@suite-common/suite-sync';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { testMocks } from '@suite-common/test-utils';
@@ -270,7 +271,6 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
     combineReducers({
         suite: createReducer(
             {
-                locks: [],
                 online: true,
                 settings: { debug: {}, theme: { variant: 'light' } },
                 evmSettings: { confirmExplanationModalClosed: {}, explanationBannerClosed: {} },
@@ -280,6 +280,7 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
             },
             () => ({}),
         ),
+        locks: locksReducer,
         device: createReducer({ selectedDevice: DEVICE, devices: [DEVICE] }, () => {}),
         wallet: combineReducers({
             send: sendFormReducer,

--- a/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/buttonRequestMiddleware.test.ts
@@ -1,3 +1,4 @@
+import { lockDevice } from '@suite/locks';
 import { routerReducer } from '@suite/router';
 import { connectInitThunk } from '@suite-common/connect-init';
 import { deviceActions } from '@suite-common/device';
@@ -7,7 +8,6 @@ import { extraDependenciesCommonMock, testMocks } from '@suite-common/test-utils
 import { UI_EVENT, UI_REQUEST } from '@trezor/connect';
 
 import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
-import { SUITE } from 'src/actions/suite/constants';
 import buttonRequestMiddleware from 'src/middlewares/suite/buttonRequestMiddleware';
 import { prepareSuiteMiddleware } from 'src/middlewares/suite/suiteMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
@@ -70,7 +70,7 @@ describe('buttonRequest middleware', () => {
         expect(store.getActions()).toMatchObject([
             { type: connectInitThunk.pending.type, payload: undefined },
             { type: connectInitThunk.fulfilled.type, payload: undefined },
-            { type: SUITE.LOCK_DEVICE, payload: true },
+            { type: lockDevice.type, payload: true },
             { type: UI_REQUEST.REQUEST_BUTTON, payload: { code: 'ButtonRequest_ProtectCall' } },
             {
                 type: deviceActions.addButtonRequest.type,
@@ -84,7 +84,7 @@ describe('buttonRequest middleware', () => {
                 type: deviceActions.addButtonRequest.type,
                 payload: { buttonRequest: { code: 'PinMatrixRequestType_NewFirst' }, device },
             },
-            { type: SUITE.LOCK_DEVICE, payload: false },
+            { type: lockDevice.type, payload: false },
             { type: deviceActions.removeButtonRequests.type, payload: { device } },
         ]);
     });

--- a/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/redirectMiddleware.test.ts
@@ -1,3 +1,4 @@
+import { locksInitialState, locksReducer } from '@suite/locks';
 import { modalReducer } from '@suite/modal';
 import { routerReducer } from '@suite/router';
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
@@ -32,6 +33,7 @@ const getInitialState = (
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,
     },
+    locks: locksInitialState,
     device: {
         ...deviceReducer(undefined, { type: 'foo' } as any),
         ...device,
@@ -55,10 +57,11 @@ const initStore = (state: State) => {
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
-        const { suite, router, device } = store.getState();
+        const { suite, router, device, locks } = store.getState();
         store.getState().suite = suiteReducer(suite, action);
         store.getState().router = routerReducer(router as RouterState, action);
         store.getState().device = deviceReducer(device, action);
+        store.getState().locks = locksReducer(locks, action);
 
         // add action back to stack
         store.getActions().push(action);

--- a/packages/suite/src/middlewares/suite/redirectMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/redirectMiddleware.ts
@@ -1,10 +1,10 @@
 import { MiddlewareAPI } from 'redux';
 
+import { selectIsRouterLocked } from '@suite/locks';
 import { selectRouteName, selectRouterApp, selectRouterParams } from '@suite/router';
 import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/device';
 
 import * as routerActions from 'src/actions/suite/routerActions';
-import { selectIsRouterLocked } from 'src/selectors/suite/suiteSelectors';
 import { Action, AppState, Dispatch, TrezorDevice } from 'src/types/suite';
 
 const handleDeviceRedirect = (dispatch: Dispatch, state: AppState, device?: TrezorDevice) => {

--- a/packages/suite/src/middlewares/wallet/__tests__/coinjoinMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/__tests__/coinjoinMiddleware.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers, createReducer } from '@reduxjs/toolkit';
 
+import { locksReducer } from '@suite/locks';
 import { routerReducer } from '@suite/router';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
@@ -24,6 +25,7 @@ const messageSystem = prepareMessageSystemReducer(extraDependencies);
 
 const rootReducer = combineReducers({
     device: createReducer({}, () => ({})),
+    locks: locksReducer,
     messageSystem,
     router: routerReducer,
     suite: suiteReducer,

--- a/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/coinjoinMiddleware.ts
@@ -1,6 +1,7 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 import type { MiddlewareAPI } from 'redux';
 
+import { lockDevice, selectIsDeviceOrUiLocked } from '@suite/locks';
 import { selectRouteName, selectSettingsBackRoute } from '@suite/router';
 import {
     Feature,
@@ -37,7 +38,7 @@ import {
     selectIsAccountWithSessionInCriticalPhaseByAccountKey,
     selectIsAnySessionInCriticalPhase,
 } from 'src/reducers/wallet/coinjoinReducer';
-import { selectIsDeviceOrUiLocked, selectTorState } from 'src/selectors/suite/suiteSelectors';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { CoinjoinService } from 'src/services/coinjoin';
 import type { Action, AppState, Dispatch } from 'src/types/suite';
 import { CoinjoinConfig } from 'src/types/wallet/coinjoin';
@@ -209,7 +210,7 @@ export const coinjoinMiddleware =
 
         // Pause/restore coinjoin session depending on current route.
         // Device may be locked by another connect call, so check on LOCK_DEVICE action as well.
-        if (action.type === ROUTER.LOCATION_CHANGE || action.type === SUITE.LOCK_DEVICE) {
+        if (action.type === ROUTER.LOCATION_CHANGE || action.type === lockDevice.type) {
             const state = api.getState();
             const isDeviceOrUiLocked = selectIsDeviceOrUiLocked(state);
             if (!isDeviceOrUiLocked) {

--- a/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/discoveryMiddleware.ts
@@ -1,3 +1,4 @@
+import { selectIsDeviceLocked } from '@suite/locks';
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
@@ -11,7 +12,6 @@ import {
 } from '@suite-common/wallet-core';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 
 // todo: this is crazy. needs some consideration
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -1,5 +1,6 @@
 import { experimentalFeedbackReducer } from '@suite/experimental-feedback';
 import { TranslationKey } from '@suite/intl';
+import { locksReducer } from '@suite/locks';
 import { metadataReducer } from '@suite/metadata';
 import { modalReducer as modal } from '@suite/modal';
 import { routerReducer } from '@suite/router';
@@ -28,6 +29,7 @@ const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 
 export default {
     suite,
+    locks: locksReducer,
     router: routerReducer,
     modal,
     device,

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -12,7 +12,6 @@ import { isWeb } from '@trezor/env-utils';
 import { SuiteThemeVariant } from '@trezor/suite-desktop-api';
 
 import { STORAGE, SUITE } from 'src/actions/suite/constants';
-import { LOCK_TYPE } from 'src/actions/suite/constants/suiteConstants';
 import { SIDEBAR_WIDTH_NUMERIC } from 'src/constants/suite/layout';
 import { Action, TorBootstrap, TorStatus } from 'src/types/suite';
 
@@ -121,7 +120,6 @@ export interface SuiteState {
     torBootstrap: TorBootstrap | null;
     lifecycle: SuiteLifecycle;
     transport?: TransportState;
-    locks: Record<(typeof SUITE.LOCK_TYPE)[keyof typeof SUITE.LOCK_TYPE], number>;
     flags: Flags;
     evmSettings: EvmSettings;
     countryCode: CountryCode | null;
@@ -137,11 +135,6 @@ const initialState: SuiteState = {
     torStatus: TorStatus.Disabled,
     torBootstrap: null,
     lifecycle: { status: 'initial' },
-    locks: {
-        [LOCK_TYPE.UI]: 0,
-        [LOCK_TYPE.ROUTER]: 0,
-        [LOCK_TYPE.DEVICE]: 0,
-    },
     flags: {
         initialRun: true,
         // recoveryCompleted: false;
@@ -216,14 +209,6 @@ const initialState: SuiteState = {
 };
 
 export const suiteInitialState = initialState;
-
-const changeLock = (
-    draft: SuiteState,
-    lock: (typeof SUITE.LOCK_TYPE)[keyof typeof SUITE.LOCK_TYPE],
-    enabled: boolean,
-) => {
-    draft.locks[lock] = Math.max(draft.locks[lock] + (enabled ? 1 : -1), 0);
-};
 
 const setFlag = (draft: SuiteState, key: keyof Flags, value: boolean) => {
     draft.flags[key] = value;
@@ -406,18 +391,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
             case SUITE.TOGGLE_ENTROPY_CHECK:
                 draft.settings.enabledSecurityChecks.entropy = action.payload;
                 break;
-            case SUITE.LOCK_UI:
-                changeLock(draft, SUITE.LOCK_TYPE.UI, action.payload);
-                break;
-
-            case SUITE.LOCK_DEVICE:
-                changeLock(draft, SUITE.LOCK_TYPE.DEVICE, action.payload);
-                break;
-
-            case SUITE.LOCK_ROUTER:
-                changeLock(draft, SUITE.LOCK_TYPE.ROUTER, action.payload);
-                break;
-
             // no default
         }
     });

--- a/packages/suite/src/reducers/wallet/coinjoinReducer.ts
+++ b/packages/suite/src/reducers/wallet/coinjoinReducer.ts
@@ -1,5 +1,6 @@
 import { produce } from 'immer';
 
+import { LocksRootState, selectIsDeviceOrUiLocked } from '@suite/locks';
 import { DeviceRootState, selectDeviceStatus } from '@suite-common/device';
 import {
     Feature,
@@ -17,7 +18,7 @@ import { BigNumber } from '@trezor/utils';
 import { STORAGE } from 'src/actions/suite/constants';
 import { COINJOIN } from 'src/actions/wallet/constants';
 import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
-import { selectIsDeviceOrUiLocked, selectTorState } from 'src/selectors/suite/suiteSelectors';
+import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import {
     CLIENT_STATUS_FALLBACK,
     DEFAULT_TARGET_ANONYMITY,
@@ -68,7 +69,8 @@ export type CoinjoinRootState = {
 } & AccountsRootState &
     SelectedAccountRootState &
     SuiteRootState &
-    MessageSystemRootState;
+    MessageSystemRootState &
+    LocksRootState;
 
 export const initialState: CoinjoinState = {
     accounts: [],
@@ -910,7 +912,7 @@ export const selectHasAnonymitySetError = (state: CoinjoinRootState) => {
 };
 
 export const selectCoinjoinSessionBlockerByAccountKey = (
-    state: CoinjoinRootState & DeviceRootState,
+    state: CoinjoinRootState & DeviceRootState & LocksRootState,
     accountKey: AccountKey | null,
 ) => {
     if (accountKey === null) {

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -3,7 +3,6 @@ import { RouterRootState, selectRouter } from '@suite/router';
 import { DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { TransportInfo } from '@trezor/connect';
 
-import { SUITE } from 'src/actions/suite/constants';
 import { SuiteRootState } from 'src/reducers/suite/suiteReducer';
 import { AppState, PrerequisiteType, TorStatus, TrezorDevice } from 'src/types/suite';
 import { getPrerequisiteName, isPrerequisiteGloballyExcluded } from 'src/utils/suite/prerequisites';
@@ -39,14 +38,6 @@ export const selectAutodetectTheme = (state: SuiteRootState) =>
     state.suite.settings.autodetect.theme;
 export const selectAddressDisplayType = (state: SuiteRootState) =>
     state.suite.settings.addressDisplayType;
-export const selectIsDeviceLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE];
-export const selectIsDeviceOrUiLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.DEVICE] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
-export const selectIsRouterLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER];
-export const selectIsRouterOrUiLocked = (state: SuiteRootState) =>
-    !!state.suite.locks[SUITE.LOCK_TYPE.ROUTER] || !!state.suite.locks[SUITE.LOCK_TYPE.UI];
 
 export const selectSuiteTransports = (state: SuiteRootState) =>
     state.suite.transport?.transports.map(({ type, version }) => ({ type, version }));

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -2,6 +2,7 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
 
 import { DesktopAnalyticsDep, createAnalytics } from '@suite/analytics';
+import { lockDevice } from '@suite/locks';
 import { metadataActions, metadataLabelingActions } from '@suite/metadata';
 import { closeModal, openModal } from '@suite/modal';
 import { createElectronPlatformEncryption } from '@suite/platform-encryption-electron';
@@ -59,7 +60,6 @@ import {
     SuiteRouterHistoryDeps,
 } from './suite/suiteRouterHistory';
 import { forgetBluetoothDeviceThunk } from '../actions/bluetooth/bluetoothEraseBondsThunk';
-import * as suiteActions from '../actions/suite/suiteActions';
 import { createDisableLegacyMetadataIfNeeded } from '../actions/suiteSync/disableLegacyMetadateIfNeeded';
 import type { BioAuthState } from '../reducers/bioAuth';
 import { AppState, TrezorDevice } from '../types/suite';
@@ -196,7 +196,7 @@ export const extraDependencies: ExtraDependenciesStatic = {
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,
-        lockDevice: suiteActions.lockDevice,
+        lockDevice,
         onModalCancel: closeModal,
         openModal,
     },

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -1,4 +1,5 @@
 import { initialState as experimentalFeedbackInitialState } from '@suite/experimental-feedback';
+import { locksInitialState } from '@suite/locks';
 import { RouterState } from '@suite/router';
 import { FirmwareUpdateState } from '@suite-common/firmware';
 import { messageSystemInitialState } from '@suite-common/message-system';
@@ -20,6 +21,7 @@ import { initialDesktopBluetoothState } from '../../../actions/bluetooth/desktop
 
 export const initialAppState: AppState = {
     suite: suiteInitialState,
+    locks: locksInitialState,
     device: initialState,
     bluetooth: initialDesktopBluetoothState,
     thp: {

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -2,6 +2,7 @@ import type { Store as ReduxStore } from 'redux';
 import type { ThunkAction as TAction, ThunkDispatch } from 'redux-thunk';
 
 import { experimentalFeedbackSlice } from '@suite/experimental-feedback';
+import type { LockAction } from '@suite/locks';
 import type { MetadataAction } from '@suite/metadata';
 import type { ModalAction } from '@suite/modal';
 import type { recoveryActions } from '@suite/recovery';
@@ -124,6 +125,7 @@ export type Action =
     | FirmwareAction
     | GeolocationAction
     | GuideAction
+    | LockAction
     | MessageSystemAction
     | MetadataAction
     | ModalAction

--- a/packages/suite/src/views/backup/BackupStep1Initial.tsx
+++ b/packages/suite/src/views/backup/BackupStep1Initial.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { selectIsDeviceLocked } from '@suite/locks';
 import { selectSelectedDevice } from '@suite-common/device';
 import { Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -6,7 +7,6 @@ import { spacings } from '@trezor/theme';
 import { ConfirmKey, backupDevice } from 'src/actions/backup/backupActions';
 import { PreBackupCheckboxes } from 'src/components/backup';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 
 import { BackupStepDescription } from './BackupStepDescription';
 import { BackupState } from '../../reducers/backup/backupReducer';

--- a/packages/suite/src/views/onboarding/steps/BackupStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/BackupStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { selectIsDeviceLocked } from '@suite/locks';
 import { SettingsAnchor } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { exhaustive } from '@trezor/type-utils';
@@ -14,7 +15,6 @@ import { OnboardingCard } from 'src/components/onboarding/OnboardingCard/Onboard
 import { SkipStepConfirmation } from 'src/components/onboarding/SkipStepConfirmation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectBackup, selectBackupStatus } from 'src/reducers/backup/backupReducer';
-import { selectIsDeviceLocked } from 'src/selectors/suite/suiteSelectors';
 import { canContinue } from 'src/utils/backup';
 
 export const BackupStep = () => {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/AddWalletButton.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { Translation } from '@suite/intl';
+import { selectIsDeviceOrUiLocked } from '@suite/locks';
 import { selectDeviceThunk, startDiscoveryThunk } from '@suite-common/wallet-core';
 import { WalletType } from '@suite-common/wallet-types';
 import { Button, Card, Column, IconButton, Row, Text, Tooltip } from '@trezor/components';
 
 import { closeModalApp, goto } from 'src/actions/suite/routerActions';
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 import { AcquiredDevice, ForegroundAppProps, TrezorDevice } from 'src/types/suite';
 
 interface AddWalletButtonProps {

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextThp.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceStatusTextThp.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { selectIsDeviceOrUiLocked } from '@suite/locks';
 import { selectKnownDeviceByDeviceId } from '@suite-common/bluetooth/src/bluetoothSelectors';
 import { selectDevices } from '@suite-common/device';
 import { TrezorDevice } from '@suite-common/suite-types';
 
 import { selectConnectingDevices } from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDeviceOrUiLocked } from 'src/selectors/suite/suiteSelectors';
 
 import { DeviceConnectionText } from './DeviceConnectionText';
 import { DeviceStatusTextVisible } from './DeviceStatusTextVisible';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -153,6 +153,7 @@
             "path": "../../suite/idb-migration-utils"
         },
         { "path": "../../suite/intl" },
+        { "path": "../../suite/locks" },
         { "path": "../../suite/metadata" },
         { "path": "../../suite/modal" },
         {

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -26,8 +26,12 @@ export const initPreloadedState = ({
 }: {
     rootReducer: Reducer<any, any, any>;
     partialState: any;
-    // TODO is this okay?
-}) => mergeDeepObject(rootReducer(undefined, { type: 'test-init' }), partialState);
+}) =>
+    mergeDeepObject.withOptions(
+        { mergeArrays: false },
+        rootReducer(undefined, { type: 'test-init' }),
+        partialState,
+    );
 
 /**
  * A mock store for testing Redux async action creators and middleware.

--- a/suite-common/test-utils/src/configureMockStore.ts
+++ b/suite-common/test-utils/src/configureMockStore.ts
@@ -26,7 +26,8 @@ export const initPreloadedState = ({
 }: {
     rootReducer: Reducer<any, any, any>;
     partialState: any;
-}) => mergeDeepObject(partialState, rootReducer(undefined, { type: 'test-init' }));
+    // TODO is this okay?
+}) => mergeDeepObject(rootReducer(undefined, { type: 'test-init' }), partialState);
 
 /**
  * A mock store for testing Redux async action creators and middleware.

--- a/suite/locks/jest.config.js
+++ b/suite/locks/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    roots: ['<rootDir>/src', '<rootDir>/tests'],
+};

--- a/suite/locks/package.json
+++ b/suite/locks/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@suite/locks",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/test-utils": "workspace:*"
+    }
+}

--- a/suite/locks/src/index.ts
+++ b/suite/locks/src/index.ts
@@ -1,0 +1,1 @@
+export * from './locksSlice';

--- a/suite/locks/src/locksSlice.ts
+++ b/suite/locks/src/locksSlice.ts
@@ -1,0 +1,56 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+export const LOCK_TYPE = {
+    ROUTER: 'router', // restricted route changes, all other actions are possible
+    DEVICE: 'device', // restricted device call (TrezorConnect)
+    UI: 'ui', // restricted most of the UI actions (buttons, keyboard etc.)
+} as const;
+
+export type LockType = (typeof LOCK_TYPE)[keyof typeof LOCK_TYPE];
+
+export type LocksState = Record<LockType, number>;
+
+export type LocksRootState = { locks: LocksState };
+
+export const locksInitialState: LocksState = {
+    [LOCK_TYPE.UI]: 0,
+    [LOCK_TYPE.ROUTER]: 0,
+    [LOCK_TYPE.DEVICE]: 0,
+};
+
+const changeLock = (state: LocksState, lock: LockType, enabled: boolean) => {
+    state[lock] = Math.max(state[lock] + (enabled ? 1 : -1), 0);
+};
+
+export const locksSlice = createSlice({
+    name: 'locks',
+    initialState: locksInitialState,
+    reducers: {
+        lockUI: (state, { payload }: PayloadAction<boolean>) => {
+            changeLock(state, LOCK_TYPE.UI, payload);
+        },
+        lockDevice: (state, { payload }: PayloadAction<boolean>) => {
+            changeLock(state, LOCK_TYPE.DEVICE, payload);
+        },
+        lockRouter: (state, { payload }: PayloadAction<boolean>) => {
+            changeLock(state, LOCK_TYPE.ROUTER, payload);
+        },
+    },
+});
+
+export const { lockUI, lockDevice, lockRouter } = locksSlice.actions;
+
+export type LockAction =
+    | ReturnType<typeof lockUI>
+    | ReturnType<typeof lockDevice>
+    | ReturnType<typeof lockRouter>;
+
+export const locksReducer = locksSlice.reducer;
+
+export const selectLocks = (state: LocksRootState) => state.locks;
+export const selectIsDeviceLocked = (state: LocksRootState) => !!state.locks[LOCK_TYPE.DEVICE];
+export const selectIsDeviceOrUiLocked = (state: LocksRootState) =>
+    !!state.locks[LOCK_TYPE.DEVICE] || !!state.locks[LOCK_TYPE.UI];
+export const selectIsRouterLocked = (state: LocksRootState) => !!state.locks[LOCK_TYPE.ROUTER];
+export const selectIsRouterOrUiLocked = (state: LocksRootState) =>
+    !!state.locks[LOCK_TYPE.ROUTER] || !!state.locks[LOCK_TYPE.UI];

--- a/suite/locks/tests/locksSlice.test.ts
+++ b/suite/locks/tests/locksSlice.test.ts
@@ -1,0 +1,100 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore } from '@suite-common/test-utils';
+
+import {
+    LOCK_TYPE,
+    lockDevice,
+    lockRouter,
+    lockUI,
+    locksInitialState,
+    locksReducer,
+    selectIsDeviceLocked,
+    selectIsDeviceOrUiLocked,
+    selectIsRouterLocked,
+    selectIsRouterOrUiLocked,
+} from '../src/locksSlice';
+
+const getStore = (overrides: Partial<typeof locksInitialState> = {}) =>
+    configureMockStore({
+        reducer: combineReducers({ locks: locksReducer }),
+        preloadedState: { locks: { ...locksInitialState, ...overrides } },
+    });
+
+const getState = (overrides: Partial<typeof locksInitialState> = {}) => ({
+    locks: { ...locksInitialState, ...overrides },
+});
+
+describe('locksReducer', () => {
+    it('initializes with all locks at 0', () => {
+        const store = getStore();
+        expect(store.getState().locks).toEqual(locksInitialState);
+    });
+
+    it('increments and decrements ui lock counter', () => {
+        const store = getStore();
+
+        store.dispatch(lockUI(true));
+        expect(store.getState().locks[LOCK_TYPE.UI]).toBe(1);
+
+        store.dispatch(lockUI(true));
+        expect(store.getState().locks[LOCK_TYPE.UI]).toBe(2);
+
+        store.dispatch(lockUI(false));
+        expect(store.getState().locks[LOCK_TYPE.UI]).toBe(1);
+
+        store.dispatch(lockUI(false));
+        expect(store.getState().locks[LOCK_TYPE.UI]).toBe(0);
+    });
+
+    it('does not decrement lock counter below 0', () => {
+        const store = getStore();
+        store.dispatch(lockDevice(false));
+        expect(store.getState().locks[LOCK_TYPE.DEVICE]).toBe(0);
+    });
+
+    it('handles device lock independently', () => {
+        const store = getStore();
+
+        store.dispatch(lockDevice(true));
+        expect(store.getState().locks[LOCK_TYPE.DEVICE]).toBe(1);
+        expect(store.getState().locks[LOCK_TYPE.UI]).toBe(0);
+
+        store.dispatch(lockDevice(false));
+        expect(store.getState().locks[LOCK_TYPE.DEVICE]).toBe(0);
+    });
+
+    it('handles router lock independently', () => {
+        const store = getStore();
+
+        store.dispatch(lockRouter(true));
+        expect(store.getState().locks[LOCK_TYPE.ROUTER]).toBe(1);
+
+        store.dispatch(lockRouter(false));
+        expect(store.getState().locks[LOCK_TYPE.ROUTER]).toBe(0);
+    });
+});
+
+describe('lock selectors', () => {
+    it('selectIsDeviceLocked', () => {
+        expect(selectIsDeviceLocked(getState())).toBe(false);
+        expect(selectIsDeviceLocked(getState({ [LOCK_TYPE.DEVICE]: 1 }))).toBe(true);
+    });
+
+    it('selectIsDeviceOrUiLocked', () => {
+        expect(selectIsDeviceOrUiLocked(getState())).toBe(false);
+        expect(selectIsDeviceOrUiLocked(getState({ [LOCK_TYPE.DEVICE]: 1 }))).toBe(true);
+        expect(selectIsDeviceOrUiLocked(getState({ [LOCK_TYPE.UI]: 1 }))).toBe(true);
+    });
+
+    it('selectIsRouterLocked', () => {
+        expect(selectIsRouterLocked(getState())).toBe(false);
+        expect(selectIsRouterLocked(getState({ [LOCK_TYPE.ROUTER]: 1 }))).toBe(true);
+    });
+
+    it('selectIsRouterOrUiLocked', () => {
+        expect(selectIsRouterOrUiLocked(getState())).toBe(false);
+        expect(selectIsRouterOrUiLocked(getState({ [LOCK_TYPE.ROUTER]: 1 }))).toBe(true);
+        expect(selectIsRouterOrUiLocked(getState({ [LOCK_TYPE.UI]: 1 }))).toBe(true);
+    });
+});

--- a/suite/locks/tsconfig.json
+++ b/suite/locks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/test-utils"
+        }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14578,6 +14578,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/locks@workspace:*, @suite/locks@workspace:suite/locks":
+  version: 0.0.0-use.local
+  resolution: "@suite/locks@workspace:suite/locks"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/test-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite/metadata@workspace:*, @suite/metadata@workspace:suite/metadata":
   version: 0.0.0-use.local
   resolution: "@suite/metadata@workspace:suite/metadata"
@@ -16065,6 +16074,7 @@ __metadata:
     "@suite/experimental-feedback": "workspace:*"
     "@suite/idb-migration-utils": "workspace:*"
     "@suite/intl": "workspace:*"
+    "@suite/locks": "workspace:*"
     "@suite/metadata": "workspace:*"
     "@suite/modal": "workspace:*"
     "@suite/platform-encryption-electron": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New `@suite/locks` package to reduce dependency on packages/suite & suiteReducer.

## Notes for QA
No need to test this one IMO.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25860

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite/locks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite/locks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite/locks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T11:53:39.310Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-11T15:28:03.482Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->