### PR TITLE
perf: add import type for type-only @trezor/connect imports to avoid …

### DIFF
--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -6,7 +6,7 @@ import {
     StakingPool,
 } from '@trezor/blockchain-link-types/src/blockbook-api';
 import { SolanaStakingAccount } from '@trezor/blockchain-link-types/src/solana';
-import { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
+import type { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
 import { Branded } from '@trezor/type-utils';
 
 export type MetadataItem = string;

--- a/suite-common/wallet-types/src/discovery.ts
+++ b/suite-common/wallet-types/src/discovery.ts
@@ -1,5 +1,4 @@
-import type { DeviceUniquePath } from '@trezor/connect';
-import { BundleProgress, StaticSessionId } from '@trezor/connect';
+import type { BundleProgress, DeviceUniquePath, StaticSessionId } from '@trezor/connect';
 
 type CommonDiscoveryStatus = {
     isAddingHiddenWallet?: boolean; // to control visibility of special loader

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -1,7 +1,7 @@
 import { CryptoId } from 'invity-api';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
-import { AccountUtxo, FeeLevel } from '@trezor/connect';
+import type { AccountUtxo, FeeLevel } from '@trezor/connect';
 
 import { AccountKey } from './account';
 import { Output, RbfTransactionParams } from './transaction';

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -1,6 +1,6 @@
 import { NetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { PROTO } from '@trezor/connect';
+import type { PROTO } from '@trezor/connect';
 
 export const AddressDisplayOptions = {
     ORIGINAL: 'original',

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -1,6 +1,6 @@
 import { Network, NetworkSymbol } from '@suite-common/wallet-config';
 import { BaseCurrencyCode } from '@trezor/blockchain-link-types';
-import {
+import type {
     AccountAddress,
     AccountTransaction,
     AccountUtxo,

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -1,4 +1,4 @@
-import { TokenInfo } from '@trezor/connect';
+import type { TokenInfo } from '@trezor/connect';
 
 import { FormStateTradingCryptoCurrency, FormStateTradingFiatCurrency } from './sendForm';
 

--- a/suite-common/wallet-types/src/transactionSimulation.ts
+++ b/suite-common/wallet-types/src/transactionSimulation.ts
@@ -1,4 +1,4 @@
-import { EthereumSignTransaction, EthereumSignTypedData } from '@trezor/connect';
+import type { EthereumSignTransaction, EthereumSignTypedData } from '@trezor/connect';
 
 type TxSimulationActionBase = {
     sourceOrigin: string;

--- a/suite-common/wallet-utils/src/amountUtils.ts
+++ b/suite-common/wallet-utils/src/amountUtils.ts
@@ -1,5 +1,5 @@
 import { NetworkSymbol, getNetworkDisplaySymbol, networks } from '@suite-common/wallet-config';
-import { TokenTransfer } from '@trezor/connect';
+import type { TokenTransfer } from '@trezor/connect';
 import { BigNumber, BigNumberValue } from '@trezor/utils';
 
 import { AmountSubunit, AmountUnit, asAmountSubunit, asAmountUnit } from './AmountTypes';

--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -1,6 +1,6 @@
 import { TrezorDevice, TrezorDeviceWithState } from '@suite-common/suite-types';
 import { asWalletDescriptor } from '@suite-common/wallet-types';
-import { StaticSessionId } from '@trezor/connect';
+import type { StaticSessionId } from '@trezor/connect';
 import { isNotNullOrUndefined, isNotUndefined } from '@trezor/utils';
 
 export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionId) => {

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.ts
@@ -1,6 +1,6 @@
 import { AccountType, NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { Account } from '@suite-common/wallet-types';
-import { StaticSessionId } from '@trezor/connect';
+import type { StaticSessionId } from '@trezor/connect';
 
 import { sortByCoin } from './accountUtils';
 

--- a/suite-common/wallet-utils/src/getMyInputsFromTransaction.ts
+++ b/suite-common/wallet-utils/src/getMyInputsFromTransaction.ts
@@ -1,5 +1,5 @@
-import { Account } from '@suite-common/wallet-types';
-import { AccountTransaction } from '@trezor/connect';
+import type { Account } from '@suite-common/wallet-types';
+import type { AccountTransaction } from '@trezor/connect';
 
 export type GetMyInputsFromTransactionParams = {
     account: Pick<Account, 'addresses'>;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -12,7 +12,7 @@ import {
     StakeFormState,
     StakeType,
 } from '@suite-common/wallet-types';
-import { CardanoOutput } from '@trezor/connect';
+import type { CardanoOutput } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { versionUtils } from '@trezor/utils';
 

--- a/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
+++ b/suite-native/device-authorization/src/__tests__/deviceAuthorizationSlice.test.ts
@@ -1,5 +1,5 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_REQUEST } from '@trezor/connect/src/exports';
 
 import {
     DeviceAuthorizationState,

--- a/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
+++ b/suite-native/device-authorization/src/deviceAuthorizationSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { UI_REQUEST } from '@trezor/connect';
+import { UI_REQUEST } from '@trezor/connect/src/exports';
 
 import {
     isFlowEndingButtonRequest,

--- a/suite-native/device-authorization/src/utils.ts
+++ b/suite-native/device-authorization/src/utils.ts
@@ -1,6 +1,7 @@
 import { UnknownAction } from '@reduxjs/toolkit';
 
-import { UI_REQUEST, UiRequestDeviceAction } from '@trezor/connect';
+import { UI_REQUEST } from '@trezor/connect/src/exports';
+import type { UiRequestDeviceAction } from '@trezor/connect/src/exports';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
 export const pinButtonRequestCodes = [


### PR DESCRIPTION
tldr not sure if this helps but it can't hurt anything

…DataManager loading

- Change UI_REQUEST/UiRequestDeviceAction in deviceAuthorizationSlice.ts, utils.ts and its test to use @trezor/connect/src/exports instead of the full @trezor/connect index, avoiding the 350 KB DataManager JSON load for deviceAuthorizationSlice.test.ts.

- Add import type to all @trezor/connect imports that are used only as TypeScript type annotations in suite-common/wallet-types (account, discovery, sendForm, settings, transaction, transactionReviewOutput, transactionSimulation) and in suite-common/wallet-utils (amountUtils, deviceUtils, filterReceiveAccounts, getMyInputsFromTransaction, reviewTransactionUtils). This makes getMyInputsFromTransaction.test.ts and amountUtils.test.ts DataManager-free.


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=minimal-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=minimal-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=minimal-imports&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-13T08:44:15.693Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T08:42:00.891Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->