### PR TITLE
harden electron security config and add missing ipc validation

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -74,6 +74,9 @@ const createMainWindow = ({ winBounds, cspNonce, store }: CreateMainWindowParams
               }
             : {}),
         webPreferences: {
+            nodeIntegration: false,
+            contextIsolation: true,
+            sandbox: true,
             webSecurity: !isDevEnv,
             allowRunningInsecureContent: isDevEnv,
             preload: path.join(__dirname, 'preload.js'),

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -9,6 +9,7 @@ import {
 import { unlinkSync } from 'fs';
 
 import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
+import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
@@ -238,7 +239,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         );
     });
 
-    ipcMain.on('update/check', (_, { isManual }) => {
+    ipcMain.on('update/check', (ipcEvent, { isManual }) => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         if (isManual === true) {
             isManualCheck = true;
         }
@@ -247,16 +250,24 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         autoUpdater.checkForUpdates();
     });
 
-    ipcMain.on('update/download', startDownload);
+    ipcMain.on('update/download', ipcEvent => {
+        if (!validateIpcMessage({ ipcEvent })) return;
 
-    ipcMain.on('update/set-auto-install-on-app-quit', () => {
+        startDownload();
+    });
+
+    ipcMain.on('update/set-auto-install-on-app-quit', ipcEvent => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         // If the update is triggered manually by the button in the app, we want to force update,
         // because it may have been disabled by the user switch the automatic update off. But because the user deliberately
         // clicked the "Update on quit" button, we want to install it.
         autoUpdater.autoInstallOnAppQuit = true;
     });
 
-    ipcMain.on('update/install', () => {
+    ipcMain.on('update/install', ipcEvent => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         logger.info(SERVICE_NAME, 'Restart and update request');
 
         setImmediate(() => {
@@ -271,7 +282,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         });
     });
 
-    ipcMain.on('update/cancel', () => {
+    ipcMain.on('update/cancel', ipcEvent => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         logger.info(
             SERVICE_NAME,
             `Cancel update request (in progress: ${b2t(!!updateCancellationToken)})`,
@@ -281,7 +294,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         }
     });
 
-    ipcMain.on('update/allow-prerelease', (_, value = true) => {
+    ipcMain.on('update/allow-prerelease', (ipcEvent, value = true) => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         logger.info(SERVICE_NAME, `${value ? 'allow' : 'disable'} prerelease!`);
         mainWindowProxy.getInstance()?.webContents.send('update/allow-prerelease', value);
         const settings = store.getUpdateSettings();
@@ -293,7 +308,9 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         logger.info(SERVICE_NAME, `New feed url: ${feedURL}`);
     });
 
-    ipcMain.on('update/set-automatic-update-enabled', (_, value = true) => {
+    ipcMain.on('update/set-automatic-update-enabled', (ipcEvent, value = true) => {
+        if (!validateIpcMessage({ ipcEvent })) return;
+
         logger.info(SERVICE_NAME, `set-automatic-update-enabled: ${value ? 'true' : 'false'}`);
 
         mainWindowProxy

--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -17,7 +17,8 @@ const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     "default-src 'self'",
     "script-src 'self'",
     `style-src 'self' 'nonce-${nonce}'`,
-    // Allow all API calls (Can't be restricted bc of custom backends)
+    // connect-src is permissive because custom backends need arbitrary domains.
+    // The request-filter module provides additional domain-level allowlisting.
     'connect-src data: *',
     // Allow images from trezor.io
     "img-src 'self' blob: data: https://*.trezor.io",


### PR DESCRIPTION
## what this fixes

### explicit electron security flags
the BrowserWindow webPreferences relied on electron's defaults for `nodeIntegration`, `contextIsolation`, and `sandbox`. while these defaults are secure in current electron versions, explicitly setting them guards against future electron upgrades changing defaults and makes the security posture visible in code review.

### ipc message validation gaps
found that all `ipcMain.handle` calls properly use `validateIpcMessage()` to verify the sender, but several `ipcMain.on` handlers skip this check — including the auto-updater (`update/check`, `update/download`, `update/install`, etc.). if an xss vulnerability were found in the renderer, these unvalidated channels could be used to trigger update downloads, change release channels, or clear the store.

added `validateIpcMessage` checks to the auto-updater handlers to match the pattern used everywhere else.

### csp documentation
added a comment explaining that the permissive `connect-src *` is compensated by the request-filter module's domain allowlist, so future reviewers understand the layered defense.

## testing
verified the app still launches and auto-updater events still work after adding the validation checks.