### PR TITLE
Feat/debug/waste labels

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/FillSuiteSyncQuota.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FillSuiteSyncQuota.tsx
@@ -1,0 +1,127 @@
+import { useRef, useState } from 'react';
+
+import { selectDeviceStaticSessionId } from '@suite-common/device';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountDescriptor } from '@suite-common/wallet-types';
+import { Button, Column, Text } from '@trezor/components';
+import { spacings } from '@trezor/theme';
+
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+
+// Each address entry creates a new Evolu row (~490 byte label + ~200 byte overhead ≈ 690 bytes).
+// 2200 iterations covers ~1.07 MB which should exhaust the 1 MB device quota.
+const FILL_QUOTA_LABEL = 'a'.repeat(490);
+const FILL_QUOTA_ITERATIONS = 2200;
+const DEBUG_ACCOUNT_DESCRIPTOR = 'debug-fill-quota-account' as AccountDescriptor;
+const DEBUG_NETWORK_SYMBOL = 'btc' as NetworkSymbol;
+
+type FillStatus = 'idle' | 'filling' | 'stopped' | 'done' | 'error';
+
+export const FillSuiteSyncQuota = () => {
+    const { suiteSync } = useSuiteServices();
+
+    const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
+
+    const [status, setStatus] = useState<FillStatus>('idle');
+    const [fillProgress, setFillProgress] = useState(0);
+    const shouldStopRef = useRef(false);
+
+    const handleFillQuota = async () => {
+        if (!deviceStaticSessionId) return;
+
+        shouldStopRef.current = false;
+        setStatus('filling');
+        setFillProgress(0);
+
+        const runId = Date.now();
+
+        for (let i = 0; i < FILL_QUOTA_ITERATIONS; i++) {
+            if (shouldStopRef.current) {
+                setStatus('stopped');
+
+                return;
+            }
+
+            const result = await suiteSync.labeling.updateAddressLabel({
+                deviceStaticSessionId,
+                address: `debug-fill-quota-${runId}-${i}`,
+                label: FILL_QUOTA_LABEL,
+                accountDescriptor: DEBUG_ACCOUNT_DESCRIPTOR,
+                networkSymbol: DEBUG_NETWORK_SYMBOL,
+            });
+
+            await new Promise(r => setTimeout(r, 300));
+
+            setFillProgress(i + 1);
+
+            if (!result.success) {
+                setStatus('error');
+
+                return;
+            }
+        }
+
+        setStatus('done');
+    };
+
+    const handleStop = () => {
+        shouldStopRef.current = true;
+    };
+
+    const isDisabled = !deviceStaticSessionId || status === 'filling';
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Fill Quota"
+                description="Writes ~1 MB of label data to the Evolu relay to exhaust the device's Suite Sync quota. "
+            />
+            <ActionColumn>
+                <Column gap={spacings.xxs}>
+                    <Button
+                        data-testid="@settings/debug/suite-sync/fill-quota-button"
+                        onClick={handleFillQuota}
+                        isLoading={status === 'filling'}
+                        isDisabled={isDisabled}
+                        intent="critical"
+                    >
+                        {status === 'filling'
+                            ? `Filling… ${fillProgress} / ${FILL_QUOTA_ITERATIONS}`
+                            : 'Fill Quota'}
+                    </Button>
+                    {status === 'filling' && (
+                        <Button
+                            data-testid="@settings/debug/suite-sync/stop-fill-quota-button"
+                            onClick={handleStop}
+                        >
+                            Stop
+                        </Button>
+                    )}
+                    {status === 'stopped' && (
+                        <Text typographyStyle="body-sm" color="textSubdued">
+                            Stopped after {fillProgress} / {FILL_QUOTA_ITERATIONS} writes.
+                        </Text>
+                    )}
+                    {status === 'done' && (
+                        <Text typographyStyle="body-sm" color="textSubdued">
+                            Done. Navigate to the home screen to see the Out of Quota banner.
+                        </Text>
+                    )}
+                    {status === 'error' && (
+                        <Text typographyStyle="body-sm" color="textAlertRed">
+                            Write failed. Check that Suite Sync is enabled and a device is
+                            connected.
+                        </Text>
+                    )}
+                    {!deviceStaticSessionId && status === 'idle' && (
+                        <Text typographyStyle="body-sm" color="textSubdued">
+                            No active device session found.
+                        </Text>
+                    )}
+                </Column>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SuiteSyncSettings.tsx
@@ -15,6 +15,8 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
+import { FillSuiteSyncQuota } from './FillSuiteSyncQuota';
+
 export const SuiteSyncSettings = () => {
     const [isLoading, setIsLoading] = useState(false);
 
@@ -92,6 +94,7 @@ export const SuiteSyncSettings = () => {
                     />
                 </ActionColumn>
             </SectionItem>
+            <FillSuiteSyncQuota />
         </SettingsSection>
     );
 };

--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -12,17 +12,19 @@ import {
     ProofOfDelegatedIdentityFailedErrType,
     WriteModeRequiredForAllocationErrType,
 } from '@suite-common/suite-sync-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
 import {
-    DEFAULT_ACCOUNT_SIZE_QUOTA,
+    DEFAULT_DEVICE_SIZE_QUOTA,
     EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
 } from './constants';
 import { quotaManagerOwnerFetched } from './quotaManagerActions';
-import { selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
+import { selectLeftDeviceQuota, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { checkStorageByOwnerId } from './storage/checkStorage';
 import { transferStorageThunk } from './storage/transferStorageThunk';
+import { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';
 import { prepareMessageBufferEvoluAddSpaceToOwner } from './util/prepareMessageBufferEvoluAddSpaceToOwner';
 
 export const WriteModeRequiredForAllocation = (): WriteModeRequiredForAllocationErrType => ({
@@ -42,13 +44,9 @@ export const ProofOfDelegatedIdentityFailed = (): ProofOfDelegatedIdentityFailed
 });
 
 export const ensureOwnerHasAllocatedQuotaThunk =
-    ({
-        ownerId,
-        walletDescriptor,
-        delegatedKey,
-        isWriteMode,
-    }: EnsureOwnerHasAllocatedQuotaParams) =>
+    ({ ownerId, deviceSessionId, delegatedKey, isWriteMode }: EnsureOwnerHasAllocatedQuotaParams) =>
     async (dispatch: Dispatch, getState: () => any): ReturnType<EnsureOwnerHasAllocatedQuota> => {
+        const { walletDescriptor, deviceId } = parseDeviceStaticSessionId(deviceSessionId);
         const quotaManagerBaseUrl = selectQuotaManagerBaseUrl(getState());
 
         const hasOwnerStorage = await checkStorageByOwnerId({
@@ -87,6 +85,12 @@ export const ensureOwnerHasAllocatedQuotaThunk =
             return err(HttpError());
         }
 
+        const leftDeviceQuota = selectLeftDeviceQuota(getState(), deviceId);
+
+        const sizeToAllocate = getAccountIncrementSizeQuota({
+            unspendStorage: leftDeviceQuota ?? DEFAULT_DEVICE_SIZE_QUOTA,
+        });
+
         const proofOfDelegatedIdentity = getProofOfDelegatedIdentity({
             delegatedKey,
             header: EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
@@ -94,7 +98,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                 publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                 ownerId,
                 challenge: sessionChallenge.payload.challenge,
-                size: DEFAULT_ACCOUNT_SIZE_QUOTA,
+                size: sizeToAllocate,
             }),
         });
 
@@ -108,11 +112,12 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                     ownerId,
                     publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                     proof: proofOfDelegatedIdentity.payload,
-                    size: DEFAULT_ACCOUNT_SIZE_QUOTA,
+                    size: sizeToAllocate,
                     challenge: sessionChallenge.payload.challenge,
                     sessionId: sessionChallenge.payload.sessionId,
                 },
                 walletDescriptor,
+                deviceId,
             }),
         );
 

