### PR TITLE
refactor(trading): simplify AssetPickerInput by replacing with FakeSelect

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInput.tsx
@@ -1,9 +1,8 @@
 import { memo, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import styled from 'styled-components';
-
 import { Translation, type TranslationKey, useTranslation } from '@suite/intl';
+import { FakeSelect } from '@suite/trading';
 import {
     type TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     type TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
@@ -13,26 +12,13 @@ import {
     type TradingSellFormProps,
     selectTradingLoadingAndTimestamp,
 } from '@suite-common/trading';
-import { Icon, Input, type InputProps, Spinner, Text } from '@trezor/components';
+import { type InputProps, Spinner, Text } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 
 import { AssetPickerInputContent } from './AssetPickerInputContent';
 
 type TradingFormValues = TradingExchangeFormProps | TradingBuyFormProps | TradingSellFormProps;
-
-const OpenModalButton = styled.button`
-    border: unset;
-    background: unset;
-    box-shadow: unset;
-    font-size: inherit;
-
-    cursor: pointer;
-
-    & input {
-        cursor: pointer;
-    }
-`;
 
 export interface AssetPickerInputProps {
     name:
@@ -76,36 +62,23 @@ export const AssetPickerInput = memo(function AssetPickerInputInner({
     }, [value, isLoading, name]);
 
     return (
-        <OpenModalButton
-            onClick={e => {
-                e.preventDefault();
-                e.stopPropagation();
-
-                if (!disabled) {
-                    onClick();
-                }
-            }}
-        >
-            <Input
-                name={name}
-                placeholder={
-                    !value && !isLoading && placeholder ? translationString(placeholder) : undefined
-                }
-                isDisabled={disabled}
-                data-testid={`${dataTestId ?? '@asset-picker'}/input`}
-                labelLeft={
-                    label && (
-                        <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation id={label} />
-                        </Text>
-                    )
-                }
-                rightContent={<Icon name="caretDown" size={20} />}
-                leftContent={leftContent}
-                bottomText={bottomText}
-                // Disable the blinking cursor when the input is focused
-                readOnly
-            />
-        </OpenModalButton>
+        <FakeSelect
+            name={name}
+            placeholder={
+                !value && !isLoading && placeholder ? translationString(placeholder) : undefined
+            }
+            isDisabled={disabled}
+            onClick={onClick}
+            labelLeft={
+                label && (
+                    <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                        <Translation id={label} />
+                    </Text>
+                )
+            }
+            leftContent={leftContent}
+            bottomText={bottomText}
+            data-testid={dataTestId}
+        />
     );
 });

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -50,8 +50,8 @@ export class TradingAssetPicker {
         );
 
     constructor(private readonly page: Page) {
-        this.openSellModal = this.page.getByTestId('@trading/sell/asset-picker/input');
-        this.openBuyModal = this.page.getByTestId('@trading/buy/asset-picker/input');
+        this.openSellModal = this.page.getByTestId('@trading/sell/asset-picker');
+        this.openBuyModal = this.page.getByTestId('@trading/buy/asset-picker');
         this.searchInput = this.page.getByTestId('@asset-picker/search/input');
         this.displaySymbol = this.page.getByTestId('@asset-picker/display-symbol');
         this.networkFilterButton = this.page.getByTestId('@asset-picker/search/filter/input');

--- a/suite/trading/src/ui/Form/FakeSelect.tsx
+++ b/suite/trading/src/ui/Form/FakeSelect.tsx
@@ -23,7 +23,7 @@ const FakeSelectContainer = styled.button<{ $isDisabled?: boolean }>`
 `;
 
 export type FakeSelectProps = Omit<FormCellProps, 'children'> &
-    Pick<InputProps, 'value' | 'placeholder' | 'size'> & {
+    Pick<InputProps, 'value' | 'placeholder' | 'size' | 'name' | 'leftContent' | 'bottomText'> & {
         isLoading?: boolean;
         onClick: () => void;
     };
@@ -37,11 +37,12 @@ export const FakeSelect = (props: FakeSelectProps) => {
         size = 'large',
         onClick,
         'data-testid': dataTestId,
+        leftContent,
         ...rest
     } = props;
 
     const formCellProps = pickFormCellProps(rest);
-    const leftContent = isLoading ? <Spinner size={20} /> : undefined;
+    const derivedLeftContent = leftContent ?? (isLoading ? <Spinner size={20} /> : undefined);
 
     return (
         <FakeSelectContainer type="button" onClick={onClick} disabled={isDisabled}>
@@ -50,7 +51,7 @@ export const FakeSelect = (props: FakeSelectProps) => {
                 value={value}
                 placeholder={placeholder}
                 size={size}
-                leftContent={leftContent}
+                leftContent={derivedLeftContent}
                 disabled={isDisabled}
                 rightContent={
                     <Icon name="caretDown" size={20} intent="neutral" priority="secondary" />


### PR DESCRIPTION
## Description

Refactor the trading asset picker input to use the shared `FakeSelect` component instead of a custom styled button/input combo, and extend `FakeSelect` to support more `Input` props (e.g. `name`, `leftContent`, `bottomText`) while keeping its loading behavior consistent.

## Notes for QA

Just dev thing, no need QA.

## Related Issue

Resolve #25353

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/25353/refactor-fakeselect-assets-picker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/25353/refactor-fakeselect-assets-picker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T07:31:36.990Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T07:07:19.806Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->