### PR TITLE
fix(trading): remove fee-clearing useEffects

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -33,7 +33,6 @@ import {
     selectTradingIsSlip24Allowed,
     selectTradingTrades,
     selectTradingVerifiedAddress,
-    tradingActions,
     tradingExchangeActions,
     tradingThunks,
 } from '@suite-common/trading';
@@ -242,19 +241,6 @@ export const useTradingExchangeForm = ({
         methods,
         setShowReserveBanner,
     });
-
-    useEffect(() => {
-        if (pageType !== 'form') return;
-
-        dispatch(tradingActions.saveComposedTransactionInfo({}));
-    }, [
-        dispatch,
-        pageType,
-        values?.sendCryptoSelect?.id,
-        values?.receiveCryptoSelect?.id,
-        output?.amount,
-        values?.provider,
-    ]);
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -209,22 +209,6 @@ export const useTradingSellForm = ({
         setShowReserveBanner,
     });
 
-    useEffect(() => {
-        if (pageType !== 'form') return;
-
-        dispatch(tradingActions.saveComposedTransactionInfo({}));
-    }, [
-        dispatch,
-        pageType,
-        values?.sendCryptoSelect?.id,
-        output?.amount,
-        output?.fiat,
-        values?.paymentMethod?.value,
-        values?.provider,
-        values?.countrySelect?.value,
-        values?.countrySubdivisionSelect?.value,
-    ]);
-
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
         account,
         methods,


### PR DESCRIPTION
## Description

Fix Sell and Swap trading forms so that using the **Max** button fills the amount without incorrectly disabling the main action button when the form is otherwise valid, for both Ethereum Sell and Ethereum→USDC Swap (and analogous cases).

## Notes for QA


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25950

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25950/max-disables-swap-sell&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25950/max-disables-swap-sell&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T13:06:14.981Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T13:04:27.784Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->