### PR TITLE
feat(trading): implement CurrencyPicker component and enhance trading forms

### DIFF
--- a/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/__tests__/tradingUtils.test.ts
@@ -1,5 +1,3 @@
-import { buildTradingFiatOption } from '@suite-common/trading';
-
 import { FIXTURE_ACCOUNT_OPTIONS } from 'src/utils/wallet/trading/__fixtures__/tradingUtils';
 import {
     getCountryLabelParts,
@@ -16,10 +14,6 @@ jest.mock('src/hooks/suite/useDefaultAccountLabel', () => ({
 }));
 
 describe('trading utils', () => {
-    it('buildFiatOption', () => {
-        expect(buildTradingFiatOption('czk')).toStrictEqual({ value: 'czk', label: 'CZK' });
-    });
-
     it('getCountryLabelParts', () => {
         expect(getCountryLabelParts('🇨🇿 Czech Republic')).toStrictEqual({
             flag: '🇨🇿',

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -77,7 +77,7 @@ export const TradingBuyFormInputs = () => {
                             cryptoInputName={TRADING_FORM_CRYPTO_INPUT}
                             fiatInputName={TRADING_FORM_FIAT_INPUT}
                             cryptoSelectName={TRADING_FORM_CRYPTO_CURRENCY_SELECT}
-                            currencySelectLabel={currencySelect.label}
+                            currencySelectLabel={currencySelect.value.toUpperCase()}
                             cryptoCurrencyLabel={cryptoSelect.id}
                         />
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -141,7 +141,7 @@ export const TradingExchangeFormInputs = () => {
                         cryptoInputName={TRADING_FORM_OUTPUT_AMOUNT}
                         fiatInputName={TRADING_FORM_OUTPUT_FIAT}
                         cryptoSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                        currencySelectLabel={currencySelect.label}
+                        currencySelectLabel={currencySelect.value.toUpperCase()}
                         cryptoCurrencyLabel={sendCryptoSelect?.id}
                     />
                     {amountInCrypto && (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -2,15 +2,19 @@ import { useMemo } from 'react';
 import { type Control, Controller } from 'react-hook-form';
 
 import {
+    CurrencyPicker,
+    mapCurrenciesToCurrencyPickerOptions,
+    mapCurrencyToCurrencyPickerOption,
+} from '@suite/trading';
+import {
     TRADING_FORM_FIAT_CURRENCY_SELECT,
     TRADING_FORM_OUTPUT_CURRENCY,
     type TradingFiatCurrencyOption,
     buildTradingFiatOption,
-    isSupportedFiatCurrency,
+    isTradingFiatCurrencyOption,
 } from '@suite-common/trading';
 import { buildCurrencyOptions, buildCurrencyShortOption } from '@suite-common/wallet-utils';
 import { isBaseCurrencyCode } from '@trezor/blockchain-link-types';
-import { Select } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import {
@@ -69,35 +73,21 @@ export const TradingFormInputCurrency = ({
             name={name}
             defaultValue={defaultCurrency}
             control={control as Control<TradingAllFormProps>}
-            render={({ field: { onChange, value } }) => {
-                const selectedCurrencyCode =
-                    typeof value === 'object' && value !== null && 'value' in value
-                        ? value.value
-                        : value;
-
-                return (
-                    <Select
-                        value={
-                            selectedCurrencyCode && isSupportedFiatCurrency(selectedCurrencyCode)
-                                ? buildTradingFiatOption(selectedCurrencyCode)
-                                : defaultCurrency
+            render={({ field: { onChange, value } }) => (
+                <CurrencyPicker
+                    options={mapCurrenciesToCurrencyPickerOptions(options)}
+                    onSelect={option => {
+                        onChange(option);
+                        setAmountLimits(undefined);
+                        if (isTradingFiatCurrencyOption(option)) {
+                            onChangeAdditional(option);
                         }
-                        onChange={(selected: TradingFiatCurrencyOption) => {
-                            onChange(selected);
-                            setAmountLimits(undefined);
-
-                            onChangeAdditional(selected);
-                        }}
-                        options={options}
-                        data-testid="@trading/form/fiat-currency-select"
-                        isClearable={false}
-                        size="small"
-                        isSearchable
-                        width={width}
-                        isClean={isClean}
-                    />
-                );
-            }}
+                    }}
+                    value={mapCurrencyToCurrencyPickerOption(value)}
+                    width={width}
+                    isClean={isClean}
+                />
+            )}
         />
     );
 };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -268,7 +268,7 @@ export const TradingFormInputFiat = ({
             rules={fiatInputRules}
             maxLength={formInputsMaxLength.amount}
             bottomText={fiatInputError?.message ?? cryptoInputError?.message ?? null}
-            rightContent={<TradingFormInputCurrency isClean />}
+            rightContent={<TradingFormInputCurrency isClean width={70} />}
             data-testid="@trading/form/fiat-input"
         />
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -107,7 +107,7 @@ export const TradingSellFormInputs = () => {
                             cryptoInputName={TRADING_FORM_OUTPUT_AMOUNT}
                             fiatInputName={TRADING_FORM_OUTPUT_FIAT}
                             cryptoSelectName={TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT}
-                            currencySelectLabel={currencySelect.label}
+                            currencySelectLabel={currencySelect.value.toUpperCase()}
                             cryptoCurrencyLabel={sendCryptoSelect?.id}
                         />
                         {amountInCrypto && (

--- a/suite-common/trading/src/__tests__/currency.test.ts
+++ b/suite-common/trading/src/__tests__/currency.test.ts
@@ -1,0 +1,46 @@
+import { isSupportedFiatCurrency, isTradingFiatCurrencyOption } from '../currency';
+
+describe('currency', () => {
+    describe('isTradingFiatCurrencyOption', () => {
+        it('returns true for valid fiat option with value and label', () => {
+            expect(isTradingFiatCurrencyOption({ value: 'usd', label: 'US Dollar' })).toBe(true);
+            expect(isTradingFiatCurrencyOption({ value: 'eur', label: 'Euro' })).toBe(true);
+            expect(isTradingFiatCurrencyOption({ value: 'czk', label: 'Czech Koruna' })).toBe(true);
+        });
+
+        it('returns false for non-null non-object', () => {
+            expect(isTradingFiatCurrencyOption(null)).toBe(false);
+            expect(isTradingFiatCurrencyOption(undefined)).toBe(false);
+            expect(isTradingFiatCurrencyOption('usd')).toBe(false);
+            expect(isTradingFiatCurrencyOption(123)).toBe(false);
+        });
+
+        it('returns false for object with value but unsupported currency code', () => {
+            expect(isTradingFiatCurrencyOption({ value: 'xyz', label: 'Unknown' })).toBe(false);
+            expect(isTradingFiatCurrencyOption({ value: 'btc', label: 'Bitcoin' })).toBe(false);
+        });
+
+        it('returns false for object with value but missing or non-string label', () => {
+            expect(isTradingFiatCurrencyOption({ value: 'usd' })).toBe(false);
+            expect(isTradingFiatCurrencyOption({ value: 'usd', label: 123 })).toBe(false);
+            expect(isTradingFiatCurrencyOption({ value: 'usd', label: null })).toBe(false);
+        });
+
+        it('returns false for object with label but missing or non-string value', () => {
+            expect(isTradingFiatCurrencyOption({ label: 'US Dollar' })).toBe(false);
+            expect(isTradingFiatCurrencyOption({ value: 123, label: 'US Dollar' })).toBe(false);
+        });
+    });
+
+    describe('isSupportedFiatCurrency', () => {
+        it('returns true for supported fiat codes', () => {
+            expect(isSupportedFiatCurrency('usd')).toBe(true);
+            expect(isSupportedFiatCurrency('eur')).toBe(true);
+        });
+
+        it('returns false for unsupported strings', () => {
+            expect(isSupportedFiatCurrency('xyz')).toBe(false);
+            expect(isSupportedFiatCurrency('btc')).toBe(false);
+        });
+    });
+});

--- a/suite-common/trading/src/currency.ts
+++ b/suite-common/trading/src/currency.ts
@@ -1,6 +1,6 @@
 import { type FiatCurrencyCode } from 'invity-api';
 
-import { typedObjectKeys } from '@trezor/utils';
+import { type TradingFiatCurrencyOption } from './types';
 
 export const supportedFiatCurrenciesMap: Record<FiatCurrencyCode, string> = {
     aed: 'United Arab Emirates Dirham',
@@ -74,6 +74,18 @@ export const supportedFiatCurrenciesMap: Record<FiatCurrencyCode, string> = {
 export const isSupportedFiatCurrency = (currency: string): currency is FiatCurrencyCode =>
     currency in supportedFiatCurrenciesMap;
 
-export const supportedFiatCurrencies = typedObjectKeys(supportedFiatCurrenciesMap);
+export const isTradingFiatCurrencyOption = (
+    currency: unknown,
+): currency is TradingFiatCurrencyOption => {
+    if (typeof currency !== 'object' || currency === null) return false;
+
+    const maybe = currency as { value?: unknown; label?: unknown };
+
+    return (
+        typeof maybe.value === 'string' &&
+        typeof maybe.label === 'string' &&
+        isSupportedFiatCurrency(maybe.value)
+    );
+};
 
 export const DEFAULT_FIAT_CURRENCY_FALLBACK = 'usd' as const;

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -20,6 +20,7 @@ import {
 import addressValidator from '@trezor/address-validator';
 import { type TokenInfo } from '@trezor/connect';
 
+import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import {
     type TradingAssetOption,
     type TradingAssetOptionNativeToken,
@@ -33,7 +34,6 @@ import {
     testnetToProdCryptoId,
 } from '../utils';
 import { useCoinsAndPlatforms } from './useCoinsAndPlatforms';
-import { TRADING_DEFAULT_CRYPTO_CURRENCY } from '../constants';
 import {
     getTradingNativeCoinSymbolByCryptoId,
     getTradingPlatformsInfoByCryptoId,

--- a/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/__fixtures__/tradingReducer.ts
@@ -3,19 +3,19 @@ import { type CryptoId, type InfoResponse } from 'invity-api';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 
+import { accounts } from './account';
 import { buyThunks } from '../../thunks/buy';
 import { exchangeThunks } from '../../thunks/exchange';
-import {
-    type TradingComposedTransactionInfo,
-    initialState,
-    tradingActions,
-} from '../tradingCommonReducer';
-import { accounts } from './account';
 import {
     type TradingPaymentMethodListProps,
     type TradingTransactionBuy,
     type TradingTransactionExchange,
 } from '../../types';
+import {
+    type TradingComposedTransactionInfo,
+    initialState,
+    tradingActions,
+} from '../tradingCommonReducer';
 
 const tradeBuy: TradingTransactionBuy = {
     date: 'ddd',

--- a/suite-common/trading/src/utils/__tests__/currencyUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/currencyUtils.test.ts
@@ -8,9 +8,15 @@ import {
 
 describe('currencyUtils', () => {
     describe('buildTradingFiatOption', () => {
-        it('should return option with value and uppercase label', () => {
-            expect(buildTradingFiatOption('czk')).toStrictEqual({ value: 'czk', label: 'CZK' });
-            expect(buildTradingFiatOption('usd')).toStrictEqual({ value: 'usd', label: 'USD' });
+        it('should return option with value and full currency-name label', () => {
+            expect(buildTradingFiatOption('czk')).toStrictEqual({
+                value: 'czk',
+                label: 'Czech Koruna',
+            });
+            expect(buildTradingFiatOption('usd')).toStrictEqual({
+                value: 'usd',
+                label: 'United States Dollar',
+            });
         });
     });
 

--- a/suite-common/trading/src/utils/currencyUtils.ts
+++ b/suite-common/trading/src/utils/currencyUtils.ts
@@ -8,10 +8,16 @@ import {
     isSupportedFiatCurrency,
     supportedFiatCurrenciesMap,
 } from '../currency';
+import { type TradingFiatCurrencyOption } from '../types';
 
-export const buildTradingFiatOption = (currency: FiatCurrencyCode) => ({
+export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string =>
+    isSupportedFiatCurrency(currencyCode)
+        ? supportedFiatCurrenciesMap[currencyCode]
+        : currencyCode.toUpperCase();
+
+export const buildTradingFiatOption = (currency: FiatCurrencyCode): TradingFiatCurrencyOption => ({
     value: currency,
-    label: currency.toUpperCase(),
+    label: getCurrencyLabel(currency),
 });
 
 export const mapFiatCurrencyCodeToBaseCurrencyCode = (
@@ -35,11 +41,6 @@ export const buildTradingBaseCurrencyOptionFromFiat = (
         label: baseCurrencyCode.toUpperCase(),
     };
 };
-
-export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string =>
-    isSupportedFiatCurrency(currencyCode)
-        ? supportedFiatCurrenciesMap[currencyCode]
-        : currencyCode.toUpperCase();
 
 export const getSupportedFiatCurrencyWithFallback = (currencyCode: string): FiatCurrencyCode => {
     if (isSupportedFiatCurrency(currencyCode)) {

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -19,9 +19,9 @@ const paymentMethodNameMap: Record<string, PaymentMethods> = {
 export class TradingFormInputs {
     readonly fiatAmount: Locator;
     readonly cryptoAmount: Locator;
-    readonly currencyDropdown: Locator;
+    readonly currencySelect: Locator;
     readonly currencyOption = (currency: BaseCurrencyCode) =>
-        this.page.getByTestId(`@trading/form/fiat-currency-select/option/${currency}`);
+        this.page.getByTestId(`@trading/form/currency-picker/option/${currency}`);
     readonly fiatCryptoSwitchButton: Locator;
     readonly fractionButtons: Locator;
     readonly bottomText: Locator;
@@ -38,7 +38,7 @@ export class TradingFormInputs {
     constructor(private readonly page: Page) {
         this.fiatAmount = this.page.getByTestId('@trading/form/fiat-input');
         this.cryptoAmount = this.page.getByTestId('@trading/form/crypto-input');
-        this.currencyDropdown = this.page.getByTestId('@trading/form/fiat-currency-select/input');
+        this.currencySelect = this.page.getByTestId('@trading/form/currency-picker/input');
         this.fiatCryptoSwitchButton = this.page.getByTestId('@trading/form/switch-crypto-fiat');
         this.fractionButtons = this.page.getByTestId('@trading/form/fraction-buttons');
         this.bottomText = this.page.getByTestId('@trading/form/crypto-input/bottom-text');
@@ -69,14 +69,15 @@ export class TradingFormInputs {
 
     @step()
     async selectFiatCurrency(currencyCode: BaseCurrencyCode) {
-        const currentCurrency = await this.currencyDropdown.textContent();
+        await expect(this.currencySelect).not.toBeEmpty();
+        const currentCurrency = (await this.currencySelect.inputValue())?.trim();
         if (currentCurrency === currencyCode.toUpperCase()) {
             return;
         }
-        await this.page.selectDropdownOptionWithRetry(
-            this.currencyDropdown,
-            this.currencyOption(currencyCode),
-        );
+        await this.currencySelect.click();
+        await expect(this.page.getByTestId('@modal/header')).toHaveTranslation('TR_CURRENCY');
+        await this.currencyOption(currencyCode).click();
+        await expect(this.currencySelect).toHaveValue(currencyCode.toUpperCase());
     }
 
     @step()

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2877,6 +2877,22 @@ export const messages = defineMessages({
         defaultMessage: 'Commodities',
         id: 'TR_BASE_CURRENCY_VALUABLES',
     },
+    TR_CURRENCY: {
+        defaultMessage: 'Currency',
+        id: 'TR_CURRENCY',
+    },
+    TR_SEARCH_CURRENCY_PLACEHOLDER: {
+        defaultMessage: 'Search currency or ticker',
+        id: 'TR_SEARCH_CURRENCY_PLACEHOLDER',
+    },
+    TR_CURRENCY_NOT_FOUND: {
+        defaultMessage: 'Currency not found',
+        id: 'TR_CURRENCY_NOT_FOUND',
+    },
+    TR_CURRENCY_NOT_FOUND_DESCRIPTION: {
+        defaultMessage: 'Try a different search or select a currency from the list.',
+        id: 'TR_CURRENCY_NOT_FOUND_DESCRIPTION',
+    },
     TR_RANDOM_SEED_WORDS_DISCLAIMER: {
         defaultMessage:
             "You may be asked to type some words that aren't part of your wallet backup as an additional security measure.",

--- a/suite/trading/jest.config.js
+++ b/suite/trading/jest.config.js
@@ -1,0 +1,19 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+    testEnvironment: 'jsdom',
+
+    setupFilesAfterEnv: [require('path').resolve(__dirname, '../../packages/suite/jest.setup.js')],
+    moduleNameMapper: {
+        ...baseConfig.moduleNameMapper,
+    },
+    coverageThreshold: {
+        global: {
+            statements: 80,
+            branches: 80,
+            functions: 80,
+            lines: 80,
+        },
+    },
+};

--- a/suite/trading/package.json
+++ b/suite/trading/package.json
@@ -8,13 +8,16 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
-        "type-check": "yarn g:tsc --build"
+        "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest --coverage",
+        "test:unit:watch": "yarn g:jest --watch"
     },
     "dependencies": {
         "@suite-common/geolocation": "workspace:*",
         "@suite-common/icons": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/trading": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite/intl": "workspace:*",
         "@suite/router": "workspace:*",
         "@trezor/components": "workspace:*",

--- a/suite/trading/src/ui/Form/FakeSelect.tsx
+++ b/suite/trading/src/ui/Form/FakeSelect.tsx
@@ -23,9 +23,13 @@ const FakeSelectContainer = styled.button<{ $isDisabled?: boolean }>`
 `;
 
 export type FakeSelectProps = Omit<FormCellProps, 'children'> &
-    Pick<InputProps, 'value' | 'placeholder' | 'size' | 'name' | 'leftContent' | 'bottomText'> & {
+    Pick<
+        InputProps,
+        'value' | 'placeholder' | 'size' | 'name' | 'leftContent' | 'bottomText' | 'width'
+    > & {
         isLoading?: boolean;
         onClick: () => void;
+        isClean?: boolean;
     };
 
 export const FakeSelect = (props: FakeSelectProps) => {
@@ -38,6 +42,7 @@ export const FakeSelect = (props: FakeSelectProps) => {
         onClick,
         'data-testid': dataTestId,
         leftContent,
+        isClean = false,
         ...rest
     } = props;
 
@@ -57,6 +62,7 @@ export const FakeSelect = (props: FakeSelectProps) => {
                     <Icon name="caretDown" size={20} intent="neutral" priority="secondary" />
                 }
                 data-testid={dataTestId}
+                isClean={isClean}
                 readOnly
             />
         </FakeSelectContainer>

--- a/suite/trading/src/ui/currency-picker/CurrencyPicker.tsx
+++ b/suite/trading/src/ui/currency-picker/CurrencyPicker.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { CurrencyPickerModal } from './CurrencyPickerModal';
+import { FakeSelect, type FakeSelectProps } from '../Form/FakeSelect';
+import { type CurrencyPickerOption } from './types/currencyPickerTypes';
+
+type CurrencyPickerProps = Omit<FakeSelectProps, 'onClick' | 'value'> & {
+    value: CurrencyPickerOption;
+    options: CurrencyPickerOption[];
+    onSelect: (currency: CurrencyPickerOption) => void;
+    dataTestId?: string;
+};
+
+export const CurrencyPicker = ({
+    value,
+    options,
+    isDisabled,
+    isLoading,
+    onSelect,
+    dataTestId = '@trading/form/currency-picker/input',
+    ...props
+}: CurrencyPickerProps) => {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const handleCurrencySelect = (currency: CurrencyPickerOption) => {
+        onSelect(currency);
+        setIsModalOpen(false);
+    };
+
+    return (
+        <>
+            <FakeSelect
+                {...props}
+                value={value.shortLabel}
+                isDisabled={isDisabled}
+                isLoading={isLoading}
+                onClick={() => setIsModalOpen(true)}
+                size="small"
+                data-testid={dataTestId}
+            />
+            {isModalOpen && (
+                <CurrencyPickerModal
+                    onCancel={() => setIsModalOpen(false)}
+                    onCurrencySelect={handleCurrencySelect}
+                    options={options}
+                />
+            )}
+        </>
+    );
+};

--- a/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
+++ b/suite/trading/src/ui/currency-picker/CurrencyPickerModal.tsx
@@ -1,0 +1,81 @@
+import { Translation, useTranslation } from '@suite/intl';
+import {
+    CardList,
+    Column,
+    IconCircle,
+    Input,
+    Modal,
+    type ModalProps,
+    Paragraph,
+    Row,
+    Text,
+} from '@trezor/components';
+
+import { useFiatCurrencyFilteredData } from './hooks/useFiatCurrencyFilteredData';
+import { type CurrencyPickerOption } from './types/currencyPickerTypes';
+
+type CurrencyPickerModalProps = ModalProps & {
+    onCurrencySelect: (currency: CurrencyPickerOption) => void;
+    options: CurrencyPickerOption[];
+};
+
+export const CurrencyPickerModal = ({
+    onCurrencySelect,
+    options,
+    ...props
+}: CurrencyPickerModalProps) => {
+    const { translationString } = useTranslation();
+    const { filteredData, setFilterValue, filterValue } = useFiatCurrencyFilteredData(options);
+    const handleCurrencySelect = (currency: CurrencyPickerOption) => {
+        onCurrencySelect(currency);
+        props.onCancel?.();
+    };
+
+    return (
+        <Modal {...props} width={400} heading={<Translation id="TR_CURRENCY" />} height="85vh">
+            <Column gap={16} height="100%">
+                <Input
+                    onChange={ev => setFilterValue(ev.target.value)}
+                    placeholder={translationString('TR_SEARCH_CURRENCY_PLACEHOLDER')}
+                    onClear={() => setFilterValue('')}
+                    showClearButton
+                    value={filterValue}
+                />
+
+                {filteredData.length > 0 && (
+                    <CardList>
+                        {filteredData.map(option => (
+                            <CardList.Item
+                                key={option.value}
+                                onClick={() => handleCurrencySelect(option)}
+                                data-testid={`@trading/form/currency-picker/option/${option.value}`}
+                            >
+                                <Row gap={16}>
+                                    <Column>
+                                        <IconCircle name="coin" size={32} intent="neutral" />
+                                    </Column>
+                                    <Column>
+                                        <Text typographyStyle="body-md">{option.label}</Text>
+                                        <Text typographyStyle="body-sm" color="textSubdued">
+                                            {option.shortLabel}
+                                        </Text>
+                                    </Column>
+                                </Row>
+                            </CardList.Item>
+                        ))}
+                    </CardList>
+                )}
+                {!filteredData.length && (
+                    <Column justifyContent="center" flex="0.75">
+                        <Paragraph align="center">
+                            <Translation id="TR_CURRENCY_NOT_FOUND" />
+                        </Paragraph>
+                        <Paragraph align="center" typographyStyle="body-sm" color="textSubdued">
+                            <Translation id="TR_CURRENCY_NOT_FOUND_DESCRIPTION" />
+                        </Paragraph>
+                    </Column>
+                )}
+            </Column>
+        </Modal>
+    );
+};

--- a/suite/trading/src/ui/currency-picker/hooks/useFiatCurrencyFilteredData.ts
+++ b/suite/trading/src/ui/currency-picker/hooks/useFiatCurrencyFilteredData.ts
@@ -1,0 +1,10 @@
+import { useListDataFilter } from '@suite-common/trading';
+
+import { type CurrencyPickerOption } from '../types/currencyPickerTypes';
+
+const filterCallback = ({ label, value }: CurrencyPickerOption, filterValue: string): boolean =>
+    label.toLowerCase().includes(filterValue.toLowerCase()) ||
+    value.toLowerCase().includes(filterValue.toLowerCase());
+
+export const useFiatCurrencyFilteredData = (supportedFiatCurrencies: CurrencyPickerOption[]) =>
+    useListDataFilter<CurrencyPickerOption>(supportedFiatCurrencies, filterCallback);

--- a/suite/trading/src/ui/currency-picker/types/currencyPickerTypes.ts
+++ b/suite/trading/src/ui/currency-picker/types/currencyPickerTypes.ts
@@ -1,0 +1,5 @@
+export type CurrencyPickerOption = {
+    value: string;
+    label: string;
+    shortLabel: string;
+};

--- a/suite/trading/src/ui/currency-picker/utils/__tests__/currencyPickerMapper.test.ts
+++ b/suite/trading/src/ui/currency-picker/utils/__tests__/currencyPickerMapper.test.ts
@@ -1,0 +1,71 @@
+import { type TradingFiatCurrencyOption } from '@suite-common/trading';
+import { type BaseCurrencyOption } from '@suite-common/wallet-types';
+
+import {
+    mapCurrenciesToCurrencyPickerOptions,
+    mapCurrencyToCurrencyPickerOption,
+} from '../currencyPickerMapper';
+
+describe('currencyPickerMapper', () => {
+    describe('mapCurrencyToCurrencyPickerOption', () => {
+        it('maps TradingFiatCurrencyOption to CurrencyPickerOption', () => {
+            const fiatCurrency: TradingFiatCurrencyOption = {
+                value: 'usd',
+                label: 'United States Dollar',
+            };
+
+            const result = mapCurrencyToCurrencyPickerOption(fiatCurrency);
+
+            expect(result).toEqual({
+                value: 'usd',
+                label: 'United States Dollar',
+                shortLabel: 'USD',
+            });
+        });
+
+        it('maps BaseCurrencyOption to CurrencyPickerOption', () => {
+            const baseCurrency: BaseCurrencyOption = {
+                value: 'eur',
+                label: 'Euro',
+            };
+
+            const result = mapCurrencyToCurrencyPickerOption(baseCurrency);
+
+            expect(result).toEqual({
+                value: 'eur',
+                label: 'Euro',
+                shortLabel: 'EUR',
+            });
+        });
+    });
+
+    describe('mapCurrenciesToCurrencyPickerOptions', () => {
+        it('maps list of currencies to CurrencyPickerOptions preserving order', () => {
+            const currencies: TradingFiatCurrencyOption[] = [
+                {
+                    value: 'usd',
+                    label: 'United States Dollar',
+                },
+                {
+                    value: 'eur',
+                    label: 'Euro',
+                },
+            ];
+
+            const result = mapCurrenciesToCurrencyPickerOptions(currencies);
+
+            expect(result).toEqual([
+                {
+                    value: 'usd',
+                    label: 'United States Dollar',
+                    shortLabel: 'USD',
+                },
+                {
+                    value: 'eur',
+                    label: 'Euro',
+                    shortLabel: 'EUR',
+                },
+            ]);
+        });
+    });
+});

--- a/suite/trading/src/ui/currency-picker/utils/currencyPickerMapper.ts
+++ b/suite/trading/src/ui/currency-picker/utils/currencyPickerMapper.ts
@@ -1,0 +1,16 @@
+import { type TradingFiatCurrencyOption } from '@suite-common/trading';
+import { type BaseCurrencyOption } from '@suite-common/wallet-types';
+
+import { type CurrencyPickerOption } from '../types/currencyPickerTypes';
+
+export const mapCurrencyToCurrencyPickerOption = (
+    currency: TradingFiatCurrencyOption | BaseCurrencyOption,
+): CurrencyPickerOption => ({
+    value: currency.value,
+    label: currency.label,
+    shortLabel: currency.value.toUpperCase(),
+});
+
+export const mapCurrenciesToCurrencyPickerOptions = (
+    currencies: (TradingFiatCurrencyOption | BaseCurrencyOption)[],
+): CurrencyPickerOption[] => currencies.map(mapCurrencyToCurrencyPickerOption);

--- a/suite/trading/src/ui/index.ts
+++ b/suite/trading/src/ui/index.ts
@@ -1,3 +1,8 @@
 export { PaymentMethodIcon } from './PaymentMethods/PaymentMethodIcon';
 export { TradingCountryInput, type TradingCountryInputProps } from './Country/TradingCountryInput';
 export { FakeSelect } from './Form/FakeSelect';
+export { CurrencyPicker } from './currency-picker/CurrencyPicker';
+export {
+    mapCurrenciesToCurrencyPickerOptions,
+    mapCurrencyToCurrencyPickerOption,
+} from './currency-picker/utils/currencyPickerMapper';

--- a/suite/trading/tsconfig.json
+++ b/suite/trading/tsconfig.json
@@ -16,6 +16,9 @@
             "path": "../../suite-common/redux-utils"
         },
         { "path": "../../suite-common/trading" },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
         { "path": "../intl" },
         { "path": "../router" },
         { "path": "../../packages/components" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14995,6 +14995,7 @@ __metadata:
     "@suite-common/icons": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/trading": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite/intl": "workspace:*"
     "@suite/router": "workspace:*"
     "@trezor/components": "workspace:*"


### PR DESCRIPTION
### Description

<!--- Describe your changes  -->

Implement currency picker for trading forms, including shared currency mapping utilities and UI components, and fix related lint issues.

### Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

- Focus on trading buy/sell/exchange flows where fiat/crypto currency selection is available.
- Verify that the new currency picker opens correctly, lists expected currencies, and updates the selected value in the form.
- Check that default/unsupported fiat currencies fall back correctly and labels are rendered as expected.
- Sanity check that no console errors appear when interacting with the picker.
  
### Related Issue

Resolves #23991 

## Screenshots:
<img width="980" height="850" alt="image" src="https://github.com/user-attachments/assets/6795f41b-512a-478d-8e57-b0236831547d" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/23991/currency-picker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/23991/currency-picker&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/23991/currency-picker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T19:03:55.880Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T08:53:01.044Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->