### PR TITLE
fix(e2e): standardize @connect-permissions-modal/app-name wait timeou…

### DIFF
--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -58,7 +58,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
 
             const connectPermissionsModal = new ConnectPermissionsModal(suite);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await connectPermissionsModal.confirmButton.click();
 
@@ -105,7 +105,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             ]);
             const modal1 = new ConnectPermissionsModal(suite1);
             await expect(modal1.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await modal1.cancelButton.click();
 
@@ -151,7 +151,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             ]);
             const connectPermissionsModal = new ConnectPermissionsModal(suite);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await connectPermissionsModal.confirmButton.click();
 
@@ -196,7 +196,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             ]);
             const connectPermissionsModal = new ConnectPermissionsModal(suite);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
 
             // Close the browser popup window directly (simulates user clicking X)
@@ -231,7 +231,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             ]);
             const modal1 = new ConnectPermissionsModal(suite1);
             await expect(modal1.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await suite1.close();
 
@@ -245,7 +245,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             ]);
             const modal2 = new ConnectPermissionsModal(suite2);
             await expect(modal2.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await modal2.confirmButton.click();
             await suite2.getByTestId('@connect-address-confirmation/confirm-button').click();
@@ -281,7 +281,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             // click until message is sent back so that submit button becomes active again
             const connectPermissionsModal = new ConnectPermissionsModal(popup1);
             await expect(connectPermissionsModal.appName).toHaveText('Trezor Connect Explorer', {
-                timeout: 15_000,
+                timeout: 20_000,
             });
             await connectPermissionsModal.confirmButton.click();
 


### PR DESCRIPTION
…t to 20s

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unify-test-timeouts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unify-test-timeouts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:46:10.776Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T17:44:36.138Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->