### PR TITLE
fix(suite-native): Fix of one of suite-native test leaks

### DIFF
--- a/suite-common/suite-types/mocks/mockSuiteDevice.ts
+++ b/suite-common/suite-types/mocks/mockSuiteDevice.ts
@@ -1,11 +1,5 @@
-import {
-    Device,
-    DeviceUniquePath,
-    Features,
-    FirmwareType,
-    asDeviceUniquePath,
-} from '@trezor/connect';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import type { Device, DeviceUniquePath, Features } from '@trezor/connect';
+import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
 import { TrezorDevice } from '../src/device';
 
@@ -114,7 +108,7 @@ export const mockConnectDevice = (
     dev?: Partial<StringPath<Device>>,
     feat?: Partial<Features>,
 ): Device => {
-    const path = asDeviceUniquePath(dev?.path ?? '1');
+    const path = (dev?.path ?? '1') as DeviceUniquePath;
 
     if (dev && typeof dev.type === 'string' && dev.type === 'unreadable') {
         return {

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -1,11 +1,11 @@
 import { DeviceMetadata } from '@suite-common/metadata-types';
 import { EncryptedHex } from '@suite-common/platform-encryption';
-import {
+import type {
     AuthenticateDeviceResult,
     DeviceButtonRequest,
     DeviceEvent,
     DeviceState,
-    type EntropyCheckResult,
+    EntropyCheckResult,
     Features,
     KnownDevice,
     PROTO,

--- a/suite-common/test-utils/src/mocks.ts
+++ b/suite-common/test-utils/src/mocks.ts
@@ -14,8 +14,8 @@ import {
     WalletAccountTransaction,
     asAccountDescriptor,
 } from '@suite-common/wallet-types';
-import { AccountUtxo, Device, Features, FirmwareType, TrezorConnect } from '@trezor/connect';
-import { DeviceModelInternal } from '@trezor/device-utils';
+import type { AccountUtxo, Device, Features, TrezorConnect } from '@trezor/connect';
+import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
 /**
  * device.firmwareReleaseConfigInfo property

--- a/suite-native/test-utils/src/extraDependenciesNative.mock.ts
+++ b/suite-native/test-utils/src/extraDependenciesNative.mock.ts
@@ -1,8 +1,8 @@
 import type { MMKV } from 'react-native-mmkv';
 
-import { ExtraDependenciesStatic } from '@suite-common/redux-utils';
+import type { ExtraDependenciesStatic } from '@suite-common/redux-utils';
 import { analyticsMock, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { NativeServices } from '@suite-native/services';
+import type { NativeServices } from '@suite-native/services';
 
 type ExtraDependenciesNativeMock = ExtraDependenciesStatic & { services: NativeServices };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `@trezor/connect` has circulars, try not to include it from tests and mocks

<!--- Describe your changes in detail -->

## Notes for QA

Nothing to test.

## Screenshots:
### Memory usage and leaks caused by `extraDependenciesNativeMock` before this PR
<img width="586" height="145" alt="Screenshot 2026-03-12 at 15 26 04" src="https://github.com/user-attachments/assets/7c778af7-2fcf-4462-8547-e82ff8590c5c" />

### Memory usage and leaks caused by `extraDependenciesNativeMock` with changes in this PR
<img width="599" height="146" alt="Screenshot 2026-03-12 at 15 26 07" src="https://github.com/user-attachments/assets/58dcd06d-5256-4acb-9971-01ecad08b227" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-native-leak-improvement&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-native-leak-improvement&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native-leak-improvement&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:30:31.001Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:28:49.765Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->