### PR TITLE
XLM - Activate token in Trading

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -235,6 +235,7 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
         <Modal
             width={600}
             onCancel={!isProcessing ? onCancel : undefined}
+            isBackdropCancelable={!isProcessing}
             heading={<Translation id={headingId} values={{ token: tokenCode }} />}
             bottomContent={
                 <Row gap={spacings.xs}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -16,7 +16,7 @@ import {
     fetchAndUpdateAccountThunk,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { type FormState } from '@suite-common/wallet-types';
+import { type Account, type FormState } from '@suite-common/wallet-types';
 import { formatNetworkAmount, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { BASE_INFO } from '@trezor/blockchain-link-utils/src/stellar';
 import { Banner, Button, Column, Modal, Row, Text } from '@trezor/components';
@@ -35,12 +35,14 @@ type StellarManageTokenModalProps =
           mode: 'activate';
           symbol: NetworkSymbol;
           contractAddress: string;
+          account?: Account;
           onCancel: () => void;
       }
     | {
           mode: 'deactivate';
           symbol: NetworkSymbol;
           contractAddress: string;
+          account?: Account;
           tokenBalance: string;
           onCancel: () => void;
       };
@@ -50,7 +52,8 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
     const { mode, symbol, contractAddress, onCancel } = props;
     const tokenBalance = mode === 'deactivate' ? props.tokenBalance : undefined;
     const dispatch = useDispatch();
-    const account = useSelector(selectSelectedAccount);
+    const selectedAccount = useSelector(selectSelectedAccount);
+    const account = props.account ?? selectedAccount;
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, symbol));
     const { translationString } = useTranslation();
     const [isProcessing, setIsProcessing] = useState(false);
@@ -231,7 +234,7 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
     return (
         <Modal
             width={600}
-            onCancel={onCancel}
+            onCancel={!isProcessing ? onCancel : undefined}
             heading={<Translation id={headingId} values={{ token: tokenCode }} />}
             bottomContent={
                 <Row gap={spacings.xs}>
@@ -293,6 +296,22 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                                         required: insufficientBalanceInfo.required,
                                         available: insufficientBalanceInfo.available,
                                     }}
