### PR TITLE
fix(suite): 26.4 migration

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Storage changelog
 
+## 26.4.0
+
+- create `phishing` object store for persisting user "marked as not scam" transaction IDs per account
+
+## 26.3.0.1
+
+- create `experimentalFeedback` object store
+
 ## 26.3.0
 
 - create `suiteSyncOwners` object store
-- create `phishing` object store for persisting user "marked as not scam" transaction IDs per account
 
 ## 26.2.0
 

--- a/packages/suite/src/storage/migrations/versions/26.4.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.ts
@@ -2,6 +2,6 @@ import { createMigration } from '@suite/idb-migration-utils';
 
 import { SuiteDBSchema } from 'src/storage/definitions';
 
-export default createMigration<SuiteDBSchema>('26.3.0', db => {
-    db.createObjectStore('suiteSyncOwners');
+export default createMigration<SuiteDBSchema>('26.4.0', db => {
+    db.createObjectStore('phishing');
 });

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -15,3 +15,4 @@ export { default as m26_1_0 } from './26.1.0';
 export { default as m26_2_0 } from './26.2.0';
 export { default as m26_3_0 } from './26.3.0';
 export { default as m26_3_0_1 } from './26.3.0.1';
+export { default as m26_4_0 } from './26.4.0';


### PR DESCRIPTION
## Description

Fix migration that was incorrectly placed to 26.3 but it's really 26.4 :warning: 
This would cause crash in production app too if not fixed before 26.4 release.  

## Notes for QA

Migrating from 26.3 to 26.4 must work on Suite Web & Desktop, that can be tested as part of release tests for 26.4

Currently can be tested too on web:
- open anonymous window, visit:
https://dev.suite.sldev.cz/suite-web/release/26.3/web/
https://dev.suite.sldev.cz/suite-web/feat/tx-phishing-detectors/web/
- see crash (screenshot below)
- close and reopen anon window, visit
https://dev.suite.sldev.cz/suite-web/release/26.3/web/
https://dev.suite.sldev.cz/suite-web/fix/26.4-migration/web/
- works :heavy_check_mark: 

## Related Issue

Fixing after #25263

## Screenshots:

<img width="802" height="379" alt="image" src="https://github.com/user-attachments/assets/195035ac-da27-4458-b61c-1e11073bfe74" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26.4-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-13T09:31:55.048Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->