### PR TITLE
Refactor CompactCardWithIconLayout

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 import { View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { GestureDetector } from 'react-native-gesture-handler';
 
 import { Icon, IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
@@ -13,6 +12,7 @@ import { Loader } from '../Loader';
 import { RoundedIcon } from '../RoundedIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
+import { useTapGesture } from '../useTapGesture';
 import { AnimatedCard, CardProps } from './Card';
 
 export const COMPACT_CARD_VARIANTS = ['normal', 'danger', 'primary'] as const;
@@ -79,33 +79,13 @@ export const CompactCardWithIconLayout = ({
     ...cardProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
-    const isPressed = useSharedValue(false);
     const { caretColor, iconColor, titleColor, subtitleColor, iconWrapperBackgroundColor } =
         cardVariantToColorsMap[variant];
 
-    const tap = Gesture.Tap()
-        .maxDuration(5000)
-        .onBegin(() => {
-            isPressed.value = true;
-        })
-        .onFinalize(() => {
-            isPressed.value = false;
-        })
-        .onTouchesCancelled(() => {
-            isPressed.value = false;
-        })
-        .onEnd(() => {
-            if (onPress) {
-                runOnJS(onPress)();
-            }
-        });
-
-    const animatedStyle = useAnimatedStyle(() => ({
-        opacity: withTiming(isPressed.value ? 0.5 : 1, { duration: 100 }),
-    }));
+    const { tapGesture, animatedStyle } = useTapGesture(onPress);
 
     return (
-        <GestureDetector gesture={tap}>
+        <GestureDetector gesture={tapGesture}>
             <View collapsable={false} testID={testID}>
                 <AnimatedCard
                     noPadding

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -24,7 +24,7 @@ export type CompactCardWithIconLayoutProps = {
     subtitle?: ReactNode;
     isDisabled?: boolean;
     alertBoxProps?: Omit<InlineAlertBoxProps, 'borderRadius'>;
-    onPress?: () => void;
+    onPress: () => void;
     variant?: CompactCardVariant;
     borderColor?: Color | null;
 } & Omit<CardProps, 'children' | 'borderColor'>;

--- a/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
@@ -1,0 +1,57 @@
+import { ReactNode } from 'react';
+import { View } from 'react-native';
+import { GestureDetector } from 'react-native-gesture-handler';
+
+import { Icon, IconName } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
+
+import { Box } from '../Box';
+import { HStack, VStack } from '../Stack';
+import { Text } from '../Text';
+import { useTapGesture } from '../useTapGesture';
+import { AnimatedCard } from './Card';
+
+const contentStyle = prepareNativeStyle(() => ({
+    flexGrow: 1,
+    flexShrink: 1,
+}));
+
+export type PressableCardWithIconLayoutProps = {
+    icon: IconName;
+    title: ReactNode;
+    description: ReactNode;
+    onPress: () => void;
+};
+
+export const PressableCardWithIconLayout = ({
+    icon,
+    title,
+    description,
+    onPress,
+}: PressableCardWithIconLayoutProps) => {
+    const { tapGesture, animatedStyle } = useTapGesture(onPress);
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <GestureDetector gesture={tapGesture}>
+            <View collapsable={false}>
+                <AnimatedCard borderColor="borderElevation1" noPadding style={animatedStyle}>
+                    <HStack margin="sp16" spacing="sp12">
+                        <Box marginVertical="sp2">
+                            <Icon name={icon} size="mediumLarge" />
+                        </Box>
+                        <VStack spacing="sp2" style={applyStyle(contentStyle)}>
+                            <Text variant="body-md-strong">{title}</Text>
+                            <Text variant="body-sm" color="textSubdued">
+                                {description}
+                            </Text>
+                        </VStack>
+                        <Box alignSelf="center">
+                            <Icon name="caretRight" size="mediumLarge" color="iconSubdued" />
+                        </Box>
+                    </HStack>
+                </AnimatedCard>
+            </View>
+        </GestureDetector>
+    );
+};

--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -43,6 +43,7 @@ export * from './Card/HeaderedCard';
 export * from './Card/CardDivider';
 export * from './Card/CardWithIconLayout';
 export * from './Card/CompactCardWithIconLayout';
+export * from './Card/PressableCardWithIconLayout';
 export * from './ScreenFooterGradient';
 export * from './ScreenHeaderWrapper';
 export * from './ErrorMessage';

--- a/suite-native/atoms/src/useTapGesture.ts
+++ b/suite-native/atoms/src/useTapGesture.ts
@@ -1,0 +1,29 @@
+import { Gesture } from 'react-native-gesture-handler';
+import { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
+export const useTapGesture = (onPress: () => void) => {
+    const isPressed = useSharedValue(false);
+
+    const tapGesture = Gesture.Tap()
+        .maxDuration(5000)
+        .onBegin(() => {
+            isPressed.value = true;
+        })
+        .onFinalize(() => {
+            isPressed.value = false;
+        })
+        .onTouchesCancelled(() => {
+            isPressed.value = false;
+        })
+        .onEnd(() => {
+            if (onPress) {
+                runOnJS(onPress)();
+            }
+        });
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        opacity: withTiming(isPressed.value ? 0.5 : 1, { duration: 100 }),
+    }));
+
+    return { tapGesture, animatedStyle };
+};

--- a/suite-native/module-settings/src/components/BitcoinBackendsCard.tsx
+++ b/suite-native/module-settings/src/components/BitcoinBackendsCard.tsx
@@ -1,17 +1,17 @@
+import { PressableCardWithIconLayout } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { SettingsStackRoutes } from '@suite-native/navigation';
 
-import { AppSettingsCardWithIconLayout } from './AppSettingsCardWithIconLayout';
 import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 
 export const BitcoinBackendsCard = () => {
     const navigateTo = useSettingsNavigateTo();
 
     return (
-        <AppSettingsCardWithIconLayout
+        <PressableCardWithIconLayout
             icon="database"
             title={<Translation id="moduleSettings.advanced.bitcoinBackends.title" />}
-            subtitle={<Translation id="moduleSettings.advanced.bitcoinBackends.subtitle" />}
+            description={<Translation id="moduleSettings.advanced.bitcoinBackends.subtitle" />}
             onPress={() => navigateTo(SettingsStackRoutes.BitcoinBackends)}
         />
     );


### PR DESCRIPTION
- `onPress` in `CompactCardWithIconLayout` made mandatory
- `useTapGesture` extracted so it's reusable
- `PressableCardWithIconLayout` atom introduced (to be also used for #25127)
- Layout of `BitcoinBackendsCard` fixed

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/native/tap-gesture&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->