### PR TITLE
Abstract method cleanup

### DIFF
--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -38,10 +38,15 @@ export type MethodInfo = {
     confirmation?: UiRequestConfirmation['payload'];
 };
 
+export type MethodContext = {
+    postMessage: (message: CoreEventMessage) => void;
+    createUiPromise: UiPromiseCreator;
+};
+
 export type MethodMessage<Name extends CallMethodPayload['method']> = {
     id?: number;
     payload: Payload<Name>;
-};
+} & MethodContext;
 
 export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
     UNKNOWN: { min: '1.0.0', max: '0' },
@@ -158,9 +163,8 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     public getButtonRequestData?(code: string, name?: string): UiRequestButtonData | undefined;
 
     // callbacks
-    // @ts-expect-error: strictPropertyInitialization
     public postMessage: (message: CoreEventMessage) => void;
-    // @ts-expect-error: strictPropertyInitialization
+
     public createUiPromise: UiPromiseCreator;
 
     public initAsync?(): Promise<void>;
@@ -170,6 +174,8 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.name = payload.method;
         this.payload = payload;
         this.responseID = message.id || 0;
+        this.postMessage = message.postMessage;
+        this.createUiPromise = message.createUiPromise;
         this.deviceState = validateDeviceState(payload.device);
         this.keepSession = typeof payload.keepSession === 'boolean' ? payload.keepSession : false;
         this.skipFinalReload = true;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -174,11 +174,11 @@ const onCall = async (context: CoreContext, message: CoreCallMessage) => {
     try {
         method = await methodSynchronize(async () => {
             _log.debug('loading method...');
-            const method2 = await getMethod(message);
+            const method2 = await getMethod(message, {
+                postMessage: sendCoreMessage,
+                createUiPromise: uiPromises.create,
+            });
             _log.debug('method selected', method2.name);
-            // bind callbacks
-            method2.postMessage = sendCoreMessage;
-            method2.createUiPromise = uiPromises.create;
             // start validation process
             method2.init();
             await method2.initAsync?.();

--- a/packages/connect/src/core/method.native.ts
+++ b/packages/connect/src/core/method.native.ts
@@ -4,6 +4,7 @@ import * as Methods from '../api';
 import type { ModuleName } from '../constants/network';
 import { MODULES } from '../constants/network';
 import type { CoreCallMessage } from '../events';
+import type { MethodContext } from './AbstractMethod';
 
 const moduleMethods = {
     cardano: require('../api/cardano/api'),
@@ -20,7 +21,7 @@ const getMethodModule = (method: CoreCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
 // eslint-disable-next-line require-await
-export const getMethod = async (message: CoreCallMessage) => {
+export const getMethod = async (message: CoreCallMessage, context: MethodContext) => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');
@@ -31,7 +32,7 @@ export const getMethod = async (message: CoreCallMessage) => {
     const MethodConstructor = methods[method];
 
     if (MethodConstructor) {
-        return new MethodConstructor(message as any);
+        return new MethodConstructor({ ...message, ...context } as any);
     }
 
     throw TypedError('Method_InvalidParameter', `Method ${method} not found`);

--- a/packages/connect/src/core/method.ts
+++ b/packages/connect/src/core/method.ts
@@ -3,12 +3,15 @@ import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import * as Methods from '../api';
 import { MODULES } from '../constants/network';
 import type { CoreCallMessage } from '../events';
-import type { AbstractMethod } from './AbstractMethod';
+import type { AbstractMethod, MethodContext } from './AbstractMethod';
 
 const getMethodModule = (method: CoreCallMessage['payload']['method']) =>
     MODULES.find(module => method.startsWith(module));
 
-export const getMethod = async (message: CoreCallMessage): Promise<AbstractMethod<any>> => {
+export const getMethod = async (
+    message: CoreCallMessage,
+    context: MethodContext,
+): Promise<AbstractMethod<any>> => {
     const { method } = message.payload;
     if (typeof method !== 'string') {
         throw TypedError('Method_InvalidParameter', 'Message method is not set');
@@ -23,7 +26,7 @@ export const getMethod = async (message: CoreCallMessage): Promise<AbstractMetho
     const MethodConstructor = methods[method];
 
     if (MethodConstructor) {
-        return new MethodConstructor(message);
+        return new MethodConstructor({ ...message, ...context });
     }
 
     throw TypedError('Method_InvalidParameter', `Method ${method} not found`);


### PR DESCRIPTION
# TLDR 

solves last 2 of 3 ts supressions metioned in https://github.com/trezor/trezor-suite/issues/5306

# Remove @ts-expect-error suppressions in AbstractMethod

## Summary
Refactored `AbstractMethod` to eliminate TypeScript suppressions for `postMessage` and `createUiPromise` using constructor-based dependency injection instead of definite assignment assertions.

## Changes
- **core/index.ts**: Pass callbacks via `getMethod()` instead of monkey-patching

## Result
✅ Type-safe, no suppressions needed  
✅ Zero breaking changes  
✅ Type-check passes cleanly

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=abstract-method-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=abstract-method-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=abstract-method-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:25:31.679Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:49:56.819Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->