### PR TITLE
fix(suite): hide empty FeedbackFormManager wrapper in sidebar QuickActions

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/QuickActions.tsx
@@ -1,5 +1,12 @@
 import { FeedbackFormManager } from '@suite/experimental-feedback';
+import type { ExperimentalFeature } from '@suite/experimental';
+import {
+    ExperimentalFeedbackRootState,
+    selectPendingFeedbackFeature,
+} from '@suite-common/feedback';
 import { Box, Column, Divider, ElevationContext, Flex } from '@trezor/components';
+
+import { useSelector } from 'src/hooks/suite';
 
 import { CustomBackend } from './CustomBackend';
 import { DebugAndExperimental } from './DebugAndExperimental';
@@ -12,28 +19,37 @@ type QuickActionsProps = {
     hideUpdateQuickAction: boolean;
 };
 
-export const QuickActions = ({ isSidebarCollapsed, hideUpdateQuickAction }: QuickActionsProps) => (
-    <Column>
-        <ElevationContext baseElevation={0}>
-            <Box padding={16}>
-                <FeedbackFormManager />
-            </Box>
-        </ElevationContext>
+export const QuickActions = ({ isSidebarCollapsed, hideUpdateQuickAction }: QuickActionsProps) => {
+    const pendingFeedbackFeature = useSelector(
+        (state: ExperimentalFeedbackRootState<ExperimentalFeature>) =>
+            selectPendingFeedbackFeature(state),
+    );
 
-        <Divider margin={{ bottom: 4 }} />
+    return (
+        <Column>
+            {pendingFeedbackFeature && (
+                <ElevationContext baseElevation={0}>
+                    <Box padding={16}>
+                        <FeedbackFormManager />
+                    </Box>
+                </ElevationContext>
+            )}
 
-        <Flex
-            gap={16}
-            padding={16}
-            alignItems="center"
-            justifyContent="space-evenly"
-            direction={isSidebarCollapsed ? 'column' : 'row'}
-        >
-            <UpdateStatusActionBarIcon hideUpdateQuickAction={hideUpdateQuickAction} />
-            <DebugAndExperimental />
-            <CustomBackend />
-            <Tor />
-            <HideBalances />
-        </Flex>
-    </Column>
-);
+            <Divider margin={{ bottom: 4 }} />
+
+            <Flex
+                gap={16}
+                padding={16}
+                alignItems="center"
+                justifyContent="space-evenly"
+                direction={isSidebarCollapsed ? 'column' : 'row'}
+            >
+                <UpdateStatusActionBarIcon hideUpdateQuickAction={hideUpdateQuickAction} />
+                <DebugAndExperimental />
+                <CustomBackend />
+                <Tor />
+                <HideBalances />
+            </Flex>
+        </Column>
+    );
+};


### PR DESCRIPTION
## Description

When FeedbackFormManager had no pending feedback to show (returned null), the wrapping ElevationContext and Box with padding={16} still rendered, creating visible empty space below the firmware update notification banner.

Conditionally render the feedback wrapper only when there is a pending feedback feature, eliminating the empty gap.

## Notes for QA

Connect Trezor with older version of FW and see the "New firmware is available" popup

## Related Issue

Resolve trezor/trezor-suite#25609

## Screenshots:

<img width="1440" height="933" alt="image" src="https://github.com/user-attachments/assets/875e1d18-e710-40b8-b415-656f48ef6140" />
