### PR TITLE
Refactor: cj circular imports

### DIFF
--- a/packages/coinjoin/src/backend/CoinjoinAddressController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinAddressController.ts
@@ -5,11 +5,14 @@ import type { Network } from '@trezor/utxo-lib';
 import { deriveAddresses } from './backendUtils';
 import { getAddressScript } from './filters';
 import { DISCOVERY_LOOKOUT, DISCOVERY_LOOKOUT_EXTENDED } from '../constants';
-import type { AccountAddress, AccountCache, ScanAccountCheckpoint } from '../types/backend';
+import type {
+    AccountAddress,
+    AccountCache,
+    AddressControllerShape,
+    ScanAccountCheckpoint,
+} from '../types/backend';
 
-export type AddressController = Pick<CoinjoinAddressController, 'receive' | 'change' | 'analyze'>;
-
-export class CoinjoinAddressController {
+export class CoinjoinAddressController implements AddressControllerShape {
     private readonly xpub;
     private readonly network;
     private readonly lookouts;

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -15,6 +15,7 @@ import type {
     BlockFilterResponse,
     BlockbookBlock,
     BlockbookTransaction,
+    CoinjoinBackendClientShape,
     MempoolFilterResponse,
 } from '../types/backend';
 import { RequestOptions, resetIdentityCircuit } from '../utils/http';
@@ -24,7 +25,7 @@ type CoinjoinBackendClientSettings = CoinjoinBackendSettings & {
     logger?: Logger;
 };
 
-export class CoinjoinBackendClient {
+export class CoinjoinBackendClient implements CoinjoinBackendClientShape {
     protected readonly logger;
     protected readonly blockbookUrls;
     protected readonly onionDomains;
@@ -65,7 +66,7 @@ export class CoinjoinBackendClient {
         );
     }
 
-    fetchTransaction(txid: string, options?: RequestOptions): Promise<BlockbookTransaction> {
+    fetchTransaction(txid: string, options?: RequestOptions) {
         const lastCharCode = txid.charCodeAt(txid.length - 1);
         const identity = this.identitiesBlockbook[lastCharCode & 0x3]; // Works only when identities.length === 4
 

--- a/packages/coinjoin/src/backend/CoinjoinFilterController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinFilterController.ts
@@ -6,11 +6,10 @@ import type {
     FilterClient,
     FilterControllerContext,
     FilterControllerParams,
+    FilterControllerShape,
 } from '../types/backend';
 
-export type FilterController = Pick<CoinjoinFilterController, 'getFilterIterator'>;
-
-export class CoinjoinFilterController {
+export class CoinjoinFilterController implements FilterControllerShape {
     private readonly client;
     private readonly batchSize;
     private readonly baseBlock;

--- a/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
+++ b/packages/coinjoin/src/backend/CoinjoinMempoolController.ts
@@ -4,18 +4,17 @@ import { arrayDistinct, createCooldown, promiseAllSequence } from '@trezor/utils
 import type { Network } from '@trezor/utxo-lib';
 
 import type { Logger } from '../types';
-import type { AddressController } from './CoinjoinAddressController';
 import { getAllTxAddresses, isDoublespend } from './backendUtils';
 import { getAddressScript, getMultiFilter } from './filters';
 import { MEMPOOL_PURGE_CYCLE, PROGRESS_INFO_COOLDOWN } from '../constants';
-import type { BlockbookTransaction, MempoolClient, OnProgressInfo } from '../types/backend';
-
-type MempoolStatus = 'stopped' | 'running';
-
-export type MempoolController = Pick<
-    CoinjoinMempoolController,
-    'status' | 'start' | 'stop' | 'init' | 'update' | 'getTransactions' | 'removeTransactions'
->;
+import type {
+    AddressControllerShape,
+    BlockbookTransaction,
+    MempoolClient,
+    MempoolControllerShape,
+    MempoolStatus,
+    OnProgressInfo,
+} from '../types/backend';
 
 type CoinjoinMempoolControllerSettings = {
     client: MempoolClient;
@@ -24,7 +23,7 @@ type CoinjoinMempoolControllerSettings = {
     logger?: Logger;
 };
 
-export class CoinjoinMempoolController {
+export class CoinjoinMempoolController implements MempoolControllerShape {
     private readonly client;
     private readonly network;
     private readonly mempool;
@@ -93,7 +92,7 @@ export class CoinjoinMempoolController {
         }
     }
 
-    async init(addressController?: AddressController, onProgressInfo?: OnProgressInfo) {
+    async init(addressController?: AddressControllerShape, onProgressInfo?: OnProgressInfo) {
         onProgressInfo?.({ stage: 'mempool', activity: 'fetch' });
 
         const filters = await this.client
@@ -193,7 +192,7 @@ export class CoinjoinMempoolController {
         this.lastPurge = now;
     }
 
-    getTransactions(addressController?: AddressController) {
+    getTransactions(addressController?: AddressControllerShape) {
         if (!addressController) return Array.from(this.mempool.values());
 
         const set = new Set<string>();

--- a/packages/coinjoin/src/backend/filters.ts
+++ b/packages/coinjoin/src/backend/filters.ts
@@ -29,7 +29,7 @@ const createFilter = (data: Buffer, { P = P_DEFAULT, M = M_DEFAULT }) => {
 };
 
 export const getAddressScript = (address: string, network: Network) =>
-    addressBjs.toOutputScript(address, network);
+    addressBjs.toOutputScript(address, network) as Buffer;
 
 export const getFilter = (filterHex: string, { P, M, key }: FilterParams = {}) => {
     if (!filterHex) return () => false;

--- a/packages/coinjoin/src/client/Alice.ts
+++ b/packages/coinjoin/src/client/Alice.ts
@@ -1,25 +1,20 @@
 import { AccountUtxo } from '../types/account';
 import {
+    AliceConfirmationInterval,
+    AlicePendingRequest,
+    AliceShape,
+    SerializedAlice,
+} from '../types/alice';
+import {
     AllowedScriptTypes,
     ConfirmationData,
     RealCredentials,
     RegistrationData,
 } from '../types/coordinator';
 import { Credentials } from '../types/middleware';
-import { CoinjoinRequestEvent, SerializedAlice } from '../types/round';
 import { getInputSize, getOutputSize, getWitnessFromSignature } from '../utils/coordinatorUtils';
 
-interface AlicePendingRequest {
-    type: CoinjoinRequestEvent['type'];
-    timestamp: number;
-}
-
-export interface AliceConfirmationInterval {
-    promise: Promise<Alice>;
-    abort: () => void;
-}
-
-export class Alice {
+export class Alice implements AliceShape {
     path: string; // utxo derivation path
     outpoint: string;
     amount: number;

--- a/packages/coinjoin/src/client/CoinjoinPrison.ts
+++ b/packages/coinjoin/src/client/CoinjoinPrison.ts
@@ -2,7 +2,11 @@ import type { ImmediateId, TimerId } from '@trezor/type-utils';
 import { TypedEmitter } from '@trezor/utils';
 
 import { WabiSabiProtocolErrorCode } from '../enums';
-import { CoinjoinPrisonEvents, CoinjoinPrisonInmate } from '../types/client';
+import type {
+    CoinjoinPrisonEvents,
+    CoinjoinPrisonInmate,
+    CoinjoinPrisonShape,
+} from '../types/prison';
 
 export type DetainObject =
     | {
@@ -27,7 +31,10 @@ export interface DetainOptions {
 // Errored or currently registered inputs and addresses are sent here
 // inspiration: WalletWasabi/WabiSabi/Backend/Banning/Prison.cs
 
-export class CoinjoinPrison extends TypedEmitter<CoinjoinPrisonEvents> {
+export class CoinjoinPrison
+    extends TypedEmitter<CoinjoinPrisonEvents>
+    implements CoinjoinPrisonShape
+{
     inmates: CoinjoinPrisonInmate[] = [];
     private changeEventThrottle: ImmediateId | TimerId | undefined;
 

--- a/packages/coinjoin/src/client/CoinjoinRound.ts
+++ b/packages/coinjoin/src/client/CoinjoinRound.ts
@@ -1,19 +1,19 @@
 import { TypedEmitter, arrayDistinct, arrayPartition, scheduleAction } from '@trezor/utils';
-import { Network } from '@trezor/utxo-lib';
 
 import { ACCOUNT_BUSY_TIMEOUT, ROUND_PHASE_PROCESS_TIMEOUT } from '../constants';
 import { EndRoundState, RoundPhase, SessionPhase } from '../enums';
 import { Account } from './Account';
 import { Alice } from './Alice';
-import { CoinjoinPrison } from './CoinjoinPrison';
-import { CoinjoinClientEvents, Logger } from '../types';
+import { Logger } from '../types';
 import { AccountAddress, RegisterAccountParams } from '../types/account';
-import { AffiliationId, CoinjoinRoundParameters, Round } from '../types/coordinator';
+import { CoinjoinRoundParameters, Round } from '../types/coordinator';
+import { CoinjoinPrisonShape } from '../types/prison';
 import {
     BroadcastedTransactionDetails,
     CoinjoinRequestEvent,
     CoinjoinResponseEvent,
     CoinjoinRoundEvent,
+    CoinjoinRoundOptions,
     CoinjoinTransactionData,
     CoinjoinTransactionLiquidityClue,
     SerializedCoinjoinRound,
@@ -29,17 +29,6 @@ import {
     getCommitmentData,
     getRoundParameters,
 } from '../utils/roundUtils';
-
-export interface CoinjoinRoundOptions {
-    network: Network;
-    signal: AbortSignal;
-    coordinatorName: string;
-    coordinatorUrl: string;
-    middlewareUrl: string;
-    logger: Logger;
-    affiliationId?: AffiliationId;
-    setSessionPhase: (event: CoinjoinClientEvents['session-phase']) => void;
-}
 
 interface Events {
     ended: CoinjoinRoundEvent;
@@ -80,7 +69,7 @@ interface CreateRoundProps {
     accounts: Account[];
     statusRounds: Round[];
     coinjoinRounds: CoinjoinRound[];
-    prison: CoinjoinPrison;
+    prison: CoinjoinPrisonShape;
     options: CoinjoinRoundOptions;
     runningAffiliateServer: boolean;
 }
@@ -90,7 +79,7 @@ export class CoinjoinRound extends TypedEmitter<Events> {
     private options: CoinjoinRoundOptions;
     private logger: Logger;
     private signed = false; // set after successful transactionSigning
-    readonly prison: CoinjoinPrison;
+    readonly prison: CoinjoinPrisonShape;
 
     // partial coordinator.Round
     id: string;
@@ -115,7 +104,7 @@ export class CoinjoinRound extends TypedEmitter<Events> {
     broadcastedTxDetails?: BroadcastedTransactionDetails; // transaction broadcasted
     liquidityClues?: CoinjoinTransactionLiquidityClue[]; // updated liquidity clues
 
-    constructor(round: Round, prison: CoinjoinPrison, options: CoinjoinRoundOptions) {
+    constructor(round: Round, prison: CoinjoinPrisonShape, options: CoinjoinRoundOptions) {
         super();
         this.id = round.Id;
         this.blameOf = round.BlameOf;
@@ -172,7 +161,7 @@ export class CoinjoinRound extends TypedEmitter<Events> {
             prison,
             options,
             runningAffiliateServer,
-        });
+        }) as Promise<CoinjoinRound | undefined>;
     }
 
     async onPhaseChange(changed: Round) {

--- a/packages/coinjoin/src/client/analyzeTransactions.ts
+++ b/packages/coinjoin/src/client/analyzeTransactions.ts
@@ -1,15 +1,15 @@
 import { arrayPartition } from '@trezor/utils';
 import { Network, address as addressBjs } from '@trezor/utxo-lib';
 
-import type { CoinjoinClient } from './CoinjoinClient';
 import * as middleware from './middleware';
 import { EnhancedVinVout, Transaction } from '../types/backend';
+import { Logger } from '../types/logger';
 import { AnalyzeExternalVinVout, AnalyzeInternalVinVout } from '../types/middleware';
 
 interface AnalyzeTransactionsOptions {
     network: Network;
     middlewareUrl: string;
-    logger: CoinjoinClient['logger'];
+    logger: Logger;
     signal: AbortSignal;
 }
 

--- a/packages/coinjoin/src/client/round/connectionConfirmation.ts
+++ b/packages/coinjoin/src/client/round/connectionConfirmation.ts
@@ -1,7 +1,7 @@
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
+import type { AliceConfirmationInterval, AliceShape } from '../../types/alice';
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import { readTimeSpan } from '../../utils/roundUtils';
-import type { Alice, AliceConfirmationInterval } from '../Alice';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
 
@@ -17,11 +17,11 @@ import * as middleware from '../middleware';
  */
 
 const confirmInput = async (
-    round: CoinjoinRound,
-    input: Alice,
+    round: CoinjoinRoundShape,
+    input: AliceShape,
     delay: number,
     options: CoinjoinRoundOptions,
-): Promise<Alice> => {
+): Promise<AliceShape> => {
     if (input.error) {
         options.logger.warn(`Trying to confirm input with error ${input.error}`);
         throw input.error;
@@ -105,8 +105,8 @@ const confirmInput = async (
 // to call `/connection-confirmation` in intervals less than connectionConfirmationTimeout * 0.5 to prevent AliceTimeout error on coordinator
 // https://github.com/trezor/WalletWasabi/blob/master/WalletWasabi/WabiSabi/Client/AliceClient.cs
 export const confirmationInterval = (
-    round: CoinjoinRound,
-    input: Alice,
+    round: CoinjoinRoundShape,
+    input: AliceShape,
     options: CoinjoinRoundOptions,
 ): AliceConfirmationInterval => {
     const intervalDelay = Math.floor(
@@ -116,7 +116,7 @@ export const confirmationInterval = (
 
     const controller = new AbortController();
 
-    const promise = new Promise<Alice>(resolve => {
+    const promise = new Promise<AliceShape>(resolve => {
         const { logger } = options;
         const done = () => {
             logger.info(`Confirmation interval for ~~${input.outpoint}~~ completed`);
@@ -184,7 +184,7 @@ export const confirmationInterval = (
 };
 
 export const connectionConfirmation = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     options: CoinjoinRoundOptions,
 ) => {
     // try to confirm each input

--- a/packages/coinjoin/src/client/round/endedRound.ts
+++ b/packages/coinjoin/src/client/round/endedRound.ts
@@ -1,8 +1,8 @@
 import { enumUtils, getWeakRandomNumberInRange } from '@trezor/utils';
 
 import { EndRoundState, WabiSabiProtocolErrorCode } from '../../enums';
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import { getBroadcastedTxDetails } from '../../utils/roundUtils';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 
 /**
  * RoundPhase: 4, Ending
@@ -13,7 +13,7 @@ import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
  * - catch transaction broadcasted
  */
 
-export const ended = (round: CoinjoinRound, { logger, network }: CoinjoinRoundOptions) => {
+export const ended = (round: CoinjoinRoundShape, { logger, network }: CoinjoinRoundOptions) => {
     const { id, endRoundState, inputs, addresses, prison } = round;
     const endRoundKey = enumUtils.getKeyByValue(EndRoundState, round.endRoundState);
     logger.info(`Ending round ~~${round.id}~~. End state: ${endRoundKey}`);

--- a/packages/coinjoin/src/client/round/inputRegistration.ts
+++ b/packages/coinjoin/src/client/round/inputRegistration.ts
@@ -1,12 +1,12 @@
 import { getWeakRandomNumberInRange } from '@trezor/utils';
 
-import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
 import { confirmationInterval } from './connectionConfirmation';
 import { ROUND_SELECTION_REGISTRATION_OFFSET } from '../../constants';
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
-import type { Alice } from '../Alice';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
+import type { AliceShape } from '../../types/alice';
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
+import * as coordinator from '../coordinator';
 
 /**
  * RoundPhase: 0, InputRegistration
@@ -19,10 +19,10 @@ import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
  */
 
 const registerInput = async (
-    round: CoinjoinRound,
-    input: Alice,
+    round: CoinjoinRoundShape,
+    input: AliceShape,
     options: CoinjoinRoundOptions,
-): Promise<Alice> => {
+): Promise<AliceShape> => {
     const { logger } = options;
     if (input.error) {
         logger.warn(`Trying to register input with error ${input.error}`);
@@ -189,7 +189,10 @@ const registerInput = async (
     }
 };
 
-export const inputRegistration = async (round: CoinjoinRound, options: CoinjoinRoundOptions) => {
+export const inputRegistration = async (
+    round: CoinjoinRoundShape,
+    options: CoinjoinRoundOptions,
+) => {
     // try to register each input
     // failed inputs will be excluded from this round, successful will continue to phase: 1 (connectionConfirmation)
     options.logger.info(`inputRegistration: ~~${round.id}~~`);

--- a/packages/coinjoin/src/client/round/outputDecomposition.ts
+++ b/packages/coinjoin/src/client/round/outputDecomposition.ts
@@ -1,9 +1,9 @@
 import { arrayToDictionary, getWeakRandomId } from '@trezor/utils';
 
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import { getExternalOutputSize } from '../../utils/coordinatorUtils';
 import { compareOutpoint, getRoundEvents, sumCredentials } from '../../utils/roundUtils';
 import type { Account } from '../Account';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
 
@@ -15,7 +15,7 @@ import * as middleware from '../middleware';
  */
 
 interface GetOutputAmountsParams {
-    round: CoinjoinRound;
+    round: CoinjoinRoundShape;
     options: CoinjoinRoundOptions;
     accountKey: string;
     availableVsize: number;
@@ -74,7 +74,7 @@ const getOutputAmounts = async (params: GetOutputAmountsParams) => {
 };
 
 interface CredentialIssuanceParams {
-    round: CoinjoinRound;
+    round: CoinjoinRoundShape;
     amountToRequest: [number, number];
     vsizeToRequest: [number, number];
     amountCredentials: [middleware.Credentials, middleware.Credentials];
@@ -256,7 +256,7 @@ export interface Bob {
 }
 
 interface CreateOutputsCredentials {
-    round: CoinjoinRound;
+    round: CoinjoinRoundShape;
     options: CoinjoinRoundOptions;
     accountKey: string;
     outputSize: number;
@@ -397,7 +397,7 @@ export interface DecomposedOutputs {
 }
 
 export const outputDecomposition = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     accounts: Account[],
     options: CoinjoinRoundOptions,
 ): Promise<DecomposedOutputs[]> => {

--- a/packages/coinjoin/src/client/round/outputRegistration.ts
+++ b/packages/coinjoin/src/client/round/outputRegistration.ts
@@ -1,14 +1,14 @@
 import { arrayShuffle, getWeakRandomId, getWeakRandomInt } from '@trezor/utils';
 
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
-import { AccountAddress } from '../../types';
+import type { AccountAddress } from '../../types/account';
+import type { AliceShape } from '../../types/alice';
 import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
 import { Bob, outputDecomposition } from './outputDecomposition';
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import { scheduleDelay } from '../../utils/roundUtils';
 import type { Account } from '../Account';
-import type { Alice } from '../Alice';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 
 /**
  * RoundPhase: 2, OutputRegistration
@@ -21,7 +21,7 @@ import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
  */
 
 const registerOutput = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     { accountKey, changeAddresses }: Account,
     { amountCredentials, vsizeCredentials }: Bob,
     assignedAddresses: AccountAddress[],
@@ -118,8 +118,8 @@ const registerOutput = async (
 };
 
 const readyToSign = (
-    { id, phaseDeadline }: CoinjoinRound,
-    input: Alice,
+    { id, phaseDeadline }: CoinjoinRoundShape,
+    input: AliceShape,
     { signal, coordinatorUrl }: CoinjoinRoundOptions,
 ) =>
     coordinator.readyToSign(id, input.registrationData!.AliceId, !!input.affiliationFlag, {
@@ -131,7 +131,7 @@ const readyToSign = (
     });
 
 export const outputRegistration = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     accounts: Account[],
     options: CoinjoinRoundOptions,
 ) => {

--- a/packages/coinjoin/src/client/round/selectRound.ts
+++ b/packages/coinjoin/src/client/round/selectRound.ts
@@ -2,27 +2,25 @@ import { arrayPartition, arrayToDictionary } from '@trezor/utils';
 
 import { ROUND_SELECTION_MAX_OUTPUTS, ROUND_SELECTION_REGISTRATION_OFFSET } from '../../constants';
 import { RoundPhase, SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
+import type { AliceGenerator, AliceShape } from '../../types/alice';
+import type { CoinjoinPrisonShape } from '../../types/prison';
+import type {
+    CoinjoinRoundGenerator,
+    CoinjoinRoundOptions,
+    CoinjoinRoundShape,
+} from '../../types/round';
 import { getInputSize, getOutputSize } from '../../utils/coordinatorUtils';
 import { Account } from '../Account';
-import { Alice } from '../Alice';
-import { CoinjoinPrison } from '../CoinjoinPrison';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 import { Round } from '../coordinator';
 import * as middleware from '../middleware';
-
-export type CoinjoinRoundGenerator = (
-    ...args: ConstructorParameters<typeof CoinjoinRound>
-) => CoinjoinRound;
-
-export type AliceGenerator = (...args: ConstructorParameters<typeof Alice>) => Alice;
 
 export interface SelectRoundProps {
     roundGenerator: CoinjoinRoundGenerator;
     aliceGenerator: AliceGenerator;
     accounts: Account[];
     statusRounds: Round[];
-    coinjoinRounds: CoinjoinRound[];
-    prison: CoinjoinPrison;
+    coinjoinRounds: CoinjoinRoundShape[];
+    prison: CoinjoinPrisonShape;
     options: CoinjoinRoundOptions;
     runningAffiliateServer: boolean;
 }
@@ -251,7 +249,7 @@ export const getAccountCandidates = ({
 };
 
 interface SelectInputsForRoundProps extends Pick<SelectRoundProps, 'aliceGenerator' | 'options'> {
-    roundCandidates: CoinjoinRound[];
+    roundCandidates: CoinjoinRoundShape[];
     accountCandidates: ReturnType<typeof getAccountCandidates>;
 }
 
@@ -262,7 +260,7 @@ const selectInputsForBlameRound = ({
     options: { logger },
 }: SelectInputsForRoundProps) =>
     roundCandidates.find(round => {
-        const inputs: CoinjoinRound['inputs'] = [];
+        const inputs: AliceShape[] = [];
         accountCandidates.forEach(account => {
             const utxos = account.blameOf ? account.blameOf[round.blameOf] : null;
             if (utxos && utxos.length > 0) {
@@ -451,7 +449,7 @@ export const selectRound = async ({
     prison,
     options,
     runningAffiliateServer,
-}: SelectRoundProps) => {
+}: SelectRoundProps): Promise<CoinjoinRoundShape | undefined> => {
     const { logger, setSessionPhase } = options;
 
     const unregisteredAccounts = getUnregisteredAccounts({ accounts, coinjoinRounds, options });

--- a/packages/coinjoin/src/client/round/transactionSigning.ts
+++ b/packages/coinjoin/src/client/round/transactionSigning.ts
@@ -3,6 +3,8 @@ import { arrayShuffle, getWeakRandomInt } from '@trezor/utils';
 import { TX_SIGNING_DELAY } from '../../constants';
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../enums';
 import { CoinjoinTransactionData } from '../../types';
+import type { AliceShape } from '../../types/alice';
+import type { CoinjoinRoundOptions, CoinjoinRoundShape } from '../../types/round';
 import {
     getAddressFromScriptPubKey,
     mergePubkeys,
@@ -19,13 +21,11 @@ import {
     scheduleDelay,
 } from '../../utils/roundUtils';
 import type { Account } from '../Account';
-import type { Alice } from '../Alice';
-import type { CoinjoinRound, CoinjoinRoundOptions } from '../CoinjoinRound';
 import * as coordinator from '../coordinator';
 import * as middleware from '../middleware';
 
 const getTransactionData = (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     options: CoinjoinRoundOptions,
 ): CoinjoinTransactionData => {
     const registeredInputs = getRoundEvents('InputAdded', round.coinjoinState.Events);
@@ -100,7 +100,7 @@ const getTransactionData = (
 };
 
 const updateRawLiquidityClue = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     accounts: Account[],
     tx: CoinjoinTransactionData,
     options: CoinjoinRoundOptions,
@@ -134,9 +134,9 @@ const updateRawLiquidityClue = async (
 };
 
 const sendTxSignature = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     resolvedTime: number,
-    input: Alice,
+    input: AliceShape,
     { signal, coordinatorUrl, logger }: CoinjoinRoundOptions,
 ) => {
     // if DelayTransactionSigning is set then start sending signatures **after** 50 seconds reduced by time spent on actual signing on the device.
@@ -174,10 +174,10 @@ const sendTxSignature = async (
 };
 
 export const transactionSigning = async (
-    round: CoinjoinRound,
+    round: CoinjoinRoundShape,
     accounts: Account[],
     options: CoinjoinRoundOptions,
-): Promise<CoinjoinRound> => {
+): Promise<CoinjoinRoundShape> => {
     const { logger } = options;
 
     logger.info(`transactionSigning: ~~${round.id}~~`);

--- a/packages/coinjoin/src/types/alice.ts
+++ b/packages/coinjoin/src/types/alice.ts
@@ -1,0 +1,66 @@
+import type { AccountUtxo } from './account';
+import type {
+    AllowedScriptTypes,
+    ConfirmationData,
+    RealCredentials,
+    RegistrationData,
+} from './coordinator';
+import type { Credentials } from './middleware';
+
+export interface AlicePendingRequest {
+    type: 'ownership' | 'signature';
+    timestamp: number;
+}
+
+export interface AliceConfirmationInterval {
+    promise: Promise<AliceShape>;
+    abort: () => void;
+}
+
+// shape of src/client/Alice.ts
+export interface AliceShape {
+    path: string; // utxo derivation path
+    outpoint: string;
+    amount: number;
+    inputSize: number;
+    outputSize: number;
+    accountKey: string; // Account.accountKey
+    scriptType: AllowedScriptTypes; // input scripType
+    requested?: AlicePendingRequest; // pending request sent to wallet (Suite)
+    resolved: AlicePendingRequest[]; // resolved requests received from wallet (Suite)
+    ownershipProof?: string; // data used in inputRegistration phase, received as response to RequestEvent, provided by wallet (Suite)
+    registrationData?: RegistrationData; // data from inputRegistration phase
+    affiliationFlag?: boolean; // affiliation flag is used in /ready-to-sign request **only** when Alice pays coordination fee
+    realAmountCredentials?: RealCredentials; // data from inputRegistration phase
+    realVsizeCredentials?: RealCredentials; // data from inputRegistration phase
+    confirmationInterval?: AliceConfirmationInterval;
+    confirmationData?: ConfirmationData; // data from connectionConfirmation phase
+    confirmedAmountCredentials?: Credentials[]; // data from connectionConfirmation phase
+    confirmedVsizeCredentials?: Credentials[]; // data from connectionConfirmation phase
+    witness?: string; // received as response to RequestEvent, provided by wallet (Suite)
+    witnessIndex?: number; // received as response to RequestEvent, provided by wallet (Suite)
+    error?: Error;
+
+    getConfirmationInterval(): AliceConfirmationInterval | undefined;
+    setConfirmationInterval(interval: AliceConfirmationInterval): void;
+    clearConfirmationInterval(): void;
+    setError(error: Error): void;
+    setConfirmationData(data: ConfirmationData): void;
+    setConfirmedCredentials(amount: Credentials[], vsize: Credentials[]): void;
+    setRegistrationData(data: RegistrationData, flag?: boolean): void;
+    setRealCredentials(amount: RealCredentials, vsize: RealCredentials): void;
+    getResolvedRequest(type: AlicePendingRequest['type']): AlicePendingRequest | undefined;
+}
+
+export type AliceGenerator = (
+    accountKey: string,
+    scriptType: AllowedScriptTypes,
+    utxo: AccountUtxo,
+) => AliceShape;
+
+export interface SerializedAlice {
+    accountKey: string;
+    path: string;
+    outpoint: string;
+    error?: string;
+}

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -9,16 +9,73 @@ import type {
 import type {
     Transaction as BlockbookTransaction,
     FilterResponse,
+    ServerInfo,
     VinVout,
 } from '@trezor/blockchain-link-types/src/blockbook';
 import type { Network } from '@trezor/utxo-lib';
 
-import type { CoinjoinBackendClient } from '../backend/CoinjoinBackendClient';
-import type { FilterController } from '../backend/CoinjoinFilterController';
-import type { MempoolController } from '../backend/CoinjoinMempoolController';
+import type { RequestOptions } from '../utils/http';
 
 export type { BlockbookTransaction, VinVout, EnhancedVinVout };
 export type { Address, Utxo, Transaction, AccountAddresses };
+
+// shape of src/backend/CoinjoinBackendClient.ts
+export interface CoinjoinBackendClientShape {
+    fetchNetworkInfo(options?: RequestOptions): Promise<ServerInfo>;
+    fetchBlock(height: number, options?: RequestOptions): Promise<{ txs: BlockbookTransaction[] }>; // BlockbookBlock
+    fetchBlockFilters(
+        bestKnownBlockHash: string,
+        pageSize: number,
+        options?: RequestOptions,
+    ): Promise<BlockFilterResponse>;
+    fetchMempoolFilters(): Promise<MempoolFilterResponse>;
+    fetchTransaction(txid: string, options?: RequestOptions): Promise<BlockbookTransaction>;
+    subscribeMempoolTxs(
+        listener: (tx: BlockbookTransaction) => void,
+        onDisconnect?: () => void,
+    ): Promise<void>;
+    unsubscribeMempoolTxs(
+        listener: (tx: BlockbookTransaction) => void,
+        onDisconnect?: () => void,
+    ): Promise<void>;
+}
+
+// shape of src/backend/CoinjoinFilterController.ts
+export interface FilterControllerShape {
+    getFilterIterator(
+        params: FilterControllerParams,
+        ctx: FilterControllerContext,
+    ): AsyncGenerator<any, void, unknown>;
+}
+
+// shape of src/backend/CoinjoinAddressController.ts
+export type AddressControllerShape = {
+    readonly receive: PrederivedAddress[];
+    readonly change: PrederivedAddress[];
+    analyze: <T>(
+        getTxs: (address: AccountAddress) => T[],
+        onTxs?: ((txs: T[]) => void) | undefined,
+    ) => {
+        receive: PrederivedAddress[];
+        change: PrederivedAddress[];
+    };
+};
+
+// shape of src/backend/CoinjoinMempoolController.ts
+export type MempoolStatus = 'stopped' | 'running';
+
+export interface MempoolControllerShape {
+    readonly status: MempoolStatus;
+    start(): Promise<void>;
+    stop(): Promise<void>;
+    init(
+        addressController?: AddressControllerShape,
+        onProgressInfo?: OnProgressInfo,
+    ): Promise<BlockbookTransaction[]>;
+    update(force?: boolean): Promise<void>;
+    getTransactions(addressController?: AddressControllerShape): BlockbookTransaction[];
+    removeTransactions(txids: string[]): void;
+}
 
 export type BlockbookBlock = {
     page: number;
@@ -44,11 +101,11 @@ export type MempoolFilterResponse = Partial<FilterResponse> & {
 };
 
 export type ScanAccountContext = {
-    client: CoinjoinBackendClient;
+    client: CoinjoinBackendClientShape;
     network: Network;
     abortSignal?: AbortSignal;
-    filters: FilterController;
-    mempool?: MempoolController;
+    filters: FilterControllerShape;
+    mempool?: MempoolControllerShape;
     onProgress: (progress: ScanAccountProgress) => void;
     onProgressInfo: OnProgressInfo;
 };
@@ -108,10 +165,13 @@ export type FilterControllerContext = {
     onProgressInfo?: OnProgressInfo;
 };
 
-export type FilterClient = Pick<CoinjoinBackendClient, 'fetchNetworkInfo' | 'fetchBlockFilters'>;
+export type FilterClient = Pick<
+    CoinjoinBackendClientShape,
+    'fetchNetworkInfo' | 'fetchBlockFilters'
+>;
 
 export type MempoolClient = Pick<
-    CoinjoinBackendClient,
+    CoinjoinBackendClientShape,
     'fetchMempoolFilters' | 'fetchTransaction' | 'subscribeMempoolTxs' | 'unsubscribeMempoolTxs'
 >;
 

--- a/packages/coinjoin/src/types/client.ts
+++ b/packages/coinjoin/src/types/client.ts
@@ -1,7 +1,7 @@
-import { SessionPhase, WabiSabiProtocolErrorCode } from '../enums';
-import { Round } from './coordinator';
-import { LogEvent } from './logger';
-import { CoinjoinRequestEvent, CoinjoinRoundEvent } from './round';
+import type { Round } from './coordinator';
+import type { LogEvent } from './logger';
+import type { CoinjoinPrisonEvents } from './prison';
+import type { CoinjoinRequestEvent, CoinjoinRoundEvent, SessionPhaseEvent } from './round';
 
 export interface CoinjoinStatusEvent {
     rounds: Round[];
@@ -29,23 +29,5 @@ export interface CoinjoinClientEvents {
     round: CoinjoinRoundEvent;
     request: CoinjoinRequestEvent[];
     log: LogEvent;
-    'session-phase': {
-        phase: SessionPhase;
-        accountKeys: string[];
-    };
-}
-
-export interface CoinjoinPrisonEvents {
-    change: { prison: CoinjoinPrisonInmate[] };
-}
-
-export interface CoinjoinPrisonInmate {
-    type: 'input' | 'output' | 'account';
-    accountKey: string;
-    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey or Account key
-    sentenceStart: number;
-    sentenceEnd: number;
-    errorCode?: WabiSabiProtocolErrorCode | 'blameOf';
-    reason?: string;
-    roundId?: string;
+    'session-phase': SessionPhaseEvent;
 }

--- a/packages/coinjoin/src/types/index.ts
+++ b/packages/coinjoin/src/types/index.ts
@@ -1,5 +1,5 @@
-import { CoinjoinPrisonInmate } from './client';
-import { AffiliationId } from './coordinator';
+import type { AffiliationId } from './coordinator';
+import type { CoinjoinPrisonInmate } from './prison';
 
 interface BaseSettings {
     network: 'btc' | 'test' | 'regtest';
@@ -26,6 +26,8 @@ export interface CoinjoinClientSettings extends BaseSettings {
 export type { ScanAccountProgress, ScanAccountCheckpoint, ScanProgressInfo } from './backend';
 
 export * from './account';
+export * from './alice';
 export * from './client';
+export * from './prison';
 export * from './round';
 export * from './logger';

--- a/packages/coinjoin/src/types/prison.ts
+++ b/packages/coinjoin/src/types/prison.ts
@@ -1,0 +1,48 @@
+import type { WabiSabiProtocolErrorCode } from '../enums';
+
+export interface CoinjoinPrisonEvents {
+    change: { prison: CoinjoinPrisonInmate[] };
+}
+
+export interface CoinjoinPrisonInmate {
+    type: 'input' | 'output' | 'account';
+    accountKey: string;
+    id: string; // AccountUtxo/Alice.outpoint or AccountAddress scriptPubKey or Account key
+    sentenceStart: number;
+    sentenceEnd: number;
+    errorCode?: WabiSabiProtocolErrorCode | 'blameOf';
+    reason?: string;
+    roundId?: string;
+}
+
+export type DetainObject =
+    | {
+          outpoint: string;
+          accountKey: string;
+      }
+    | {
+          address: string;
+          accountKey: string;
+      }
+    | {
+          accountKey: string;
+      };
+
+export interface DetainOptions {
+    roundId?: string;
+    errorCode?: CoinjoinPrisonInmate['errorCode'];
+    reason?: CoinjoinPrisonInmate['reason'];
+    sentenceEnd?: number;
+}
+
+// shape if src/client/CoinjoinPrison.ts
+export interface CoinjoinPrisonShape {
+    inmates: CoinjoinPrisonInmate[];
+    detain(inmate: DetainObject, options?: DetainOptions): void;
+    isDetained(inmate: string | DetainObject): CoinjoinPrisonInmate | undefined;
+    detainForBlameRound(inmates: DetainObject[], roundId: string): void;
+    getBlameOfInmates(): CoinjoinPrisonInmate[];
+    releaseBlameOfInmates(roundId: string): void;
+    releaseRegisteredInmates(roundId: string): void;
+    release(rounds: string[]): void;
+}

--- a/packages/coinjoin/src/types/round.ts
+++ b/packages/coinjoin/src/types/round.ts
@@ -1,14 +1,69 @@
-import { AccountAddress } from './account';
-import { CoinjoinAffiliateRequest } from './coordinator';
-import { RawLiquidityClue } from './middleware';
-import { EndRoundState, RoundPhase } from '../enums';
+import type { Network } from '@trezor/utxo-lib';
 
-export interface SerializedAlice {
-    accountKey: string;
-    path: string;
-    outpoint: string;
-    error?: string;
+import type { AccountAddress } from './account';
+import type { AliceShape, SerializedAlice } from './alice';
+import type {
+    AffiliationId,
+    CoinjoinAffiliateRequest,
+    CoinjoinRoundParameters,
+    Round,
+} from './coordinator';
+import type { Logger } from './logger';
+import type { RawLiquidityClue } from './middleware';
+import type { CoinjoinPrisonShape } from './prison';
+import type { EndRoundState, RoundPhase, SessionPhase } from '../enums';
+
+export type SessionPhaseEvent = {
+    phase: SessionPhase;
+    accountKeys: string[];
+};
+
+export interface CoinjoinRoundOptions {
+    network: Network;
+    signal: AbortSignal;
+    coordinatorName: string;
+    coordinatorUrl: string;
+    middlewareUrl: string;
+    logger: Logger;
+    affiliationId?: AffiliationId;
+    setSessionPhase: (event: SessionPhaseEvent) => void;
 }
+
+// shape if src/client/CoinjoinRound.ts
+export interface CoinjoinRoundShape {
+    readonly prison: CoinjoinPrisonShape;
+    id: string;
+    blameOf: string;
+    phase: RoundPhase;
+    endRoundState: EndRoundState;
+    coinjoinState: Round['CoinjoinState'];
+    inputRegistrationEnd: string;
+    amountCredentialIssuerParameters: Round['AmountCredentialIssuerParameters'];
+    vsizeCredentialIssuerParameters: Round['VsizeCredentialIssuerParameters'];
+    affiliateRequest: Round['AffiliateRequest'];
+
+    roundParameters: CoinjoinRoundParameters;
+    inputs: AliceShape[]; // list of registered inputs
+    failed: AliceShape[]; // list of failed inputs
+    phaseDeadline: number; // deadline is inaccurate, phase may change earlier
+    roundDeadline: number; // deadline is inaccurate,round may end earlier
+    commitmentData: string; // commitment data used for ownership proof and witness requests
+    addresses: (AccountAddress & { accountKey: string })[]; // list of addresses (outputs) used in this round in outputRegistration phase
+    transactionSignTries: number[]; // timestamps for processing transactionSigning phase
+    transactionData?: CoinjoinTransactionData; // transaction to sign
+    broadcastedTxDetails?: BroadcastedTransactionDetails; // transaction broadcasted
+    liquidityClues?: CoinjoinTransactionLiquidityClue[]; // updated liquidity clues
+
+    setSessionPhase(phase: SessionPhase): void;
+    signedSuccessfully(): void;
+    isSignedSuccessfully(): boolean;
+}
+
+export type CoinjoinRoundGenerator = (
+    round: Round,
+    prison: CoinjoinPrisonShape,
+    options: CoinjoinRoundOptions,
+) => CoinjoinRoundShape;
 
 export interface SerializedCoinjoinRound {
     id: string;

--- a/packages/coinjoin/tests/client/selectRound.test.ts
+++ b/packages/coinjoin/tests/client/selectRound.test.ts
@@ -2,8 +2,6 @@ import { Alice } from '../../src/client/Alice';
 import { CoinjoinPrison } from '../../src/client/CoinjoinPrison';
 import { CoinjoinRound } from '../../src/client/CoinjoinRound';
 import {
-    AliceGenerator,
-    CoinjoinRoundGenerator,
     getAccountCandidates,
     getRoundCandidates,
     getUnregisteredAccounts,
@@ -12,6 +10,8 @@ import {
 } from '../../src/client/round/selectRound';
 import { ROUND_SELECTION_MAX_OUTPUTS } from '../../src/constants';
 import { SessionPhase, WabiSabiProtocolErrorCode } from '../../src/enums';
+import { AliceGenerator } from '../../src/types/alice';
+import { CoinjoinRoundGenerator } from '../../src/types/round';
 import {
     DEFAULT_ROUND,
     ROUND_CREATION_EVENT,

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -1,10 +1,6 @@
 
 
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
-packages/coinjoin/src/backend/CoinjoinAddressController.ts > packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts > packages/coinjoin/src/backend/CoinjoinWebsocketController.ts
-packages/coinjoin/src/backend/backendUtils.ts > packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
 packages/coinjoin/src/client/CoinjoinClient.ts > packages/coinjoin/src/client/analyzeTransactions.ts
 packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/connectionConfirmation.ts
 packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/endedRound.ts
@@ -13,10 +9,6 @@ packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/rou
 packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/outputRegistration.ts > packages/coinjoin/src/client/round/outputDecomposition.ts
 packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/selectRound.ts
 packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/transactionSigning.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinBackendClient.ts > packages/coinjoin/src/backend/CoinjoinWebsocketController.ts > packages/coinjoin/src/types/index.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinFilterController.ts
-packages/coinjoin/src/types/backend.ts > packages/coinjoin/src/backend/CoinjoinMempoolController.ts
 packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -1,14 +1,6 @@
 
 
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
-packages/coinjoin/src/client/CoinjoinClient.ts > packages/coinjoin/src/client/analyzeTransactions.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/connectionConfirmation.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/endedRound.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/inputRegistration.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/outputRegistration.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/outputRegistration.ts > packages/coinjoin/src/client/round/outputDecomposition.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/selectRound.ts
-packages/coinjoin/src/client/CoinjoinRound.ts > packages/coinjoin/src/client/round/transactionSigning.ts
 packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
resolve circular imports in coinjoin package, followup to https://github.com/trezor/trezor-suite/pull/25856

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/cj-circular-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/cj-circular-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:49:43.000Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T14:48:41.720Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->