### PR TITLE
Use DEV Relay and Quota Manager by default for all non-production builds

### DIFF
--- a/suite-common/suite-sync-quota-manager/package.json
+++ b/suite-common/suite-sync-quota-manager/package.json
@@ -20,7 +20,6 @@
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/suite-sync-quota-manager/src/constants.ts
+++ b/suite-common/suite-sync-quota-manager/src/constants.ts
@@ -1,4 +1,4 @@
-import { isDevEnv } from '@suite-common/suite-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 /**
  * Device size quota is set to 1 MB, which is approximately enough for 2500 label edits.
@@ -16,9 +16,9 @@ export const DEFAULT_ACCOUNT_SIZE_QUOTA = Math.round(DEFAULT_DEVICE_SIZE_QUOTA /
  */
 export const DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA = DEFAULT_ACCOUNT_SIZE_QUOTA;
 
-export const DEFAULT_QUOTA_MANAGER_URL = isDevEnv
-    ? 'https://suite-sync-dev.suite.sldev.cz/quota-manager/'
-    : 'https://suite-sync.trezor.io/quota-manager/';
+export const DEFAULT_QUOTA_MANAGER_URL = isCodesignBuild()
+    ? 'https://suite-sync.trezor.io/quota-manager/'
+    : 'https://suite-sync-dev.suite.sldev.cz/quota-manager/';
 
 /**
  * Header used for signing add space to owner requests.

--- a/suite-common/suite-sync-quota-manager/tsconfig.json
+++ b/suite-common/suite-sync-quota-manager/tsconfig.json
@@ -14,7 +14,6 @@
         { "path": "../suite-sync-storage" },
         { "path": "../suite-sync-types" },
         { "path": "../suite-types" },
-        { "path": "../suite-utils" },
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },
         { "path": "../../packages/connect" },

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -23,7 +23,6 @@
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-common/suite-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/transaction-search": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
@@ -31,6 +30,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     }

--- a/suite-common/suite-sync/src/relay/relayUrl.ts
+++ b/suite-common/suite-sync/src/relay/relayUrl.ts
@@ -1,7 +1,7 @@
-import { isDevEnv } from '@suite-common/suite-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 // The `https://suite-sync.trezor.io/` MUST have the last `/` in the URL.
 
-export const DEFAULT_SUITE_SYNC_RELAY_URL = isDevEnv
-    ? 'https://suite-sync-dev.suite.sldev.cz/evolu/'
-    : 'https://suite-sync.trezor.io/evolu/';
+export const DEFAULT_SUITE_SYNC_RELAY_URL = isCodesignBuild()
+    ? 'https://suite-sync.trezor.io/evolu/'
+    : 'https://suite-sync-dev.suite.sldev.cz/evolu/';

--- a/suite-common/suite-sync/tsconfig.json
+++ b/suite-common/suite-sync/tsconfig.json
@@ -18,7 +18,6 @@
         { "path": "../suite-sync-storage" },
         { "path": "../suite-sync-types" },
         { "path": "../suite-types" },
-        { "path": "../suite-utils" },
         { "path": "../toast-notifications" },
         { "path": "../transaction-search" },
         { "path": "../wallet-config" },
@@ -26,6 +25,7 @@
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },
         { "path": "../../packages/connect" },
+        { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -11387,7 +11387,6 @@ __metadata:
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
-    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
@@ -11441,7 +11440,6 @@ __metadata:
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
-    "@suite-common/suite-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/transaction-search": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -11449,6 +11447,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Only production and staging should use production servers; for testing on develop builds, we should use DEV servers by default.
- This applies to both mobile and desktop.
- So far, we have used DEV servers by default only for local (debug) builds.
- The DEV servers should behave exactly the same as PROD now, including quota management.

## Notes for QA

Make sure that on Release Candidates and production there are production servers for Suite Sync and Quota Manager by default.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/dev-relay-by-default-except-production&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/dev-relay-by-default-except-production&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/dev-relay-by-default-except-production&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T12:20:30.827Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T12:17:50.920Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->