### PR TITLE
Connect circulars

### DIFF
--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -11,6 +11,7 @@ import {
     uploadFirmware,
 } from '../api/firmware';
 import { PROTO } from '../constants';
+import { DataManager } from '../data/DataManager';
 import { getFirmwareLocation, getReleaseByVersion } from '../data/firmwareInfo';
 import type { Device } from '../device/Device';
 import { DeviceList } from '../device/DeviceList';
@@ -494,7 +495,10 @@ export const onCallFirmwareUpdate = async ({
     // We have completed binary download, and we should notify sending an event,
     // if desktop wants to store it. We only do this for final FW, not intermediaries.
     // We also check if `BinaryInfo.release` is present, otherwise it is custom FW, not to store.
-    if (isFirmwareCacheUsedForSelectedSource() && finalBinaryInfo.release) {
+    if (
+        isFirmwareCacheUsedForSelectedSource(DataManager.getSettings('firmwareChannel')) &&
+        finalBinaryInfo.release
+    ) {
         const message = createUiMessage(UI_REQUEST.FIRMWARE_DOWNLOADED, {
             binary: finalBinaryInfo.binary,
             binaryVersion: finalBinaryInfo.binaryVersion,

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -236,7 +236,10 @@ export const getReleaseByVersion = async (
     const releaseName = buildLocalReleaseName(firmwareType, deviceModel, firmwareVersion);
 
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (isFirmwareCacheUsedForSelectedSource() && firmwareList.includes(releaseName)) {
+    if (
+        isFirmwareCacheUsedForSelectedSource(DataManager.getSettings('firmwareChannel')) &&
+        firmwareList.includes(releaseName)
+    ) {
         const localReleasePath = `${firmwareDir}${releaseName}`;
         const localReleaseBuffer = await httpRequest(localReleasePath, 'json');
 
@@ -694,7 +697,10 @@ export const getFirmwareLocation = ({
     }
 
     const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
-    if (isFirmwareCacheUsedForSelectedSource() && firmwareList.includes(firmwareName)) {
+    if (
+        isFirmwareCacheUsedForSelectedSource(DataManager.getSettings('firmwareChannel')) &&
+        firmwareList.includes(firmwareName)
+    ) {
         return {
             baseUrl: firmwareDir,
             path: firmwareName,

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -15,8 +15,9 @@ import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from './DataManager';
-import { Features, StrictFeatures } from '../types/device';
+import type { Features, StrictFeatures } from '../types/device';
 import { FirmwareChannel, FirmwareReleaseConfigInfo } from '../types/firmware';
+import type { CurrentVersion } from '../types/firmware';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
 import {
@@ -356,10 +357,7 @@ export const getLanguage = (languageBinPath: string) => {
     return httpRequest(url, 'binary');
 };
 
-export type CurrentVersion = {
-    bootloaderVersion: VersionArray | null;
-    firmwareVersion: VersionArray | null;
-};
+export type { CurrentVersion } from '../types/firmware';
 
 const getCurrentVersion = (features: Features): CurrentVersion => {
     if (!isStrictFeatures(features)) {

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -5,10 +5,10 @@ import { MessagesSchema as Messages } from '@trezor/protobuf';
 
 import { PROTO } from '../constants';
 import { getBech32Network, getSegwitNetwork } from '../data/coinInfo';
-import type { TypedCallProvider } from '../device/DeviceCurrentSession';
 import { resolveDescriptorForTaproot } from '../device/resolveDescriptorForTaproot';
 import type { HDNodeResponse } from '../types/api/getPublicKey';
 import type { BitcoinNetworkInfo, CoinInfo, Network } from '../types/coinInfo';
+import type { TypedCallProvider } from '../types/typed-call-provider';
 import * as hdnodeUtils from '../utils/hdnodeUtils';
 import { getScriptType, getSerializedPath, isTaprootPath } from '../utils/pathUtils';
 

--- a/packages/connect/src/types/firmware.ts
+++ b/packages/connect/src/types/firmware.ts
@@ -56,3 +56,8 @@ export type FirmwareChannel =
     | 'test-signed'
     | 'localhost-unsigned'
     | 'localhost-signed';
+
+export type CurrentVersion = {
+    bootloaderVersion: VersionArray | null;
+    firmwareVersion: VersionArray | null;
+};

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -3,9 +3,8 @@ import type { DeviceModelInternal, FirmwareRelease } from '@trezor/device-utils'
 import { versionUtils } from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
-import { DataManager } from '../data/DataManager';
 import type { Features, StrictFeatures } from '../types/device';
-import type { CurrentVersion } from '../types/firmware';
+import type { CurrentVersion, FirmwareChannel } from '../types/firmware';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>
     [1, 2].includes(extFeatures.major_version) &&
@@ -134,5 +133,5 @@ export const getFirmwareType = (features: Features) => {
     return type;
 };
 
-export const isFirmwareCacheUsedForSelectedSource = () =>
-    DataManager.getSettings('firmwareChannel') === 'production';
+export const isFirmwareCacheUsedForSelectedSource = (firmwareChannel?: FirmwareChannel) =>
+    firmwareChannel === 'production';

--- a/packages/connect/src/utils/firmwareUtils.ts
+++ b/packages/connect/src/utils/firmwareUtils.ts
@@ -4,8 +4,8 @@ import { versionUtils } from '@trezor/utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from '../data/DataManager';
-import type { CurrentVersion } from '../data/firmwareInfo';
 import type { Features, StrictFeatures } from '../types/device';
+import type { CurrentVersion } from '../types/firmware';
 
 export const isStrictFeatures = (extFeatures: Features): extFeatures is StrictFeatures =>
     [1, 2].includes(extFeatures.major_version) &&

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -3,7 +3,6 @@
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
 packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
-packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -5,7 +5,7 @@ packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
 packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCommands.ts > packages/connect/src/device/DeviceCurrentSession.ts
+packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts > packages/connect/src/device/thp/thpCall.ts

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -4,7 +4,6 @@ packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/sr
 packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
-packages/connect/src/data/firmwareInfo.ts > packages/connect/src/utils/firmwareUtils.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts
 packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

https://github.com/trezor/trezor-suite/issues/23850

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-circulars&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-circulars&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-circulars&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:08:15.668Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:08:43.747Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->