### PR TITLE
refactor(connect): move `changeLanguage` to standalone workflow

### DIFF
--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -3,6 +3,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { AbstractMethod, MethodPermission, Payload } from '../core/AbstractMethod';
+import { changeLanguage } from '../device/workflow/changeLanguage';
 import { UI_REQUEST } from '../events';
 import { ChangeLanguage as ChangeLanguageSchema } from '../types/api/changeLanguage';
 
@@ -41,9 +42,9 @@ export default class ChangeLanguage extends AbstractMethod<'changeLanguage', Cha
         const { language, binary } = this.params;
 
         if (binary) {
-            return this.getDevice().changeLanguage({ binary });
+            return changeLanguage({ device: this.getDevice(), binary });
         } else {
-            return this.getDevice().changeLanguage({ language });
+            return changeLanguage({ device: this.getDevice(), language });
         }
     }
 }

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -25,12 +25,12 @@ import { FIRMWARE, PROTO } from '../constants';
 import { DeviceCurrentSession, TypedCallProvider } from './DeviceCurrentSession';
 import { checkFirmwareRevision } from './checkFirmwareRevision';
 import { abortThpWorkflow, getThpChannel } from './thp';
+import { changeLanguage } from './workflow/changeLanguage';
 import { checkFirmwareHashWithRetries } from './workflow/checkFirmwareHashWithRetries';
 import { getAllNetworks } from '../data/coinInfo';
 import {
     getFirmwareReleaseConfigInfo,
     getFirmwareStatus,
-    getLanguage,
     getReleaseByVersion,
 } from '../data/firmwareInfo';
 import {
@@ -583,7 +583,7 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             _log.info('language version mismatch. silently updating...');
 
             try {
-                await this.changeLanguage({ language: this.features.language });
+                await changeLanguage({ device: this, language: this.features.language });
             } catch (err) {
                 _log.error('change language failed silently', err);
             }
@@ -740,86 +740,6 @@ export class Device extends TypedEmitter<DeviceEvents> implements IDevice {
             ...this.authenticityChecks,
             firmwareRevision: result,
         };
-    }
-
-    async changeLanguage({
-        language,
-        binary,
-    }: { language?: undefined; binary: ArrayBuffer } | { language: string; binary?: undefined }) {
-        if (language === 'en-US') {
-            return this._uploadTranslationData(null);
-        }
-
-        if (binary) {
-            return this._uploadTranslationData(binary);
-        }
-
-        const version = this.getVersion();
-        if (!version) {
-            throw ERRORS.TypedError('Runtime', 'changeLanguage: device version unknown');
-        }
-
-        if (!this.firmwareType) {
-            throw ERRORS.TypedError('Runtime', 'changeLanguage: firmware type unknown');
-        }
-
-        if (!this._currentRelease) {
-            throw ERRORS.TypedError('Runtime', 'changeLanguage: release not found');
-        }
-        const languageBinPath = this._currentRelease.translations[language];
-        const downloadedBinary = await getLanguage(languageBinPath);
-
-        if (!downloadedBinary) {
-            throw ERRORS.TypedError('Runtime', 'changeLanguage: translation not found');
-        }
-
-        // This is mostly to satisfy Types, since `downloadedBinary` could be ArrayBuffer or Buffer<ArrayBufferLike>
-        // but `_uploadTranslationData` takes only ArrayBuffer or null.
-        let dataToSend: ArrayBuffer;
-        if (Buffer.isBuffer(downloadedBinary)) {
-            // Creates a "copy" if given a Buffer/Uint8Array in order to guarantee dataToSend is ArrayBuffer.
-            dataToSend = new Uint8Array(downloadedBinary).buffer;
-        } else {
-            dataToSend = downloadedBinary;
-        }
-
-        return this._uploadTranslationData(dataToSend);
-    }
-
-    private async _uploadTranslationData(payload: ArrayBuffer | null) {
-        if (payload === null) {
-            const response = await this.getCurrentSession().typedCall(
-                'ChangeLanguage',
-                ['Success'],
-                { data_length: 0 }, // For en-US where we just send `ChangeLanguage(size=0)`
-            );
-
-            return response.message;
-        }
-
-        const length = payload.byteLength;
-
-        let response = await this.getCurrentSession().typedCall(
-            'ChangeLanguage',
-            ['DataChunkRequest', 'Success'],
-            { data_length: length },
-        );
-
-        while (response.type !== 'Success') {
-            const start = response.message.data_offset!;
-            const end = response.message.data_offset! + response.message.data_length!;
-            const chunk = payload.slice(start, end);
-
-            response = await this.getCurrentSession().typedCall(
-                'DataChunkAck',
-                ['DataChunkRequest', 'Success'],
-                {
-                    data_chunk: Buffer.from(chunk).toString('hex'),
-                },
-            );
-        }
-
-        return response.message;
     }
 
     private async _updateCurrentRelease(feat: Features) {

--- a/packages/connect/src/device/workflow/changeLanguage.ts
+++ b/packages/connect/src/device/workflow/changeLanguage.ts
@@ -1,0 +1,81 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import { getLanguage } from '../../data/firmwareInfo';
+import type { IDevice } from '../../types/idevice';
+
+const uploadTranslationData = async (device: IDevice, payload: ArrayBuffer | null) => {
+    if (payload === null) {
+        const response = await device.getCurrentSession().typedCall(
+            'ChangeLanguage',
+            ['Success'],
+            { data_length: 0 }, // For en-US where we just send `ChangeLanguage(size=0)`
+        );
+
+        return response.message;
+    }
+
+    const length = payload.byteLength;
+
+    let response = await device
+        .getCurrentSession()
+        .typedCall('ChangeLanguage', ['DataChunkRequest', 'Success'], { data_length: length });
+
+    while (response.type !== 'Success') {
+        const start = response.message.data_offset!;
+        const end = response.message.data_offset! + response.message.data_length!;
+        const chunk = payload.slice(start, end);
+
+        response = await device
+            .getCurrentSession()
+            .typedCall('DataChunkAck', ['DataChunkRequest', 'Success'], {
+                data_chunk: Buffer.from(chunk).toString('hex'),
+            });
+    }
+
+    return response.message;
+};
+
+type Context = {
+    device: IDevice;
+} & ({ language?: undefined; binary: ArrayBuffer } | { language: string; binary?: undefined });
+
+export const changeLanguage = async ({ device, language, binary }: Context) => {
+    if (language === 'en-US') {
+        return uploadTranslationData(device, null);
+    }
+
+    if (binary) {
+        return uploadTranslationData(device, binary);
+    }
+
+    const version = device.getVersion();
+    if (!version) {
+        throw ERRORS.TypedError('Runtime', 'changeLanguage: device version unknown');
+    }
+
+    if (!device.firmwareType) {
+        throw ERRORS.TypedError('Runtime', 'changeLanguage: firmware type unknown');
+    }
+
+    if (!device.currentRelease) {
+        throw ERRORS.TypedError('Runtime', 'changeLanguage: release not found');
+    }
+    const languageBinPath = device.currentRelease.translations[language];
+    const downloadedBinary = await getLanguage(languageBinPath);
+
+    if (!downloadedBinary) {
+        throw ERRORS.TypedError('Runtime', 'changeLanguage: translation not found');
+    }
+
+    // This is mostly to satisfy Types, since `downloadedBinary` could be ArrayBuffer or Buffer<ArrayBufferLike>
+    // but `_uploadTranslationData` takes only ArrayBuffer or null.
+    let dataToSend: ArrayBuffer;
+    if (Buffer.isBuffer(downloadedBinary)) {
+        // Creates a "copy" if given a Buffer/Uint8Array in order to guarantee dataToSend is ArrayBuffer.
+        dataToSend = new Uint8Array(downloadedBinary).buffer;
+    } else {
+        dataToSend = downloadedBinary;
+    }
+
+    return uploadTranslationData(device, dataToSend);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

some random refactor, moving `changeLanguage` to a separate file

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-change-lang&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/connect-change-lang&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-11T19:31:05.735Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->