### PR TITLE
chore(suite-desktop): fix circular imports

### DIFF
--- a/packages/suite-desktop-core/src/modules/event-logging/app.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/app.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron';
 
-import type { ModuleInit } from '../index';
+import type { ModuleInit } from '../module';
 
 export const SERVICE_NAME = 'app';
 

--- a/packages/suite-desktop-core/src/modules/event-logging/contents.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/contents.ts
@@ -1,5 +1,5 @@
 import { hasSwitch } from '../../libs/process-switches';
-import type { ModuleInit } from '../index';
+import type { ModuleInit } from '../module';
 
 const logUI = hasSwitch('log-ui');
 

--- a/packages/suite-desktop-core/src/modules/event-logging/index.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/index.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from '../../typed-electron';
-import type { ModuleInit } from '../index';
+import type { ModuleInit } from '../module';
 
 export const SERVICE_NAME = 'event-logging';
 

--- a/packages/suite-desktop-core/src/modules/event-logging/process.ts
+++ b/packages/suite-desktop-core/src/modules/event-logging/process.ts
@@ -1,4 +1,4 @@
-import type { ModuleInit } from '../index';
+import type { ModuleInit } from '../module';
 
 export const SERVICE_NAME = 'event-logging/process';
 

--- a/packages/suite-desktop-core/src/modules/index.ts
+++ b/packages/suite-desktop-core/src/modules/index.ts
@@ -23,7 +23,13 @@ import * as firmware from './firmware';
 import * as httpReceiverModule from './http-receiver';
 import * as menu from './menu';
 import * as metadata from './metadata';
-import { Dependencies, ModuleInit, ModuleInitBackground, ModuleLoad, ModuleQuit } from './module';
+import type {
+    Dependencies,
+    ModuleInit,
+    ModuleInitBackground,
+    ModuleLoad,
+    ModuleQuit,
+} from './module';
 import * as powerMonitor from './power-monitor';
 import * as requestFilter from './request-filter';
 import * as requestInterceptor from './request-interceptor';

--- a/scripts/circular-dependencies/madge-snapshot.txt
+++ b/scripts/circular-dependencies/madge-snapshot.txt
@@ -2,10 +2,6 @@
 
 packages/blockchain-link-types/src/common.ts > packages/blockchain-link-types/src/blockbook.ts
 packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx > packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/app.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/contents.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/index.ts
-packages/suite-desktop-core/src/modules/index.ts > packages/suite-desktop-core/src/modules/event-logging/process.ts
 packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx > packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
 packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx > packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
 packages/suite/src/components/suite/modals/ReduxModal/ReduxModal.tsx > packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/DeviceConfirmationModal.tsx


### PR DESCRIPTION
## Description

Fix import circulars in `suite-desktop-core` simply by directly importing instead of barrel import.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-desktop-core-circulars&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-desktop-core-circulars&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Sell inputs > Sell form % inputs and limits | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-13T11:29:19.823Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T11:27:42.518Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->