### PR TITLE
fix(trading): fix toggling between fiat/crypto in buy form

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -4,33 +4,24 @@ import {
     type TRADING_FORM_CRYPTO_INPUT,
     type TRADING_FORM_FIAT_INPUT,
     TRADING_FORM_OUTPUT_AMOUNT,
-    TRADING_FORM_OUTPUT_CURRENCY,
     type TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
 } from '@suite-common/trading';
-import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
-    fromBaseCurrencyToCryptoUnit,
-    getFiatRateKey,
 } from '@suite-common/wallet-utils';
 import { useDidUpdate } from '@trezor/react-utils';
 
-import { useSelector } from 'src/hooks/suite';
-import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import {
     type TradingAllFormProps,
     type TradingSellExchangeFormProps,
 } from 'src/types/trading/tradingForm';
 import { type SendContextValues } from 'src/types/wallet/sendForm';
-import { tradingGetRoundedFiatAmount } from 'src/utils/wallet/trading/tradingUtils';
 
 import { useTradingAssetDecimals } from './useTradingAssetDecimals';
-
-const DEFAULT_FIAT_RATE_FALLBACK = 'usd';
 
 interface TradingUseCurrencySwitcherProps<T extends TradingAllFormProps> {
     account: Account;
@@ -53,47 +44,17 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
 }: TradingUseCurrencySwitcherProps<T>) => {
     const { setValue, getValues, control } =
         methods as unknown as UseFormReturn<TradingAllFormProps>;
-    const rates = useSelector(selectCurrentFiatRates);
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const cryptoInputValue = useWatch({ control, name: inputNames.cryptoInput });
-    const fiatInputValue = useWatch({ control, name: inputNames.fiatInput });
     const sendCryptoSelect = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);
-    const currencySelect = getValues(TRADING_FORM_OUTPUT_CURRENCY);
     const { getAssetDecimals } = useTradingAssetDecimals();
     const networkDecimals = getAssetDecimals({
         accountKey: sendCryptoSelect?.accountKey,
         cryptoId: sendCryptoSelect?.id,
     });
 
-    const fiatRateKey = getFiatRateKey(
-        account.symbol,
-        currencySelect?.value ? currencySelect.value : DEFAULT_FIAT_RATE_FALLBACK,
-    );
-    const rate = rates && rates[fiatRateKey] ? rates[fiatRateKey].rate : undefined;
-    const { fiatAmount } = useFiatFromCryptoValue({
-        amount: cryptoInputValue ?? '',
-        symbol: account.symbol,
-    });
-
-    const cryptoAmount = fiatInputValue
-        ? fromBaseCurrencyToCryptoUnit({
-              fiatAmount: fiatInputValue,
-              rate,
-          })
-        : undefined;
-
     const toggleAmountInCrypto = () => {
         const { amountInCrypto } = getValues();
-
-        if (!amountInCrypto) {
-            if (cryptoAmount) {
-                setValue(inputNames.cryptoInput, cryptoAmount.toFixed(networkDecimals));
-            }
-        } else {
-            if (fiatAmount) {
-                setValue(inputNames.fiatInput, tradingGetRoundedFiatAmount(fiatAmount.toString()));
-            }
-        }
 
         setValue('amountInCrypto', !amountInCrypto);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -165,7 +165,7 @@ export const useTradingBuyForm = ({
         values.cryptoSelect?.networkSymbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY,
     );
 
-    const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
+    const { toggleAmountInCrypto: baseToggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,
         methods,
         inputNames: {
@@ -173,6 +173,12 @@ export const useTradingBuyForm = ({
             fiatInput: TRADING_FORM_FIAT_INPUT,
         },
     });
+
+    const toggleAmountInCrypto = () => {
+        setValue(TRADING_FORM_CRYPTO_INPUT, '');
+        setValue(TRADING_FORM_FIAT_INPUT, '');
+        baseToggleAmountInCrypto();
+    };
 
     const { handleChange } = useTradingBuyHandleChange({
         formValues: values,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -25,12 +25,12 @@ import { TradingFormInputPaymentMethod } from 'src/views/wallet/trading/common/T
 
 import { TradingFormCard } from './TradingFormCard';
 import { TradingFormSection } from './TradingFormSection';
+import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 import { TradingSelectedOfferProvider } from '../TradingSelectedOffer/TradingSelectedOfferProvider';
 import {
     TradingFormInputBuyAsset,
     type TradingFormInputBuyAssetProps,
 } from './TradingFormInput/TradingFormInputBuyAsset/TradingFormInputBuyAsset';
-import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFormInputCountry/TradingFormInputCountrySubdivision';
 
 export const TradingBuyFormInputs = () => {
@@ -56,6 +56,8 @@ export const TradingBuyFormInputs = () => {
 
     const handleCryptoSelect = useCallback<TradingFormInputBuyAssetProps['onAssetSelect']>(
         asset => {
+            setValueRef.current(TRADING_FORM_CRYPTO_INPUT, '', { shouldDirty: true });
+            setValueRef.current(TRADING_FORM_FIAT_INPUT, '', { shouldDirty: true });
             setValueRef.current(TRADING_FORM_CRYPTO_CURRENCY_SELECT, asset, { shouldDirty: true });
             setAmountLimitsRef.current(undefined);
             dispatch(tradingActions.setModalCryptoCurrency(asset.id));


### PR DESCRIPTION
## Description

- Fix buy trading form so that changing the selected asset does not leave stale / nonsensical values by clearing the input amounts and resetting buy limits.
- Ensure the form state is consistent with the newly selected asset so quotes and receive address logic work off up-to-date values.

## Notes for QA

- Focus on the **Buy** form:
  - Enter a fiat or crypto amount, then change the **buy asset** and verify that the amounts are cleared and no stale values remain.
  - Check that offers/quotes and the receive address behave consistently after changing the asset (no mismatched amounts or currencies).
- No other areas of Suite should be affected.

## Related Issue

Resolve [https://github.com/trezor/trezor-suite/issues/25766](https://github.com/trezor/trezor-suite/issues/25766)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/buy-form-asset-change-25766&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/buy-form-asset-change-25766&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T09:47:48.747Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T09:45:35.259Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->