### PR TITLE
feat(ci): reenable type-check nx cache

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -55,8 +55,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Type Check
-        # Temporarily disabling the cache (false positives because of cache mismatch after NX update)
-        run: yarn nx:type-check --output-style=stream --skip-nx-cache
+        run: yarn nx:type-check --output-style=stream
 
   lint:
     name: Linting and formatting


### PR DESCRIPTION
## Description

Reenable type-check cache in Nx cloud.

Now I am fairly confident that it will work. [The problems](https://github.com/trezor/trezor-suite/pull/24271) we faced after bumping Nx in January were bypassed by disabling cache, but I believe they are now solved by #24605 and #25816.

I believe that the core of the problem was missing `"default"` in task `inputs`, see below:

## Notes for QA

Here's how you can reproduce false negative with old configuration [as of January](https://github.com/trezor/trezor-suite/blob/60e0280a88709db7e152bd19f424cbc8b35e9be9/nx.json#L33-L37), i.e. type errors passing the validation and getting committed:

```
git fetch origin feat/nx-reenable-tsc-cache-PLAYGROUND && git checkout feat/nx-reenable-tsc-cache-PLAYGROUND
git branch -f origin/develop HEAD # to make nx think that we are up-to-date with develop
yarn nx reset

echo "// no-op" >> ./packages/test/src/index.ts
yarn nx run @trezor/test:type-check --no-cloud
# cache miss, should run with success and persist cache

yarn nx run @trezor/test:type-check --no-cloud
# no-op :)

echo "export const a = (arg: number): number => arg.toString();" >> ./packages/test/src/index.ts
yarn nx run @trezor/test:type-check --no-cloud
# cache hit, success, BUT IT SHOULD FAIL!!!

yarn nx run @trezor/test-downstream:type-check --no-cloud
# cache miss, now it fails in a wrong package because it reads the corrupted `test`!
```

Now how does this PR fix it?
Do the same as above, but after the first line (checkout), do `git revert HEAD~1 --no-edit`
Cache is correctly invalidated and errors are caught when they should be :heavy_check_mark: 