--- a/suite-common/suite-sync-quota-manager/src/increaseOwnerQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/increaseOwnerQuotaThunk.ts
@@ -12,11 +12,12 @@ import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
 import {
-    DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+    DEFAULT_DEVICE_SIZE_QUOTA,
     EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
 } from './constants';
-import { selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
+import { selectLeftDeviceQuota, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { transferStorageThunk } from './storage/transferStorageThunk';
+import { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';
 import { prepareMessageBufferEvoluAddSpaceToOwner } from './util/prepareMessageBufferEvoluAddSpaceToOwner';
 
 type AllocateMoreOwnerQuotaParams = {
@@ -33,6 +34,12 @@ export const increaseOwnerQuotaThunk =
         }
         const { walletDescriptor } = parseDeviceStaticSessionId(device.state.staticSessionId);
         const quotaManagerBaseUrl = selectQuotaManagerBaseUrl(getState());
+
+        const leftDeviceQuota = selectLeftDeviceQuota(getState(), device.id);
+
+        const sizeToAllocate = getAccountIncrementSizeQuota({
+            unspendStorage: leftDeviceQuota ?? DEFAULT_DEVICE_SIZE_QUOTA,
+        });
 
         const delegatedKey = await extra.services.ensureDelegatedIdentityKey({ device });
         if (!delegatedKey.success) {
@@ -55,7 +62,7 @@ export const increaseOwnerQuotaThunk =
             appendMessageBuffer: prepareMessageBufferEvoluAddSpaceToOwner({
                 ownerId,
                 challenge: sessionChallenge.payload.challenge,
-                size: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                size: sizeToAllocate,
                 publicKey: delegatedPublicKey,
             }),
         });
@@ -66,10 +73,11 @@ export const increaseOwnerQuotaThunk =
 
         dispatch(
             transferStorageThunk({
+                deviceId: device.id,
                 walletDescriptor,
                 params: {
                     ownerId,
-                    size: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                    size: sizeToAllocate,
                     proof: proof.payload,
                     sessionId: sessionChallenge.payload.sessionId,
                     challenge: sessionChallenge.payload.challenge,

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -55,3 +55,8 @@ export {
  * Constants.
  */
 export { DEFAULT_DEVICE_SIZE_QUOTA } from './constants';
+
+/**
+ * Utils.
+ */
+export { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -3,6 +3,7 @@ import { mocked } from 'jest-mock';
 import { DELEGATED_IDENTITY_KEY } from '@suite-common/delegated-identity-key-types/mocks';
 import { asSuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
 import { WalletDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+import { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from '../challenge/prepareChallengeSession';
@@ -34,6 +35,8 @@ const createGetState = (statePatch?: Partial<SuiteSyncQuotaManagerState>) => () 
 
 const ownerId = asSuiteSyncOwnerId('owner-id');
 const walletDescriptor: WalletDescriptor = asWalletDescriptor('descriptor');
+const deviceId = 'device-123';
+const deviceSessionId = `${walletDescriptor}@${deviceId}` as StaticSessionId;
 
 const prepareChallengeSessionMock = mocked(prepareChallengeSession);
 const checkStorageByOwnerIdMock = mocked(checkStorageByOwnerId);
@@ -54,7 +57,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceSessionId,
             isWriteMode: false,
         })(dispatch, getState);
 
@@ -86,7 +89,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceSessionId,
             isWriteMode: false,
         })(dispatch, getState);
 
@@ -115,7 +118,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceSessionId,
             isWriteMode: true,
         })(dispatch, getState);
 
@@ -133,6 +136,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
                 sessionId: 'session-123',
             },
             walletDescriptor,
+            deviceId,
         });
         expect(transferThunkInner).toHaveBeenCalled();
     });

