### PR TITLE
fix(suite-native): fix earn modal

### DIFF
--- a/suite-native/module-earn/src/components/EarnItemInfoModal.tsx
+++ b/suite-native/module-earn/src/components/EarnItemInfoModal.tsx
@@ -14,7 +14,7 @@ import { Translation, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 import { SUITE_URL } from '@trezor/urls';
 
-type EarnType = 'staking' | 'stablecoin-yield';
+export type EarnType = 'staking' | 'stablecoin-yield';
 type EarnItemInfoModalProps = {
     ref: BottomSheetModalRef;
     type?: EarnType;

--- a/suite-native/module-earn/src/components/EarnListItem.tsx
+++ b/suite-native/module-earn/src/components/EarnListItem.tsx
@@ -1,10 +1,7 @@
-import { events } from '@suite-native/analytics';
-import { PressableOpacity, useBottomSheetModal } from '@suite-native/atoms';
-import { useAnalytics } from '@suite-native/services';
+import { PressableOpacity } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { type EarnPromoItem } from '../types';
-import { EarnItemInfoModal } from './EarnItemInfoModal';
 import { EarnItemOverviewSection } from './EarnItemOverviewSection';
 
 const promoItemStyle = prepareNativeStyle(utils => ({
@@ -12,31 +9,21 @@ const promoItemStyle = prepareNativeStyle(utils => ({
     minHeight: 70,
 }));
 
-export type EarnListItemProps = EarnPromoItem;
+type EarnListItemProps = EarnPromoItem & {
+    onPress: (type: EarnPromoItem['type']) => void;
+};
 
 export const EarnListItem = (item: EarnListItemProps) => {
+    const { onPress, type } = item;
     const { applyStyle } = useNativeStyles();
-    const { bottomSheetRef, openModal } = useBottomSheetModal();
-    const analytics = useAnalytics();
 
     const handlePress = () => {
-        openModal();
-
-        analytics.report({
-            type:
-                item.type === 'staking'
-                    ? events.earnStakeTilePressedEvent.name
-                    : events.earnStablecoinYieldTilePressedEvent.name,
-        });
+        onPress(type);
     };
 
     return (
-        <>
-            <PressableOpacity style={applyStyle(promoItemStyle)} onPress={handlePress}>
-                <EarnItemOverviewSection {...item} />
-            </PressableOpacity>
-
-            <EarnItemInfoModal ref={bottomSheetRef} type={item.type} />
-        </>
+        <PressableOpacity style={applyStyle(promoItemStyle)} onPress={handlePress}>
+            <EarnItemOverviewSection {...item} />
+        </PressableOpacity>
     );
 };

--- a/suite-native/module-earn/src/components/EarnPromoListRow.tsx
+++ b/suite-native/module-earn/src/components/EarnPromoListRow.tsx
@@ -23,15 +23,18 @@ const rowContainerStyle = prepareNativeStyle(
 type EarnPromoListRowProps = {
     item: EarnPromoItem;
     isLastInSection: boolean;
+    onInfoPress: (type: EarnPromoItem['type']) => void;
 };
 
-export const EarnPromoListRow = React.memo(({ item, isLastInSection }: EarnPromoListRowProps) => {
-    const { applyStyle } = useNativeStyles();
+export const EarnPromoListRow = React.memo(
+    ({ item, isLastInSection, onInfoPress }: EarnPromoListRowProps) => {
+        const { applyStyle } = useNativeStyles();
 
-    return (
-        <Box style={applyStyle(rowContainerStyle, { isLastInSection })}>
-            <CardDivider />
-            <EarnListItem {...item} />
-        </Box>
-    );
-});
+        return (
+            <Box style={applyStyle(rowContainerStyle, { isLastInSection })}>
+                <CardDivider />
+                <EarnListItem {...item} onPress={onInfoPress} />
+            </Box>
+        );
+    },
+);

--- a/suite-native/module-earn/src/screens/EarnScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnScreen.tsx
@@ -4,12 +4,13 @@ import { useFocusEffect } from '@react-navigation/native';
 import { FlashList } from '@shopify/flash-list';
 
 import { events } from '@suite-native/analytics';
-import { ListItemSkeleton, TitleHeader, VStack } from '@suite-native/atoms';
+import { ListItemSkeleton, TitleHeader, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { DeviceManagerScreenHeader } from '@suite-native/device-manager';
 import { Translation } from '@suite-native/intl';
 import { Screen } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 
+import { EarnItemInfoModal, EarnType } from '../components/EarnItemInfoModal';
 import { EarnPromoListHeader } from '../components/EarnPromoListHeader';
 import { EarnPromoListRow } from '../components/EarnPromoListRow';
 import { EarnScreenListHeader } from '../components/EarnScreenListHeader';
@@ -25,6 +26,10 @@ const getEarnListItemKey = (item: EarnPromoListDataItem) =>
 
 export const EarnScreen = () => {
     const analytics = useAnalytics();
+    const { bottomSheetRef: stakingBottomSheetRef, openModal: openStakingModal } =
+        useBottomSheetModal();
+    const { bottomSheetRef: stablecoinYieldBottomSheetRef, openModal: openStablecoinYieldModal } =
+        useBottomSheetModal();
     const {
         promoListData: stakingPromoItems,
         activeItems: stakingActiveItems,
@@ -44,6 +49,24 @@ export const EarnScreen = () => {
         }, [analytics]),
     );
 
+    const handleInfoRequested = useCallback(
+        (type: EarnType) => {
+            analytics.report({
+                type:
+                    type === 'staking'
+                        ? events.earnStakeTilePressedEvent.name
+                        : events.earnStablecoinYieldTilePressedEvent.name,
+            });
+
+            if (type === 'staking') {
+                openStakingModal();
+            } else {
+                openStablecoinYieldModal();
+            }
+        },
+        [analytics, openStakingModal, openStablecoinYieldModal],
+    );
+
     const renderItem = useCallback(
         ({ item, index }: { item: EarnPromoListDataItem; index: number }) => {
             if (typeof item === 'string') {
@@ -57,9 +80,15 @@ export const EarnScreen = () => {
                 return <ListItemSkeleton />;
             }
 
-            return <EarnPromoListRow item={item} isLastInSection={isLastInSection} />;
+            return (
+                <EarnPromoListRow
+                    item={item}
+                    isLastInSection={isLastInSection}
+                    onInfoPress={handleInfoRequested}
+                />
+            );
         },
-        [earnListData],
+        [earnListData, handleInfoRequested],
     );
 
     return (
@@ -86,6 +115,9 @@ export const EarnScreen = () => {
                     keyExtractor={getEarnListItemKey}
                     renderItem={renderItem}
                 />
+
+                <EarnItemInfoModal ref={stakingBottomSheetRef} type="staking" />
+                <EarnItemInfoModal ref={stablecoinYieldBottomSheetRef} type="stablecoin-yield" />
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Centralize earn info modal state at the screen level to avoid race conditions when tapping multiple items quickly.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24503

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/earn-modal-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->