### PR TITLE
feat(ci): New quarantineBot features and nightly unquarantine

### DIFF
--- a/.github/workflows/check-test-health-nightly.yml
+++ b/.github/workflows/check-test-health-nightly.yml
@@ -1,0 +1,48 @@
+name: "[Check] Test Health Nightly"
+
+# Nightly scheduled check on develop branch
+on:
+  schedule:
+    - cron: "0 5 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check-test-health-nightly:
+    name: Check test health & manage quarantine (nightly)
+    runs-on: ubuntu-latest
+    # Only run in the canonical repository, not forks.
+    if: github.repository == 'trezor/trezor-suite'
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: node_modules-
+
+      - name: Install dependencies
+        shell: bash
+        run: yarn workspaces focus @trezor/e2e-utils
+
+      - name: Check test health and manage quarantine
+        env:
+          CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+          E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK: ${{ secrets.E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          yarn workspace @trezor/e2e-utils test-health --nightlyUnquarantine

--- a/packages/e2e-utils/src/currentsApi/api.ts
+++ b/packages/e2e-utils/src/currentsApi/api.ts
@@ -1,7 +1,12 @@
 import { CURRENTS_API_BASE, DEVELOP_BRANCH, TEST_RESULTS_PAGE_SIZE } from './config';
+import { SpecFetchMode } from './types';
 import type {
     Action,
     ActionsListResponse,
+    RawInstanceTest,
+    RunData,
+    RunResponse,
+    RunTest,
     TestExplorerItem,
     TestResultItem,
     TestResultsResponse,
@@ -56,7 +61,7 @@ export async function currentsRequest<T>(
  * Pending results are stripped — they represent incomplete runs and would
  * skew failure-rate calculations.
  */
-async function* paginateTestResults(
+export async function* paginateTestResults(
     signature: string,
     lookbackDays: number,
 ): AsyncGenerator<TestResultItem[]> {
@@ -205,4 +210,100 @@ export function createAction(
         method: 'POST',
         body: JSON.stringify(body),
     });
+}
+
+/**
+ * Fetch the individual test results for a spec instance.
+ * Currents stores them separately under GET /instances/{instanceId};
+ * the run endpoint only exposes aggregate stats per spec.
+ * Normalises the minified `_s` status field into a readable `state`.
+ */
+async function getInstanceTests(instanceId: string): Promise<RunTest[]> {
+    const response = await currentsRequest<{
+        status: string;
+        data: { results?: { tests?: RawInstanceTest[] } };
+    }>(`/instances/${instanceId}`);
+    const tests = response.data.results?.tests ?? [];
+
+    return tests.map(t => ({
+        testId: t.testId,
+        title: t.title,
+        state: t._s,
+    }));
+}
+
+/**
+ * Fetch a single run by its ID.
+ * Only fetches individual instances for specs that match `mode`, reducing
+ * the number of API calls for large runs:
+ *  - `SpecFetchMode.FailuresOnly` – only specs with ≥1 failure  (default for manual quarantine)
+ *  - `SpecFetchMode.PassesOnly`   – only specs with ≥1 pass     (default for nightly unquarantine)
+ *  - `SpecFetchMode.All`          – fetch every instance
+ */
+export async function getRunById(runId: string, mode: SpecFetchMode): Promise<RunData> {
+    const response = await currentsRequest<RunResponse>(`/runs/${runId}`);
+    const run = response.data;
+
+    const specsToFetch = run.specs.filter(spec => {
+        const stats = spec.results?.stats;
+        if (mode === SpecFetchMode.FailuresOnly) return (stats?.failures ?? 0) > 0;
+        if (mode === SpecFetchMode.PassesOnly) return (stats?.passes ?? 0) > 0;
+
+        return true;
+    });
+
+    await Promise.all(
+        specsToFetch.map(async spec => {
+            const tests = await getInstanceTests(spec.instanceId);
+            spec.results = { ...spec.results, tests };
+        }),
+    );
+
+    return run;
+}
+
+/**
+ * Fetch just the run ID for the latest completed run on the specified branch,
+ * without loading any spec instance details. Returns null if no run exists.
+ */
+export async function getLatestRunIdOnBranch(
+    projectId: string,
+    branch: string,
+): Promise<string | null> {
+    const query = [`projectId=${projectId}`, `branch=${encodeURIComponent(branch)}`].join('&');
+    try {
+        const response = await currentsRequest<RunResponse>(`/runs/find?${query}`);
+
+        return response.data.runId;
+    } catch (err) {
+        if (err instanceof Error && err.message.includes('→ 404:')) {
+            return null;
+        }
+        throw err;
+    }
+}
+
+/**
+ * Fetch all individual test-result entries for `signature` that belong to
+ * the given `runId`. Paginates within the lookback window and stops as soon
+ * as a full page contains no entries from the target run (results are
+ * newest-first and run entries cluster together in time).
+ */
+export async function getResultsFromRun(
+    signature: string,
+    runId: string,
+    lookbackDays: number,
+): Promise<TestResultItem[]> {
+    const results: TestResultItem[] = [];
+    for await (const page of paginateTestResults(signature, lookbackDays)) {
+        const matching = page.filter(r => r.runId === runId);
+        results.push(...matching);
+        // Once we see a non-empty page with no matching entries the run has
+        // scrolled out of view — no need to paginate further.
+        if (page.length > 0 && matching.length === 0) {
+            break;
+        }
+    }
+
+    return results;
 }

--- a/packages/e2e-utils/src/currentsApi/types.ts
+++ b/packages/e2e-utils/src/currentsApi/types.ts
@@ -104,3 +104,66 @@ export interface TestResultsResponse {
     has_more: boolean;
     data: TestResultItem[];
 }
+
+export interface RunTest {
+    testId: string | undefined;
+    /** Title parts as returned by Currents: [describe, ..., test-name]. */
+    title: string[];
+    state: 'passed' | 'failed' | 'pending' | 'skipped';
+}
+
+/**
+ * Raw test shape returned by GET /v1/instances/{instanceId}.
+ * Currents uses short/minified field names; `_s` is the test state.
+ */
+export interface RawInstanceTest {
+    _s: 'passed' | 'failed' | 'pending' | 'skipped';
+    testId: string | undefined;
+    title: string[];
+    spec: string;
+}
+
+export interface RunSpec {
+    instanceId: string;
+    spec: string;
+    /** Aggregate stats returned directly by the run endpoint. */
+    results?: {
+        stats?: { failures?: number; passes?: number };
+        tests?: RunTest[];
+    };
+}
+
+export interface RunData {
+    runId: string;
+    projectId: string;
+    specs: RunSpec[];
+}
+
+export interface RunResponse {
+    status: string;
+    data: RunData;
+}
+
+export interface RunListItem {
+    runId: string;
+    projectId: string;
+}
+
+export interface RunsListResponse {
+    status: string;
+    data: RunListItem[];
+}
+
+/**
+ * Controls which spec instances are fetched when loading a run.
+ * Only specs matching the filter have their individual test results hydrated;
+ * the rest are left with stats only (reducing API calls).
+ */
+export enum SpecFetchMode {
+    /** Fetch instances only for specs with ≥1 failure (used by manual quarantine). */
+    FailuresOnly = 'failures-only',
+    /** Fetch instances only for specs with ≥1 pass (used by nightly unquarantine). */
+    PassesOnly = 'passes-only',
+    /** Fetch every instance regardless. */
+    All = 'all',
+}

--- a/packages/e2e-utils/src/quarantineBot/actions.ts
+++ b/packages/e2e-utils/src/quarantineBot/actions.ts
@@ -1,4 +1,4 @@
-import type { Action, TestExplorerItem, TestResultItem } from './types';
+import type { Action, TestExplorerItem, TestResultItem } from '../currentsApi/types';
 
 /**
  * Normalise a test's title path into individual parts.

--- a/packages/e2e-utils/src/quarantineBot/api.ts
+++ b/packages/e2e-utils/src/quarantineBot/api.ts
@@ -1,7 +1,7 @@
 import { computeStats, normalizeTitlePath } from './actions';
-import { AUTO_QUARANTINE_PREFIX } from './config';
-import { createAction, getActions } from '../currentsApi/api';
-import type { Action, TestExplorerItem } from '../currentsApi/types';
+import { AUTO_QUARANTINE_PREFIX, EXPLORER_LOOKBACK_DAYS } from './config';
+import { createAction, currentsRequest, getActions } from '../currentsApi/api';
+import type { Action, TestExplorerItem, TestsExplorerResponse } from '../currentsApi/types';
 
 export async function getAutoQuarantineActions(projectId: string): Promise<Action[]> {
     const actions = await getActions(projectId);
@@ -12,25 +12,15 @@ export async function getAutoQuarantineActions(projectId: string): Promise<Actio
 }
 
 /**
- * Create a quarantine action for a failing test.
+ * Shared low-level helper that POSTs a quarantine action to Currents.
+ * Callers are responsible for building the appropriate description string.
  */
-export function createQuarantineAction(
+function postQuarantineAction(
     projectId: string,
-    test: TestExplorerItem,
-    stats: ReturnType<typeof computeStats>,
+    titlePath: string[],
+    description: string,
 ): Promise<Action> {
-    const failurePercent = Math.round(stats.failureRate * 100);
-    const name = `${AUTO_QUARANTINE_PREFIX} ${test.title.slice(0, 80)}`;
-
-    // Use the normalised titlePath (individual spec / describe / test-name parts)
-    // rather than the raw title, which Currents often returns as a single ' > '-joined string.
-    const titlePath = normalizeTitlePath(test);
-
-    const description =
-        `Automatically quarantined by test-health-check workflow.\n` +
-        `Reason: ${failurePercent}% failure rate (${stats.failures}/${stats.executions} latest executions).\n` +
-        `Spec: ${test.spec}\n` +
-        `Full title path: ${titlePath.join(' > ')}`;
+    const name = `${AUTO_QUARANTINE_PREFIX} ${titlePath.join(' > ').slice(0, 80)}`;
 
     return createAction(projectId, {
         name,
@@ -41,4 +31,88 @@ export function createQuarantineAction(
             cond: [{ type: 'titlePath', op: 'incAll', value: titlePath }],
         },
     });
+}
+
+/**
+ * Create a quarantine action for a failing test discovered by the health-check workflow.
+ */
+export function createQuarantineAction(
+    projectId: string,
+    test: TestExplorerItem,
+    stats: ReturnType<typeof computeStats>,
+): Promise<Action> {
+    const failurePercent = Math.round(stats.failureRate * 100);
+    // Use the normalised titlePath (individual spec / describe / test-name parts)
+    // rather than the raw title, which Currents often returns as a single ' > '-joined string.
+    const titlePath = normalizeTitlePath(test);
+    const description =
+        `Automatically quarantined by test-health-check workflow.\n` +
+        `Reason: ${failurePercent}% failure rate (${stats.failures}/${stats.executions} latest executions).\n` +
+        `Spec: ${test.spec}\n` +
+        `Full title path: ${titlePath.join(' > ')}`;
+
+    return postQuarantineAction(projectId, titlePath, description);
+}
+
+/**
+ * Create a quarantine action for a test identified by its titlePath.
+ * Used for manually-triggered quarantines (e.g. from a specific run).
+ */
+export function createManualQuarantineAction(
+    projectId: string,
+    titlePath: string[],
+    spec: string,
+    runId: string,
+): Promise<Action> {
+    const description =
+        `Automatically quarantined from Currents run ${runId}.\n` +
+        `Spec: ${spec}\n` +
+        `Full title path: ${titlePath.join(' > ')}`;
+
+    return postQuarantineAction(projectId, titlePath, description);
+}
+
+/**
+ * Page through the Tests Explorer until signatures are found for every
+ * title key in `titleKeys`, or all pages are exhausted.
+ * Returns a map of titleKey → signature for every key that was located.
+ */
+export async function findSignaturesForTitleKeys(
+    projectId: string,
+    titleKeys: Set<string>,
+): Promise<Map<string, string>> {
+    const found = new Map<string, string>();
+    const dateEnd = new Date();
+    const dateStart = new Date(dateEnd.getTime() - EXPLORER_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+    const toDateString = (d: Date) => d.toISOString().slice(0, 10);
+    const limit = 25;
+    let page = 0;
+    let nextPage = true;
+
+    while (nextPage && found.size < titleKeys.size) {
+        const queryString = [
+            `date_start=${toDateString(dateStart)}`,
+            `date_end=${toDateString(dateEnd)}`,
+            `order=failRateXSamples`,
+            `dir=desc`,
+            `page=${page}`,
+            `limit=${limit}`,
+        ].join('&');
+
+        const response = await currentsRequest<TestsExplorerResponse>(
+            `/tests/${projectId}?${queryString}`,
+        );
+
+        for (const item of response.data.list) {
+            const key = JSON.stringify(normalizeTitlePath(item));
+            if (titleKeys.has(key) && item.signature) {
+                found.set(key, item.signature);
+            }
+        }
+
+        nextPage = response.data.nextPage;
+        page++;
+    }
+
+    return found;
 }

--- a/packages/e2e-utils/src/quarantineBot/index.ts
+++ b/packages/e2e-utils/src/quarantineBot/index.ts
@@ -9,6 +9,8 @@ import {
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
 import { listAllQuarantinedTests } from './list';
+import { quarantineFromRun } from './manualQuarantine';
+import { nightlyUnquarantineFromLatestRun } from './nightlyUnquarantine';
 import { quarantineFailingTests, unquarantinePassingTests } from './quarantine';
 import { buildSlackSummary, sendSlackNotification } from './slack';
 import type { SlackEvent } from './types';
@@ -34,8 +36,20 @@ async function main(): Promise<void> {
                 '  --list --project <name>    Same as --list but limited to the specified project.',
                 `                             Known project names: ${PROJECTS.map(p => p.name).join(', ')}.`,
                 '',
+                '  --quarantine <runId>       Quarantine all tests that failed in the given Currents run ID.',
+                '                             Combine with -i / --interactive to approve each test manually.',
+                '                             Sends a Slack notification (with a “manually triggered” note)',
+                '                             when E2E_TEST_SLACK_QUARANTINE_BOT_WEBHOOK is configured.',
+                '',
+                '  -i, --interactive          Used together with --quarantine: prompt for each failed test',
+                '                             before quarantining it.',
+                '',
                 '  --wipeAutoQuarantine       Delete ALL auto-quarantine actions (those created by this bot)',
                 '                             across every monitored project. Use with caution.',
+                '',
+                '  --nightlyUnquarantine      Find the latest run on the default (develop) branch for',
+                '                             each monitored project and unquarantine all auto-quarantined',
+                '                             tests that passed in that run.',
                 '',
                 '  --help, -h                 Show this help message and exit.',
                 '',
@@ -59,6 +73,74 @@ async function main(): Promise<void> {
 
     if (args.includes('--wipeAutoQuarantine')) {
         await wipeAllAutoQuarantineActions();
+
+        return;
+    }
+
+    if (args.includes('--nightlyUnquarantine')) {
+        console.log('=== Nightly Unquarantine ===');
+        console.log(`Timestamp: ${new Date().toISOString()}`);
+        console.log(`Projects: ${PROJECTS.map(p => `${p.label} (${p.id})`).join(', ')}`);
+        console.log('');
+
+        let hasError = false;
+        const slackEvents: SlackEvent[] = [];
+
+        for (const project of PROJECTS) {
+            try {
+                await nightlyUnquarantineFromLatestRun(project.id, project.label, slackEvents);
+            } catch (err) {
+                console.error(
+                    `\n[ERROR] Failed processing project ${project.label} (${project.id}):`,
+                    err,
+                );
+                hasError = true;
+            }
+        }
+
+        const summary = buildSlackSummary(PROJECTS, slackEvents, {
+            headerNote: 'Nightly unquarantine from latest develop run.',
+        });
+        if (summary) {
+            await sendSlackNotification(summary);
+        }
+
+        console.log('\n=== Done ===');
+
+        if (hasError) {
+            process.exit(1);
+        }
+
+        return;
+    }
+
+    const quarantineFlagIndex = args.indexOf('--quarantine');
+    if (quarantineFlagIndex !== -1) {
+        const runId = args[quarantineFlagIndex + 1];
+        if (!runId || runId.startsWith('-')) {
+            console.error('[ERROR] --quarantine requires a run ID argument.');
+            process.exit(1);
+        }
+
+        const interactive = args.includes('-i') || args.includes('--interactive');
+        const slackEvents: SlackEvent[] = [];
+
+        const { projectId, projectLabel } = await quarantineFromRun(
+            runId,
+            interactive,
+            slackEvents,
+        );
+
+        // Build Slack summary using the run's project so the events are attributed correctly.
+        const projectEntry = { id: projectId, label: projectLabel };
+        const summary = buildSlackSummary([projectEntry], slackEvents, {
+            headerNote: `Manually triggered quarantine from <https://app.currents.dev/runs/${runId}|run ${runId}>.`,
+        });
+        if (summary) {
+            await sendSlackNotification(summary);
+        }
+
+        console.log('\n=== Done ===');
 
         return;
     }

--- a/packages/e2e-utils/src/quarantineBot/list.ts
+++ b/packages/e2e-utils/src/quarantineBot/list.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 import { extractKeyFromAction } from './actions';
 import { AUTO_QUARANTINE_PREFIX, PROJECTS } from './config';
-import type { Action } from './types';
 import { getAllQuarantineActions } from '../currentsApi/api';
+import type { Action } from '../currentsApi/types';
 
 interface QuarantinedTestEntry {
     name: string;

--- a/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/manualQuarantine.ts
@@ -1,0 +1,133 @@
+/* eslint-disable no-console */
+import * as readline from 'readline';
+
+import { extractKeyFromAction } from './actions';
+import { createManualQuarantineAction } from './api';
+import { PROJECTS } from './config';
+import type { FailedTestFromRun, SlackEvent } from './types';
+import { getAllQuarantineActions, getRunById } from '../currentsApi/api';
+import { SpecFetchMode } from '../currentsApi/types';
+
+function promptUser(question: string): Promise<boolean> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    return new Promise(resolve => {
+        rl.question(`${question} [y/N] `, answer => {
+            rl.close();
+            resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+        });
+    });
+}
+
+/**
+ * Quarantine all (or interactively selected) failed tests from a specific Currents run.
+ *
+ * @param runId      - The Currents run ID to inspect.
+ * @param interactive - When true, prompt the user before quarantining each test.
+ * @param slackEvents - Accumulator for Slack notification events.
+ * @returns The project ID and label associated with the run.
+ */
+export async function quarantineFromRun(
+    runId: string,
+    interactive: boolean,
+    slackEvents: SlackEvent[],
+): Promise<{ projectId: string; projectLabel: string }> {
+    console.log(`\n=== Manual Quarantine from Run ${runId} ===`);
+    console.log(`Timestamp: ${new Date().toISOString()}`);
+
+    // Fetch run — only populate specs that had at least one failure.
+    console.log('\nFetching run data...');
+    const run = await getRunById(runId, SpecFetchMode.FailuresOnly);
+    const { projectId } = run;
+
+    const project = PROJECTS.find(p => p.id === projectId);
+    const projectLabel = project?.label ?? projectId;
+
+    console.log(`Project: ${projectLabel} (${projectId})`);
+
+    // Collect failed tests from all specs in the run
+    const failedTests: FailedTestFromRun[] = [];
+    for (const spec of run.specs) {
+        if (!spec.results?.tests) {
+            continue;
+        }
+        for (const test of spec.results.tests) {
+            if (test.state === 'failed') {
+                failedTests.push({ titlePath: test.title, spec: spec.spec });
+            }
+        }
+    }
+
+    if (failedTests.length === 0) {
+        console.log('\n  ✓ No failed tests found in this run.');
+
+        return { projectId, projectLabel };
+    }
+
+    console.log(`\nFound ${failedTests.length} failed test(s).`);
+
+    // Fetch existing quarantine actions so we can skip already-quarantined tests.
+    // We also track keys we quarantine during this run to avoid creating duplicates
+    // if the same test failed in multiple specs within the same run.
+    const existingActions = await getAllQuarantineActions(projectId);
+    const existingTitleKeys = new Set(
+        existingActions.map(a => extractKeyFromAction(a)).filter(Boolean),
+    );
+
+    let quarantinedCount = 0;
+    let skippedCount = 0;
+
+    for (const test of failedTests) {
+        // Normalize the title path the same way auto-quarantine does so the key
+        // comparison works consistently against both auto- and manual-quarantine
+        // actions that may store titles as concatenated ' > ' strings.
+        const normalizedTitlePath = test.titlePath.flatMap(part => part.split(' > '));
+        const titleKey = JSON.stringify(normalizedTitlePath);
+        const testTitle = normalizedTitlePath.join(' > ');
+
+        if (existingTitleKeys.has(titleKey)) {
+            console.log(`  ↳ Already quarantined: "${testTitle.slice(0, 80)}"`);
+            skippedCount++;
+            continue;
+        }
+
+        if (interactive) {
+            console.log(`\n  Test: "${testTitle.slice(0, 100)}"`);
+            console.log(`  Spec: ${test.spec}`);
+            const confirmed = await promptUser('  Quarantine this test?');
+            if (!confirmed) {
+                console.log('  ↳ Skipped.');
+                skippedCount++;
+                continue;
+            }
+        } else {
+            console.log(`  ↳ Quarantining: "${testTitle.slice(0, 80)}"`);
+        }
+
+        const action = await createManualQuarantineAction(
+            projectId,
+            normalizedTitlePath,
+            test.spec,
+            runId,
+        );
+        quarantinedCount++;
+        // Track the key so a duplicate failure of the same test within this run
+        // is not quarantined a second time.
+        existingTitleKeys.add(titleKey);
+
+        slackEvents.push({
+            kind: 'quarantined',
+            projectId,
+            titlePath: normalizedTitlePath,
+            // No cross-run signature available for manually-triggered quarantines.
+            signature: undefined,
+            actionId: action.actionId,
+            failures: 1,
+            executions: 1,
+        });
+    }
+
+    console.log(`\n  Summary: ${quarantinedCount} quarantined, ${skippedCount} skipped.`);
+
+    return { projectId, projectLabel };
+}

--- a/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
@@ -1,0 +1,136 @@
+/* eslint-disable no-console */
+import { extractKeyFromAction } from './actions';
+import { findSignaturesForTitleKeys, getAutoQuarantineActions } from './api';
+import { DEVELOP_BRANCH, EXPLORER_LOOKBACK_DAYS } from './config';
+import type { SlackEvent } from './types';
+import { deleteAction, getLatestRunIdOnBranch, getResultsFromRun } from '../currentsApi/api';
+
+/**
+ * Unquarantine auto-quarantined tests that passed in the latest run on the
+ * default (develop) branch.
+ *
+ * This is intended to be run nightly so that tests whose quarantine was
+ * triggered automatically are restored as soon as they demonstrate they pass
+ * on the main branch — without waiting for the broader statistical threshold
+ * used by the regular health-check (`unquarantinePassingTests`).
+ *
+ * A test is only unquarantined if ALL its instances in the run passed (i.e.
+ * every Playwright project that executed it reported a pass). This handles
+ * multi-project runs where the same test title can appear more than once.
+ *
+ * To minimise API calls the function never loads the full run. Instead it:
+ *   1. Fetches only the auto-quarantined actions (one API call).
+ *   2. Pages through the Tests Explorer only until signatures are found for
+ *      every quarantined test (early-exit pagination).
+ *   3. Resolves the latest develop runId with a single metadata call.
+ *   4. For each quarantined test individually fetches only its own results
+ *      filtered to that runId.
+ */
+export async function nightlyUnquarantineFromLatestRun(
+    projectId: string,
+    projectLabel: string,
+    slackEvents: SlackEvent[],
+): Promise<void> {
+    console.log(
+        `\n── [${projectLabel}] Nightly unquarantine from latest "${DEVELOP_BRANCH}" run ──`,
+    );
+
+    // Load the smaller set first: only the currently auto-quarantined tests.
+    // This lets us bail early when there is nothing to do and avoids fetching
+    // the full run just to find out there are no candidates.
+    const existingActions = await getAutoQuarantineActions(projectId);
+    if (existingActions.length === 0) {
+        console.log('  ✓ No auto-quarantined tests to check.');
+
+        return;
+    }
+
+    console.log(`  ${existingActions.length} auto-quarantined test(s) to evaluate.`);
+
+    // Build titleKey → action map and collect the set of keys we need signatures for.
+    const quarantinedByKey = new Map<string, (typeof existingActions)[number]>();
+    const titleKeys = new Set<string>();
+    for (const action of existingActions) {
+        const key = extractKeyFromAction(action);
+        if (key) {
+            quarantinedByKey.set(key, action);
+            titleKeys.add(key);
+        } else {
+            console.warn(`  ↳ Could not extract title from action "${action.name}", skipping.`);
+        }
+    }
+
+    // Resolve the latest develop runId and each test's signature in parallel.
+    // The explorer pagination stops as soon as signatures for all quarantined
+    // tests are found, so it typically completes in very few requests.
+    const [runId, signatureByKey] = await Promise.all([
+        getLatestRunIdOnBranch(projectId, DEVELOP_BRANCH),
+        findSignaturesForTitleKeys(projectId, titleKeys),
+    ]);
+
+    if (!runId) {
+        console.log(`  No run found on branch "${DEVELOP_BRANCH}" for this project.`);
+
+        return;
+    }
+
+    console.log(`  Found run: ${runId}`);
+
+    // For each quarantined test, fetch only its own results filtered to the
+    // latest run. One API call per test — no unrelated spec data is loaded.
+    const instanceStats = new Map<string, { total: number; passed: number }>();
+    await Promise.all(
+        [...quarantinedByKey.keys()].map(async key => {
+            const signature = signatureByKey.get(key);
+            if (!signature) {
+                return; // test not seen in the explorer lookback window — leave quarantined
+            }
+            const results = await getResultsFromRun(signature, runId, EXPLORER_LOOKBACK_DAYS);
+            if (results.length === 0) {
+                return;
+            }
+            instanceStats.set(key, {
+                total: results.length,
+                passed: results.filter(r => r.status === 'passed').length,
+            });
+        }),
+    );
+
+    let unquarantinedCount = 0;
+
+    for (const [testKey, action] of quarantinedByKey) {
+        const testTitle = (JSON.parse(testKey) as string[]).join(' > ');
+        const stats = instanceStats.get(testKey);
+
+        if (!stats || stats.total === 0) {
+            console.log(`  ↳ Not seen in run: "${testTitle.slice(0, 80)}" — keeping quarantine.`);
+            continue;
+        }
+
+        if (stats.passed < stats.total) {
+            console.log(
+                `  ↳ Not all instances passed (${stats.passed}/${stats.total}): "${testTitle.slice(0, 80)}" — keeping quarantine.`,
+            );
+            continue;
+        }
+
+        console.log(
+            `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" (${stats.total} instance(s) all passed) ✓`,
+        );
+        await deleteAction(action.actionId);
+        unquarantinedCount++;
+
+        slackEvents.push({
+            kind: 'unquarantined',
+            projectId,
+            titlePath: JSON.parse(testKey) as string[],
+            signature: undefined,
+            passes: stats.passed,
+            executions: stats.total,
+        });
+    }
+
+    if (unquarantinedCount === 0) {
+        console.log('  ✓ No quarantined tests found passing in all instances of the latest run.');
+    }
+}

--- a/packages/e2e-utils/src/quarantineBot/quarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/quarantine.ts
@@ -9,12 +9,13 @@ import {
     UNQUARANTINE_FAILURE_RATE,
     UNQUARANTINE_LAST_N_EXECUTIONS,
 } from './config';
-import type { Action, SlackEvent, TestExplorerItem } from './types';
+import type { SlackEvent } from './types';
 import {
     deleteAction,
     getLastNResults,
     getLastNResultsFromDistinctBranches,
 } from '../currentsApi/api';
+import type { Action, TestExplorerItem } from '../currentsApi/types';
 
 export async function quarantineFailingTests(
     projectId: string,

--- a/packages/e2e-utils/src/quarantineBot/slack.ts
+++ b/packages/e2e-utils/src/quarantineBot/slack.ts
@@ -42,12 +42,17 @@ function currentsActionUrl(projectId: string, actionId: string): string {
 export function buildSlackSummary(
     projects: Array<{ id: string; label: string }>,
     events: SlackEvent[],
+    options: { headerNote?: string } = {},
 ): string | null {
     if (events.length === 0) {
         return null;
     }
 
     const sections: string[] = [];
+
+    if (options.headerNote) {
+        sections.push(`:information_source: ${options.headerNote}`);
+    }
 
     for (const { id: projectId, label: projectLabel } of projects) {
         const projectEvents = events.filter(e => e.projectId === projectId);
@@ -63,10 +68,12 @@ export function buildSlackSummary(
         if (quarantinedEvents.length > 0) {
             lines.push(`:warning: *Quarantined (${quarantinedEvents.length})*`);
             for (const event of quarantinedEvents) {
-                const testUrl = currentsTestUrl(projectId, event.signature);
                 const actionUrl = currentsActionUrl(projectId, event.actionId);
+                const testLink = event.signature
+                    ? ` · <${currentsTestUrl(projectId, event.signature)}|results>`
+                    : '';
                 lines.push(
-                    `• ${truncateTitle(event.titlePath)} — ${event.failures}/${event.executions} failed · <${actionUrl}|action> · <${testUrl}|results>`,
+                    `• ${truncateTitle(event.titlePath)} — ${event.failures}/${event.executions} failed · <${actionUrl}|action>${testLink}`,
                 );
             }
         }
@@ -74,9 +81,11 @@ export function buildSlackSummary(
         if (unquarantinedEvents.length > 0) {
             lines.push(`:white_check_mark: *Restored (${unquarantinedEvents.length})*`);
             for (const event of unquarantinedEvents) {
-                const testUrl = currentsTestUrl(projectId, event.signature);
+                const resultsLink = event.signature
+                    ? ` · <${currentsTestUrl(projectId, event.signature)}|results>`
+                    : '';
                 lines.push(
-                    `• ${truncateTitle(event.titlePath)} — ${event.passes}/${event.executions} passed · <${testUrl}|results>`,
+                    `• ${truncateTitle(event.titlePath)} — ${event.passes}/${event.executions} passed${resultsLink}`,
                 );
             }
         }

--- a/packages/e2e-utils/src/quarantineBot/types.ts
+++ b/packages/e2e-utils/src/quarantineBot/types.ts
@@ -1,23 +1,9 @@
-export type {
-    Action,
-    ActionsListResponse,
-    TestExplorerItem,
-    TestExplorerMetrics,
-    TestResultCommit,
-    TestResultItem,
-    TestResultsResponse,
-    TestsExplorerResponse,
-    RuleMatcherCondition,
-    RuleMatcher,
-    RuleAction,
-} from '../currentsApi/types';
-
 export type SlackEvent =
     | {
           kind: 'quarantined';
           projectId: string;
           titlePath: string[];
-          signature: string;
+          signature: string | undefined;
           actionId: string;
           failures: number;
           executions: number;
@@ -26,7 +12,12 @@ export type SlackEvent =
           kind: 'unquarantined';
           projectId: string;
           titlePath: string[];
-          signature: string;
+          signature: string | undefined;
           passes: number;
           executions: number;
       };
+
+export interface FailedTestFromRun {
+    titlePath: string[];
+    spec: string;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-autoquarantine-manual&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-autoquarantine-manual&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T12:26:51.405Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T12:25:22.511Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->