--- a/suite-common/suite-sync-quota-manager/src/util/getAccountIncrementSizeQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/util/getAccountIncrementSizeQuota.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA } from '../constants';
+
+type GetAccountSizeQuotaParams = {
+    unspendStorage: number;
+};
+
+export const getAccountIncrementSizeQuota = ({ unspendStorage }: GetAccountSizeQuotaParams) => {
+    if (unspendStorage < DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA) {
+        return unspendStorage;
+    }
+
+    return DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA;
+};

--- a/suite-common/suite-sync-quota-manager/src/util/tests/getAccountIncrementSizeQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/util/tests/getAccountIncrementSizeQuota.test.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA, DEFAULT_DEVICE_SIZE_QUOTA } from '../../constants';
+import { getAccountIncrementSizeQuota } from '../getAccountIncrementSizeQuota';
+
+describe(getAccountIncrementSizeQuota.name, () => {
+    it('should return default account size quota if unspend storage is bigger than default', () => {
+        const result = getAccountIncrementSizeQuota({ unspendStorage: DEFAULT_DEVICE_SIZE_QUOTA });
+
+        expect(result).toBe(DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA);
+    });
+
+    it("should return remaining unspend storage if it's smaller than default account size quota", () => {
+        const unspendStorage = 500;
+        const result = getAccountIncrementSizeQuota({ unspendStorage });
+
+        expect(result).toBe(unspendStorage);
+    });
+});

