### PR TITLE
chore(suite): flags package

### DIFF
--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -15,6 +15,7 @@
         "@sentry/electron": "^7.8.0",
         "@suite-common/suite-types": "workspace:*",
         "@suite/analytics": "workspace:*",
+        "@suite/flags": "workspace:*",
         "@suite/intl": "workspace:*",
         "@suite/sentry": "workspace:*",
         "@trezor/components": "workspace:*",

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/Available.tsx
@@ -1,13 +1,12 @@
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { Card, Checkbox, Column, H4, Modal, Paragraph } from '@trezor/components';
 import { UpdateInfo, desktopApi } from '@trezor/suite-desktop-api';
 import { spacings } from '@trezor/theme';
 
 import { download } from 'src/actions/suite/desktopUpdateActions';
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { MarkdownWithComponents } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { getVersionName } from './getVersionName';
 
@@ -18,7 +17,7 @@ interface AvailableProps {
 
 export const Available = ({ onCancel, latest }: AvailableProps) => {
     const dispatch = useDispatch();
-    const { enableAutoupdateOnNextRun } = useSelector(selectSuiteFlags);
+    const { enableAutoupdateOnNextRun } = useSelector(selectFlags);
 
     const downloadUpdate = () => {
         dispatch(download());
@@ -32,7 +31,7 @@ export const Available = ({ onCancel, latest }: AvailableProps) => {
     });
 
     const handleToggleAutoUpdateClick = () =>
-        dispatch(setFlag('enableAutoupdateOnNextRun', !enableAutoupdateOnNextRun));
+        dispatch(setFlag({ key: 'enableAutoupdateOnNextRun', value: !enableAutoupdateOnNextRun }));
 
     return (
         <Modal

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -13,6 +13,7 @@
             "path": "../../suite-common/suite-types"
         },
         { "path": "../../suite/analytics" },
+        { "path": "../../suite/flags" },
         { "path": "../../suite/intl" },
         { "path": "../../suite/sentry" },
         { "path": "../components" },

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -75,6 +75,7 @@
         "@suite/analytics": "workspace:*",
         "@suite/experimental": "workspace:*",
         "@suite/experimental-feedback": "workspace:*",
+        "@suite/flags": "workspace:*",
         "@suite/idb-migration-utils": "workspace:*",
         "@suite/intl": "workspace:*",
         "@suite/locks": "workspace:*",

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,4 +1,5 @@
 import { OnboardingAnalytics, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { initialRunCompleted } from '@suite/flags';
 import { closeModal } from '@suite/modal';
 import { recoveryRerunThunk } from '@suite/recovery';
 import { closeModalApp, goto } from '@suite/router';
@@ -21,7 +22,6 @@ import {
 } from 'src/utils/onboarding/steps';
 
 import { selectOnboardingAnalytics } from '../../reducers/onboarding/onboardingReducer';
-import * as suiteActions from '../suite/suiteActions';
 
 export type OnboardingAction =
     | {
@@ -116,7 +116,7 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
     // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
     dispatch(closeModal());
 
-    dispatch(suiteActions.initialRunCompleted());
+    dispatch(initialRunCompleted());
     dispatch(resetOnboarding());
     dispatch(closeModalApp(true));
 

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -7,7 +7,6 @@ import { DEVICE, Device, TRANSPORT } from '@trezor/connect';
 import { SUITE } from 'src/actions/suite/constants';
 import { AppState, TorStatus } from 'src/types/suite';
 
-import { SuiteState } from '../../../reducers/suite/suiteReducer';
 import * as suiteActions from '../suiteActions';
 
 const SUITE_DEVICE = mockSuiteDevice({ path: '1' });
@@ -134,41 +133,6 @@ const reducerActions = [
                 },
             },
         ],
-    },
-];
-
-const initialRun: Array<{ description: string; state?: Partial<SuiteState> }> = [
-    {
-        description: `initialRunCompleted (initialRun = true)`,
-    },
-    {
-        description: `initialRunCompleted (initialRun = false)`,
-        state: {
-            flags: {
-                initialRun: false,
-                discreetModeCompleted: false,
-                taprootBannerClosed: false,
-                firmwareTypeBannerClosed: false,
-                dashboardGraphHidden: false,
-                securityStepsHidden: false,
-                dashboardAssetsGridMode: true,
-                showTEXDashboardPromoBanner: true,
-                showTS7DashboardPromoBanner: true,
-                showSettingsDesktopAppPromoBanner: true,
-                stakeEthBannerClosed: false,
-                stakeSolBannerClosed: false,
-                stakeCardanoBannerClosed: false,
-                suspiciousTransactionsTooltipClosed: false,
-                showDashboardStakingPromoBanner: true,
-                showCopyAddressModal: true,
-                showUnhideTokenModal: true,
-                enableAutoupdateOnNextRun: false,
-                showBluetoothDebugInfo: false,
-                stellarLimitedHistoryBannerClosed: false,
-                solanaLimitedHistoryBannerClosed: false,
-                hasSeenDisconnectTooltip: false,
-            },
-        },
     },
 ];
 
