### PR TITLE
Fix OAuth state

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -51,7 +51,15 @@ export interface MainChannels {
 // Handled by DesktopApi.on/once (see ./main)
 export interface RendererChannels {
     // oauth
-    'oauth/response': { [key: string]: string };
+    'oauth/response':
+        | {
+              key: 'trezor-oauth';
+              search: string;
+          }
+        | {
+              key: 'trezor-oauth';
+              hash: string;
+          };
 
     // Update events
     'update/checking': void;

--- a/packages/suite-desktop-core/src/__fixtures__/http.ts
+++ b/packages/suite-desktop-core/src/__fixtures__/http.ts
@@ -4,7 +4,14 @@ export const fixtures = [
         path: '/oauth',
         search: '?code=meow',
         result: {
-            emit: ['oauth/response', { search: '?code=meow' }],
+            emit: [
+                'oauth/response',
+                {
+                    key: 'trezor-oauth',
+                    hash: null,
+                    search: '?code=meow',
+                },
+            ],
             response: {
                 status: 200,
             },

--- a/packages/suite-desktop-core/src/__tests__/http.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/http.test.ts
@@ -6,47 +6,51 @@ global.logger = new Logger('mute');
 
 describe('http receiver', () => {
     it('start should emit started event', async () => {
-        const receiver = createHttpReceiver();
+        const receiver = createHttpReceiver({ port: 0 });
 
         const spy = jest.spyOn(receiver, 'emit');
-        await receiver.start();
-        expect(spy).toHaveBeenCalledWith('server/listening', {
-            port: 21335,
-            address: '127.0.0.1',
-            family: 'IPv4',
-        });
-        receiver.stop();
+        const startResult = await receiver.start();
+        expect(startResult.success).toBe(true);
+        if (startResult.success) {
+            expect(spy).toHaveBeenCalledWith('server/listening', {
+                port: startResult.payload.port,
+                address: '127.0.0.1',
+                family: 'IPv4',
+            });
+        }
+        await receiver.stop();
     });
 
-    fixtures.forEach(f => {
-        it(`${f.method}: ${f.path}`, async () => {
-            const receiver = createHttpReceiver();
-            const spy = jest.spyOn(receiver, 'emit');
+    it.each(fixtures)('$method: $path', async ({ method, path, search, result }) => {
+        const receiver = createHttpReceiver({ port: 0 });
+        const spy = jest.spyOn(receiver, 'emit');
 
-            await receiver.start();
+        try {
+            const startResult = await receiver.start();
+            if (!startResult.success) {
+                throw new Error(`Server failed to start: ${startResult.message}`);
+            }
 
             const address = receiver.getServerAddress();
             if (!address) return; // ts-stuff
-            const url = `http://${address.address}:${address.port}${f.path}${f.search}`;
+            const url = `http://${address.address}:${address.port}${path}${search}`;
 
-            receiver.activateRoute(f.path);
+            receiver.activateRoute(path);
             expect(spy).toHaveBeenLastCalledWith('server/listening', {
-                port: 21335,
+                port: startResult.payload.port,
                 address: '127.0.0.1',
                 family: 'IPv4',
             });
 
-            const response = await fetch(url, {
-                method: f.method,
-            });
+            const response = await fetch(url, { method });
 
-            if (f.result.emit) {
-                expect(spy).toHaveBeenLastCalledWith(...f.result.emit);
+            if (result.emit) {
+                expect(spy).toHaveBeenLastCalledWith(...result.emit);
             }
 
-            expect(response.status).toEqual(f.result.response.status);
-
-            receiver.stop();
-        });
+            expect(response.status).toEqual(result.response.status);
+        } finally {
+            await receiver.stop();
+        }
     });
 });

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -2,6 +2,7 @@ import * as url from 'url';
 
 import { trezorLogo } from '@suite-common/suite-constants';
 import { HttpServer, allowReferers } from '@trezor/node-utils';
+import { type RendererChannels } from '@trezor/suite-desktop-api';
 import { xssFilters } from '@trezor/utils';
 
 import { convertILoggerToLog } from '../utils/IloggerToLog';
@@ -14,7 +15,7 @@ type TemplateOptions = {
  * Events that may be emitted or listened to by HttpReceiver
  */
 interface Events {
-    'oauth/response': (response: { [key: string]: string }) => void;
+    'oauth/response': (response: RendererChannels['oauth/response']) => void;
     'oauth/error': (message: string) => void;
     'buy/redirect': (url: string) => void;
     'sell/redirect': (url: string) => void;
@@ -64,10 +65,10 @@ const applyTemplate = (content = 'You may now close this window.', options?: Tem
     return template;
 };
 
-export const createHttpReceiver = () => {
+export const createHttpReceiver = (options?: { port?: number }) => {
     const httpReceiver = new HttpServer<Events>({
         logger: convertILoggerToLog(global.logger, { serviceName: 'http-receiver' }),
-        port: 21335,
+        port: options?.port ?? 21335,
     });
 
     httpReceiver.use([
@@ -80,22 +81,16 @@ export const createHttpReceiver = () => {
     httpReceiver.get('/oauth', [
         allowReferers(['', '127.0.0.1', 'www.dropbox.com']), // No referer is sent by Google, Dropbox sends referer when using Safari
         (request, response) => {
-            const { search } = url.parse(request.url, true);
-            if (search) {
-                // send data back to main window
-                httpReceiver.emit('oauth/response', { search });
-            }
+            const { search, hash } = url.parse(request.url, true);
 
-            // replace # with ? so that query parameters can be read by renderer
-            const script = `
-                <script>
-                    if (window.location.href.includes('#')) {
-                        fetch(window.location.href.replace('#', '?'))
-                    }
-                </script>
-            `;
-            const template = applyTemplate(undefined, { script });
-            response.end(template);
+            // send data back to main window
+            httpReceiver.emit('oauth/response', {
+                key: 'trezor-oauth',
+                hash: hash!,
+                search: search!,
+            });
+
+            response.end(applyTemplate());
         },
     ]);
     httpReceiver.deactivateRoute('/oauth');

--- a/suite/e2e/support/analytics.ts
+++ b/suite/e2e/support/analytics.ts
@@ -1,12 +1,9 @@
 import { Page } from '@playwright/test';
 import { RequireExactlyOne } from 'type-fest';
 
-// Hack: direct import to prevent some nasty import cascade resulting in error while importing icons
-import { urlSearchParams } from '@suite/metadata/src/metadataUtils';
-
 import { step } from './common';
 import { expect } from './testExtends/customMatchers';
-import { EventPayload, Requests, SuiteDesktopAnalyticsEventsForE2e } from './types';
+import { EventPayload, SuiteDesktopAnalyticsEventsForE2e } from './types';
 
 type AnalyticsOptions = RequireExactlyOne<
     {
@@ -130,7 +127,7 @@ export class AnalyticsHelper {
 export class AnalyticsFixture {
     private page: Page;
     private lastRequestCount = 0;
-    requests: Requests = [];
+    requests: Record<string, string>[] = [];
 
     constructor(page: Page) {
         this.page = page;
@@ -163,8 +160,8 @@ export class AnalyticsFixture {
     async interceptAnalytics() {
         await this.page.route('**://data.trezor.io/suite/log/**', route => {
             const url = route.request().url();
-            const params = urlSearchParams(url);
-            this.requests.push(params);
+            const params = new URLSearchParams(url);
+            this.requests.push(Object.fromEntries(params.entries()));
             route.continue();
         });
     }

--- a/suite/e2e/support/mocks/metadataMock.ts
+++ b/suite/e2e/support/mocks/metadataMock.ts
@@ -18,9 +18,15 @@ const stubOpen = `
     Math.random = () => 0.4;
 
     window.open = (url, target, features) => {
-        console.log('Intercepted window.open call:', url);
+        console.log('Intercepted window.open call:', url.toString());
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        const state = urlObj.searchParams?.get('state') || new Array(128).fill('Y').join('');
         window.postMessage(
-            { search: '?code=chicken-cho-cha&state=YYYYYYYYYY', key: 'trezor-oauth' });
+            { 
+              search: '?' + new URLSearchParams({ state, code: 'chicken-cho-cha', }).toString(),
+              key: 'trezor-oauth' 
+            },
+        );
     };
 `;
 

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -2,13 +2,10 @@ import { CryptoId } from 'invity-api';
 import { RequireExactlyOne } from 'type-fest';
 
 import { AnalyticsDesktopEvents } from '@suite/analytics';
-// Hack: direct import to prevent some nasty import cascade resulting in error while importing icons
-import { urlSearchParams } from '@suite/metadata/src/metadataUtils';
 import { NetworkConfigWithoutTestnets, NetworkSymbol } from '@suite-common/wallet-config';
 import { TrezorUserEnvLinkClass } from '@trezor/trezor-user-env-link';
 
 import { LaunchSuiteParams } from '../electron';
-export type Requests = ReturnType<typeof urlSearchParams>[];
 
 /**
  * Desktop analytics events for e2e (findAnalyticsEventByType).

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -42,6 +42,7 @@
         "react-redux": "9.2.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "styled-components": "^6.1.19"
+        "styled-components": "^6.1.19",
+        "zod": "4.3.6"
     }
 }

--- a/suite/metadata/src/__tests__/metadataUtils.test.ts
+++ b/suite/metadata/src/__tests__/metadataUtils.test.ts
@@ -8,7 +8,6 @@ import {
     deriveFilename,
     deriveMetadataKey,
     encrypt,
-    urlSearchParams,
 } from '../metadataUtils';
 
 const filename = '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85';
@@ -107,19 +106,5 @@ describe('metadata', () => {
 
         const content = arrayBufferToBuffer(toArrayBuffer(file));
         expect(content).toEqual(file);
-    });
-
-    it('urlSearchParams', () => {
-        const input1 =
-            '?code=mnau-haf&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.appdata';
-        expect(urlSearchParams(input1)).toEqual({
-            code: 'mnau-haf',
-            scope: 'https://www.googleapis.com/auth/drive.appdata',
-        });
-
-        const input2 = '?code=mnau-ha?#f';
-        expect(urlSearchParams(input2)).toEqual({
-            code: 'mnau-ha?#f',
-        });
     });
 });

--- a/suite/metadata/src/google.ts
+++ b/suite/metadata/src/google.ts
@@ -96,18 +96,18 @@ class Client {
     static initPromise: Promise<Client> | undefined;
     static accessToken: string;
     static refreshToken: string;
-    static authServerUrl: string;
+    static authServerUrl: (typeof Client.servers)[keyof typeof Client.servers];
     static servers = {
         production: 'https://suite-auth.trezor.io',
         staging: 'https://staging-suite-auth.trezor.io',
         localhost: 'http://localhost:3005',
-    };
+    } as const satisfies Record<OAuthServerEnvironment, string>;
 
-    public static setEnvironment(environment: OAuthServerEnvironment) {
+    public static setEnvironment(environment: keyof typeof Client.servers) {
         Client.authServerUrl = Client.servers[environment];
     }
 
-    static init({ accessToken, refreshToken }: Tokens, environment: OAuthServerEnvironment) {
+    static init({ accessToken, refreshToken }: Tokens, environment: keyof typeof Client.servers) {
         Client.initPromise = new Promise(resolve => {
             Client.nameIdMap = {};
             Client.setEnvironment(environment);
@@ -178,36 +178,32 @@ class Client {
 
     static async authorize() {
         await Client.initPromise;
+
         const redirectUri = await getOauthReceiverUrl();
+
         if (!redirectUri) return;
 
-        const random = getCodeChallenge();
+        const url = new URL(`https://accounts.google.com/o/oauth2/v2/auth`);
 
-        const options = {
-            client_id: Client.clientId,
-            redirect_uri: redirectUri,
-            scope: SCOPES,
-        };
+        url.searchParams.set('client_id', Client.clientId);
+        url.searchParams.set('redirect_uri', redirectUri);
+        url.searchParams.set('scope', SCOPES);
+
+        const challenge = getCodeChallenge();
 
         if (Client.flow === 'code') {
             // authorization code flow with PKCE
-            Object.assign(options, {
-                code_challenge: random,
-                code_challenge_method: 'plain',
-                response_type: 'code',
-            });
+            url.searchParams.set('code_challenge', challenge);
+            url.searchParams.set('code_challenge_method', 'plain');
+            url.searchParams.set('response_type', 'code');
         } else {
             // implicit flow
-            Object.assign(options, {
-                response_type: 'token',
-            });
+            url.searchParams.set('response_type', 'token');
         }
 
-        const url = `https://accounts.google.com/o/oauth2/v2/auth?${new URLSearchParams(
-            options,
-        ).toString()}`;
-        const response = await extractCredentialsFromAuthorizationFlow(url);
-        const { access_token, code } = response;
+        url.searchParams.set('state', getCodeChallenge());
+
+        const { access_token, code } = await extractCredentialsFromAuthorizationFlow(url);
 
         if (access_token) {
             // implicit flow returns short lived access_token directly
@@ -220,7 +216,7 @@ class Client {
                     body: JSON.stringify({
                         clientId: Client.clientId,
                         code,
-                        codeVerifier: random,
+                        codeVerifier: challenge,
                         redirectUri,
                     }),
                     headers: {
@@ -229,6 +225,7 @@ class Client {
                 });
 
                 const json = await res.json();
+
                 if (!json?.access_token || !json?.refresh_token) {
                     throw new Error('Could not retrieve the tokens.');
                 }

--- a/suite/metadata/src/metadataUtils.ts
+++ b/suite/metadata/src/metadataUtils.ts
@@ -123,35 +123,6 @@ export const decrypt = (input: Buffer, key: string | Buffer) => {
     return JSON.parse(stringified);
 };
 
-/**
- * parse object from url hash params string
- */
-export const urlHashParams = (hash: string) => {
-    const result: { [param: string]: string } = {};
-    if (!hash) return result;
-    if (hash[0] === '#') {
-        hash = hash.substring(1, hash.length);
-    }
-    const parts = hash.split('&');
-    parts.forEach(part => {
-        const [key, value] = part.split('=');
-        result[key] = decodeURIComponent(value);
-    });
-
-    return result;
-};
-
-/**
- * parse object from url search params string
- */
-export const urlSearchParams = (search: string) => {
-    if (search[0] === '?') {
-        search = search.substring(1);
-    }
-
-    return urlHashParams(search);
-};
-
 export const getFetchTrackingId = (
     dataType: DataType,
     clientId: MetadataProvider['clientId'],

--- a/suite/metadata/src/oauth.ts
+++ b/suite/metadata/src/oauth.ts
@@ -1,19 +1,19 @@
+import z, { ZodError } from 'zod';
+
 import { desktopApi } from '@trezor/suite-desktop-api';
 import { type Deferred, createDeferred } from '@trezor/utils';
 
 import * as METADATA_PROVIDER from './metadataProviderConstants';
-import { urlHashParams, urlSearchParams } from './metadataUtils';
 
 // Copy-pasted from packages/suite/src/utils/suite/router.ts to break dependency
 //
 // Prefix a url with ASSET_PREFIX (eg. name of the branch in CI)
 // Useful with next.js Router.push() that accepts `as` prop as second arg
-export const getPrefixedURL = (url: string) => {
+export const getPrefixedURL = (pathname: string) => {
     // do not use object destructuring https://github.com/webpack/webpack/issues/5392
     const prefix = process.env.ASSET_PREFIX;
-    if (prefix && url.indexOf(prefix) !== 0) return prefix + url;
 
-    return url;
+    return prefix && !pathname.startsWith(prefix) ? `${prefix}${pathname}` : pathname;
 };
 
 /**
@@ -21,17 +21,14 @@ export const getPrefixedURL = (url: string) => {
  */
 export const getOauthReceiverUrl = () => {
     if (!desktopApi.available) {
-        return `${window.location.origin}${getPrefixedURL('/static/oauth/oauth_receiver.html')}`;
+        return new URL(
+            getPrefixedURL('/static/oauth/oauth_receiver.html'),
+            window.location.origin,
+        ).toString();
     }
 
     return desktopApi.getHttpReceiverAddress('/oauth');
 };
-
-type Credentials =
-    | { access_token?: undefined; code: string }
-    | { access_token: string; code?: undefined };
-
-type Message = { [key: string]: string };
 
 let interval: number;
 
@@ -44,17 +41,17 @@ let interval: number;
  * @param closeCallback
  */
 const openWindowOnAnotherDomain = (
-    uri: string,
+    url: URL,
     name: string,
     options: string,
     closeCallback: () => void,
 ) => {
-    const win = window.open(uri, name, options);
+    const win = window.open(url, name, options);
     clearInterval(interval);
     interval = window.setInterval(() => {
         // todo: for some reason, when used in electron, win has closed=true right from the start and thus closeCallback
         // is invoked immediately. temporary workaround is not to use openWindowOnAnotherDomain in electron
-        if (!win || win.closed) {
+        if (!win) {
             window.clearInterval(interval);
             closeCallback();
         }
@@ -63,49 +60,100 @@ const openWindowOnAnotherDomain = (
     return win;
 };
 
-const handleResponse = (
-    message: Message,
-    originalParams: { [key: string]: string },
-    onSuccess: (result: Credentials) => void,
-    onError: (error: any) => void,
-) => {
-    if (!message.search && !message.hash) return;
-    let parsedMessage;
+const oauthResponseMessage = z
+    .object({
+        key: z.literal('trezor-oauth'),
+        search: z.string().startsWith('?'),
+    })
+    .or(
+        z.object({
+            key: z.literal('trezor-oauth'),
+            hash: z.string().startsWith('#'),
+        }),
+    );
 
-    if (message.search) {
-        parsedMessage = urlSearchParams(message.search);
-    } else if (message.hash) {
-        parsedMessage = urlHashParams(message.hash);
+export type OAuthResponseMessage = z.infer<typeof oauthResponseMessage>;
+
+const oauthResult = oauthResponseMessage.transform(value => {
+    const searchOrHash = 'search' in value ? value.search : value.hash;
+
+    return Object.fromEntries(new URLSearchParams(searchOrHash.slice(1)).entries());
+});
+
+const oauthResultParams = z.object({
+    access_token: z.string().optional(),
+    code: z.string().optional(),
+    state: z.string().optional(),
+    error: z.string().optional(),
+    error_description: z.string().optional(),
+});
+
+type OAuthResultParams = z.infer<typeof oauthResultParams>;
+type OAuthCredentials = Pick<OAuthResultParams, 'code' | 'access_token'>;
+
+const oauthOriginalParams = z.object({
+    state: z.string().nonempty(),
+});
+
+function handleResponseError(error?: string, errorDescription?: string) {
+    if (!error) {
+        return;
     }
 
-    if (!parsedMessage) return;
+    switch (error) {
+        case 'access_denied':
+            // user clicks cancel in popup interface. This is the same as if user closed the window,
+            return new Error('Window closed');
+        default:
+            // otherwise just show error. This should not happen often, most of the errors can be caused by improper
+            // implementation only. Possibly "temporarily_unavailable" or "server_error" may appear
+            // see possible errors in oauth protocol described here https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+            return new Error(`${error}: ${errorDescription?.replace(/\+/g, ' ')}`);
+    }
+}
 
-    const { code, access_token, state, error_description, error } = parsedMessage;
+const handleResponse = (
+    response: OAuthResponseMessage,
+    originalParams: URLSearchParams,
+    onSuccess: (result: OAuthCredentials) => void,
+    onError: (error: Error) => void,
+) => {
+    try {
+        const resultParams = oauthResult.parse(response);
+        const parsedResultParams = oauthResultParams.parse(resultParams);
+        const parsedOriginalParams = oauthOriginalParams.parse({
+            state: originalParams.get('state'),
+        });
 
-    if (error === 'access_denied') {
-        // user clicks cancel in popup interface. This is the same as if user closed the window,
-        onError(new Error('window closed'));
-    } else if (error) {
-        // otherwise just show error. This should not happen often, most of the errors can be caused by improper
-        // implementation only. Possibly "temporarily_unavailable" or "server_error" may appear
-        // see possible errors in oauth protocol described here https://tools.ietf.org/html/rfc6749#section-4.1.2.1
-        onError(new Error(`${error}: ${error_description.replace(/\+/g, ' ')}`));
-    } else if (originalParams.state && state !== originalParams.state) {
-        onError(new Error('state does not match'));
-    } else if (code || access_token) {
-        onSuccess({ code, access_token } as unknown as Credentials);
-    } else {
-        onError(new Error('Unexpected response form data provider'));
+        const { code, access_token, state, error_description, error } = parsedResultParams;
+
+        if (state !== parsedOriginalParams.state) {
+            return onError(new Error('Invalid response from data provider'));
+        }
+
+        handleResponseError(error, error_description);
+
+        onSuccess({ code, access_token });
+    } catch (error) {
+        if (error instanceof ZodError) {
+            console.error(error);
+
+            return onError(new Error('Invalid response from data provider'));
+        }
+
+        onError(
+            error instanceof Error ? error : new Error('Unexpected response form data provider'),
+        );
     }
 };
 
 // keep handler function instance in top level scope
-let desktopHandlerInstance: (message: Message) => void;
-let webHandlerInstance: (e: MessageEvent<Message>) => void;
+let desktopHandlerInstance: (message: OAuthResponseMessage) => void;
+let webHandlerInstance: (e: MessageEvent<OAuthResponseMessage>) => void;
 
 const getDesktopHandlerInstance = (
-    dfd: Deferred<Credentials>,
-    originalParams: { [key: string]: string },
+    dfd: Deferred<OAuthCredentials>,
+    originalParams: URLSearchParams,
 ) => {
     desktopHandlerInstance = message => {
         handleResponse(
@@ -126,16 +174,15 @@ const getDesktopHandlerInstance = (
 };
 
 const getWebHandlerInstance = (
-    dfd: Deferred<Credentials>,
-    originalParams: { [key: string]: string },
+    dfd: Deferred<OAuthCredentials>,
+    originalParams: URLSearchParams,
 ) => {
     if (webHandlerInstance) {
         window.removeEventListener('message', webHandlerInstance);
     }
-    webHandlerInstance = (e: MessageEvent<Message>) => {
+    webHandlerInstance = (e: MessageEvent<OAuthResponseMessage>) => {
         if (window.location.origin !== e.origin) return;
-        if (!e.data.search && !e.data.hash) return;
-        if (e.data.key !== 'trezor-oauth') return;
+        if (!oauthResult.safeParse(e.data).success) return;
 
         handleResponse(
             e.data,
@@ -155,18 +202,19 @@ const getWebHandlerInstance = (
 /**
  * Handle extraction of authorization code from Oauth2 protocol
  */
-export const extractCredentialsFromAuthorizationFlow = (url: string) => {
-    const originalParams = urlHashParams(url);
-    const dfd = createDeferred<Credentials>();
+export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
+    const dfd = createDeferred<OAuthCredentials>();
 
     if (desktopApi.available) {
         // to make sure that there is always only one listener registered remove all listeners before creating a new one
         desktopApi.removeAllListeners('oauth/response');
         // this listener may never be called in some cases
-        desktopApi.once('oauth/response', getDesktopHandlerInstance(dfd, originalParams));
+        desktopApi.once('oauth/response', getDesktopHandlerInstance(dfd, url.searchParams));
         window.open(url, METADATA_PROVIDER.AUTH_WINDOW_TITLE, METADATA_PROVIDER.AUTH_WINDOW_PROPS);
     } else {
-        window.addEventListener('message', getWebHandlerInstance(dfd, originalParams));
+        const messageHandler = getWebHandlerInstance(dfd, url.searchParams);
+
+        window.addEventListener('message', messageHandler);
         openWindowOnAnotherDomain(
             url,
             METADATA_PROVIDER.AUTH_WINDOW_TITLE,
@@ -175,10 +223,7 @@ export const extractCredentialsFromAuthorizationFlow = (url: string) => {
                 // note that this rejection happens even on successful authorization.
                 // 'window closed' error message may be used to differentiate between errors
                 setTimeout(() => {
-                    window.removeEventListener(
-                        'message',
-                        getWebHandlerInstance(dfd, originalParams),
-                    );
+                    window.removeEventListener('message', messageHandler);
                     dfd.reject(new Error('window closed'));
                 }, 5000);
             },

--- a/suite/metadata/src/providers/DropboxProvider.ts
+++ b/suite/metadata/src/providers/DropboxProvider.ts
@@ -69,8 +69,7 @@ export class DropboxProvider extends AbstractMetadataProvider {
 
         try {
             // dropbox supports authorization code flow for both web and desktop
-            // @ts-expect-error dropbox lib types url as String object, but it is primite string
-            const { code } = await extractCredentialsFromAuthorizationFlow(url);
+            const { code } = await extractCredentialsFromAuthorizationFlow(new URL(url.toString()));
 
             if (!code)
                 return this.error('AUTH_ERROR', 'Failed to extract code from authorization flow');

--- a/yarn.lock
+++ b/yarn.lock
@@ -14867,6 +14867,7 @@ __metadata:
     redux: "npm:^5.0.1"
     redux-thunk: "npm:^3.1.0"
     styled-components: "npm:^6.1.19"
+    zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Enhance OAuth handling with zod validation and update response structure:
- __Always send `state` param in OAuth req__.
- __Always validate the `state` in OAuth res__.
- Use native API instead of custom ones.
- Fix removing message listener (removeEventListener must accept same fn ref as addEventListener received).
- Improve type-safety.
- Don't use `window.closed` (Cross-Origin-Opener-Policy policy violation).

## Notes for QA

- Labelling should still work on web/desktop for G Drive and Dropbox.
- I went through all of these scenarios. 🟢 

## Related Issue

Resolve [#199](https://github.com/trezor/trezor-suite-private/issues/199)



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/oauth-security&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/oauth-security&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-13T12:03:17.666Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T10:44:25.878Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->