### PR TITLE
chore(type-utils): unify scattered UnionToIntersection type

### DIFF
--- a/packages/connect/src/types/emitter.ts
+++ b/packages/connect/src/types/emitter.ts
@@ -1,6 +1,6 @@
+import type { UnionToIntersection } from '@trezor/type-utils';
 import { TypedEmitter } from '@trezor/utils';
 
-import type { UnionToIntersection } from './utils';
 import type {
     BLOCKCHAIN_EVENT,
     BlockchainEvent,

--- a/packages/connect/src/types/utils.ts
+++ b/packages/connect/src/types/utils.ts
@@ -1,9 +1,4 @@
-// TODO: https://github.com/trezor/trezor-suite/issues/4786
-export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-    k: infer I,
-) => void
-    ? I
-    : never;
+import type { UnionToIntersection } from '@trezor/type-utils';
 
 export type MessageFactoryFn<Group, Event> = UnionToIntersection<
     Event extends { type: string }

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -36,6 +36,7 @@
     },
     "dependencies": {
         "@sinclair/typebox": "^0.33.7",
+        "@trezor/type-utils": "workspace:*",
         "ts-mixer": "^6.0.3"
     },
     "peerDependencies": {

--- a/packages/schema-utils/src/custom-types/keyof-enum.ts
+++ b/packages/schema-utils/src/custom-types/keyof-enum.ts
@@ -9,12 +9,7 @@ import {
     TUnion,
 } from '@sinclair/typebox';
 
-// UnionToIntersection<A | B> = A & B
-type UnionToIntersection<U> = (U extends unknown ? (arg: U) => 0 : never) extends (
-    arg: infer I,
-) => 0
-    ? I
-    : never;
+import { UnionToIntersection } from '@trezor/type-utils';
 
 // LastInUnion<A | B> = B
 type LastInUnion<U> =

--- a/packages/schema-utils/tsconfig.json
+++ b/packages/schema-utils/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../eslint" }]
+    "references": [
+        { "path": "../type-utils" },
+        { "path": "../eslint" }
+    ]
 }

--- a/packages/schema-utils/tsconfig.lib.json
+++ b/packages/schema-utils/tsconfig.lib.json
@@ -6,6 +6,9 @@
     "include": ["./src"],
     "references": [
         {
+            "path": "../type-utils"
+        },
+        {
             "path": "../eslint"
         }
     ]

--- a/packages/schema-utils/tsconfig.libESM.json
+++ b/packages/schema-utils/tsconfig.libESM.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../type-utils"
+        },
+        {
             "path": "../eslint"
         }
     ]

--- a/packages/suite-desktop-api/src/methods.ts
+++ b/packages/suite-desktop-api/src/methods.ts
@@ -1,6 +1,4 @@
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (k: infer I) => void
-    ? I
-    : never;
+import { UnionToIntersection } from '@trezor/type-utils';
 
 type MethodFactory<Union> = UnionToIntersection<Union[keyof Union]>;
 

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -7,6 +7,20 @@
  *  type U = UnionSubset<T, 'a' | 'c'>; // 'a' | 'c'
  *  ```
  */
+/**
+ * Convert a union type to an intersection type.
+ *
+ * Example:
+ *  ```
+ *  type T = UnionToIntersection<A | B>; // A & B
+ *  ```
+ */
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+    k: infer I,
+) => void
+    ? I
+    : never;
+
 export type UnionSubset<T, U extends T> = U;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -15821,6 +15821,7 @@ __metadata:
     "@sinclair/typebox": "npm:^0.33.7"
     "@sinclair/typebox-codegen": "npm:^0.10.4"
     "@trezor/eslint": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     ts-mixer: "npm:^6.0.3"
     ts-node: "npm:^10.9.2"
   peerDependencies:


### PR DESCRIPTION
simple refactoring

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=type-unification&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=type-unification&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=type-unification&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T08:00:39.199Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T07:59:03.203Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->