@@ -760,7 +724,6 @@ const acquireDevice = [
 
 export default {
     reducerActions,
-    initialRun,
     selectDevice,
     markDeviceAsRecentlyConnected,
     handleDeviceDisconnect,

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -1,5 +1,6 @@
 import { createMemoryHistory } from 'history';
 
+import { prepareFlagsReducer } from '@suite/flags';
 import { lockRouter, locksInitialState, locksReducer } from '@suite/locks';
 import { metadataReducer } from '@suite/metadata';
 import { modalReducer } from '@suite/modal';
@@ -60,6 +61,7 @@ import type { AppState } from 'src/types/suite';
 const deviceReducer = prepareDeviceReducer(extraDependencies);
 const analyticsReducer = prepareAnalyticsReducer(extraDependencies);
 const messageSystemReducer = prepareMessageSystemReducer(extraDependencies);
+const flagsReducer = prepareFlagsReducer(extraDependencies);
 
 global.fetch = jest.fn().mockImplementation(() =>
     Promise.resolve({
@@ -71,19 +73,14 @@ global.fetch = jest.fn().mockImplementation(() =>
 const EMPTY_ACTION = { type: 'foo' } as any;
 
 const getInitialState = (initialRun?: boolean) => {
-    const initialSuiteState = suiteReducer(undefined, EMPTY_ACTION);
+    const initialFlagsState = flagsReducer(undefined, EMPTY_ACTION);
 
     return {
-        suite: {
-            ...initialSuiteState,
+        suite: suiteReducer(undefined, EMPTY_ACTION),
+        flags: {
             ...(initialRun !== undefined
-                ? {
-                      flags: {
-                          ...initialSuiteState.flags,
-                          initialRun,
-                      },
-                  }
-                : {}),
+                ? { ...initialFlagsState, initialRun }
+                : { ...initialFlagsState }),
         },
         locks: locksInitialState,
         router: routerReducer(undefined, EMPTY_ACTION),

--- a/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/storageActions.test.ts
@@ -1,5 +1,6 @@
 import '@suite-common/test-utils/src/globalOverrides';
 
+import { initialRunCompleted, prepareFlagsReducer } from '@suite/flags';
 import { deviceActions, selectDevices, selectDevicesCount } from '@suite-common/device';
 import { asEncryptedHex } from '@suite-common/platform-encryption';
 import { setSuiteSyncOwner } from '@suite-common/suite-sync';
@@ -33,12 +34,12 @@ import { configureStore } from 'src/support/tests/configureStore';
 import { AcquiredDevice, AppState } from 'src/types/suite';
 
 import * as storageActions from '../storageActions';
-import * as suiteActions from '../suiteActions';
 
 const { getWalletTransaction } = testMocks;
 
 const discoveryReducer = prepareDiscoveryReducer(extraDependencies);
 const deviceReducer = deviceSlice.prepareReducer(extraDependencies);
+const flagsReducer = prepareFlagsReducer(extraDependencies);
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 const walletSettingsReducer = discoveryActions.prepareWalletSettingsReducer(extraDependencies);
 const quotaManagerSliceReducer = suiteSyncQuotaManagerSlice.prepareReducer(extraDependencies);
@@ -90,7 +91,10 @@ const tx2 = getWalletTransaction({
     symbol: 'btc',
 });
 
-type PartialState = Pick<AppState, 'suite' | 'device' | 'suiteSync' | 'suiteSyncQuotaManager'> & {
+type PartialState = Pick<
+    AppState,
+    'suite' | 'device' | 'suiteSync' | 'suiteSyncQuotaManager' | 'flags'
+> & {
     wallet: Partial<
         Pick<
             AppState['wallet'],
@@ -109,6 +113,10 @@ type PartialState = Pick<AppState, 'suite' | 'device' | 'suiteSync' | 'suiteSync
 const getInitialState = (prevState?: Partial<PartialState>, action?: any) => ({
     suite: suiteReducer(
         prevState ? prevState.suite : undefined,
+        action || ({ type: 'foo' } as any),
+    ),
+    flags: flagsReducer(
+        prevState ? prevState.flags : undefined,
         action || ({ type: 'foo' } as any),
     ),
     suiteSync: suiteSyncReducer(
@@ -172,6 +180,7 @@ const updateStore = (store: mockStoreType) => {
         const action = store.getActions().pop();
         const prevState = store.getState();
         store.getState().suite = getInitialState(prevState, action).suite;
+        store.getState().flags = getInitialState(prevState, action).flags;
         store.getState().suiteSync = getInitialState(prevState, action).suiteSync;
         store.getState().device = getInitialState(prevState, action).device;
         store.getState().wallet = getInitialState(prevState, action).wallet;
@@ -215,10 +224,10 @@ describe('Storage actions', () => {
         const f = global.fetch;
         global.fetch = mockFetch({ TR_ID: 'Message' });
         await store.dispatch(storageActions.saveSuiteSettings());
-        await store.dispatch(suiteActions.initialRunCompleted());
+        await store.dispatch(initialRunCompleted());
         store.dispatch(await preloadStore());
 
-        expect(store.getState().suite.flags.initialRun).toEqual(false);
+        expect(store.getState().flags.initialRun).toEqual(false);
         global.fetch = f;
     });
 

--- a/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/suiteActions.test.ts
@@ -1,5 +1,6 @@
 // unit test for suite actions
 // data provided by TrezorConnect are mocked
+import { flagsInitialState, prepareFlagsReducer } from '@suite/flags';
 import { modalReducer } from '@suite/modal';
 import { routerReducer } from '@suite/router';
 import { connectInitThunk } from '@suite-common/connect-init';
@@ -30,6 +31,7 @@ import * as suiteActions from '../suiteActions';
 
 const firmwareReducer = prepareFirmwareReducer(extraDependencies);
 const deviceReducer = prepareDeviceReducer(extraDependencies);
+const flagsReducer = prepareFlagsReducer(extraDependencies);
 
 const TrezorConnect = testMocks.getTrezorConnectMock();
 
@@ -75,6 +77,7 @@ const getInitialState = (
         ...suiteReducer(undefined, { type: 'foo' } as any),
         ...suite,
     },
+    flags: flagsInitialState,
     device: {
         ...deviceReducer(undefined, { type: 'foo' } as any),
         ...device,
@@ -108,8 +111,9 @@ const initStore = (state: State) => {
     const store = mockStore(state);
     store.subscribe(() => {
         const action = store.getActions().pop();
-        const { suite, device, router } = store.getState();
+        const { suite, flags, device, router } = store.getState();
         store.getState().suite = suiteReducer(suite, action);
+        store.getState().flags = flagsReducer(flags, action);
         store.getState().device = deviceReducer(device, action);
         store.getState().router = routerReducer(router, action);
         // add action back to stack
@@ -128,15 +132,6 @@ describe('Suite Actions', () => {
                 store.dispatch(action);
                 expect(store.getState().suite).toMatchObject(f.result[i]);
             });
-        });
-    });
-
-    fixtures.initialRun.forEach(f => {
-        it(f.description, () => {
-            const state = getInitialState(f.state);
-            const store = initStore(state);
-            store.dispatch(suiteActions.initialRunCompleted());
-            expect(store.getState().suite.flags.initialRun).toBe(false);
         });
     });
 

--- a/packages/suite/src/actions/suite/constants/suiteConstants.ts
+++ b/packages/suite/src/actions/suite/constants/suiteConstants.ts
@@ -5,7 +5,6 @@ export const DESKTOP_HANDSHAKE = '@suite/desktop-handshake';
 export const TOGGLE_BIO_AUTH_VALIDATION_REQUESTED = '@suite/toggle-bio-auth-validation-requested';
 export const SET_LANGUAGE = '@suite/set-language';
 export const SET_DEBUG_MODE = '@suite/set-debug-mode';
-export const SET_FLAG = '@suite/set-flag';
 export const SET_RECENTLY_CONNECTED_DEVICE = '@suite/set-recently-connected-device';
 export const SET_RECENTLY_DISCONNECTED_DEVICE = '@suite/set-recently-disconnected-device';
 export const ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION =

--- a/packages/suite/src/actions/suite/initAction.ts
+++ b/packages/suite/src/actions/suite/initAction.ts
@@ -1,3 +1,4 @@
+import { selectFlags, setFlag } from '@suite/flags';
 import { metadataLabelingActions } from '@suite/metadata';
 import { openModal, preserveModal } from '@suite/modal';
 import { recoveryActions, selectRecoveryStatus } from '@suite/recovery';
@@ -24,19 +25,19 @@ import { markDeviceAsRecentlyConnectedThunk } from 'src/actions/wallet/markDevic
 import type { Dispatch, GetState } from 'src/types/suite';
 
 import { SUITE } from './constants';
-import { onSuiteReady, setFlag } from './suiteActions';
+import { onSuiteReady } from './suiteActions';
 
 export const init = () => async (dispatch: Dispatch, getState: GetState) => {
     const {
         suite: {
             settings: { language },
             lifecycle: { status },
-            flags: { enableAutoupdateOnNextRun },
         },
         wallet: {
             settings: { localCurrency },
         },
     } = getState();
+    const { enableAutoupdateOnNextRun } = selectFlags(getState());
 
     if (status !== 'initial') return;
 
@@ -63,12 +64,12 @@ export const init = () => async (dispatch: Dispatch, getState: GetState) => {
 
     // 4. turn on auto updates if needed
     if (isDesktop() && enableAutoupdateOnNextRun) {
-        dispatch(setFlag('enableAutoupdateOnNextRun', false));
+        dispatch(setFlag({ key: 'enableAutoupdateOnNextRun', value: false }));
         desktopApi.setAutomaticUpdateEnabled(true);
     }
 
     // 5. redirecting user into welcome screen (if needed)
-    dispatch(initialRedirection({ isInitialRun: getState().suite.flags.initialRun }));
+    dispatch(initialRedirection({ isInitialRun: selectFlags(getState()).initialRun }));
 
     // 6. init connect (could throw an error,
     // then the error is caught in <ErrorBoundary /> in Main.tsx

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -102,7 +102,7 @@ const removeCoinjoinRelatedSetting = (state: AppState) => {
         'suiteSettings',
         {
             settings,
-            flags: state.suite.flags,
+            flags: state.flags,
             evmSettings: state.suite.evmSettings,
             seenDisconnectNotificationForDeviceIds:
                 state.suite.seenDisconnectNotificationForDeviceIds,
@@ -391,7 +391,7 @@ export const saveSuiteSettings =
     () =>
     (_dispatch: Dispatch, getState: GetState): Promise<void> => {
         if (!db.isAccessible()) return Promise.resolve();
-        const { suite } = getState();
+        const { suite, flags } = getState();
 
         const result = db.addItem(
             'suiteSettings',
@@ -403,7 +403,7 @@ export const saveSuiteSettings =
                         e => e !== 'password-manager',
                     ),
                 },
-                flags: suite.flags,
+                flags,
                 evmSettings: suite.evmSettings,
                 seenDisconnectNotificationForDeviceIds:
                     suite.seenDisconnectNotificationForDeviceIds,

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -49,11 +49,6 @@ export type SuiteAction =
     | { type: typeof SUITE.TOGGLE_DEVICE_META_CHECKS; payload: boolean }
     | { type: typeof SUITE.COINJOIN_RECEIVE_WARNING; payload: boolean }
     | {
-          type: typeof SUITE.SET_FLAG;
-          key: keyof AppState['suite']['flags'];
-          value: boolean;
-      }
-    | {
           type: typeof SUITE.SET_RECENTLY_CONNECTED_DEVICE;
           payload: string | null;
       }
@@ -128,12 +123,6 @@ export const setAutodetect = (payload: Partial<AutodetectSettings>): SuiteAction
     payload,
 });
 
-export const setFlag = (key: keyof AppState['suite']['flags'], value: boolean): SuiteAction => ({
-    type: SUITE.SET_FLAG,
-    key,
-    value,
-});
-
 export const setRecentlyConnectedDevicePath = (payload: string | null): SuiteAction => ({
     type: SUITE.SET_RECENTLY_CONNECTED_DEVICE,
     payload,
@@ -146,12 +135,6 @@ export const addDeviceIdToSeenDisconnectNotification = (deviceId: string): Suite
     type: SUITE.ADD_DEVICE_ID_TO_SEEN_DISCONNECT_NOTIFICATION,
     payload: { deviceId },
 });
-
-export const initialRunCompleted = () => (dispatch: Dispatch, getState: GetState) => {
-    if (getState().suite.flags.initialRun) {
-        dispatch(setFlag('initialRun', false));
-    }
-};
 
 export const setSidebarWidth = (payload: { width: number }): SuiteAction => ({
     type: SUITE.SET_SIDEBAR_WIDTH,

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -1,7 +1,6 @@
+import { selectFlags } from '@suite/flags';
 import { Column, Image, ImageKey, InfoSegments, Row, Text } from '@trezor/components';
 import { DeviceModelInternal, models } from '@trezor/device-utils';
-
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { BluetoothDebugInfo } from './BluetoothDebugInfo';
 import { DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
@@ -36,7 +35,7 @@ export const BluetoothDeviceComponent = ({ device }: BluetoothDeviceProps) => {
     const color = getTHPVideoColor(device);
     const colorName = modelConfig.colors[color.toString()];
 
-    const { showBluetoothDebugInfo } = useSelector(selectSuiteFlags);
+    const { showBluetoothDebugInfo } = useSelector(selectFlags);
 
     return (
         <Row gap={12} alignItems="stretch">

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -2,13 +2,14 @@ import { FC, useMemo } from 'react';
 
 import styled from 'styled-components';
 
+import { selectIsInitialRun } from '@suite/flags';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { Route } from '@suite-common/suite-types';
 import { selectIsAnyNonBitcoinLikeNetworkEnabled } from '@suite-common/wallet-core';
 import { type SpacingPxValues, spacingsPx } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
-import { selectIsDebugModeActive, selectIsInitialRun } from 'src/selectors/suite/suiteSelectors';
+import { selectIsDebugModeActive } from 'src/selectors/suite/suiteSelectors';
 
 import { NavigationItem, NavigationItemProps } from './NavigationItem';
 import { NotificationDropdown } from './NotificationDropdown';

--- a/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/CopyAddressModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { AddressType } from '@suite-common/wallet-types';
@@ -7,7 +8,6 @@ import { Card, Checkbox, H2, Modal, Paragraph } from '@trezor/components';
 import { copyToClipboard } from '@trezor/dom-utils';
 import { spacings } from '@trezor/theme';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 
 const getAddressTypeText = (addressType: AddressType) => {
@@ -34,7 +34,7 @@ export const CopyAddressModal = ({ address, onCancel, addressType }: CopyAddress
 
     const onCopyAddress = () => {
         if (checked) {
-            dispatch(setFlag('showCopyAddressModal', false));
+            dispatch(setFlag({ key: 'showCopyAddressModal', value: false }));
         }
 
         const result = copyToClipboard(address);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UnhideTokenModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import {
     DefinitionType,
@@ -9,7 +10,6 @@ import {
 import { Card, Checkbox, H2, Modal, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useSelector } from 'src/hooks/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
@@ -29,7 +29,7 @@ export const UnhideTokenModal = ({ address, onCancel }: UnhideTokenModalProps) =
 
     const onUnhide = () => {
         if (checked) {
-            dispatch(setFlag('showUnhideTokenModal', false));
+            dispatch(setFlag({ key: 'showUnhideTokenModal', value: false }));
         }
         dispatch(
             tokenDefinitionsActions.setTokenStatus({

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/SolanaLimitedHistoryBanner.tsx
@@ -1,10 +1,9 @@
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { Account } from '@suite-common/wallet-types';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';
@@ -17,7 +16,7 @@ const SOLANA_TX_HISTORY_LIMIT = 100;
 
 export const SolanaLimitedHistoryBanner = ({ account }: SolanaLimitedHistoryBannerProps) => {
     const dispatch = useDispatch();
-    const { solanaLimitedHistoryBannerClosed } = useSelector(selectSuiteFlags);
+    const { solanaLimitedHistoryBannerClosed } = useSelector(selectFlags);
 
     const isSolanaAccount = account.networkType === 'solana';
     const hasTxCountAboveLimit = account.history.total > SOLANA_TX_HISTORY_LIMIT;
@@ -27,7 +26,7 @@ export const SolanaLimitedHistoryBanner = ({ account }: SolanaLimitedHistoryBann
     }
 
     const handleClose = () => {
-        dispatch(setFlag('solanaLimitedHistoryBannerClosed', true));
+        dispatch(setFlag({ key: 'solanaLimitedHistoryBannerClosed', value: true }));
     };
 
     const points = [

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { events } from '@suite/analytics';
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useFormatters } from '@suite-common/formatters';
@@ -18,9 +19,7 @@ import { Banner } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { formatApyValue } from 'src/views/wallet/staking/utils/formatStakeValues';
 
@@ -33,7 +32,7 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
     const { stakeEthBannerClosed, stakeSolBannerClosed, stakeCardanoBannerClosed } =
-        useSelector(selectSuiteFlags);
+        useSelector(selectFlags);
     const { route } = useSelector(state => state.router);
     const apy = useSelector(state => selectPoolStatsApyData(state, account));
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
@@ -63,13 +62,13 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     const closeBanner = () => {
         switch (account.networkType) {
             case 'ethereum':
-                dispatch(setFlag('stakeEthBannerClosed', true));
+                dispatch(setFlag({ key: 'stakeEthBannerClosed', value: true }));
                 break;
             case 'solana':
-                dispatch(setFlag('stakeSolBannerClosed', true));
+                dispatch(setFlag({ key: 'stakeSolBannerClosed', value: true }));
                 break;
             case 'cardano':
-                dispatch(setFlag('stakeCardanoBannerClosed', true));
+                dispatch(setFlag({ key: 'stakeCardanoBannerClosed', value: true }));
                 break;
             default:
                 if (isSupportedStakingNetworkSymbol(account.symbol)) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StellarLimitedHistoryBanner.tsx
@@ -1,23 +1,22 @@
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { BannerPoints } from './BannerPoints';
 import { CloseableBanner } from './CloseableBanner';
 
 export const StellarLimitedHistoryBanner = () => {
     const dispatch = useDispatch();
-    const { stellarLimitedHistoryBannerClosed } = useSelector(selectSuiteFlags);
+    const { stellarLimitedHistoryBannerClosed } = useSelector(selectFlags);
 
     if (stellarLimitedHistoryBannerClosed) {
         return null;
     }
 
     const handleClose = () => {
-        dispatch(setFlag('stellarLimitedHistoryBannerClosed', true));
+        dispatch(setFlag({ key: 'stellarLimitedHistoryBannerClosed', value: true }));
     };
 
     const points = [

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/TaprootBanner.tsx
@@ -1,12 +1,11 @@
 import styled from 'styled-components';
 
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { getBip43Type } from '@suite-common/wallet-utils';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useSelector } from 'src/hooks/suite/useSelector';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { Account } from 'src/types/wallet';
 
 import { BannerPoints } from './BannerPoints';
@@ -21,7 +20,7 @@ const Dark = styled.span`
 `;
 
 export const TaprootBanner = ({ account }: TaprootBannerProps) => {
-    const { taprootBannerClosed } = useSelector(selectSuiteFlags);
+    const { taprootBannerClosed } = useSelector(selectFlags);
     const dispatch = useDispatch();
 
     const isVisible =
@@ -31,7 +30,7 @@ export const TaprootBanner = ({ account }: TaprootBannerProps) => {
         return null;
     }
 
-    const closeTaprootBanner = () => dispatch(setFlag('taprootBannerClosed', true));
+    const closeTaprootBanner = () => dispatch(setFlag({ key: 'taprootBannerClosed', value: true }));
 
     return (
         <CloseableBanner

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -275,12 +275,15 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
                 settings: { debug: {}, theme: { variant: 'light' } },
                 evmSettings: { confirmExplanationModalClosed: {}, explanationBannerClosed: {} },
                 prefillFields: { sendForm: '', transactionHistory: '' },
-                flags: { stakeEthBannerClosed: false, stakeSolBannerClosed: false },
                 countryCode: null,
             },
             () => ({}),
         ),
         locks: locksReducer,
+        flags: createReducer(
+            { stakeEthBannerClosed: false, stakeSolBannerClosed: false },
+            () => {},
+        ),
         device: createReducer({ selectedDevice: DEVICE, devices: [DEVICE] }, () => {}),
         wallet: combineReducers({
             send: sendFormReducer,

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -1,6 +1,7 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { setFlag } from '@suite/flags';
 import { anchorChange, routerLocationChange, selectRouterUrl } from '@suite/router';
 import { deviceActions, selectDevices, selectDevicesCount } from '@suite-common/device';
 import { firmwareUpdate } from '@suite-common/firmware';
@@ -30,7 +31,6 @@ import {
 import { BigNumber } from '@trezor/utils';
 
 import { SUITE } from 'src/actions/suite/constants';
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { updateLastAnonymityReportTimestamp } from 'src/actions/wallet/coinjoinAccountActions';
 import { COINJOIN } from 'src/actions/wallet/constants';
 import {
@@ -289,8 +289,8 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                 break;
 
             case WALLET_SETTINGS.SET_HIDE_BALANCE:
-                if (!state.suite.flags.discreetModeCompleted) {
-                    dispatch(setFlag('discreetModeCompleted', true));
+                if (!state.flags.discreetModeCompleted) {
+                    dispatch(setFlag({ key: 'discreetModeCompleted', value: true }));
                 }
                 asTypedDesktopAnalytics(analytics).report({
                     type: events.menuToggleDiscreetEvent.name,

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -77,7 +77,7 @@ export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
                     const isModalActive = hasModalContext || isForegroundApp;
 
                     if (
-                        !state.suite.flags.hasSeenDisconnectTooltip &&
+                        !state.flags.hasSeenDisconnectTooltip &&
                         state.wallet.accounts.length > 0 &&
                         !isModalActive
                     ) {

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -2,6 +2,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 import { MiddlewareAPI } from 'redux';
 
 import { featureUsed, feedbackDismissed, feedbackRequested } from '@suite/experimental-feedback';
+import { setFlag } from '@suite/flags';
 import { METADATA, metadataActions } from '@suite/metadata';
 import { analyticsActions } from '@suite-common/analytics-redux';
 import { bluetoothActions } from '@suite-common/bluetooth';
@@ -330,7 +331,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
 
                     break;
                 case SUITE.SET_LANGUAGE:
-                case SUITE.SET_FLAG:
+                case setFlag.type:
                 case SUITE.SET_DEBUG_MODE:
                 case SUITE.SET_EXPERIMENTAL_FEATURES:
                 case SUITE.ONION_LINKS:

--- a/packages/suite/src/reducers/suite/index.ts
+++ b/packages/suite/src/reducers/suite/index.ts
@@ -1,4 +1,5 @@
 import { experimentalFeedbackReducer } from '@suite/experimental-feedback';
+import { prepareFlagsReducer } from '@suite/flags';
 import { TranslationKey } from '@suite/intl';
 import { locksReducer } from '@suite/locks';
 import { metadataReducer } from '@suite/metadata';
@@ -24,11 +25,13 @@ const analytics = prepareAnalyticsReducer(extraDependencies);
 // Type annotation as a workaround for type-check error "The inferred type of 'default' cannot be named..."
 const messageSystem = prepareMessageSystemReducer(extraDependencies);
 const device = deviceSlice.prepareReducer(extraDependencies);
+const flags = prepareFlagsReducer(extraDependencies);
 const connectPopupReducer = prepareConnectPopupReducer(extraDependencies);
 const walletConnectReducer = prepareWalletConnectReducer(extraDependencies);
 
 export default {
     suite,
+    flags,
     locks: locksReducer,
     router: routerReducer,
     modal,

--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -45,35 +45,6 @@ type SuiteLifecycle =
     // inconsistent IDB state detected, need to reset storage
     | { status: 'db-corrupted'; error: unknown };
 
-export interface Flags {
-    initialRun: boolean; // true on very first launch of Suite, will switch to false after completing onboarding process
-    // is not saved to storage at the moment, so for simplicity of types set to be optional now
-    // recoveryCompleted: boolean;
-    // pinCompleted: boolean;
-    // passphraseCompleted: boolean;
-    taprootBannerClosed: boolean; // banner in account view informing about advantages of using Taproot
-    firmwareTypeBannerClosed: boolean; // banner in Crypto settings suggesting switching firmware type
-    discreetModeCompleted: boolean; // dashboard UI, user tried discreet mode
-    securityStepsHidden: boolean; // dashboard UI
-    dashboardGraphHidden: boolean; // dashboard UI
-    dashboardAssetsGridMode: boolean; // dashboard UI
-    showTEXDashboardPromoBanner: boolean;
-    showTS7DashboardPromoBanner: boolean;
-    showSettingsDesktopAppPromoBanner: boolean;
-    stakeEthBannerClosed: boolean; // banner in account view (Overview tab) presenting ETH staking feature
-    stakeSolBannerClosed: boolean; // banner in account view (Overview tab) presenting SOL staking feature
-    stakeCardanoBannerClosed: boolean; // banner in account view (Overview tab) presenting Cardano staking feature
-    showDashboardStakingPromoBanner: boolean;
-    suspiciousTransactionsTooltipClosed: boolean;
-    showUnhideTokenModal: boolean;
-    showCopyAddressModal: boolean;
-    enableAutoupdateOnNextRun: boolean;
-    showBluetoothDebugInfo: boolean;
-    stellarLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Stellar
-    solanaLimitedHistoryBannerClosed: boolean; // banner in account view (Overview tab) presenting limited history for Solana
-    hasSeenDisconnectTooltip: boolean; // tooltip shown when device disconnects - show only once ever
-}
-
 export interface EvmSettings {
     confirmExplanationModalClosed: Partial<Record<NetworkSymbol, Record<string, boolean>>>;
     explanationBannerClosed: Partial<Record<NetworkSymbol, boolean>>;
@@ -120,7 +91,6 @@ export interface SuiteState {
     torBootstrap: TorBootstrap | null;
     lifecycle: SuiteLifecycle;
     transport?: TransportState;
-    flags: Flags;
     evmSettings: EvmSettings;
     countryCode: CountryCode | null;
     prefillFields: PrefillFields;
@@ -135,33 +105,6 @@ const initialState: SuiteState = {
     torStatus: TorStatus.Disabled,
     torBootstrap: null,
     lifecycle: { status: 'initial' },
-    flags: {
-        initialRun: true,
-        // recoveryCompleted: false;
-        // pinCompleted: false;
-        // passphraseCompleted: false;
-        discreetModeCompleted: false,
-        taprootBannerClosed: false,
-        firmwareTypeBannerClosed: false,
-        securityStepsHidden: false,
-        dashboardGraphHidden: false,
-        dashboardAssetsGridMode: true,
-        showTEXDashboardPromoBanner: true,
-        showTS7DashboardPromoBanner: true,
-        showSettingsDesktopAppPromoBanner: true,
-        stakeEthBannerClosed: false,
-        stakeSolBannerClosed: false,
-        stakeCardanoBannerClosed: false,
-        showDashboardStakingPromoBanner: true,
-        suspiciousTransactionsTooltipClosed: false,
-        showCopyAddressModal: true,
-        showUnhideTokenModal: true,
-        enableAutoupdateOnNextRun: false,
-        showBluetoothDebugInfo: false,
-        stellarLimitedHistoryBannerClosed: false,
-        solanaLimitedHistoryBannerClosed: false,
-        hasSeenDisconnectTooltip: false,
-    },
     evmSettings: {
         confirmExplanationModalClosed: {},
         explanationBannerClosed: {},
@@ -210,18 +153,10 @@ const initialState: SuiteState = {
 
 export const suiteInitialState = initialState;
 
-const setFlag = (draft: SuiteState, key: keyof Flags, value: boolean) => {
-    draft.flags[key] = value;
-};
-
 const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteState =>
     produce(state, draft => {
         switch (action.type) {
             case STORAGE.LOAD:
-                draft.flags = {
-                    ...draft.flags,
-                    ...action.payload.suiteSettings?.flags,
-                };
                 draft.evmSettings = {
                     ...draft.evmSettings,
                     ...action.payload.suiteSettings?.evmSettings,
@@ -266,10 +201,6 @@ const suiteReducer = (state: SuiteState = initialState, action: Action): SuiteSt
 
             case SUITE.SET_EXPERIMENTAL_FEATURES:
                 draft.settings.experimental = action.payload.enabledFeatures;
-                break;
-
-            case SUITE.SET_FLAG:
-                setFlag(draft, action.key, action.value);
                 break;
 
             case SUITE.SET_RECENTLY_CONNECTED_DEVICE:

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -68,18 +68,6 @@ export const selectPrerequisite = (
     return prerequisite;
 };
 
-export const selectIsTEXDashboardPromoBannerShown = (state: SuiteRootState) =>
-    state.suite.flags.showTEXDashboardPromoBanner;
-export const selectIsTS7DashboardPromoBannerShown = (state: SuiteRootState) =>
-    state.suite.flags.showTS7DashboardPromoBanner;
-export const selectIsSettingsDesktopAppPromoBannerShown = (state: SuiteRootState) =>
-    state.suite.flags.showSettingsDesktopAppPromoBanner;
-export const selectIsUnhideTokenModalShown = (state: SuiteRootState) =>
-    state.suite.flags.showUnhideTokenModal;
-export const selectIsCopyAddressModalShown = (state: SuiteRootState) =>
-    state.suite.flags.showCopyAddressModal;
-export const selectIsInitialRun = (state: SuiteRootState) => state.suite.flags.initialRun;
-export const selectSuiteFlags = (state: SuiteRootState) => state.suite.flags;
 export const selectHasExperimentalFeature =
     (feature: ExperimentalFeature) => (state: SuiteRootState) =>
         state.suite.settings.experimental?.includes(feature) ?? false;

--- a/packages/suite/src/storage/definitions.ts
+++ b/packages/suite/src/storage/definitions.ts
@@ -2,6 +2,7 @@ import { FieldValues } from 'react-hook-form';
 
 import type { DBSchema } from 'idb';
 
+import type { FlagsState } from '@suite/flags';
 import { AnalyticsState } from '@suite-common/analytics-redux';
 import { AppRememberedPermission } from '@suite-common/connect-popup/src/connectPopupTypes';
 import { ExperimentalFeedbackState } from '@suite-common/feedback';
@@ -75,7 +76,7 @@ export interface SuiteDBSchema extends DBSchema {
         key: string;
         value: {
             settings: SuiteState['settings'];
-            flags: SuiteState['flags'];
+            flags: FlagsState;
             evmSettings: SuiteState['evmSettings'];
             seenDisconnectNotificationForDeviceIds: SuiteState['seenDisconnectNotificationForDeviceIds'];
         };

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -2,6 +2,7 @@ import { PayloadAction } from '@reduxjs/toolkit';
 import { saveAs } from 'file-saver';
 
 import { DesktopAnalyticsDep, createAnalytics } from '@suite/analytics';
+import type { FlagsState } from '@suite/flags';
 import { lockDevice } from '@suite/locks';
 import { metadataActions, metadataLabelingActions } from '@suite/metadata';
 import { closeModal, openModal } from '@suite/modal';
@@ -297,7 +298,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
         },
         storageLoadWalletSettings: (state: WalletSettingsState, { payload }: StorageLoadAction) =>
             payload.walletSettings ? { ...state, ...payload.walletSettings } : state,
-
         // this is deprecated, bioAuth settings is now stored in electron store
         storageLoadBioAuth: (state: BioAuthState, { payload }: StorageLoadAction) => {
             if (!payload?.bioAuth) return state;
@@ -312,6 +312,8 @@ export const extraDependencies: ExtraDependenciesStatic = {
 
             return state;
         },
+        storageLoadFlags: (state: FlagsState, { payload }: StorageLoadAction) =>
+            payload.suiteSettings?.flags ? { ...state, ...payload.suiteSettings.flags } : state,
     },
 };
 

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -1,4 +1,5 @@
 import { initialState as experimentalFeedbackInitialState } from '@suite/experimental-feedback';
+import { flagsInitialState } from '@suite/flags';
 import { locksInitialState } from '@suite/locks';
 import { RouterState } from '@suite/router';
 import { FirmwareUpdateState } from '@suite-common/firmware';
@@ -21,6 +22,7 @@ import { initialDesktopBluetoothState } from '../../../actions/bluetooth/desktop
 
 export const initialAppState: AppState = {
     suite: suiteInitialState,
+    flags: flagsInitialState,
     locks: locksInitialState,
     device: initialState,
     bluetooth: initialDesktopBluetoothState,

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -2,6 +2,7 @@ import type { Store as ReduxStore } from 'redux';
 import type { ThunkAction as TAction, ThunkDispatch } from 'redux-thunk';
 
 import { experimentalFeedbackSlice } from '@suite/experimental-feedback';
+import type { flagsActions } from '@suite/flags';
 import type { LockAction } from '@suite/locks';
 import type { MetadataAction } from '@suite/metadata';
 import type { ModalAction } from '@suite/modal';
@@ -107,6 +108,7 @@ type DeviceActionDesktop = ReturnType<
 type ThpAction = ReturnType<(typeof thpActions)[keyof typeof thpActions]>;
 type GeolocationAction = ReturnType<(typeof geolocationActions)[keyof typeof geolocationActions]>;
 type FeeAction = ReturnType<(typeof feesActions)[keyof typeof feesActions]>;
+type FlagsAction = ReturnType<(typeof flagsActions)[keyof typeof flagsActions]>;
 type RecoveryAction = ReturnType<(typeof recoveryActions)[keyof typeof recoveryActions]>;
 
 // all actions from all apps used to properly type Dispatch.
@@ -123,6 +125,7 @@ export type Action =
     | DiscoveryAction
     | FeeAction
     | FirmwareAction
+    | FlagsAction
     | GeolocationAction
     | GuideAction
     | LockAction

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { AssetFiatBalance } from '@suite-common/assets';
@@ -34,7 +35,6 @@ import { spacings, spacingsPx, typography } from '@trezor/theme';
 import { PartialRecord } from '@trezor/type-utils';
 import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDiscovery, useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
@@ -90,7 +90,7 @@ const useAssetsFiatBalances = (
     }, []);
 
 export const AssetsView = () => {
-    const { dashboardAssetsGridMode } = useSelector(s => s.suite.flags);
+    const { dashboardAssetsGridMode } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
     const dispatch = useDispatch();
@@ -174,8 +174,8 @@ export const AssetsView = () => {
         discoveryStatus && discoveryStatus.status === 'exception' && !assetSymbols.length;
 
     const goToCoinsSettings = () => dispatch(goto({ routeName: 'settings-coins' }));
-    const setTable = () => dispatch(setFlag('dashboardAssetsGridMode', false));
-    const setGrid = () => dispatch(setFlag('dashboardAssetsGridMode', true));
+    const setTable = () => dispatch(setFlag({ key: 'dashboardAssetsGridMode', value: false }));
+    const setGrid = () => dispatch(setFlag({ key: 'dashboardAssetsGridMode', value: true }));
 
     const showCards = isBelowTablet || dashboardAssetsGridMode;
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
@@ -1,12 +1,11 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { FlagsState, setFlag } from '@suite/flags';
 import { IconButton } from '@trezor/components';
 import { borders, spacingsPx } from '@trezor/theme';
 
-import { setFlag } from '../../../actions/suite/suiteActions';
 import { useDispatch } from '../../../hooks/suite';
-import { Flags } from '../../../reducers/suite/suiteReducer';
 import { bannerAnimationConfig } from '../banner-animations';
 
 const CloseButtonContainer = styled.div`
@@ -41,7 +40,7 @@ const BannerWrapper = styled(motion.div)`
 type AnimatedWrapperProps = {
     children: React.ReactNode;
     isVisible: boolean;
-    flagToHide: keyof Flags;
+    flagToHide: keyof FlagsState;
 };
 
 export const AnimatedWrapper = ({ children, isVisible, flagToHide }: AnimatedWrapperProps) => {
@@ -54,7 +53,7 @@ export const AnimatedWrapper = ({ children, isVisible, flagToHide }: AnimatedWra
                     key="container"
                     {...bannerAnimationConfig}
                     onAnimationComplete={() => {
-                        dispatch(setFlag(flagToHide, false));
+                        dispatch(setFlag({ key: flagToHide, value: false }));
                     }}
                 >
                     {children}

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 
 import { events } from '@suite/analytics';
+import {
+    selectIsTEXDashboardPromoBannerShown,
+    selectIsTS7DashboardPromoBannerShown,
+} from '@suite/flags';
 import { selectSelectedDevice } from '@suite-common/device';
 import { Feature, selectFeaturesConfig } from '@suite-common/message-system';
 import { Feature as MessageFeature } from '@suite-common/suite-types';
@@ -8,10 +12,6 @@ import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { useSelector } from 'src/hooks/suite';
-import {
-    selectIsTEXDashboardPromoBannerShown,
-    selectIsTS7DashboardPromoBannerShown,
-} from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { TS7Banner } from './TS7Banner';

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from 'react';
 
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { networksCollection } from '@suite-common/wallet-config';
 import {
@@ -12,7 +13,6 @@ import { isAccountFailed } from '@suite-common/wallet-utils';
 import { Box, Card, Column, Dropdown, Switch } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { DashboardSection } from 'src/components/dashboard';
 import { GraphScaleDropdownItem, GraphSkeleton } from 'src/components/suite';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
@@ -38,7 +38,7 @@ export const PortfolioCard = memo(() => {
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
     const accounts = useSelector(selectAllAccountsToList);
-    const { dashboardGraphHidden } = useSelector(s => s.suite.flags);
+    const { dashboardGraphHidden } = useSelector(selectFlags);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const isDeviceEmpty = useMemo(() => accounts.every(a => a.empty), [accounts]);
@@ -159,7 +159,10 @@ export const PortfolioCard = memo(() => {
                                     size="small"
                                     onChange={() =>
                                         dispatch(
-                                            setFlag('dashboardGraphHidden', !dashboardGraphHidden),
+                                            setFlag({
+                                                key: 'dashboardGraphHidden',
+                                                value: !dashboardGraphHidden,
+                                            }),
                                         )
                                     }
                                     label={<Translation id="TR_SHOW_GRAPH" />}

--- a/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
+++ b/packages/suite/src/views/dashboard/useNotificationForDisconnectedDevice.tsx
@@ -14,9 +14,7 @@ export const useNotificationForDisconnectedDevice = () => {
         state => state.suite.seenDisconnectNotificationForDeviceIds,
     );
     const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
-    const hasSeenDisconnectTooltip = useSelector(
-        state => state.suite.flags.hasSeenDisconnectTooltip,
-    );
+    const hasSeenDisconnectTooltip = useSelector(state => state.flags.hasSeenDisconnectTooltip);
 
     useEffect(() => {
         const deviceId = selectedDevice?.id;

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { events } from '@suite/analytics';
+import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectRecoveryStatus } from '@suite/recovery';
 import { goto } from '@suite/router';
@@ -37,7 +38,6 @@ import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/Security
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { SecurityChecklist } from './SecurityChecklist';
@@ -300,7 +300,7 @@ const SecurityCheckContent = ({
 export const SecurityCheck = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const devices = useSelector(selectDevices);
-    const { initialRun } = useSelector(selectSuiteFlags);
+    const { initialRun } = useSelector(selectFlags);
     const isDeviceAuthenticityCheckEnabled = useSelector(
         state => state.suite.settings.enabledSecurityChecks.deviceAuthenticity,
     );

--- a/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/FirmwareTypeSuggestion.tsx
@@ -1,9 +1,9 @@
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor, goto } from '@suite/router';
 import { Banner, Paragraph } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDevice, useDispatch } from 'src/hooks/suite';
 
 export const FirmwareTypeSuggestion = () => {
@@ -14,7 +14,7 @@ export const FirmwareTypeSuggestion = () => {
         ? 'TR_SETTINGS_COINS_REGULAR_FIRMWARE_SUGGESTION'
         : 'TR_SETTINGS_COINS_BITCOIN_ONLY_FIRMWARE_SUGGESTION';
 
-    const handleClose = () => dispatch(setFlag('firmwareTypeBannerClosed', true));
+    const handleClose = () => dispatch(setFlag({ key: 'firmwareTypeBannerClosed', value: true }));
 
     const goToFirmwareType = () =>
         dispatch(goto({ routeName: 'settings-device', anchor: SettingsAnchor.FirmwareType }));

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
+import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor } from '@suite/router';
 import { Context } from '@suite-common/message-system';
@@ -22,7 +23,7 @@ import { CoinGroup } from 'src/components/suite';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDevice, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
-import { selectHasExperimentalFeature, selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature } from 'src/selectors/suite/suiteSelectors';
 import { isCoinjoinSupportedSymbol } from 'src/utils/wallet/coinjoinUtils';
 
 import { FirmwareTypeSuggestion } from './FirmwareTypeSuggestion';
@@ -73,7 +74,7 @@ const getDiscoveryButtonAnimationConfig = (isConfirmed: boolean): MotionProps =>
 });
 
 export const SettingsCoins = () => {
-    const { firmwareTypeBannerClosed } = useSelector(selectSuiteFlags);
+    const { firmwareTypeBannerClosed } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const { showUnsupportedCoins, supportedMainnets, unsupportedMainnets, supportedTestnets } =
         useNetworkSupport();

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -1,3 +1,4 @@
+import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { Context } from '@suite-common/message-system';
 import { isDesktop } from '@trezor/env-utils';
@@ -6,7 +7,6 @@ import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
 
 import { AnalyticsLogging } from './AnalyticsLogging';
 import { Backends } from './Backends';
@@ -40,7 +40,7 @@ import { TriggerToast } from './TriggerToast';
 import { WipeData } from './WipeData';
 
 export const SettingsDebug = () => {
-    const flags = useSelector(selectSuiteFlags);
+    const flags = useSelector(selectFlags);
 
     return (
         <SettingsLayout>

--- a/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ShowBluetoothDebugInfo.tsx
@@ -1,17 +1,15 @@
+import { selectFlags, setFlag } from '@suite/flags';
 import { Checkbox } from '@trezor/components';
 
 import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
-
-import { setFlag } from '../../../actions/suite/suiteActions';
 
 export const ShowBluetoothDebugInfo = () => {
-    const { showBluetoothDebugInfo } = useSelector(selectSuiteFlags);
+    const { showBluetoothDebugInfo } = useSelector(selectFlags);
     const dispatch = useDispatch();
 
     const handleOnClick = () => {
-        dispatch(setFlag('showBluetoothDebugInfo', !showBluetoothDebugInfo));
+        dispatch(setFlag({ key: 'showBluetoothDebugInfo', value: !showBluetoothDebugInfo }));
     };
 
     return (

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -4,13 +4,13 @@ import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 
 import { events } from '@suite/analytics';
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { Box, Button, H2, Icon, IconButton, Image, Paragraph, Row } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { SUITE_URL } from '@trezor/urls';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useAnalytics } from 'src/support/useAnalytics';
 
@@ -70,7 +70,11 @@ export const DesktopSuiteBanner = () => {
                 <Container
                     key="container"
                     onAnimationComplete={() =>
-                        dispatch(dispatch(setFlag('showSettingsDesktopAppPromoBanner', false)))
+                        dispatch(
+                            dispatch(
+                                setFlag({ key: 'showSettingsDesktopAppPromoBanner', value: false }),
+                            ),
+                        )
                     }
                     {...bannerAnimationConfig}
                 >

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -1,3 +1,4 @@
+import { selectIsSettingsDesktopAppPromoBannerShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectIsMetadataEnabled, selectSelectedProviderForLabels } from '@suite/metadata';
 import { Context } from '@suite-common/message-system';
@@ -13,11 +14,7 @@ import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { SettingsSection } from 'src/components/settings/SettingsSection';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
-import {
-    selectHasExperimentalFeature,
-    selectIsSettingsDesktopAppPromoBannerShown,
-    selectTorState,
-} from 'src/selectors/suite/suiteSelectors';
+import { selectHasExperimentalFeature, selectTorState } from 'src/selectors/suite/suiteSelectors';
 import { TorStatus } from 'src/types/suite';
 
 import { AddressDisplay } from './AddressDisplay';

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useState } from 'react';
 
+import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor, goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
@@ -11,7 +12,6 @@ import { spacings } from '@trezor/theme';
 
 import {
     addDeviceIdToSeenDisconnectNotification,
-    setFlag,
     setRecentlyDisconnectedDevice,
 } from 'src/actions/suite/suiteActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -47,9 +47,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
     const selectedDevice = useSelector(selectSelectedDevice);
     const deviceId = selectedDevice?.id;
     const recentlyDisconnectedDevice = useSelector(state => state.suite.recentlyDisconnectedDevice);
-    const hasSeenDisconnectTooltip = useSelector(
-        state => state.suite.flags.hasSeenDisconnectTooltip,
-    );
+    const hasSeenDisconnectTooltip = useSelector(state => state.flags.hasSeenDisconnectTooltip);
     const [showTooltip, setShowTooltip] = useState(false);
     const deviceModelInternal = device.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const instancesWithState = instances.filter(i => i.state);
@@ -76,7 +74,7 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
     const onTooltipClose = () => {
         setShowTooltip(false);
         dispatch(setRecentlyDisconnectedDevice(null));
-        dispatch(setFlag('hasSeenDisconnectTooltip', true));
+        dispatch(setFlag({ key: 'hasSeenDisconnectTooltip', value: true }));
 
         if (deviceId) {
             dispatch(addDeviceIdToSeenDisconnectNotification(deviceId));

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { selectIsCopyAddressModalShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import {
@@ -36,7 +37,6 @@ import { copyAddressToClipboard, showCopyAddressModal } from 'src/actions/suite/
 import { Address, HiddenPlaceholder } from 'src/components/suite';
 import { RedactNumericalValue } from 'src/components/suite/RedactNumericalValue';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { selectIsCopyAddressModalShown } from 'src/selectors/suite/suiteSelectors';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { DropdownRow } from '../../tokens/DropdownRow';

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { selectIsCopyAddressModalShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
 import {
@@ -30,7 +31,6 @@ import {
 } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
-import { selectIsCopyAddressModalShown } from 'src/selectors/suite/suiteSelectors';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import { SelectTokenAssetModal } from './SelectTokenAssetModal/SelectTokenAssetModal';

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 
 import { events } from '@suite/analytics';
+import { selectIsCopyAddressModalShown, selectIsUnhideTokenModalShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
@@ -64,10 +65,6 @@ import {
     useSelector,
 } from 'src/hooks/suite';
 import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
-import {
-    selectIsCopyAddressModalShown,
-    selectIsUnhideTokenModalShown,
-} from 'src/selectors/suite/suiteSelectors';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import {
     selectIsHideSuspiciousTransactions,
@@ -20,9 +21,6 @@ import {
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { setFlag } from 'src/actions/suite/suiteActions';
-import { selectSuiteFlags } from 'src/selectors/suite/suiteSelectors';
-
 const options = [
     {
         id: 0,
@@ -36,14 +34,14 @@ const options = [
 ] as const;
 
 export const FilterAction = () => {
-    const { suspiciousTransactionsTooltipClosed } = useSelector(selectSuiteFlags);
+    const { suspiciousTransactionsTooltipClosed } = useSelector(selectFlags);
     const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
     const dispatch = useDispatch();
 
     const isOpen = !suspiciousTransactionsTooltipClosed;
 
     const handleClose = () => {
-        dispatch(setFlag('suspiciousTransactionsTooltipClosed', true));
+        dispatch(setFlag({ key: 'suspiciousTransactionsTooltipClosed', value: true }));
     };
     const dataTest = '@wallet/accounts/hide-scam-transactions';
 

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -149,6 +149,7 @@
         {
             "path": "../../suite/experimental-feedback"
         },
+        { "path": "../../suite/flags" },
         {
             "path": "../../suite/idb-migration-utils"
         },

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -117,6 +117,7 @@ export type ExtraDependenciesStatic = {
         storageLoadTokenManagement: StorageLoadReducer;
         storageLoadWalletSettings: StorageLoadReducer;
         storageLoadBioAuth: StorageLoadReducer;
+        storageLoadFlags: StorageLoadReducer;
     };
 };
 

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -166,5 +166,6 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         storageLoadTokenManagement: notImplementedReducer('storageLoadTokenManagement'),
         storageLoadWalletSettings: notImplementedReducer('storageLoadWalletSettings'),
         storageLoadBioAuth: notImplementedReducer('storageLoadBioAuth'),
+        storageLoadFlags: notImplementedReducer('storageLoadFlags'),
     },
 };

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -195,5 +195,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
         storageLoadTokenManagement: notImplementedReducer('storageLoadTokenManagement'),
         storageLoadWalletSettings: notImplementedReducer('storageLoadWalletSettings'),
         storageLoadBioAuth: notImplementedReducer('storageLoadBioAuth'),
+        storageLoadFlags: notImplementedReducer('storageLoadFlags'),
     },
 };

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -44,6 +44,7 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite/analytics": "workspace:*",
+        "@suite/flags": "workspace:*",
         "@suite/intl": "workspace:^",
         "@suite/metadata": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:^",

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -1,5 +1,6 @@
 import { Locator, Page, expect } from '@playwright/test';
 
+import { setFlag } from '@suite/flags';
 import { BackupType } from '@suite-common/suite-types';
 import { SUITE as SuiteActions } from '@trezor/suite/src/actions/suite/constants';
 import { Model } from '@trezor/trezor-user-env-link';
@@ -215,11 +216,10 @@ export class OnboardingPage {
     @step()
     async disableDisconnectPrompt() {
         await this.page.ensureStoreOnDesktop();
-        await this.page.evaluate(action => window.store.dispatch(action), {
-            type: SuiteActions.SET_FLAG,
-            key: 'hasSeenDisconnectTooltip',
-            value: true,
-        });
+        await this.page.evaluate(
+            action => window.store.dispatch(action),
+            setFlag({ key: 'hasSeenDisconnectTooltip', value: true }),
+        );
     }
 
     @step()

--- a/suite/e2e/tsconfig.json
+++ b/suite/e2e/tsconfig.json
@@ -48,6 +48,7 @@
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../analytics" },
+        { "path": "../flags" },
         { "path": "../intl" },
         { "path": "../metadata" },
         {

--- a/suite/flags/jest.config.js
+++ b/suite/flags/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite/flags/package.json
+++ b/suite/flags/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@suite/flags",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/test-utils": "workspace:*"
+    }
+}

--- a/suite/flags/src/__tests__/flagsSlice.test.ts
+++ b/suite/flags/src/__tests__/flagsSlice.test.ts
@@ -1,0 +1,42 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+
+import { flagsInitialState, prepareFlagsReducer, selectFlags, setFlag } from '../flagsSlice';
+
+const flagsReducer = prepareFlagsReducer(extraDependenciesCommonMock);
+
+const initStore = (preloadedState = flagsInitialState) =>
+    configureStore({
+        reducer: { flags: flagsReducer },
+        preloadedState: { flags: preloadedState },
+    });
+
+describe('flagsSlice', () => {
+    it('should return initial state', () => {
+        const store = initStore();
+        expect(selectFlags(store.getState())).toEqual(flagsInitialState);
+    });
+
+    it('should set a flag to true', () => {
+        const store = initStore();
+        store.dispatch(setFlag({ key: 'initialRun', value: false }));
+        expect(store.getState().flags.initialRun).toBe(false);
+    });
+
+    it('should set a flag to false', () => {
+        const store = initStore();
+        store.dispatch(setFlag({ key: 'dashboardAssetsGridMode', value: false }));
+        expect(store.getState().flags.dashboardAssetsGridMode).toBe(false);
+    });
+
+    it('should not affect other flags when setting one', () => {
+        const store = initStore();
+        store.dispatch(setFlag({ key: 'taprootBannerClosed', value: true }));
+
+        const state = store.getState().flags;
+        expect(state.taprootBannerClosed).toBe(true);
+        expect(state.initialRun).toBe(flagsInitialState.initialRun);
+        expect(state.dashboardAssetsGridMode).toBe(flagsInitialState.dashboardAssetsGridMode);
+    });
+});

--- a/suite/flags/src/__tests__/flagsThunks.test.ts
+++ b/suite/flags/src/__tests__/flagsThunks.test.ts
@@ -1,0 +1,27 @@
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+
+import { FlagsState, flagsInitialState, prepareFlagsReducer } from '../flagsSlice';
+import { initialRunCompleted } from '../flagsThunks';
+
+const flagsReducer = prepareFlagsReducer(extraDependenciesCommonMock);
+
+const initStore = (flags?: Partial<FlagsState>) =>
+    configureMockStore({
+        extra: extraDependenciesCommonMock,
+        reducer: { flags: flagsReducer },
+        preloadedState: { flags: { ...flagsInitialState, ...flags } },
+    });
+
+describe('initialRunCompleted', () => {
+    it('should set initialRun to false when initialRun is true', async () => {
+        const store = initStore();
+        await store.dispatch(initialRunCompleted());
+        expect(store.getState().flags.initialRun).toBe(false);
+    });
+
+    it('should set initialRun to false when initialRun is already false', async () => {
+        const store = initStore({ initialRun: false });
+        await store.dispatch(initialRunCompleted());
+        expect(store.getState().flags.initialRun).toBe(false);
+    });
+});

--- a/suite/flags/src/flagsConstants.ts
+++ b/suite/flags/src/flagsConstants.ts
@@ -1,0 +1,1 @@
+export const FLAGS_MODULE_PREFIX = '@suite/flags';

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -1,0 +1,85 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+
+import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+
+export interface FlagsState {
+    initialRun: boolean;
+    taprootBannerClosed: boolean;
+    firmwareTypeBannerClosed: boolean;
+    discreetModeCompleted: boolean;
+    securityStepsHidden: boolean;
+    dashboardGraphHidden: boolean;
+    dashboardAssetsGridMode: boolean;
+    showTEXDashboardPromoBanner: boolean;
+    showTS7DashboardPromoBanner: boolean;
+    showSettingsDesktopAppPromoBanner: boolean;
+    stakeEthBannerClosed: boolean;
+    stakeSolBannerClosed: boolean;
+    stakeCardanoBannerClosed: boolean;
+    showDashboardStakingPromoBanner: boolean;
+    suspiciousTransactionsTooltipClosed: boolean;
+    showUnhideTokenModal: boolean;
+    showCopyAddressModal: boolean;
+    enableAutoupdateOnNextRun: boolean;
+    showBluetoothDebugInfo: boolean;
+    stellarLimitedHistoryBannerClosed: boolean;
+    solanaLimitedHistoryBannerClosed: boolean;
+    hasSeenDisconnectTooltip: boolean;
+}
+
+export type FlagsRootState = { flags: FlagsState };
+
+export const flagsInitialState: FlagsState = {
+    initialRun: true,
+    discreetModeCompleted: false,
+    taprootBannerClosed: false,
+    firmwareTypeBannerClosed: false,
+    securityStepsHidden: false,
+    dashboardGraphHidden: false,
+    dashboardAssetsGridMode: true,
+    showTEXDashboardPromoBanner: true,
+    showTS7DashboardPromoBanner: true,
+    showSettingsDesktopAppPromoBanner: true,
+    stakeEthBannerClosed: false,
+    stakeSolBannerClosed: false,
+    stakeCardanoBannerClosed: false,
+    showDashboardStakingPromoBanner: true,
+    suspiciousTransactionsTooltipClosed: false,
+    showCopyAddressModal: true,
+    showUnhideTokenModal: true,
+    enableAutoupdateOnNextRun: false,
+    showBluetoothDebugInfo: false,
+    stellarLimitedHistoryBannerClosed: false,
+    solanaLimitedHistoryBannerClosed: false,
+    hasSeenDisconnectTooltip: false,
+};
+
+const flagsSlice = createSliceWithExtraDeps({
+    name: 'flags',
+    initialState: flagsInitialState,
+    reducers: {
+        setFlag: (state, { payload }: PayloadAction<{ key: keyof FlagsState; value: boolean }>) => {
+            state[payload.key] = payload.value;
+        },
+    },
+    extraReducers: (builder, extra) => {
+        builder.addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadFlags);
+    },
+});
+
+export const { setFlag } = flagsSlice.actions;
+export const flagsActions = flagsSlice.actions;
+export const prepareFlagsReducer = flagsSlice.prepareReducer;
+
+export const selectFlags = (state: FlagsRootState) => state.flags;
+export const selectIsInitialRun = (state: FlagsRootState) => state.flags.initialRun;
+export const selectIsTEXDashboardPromoBannerShown = (state: FlagsRootState) =>
+    state.flags.showTEXDashboardPromoBanner;
+export const selectIsTS7DashboardPromoBannerShown = (state: FlagsRootState) =>
+    state.flags.showTS7DashboardPromoBanner;
+export const selectIsSettingsDesktopAppPromoBannerShown = (state: FlagsRootState) =>
+    state.flags.showSettingsDesktopAppPromoBanner;
+export const selectIsUnhideTokenModalShown = (state: FlagsRootState) =>
+    state.flags.showUnhideTokenModal;
+export const selectIsCopyAddressModalShown = (state: FlagsRootState) =>
+    state.flags.showCopyAddressModal;

--- a/suite/flags/src/flagsThunks.ts
+++ b/suite/flags/src/flagsThunks.ts
@@ -1,0 +1,13 @@
+import { createThunk } from '@suite-common/redux-utils';
+
+import { FLAGS_MODULE_PREFIX } from './flagsConstants';
+import { selectIsInitialRun, setFlag } from './flagsSlice';
+
+export const initialRunCompleted = createThunk(
+    `${FLAGS_MODULE_PREFIX}/initialRunCompleted`,
+    (_, { dispatch, getState }) => {
+        if (selectIsInitialRun(getState())) {
+            dispatch(setFlag({ key: 'initialRun', value: false }));
+        }
+    },
+);

--- a/suite/flags/src/index.ts
+++ b/suite/flags/src/index.ts
@@ -1,0 +1,3 @@
+export * from './flagsConstants';
+export * from './flagsSlice';
+export * from './flagsThunks';

--- a/suite/flags/tsconfig.json
+++ b/suite/flags/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/test-utils"
+        }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14804,6 +14804,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/flags@workspace:*, @suite/flags@workspace:suite/flags":
+  version: 0.0.0-use.local
+  resolution: "@suite/flags@workspace:suite/flags"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/test-utils": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite/idb-migration-utils@workspace:*, @suite/idb-migration-utils@workspace:suite/idb-migration-utils":
   version: 0.0.0-use.local
   resolution: "@suite/idb-migration-utils@workspace:suite/idb-migration-utils"
@@ -16138,6 +16148,7 @@ __metadata:
     "@sentry/electron": "npm:^7.8.0"
     "@suite-common/suite-types": "workspace:*"
     "@suite/analytics": "workspace:*"
+    "@suite/flags": "workspace:*"
     "@suite/intl": "workspace:*"
     "@suite/sentry": "workspace:*"
     "@trezor/components": "workspace:*"
@@ -16202,6 +16213,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite/analytics": "workspace:*"
+    "@suite/flags": "workspace:*"
     "@suite/intl": "workspace:^"
     "@suite/metadata": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:^"
@@ -16333,6 +16345,7 @@ __metadata:
     "@suite/analytics": "workspace:*"
     "@suite/experimental": "workspace:*"
     "@suite/experimental-feedback": "workspace:*"
+    "@suite/flags": "workspace:*"
     "@suite/idb-migration-utils": "workspace:*"
     "@suite/intl": "workspace:*"
     "@suite/locks": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Flags is a simple config with not much logic and dependencies, so this PR moves it into reusable package that can be imported throughout the `@suite/*` folders without any cyclic dependencies. 

## Notes for QA
Nothing to test.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25956

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite-flags&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite-flags&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite-flags&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-13T18:29:46.573Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T13:00:05.157Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->