+                                />
+                            }
+                        />
+                    )}
+
+                    {isProcessing && (
+                        <Banner
+                            intent="info"
+                            icon="spinner"
+                            description={
+                                <Translation
+                                    id={
+                                        mode === 'activate'
+                                            ? 'TR_ACTIVATION_IN_PROGRESS_BANNER'
+                                            : 'TR_DEACTIVATION_IN_PROGRESS_BANNER'
+                                    }
                                 />
                             }
                         />

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -17,6 +17,7 @@ import {
     tradingBuyActions,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { filterReceiveAccounts } from '@suite-common/wallet-utils';
 import addressValidator from '@trezor/address-validator';
@@ -89,6 +90,8 @@ export const useTradingReceiveAddress = ({
     const [selectedAccount, setSelectedAccount] = useState<Account | null | undefined>(undefined);
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState<boolean | undefined>(undefined);
+
+    const receiveAccount = useSelector(state => selectAccountByKey(state, selectedAccount?.key));
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,
@@ -263,7 +266,7 @@ export const useTradingReceiveAddress = ({
     const receiveAddressValue = methods.watch('address');
     const extraFieldValue = methods.watch('extraField');
 
-    const addressDictionary = useAccountAddressDictionary(selectedAccount ?? undefined);
+    const addressDictionary = useAccountAddressDictionary(receiveAccount ?? undefined);
     const accountAddress = receiveAddressValue ? addressDictionary[receiveAddressValue] : undefined;
 
     const receiveAddress = useMemo(() => {
@@ -306,20 +309,20 @@ export const useTradingReceiveAddress = ({
         if (pageType === 'retry') return;
 
         if (type === 'exchange') {
-            dispatch(tradingExchangeActions.setReceiveAccountKey(selectedAccount?.key));
+            dispatch(tradingExchangeActions.setReceiveAccountKey(receiveAccount?.key));
         }
 
         if (type === 'buy') {
-            dispatch(tradingBuyActions.setReceiveAccountKey(selectedAccount?.key));
+            dispatch(tradingBuyActions.setReceiveAccountKey(receiveAccount?.key));
         }
-    }, [selectedAccount, pageType, type, dispatch]);
+    }, [receiveAccount, pageType, type, dispatch]);
 
     return {
         form: {
             ...methods,
         },
         suiteReceiveAccounts,
-        selectedAccount,
+        selectedAccount: receiveAccount,
         accountAddress,
         isMenuOpen,
         onChangeAccount,

--- a/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { type CryptoId } from 'invity-api';
+
+import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
+import { cryptoIdToNetworkAndContractAddress } from '@suite-common/trading';
+import { type Account } from '@suite-common/wallet-types';
+
+import { getInactiveStellarTokens } from 'src/views/wallet/tokens/inactive-tokens/InactiveTokensTable';
+
+interface UseTradingStellarActivateTokenProps {
+    account?: Account;
+    receiveCryptoId?: CryptoId;
+}
+
+export const useTradingStellarActivateToken = ({
+    account,
+    receiveCryptoId,
+}: UseTradingStellarActivateTokenProps) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const { data: inactiveTokens, refetch } = useQuery({
+        enabled: account?.symbol === 'xlm',
+        queryKey: [desktopQueryKeys.inactiveTokens(account?.symbol ?? 'xlm', account?.key)],
+        queryFn: () => getInactiveStellarTokens(account!),
+        initialData: [],
+    });
+
+    const { contractAddress: selectedAssetContractAddress } =
+        cryptoIdToNetworkAndContractAddress(receiveCryptoId);
+
+    const inactiveToken = inactiveTokens?.find(
+        token => token.contract === selectedAssetContractAddress,
+    );
+
+    const onModalOpen = () => setIsModalOpen(true);
+
+    const onModalClose = () => {
+        setIsModalOpen(false);
+        refetch();
+    };
+
+    return {
+        inactiveToken,
+        modal: {
+            isOpen: isModalOpen,
+            onOpen: onModalOpen,
+            onClose: onModalClose,
+        },
+    };
+};

--- a/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
@@ -5,8 +5,7 @@ import { type CryptoId } from 'invity-api';
 import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
 import { cryptoIdToNetworkAndContractAddress } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
-
-import { getInactiveStellarTokens } from 'src/views/wallet/tokens/inactive-tokens/InactiveTokensTable';
+import { getStellarInactiveTokens } from '@suite-common/wallet-utils';
 
 interface UseTradingStellarActivateTokenProps {
     account?: Account;
@@ -21,8 +20,8 @@ export const useTradingStellarActivateToken = ({
 
     const { data: inactiveTokens, refetch } = useQuery({
         enabled: account?.symbol === 'xlm',
-        queryKey: [desktopQueryKeys.inactiveTokens(account?.symbol ?? 'xlm', account?.key)],
-        queryFn: () => getInactiveStellarTokens(account!),
+        queryKey: desktopQueryKeys.inactiveTokens(account?.symbol ?? 'xlm', account?.key),
+        queryFn: () => getStellarInactiveTokens(account!),
         initialData: [],
     });
 

--- a/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
@@ -6,9 +6,8 @@ import { Translation } from '@suite/intl';
 import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getCoingeckoId } from '@suite-common/wallet-config';
-import { type Account, type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import type { TokenDetailByMint, TokenInfo } from '@trezor/blockchain-link-types';
-import { STELLAR_DECIMALS, getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
+import { type SelectedAccountLoaded, type StellarTokenInfo } from '@suite-common/wallet-types';
+import { getStellarInactiveTokens } from '@suite-common/wallet-utils';
 import { Button, Card, Row, Table, Text, Tooltip } from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
@@ -33,47 +32,6 @@ const DashedText = ({ children, ...props }: React.ComponentProps<typeof Text>) =
     </DashedTextWrapper>
 );
 
-export interface StellarTokenInfo extends TokenInfo {
-    homeDomain?: string;
-    rating?: number;
-}
-
-/**
- * Get the list of inactive Stellar tokens for the user account
- */
-export const getInactiveStellarTokens = async (account: Account): Promise<StellarTokenInfo[]> => {
-    if (account.symbol !== 'xlm') return [];
-
-    const allTokens: TokenDetailByMint = await getTokenMetadata();
-
-    // Get the currently active token contract addresses for the user
-    const activeTokenContracts = new Set(account.tokens?.map(token => token.contract) || []);
-
-    // Return tokens that the user has not activated yet
-    const inactiveTokens = Object.entries(allTokens)
-        .filter(([contractAddress]) => !activeTokenContracts.has(contractAddress))
-        .map(([contract]) => ({
-            type: 'STELLAR-CLASSIC' as const,
-            standard: 'STELLAR-CLASSIC' as const,
-            contract,
-            name: allTokens[contract]?.name,
-            symbol: contract.split('-')[0],
-            decimals: STELLAR_DECIMALS,
-            homeDomain: allTokens[contract]?.home_domain,
-            rating: allTokens[contract]?.rating,
-        }))
-        .sort((a, b) => {
-            // Place tokens without ratings last, otherwise sort high to low
-            if (a.rating == null && b.rating == null) return 0;
-            if (a.rating == null) return 1;
-            if (b.rating == null) return -1;
-
-            return b.rating - a.rating;
-        });
-
-    return inactiveTokens;
-};
-
 interface InactiveTokensTableProps {
     selectedAccount: SelectedAccountLoaded;
     searchQuery: string;
@@ -94,7 +52,7 @@ export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTo
         queryKey: desktopQueryKeys.inactiveTokens(account.symbol),
         queryFn: () => {
             try {
-                return getInactiveStellarTokens(account);
+                return getStellarInactiveTokens(account);
             } catch (error) {
                 dispatch(
                     notificationsActions.addToast({

--- a/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
@@ -33,7 +33,7 @@ const DashedText = ({ children, ...props }: React.ComponentProps<typeof Text>) =
     </DashedTextWrapper>
 );
 
-interface StellarTokenInfo extends TokenInfo {
+export interface StellarTokenInfo extends TokenInfo {
     homeDomain?: string;
     rating?: number;
 }
@@ -41,7 +41,7 @@ interface StellarTokenInfo extends TokenInfo {
 /**
  * Get the list of inactive Stellar tokens for the user account
  */
-const getInactiveStellarTokens = async (account: Account): Promise<StellarTokenInfo[]> => {
+export const getInactiveStellarTokens = async (account: Account): Promise<StellarTokenInfo[]> => {
     if (account.symbol !== 'xlm') return [];
 
     const allTokens: TokenDetailByMint = await getTokenMetadata();

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -18,9 +18,11 @@ import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button, Card, Column, Paragraph } from '@trezor/components';
 import { breakpoints } from '@trezor/theme';
 
+import { StellarManageTokenModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useTradingStellarActivateToken } from 'src/hooks/wallet/trading/useTradingStellarActivateToken';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { type TradingFormContextValues } from 'src/types/trading/tradingForm';
 import {
@@ -110,6 +112,8 @@ export const TradingFormOffer = () => {
         isTradingExchangeContext(context) || isTradingBuyContext(context)
             ? context.tradingReceiveAddress
             : undefined;
+
+    const isReceiveAddressSelected = !!tradingReceiveAddress?.receiveAddress;
 
     const isLoadingQuote = isTradingExchangeContext(context) && context.isLoadingQuote;
 
@@ -257,9 +261,11 @@ export const TradingFormOffer = () => {
             ? receiveCurrency
             : (selectedCryptoId ?? undefined);
 
-    const isReceiveAddressSelected =
-        (isTradingExchangeContext(context) || isTradingBuyContext(context)) &&
-        !!context.tradingReceiveAddress.receiveAddress;
+    const { inactiveToken: stellarInactiveToken, modal: stellarActivateTokenModal } =
+        useTradingStellarActivateToken({
+            account: tradingReceiveAddress?.selectedAccount ?? undefined,
+            receiveCryptoId: selectedAssetCryptoId,
+        });
 
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint(breakpoints.tablet);
 
@@ -349,48 +355,84 @@ export const TradingFormOffer = () => {
                     !isLoading ? (
                         <TradingFormApproval />
                     ) : (
-                        <Button
-                            onClick={onSelectQuote}
-                            intent="brand"
-                            margin={{
-                                top: 16,
-                            }}
-                            size="large"
-                            isDisabled={isButtonDisabled || isLoading}
-                            isLoading={
-                                areFeesLoading ||
-                                (preselectedQuote && state.isFormLoading) ||
-                                (state.isFormLoading &&
-                                    !isAmountEmpty &&
-                                    (type === 'sell' || isReceiveAddressSelected))
-                            }
-                            data-testid={`@trading/form/${type}-button`}
-                            minWidth={160}
-                            width={isContentBelowBreakpoint ? undefined : '100%'}
-                        >
-                            <Translation
-                                id={
-                                    state.isFormLoading &&
-                                    !isAmountEmpty &&
-                                    (type === 'sell' || isReceiveAddressSelected)
-                                        ? 'TR_TRADING_OFFER_LOOKING'
-                                        : tradingGetSectionActionLabel(type)
-                                }
-                            />
-                        </Button>
+                        <>
+                            {stellarInactiveToken ? (
+                                <Button
+                                    intent="brand"
+                                    margin={{
+                                        top: 16,
+                                    }}
+                                    size="large"
+                                    minWidth={160}
+                                    width={isContentBelowBreakpoint ? undefined : '100%'}
+                                    onClick={stellarActivateTokenModal.onOpen}
+                                    isDisabled={!tradingReceiveAddress?.selectedAccount?.symbol}
+                                >
+                                    <Translation
+                                        id="TR_ACTIVATE_TOKEN"
+                                        values={{ token: stellarInactiveToken.symbol }}
+                                    />
+                                </Button>
+                            ) : (
+                                <Button
+                                    onClick={onSelectQuote}
+                                    intent="brand"
+                                    margin={{
+                                        top: 16,
+                                    }}
+                                    size="large"
+                                    isDisabled={isButtonDisabled || isLoading}
+                                    isLoading={
+                                        areFeesLoading ||
+                                        (preselectedQuote && state.isFormLoading) ||
+                                        (state.isFormLoading &&
+                                            !isAmountEmpty &&
+                                            (type === 'sell' || isReceiveAddressSelected))
+                                    }
+                                    data-testid={`@trading/form/${type}-button`}
+                                    minWidth={160}
+                                    width={isContentBelowBreakpoint ? undefined : '100%'}
+                                >
+                                    <Translation
+                                        id={
+                                            state.isFormLoading &&
+                                            !isAmountEmpty &&
+                                            (type === 'sell' || isReceiveAddressSelected)
+                                                ? 'TR_TRADING_OFFER_LOOKING'
+                                                : tradingGetSectionActionLabel(type)
+                                        }
+                                    />
+                                </Button>
+                            )}
+                        </>
                     )}
                 </>
             )}
+
             {(type === 'buy' || type === 'sell') && <TradingFormOfferOTC />}
+
             {isTradingExchangeContext(context) && bestScoredQuoteAmounts?.sendCurrency && (
                 <TradingApproveModal
                     amount={amount}
                     cryptoId={bestScoredQuoteAmounts.sendCurrency as CryptoId}
                 />
             )}
+
             {isTradingExchangeContext(context) && bestScoredQuoteAmounts?.sendCurrency && (
                 <TradingRevokeModal cryptoId={bestScoredQuoteAmounts.sendCurrency as CryptoId} />
             )}
+
+            {stellarActivateTokenModal.isOpen &&
+                stellarInactiveToken &&
+                tradingReceiveAddress?.selectedAccount?.symbol && (
+                    <StellarManageTokenModal
+                        mode="activate"
+                        account={tradingReceiveAddress.selectedAccount}
+                        symbol={tradingReceiveAddress.selectedAccount.symbol}
+                        contractAddress={stellarInactiveToken.contract}
+                        onCancel={stellarActivateTokenModal.onClose}
+                    />
+                )}
         </Column>
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -267,9 +267,22 @@ export const TradingFormOffer = () => {
             receiveCryptoId: selectedAssetCryptoId,
         });
 
+    const isStellarActivateTokenModalOpen =
+        stellarActivateTokenModal.isOpen && !!stellarInactiveToken;
+
     const isContentBelowBreakpoint = useIsContentBelowBreakpoint(breakpoints.tablet);
 
     const noOffersWithTor = isTorEnabled && !quote && !isLoading;
+
+    const isConfirmButtonLoading =
+        areFeesLoading ||
+        (preselectedQuote && state.isFormLoading) ||
+        (state.isFormLoading && !isAmountEmpty && (type === 'sell' || isReceiveAddressSelected));
+
+    const confirmButtonTranslationId =
+        state.isFormLoading && !isAmountEmpty && (type === 'sell' || isReceiveAddressSelected)
+            ? 'TR_TRADING_OFFER_LOOKING'
+            : tradingGetSectionActionLabel(type);
 
     return (
         <Column gap={20}>
@@ -382,26 +395,12 @@ export const TradingFormOffer = () => {
                                     }}
                                     size="large"
                                     isDisabled={isButtonDisabled || isLoading}
-                                    isLoading={
-                                        areFeesLoading ||
-                                        (preselectedQuote && state.isFormLoading) ||
-                                        (state.isFormLoading &&
-                                            !isAmountEmpty &&
-                                            (type === 'sell' || isReceiveAddressSelected))
-                                    }
+                                    isLoading={isConfirmButtonLoading}
                                     data-testid={`@trading/form/${type}-button`}
                                     minWidth={160}
                                     width={isContentBelowBreakpoint ? undefined : '100%'}
                                 >
-                                    <Translation
-                                        id={
-                                            state.isFormLoading &&
-                                            !isAmountEmpty &&
-                                            (type === 'sell' || isReceiveAddressSelected)
-                                                ? 'TR_TRADING_OFFER_LOOKING'
-                                                : tradingGetSectionActionLabel(type)
-                                        }
-                                    />
+                                    <Translation id={confirmButtonTranslationId} />
                                 </Button>
                             )}
                         </>
@@ -422,17 +421,15 @@ export const TradingFormOffer = () => {
                 <TradingRevokeModal cryptoId={bestScoredQuoteAmounts.sendCurrency as CryptoId} />
             )}
 
-            {stellarActivateTokenModal.isOpen &&
-                stellarInactiveToken &&
-                tradingReceiveAddress?.selectedAccount?.symbol && (
-                    <StellarManageTokenModal
-                        mode="activate"
-                        account={tradingReceiveAddress.selectedAccount}
-                        symbol={tradingReceiveAddress.selectedAccount.symbol}
-                        contractAddress={stellarInactiveToken.contract}
-                        onCancel={stellarActivateTokenModal.onClose}
-                    />
-                )}
+            {isStellarActivateTokenModalOpen && !!tradingReceiveAddress?.selectedAccount && (
+                <StellarManageTokenModal
+                    mode="activate"
+                    account={tradingReceiveAddress.selectedAccount}
+                    symbol={tradingReceiveAddress.selectedAccount.symbol}
+                    contractAddress={stellarInactiveToken.contract}
+                    onCancel={stellarActivateTokenModal.onClose}
+                />
+            )}
         </Column>
     );
 };

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -14,7 +14,8 @@ export const commonQueryKeys = {
 export const desktopQueryKeys = {
     defaultUrls: (symbol: string) => ['default-urls', symbol],
     proxyImage: (src?: string) => ['proxy-image', src],
-    inactiveTokens: (symbol: string) => ['inactive-tokens', symbol],
+    inactiveTokens: (symbol: string, accountKey?: string) =>
+        accountKey ? ['inactive-tokens', symbol, accountKey] : ['inactive-tokens', symbol],
     yieldOpportunities: (pagination: any) => ['yield-opportunities', pagination],
 } as const satisfies Record<string, AllowedQueryKey>;
 

--- a/suite-common/wallet-types/src/index.ts
+++ b/suite-common/wallet-types/src/index.ts
@@ -18,3 +18,4 @@ export type * from './globalSendReceive';
 export * from './baseCurrency';
 export type * from './transactionSimulation';
 export * from './stakeTypes';
+export type * from './stellarTokens';

--- a/suite-common/wallet-types/src/stellarTokens.ts
+++ b/suite-common/wallet-types/src/stellarTokens.ts
@@ -1,0 +1,6 @@
+import { type TokenInfo } from '@trezor/blockchain-link-types';
+
+export interface StellarTokenInfo extends TokenInfo {
+    homeDomain?: string;
+    rating?: number;
+}

--- a/suite-common/wallet-utils/src/__tests__/stellarTokens.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/stellarTokens.test.ts
@@ -1,0 +1,94 @@
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
+
+import { getStellarInactiveTokens } from '../stellarTokens';
+
+jest.mock('@trezor/blockchain-link-utils/src/stellar', () => ({
+    STELLAR_DECIMALS: 7,
+    getTokenMetadata: jest.fn(),
+}));
+
+const mockedGetTokenMetadata = jest.mocked(getTokenMetadata);
+
+describe(getStellarInactiveTokens.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns empty array for non-Stellar accounts', async () => {
+        const account = mockWalletAccount({ symbol: 'btc' });
+
+        await expect(getStellarInactiveTokens(account)).resolves.toEqual([]);
+        expect(mockedGetTokenMetadata).not.toHaveBeenCalled();
+    });
+
+    it('returns all tokens when account has no active Stellar tokens', async () => {
+        const account = mockWalletAccount({ symbol: 'xlm', tokens: undefined });
+
+        mockedGetTokenMetadata.mockResolvedValue({
+            'USDC-GA123': { name: 'USD Coin', symbol: 'USDC', home_domain: 'centre.io', rating: 5 },
+            'AQUA-GB456': { name: 'Aqua', symbol: 'AQUA', home_domain: 'aqua.network', rating: 2 },
+        });
+
+        await expect(getStellarInactiveTokens(account)).resolves.toEqual([
+            {
+                type: 'STELLAR-CLASSIC',
+                standard: 'STELLAR-CLASSIC',
+                contract: 'USDC-GA123',
+                name: 'USD Coin',
+                symbol: 'USDC',
+                decimals: 7,
+                homeDomain: 'centre.io',
+                rating: 5,
+            },
+            {
+                type: 'STELLAR-CLASSIC',
+                standard: 'STELLAR-CLASSIC',
+                contract: 'AQUA-GB456',
+                name: 'Aqua',
+                symbol: 'AQUA',
+                decimals: 7,
+                homeDomain: 'aqua.network',
+                rating: 2,
+            },
+        ]);
+    });
+
+    it('filters out active Stellar tokens', async () => {
+        const account = mockWalletAccount({
+            symbol: 'xlm',
+            tokens: [{ contract: 'YBX-GC789' }] as never,
+        });
+
+        mockedGetTokenMetadata.mockResolvedValue({
+            'USDC-GA123': { name: 'USD Coin', symbol: 'USDC', home_domain: 'centre.io', rating: 5 },
+            'AQUA-GB456': { name: 'Aqua', symbol: 'AQUA', home_domain: 'aqua.network', rating: 2 },
+            'YBX-GC789': { name: 'YBX', symbol: 'YBX', home_domain: 'ultra.io', rating: 1 },
+        });
+
+        await expect(getStellarInactiveTokens(account)).resolves.toEqual([
+            expect.objectContaining({ contract: 'USDC-GA123' }),
+            expect.objectContaining({ contract: 'AQUA-GB456' }),
+        ]);
+    });
+
+    it('sorts tokens by rating in descending order and keeps unrated tokens last', async () => {
+        const account = mockWalletAccount({ symbol: 'xlm' });
+
+        mockedGetTokenMetadata.mockResolvedValue({
+            'LOW-GA111': { name: 'Low', symbol: 'LOW', home_domain: 'low.org', rating: 1 },
+            'UNRATED-GA222': { name: 'Unrated', symbol: 'UNRATED', home_domain: 'none.org' },
+            'HIGH-GA333': { name: 'High', symbol: 'HIGH', home_domain: 'high.org', rating: 9 },
+        });
+
+        const result = await getStellarInactiveTokens(account);
+
+        expect(result.map(token => token.contract)).toEqual([
+            'HIGH-GA333',
+            'LOW-GA111',
+            'UNRATED-GA222',
+        ]);
+
+        expect(result[2]?.rating).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-utils/src/index.ts
+++ b/suite-common/wallet-utils/src/index.ts
@@ -31,3 +31,4 @@ export * from './cardanoStakingUtils';
 export * from './amountUtils';
 export * from './bigNumberUtils';
 export * from './feeUnitUtils';
+export * from './stellarTokens';

--- a/suite-common/wallet-utils/src/stellarTokens.ts
+++ b/suite-common/wallet-utils/src/stellarTokens.ts
@@ -1,0 +1,37 @@
+import type { Account, StellarTokenInfo } from '@suite-common/wallet-types';
+import type { TokenDetailByMint } from '@trezor/blockchain-link-types';
+import { STELLAR_DECIMALS, getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
+
+/** Get the list of inactive Stellar tokens for the user account */
+export const getStellarInactiveTokens = async (account: Account): Promise<StellarTokenInfo[]> => {
+    if (account.symbol !== 'xlm') return [];
+
+    const allTokens: TokenDetailByMint = await getTokenMetadata();
+
+    // Get the currently active token contract addresses for the user
+    const activeTokenContracts = new Set(account.tokens?.map(token => token.contract) || []);
+
+    // Return tokens that the user has not activated yet
+    const inactiveTokens = Object.entries(allTokens)
+        .filter(([contractAddress]) => !activeTokenContracts.has(contractAddress))
+        .map(([contract]) => ({
+            type: 'STELLAR-CLASSIC' as const,
+            standard: 'STELLAR-CLASSIC' as const,
+            contract,
+            name: allTokens[contract]?.name,
+            symbol: contract.split('-')[0],
+            decimals: STELLAR_DECIMALS,
+            homeDomain: allTokens[contract]?.home_domain,
+            rating: allTokens[contract]?.rating,
+        }))
+        .sort((a, b) => {
+            // Place tokens without ratings last, otherwise sort high to low
+            if (a.rating == null && b.rating == null) return 0;
+            if (a.rating == null) return 1;
+            if (b.rating == null) return -1;
+
+            return b.rating - a.rating;
+        });
+
+    return inactiveTokens;
+};

--- a/suite-native/module-stellar-token-management/src/components/TokenListItem.tsx
+++ b/suite-native/module-stellar-token-management/src/components/TokenListItem.tsx
@@ -1,10 +1,9 @@
 import { Pressable } from 'react-native';
 
+import { type StellarTokenInfo } from '@suite-common/wallet-types';
 import { Box, Text } from '@suite-native/atoms';
 import { CryptoIcon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-
-import { type StellarTokenInfo } from '../hooks/useInactiveStellarTokens';
 
 type TokenListItemProps = {
     token: StellarTokenInfo;

--- a/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useInactiveStellarTokens.ts
@@ -6,19 +6,14 @@ import {
     selectCoinDefinitions,
 } from '@suite-common/token-definitions';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
-import { type TokenDetailByMint, type TokenInfo } from '@trezor/blockchain-link-types';
+import { type AccountKey, type StellarTokenInfo } from '@suite-common/wallet-types';
+import { type TokenDetailByMint } from '@trezor/blockchain-link-types';
 import { STELLAR_DECIMALS, getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
 import { createLazy } from '@trezor/utils';
 
-export interface StellarTokenInfo extends TokenInfo {
-    homeDomain?: string;
-    rating?: number;
-}
-
 export const lazyTokenMetadata = createLazy(getTokenMetadata);
 
-export const useInactiveStellarTokens = (accountKey: AccountKey) => {
+export const useInactiveStellarTokens = (accountKey?: AccountKey) => {
     const [tokenMetadata, setTokenMetadata] = useState<TokenDetailByMint | null>(
         lazyTokenMetadata.get() ?? null,
     );

--- a/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarFeeScreen.ts
@@ -230,7 +230,7 @@ export const useStellarFeeScreen = ({
 
             if (isFulfilled(result)) {
                 // Refresh account data
-                dispatch(fetchAndUpdateAccountThunk({ accountKey }));
+                await dispatch(fetchAndUpdateAccountThunk({ accountKey }));
 
                 // Execute success callback
                 onSuccess();

--- a/suite-native/module-stellar-token-management/src/hooks/useStellarTokenInfo.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/useStellarTokenInfo.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import { type TokenAddress } from '@suite-common/wallet-types';
+import type { StellarTokenInfo, TokenAddress } from '@suite-common/wallet-types';
 import { STELLAR_DECIMALS } from '@trezor/blockchain-link-utils/src/stellar';
 
-import { type StellarTokenInfo, lazyTokenMetadata } from './useInactiveStellarTokens';
+import { lazyTokenMetadata } from './useInactiveStellarTokens';
 
 export const useStellarTokenInfo = (tokenContract: TokenAddress) => {
     const [tokenInfo, setTokenInfo] = useState<StellarTokenInfo | null>(null);

--- a/suite-native/module-stellar-token-management/src/index.ts
+++ b/suite-native/module-stellar-token-management/src/index.ts
@@ -1,2 +1,3 @@
 export { StellarManageTokenStackNavigator } from './navigation/StellarManageTokenStackNavigator';
 export { composeStellarTrustlineFeesThunk } from './thunks';
+export { useInactiveStellarTokens } from './hooks/useInactiveStellarTokens';

--- a/suite-native/module-stellar-token-management/src/screens/ActivationFeeScreen.tsx
+++ b/suite-native/module-stellar-token-management/src/screens/ActivationFeeScreen.tsx
@@ -41,10 +41,16 @@ type NavigationProp = StackToStackCompositeNavigationProps<
 
 export const ActivationFeeScreen = () => {
     const route = useRoute<RouteProps>();
-    const { accountKey, tokenContract } = route.params;
+    const { accountKey, tokenContract, isTrading } = route.params;
     const navigation = useNavigation<NavigationProp>();
 
     const handleSuccess = useCallback(() => {
+        if (isTrading) {
+            navigation.pop();
+
+            return;
+        }
+
         // Navigate to home page after activation
         navigation.popTo(RootStackRoutes.AppTabs, {
             screen: AppTabsRoutes.HomeStack,
@@ -52,7 +58,7 @@ export const ActivationFeeScreen = () => {
                 screen: HomeStackRoutes.Home,
             },
         });
-    }, [navigation]);
+    }, [navigation, isTrading]);
 
     const {
         account,

--- a/suite-native/module-stellar-token-management/src/screens/TokenSelectionScreen.tsx
+++ b/suite-native/module-stellar-token-management/src/screens/TokenSelectionScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { type TokenAddress } from '@suite-common/wallet-types';
+import type { StellarTokenInfo, TokenAddress } from '@suite-common/wallet-types';
 import { useAlert } from '@suite-native/alerts';
 import { Box, Button, Card, Loader, SearchInput, Text, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -21,7 +21,7 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { TokenListItem } from '../components/TokenListItem';
-import { type StellarTokenInfo, useInactiveStellarTokens } from '../hooks/useInactiveStellarTokens';
+import { useInactiveStellarTokens } from '../hooks/useInactiveStellarTokens';
 import { composeStellarTrustlineFeesThunk } from '../thunks';
 
 type RouteProps = StackProps<

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -57,6 +57,7 @@
         "@suite-native/link": "workspace:*",
         "@suite-native/message-system": "workspace:*",
         "@suite-native/module-add-accounts": "workspace:*",
+        "@suite-native/module-stellar-token-management": "workspace:*",
         "@suite-native/navigation": "workspace:*",
         "@suite-native/services": "workspace:*",
         "@suite-native/toasts": "workspace:*",

--- a/suite-native/module-trading/src/components/buy/BuyConfirmation.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyConfirmation.tsx
@@ -5,6 +5,7 @@ import { Translation } from '@suite-native/intl';
 
 import { useBuyFlow } from '../../hooks/buy/useBuyFlow';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { useTradingStellarActivateToken } from '../../hooks/general/useTradingStellarActivateToken';
 
 export type ConfirmationProps = {
     enteringAnimation?: AnimatedProps<any>['entering'];
@@ -14,18 +15,31 @@ const CONFIRMATION_TEST_ID = '@trading/buy/continue-button';
 
 export const BuyConfirmation = ({ enteringAnimation }: ConfirmationProps) => {
     const form = useBuyFormContext();
+    const receiveAsset = form.watch('asset');
+    const receiveCryptoId = receiveAsset?.cryptoId;
 
     const { canProceed, selectQuote } = useBuyFlow(form);
 
+    const quote = form.watch('quote');
+
+    const { isReceivingInactiveStellarToken, activateButtonElement } =
+        useTradingStellarActivateToken({
+            quote,
+            receiveCryptoId,
+            buttonTestId: CONFIRMATION_TEST_ID,
+        });
+
     return (
         <AnimatedBox entering={enteringAnimation} exiting={FadeOutDown}>
-            {canProceed && (
-                <AnimatedBox entering={FadeIn}>
-                    <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
-                        <Translation id="moduleTrading.tradingScreen.buttons.continue" />
-                    </Button>
-                </AnimatedBox>
-            )}
+            {isReceivingInactiveStellarToken
+                ? activateButtonElement
+                : canProceed && (
+                      <AnimatedBox entering={FadeIn}>
+                          <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
+                              <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                          </Button>
+                      </AnimatedBox>
+                  )}
         </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@suite-native/atoms';
 import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
@@ -13,13 +14,26 @@ jest.mock('../../../hooks/buy/useBuyFormContext', () => ({
     }),
 }));
 
+jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
+    useTradingStellarActivateToken: jest.fn(),
+}));
+
 describe('BuyConfirmation', () => {
     const mockUseBuyFlow = require('../../../hooks/buy/useBuyFlow').useBuyFlow;
+    const mockUseTradingStellarActivateToken =
+        require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
     const renderConfirmation = () =>
         renderWithStoreProvider(<BuyConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
+
+    beforeEach(() => {
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: false,
+            activateButtonElement: null,
+        });
+    });
 
     it('should render continue button when canProceed is true', () => {
         mockUseBuyFlow.mockReturnValue({
@@ -46,5 +60,43 @@ describe('BuyConfirmation', () => {
         const { queryByText } = renderConfirmation();
 
         expect(queryByText('Continue')).toBeNull();
+    });
+
+    it('should render activate button when trading inactive Stellar token', () => {
+        mockUseBuyFlow.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: true,
+            activateButtonElement: <Button>Activate</Button>,
+        });
+
+        const { queryByText } = renderConfirmation();
+        expect(queryByText('Activate')).toBeTruthy();
+        expect(queryByText('Continue')).toBeNull();
+    });
+
+    it('should not render activate button when not trading inactive Stellar token', () => {
+        mockUseBuyFlow.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: false,
+            activateButtonElement: <Button>Activate</Button>,
+        });
+
+        const { queryByText } = renderConfirmation();
+        expect(queryByText('Activate')).toBeNull();
+        expect(queryByText('Continue')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -12,6 +12,7 @@ import { Translation } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { useExchangeSelectQuote } from '../../hooks/exchange/useExchangeSelectQuote';
+import { useTradingStellarActivateToken } from '../../hooks/general/useTradingStellarActivateToken';
 
 export type ExchangeConfirmationProps = {
     enteringAnimation?: AnimatedProps<any>['entering'];
@@ -22,6 +23,8 @@ export const REVOKE_TEST_ID = '@trading/exchange/revoke-button';
 
 export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmationProps) => {
     const form = useExchangeFormContext();
+    const receiveAsset = form.watch('receiveAsset');
+    const receiveCryptoId = receiveAsset?.cryptoId;
 
     const { canProceed, selectQuote } = useExchangeSelectQuote(form);
 
@@ -31,25 +34,38 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
         approvalStatus,
     );
 
+    const { isReceivingInactiveStellarToken, activateButtonElement } =
+        useTradingStellarActivateToken({
+            quote,
+            receiveCryptoId,
+            buttonTestId: CONFIRMATION_TEST_ID,
+        });
+
     return (
         <AnimatedVStack entering={enteringAnimation} exiting={FadeOutDown} spacing="sp16">
-            {canProceed && (
-                <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
-                    <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
-                        <Translation id="moduleTrading.tradingScreen.buttons.continue" />
-                    </Button>
-                </AnimatedBox>
-            )}
-            {canRevoke && (
-                <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
-                    <Button
-                        onPress={() => {}}
-                        testID={REVOKE_TEST_ID}
-                        colorScheme="tertiaryElevation0"
-                    >
-                        <Translation id="moduleTrading.tradingScreen.buttons.revoke" />
-                    </Button>
-                </AnimatedBox>
+            {isReceivingInactiveStellarToken ? (
+                activateButtonElement
+            ) : (
+                <>
+                    {canProceed && (
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                            <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
+                                <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                            </Button>
+                        </AnimatedBox>
+                    )}
+                    {canRevoke && (
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                            <Button
+                                onPress={() => {}}
+                                testID={REVOKE_TEST_ID}
+                                colorScheme="tertiaryElevation0"
+                            >
+                                <Translation id="moduleTrading.tradingScreen.buttons.revoke" />
+                            </Button>
+                        </AnimatedBox>
+                    )}
+                </>
             )}
         </AnimatedVStack>
     );

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -1,5 +1,6 @@
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { Button } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
@@ -18,9 +19,15 @@ jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
     }),
 }));
 
+jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
+    useTradingStellarActivateToken: jest.fn(),
+}));
+
 describe('ExchangeConfirmation', () => {
     const mockUseExchangeSelectQuote =
         require('../../../hooks/exchange/useExchangeSelectQuote').useExchangeSelectQuote;
+    const mockUseTradingStellarActivateToken =
+        require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
     const renderConfirmation = () =>
         renderWithStoreProvider(<ExchangeConfirmation />, {
@@ -40,6 +47,11 @@ describe('ExchangeConfirmation', () => {
             exchange: 'test-provider',
             isDex: false,
         };
+
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: false,
+            activateButtonElement: null,
+        });
     });
 
     it('should render "Continue" button when canProceed is true', () => {
@@ -167,5 +179,43 @@ describe('ExchangeConfirmation', () => {
         renderConfirmation();
 
         expect(queryRevokeButton()).toBeOnTheScreen();
+    });
+
+    it('should render activate button when trading inactive Stellar token', () => {
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: true,
+            activateButtonElement: <Button>Activate</Button>,
+        });
+
+        const { queryByText } = renderConfirmation();
+        expect(queryByText('Activate')).toBeTruthy();
+        expect(queryByText('Continue')).toBeNull();
+    });
+
+    it('should not render activate button when not trading inactive Stellar token', () => {
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        mockUseTradingStellarActivateToken.mockReturnValue({
+            isReceivingInactiveStellarToken: false,
+            activateButtonElement: <Button>Activate</Button>,
+        });
+
+        const { queryByText } = renderConfirmation();
+        expect(queryByText('Activate')).toBeNull();
+        expect(queryByText('Continue')).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingStellarActivateToken.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingStellarActivateToken.test.ts
@@ -1,0 +1,223 @@
+import type { BuyTrade, CryptoId, ExchangeTrade } from 'invity-api';
+
+import { act, renderHook, waitFor } from '@suite-native/test-utils';
+
+import { useTradingStellarActivateToken } from '../useTradingStellarActivateToken';
+
+const mockDispatch = jest.fn();
+const mockUseSelector = jest.fn();
+const mockNavigate = jest.fn();
+const mockShowAlert = jest.fn();
+const mockCryptoIdToNetworkAndContractAddress = jest.fn();
+const mockUseInactiveStellarTokens = jest.fn();
+const mockComposeStellarTrustlineFeesThunk = jest.fn();
+const mockSelectExchangeSelectedReceiveAccount = jest.fn();
+
+jest.mock('@reduxjs/toolkit', () => ({
+    ...jest.requireActual('@reduxjs/toolkit'),
+    isFulfilled: (action: { meta?: { requestStatus?: string } }) =>
+        action?.meta?.requestStatus === 'fulfilled',
+}));
+
+jest.mock('react-redux', () => ({
+    useDispatch: () => mockDispatch,
+    useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+    ...jest.requireActual('@react-navigation/native'),
+    useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@suite-native/alerts', () => ({
+    useAlert: () => ({ showAlert: mockShowAlert }),
+}));
+
+jest.mock('@suite-native/intl', () => ({
+    Translation: () => null,
+    useTranslate: () => ({ translate: jest.fn(id => id) }),
+}));
+
+jest.mock('@suite-common/trading', () => ({
+    cryptoIdToNetworkAndContractAddress: (cryptoId?: string) =>
+        mockCryptoIdToNetworkAndContractAddress(cryptoId),
+}));
+
+jest.mock('@suite-native/trading-state', () => ({
+    selectExchangeSelectedReceiveAccount: (state: unknown) =>
+        mockSelectExchangeSelectedReceiveAccount(state),
+}));
+
+jest.mock('@suite-native/module-stellar-token-management', () => ({
+    composeStellarTrustlineFeesThunk: (payload: unknown) =>
+        mockComposeStellarTrustlineFeesThunk(payload),
+    useInactiveStellarTokens: (accountKey?: string) => mockUseInactiveStellarTokens(accountKey),
+}));
+
+const RECEIVE_CRYPTO_ID = 'stellar:USDC' as CryptoId;
+const TOKEN_CONTRACT = 'USDC-GA123';
+const ACCOUNT_KEY = 'xlm-account-key';
+
+const renderUseTradingStellarActivateToken = (options?: {
+    quote?: ExchangeTrade | BuyTrade;
+    receiveCryptoId?: CryptoId;
+    buttonTestId?: string;
+}) =>
+    renderHook(() =>
+        useTradingStellarActivateToken({
+            quote: options?.quote,
+            receiveCryptoId: options?.receiveCryptoId,
+            buttonTestId: options?.buttonTestId,
+        }),
+    );
+
+const getButtonProps = (
+    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+) => result.current.activateButtonElement?.props.children.props;
+
+const onActivateButtonPressStart = (
+    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+) => {
+    const onPress = getButtonProps(result)?.onPress as (() => Promise<void>) | undefined;
+    let onPressPromise: Promise<void> | undefined;
+
+    act(() => {
+        onPressPromise = onPress?.();
+    });
+
+    return onPressPromise;
+};
+
+const onActivateButtonPress = async (
+    result: ReturnType<typeof renderUseTradingStellarActivateToken>['result'],
+) => {
+    const onPressPromise = onActivateButtonPressStart(result);
+    await act(async () => await onPressPromise);
+};
+
+describe('useTradingStellarActivateToken', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockUseSelector.mockImplementation(selector => selector({}));
+        mockSelectExchangeSelectedReceiveAccount.mockReturnValue({ account: { key: ACCOUNT_KEY } });
+
+        mockCryptoIdToNetworkAndContractAddress.mockReturnValue({
+            contractAddress: TOKEN_CONTRACT,
+        });
+
+        mockUseInactiveStellarTokens.mockReturnValue({
+            inactiveTokens: [{ contract: TOKEN_CONTRACT }],
+        });
+
+        mockComposeStellarTrustlineFeesThunk.mockImplementation(payload => ({
+            type: 'composeStellarTrustlineFeesThunkMock',
+            payload,
+        }));
+    });
+
+    it('returns activate button when receiving inactive Stellar token', () => {
+        const { result } = renderUseTradingStellarActivateToken({
+            quote: { receive: 'USDC' } as ExchangeTrade,
+            receiveCryptoId: RECEIVE_CRYPTO_ID,
+            buttonTestId: 'activate-stellar-token',
+        });
+
+        expect(result.current.isReceivingInactiveStellarToken).toBe(true);
+        expect(result.current.activateButtonElement).not.toBeNull();
+        expect(getButtonProps(result)?.testID).toBe('activate-stellar-token');
+    });
+
+    it('does not return activate button when token is already active', () => {
+        mockUseInactiveStellarTokens.mockReturnValue({
+            inactiveTokens: [{ contract: 'AQUA-GB456' }],
+        });
+
+        const { result } = renderUseTradingStellarActivateToken({
+            quote: { receive: 'USDC' } as ExchangeTrade,
+            receiveCryptoId: RECEIVE_CRYPTO_ID,
+        });
+
+        expect(result.current.isReceivingInactiveStellarToken).toBe(false);
+        expect(result.current.activateButtonElement).toBeNull();
+    });
+
+    it('navigates to activation fee screen when trustline fee composition succeeds', async () => {
+        mockDispatch.mockResolvedValue({
+            type: 'module-stellar-token-management/composeStellarTrustlineFeesThunk/fulfilled',
+            meta: { requestStatus: 'fulfilled' },
+        });
+
+        const { result } = renderUseTradingStellarActivateToken({
+            quote: { receive: 'USDC' } as ExchangeTrade,
+            receiveCryptoId: RECEIVE_CRYPTO_ID,
+        });
+
+        await onActivateButtonPress(result);
+
+        expect(mockComposeStellarTrustlineFeesThunk).toHaveBeenCalledWith({
+            accountKey: ACCOUNT_KEY,
+            tokenContract: TOKEN_CONTRACT,
+        });
+        expect(mockNavigate).toHaveBeenCalledWith('StellarManageTokenStack', {
+            screen: 'ActivationFee',
+            params: {
+                accountKey: ACCOUNT_KEY,
+                tokenContract: TOKEN_CONTRACT,
+                isTrading: true,
+            },
+        });
+        expect(mockShowAlert).not.toHaveBeenCalled();
+    });
+
+    it('shows activation failed alert when trustline fee composition fails', async () => {
+        mockDispatch.mockResolvedValue({
+            type: 'module-stellar-token-management/composeStellarTrustlineFeesThunk/rejected',
+            meta: { requestStatus: 'rejected' },
+        });
+
+        const { result } = renderUseTradingStellarActivateToken({
+            quote: { receive: 'USDC' } as ExchangeTrade,
+            receiveCryptoId: RECEIVE_CRYPTO_ID,
+        });
+
+        await onActivateButtonPress(result);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+        expect(mockShowAlert).toHaveBeenCalledWith({
+            title: 'moduleStellarToken.networkFee.activationFailed',
+            description: 'moduleStellarToken.networkFee.activationFailedDescription',
+            primaryButtonTitle: 'generic.buttons.gotIt',
+        });
+    });
+
+    it('toggles loading state during trustline fee composition', async () => {
+        let resolveDispatch: ((value: unknown) => void) | undefined;
+
+        mockDispatch.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveDispatch = resolve;
+                }),
+        );
+
+        const { result } = renderUseTradingStellarActivateToken({
+            quote: { receive: 'USDC' } as ExchangeTrade,
+            receiveCryptoId: RECEIVE_CRYPTO_ID,
+        });
+
+        const activatePromise = onActivateButtonPressStart(result);
+
+        await waitFor(() => expect(getButtonProps(result)?.isLoading).toBe(true));
+
+        act(() => {
+            resolveDispatch?.({
+                type: 'module-stellar-token-management/composeStellarTrustlineFeesThunk/fulfilled',
+                meta: { requestStatus: 'fulfilled' },
+            });
+        });
+
+        await act(async () => await activatePromise);
+        await waitFor(() => expect(getButtonProps(result)?.isLoading).toBe(false));
+    });
+});

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useMemo, useState } from 'react';
+import { FadeIn } from 'react-native-reanimated';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { isFulfilled } from '@reduxjs/toolkit';
+import { type BuyTrade, type CryptoId, type ExchangeTrade } from 'invity-api';
+
+import { cryptoIdToNetworkAndContractAddress } from '@suite-common/trading';
+import { type TokenAddress } from '@suite-common/wallet-types';
+import { useAlert } from '@suite-native/alerts';
+import { AnimatedBox, Button } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    composeStellarTrustlineFeesThunk,
+    useInactiveStellarTokens,
+} from '@suite-native/module-stellar-token-management';
+import {
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+    StellarManageTokenStackRoutes,
+} from '@suite-native/navigation';
+import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
+
+type NavigationProps = StackNavigationProps<RootStackParamList, RootStackRoutes.AppTabs>;
+
+interface UseTradingStellarActivateTokenProps {
+    quote?: ExchangeTrade | BuyTrade | undefined;
+    receiveCryptoId?: CryptoId;
+    buttonTestId?: string;
+}
+
+export const useTradingStellarActivateToken = ({
+    quote,
+    receiveCryptoId,
+    buttonTestId,
+}: UseTradingStellarActivateTokenProps) => {
+    const dispatch = useDispatch();
+    const { translate } = useTranslate();
+    const { showAlert } = useAlert();
+
+    const navigation = useNavigation<NavigationProps>();
+
+    const selectedReceiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
+
+    const { contractAddress: receiveContractAddress } =
+        cryptoIdToNetworkAndContractAddress(receiveCryptoId);
+
+    const { inactiveTokens } = useInactiveStellarTokens(selectedReceiveAccount?.account.key);
+
+    const isReceivingInactiveStellarToken =
+        !!quote &&
+        !!selectedReceiveAccount &&
+        !!receiveContractAddress &&
+        !!inactiveTokens.find(token => token.contract === receiveContractAddress);
+
+    const [isComposingFees, setIsComposingFees] = useState(false);
+
+    const onActivatePress = useCallback(async () => {
+        if (!selectedReceiveAccount) return;
+        if (!receiveContractAddress) return;
+
+        const accountKey = selectedReceiveAccount.account.key;
+        const tokenContract = receiveContractAddress as TokenAddress;
+
+        setIsComposingFees(true);
+
+        try {
+            const result = await dispatch(
+                composeStellarTrustlineFeesThunk({ accountKey, tokenContract }),
+            );
+
+            if (isFulfilled(result)) {
+                navigation.navigate(RootStackRoutes.StellarManageTokenStack, {
+                    screen: StellarManageTokenStackRoutes.ActivationFee,
+                    params: {
+                        accountKey: selectedReceiveAccount.account.key,
+                        tokenContract: receiveContractAddress as TokenAddress,
+                        isTrading: true,
+                    },
+                });
+            } else {
+                showAlert({
+                    title: translate('moduleStellarToken.networkFee.activationFailed'),
+                    description: translate(
+                        'moduleStellarToken.networkFee.activationFailedDescription',
+                    ),
+                    primaryButtonTitle: translate('generic.buttons.gotIt'),
+                });
+            }
+        } finally {
+            setIsComposingFees(false);
+        }
+    }, [
+        selectedReceiveAccount,
+        receiveContractAddress,
+        dispatch,
+        navigation,
+        showAlert,
+        translate,
+    ]);
+
+    const activateButtonElement = useMemo(() => {
+        if (!isReceivingInactiveStellarToken) {
+            return null;
+        }
+
+        return (
+            <AnimatedBox entering={FadeIn}>
+                <Button onPress={onActivatePress} testID={buttonTestId} isLoading={isComposingFees}>
+                    <Translation id="generic.buttons.continue" />
+                </Button>
+            </AnimatedBox>
+        );
+    }, [isReceivingInactiveStellarToken, isComposingFees, buttonTestId, onActivatePress]);
+
+    return { isReceivingInactiveStellarToken, activateButtonElement };
+};

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -62,6 +62,9 @@
         { "path": "../link" },
         { "path": "../message-system" },
         { "path": "../module-add-accounts" },
+        {
+            "path": "../module-stellar-token-management"
+        },
         { "path": "../navigation" },
         { "path": "../services" },
         { "path": "../toasts" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -471,6 +471,7 @@ export type StellarManageTokenStackParamList = {
     [StellarManageTokenStackRoutes.ActivationFee]: {
         accountKey: AccountKey;
         tokenContract: TokenAddress;
+        isTrading?: boolean;
     };
     [StellarManageTokenStackRoutes.DeactivationFee]: {
         accountKey: AccountKey;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -4353,6 +4353,14 @@ export const messages = defineMessages({
         id: 'TR_INACTIVE_COINS',
         defaultMessage: 'Available assets to activate',
     },
+    TR_ACTIVATION_IN_PROGRESS_BANNER: {
+        id: 'TR_ACTIVATION_IN_PROGRESS_BANNER',
+        defaultMessage: 'Activation transaction is being processed.',
+    },
+    TR_DEACTIVATION_IN_PROGRESS_BANNER: {
+        id: 'TR_DEACTIVATION_IN_PROGRESS_BANNER',
+        defaultMessage: 'Deactivation transaction is being processed.',
+    },
     TR_ACTIVATE: {
         id: 'TR_ACTIVATE',
         defaultMessage: 'Activate',

--- a/yarn.lock
+++ b/yarn.lock
@@ -14066,6 +14066,7 @@ __metadata:
     "@suite-native/link": "workspace:*"
     "@suite-native/message-system": "workspace:*"
     "@suite-native/module-add-accounts": "workspace:*"
+    "@suite-native/module-stellar-token-management": "workspace:*"
     "@suite-native/navigation": "workspace:*"
     "@suite-native/services": "workspace:*"
     "@suite-native/test-utils": "workspace:*"


### PR DESCRIPTION
## Description

When the user wants to trade an XLM token that is not yet activated, provide the ability to activate it directly in the trading form.

Not tested for Buy on mobile, as no Stellar tokens are available.

## Related Issue

Resolve #20422 

## Screenshots

https://github.com/user-attachments/assets/29703a2e-0c19-425c-9b30-d6753be50cb3

https://github.com/user-attachments/assets/d7970389-51f9-4e05-8a8d-86ef2bc2b040

https://github.com/user-attachments/assets/fd45b9f1-1f5d-46ae-b288-cd13ab712f33


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-xlm-activate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-xlm-activate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-xlm-activate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T08:14:04.821Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T08:12:25.957Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->