### PR TITLE
all connect circulars are now gone

### DIFF
--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -6,14 +6,14 @@ import { TRANSPORT } from '@trezor/transport';
 import { isWithinRange } from '@trezor/utils/src/versionUtils';
 
 import { PROTO } from '../../constants';
-import type { Device } from '../../device/Device';
 import type { TypedCall } from '../../device/DeviceCommands';
 import { CoreEventMessage, DEVICE, UI_REQUEST, createUiMessage } from '../../events';
 import { FirmwareUpdateFlowType } from '../../types';
+import type { IDevice } from '../../types/idevice';
 
 // Each FW update flow starts with confirmation to restart into bootloader, and in some cases a confirmation for the FW
 // update itself. But device sends no ButtonRequest at that point, so create a synthethic ButtonRequest.
-const postConfirmationMessage = (device: Device, updateFlowType: FirmwareUpdateFlowType) => {
+const postConfirmationMessage = (device: IDevice, updateFlowType: FirmwareUpdateFlowType) => {
     // Device does not require confirmation if fresh install, or if the flow is 'reboot_and_upgrade'.
     const freshInstall = device.features.firmware_present === false;
     if (freshInstall || updateFlowType === 'reboot_and_upgrade') return;
@@ -22,7 +22,7 @@ const postConfirmationMessage = (device: Device, updateFlowType: FirmwareUpdateF
 };
 
 const postProgressMessage = (
-    device: Device,
+    device: IDevice,
     progress: number,
     postMessage: (message: CoreEventMessage) => void,
 ) => {
@@ -42,7 +42,7 @@ const TIMEOUT_MAX_FW_VERSION = '1.13.0';
 type UploadFirmwareProps = {
     typedCall: TypedCall;
     postMessage: (message: CoreEventMessage) => void;
-    device: Device;
+    device: IDevice;
     firmwareUploadRequest: PROTO.FirmwareUpload;
     updateFlowType: FirmwareUpdateFlowType;
 };

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -7,7 +7,7 @@ import { Log } from '@trezor/utils';
 import * as mockFwHash from '../../api/firmware/calculateFirmwareHash';
 import { DataManager } from '../../data/DataManager';
 import { parseConnectSettings } from '../../data/connectSettings';
-import { getBundledRelease } from '../../data/firmwareInfo';
+import { getBundledRelease, initializeFirmwareConfig } from '../../data/firmwareInfo';
 import { DeviceList } from '../../device/DeviceList';
 // mocks
 import * as mockAssets from '../../utils/assets';
@@ -232,7 +232,7 @@ const setupTest = () => {
 
 describe('onCallFirmwareUpdate', () => {
     beforeAll(async () => {
-        await DataManager.load(parseConnectSettings({}), true, true);
+        await DataManager.load(parseConnectSettings({}), true, true, initializeFirmwareConfig);
     });
     beforeEach(() => {
         if (!ASSETS_BASE_URL) {

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -11,6 +11,7 @@ import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { DataManager } from '../data/DataManager';
 import { parseLocalFirmwares } from '../data/connectSettings';
+import { initializeFirmwareConfig } from '../data/firmwareInfo';
 import type { Device, DeviceEvents } from '../device/Device';
 import { DeviceList, IDeviceList, assertDeviceListConnected } from '../device/DeviceList';
 import * as workflows from '../device/workflow';
@@ -871,7 +872,7 @@ export class Core extends EventEmitter {
             throttlePromise.promise.then(() => onCoreEvent(message));
 
         try {
-            await DataManager.load(settings);
+            await DataManager.load(settings, true, false, initializeFirmwareConfig);
             const localFirmwares =
                 settings.localFirmwares && parseLocalFirmwares(settings.localFirmwares);
             if (localFirmwares) {

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -13,12 +13,19 @@ import {
 import messages from '@trezor/protobuf/messages.json';
 
 import { parseCoinsJson } from './coinInfo';
-import { initializeFirmwareConfig } from './firmwareInfo';
 import type { ConnectSettings, LocalFirmwares } from '../types/settings';
 import {
     getFirmwareReleaseConfig,
     getOnlyLocalFirmwareReleaseConfig,
 } from '../utils/firmwareReleaseConfigUtils';
+
+export type InitializeFirmwareConfig = (
+    config: FirmwareReleaseConfig,
+    isRemote: boolean,
+) => Promise<{
+    releases: ReleasesConfig;
+    intermediaries: Record<DeviceModelInternal, IntermediaryReleaseConfig[]>;
+}>;
 
 type AssetKeys = `firmware-${string}` | 'coins' | 'coinsEth';
 type AssetCollection = {
@@ -40,12 +47,17 @@ export class DataManager {
         | Record<keyof typeof DeviceModelInternal, IntermediaryReleaseConfig[]>
         | undefined;
     private static localFirmwareReleaseConfig: FirmwareReleaseConfig;
+    private static initializeFirmwareConfig: InitializeFirmwareConfig;
 
     public static async load(
         settings: ConnectSettings,
         withAssets = true,
         onlyLocalFirmwareConfig = false,
+        initializeFirmwareConfig?: InitializeFirmwareConfig,
     ) {
+        if (initializeFirmwareConfig) {
+            this.initializeFirmwareConfig = initializeFirmwareConfig;
+        }
         this.settings = settings;
 
         if (!withAssets) return;
@@ -79,10 +91,10 @@ export class DataManager {
                 isRemote: false,
             };
         } else {
-            firmwareReleaseConfig = await getFirmwareReleaseConfig();
+            firmwareReleaseConfig = await getFirmwareReleaseConfig(this.settings?.firmwareChannel);
         }
         const { config, isRemote } = firmwareReleaseConfig;
-        const firmwareConfig = await initializeFirmwareConfig(config, isRemote);
+        const firmwareConfig = await this.initializeFirmwareConfig(config, isRemote);
         this.setFirmwareReleaseConfig(firmwareConfig.releases);
         this.setFirmwareIntermediaryReleaseConfig(firmwareConfig.intermediaries);
     }

--- a/packages/connect/src/data/__tests__/firmwareInfo.test.ts
+++ b/packages/connect/src/data/__tests__/firmwareInfo.test.ts
@@ -6,7 +6,11 @@ import { versionUtils } from '@trezor/utils';
 import { getDeviceFeatures } from '../../../setupJest';
 import { DataManager } from '../DataManager';
 import { parseConnectSettings } from '../connectSettings';
-import { getFirmwareReleaseConfigInfo, getFirmwareStatus } from '../firmwareInfo';
+import {
+    getFirmwareReleaseConfigInfo,
+    getFirmwareStatus,
+    initializeFirmwareConfig,
+} from '../firmwareInfo';
 
 describe('data/firmwareInfo', () => {
     describe('getFirmwareStatus', () => {
@@ -30,7 +34,7 @@ describe('data/firmwareInfo', () => {
     });
     describe('getFirmwareReleaseConfigInfo', () => {
         beforeAll(async () => {
-            await DataManager.load(parseConnectSettings({}), true, true);
+            await DataManager.load(parseConnectSettings({}), true, true, initializeFirmwareConfig);
         });
         it('should offer latest compatible relase when latest one is not compatible', () => {
             const features = getDeviceFeatures({

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -16,10 +16,11 @@ import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from './DataManager';
 import type { Features, StrictFeatures } from '../types/device';
-import { FirmwareChannel, FirmwareReleaseConfigInfo } from '../types/firmware';
+import { FirmwareReleaseConfigInfo } from '../types/firmware';
 import type { CurrentVersion } from '../types/firmware';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
+import { getOnlineFirmwareBaseUrl } from '../utils/firmwareReleaseConfigUtils';
 import {
     buildIntermediaryFirmwareFileName,
     buildLocalFirmwareFileName,
@@ -28,71 +29,6 @@ import {
     isFirmwareCacheUsedForSelectedSource,
     isStrictFeatures,
 } from '../utils/firmwareUtils';
-
-interface RemoteBaseInfo {
-    BASE_URL: string;
-    MIDDLE_PATH: string;
-}
-const RELEASES_URL_REMOTE_BASE = {
-    BASE_URL: 'https://data.trezor.io',
-    MIDDLE_PATH: 'firmware',
-};
-const UNSIGNED_URL_REMOTE_BASE = {
-    BASE_URL: 'https://data.trezor.io',
-    MIDDLE_PATH: 'dev/firmware/releases/unsigned',
-};
-const UNSIGNED_STABLE_URL_REMOTE_BASE = {
-    BASE_URL: 'https://data.trezor.io',
-    MIDDLE_PATH: 'dev/firmware/releases/unsigned-stable',
-};
-const SIGNED_URL_REMOTE_BASE = {
-    BASE_URL: 'https://suite.corp.sldev.cz',
-    MIDDLE_PATH: 'firmware/signed',
-};
-const SIGNED_LOCALHOST = {
-    BASE_URL: 'http://localhost:3000',
-    MIDDLE_PATH: 'firmware/signed',
-};
-const UNSIGNED_LOCALHOST = {
-    BASE_URL: 'http://localhost:3000',
-    MIDDLE_PATH: 'firmware/unsigned',
-};
-const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
-    production: RELEASES_URL_REMOTE_BASE,
-    'production-early-access': RELEASES_URL_REMOTE_BASE,
-    'test-unsigned': UNSIGNED_URL_REMOTE_BASE,
-    'test-unsigned-stable': UNSIGNED_STABLE_URL_REMOTE_BASE,
-    'test-signed': SIGNED_URL_REMOTE_BASE,
-    'localhost-unsigned': UNSIGNED_LOCALHOST,
-    'localhost-signed': SIGNED_LOCALHOST,
-};
-
-type OnlineFirmwareBaseUrl = RemoteBaseInfo & { firmwareChannel: FirmwareChannel };
-
-/**
- * Obtains the base URL and middle path where to find firmware releases, based on the current settings.
- * Examples:
- *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production' }
- *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production-early-access' }
- *   { BASE_URL: 'https://suite.corp.sldev.cz', MIDDLE_PATH: 'firmware/signed', firmwareChannel: 'test-signed' }
- *   { BASE_URL: 'http://localhost:3000', MIDDLE_PATH: 'firmware/unsigned', firmwareChannel: 'localhost-unsigned' }
- */
-export const getOnlineFirmwareBaseUrl = (): OnlineFirmwareBaseUrl => {
-    const firmwareChannel = DataManager.getSettings('firmwareChannel');
-
-    if (!firmwareChannel) {
-        // If for some reason `firmwareChannel` settings is not set we return production one.
-        return {
-            ...FIRMWARE_REMOTE_BASE_URLS['production'],
-            firmwareChannel: 'production' as FirmwareChannel,
-        };
-    }
-
-    return {
-        ...FIRMWARE_REMOTE_BASE_URLS[firmwareChannel],
-        firmwareChannel,
-    };
-};
 
 // We use `bundledReleases` to know what are the binaries that are bundled so we do not need to download them if they are needed.
 const getBundledFirmwareVersion = (
@@ -141,7 +77,9 @@ const getOnlineReleaseByPath = async (releasePath: string) => {
         - test-unsigned-stable https://data.trezor.io/dev/firmware/releases/unsigned-stable/t3t1/universal/t3t1-2.8.10-universal.json
         - localhost-unsigned http://localhost:3000/firmware/unsigned/t3t1/universal/t3t1-2.8.10-universal.json
      */
-    const onlineFirmwareBaseUrl = getOnlineFirmwareBaseUrl();
+    const onlineFirmwareBaseUrl = getOnlineFirmwareBaseUrl(
+        DataManager.getSettings('firmwareChannel'),
+    );
     const url = `${onlineFirmwareBaseUrl.BASE_URL}/${releasePath}`;
 
     const response = await httpRequest(url, 'json', {
@@ -161,7 +99,9 @@ const getOnlineReleasePath = (
     firmwareVersion: VersionArray,
     firmwareType: FirmwareType,
 ): string => {
-    const onlineFirmwareBaseUrl = getOnlineFirmwareBaseUrl();
+    const onlineFirmwareBaseUrl = getOnlineFirmwareBaseUrl(
+        DataManager.getSettings('firmwareChannel'),
+    );
     const firmwareTypeFileString =
         firmwareType === FirmwareType.BitcoinOnly ? 'bitcoinonly' : 'universal';
     const relaseJsonFilename = `${deviceModel.toLowerCase()}-${firmwareVersion.join('.')}-${firmwareTypeFileString}.json`;
@@ -354,7 +294,7 @@ export const initializeFirmwareConfig = async (
 };
 
 export const getLanguage = (languageBinPath: string) => {
-    const baseUrl = getOnlineFirmwareBaseUrl();
+    const baseUrl = getOnlineFirmwareBaseUrl(DataManager.getSettings('firmwareChannel'));
     const url = `${baseUrl.BASE_URL}/${languageBinPath}`;
 
     return httpRequest(url, 'binary');
@@ -707,7 +647,7 @@ export const getFirmwareLocation = ({
         };
     }
 
-    const onlineBaseUrl = getOnlineFirmwareBaseUrl();
+    const onlineBaseUrl = getOnlineFirmwareBaseUrl(DataManager.getSettings('firmwareChannel'));
 
     return {
         baseUrl: onlineBaseUrl.BASE_URL,

--- a/packages/connect/src/device/Device.ts
+++ b/packages/connect/src/device/Device.ts
@@ -8,7 +8,6 @@ import {
     models,
 } from '@trezor/device-utils';
 import {
-    type DecodedTrezorPushNotification,
     TransportProtocol,
     thp as protocolThp,
     v1 as protocolV1,
@@ -33,19 +32,7 @@ import {
     getFirmwareStatus,
     getReleaseByVersion,
 } from '../data/firmwareInfo';
-import {
-    DEVICE,
-    DeviceButtonRequestPayload,
-    DeviceThpCredentialsChangedPayload,
-    DeviceThpPairingPayload,
-    DeviceThpPairingStatus,
-    DeviceVersionChanged,
-    UI_REQUEST,
-    UiResponsePassphrase,
-    UiResponsePin,
-    UiResponseThpPairingTag,
-    UiResponseWord,
-} from '../events';
+import { DEVICE, UI_REQUEST } from '../events';
 import {
     DeviceBusyStatus,
     DeviceFirmwareStatus,
@@ -61,7 +48,7 @@ import {
     KnownDevice,
     UnavailableCapabilities,
 } from '../types';
-import { DeviceLifecycleEvents, IDevice, RunOptions } from '../types/idevice';
+import { DeviceEvents, DeviceLifecycleEvents, IDevice, RunOptions } from '../types/idevice';
 import { handshakeCancel } from './workflow/handshake';
 import { getReleaseAsset } from '../utils/assetUtils';
 import { initLog } from '../utils/debug';
@@ -76,34 +63,7 @@ import { getFirmwareMode, getFirmwareType } from '../utils/firmwareUtils';
 // custom log
 const _log = initLog('Device');
 
-type Result<T> = { success: true; payload: T } | { success: false; error: Error };
-
-export interface DeviceEvents {
-    [DEVICE.PIN]: {
-        type: PROTO.PinMatrixRequestType | undefined;
-        callback: (response: Result<UiResponsePin['payload']>) => void;
-    };
-    [DEVICE.WORD]: {
-        type: PROTO.WordRequestType;
-        callback: (response: Result<UiResponseWord['payload']>) => void;
-    };
-    [DEVICE.PASSPHRASE]: {
-        callback: (response: Result<UiResponsePassphrase['payload']>) => void;
-    };
-    [DEVICE.PASSPHRASE_ON_DEVICE]: void;
-    [DEVICE.BUTTON]: { device: Device; payload: DeviceButtonRequestPayload };
-    [DEVICE.FIRMWARE_VERSION_CHANGED]: DeviceVersionChanged['payload'];
-    [DEVICE.TREZOR_PUSH_NOTIFICATION]: {
-        device: DeviceTyped;
-        payload: DecodedTrezorPushNotification;
-    };
-    [DEVICE.THP_PAIRING]: {
-        payload: DeviceThpPairingPayload;
-        callback: (response: Result<UiResponseThpPairingTag['payload']>) => void;
-    };
-    [DEVICE.THP_CREDENTIALS_CHANGED]: DeviceThpCredentialsChangedPayload;
-    [DEVICE.THP_PAIRING_STATUS_CHANGED]: DeviceThpPairingStatus;
-}
+export { type DeviceEvents } from '../types/idevice';
 
 type DeviceParams = {
     id: DeviceUniquePath;

--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -7,8 +7,8 @@ import { MessageResponse, Session, TRANSPORT, Transport } from '@trezor/transpor
 import { isErrorWithoutDeviceInteraction } from '@trezor/transport/src/errors-groups';
 import { scheduleAction } from '@trezor/utils';
 
-import { Device } from './Device';
 import { DEVICE } from '../events';
+import type { IDevice } from '../types/idevice';
 import type { TypedCallProvider } from '../types/typed-call-provider';
 import { initLog } from '../utils/debug';
 
@@ -67,7 +67,7 @@ const fail = (msg: string) =>
 export type { TypedCallProvider } from '../types/typed-call-provider';
 
 export class DeviceCurrentSession implements TypedCallProvider {
-    private readonly device: Device;
+    private readonly device: IDevice;
     private readonly transport: Transport;
     private readonly session: Session;
 
@@ -75,7 +75,7 @@ export class DeviceCurrentSession implements TypedCallProvider {
     private callPromise?: Promise<unknown>;
     private abortController?: AbortController;
 
-    constructor(device: Device, transport: Transport, session: Session) {
+    constructor(device: IDevice, transport: Transport, session: Session) {
         this.device = device;
         this.transport = transport;
         this.session = session;

--- a/packages/connect/src/device/__tests__/DeviceList.test.ts
+++ b/packages/connect/src/device/__tests__/DeviceList.test.ts
@@ -1,5 +1,6 @@
 import { DataManager } from '../../data/DataManager';
 import { parseConnectSettings } from '../../data/connectSettings';
+import { initializeFirmwareConfig } from '../../data/firmwareInfo';
 import { DeviceList } from '../DeviceList';
 
 const { createTestTransport, createTestTransportClass } = global.JestMocks;
@@ -28,6 +29,7 @@ describe('DeviceList', () => {
             },
             true,
             true,
+            initializeFirmwareConfig,
         );
     });
 

--- a/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/__tests__/handshakeWorkflow.test.ts
@@ -1,5 +1,6 @@
 import { DataManager } from '../../data/DataManager';
 import { parseConnectSettings } from '../../data/connectSettings';
+import { initializeFirmwareConfig } from '../../data/firmwareInfo';
 import { Device } from '../Device';
 import { handshakeCancel } from '../workflow/handshake';
 
@@ -50,6 +51,7 @@ describe('workflow/handshake', () => {
             },
             true,
             true,
+            initializeFirmwareConfig,
         );
     });
 

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -6,7 +6,7 @@ import { ThpPairingMethod, thp as protocolThp } from '@trezor/protocol';
 
 import { thpCall } from './thpCall';
 import { DataManager } from '../../data/DataManager';
-import type { Device } from '../Device';
+import type { IDevice } from '../../types/idevice';
 
 // intersection of device acceptable methods and host acceptable methods
 const getPairingMethods = (
@@ -25,7 +25,7 @@ const getPairingMethods = (
 // State HH0
 // TODO: link-to-public-docs
 // https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
-export const createThpChannel = async (device: Device) => {
+export const createThpChannel = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -66,7 +66,7 @@ export const createThpChannel = async (device: Device) => {
 // State HH1 and HH2
 // TODO: link-to-public-docs
 // https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
-export const thpHandshake = async (device: Device, unlockPin = false) => {
+export const thpHandshake = async (device: IDevice, unlockPin = false) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');

--- a/packages/connect/src/device/thp/index.ts
+++ b/packages/connect/src/device/thp/index.ts
@@ -1,13 +1,13 @@
-import { DEVICE } from '../../events/device';
-import type { Device } from '../Device';
 import { createThpChannel, thpHandshake } from './handshake';
 import { thpPairing } from './pairing';
+import { DEVICE } from '../../events/device';
+import type { IDevice } from '../../types/idevice';
 
 export { abortThpWorkflow } from './thpCall';
 export { getThpCredentials } from './pairing';
 export { createThpSession } from './session';
 
-export const getThpChannel = async (device: Device, withInteraction?: boolean) => {
+export const getThpChannel = async (device: IDevice, withInteraction?: boolean) => {
     const thpState = device.getThpState();
 
     if (!thpState) return;

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -7,9 +7,9 @@ import { createDeferred } from '@trezor/utils';
 import { abortThpWorkflow, thpCall } from './thpCall';
 import { DataManager } from '../../data/DataManager';
 import { DEVICE, UiResponseThpPairingTag } from '../../events';
-import type { Device } from '../Device';
+import type { IDevice } from '../../types/idevice';
 
-const processQrCodeTag = async (device: Device, value: string) => {
+const processQrCodeTag = async (device: IDevice, value: string) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -32,7 +32,7 @@ const processQrCodeTag = async (device: Device, value: string) => {
     return qrCodeSecret;
 };
 
-const processNfcTag = async (device: Device, value: string) => {
+const processNfcTag = async (device: IDevice, value: string) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -60,7 +60,7 @@ const processNfcTag = async (device: Device, value: string) => {
     return nfcTagTrezor;
 };
 
-const processCodeEntry = async (device: Device, value: string) => {
+const processCodeEntry = async (device: IDevice, value: string) => {
     const codeValue = Buffer.from(value, 'ascii');
 
     const thpState = device.getThpState();
@@ -90,7 +90,10 @@ const processCodeEntry = async (device: Device, value: string) => {
     return codeEntrySecret;
 };
 
-const processThpPairingResponse = (device: Device, payload: UiResponseThpPairingTag['payload']) => {
+const processThpPairingResponse = (
+    device: IDevice,
+    payload: UiResponseThpPairingTag['payload'],
+) => {
     if ('selectedMethod' in payload) {
         // change pairing method
         const selectedMethod = protocolThp.getThpPairingMethod(payload.selectedMethod);
@@ -117,7 +120,7 @@ const processThpPairingResponse = (device: Device, payload: UiResponseThpPairing
     throw ERRORS.TypedError('Device_ThpPairingMethodsException');
 };
 
-const waitForPairingCancel = (device: Device) => {
+const waitForPairingCancel = (device: IDevice) => {
     const readAbort = new AbortController();
     device.getThpState()?.setExpectedResponses([0x04]); // expect Cancel
     const readCancel = device.getCurrentSession().receive({ signal: readAbort.signal });
@@ -128,7 +131,7 @@ const waitForPairingCancel = (device: Device) => {
     };
 };
 
-const waitForPairingTag = async (device: Device) => {
+const waitForPairingTag = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -223,7 +226,7 @@ const waitForPairingTag = async (device: Device) => {
     });
 };
 
-export const getThpCredentials = async (device: Device, autoconnect = false) => {
+export const getThpCredentials = async (device: IDevice, autoconnect = false) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
@@ -240,7 +243,7 @@ export const getThpCredentials = async (device: Device, autoconnect = false) => 
     return { ...credentials.message, autoconnect, host_static_key };
 };
 
-export const thpPairingEnd = async (device: Device) => {
+export const thpPairingEnd = async (device: IDevice) => {
     const result = await thpCall(device, 'ThpEndRequest', {});
     device.getThpState()?.setPhase('paired');
 
@@ -251,7 +254,7 @@ export const thpPairingEnd = async (device: Device) => {
 // Workflow will require user interaction
 // TODO: link-to-public-docs
 // https://www.notion.so/satoshilabs/THP-Specification-2-1-203dc5260606804192aecaa58fb961ca
-export const thpPairing = async (device: Device) => {
+export const thpPairing = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');

--- a/packages/connect/src/device/thp/session.ts
+++ b/packages/connect/src/device/thp/session.ts
@@ -1,9 +1,9 @@
 import { thp as protocolThp } from '@trezor/protocol';
 
-import type { Device } from '../Device';
 import { thpCall } from './thpCall';
+import type { IDevice } from '../../types/idevice';
 
-export const createThpSession = async (device: Device, deriveCardano: boolean) => {
+export const createThpSession = async (device: IDevice, deriveCardano: boolean) => {
     let passphrase: protocolThp.ThpCreateNewSession;
     if (device.features.passphrase_protection === false) {
         passphrase = { passphrase: '' };

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -2,7 +2,7 @@ import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { thp as protocolThp } from '@trezor/protocol';
 
 import { DEVICE } from '../../events';
-import type { Device } from '../Device';
+import type { IDevice } from '../../types/idevice';
 
 type ThpTypedCall = {
     ThpCreateChannelRequest: 'ThpCreateChannelResponse';
@@ -47,7 +47,7 @@ type ThpCallResponse = {
 type ThpMessagePayload<T extends MessageKey = MessageKey> = ThpMessage[T];
 
 export const thpCall = async <T extends MessageKey>(
-    device: Device,
+    device: IDevice,
     name: T,
     data: ThpMessagePayload<T>,
 ): Promise<ThpCallResponse[T]> => {
@@ -88,7 +88,7 @@ export const thpCall = async <T extends MessageKey>(
     return result.payload as ThpCallResponse[T];
 };
 
-export const abortThpWorkflow = async (device: Device) => {
+export const abortThpWorkflow = async (device: IDevice) => {
     const thpState = device.getThpState();
     if (!thpState || !device.currentRun) {
         return Promise.resolve(); // not a THP device

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -6,9 +6,9 @@ import { calculateFirmwareHash, getBinaryOptional, stripFwHeaders } from '../../
 import { DataManager } from '../../data/DataManager';
 import { getFirmwareLocation, getReleaseByVersion } from '../../data/firmwareInfo';
 import { FirmwareHashCheckError, FirmwareHashCheckResult } from '../../types';
+import type { IDevice } from '../../types/idevice';
 import { Log } from '../../utils/debug';
 import { getFirmwareType } from '../../utils/firmwareUtils';
-import type { Device } from '../Device';
 
 const createFailResult = (error: FirmwareHashCheckError, errorPayload?: unknown) => ({
     success: false,
@@ -17,7 +17,7 @@ const createFailResult = (error: FirmwareHashCheckError, errorPayload?: unknown)
 });
 
 type Context = {
-    device: Device;
+    device: IDevice;
     logger: Log;
 };
 

--- a/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
@@ -1,12 +1,12 @@
 import { isArrayMember } from '@trezor/utils';
 
-import { FIRMWARE } from '../../constants';
-import { Log } from '../../utils/debug';
-import type { Device } from '../Device';
 import { checkFirmwareHash } from './checkFirmwareHash';
+import { FIRMWARE } from '../../constants';
+import type { IDevice } from '../../types/idevice';
+import { Log } from '../../utils/debug';
 
 type Context = {
-    device: Device;
+    device: IDevice;
     logger: Log;
 };
 

--- a/packages/connect/src/types/idevice.ts
+++ b/packages/connect/src/types/idevice.ts
@@ -1,4 +1,5 @@
 import { FirmwareRelease, FirmwareType } from '@trezor/device-utils';
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type {
     DecodedTrezorPushNotification,
     TransportProtocol,
@@ -20,6 +21,20 @@ import type {
 } from './device';
 import type { FirmwareReleaseConfigInfo } from './firmware';
 import type { TypedCallProvider } from './typed-call-provider';
+import type { DeviceCommands } from '../device/DeviceCommands';
+import type {
+    DeviceButtonRequestPayload,
+    DeviceThpCredentialsChangedPayload,
+    DeviceThpPairingPayload,
+    DeviceThpPairingStatus,
+    DeviceVersionChanged,
+} from '../events/device';
+import type {
+    UiResponsePassphrase,
+    UiResponsePin,
+    UiResponseThpPairingTag,
+    UiResponseWord,
+} from '../events/ui-response';
 
 /**
  * Events emitted on the `device.lifecycle` emitter (separate from the main device TypedEmitter).
@@ -36,6 +51,45 @@ export interface DeviceLifecycleEvents {
     'device-changed': void;
     'device-disconnect': void;
     'device-trezor_push_notification': DecodedTrezorPushNotification;
+}
+
+/**
+ * Result type for device prompt callbacks.
+ */
+export type PromptResult<T> = { success: true; payload: T } | { success: false; error: Error };
+
+/**
+ * Events emitted on the main device TypedEmitter (not the lifecycle emitter).
+ *
+ * String literal keys MUST match the corresponding `DEVICE.*` constants in `events/device.ts`.
+ * Defined here so that `IDevice.emit` / `IDevice.prompt` can be typed without importing
+ * from the device/Device.ts module, which would create circular dependencies.
+ */
+export interface DeviceEvents {
+    pin: {
+        type: PROTO.PinMatrixRequestType | undefined;
+        callback: (response: PromptResult<UiResponsePin['payload']>) => void;
+    };
+    word: {
+        type: PROTO.WordRequestType;
+        callback: (response: PromptResult<UiResponseWord['payload']>) => void;
+    };
+    passphrase: {
+        callback: (response: PromptResult<UiResponsePassphrase['payload']>) => void;
+    };
+    passphrase_on_device: void;
+    button: { device: IDevice; payload: DeviceButtonRequestPayload };
+    'device-firmware_version_changed': DeviceVersionChanged['payload'];
+    'device-trezor_push_notification': {
+        device: Device;
+        payload: DecodedTrezorPushNotification;
+    };
+    thp_pairing: {
+        payload: DeviceThpPairingPayload;
+        callback: (response: PromptResult<UiResponseThpPairingTag['payload']>) => void;
+    };
+    'device-thp_credentials_changed': DeviceThpCredentialsChangedPayload;
+    'device-thp_pairing_status_changed': DeviceThpPairingStatus;
 }
 
 /**
@@ -103,6 +157,7 @@ export interface IDevice {
     getAuthenticityChecks(): KnownDevice['authenticityChecks'];
     setAuthenticityChecks(firmwareHash: FirmwareHashCheckResult | null): void;
     getCurrentSession(): TypedCallProvider;
+    getCommands(): ReturnType<typeof DeviceCommands>;
 
     // ─── Status predicates ──────────────────────────────────────────────────────
     isUnacquired(): boolean;
@@ -119,4 +174,12 @@ export interface IDevice {
 
     // ─── Serialization ──────────────────────────────────────────────────────────
     toMessageObject(): Device;
+
+    // ─── Event methods ──────────────────────────────────────────────────────────
+    emit: TypedEmitter<DeviceEvents>['emit'];
+    prompt<T extends 'pin' | 'passphrase' | 'word' | 'thp_pairing'>(
+        type: T,
+        args: Omit<DeviceEvents[T], 'callback'>,
+    ): Promise<Parameters<DeviceEvents[T]['callback']>[0]>;
+    getFeatures(): Promise<void>;
 }

--- a/packages/connect/src/types/workflow.ts
+++ b/packages/connect/src/types/workflow.ts
@@ -1,13 +1,24 @@
-import type { AbstractMethod } from '../core/AbstractMethod';
-import type { Device } from '../device/Device';
+import type { IDevice } from './idevice';
+import type { CoreEventMessage } from '../events/core';
+
+/**
+ * Minimal method interface for device workflows.
+ * Avoids importing AbstractMethod (which would create a circular dependency
+ * through AbstractMethod → Device → handshake → types/workflow).
+ */
+export interface WorkflowMethod {
+    preauthorized?: boolean;
+    useCardanoDerivation: boolean;
+    postMessage: (message: CoreEventMessage) => void;
+}
 
 export type WorkflowContext = {
-    device: Device;
-    method: AbstractMethod<any>;
+    device: IDevice;
+    method: WorkflowMethod;
     signal: AbortSignal;
 };
 
 export type TpnWorkflowContext = {
-    device: Device;
+    device: IDevice;
     message: number[];
 };

--- a/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
+++ b/packages/connect/src/utils/firmwareReleaseConfigUtils.ts
@@ -4,8 +4,72 @@ import { getFirmwareReleaseJwsPublicKey } from '@trezor/connect-data';
 import { FirmwareReleaseConfig } from '@trezor/device-utils';
 
 import { firmwareReleaseConfigAssets } from './assetUtils';
-import { getOnlineFirmwareBaseUrl } from '../data/firmwareInfo';
 import { FirmwareChannel } from '../types/firmware';
+
+interface RemoteBaseInfo {
+    BASE_URL: string;
+    MIDDLE_PATH: string;
+}
+
+const RELEASES_URL_REMOTE_BASE = {
+    BASE_URL: 'https://data.trezor.io',
+    MIDDLE_PATH: 'firmware',
+};
+const UNSIGNED_URL_REMOTE_BASE = {
+    BASE_URL: 'https://data.trezor.io',
+    MIDDLE_PATH: 'dev/firmware/releases/unsigned',
+};
+const UNSIGNED_STABLE_URL_REMOTE_BASE = {
+    BASE_URL: 'https://data.trezor.io',
+    MIDDLE_PATH: 'dev/firmware/releases/unsigned-stable',
+};
+const SIGNED_URL_REMOTE_BASE = {
+    BASE_URL: 'https://suite.corp.sldev.cz',
+    MIDDLE_PATH: 'firmware/signed',
+};
+const SIGNED_LOCALHOST = {
+    BASE_URL: 'http://localhost:3000',
+    MIDDLE_PATH: 'firmware/signed',
+};
+const UNSIGNED_LOCALHOST = {
+    BASE_URL: 'http://localhost:3000',
+    MIDDLE_PATH: 'firmware/unsigned',
+};
+const FIRMWARE_REMOTE_BASE_URLS: Record<FirmwareChannel, RemoteBaseInfo> = {
+    production: RELEASES_URL_REMOTE_BASE,
+    'production-early-access': RELEASES_URL_REMOTE_BASE,
+    'test-unsigned': UNSIGNED_URL_REMOTE_BASE,
+    'test-unsigned-stable': UNSIGNED_STABLE_URL_REMOTE_BASE,
+    'test-signed': SIGNED_URL_REMOTE_BASE,
+    'localhost-unsigned': UNSIGNED_LOCALHOST,
+    'localhost-signed': SIGNED_LOCALHOST,
+};
+
+type OnlineFirmwareBaseUrl = RemoteBaseInfo & { firmwareChannel: FirmwareChannel };
+
+/**
+ * Obtains the base URL and middle path where to find firmware releases, based on the current settings.
+ * Examples:
+ *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production' }
+ *   { BASE_URL: 'https://data.trezor.io', MIDDLE_PATH: 'firmware', firmwareChannel: 'production-early-access' }
+ *   { BASE_URL: 'https://suite.corp.sldev.cz', MIDDLE_PATH: 'firmware/signed', firmwareChannel: 'test-signed' }
+ *   { BASE_URL: 'http://localhost:3000', MIDDLE_PATH: 'firmware/unsigned', firmwareChannel: 'localhost-unsigned' }
+ */
+export const getOnlineFirmwareBaseUrl = (
+    firmwareChannel?: FirmwareChannel,
+): OnlineFirmwareBaseUrl => {
+    if (!firmwareChannel) {
+        return {
+            ...FIRMWARE_REMOTE_BASE_URLS['production'],
+            firmwareChannel: 'production' as FirmwareChannel,
+        };
+    }
+
+    return {
+        ...FIRMWARE_REMOTE_BASE_URLS[firmwareChannel],
+        firmwareChannel,
+    };
+};
 
 const JWS_CONFIG = {
     SIGN_ALGORITHM: 'ES256',
@@ -24,9 +88,13 @@ const CONFIG_PATH_BY_CHANNEL: Partial<Record<FirmwareChannel, string>> = {
     'production-early-access': 'config-early-access/',
 };
 
-const fetchRemoteJws = async (): Promise<JwsInfo> => {
-    const { BASE_URL, MIDDLE_PATH, firmwareChannel } = getOnlineFirmwareBaseUrl();
-    const configPath = CONFIG_PATH_BY_CHANNEL[firmwareChannel] ?? '';
+const fetchRemoteJws = async (firmwareChannel?: FirmwareChannel): Promise<JwsInfo> => {
+    const {
+        BASE_URL,
+        MIDDLE_PATH,
+        firmwareChannel: resolvedChannel,
+    } = getOnlineFirmwareBaseUrl(firmwareChannel);
+    const configPath = CONFIG_PATH_BY_CHANNEL[resolvedChannel] ?? '';
     const path = `${MIDDLE_PATH}/${configPath}${JWS_CONFIG.REMOTE_FILENAME}`;
     const remoteReleasesUrl = new URL(path, BASE_URL);
 
@@ -50,7 +118,7 @@ const fetchRemoteJws = async (): Promise<JwsInfo> => {
             throw new Error('Invalid response format: "jws" property missing or not a string.');
         }
 
-        return { jws: data.jws, firmwareChannel };
+        return { jws: data.jws, firmwareChannel: resolvedChannel };
     } catch (error) {
         throw new Error(
             `Failed to fetch remote JWS: ${error instanceof Error ? error.message : String(error)}`,
@@ -82,12 +150,12 @@ const verifyAndDecodeJws = (jws: string, publicKey: string): FirmwareReleaseConf
     return parsedPayload;
 };
 
-export const getFirmwareReleaseConfig = async () => {
+export const getFirmwareReleaseConfig = async (firmwareChannel?: FirmwareChannel) => {
     try {
-        const { jws, firmwareChannel } = await fetchRemoteJws();
+        const { jws, firmwareChannel: resolvedChannel } = await fetchRemoteJws(firmwareChannel);
 
         const useProductionKey = ['test-signed', 'production-early-access', 'production'].includes(
-            firmwareChannel,
+            resolvedChannel,
         );
         const publicKey = getFirmwareReleaseJwsPublicKey(useProductionKey);
         const remoteConfig = verifyAndDecodeJws(jws, publicKey);

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -1,18 +1,7 @@
 
 
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
-packages/connect/src/core/AbstractMethod.ts > packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/DeviceCurrentSession.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/handshake.ts > packages/connect/src/device/thp/thpCall.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/pairing.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/thp/index.ts > packages/connect/src/device/thp/session.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/checkFirmwareHashWithRetries.ts > packages/connect/src/device/workflow/checkFirmwareHash.ts > packages/connect/src/api/firmware/index.ts > packages/connect/src/api/firmware/uploadFirmware.ts
-packages/connect/src/device/Device.ts > packages/connect/src/device/workflow/handshake.ts > packages/connect/src/types/workflow.ts
 packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx > packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/app.ts
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/contents.ts

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -1,7 +1,6 @@
 
 
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
-packages/connect/src/data/DataManager.ts > packages/connect/src/data/firmwareInfo.ts
 packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx > packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/app.ts
 packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/contents.ts


### PR DESCRIPTION
resolve https://github.com/trezor/trezor-suite/issues/23850
maybe not always the best way to solve this but at least for now cycles are fully gone.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-circulars-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-circulars-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-circulars-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-12T18:09:56.141Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-12T18:07:45.445Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->