--- a/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -1,6 +1,6 @@
 import { SuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
 import { DelegatedIdentityKey } from '@suite-common/suite-types';
-import { WalletDescriptor } from '@suite-common/wallet-types';
+import { StaticSessionId } from '@trezor/connect';
 import { Result } from '@trezor/type-utils';
 
 import { WriteModeRequiredForAllocationErrType } from './quotaManagerTypes';
@@ -13,7 +13,7 @@ export type ProofOfDelegatedIdentityFailedErrType = { type: 'ProofOfDelegatedIde
 
 export type EnsureOwnerHasAllocatedQuotaParams = {
     ownerId: SuiteSyncOwnerId;
-    walletDescriptor: WalletDescriptor;
+    deviceSessionId: StaticSessionId;
     delegatedKey: DelegatedIdentityKey;
     isWriteMode: boolean;
 };

--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -72,7 +72,7 @@ export const createEnsureQuota =
 
         const allocatedQuota = await deps.dispatch(
             ensureOwnerHasAllocatedQuotaThunk({
-                walletDescriptor,
+                deviceSessionId: deviceStaticSessionId,
                 ownerId: owner.ownerId,
                 delegatedKey,
                 isWriteMode,

--- a/suite-native/module-dev-utils/src/components/FillSuiteSyncQuota.tsx
+++ b/suite-native/module-dev-utils/src/components/FillSuiteSyncQuota.tsx
@@ -1,0 +1,123 @@
+import { useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectDeviceStaticSessionId } from '@suite-common/device';
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountDescriptor } from '@suite-common/wallet-types';
+import { Button, Card, Text, VStack } from '@suite-native/atoms';
+import { useNativeServices } from '@suite-native/services';
+
+const FILL_QUOTA_LABEL = 'a'.repeat(50);
+const FILL_QUOTA_ITERATIONS = 4000;
+const DEBUG_ACCOUNT_DESCRIPTOR = 'debug-fill-quota-account' as AccountDescriptor;
+const DEBUG_NETWORK_SYMBOL = 'btc' as NetworkSymbol;
+
+type FillStatus = 'idle' | 'filling' | 'stopped' | 'done' | 'error';
+
+export const FillSuiteSyncQuota = () => {
+    const { suiteSync } = useNativeServices();
+
+    const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
+
+    const [status, setStatus] = useState<FillStatus>('idle');
+    const [fillProgress, setFillProgress] = useState(0);
+    const shouldStopRef = useRef(false);
+
+    const handleFillQuota = async () => {
+        if (!deviceStaticSessionId) return;
+
+        shouldStopRef.current = false;
+        setStatus('filling');
+        setFillProgress(0);
+
+        const runId = Date.now();
+
+        for (let i = 0; i < FILL_QUOTA_ITERATIONS; i++) {
+            if (shouldStopRef.current) {
+                setStatus('stopped');
+
+                return;
+            }
+
+            const result = await suiteSync.labeling.updateAddressLabel({
+                deviceStaticSessionId,
+                address: `debug-fill-quota-${runId}-${i}`,
+                label: FILL_QUOTA_LABEL,
+                accountDescriptor: DEBUG_ACCOUNT_DESCRIPTOR,
+                networkSymbol: DEBUG_NETWORK_SYMBOL,
+            });
+
+            if (shouldStopRef.current) {
+                setStatus('stopped');
+                setFillProgress(i + 1);
+
+                return;
+            }
+
+            if (shouldStopRef.current) {
+                setStatus('stopped');
+                setFillProgress(i + 1);
+
+                return;
+            }
+
+            setFillProgress(i + 1);
+
+            if (!result.success) {
+                setStatus('error');
+
+                return;
+            }
+        }
+
+        setStatus('done');
+    };
+
+    const handleStop = () => {
+        shouldStopRef.current = true;
+    };
+
+    const isDisabled = !deviceStaticSessionId || status === 'filling';
+
+    return (
+        <Card>
+            <VStack spacing="sp12">
+                <Text variant="headline-sm">Fill Suite Sync Quota</Text>
+                <Text variant="body-sm" color="textSubdued">
+                    Writes ~1 MB of label data to the Evolu relay to exhaust the device&apos;s Suite
+                    Sync quota.
+                </Text>
+                <Button colorScheme="redBold" onPress={handleFillQuota} isDisabled={isDisabled}>
+                    {status === 'filling'
+                        ? `Filling… ${fillProgress} / ${FILL_QUOTA_ITERATIONS}`
+                        : 'Fill Quota'}
+                </Button>
+                {status === 'filling' && (
+                    <Button colorScheme="tertiaryElevation0" onPress={handleStop}>
+                        Stop
+                    </Button>
+                )}
+                {status === 'stopped' && (
+                    <Text variant="body-sm" color="textSubdued">
+                        Stopped after {fillProgress} / {FILL_QUOTA_ITERATIONS} writes.
+                    </Text>
+                )}
+                {status === 'done' && (
+                    <Text variant="body-sm" color="textSubdued">
+                        Done. Navigate to the home screen to see the Out of Quota banner.
+                    </Text>
+                )}
+                {status === 'error' && (
+                    <Text variant="body-sm" color="textAlertRed">
+                        Write failed. Check that Suite Sync is enabled and a device is connected.
+                    </Text>
+                )}
+                {!deviceStaticSessionId && status === 'idle' && (
+                    <Text variant="body-sm" color="textSubdued">
+                        No active device session found.
+                    </Text>
+                )}
+            </VStack>
+        </Card>
+    );
+};

--- a/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DevUtilsScreen.tsx
@@ -6,6 +6,7 @@ import { AnalyticsLogging } from '../components/AnalyticsLogging';
 import { DangerZoneCard } from '../components/DangerZoneCard';
 import { DebuggingCard } from '../components/DebuggingCard';
 import { FeatureFlagsCard } from '../components/FeatureFlagsCard';
+import { FillSuiteSyncQuota } from '../components/FillSuiteSyncQuota';
 import { FirmwareSourceCard } from '../components/FirmwareSourceCard';
 import { InfoCard } from '../components/InfoCard';
 import { MessageSystemCard } from '../components/MessageSystemCard';
@@ -33,6 +34,7 @@ export const DevUtilsScreen = () => (
             <FirmwareSourceCard />
             <SuiteSyncRelaySettings />
             <SuiteSyncQuotaManager />
+            <FillSuiteSyncQuota />
             <DebuggingCard />
             <DangerZoneCard />
         </VStack>


### PR DESCRIPTION
**Changes**:
- feat: added debug utility to waste your labels
- fixed debug unspentstorage size refreshing on increaseQuotaThunk
- added fn to allocate remaining quota if its less than the default

## Notes for QA

- in debug, you can use the button to waste your labels


## Related Issue

Resolve <!--- link the issue here -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/debug/waste-labels&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/debug/waste-labels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/debug/waste-labels&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T13:30:58.618Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T13:29:40.794Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->