### PR TITLE
fix: makre sure that app is no acciessle when bio auth enabled but no…

### DIFF
--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -34,8 +34,7 @@ export const init = createThunk(`${BIO_AUTH_PREFIX}/init`, (_args, { dispatch })
 
     const onBioAuthAvailable = (available: boolean) => {
         dispatch(bioAuthActions.setIsBioAuthAvailable(available));
-        if (!available) return;
-        // ensure this api is called only when & if BioAuthModule is available = initialized
+        // ensure this api is called regardlesss if the bio auth is available or not
         desktopApi.getBioAuthStatus().then(validated => {
             dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
         });
@@ -95,7 +94,6 @@ export const requestBioAuthValidationThunk = createThunk(
     `${BIO_AUTH_PREFIX}/validateAuth`,
     async ({ messageSuccess, messageError }: RequestBioAuthValidationThunkParams, { dispatch }) => {
         if (!(await desktopApi.isBioAuthAvailable())) {
-            await desktopApi.setBioAuthSettings({ enabled: false });
             dispatch(
                 notificationsActions.addToast({
                     type: 'error',

--- a/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
+++ b/packages/suite/src/components/suite/BioAuthGuard/BioAuthGuard.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { Button, Icon, Paragraph, Row, useElevation } from '@trezor/components';
+import { Button, Icon, Paragraph, Row, Tooltip, useElevation } from '@trezor/components';
 import { isMacOs } from '@trezor/env-utils';
 import {
     Elevation,
@@ -38,7 +38,13 @@ const Container = styled.div<{ $elevation: Elevation }>`
     padding: ${spacingsPx.sm} ${spacingsPx.xxs};
 `;
 
-const BioAuthOverlay = ({ onPrimaryButtonClick }: { onPrimaryButtonClick: () => void }) => {
+const BioAuthOverlay = ({
+    isBioAuthAvailable,
+    onPrimaryButtonClick,
+}: {
+    isBioAuthAvailable: boolean;
+    onPrimaryButtonClick: () => void;
+}) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
     const { elevation } = useElevation();
 
@@ -66,13 +72,22 @@ const BioAuthOverlay = ({ onPrimaryButtonClick }: { onPrimaryButtonClick: () => 
                                             <Translation id="TR_BIO_AUTH_LOCKED_TEXT_WIN" />
                                         )}
                                     </Paragraph>
-                                    <Button
+                                    <Tooltip
                                         width="100%"
-                                        intent="brand"
-                                        onClick={() => onPrimaryButtonClick()}
+                                        isActive={!isBioAuthAvailable}
+                                        content={
+                                            <Translation id="TR_BIO_AUTH_NOT_AVAILABLE_TOOLTIP_CONTENT" />
+                                        }
                                     >
-                                        <Translation id="TR_BIO_AUTH_UNLOCK" />
-                                    </Button>
+                                        <Button
+                                            isDisabled={!isBioAuthAvailable}
+                                            width="100%"
+                                            intent="brand"
+                                            onClick={() => onPrimaryButtonClick()}
+                                        >
+                                            <Translation id="TR_BIO_AUTH_UNLOCK" />
+                                        </Button>
+                                    </Tooltip>
                                 </Container>
                             </Row>
                         </MainContent>
@@ -99,7 +114,6 @@ export const BioAuthGuard = ({ children }: { children: React.ReactNode }) => {
 
     useEffect(() => {
         if (!isBioAuthEnabled) return;
-        if (!isBioAuthAvailable) return;
 
         const handleBlur = () => {
             setIsWindowFocused(false);
@@ -116,7 +130,7 @@ export const BioAuthGuard = ({ children }: { children: React.ReactNode }) => {
             window.removeEventListener('blur', handleBlur);
             window.removeEventListener('focus', handleFocus);
         };
-    }, [dispatch, isBioAuthAvailable, isBioAuthEnabled]);
+    }, [dispatch, isBioAuthEnabled]);
 
     useEffect(() => {
         if (!isBioAuthEnabled) return;
@@ -137,8 +151,11 @@ export const BioAuthGuard = ({ children }: { children: React.ReactNode }) => {
         requestBioAuthValidation,
     ]);
 
-    return isBioAuthEnabled && isBioAuthAvailable && isBioAuthValidationRequired ? (
-        <BioAuthOverlay onPrimaryButtonClick={requestBioAuthValidation} />
+    return isBioAuthEnabled && isBioAuthValidationRequired ? (
+        <BioAuthOverlay
+            isBioAuthAvailable={isBioAuthAvailable}
+            onPrimaryButtonClick={requestBioAuthValidation}
+        />
     ) : (
         children
     );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2954,6 +2954,11 @@ export const messages = defineMessages({
         defaultMessage: 'Perform a simulated recovery to verify your wallet backup.',
         id: 'TR_CHECK_RECOVERY_SEED_DESCRIPTION',
     },
+    TR_BIO_AUTH_NOT_AVAILABLE_TOOLTIP_CONTENT: {
+        id: 'TR_BIO_AUTH_NOT_AVAILABLE_TOOLTIP_CONTENT',
+        defaultMessage:
+            "Biometrics is not currently available on this device. Try restarting your device or opening Trezor Suite on the primary device display. If these steps don't help, reinstall the application and reconnect your Trezor devices.",
+    },
     TR_RECOVERY_TYPES_DESCRIPTION: {
         defaultMessage:
             'Both methods are secure. Choose advanced recovery if you prefer entering your wallet backup on your Trezor’s screen.',


### PR DESCRIPTION
…t available

<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensures , that the app is not available when locked but bio auth not available

## Notes for QA

QA notes https://github.com/trezor/trezor-suite-private/issues/198

## Related Issue

resolve: https://github.com/trezor/trezor-suite-private/issues/198


## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=make-sure-that-app-inavailable-when-bio-unavailable&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=make-sure-that-app-inavailable-when-bio-unavailable&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:58:45.808Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:32:00.731Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->