### PR TITLE
chore(ci): upgrade version actions for node v24

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/build-analytics-docs.yml
+++ b/.github/workflows/build-analytics-docs.yml
@@ -31,7 +31,7 @@ jobs:
           aws-region: eu-central-1
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -46,7 +46,7 @@ jobs:
           lfs: true
           submodules: true
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -100,7 +100,7 @@ jobs:
           lfs: true
           submodules: true
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/build-node-bridge.yml
+++ b/.github/workflows/build-node-bridge.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/build-storybook-native.yml
+++ b/.github/workflows/build-storybook-native.yml
@@ -27,19 +27,19 @@ jobs:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
           aws-region: eu-central-1
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -27,7 +27,7 @@ jobs:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_trezor_suite_dev_deploy
           aws-region: eu-central-1
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/build-suite-desktop-e2e.yml
+++ b/.github/workflows/build-suite-desktop-e2e.yml
@@ -14,13 +14,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "Selected platform: ${{ github.event.inputs.PLATFORM }}"
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -39,7 +39,7 @@ jobs:
       actions: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/build-suite-web-e2e.yml
+++ b/.github/workflows/build-suite-web-e2e.yml
@@ -35,13 +35,13 @@ jobs:
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/build-suite-web.yml
+++ b/.github/workflows/build-suite-web.yml
@@ -52,7 +52,7 @@ jobs:
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -21,14 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: Yarn Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
@@ -70,7 +70,7 @@ jobs:
         uses: ./.github/actions/minimal-yarn-install
 
       - name: ESlint Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             **/.eslintcache

--- a/.github/workflows/check-test-health.yml
+++ b/.github/workflows/check-test-health.yml
@@ -35,13 +35,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/chore-purge-android-e2e-build.yml
+++ b/.github/workflows/chore-purge-android-e2e-build.yml
@@ -22,13 +22,13 @@ jobs:
           submodules: "true"
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}

--- a/.github/workflows/release-connect-bump-versions.yml
+++ b/.github/workflows/release-connect-bump-versions.yml
@@ -39,7 +39,7 @@ jobs:
           submodules: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-init.yml
+++ b/.github/workflows/release-connect-init.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.inputs.commit_sha }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-v10-production.yml
+++ b/.github/workflows/release-connect-v10-production.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-v10-staging.yml
+++ b/.github/workflows/release-connect-v10-staging.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -55,7 +55,7 @@ jobs:
           ref: release/connect/${{  needs.extract-version.outputs.version }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -84,7 +84,7 @@ jobs:
           ref: release/connect/${{  needs.extract-version.outputs.version }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-v9-production.yml
+++ b/.github/workflows/release-connect-v9-production.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-connect-v9-staging.yml
+++ b/.github/workflows/release-connect-v9-staging.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -55,7 +55,7 @@ jobs:
           ref: release/connect/${{  needs.extract-version.outputs.version }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -84,7 +84,7 @@ jobs:
           ref: release/connect/${{  needs.extract-version.outputs.version }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -58,7 +58,7 @@ jobs:
           lfs: true
           submodules: recursive
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -180,7 +180,7 @@ jobs:
           role-to-assume: arn:aws:iam::538326561891:role/gh_actions_suite_production
           aws-region: eu-central-1
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
@@ -234,7 +234,7 @@ jobs:
           lfs: true
           submodules: recursive
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -24,7 +24,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -31,7 +31,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
@@ -61,7 +61,7 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
@@ -92,7 +92,7 @@ jobs:
       EXPO_PUBLIC_ENVIRONMENT: production
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/suite-native-monthly-version-bump.yml
+++ b/.github/workflows/suite-native-monthly-version-bump.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
 
       - name: Set Version Variable
         run: |

--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           submodules: true
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -55,7 +55,7 @@ jobs:
           large-packages: false
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/template-suite-native-prepare-test-app-android.yml
+++ b/.github/workflows/template-suite-native-prepare-test-app-android.yml
@@ -33,13 +33,13 @@ jobs:
           large-packages: false
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/template-suite-run-e2e.yml
+++ b/.github/workflows/template-suite-run-e2e.yml
@@ -106,13 +106,13 @@ jobs:
           echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}
@@ -121,7 +121,7 @@ jobs:
       - name: Cache Playwright Browsers
         id: playwright-cache
         if: inputs.target == 'web'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test-blockchain-link.yml
+++ b/.github/workflows/test-blockchain-link.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           submodules: true
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -27,7 +27,7 @@ jobs:
           submodules: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -57,7 +57,7 @@ jobs:
           submodules: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -67,7 +67,7 @@ jobs:
           submodules: recursive
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -116,7 +116,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/test-request-manager.yml
+++ b/.github/workflows/test-request-manager.yml
@@ -26,7 +26,7 @@ jobs:
           lfs: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/test-suite-desktop-e2e-pr.yml
+++ b/.github/workflows/test-suite-desktop-e2e-pr.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
       - name: Generate GitHub App token

--- a/.github/workflows/test-suite-manual-release.yml
+++ b/.github/workflows/test-suite-manual-release.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/test-suite-native-e2e-ios.yml
+++ b/.github/workflows/test-suite-native-e2e-ios.yml
@@ -38,13 +38,13 @@ jobs:
           submodules: "true"
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Setup node_modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}
@@ -71,14 +71,14 @@ jobs:
         run: yarn sign-config
 
       - name: Cache CocoaPods
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: suite-native/app/ios/Pods
           key: pods-${{ hashFiles('suite-native/app/ios/Podfile.lock') }}
           restore-keys: pods-
 
       - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: suite-native/app/ios/build
           key: xcode-derived-${{ hashFiles('suite-native/app/ios/Podfile.lock') }}-${{ github.sha }}
@@ -109,13 +109,13 @@ jobs:
           submodules: "true"
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Load node modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}
@@ -155,7 +155,7 @@ jobs:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
 
       - name: Cache Detox framework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Detox
           key: detox-framework-${{ hashFiles('**/node_modules/detox/package.json') }}

--- a/.github/workflows/test-suite-native-e2e-manual-reporter.yml
+++ b/.github/workflows/test-suite-native-e2e-manual-reporter.yml
@@ -32,13 +32,13 @@ jobs:
           submodules: "true"
 
       - name: Install node and yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn
 
       - name: Load node modules cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node_modules/${{ github.ref }}/${{github.run_id}}

--- a/.github/workflows/test-suite-web-e2e-pr.yml
+++ b/.github/workflows/test-suite-web-e2e-pr.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
       - name: Generate GitHub App token

--- a/.github/workflows/test-transport.yml
+++ b/.github/workflows/test-transport.yml
@@ -36,7 +36,7 @@ jobs:
           submodules: true
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 
@@ -77,7 +77,7 @@ jobs:
           ref: ${{ needs.extract-branch.outputs.branch }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{github.event.after}}
           fetch-depth: 2
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           cache: yarn

--- a/.github/workflows/test-urls.yml
+++ b/.github/workflows/test-urls.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/update-tor.yml
+++ b/.github/workflows/update-tor.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I saw this warning on our CI about actions compatibility with node 24. This PR adressess it.

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/setup-node@v4, nrwl/nx-set-shas@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/upgrade-actions-versions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/upgrade-actions-versions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/upgrade-actions-versions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T16:37:59.310Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T16:36:31.228Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->