### PR TITLE
feat(suite-native): make secondary button in CardStepper optional

### DIFF
--- a/suite-native/atoms/src/CardStepper/CardStepper.tsx
+++ b/suite-native/atoms/src/CardStepper/CardStepper.tsx
@@ -18,8 +18,8 @@ export type CardStepperMap<ContentIdType = undefined> = Record<
 export type CardStepperProps<ContentIdType = undefined> = {
     onFinish: () => void;
     primaryButtonText: ReactNode;
-    secondaryButtonText: ReactNode;
-    onPressSecondaryButton: (id?: ContentIdType) => void;
+    secondaryButtonText?: ReactNode;
+    onPressSecondaryButton?: (id?: ContentIdType) => void;
     buttonsActionType?: CardStepperButtonsActionType;
     stepToContentMap: CardStepperMap<ContentIdType>;
 };
@@ -44,14 +44,6 @@ export const CardStepper = <ContentIdType = undefined,>({
         onFinish();
     };
 
-    const handlePressSecondaryButton = (contentId?: ContentIdType) => {
-        if (contentId) {
-            onPressSecondaryButton(contentId);
-        } else {
-            onPressSecondaryButton();
-        }
-    };
-
     return (
         <VStack spacing="sp16">
             {Object.entries(stepToContentMap).map(([stepIndex, content]) => (
@@ -67,7 +59,7 @@ export const CardStepper = <ContentIdType = undefined,>({
                     primaryButtonText={primaryButtonText}
                     secondaryButtonText={secondaryButtonText}
                     onPressSecondaryButton={() =>
-                        handlePressSecondaryButton(content.secondaryButtonParameter)
+                        onPressSecondaryButton?.(content.secondaryButtonParameter)
                     }
                 />
             ))}

--- a/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
+++ b/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
@@ -20,7 +20,7 @@ type CardStepperItemProps = {
     isOpened: boolean;
     icon: IconName;
     primaryButtonText: ReactNode;
-    secondaryButtonText: ReactNode;
+    secondaryButtonText?: ReactNode;
     onPressConfirmButton: () => void;
     onPressSecondaryButton: () => void;
     buttonsActionType?: CardStepperButtonsActionType;
@@ -108,20 +108,17 @@ export const CardStepperItem = ({
                         exiting={EXITING_ANIMATION}
                     >
                         <Text variant="body-md-strong">{description}</Text>
-                        <HStack
-                            flex={1}
-                            spacing="sp12"
-                            justifyContent="space-between"
-                            paddingBottom="sp4"
-                        >
-                            <Button
-                                size="small"
-                                style={applyStyle(buttonStyle)}
-                                colorScheme={buttonsColorSchemeMap[buttonsActionType].secondary}
-                                onPress={onPressSecondaryButton}
-                            >
-                                {secondaryButtonText}
-                            </Button>
+                        <HStack flex={1} spacing="sp12" paddingBottom="sp4">
+                            {secondaryButtonText && (
+                                <Button
+                                    size="small"
+                                    style={applyStyle(buttonStyle)}
+                                    colorScheme={buttonsColorSchemeMap[buttonsActionType].secondary}
+                                    onPress={onPressSecondaryButton}
+                                >
+                                    {secondaryButtonText}
+                                </Button>
+                            )}
                             <Button
                                 size="small"
                                 style={applyStyle(buttonStyle)}


### PR DESCRIPTION
## Related Issue

Required for #25127

## Screenshots:
| 1 | 2 |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/59b73805-e4bc-407c-9bc8-c8d6d069af25" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/25de72eb-a0c1-45f9-81df-7a7081022d2d" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/card-stepper-secondary-button&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->