### PR TITLE
chore(suite): update copy in failed to communicate with trezor step

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1500,7 +1500,7 @@
   "TR_NEEDS_ATTENTION_INITIALIZE": "Your Trezor isn't set up.",
   "TR_NEEDS_ATTENTION_NEW_DEVICE": "A new Trezor is connected.",
   "TR_NEEDS_ATTENTION_SEEDLESS": "Your Trezor doesn't have a wallet backup.",
-  "TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT": "Failed to communicate with your Trezor",
+  "TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT": "We can’t connect to your Trezor",
   "TR_NEEDS_ATTENTION_UNACQUIRED": "Your Trezor is already in use in another window.",
   "TR_NEEDS_ATTENTION_UNACQUIRED_THP_REQUIRED": "A secure connection isn't set up.",
   "TR_NEEDS_ATTENTION_UNAVAILABLE": "Your Trezor isn't available.",

--- a/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/DeviceAcquire.tsx
@@ -37,7 +37,7 @@ export const DeviceAcquire = () => {
 
     return (
         <TroubleshootingTips
-            label={<Translation id="TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT" />}
+            label={<Translation id="TR_NEEDS_ATTENTION_CONNECT_USB_OR_BLUETOOTH" />}
             cta={ctaButton}
             items={tips}
         />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1993,8 +1993,12 @@ export const messages = defineMessages({
         id: 'TR_NEEDS_ATTENTION_UNACQUIRED_THP_REQUIRED',
     },
     TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT: {
-        defaultMessage: 'Failed to communicate with your Trezor',
+        defaultMessage: 'We can’t connect to your Trezor',
         id: 'TR_NEEDS_ATTENTION_UNABLE_TO_CONNECT',
+    },
+    TR_NEEDS_ATTENTION_CONNECT_USB_OR_BLUETOOTH: {
+        id: 'TR_NEEDS_ATTENTION_CONNECT_USB_OR_BLUETOOTH',
+        defaultMessage: 'Make sure your Trezor is connected via USB or Bluetooth and unlocked.',
     },
     TR_NEEDS_ATTENTION_DEVICE_BUSY: {
         defaultMessage: 'Your Trezor is in an incorrect state. Restart it to connect.',


### PR DESCRIPTION
## Description

Update copies in "Failed to communicate with Trezor" step.

## Related Issue

Resolve #25214 

## Screenshots:

<img width="100%" alt="Screenshot 2026-03-16 at 12 27 48" src="https://github.com/user-attachments/assets/f523325a-5ce5-4a43-af23-de6cda3de7b8" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/device-connect-issue-intl&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/device-connect-issue-intl&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T11:36:11.977Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T11:34:54.765Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->