### PR TITLE
Fix/connect cancel hanshake timeout

### DIFF
--- a/packages/connect/src/device/workflow/handshake.ts
+++ b/packages/connect/src/device/workflow/handshake.ts
@@ -52,7 +52,9 @@ export const handshakeCancel = async ({ device, logger, signal }: Context) => {
     for (let attempt = 0; attempt < ATTEMPTS_LIMIT; ++attempt) {
         logger?.debug(`handshake Cancel read attempt ${attempt}`);
 
-        const result = await device.getCurrentSession().receive({ signal, timeout });
+        const result = await device
+            .getCurrentSession()
+            .receive({ signal, timeout: CANCEL_TIMEOUT });
 
         // Older T1 don't respond to Cancel message which seems to be recoverable only by reacquiring
         if (!result.success && result.error.message === TRANSPORT_ERROR.ABORTED_BY_TIMEOUT) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
bug introduced here:

https://github.com/trezor/trezor-suite/commit/314b729df94157e4783d5bd22a083f24fe3ca363

reading the response for initial `Cancel` (first message to the device) should have a timeout, otherwise it is endlessly stuck in "read"  and never reties




## Notes for QA

It is quite hard to simulate it, while using bluetooth if you put the device out of range (put it in to faradays cage) during homescreen upload. then try connect (autoconnect) it again.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-cancel-hanshake-timeout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-cancel-hanshake-timeout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-cancel-hanshake-timeout&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T16:09:53.737Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T14:35:46.894Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->