### PR TITLE
test(suite): fail tests on reselect identity warnings

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -47,10 +47,7 @@ module.exports = {
     // to be considered 'visible' to the module loader
     modulePathIgnorePatterns: ['libDev'],
     moduleNameMapper: {
-        '^reselect$': path.resolve(
-            __dirname,
-            'suite-native/test-utils/src/mocks/reselectMock.ts',
-        ),
+        '^reselect$': path.resolve(__dirname, 'suite-native/test-utils/src/mocks/reselectMock.ts'),
         // Enforce usage of JS version of bcrypto in tests because on CI we don't build native modules because it's slowing yarn install
         '^bcrypto/lib/(.*)$': 'bcrypto/lib/$1-browser',
         '^uint8array-tools$': require.resolve('uint8array-tools'), // same case as with uuid

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const babelConfig = {
     presets: [
         ['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }],
@@ -45,6 +47,10 @@ module.exports = {
     // to be considered 'visible' to the module loader
     modulePathIgnorePatterns: ['libDev'],
     moduleNameMapper: {
+        '^reselect$': path.resolve(
+            __dirname,
+            'suite-native/test-utils/src/mocks/reselectMock.ts',
+        ),
         // Enforce usage of JS version of bcrypto in tests because on CI we don't build native modules because it's slowing yarn install
         '^bcrypto/lib/(.*)$': 'bcrypto/lib/$1-browser',
         '^uint8array-tools$': require.resolve('uint8array-tools'), // same case as with uuid

--- a/suite-native/accounts/package.json
+++ b/suite-native/accounts/package.json
@@ -18,6 +18,8 @@
         "@suite-common/formatters": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
+        "@suite-common/suite-sync-storage": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-native/accounts/src/selectors.ts
+++ b/suite-native/accounts/src/selectors.ts
@@ -57,17 +57,12 @@ export type NativeAccountsRootState = AccountsRootState &
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NativeAccountsRootState>();
 
-export const selectVisibleAccountsWithLabel = createMemoizedSelector(
-    [
-        (state: NativeAccountsRootState) =>
-            selectAccountsWithSuiteSyncLabel(
-                state,
-                selectVisibleDeviceAccounts(state),
-                selectDeviceStaticSessionId(state),
-            ),
-    ],
-    accounts => accounts,
-);
+export const selectVisibleAccountsWithLabel = (state: NativeAccountsRootState) =>
+    selectAccountsWithSuiteSyncLabel(
+        state,
+        selectVisibleDeviceAccounts(state),
+        selectDeviceStaticSessionId(state),
+    );
 
 // TODO: It searches for filterValue even in tokens without fiat rates.
 // These are currently hidden in UI, but they should be made accessible in some way.

--- a/suite-native/accounts/src/tests/selectFilteredDeviceAccountsGroupedByNetworkAccountType.test.ts
+++ b/suite-native/accounts/src/tests/selectFilteredDeviceAccountsGroupedByNetworkAccountType.test.ts
@@ -1,0 +1,191 @@
+import { AccountWithSuiteSyncLabel } from '@suite-common/suite-sync';
+import { SuiteSyncAccount, createSuiteSyncAccountId } from '@suite-common/suite-sync-storage';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { Account, asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
+
+import {
+    NativeAccountsRootState,
+    selectFilteredDeviceAccountsGroupedByNetworkAccountType,
+} from '../selectors';
+
+const SELECTED_WALLET_DESCRIPTOR = asWalletDescriptor('selected-wallet');
+const SELECTED_DEVICE_STATIC_SESSION_ID = 'selected-wallet@device-id:0';
+const OTHER_WALLET_DESCRIPTOR = asWalletDescriptor('other-wallet');
+const OTHER_DEVICE_STATIC_SESSION_ID = 'other-wallet@device-id:0';
+
+const selectedDevice = mockSuiteDevice({
+    id: 'selected-device',
+    connected: true,
+    available: true,
+    remember: true,
+    state: { staticSessionId: SELECTED_DEVICE_STATIC_SESSION_ID },
+});
+
+const btcDefaultAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btc-default'),
+    deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+    availableBalance: '0',
+});
+
+const btcTaprootAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btc-taproot'),
+    deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
+    accountType: 'taproot',
+    index: 1,
+    availableBalance: '5',
+});
+
+const ethAccount = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor('eth-default'),
+    deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+    availableBalance: '10',
+});
+
+const adaAccount = mockWalletAccount(
+    {
+        symbol: 'ada',
+        descriptor: asAccountDescriptor('ada-default'),
+        deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
+        accountType: 'normal',
+        index: 0,
+        availableBalance: '25',
+    },
+    networkSpecificDefaultCardano,
+);
+
+const hiddenLtcAccount = mockWalletAccount({
+    symbol: 'ltc',
+    descriptor: asAccountDescriptor('ltc-hidden'),
+    deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+    availableBalance: '15',
+    visible: false,
+});
+
+const otherDeviceBtcAccount = mockWalletAccount({
+    symbol: 'btc',
+    descriptor: asAccountDescriptor('btc-other-device'),
+    deviceState: OTHER_DEVICE_STATIC_SESSION_ID,
+    accountType: 'normal',
+    index: 0,
+    availableBalance: '30',
+});
+
+const createSuiteSyncAccount = (account: Account, label: string): SuiteSyncAccount => ({
+    id: createSuiteSyncAccountId(account.descriptor, account.symbol),
+    accountDescriptor: account.descriptor,
+    networkSymbol: account.symbol,
+    label,
+});
+
+const createSuiteSyncAccountsRecord = (accounts: SuiteSyncAccount[]) =>
+    accounts.reduce<Record<SuiteSyncAccount['id'], SuiteSyncAccount>>((acc, account) => {
+        acc[account.id] = account;
+
+        return acc;
+    }, {});
+
+const withLabel = (account: Account, label: string | null): AccountWithSuiteSyncLabel => ({
+    ...account,
+    label,
+});
+
+const createState = (accounts: Account[]): NativeAccountsRootState => ({
+    device: {
+        devices: [selectedDevice],
+        persistentDeviceData: [],
+        selectedDevice,
+    },
+    wallet: {
+        accounts,
+        settings: {
+            ...initialWalletSettingsState,
+            enabledNetworks: ['btc', 'eth', 'ada', 'ltc'],
+        },
+        fiat: {
+            current: {},
+            lastWeek: {},
+            historic: {},
+        },
+        transactions: {
+            transactions: {},
+            phishing: {},
+            fetchStatusDetail: {},
+        },
+    },
+    suiteSyncData: {
+        wallets: {
+            [SELECTED_WALLET_DESCRIPTOR]: {
+                wallet: {
+                    walletDescriptor: SELECTED_WALLET_DESCRIPTOR,
+                    label: null,
+                },
+                accounts: createSuiteSyncAccountsRecord([
+                    createSuiteSyncAccount(btcDefaultAccount, 'Daily spending'),
+                    createSuiteSyncAccount(ethAccount, 'Long-term ETH'),
+                ]),
+                addresses: {},
+                outputs: {},
+            },
+            [OTHER_WALLET_DESCRIPTOR]: {
+                wallet: {
+                    walletDescriptor: OTHER_WALLET_DESCRIPTOR,
+                    label: null,
+                },
+                accounts: createSuiteSyncAccountsRecord([
+                    createSuiteSyncAccount(otherDeviceBtcAccount, 'Other device BTC'),
+                ]),
+                addresses: {},
+                outputs: {},
+            },
+        },
+    },
+    tokenDefinitions: {},
+});
+
+describe('selectFilteredDeviceAccountsGroupedByNetworkAccountType', () => {
+    const state = createState([
+        ethAccount,
+        hiddenLtcAccount,
+        otherDeviceBtcAccount,
+        adaAccount,
+        btcTaprootAccount,
+        btcDefaultAccount,
+    ]);
+
+    it('groups only visible accounts for the selected device and sorts them by network and account type', () => {
+        expect(selectFilteredDeviceAccountsGroupedByNetworkAccountType(state, '')).toEqual({
+            'Bitcoin default accounts': [withLabel(btcDefaultAccount, 'Daily spending')],
+            'Bitcoin Taproot accounts': [withLabel(btcTaprootAccount, null)],
+            'Ethereum default accounts': [withLabel(ethAccount, 'Long-term ETH')],
+            'Cardano default accounts': [withLabel(adaAccount, null)],
+        });
+    });
+
+    it('filters using suite sync labels and network names', () => {
+        expect(selectFilteredDeviceAccountsGroupedByNetworkAccountType(state, 'daily')).toEqual({
+            'Bitcoin default accounts': [withLabel(btcDefaultAccount, 'Daily spending')],
+        });
+
+        expect(selectFilteredDeviceAccountsGroupedByNetworkAccountType(state, 'ETHEREUM')).toEqual({
+            'Ethereum default accounts': [withLabel(ethAccount, 'Long-term ETH')],
+        });
+    });
+
+    it('keeps only send-available accounts when the send filter is enabled', () => {
+        expect(selectFilteredDeviceAccountsGroupedByNetworkAccountType(state, '', true)).toEqual({
+            'Bitcoin Taproot accounts': [withLabel(btcTaprootAccount, null)],
+            'Ethereum default accounts': [withLabel(ethAccount, 'Long-term ETH')],
+        });
+    });
+});

--- a/suite-native/accounts/tsconfig.json
+++ b/suite-native/accounts/tsconfig.json
@@ -13,6 +13,12 @@
             "path": "../../suite-common/suite-sync"
         },
         {
+            "path": "../../suite-common/suite-sync-storage"
+        },
+        {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/token-definitions"
         },
         {

--- a/suite-native/test-utils/src/mocks/reselectMock.ts
+++ b/suite-native/test-utils/src/mocks/reselectMock.ts
@@ -1,0 +1,33 @@
+const actualReselect = require('../../../../node_modules/reselect/dist/cjs/reselect.cjs');
+
+const IDENTITY_FUNCTION_CHECK_MESSAGE =
+    'The result function returned its own inputs without modification.';
+const IDENTITY_FUNCTION_CHECK_ERROR =
+    'Reselect identityFunctionCheck failed: selector result function returned its input unchanged.';
+
+type GlobalWithReselectWarnPatch = typeof globalThis & {
+    __trezorReselectIdentityWarnPatched__?: boolean;
+    __trezorReselectOriginalWarn__?: typeof console.warn;
+};
+
+const globalScope = globalThis as GlobalWithReselectWarnPatch;
+
+if (!globalScope.__trezorReselectIdentityWarnPatched__) {
+    const originalWarn = console.warn.bind(console);
+
+    globalScope.__trezorReselectOriginalWarn__ = originalWarn;
+
+    console.warn = (...warnArgs: Parameters<typeof console.warn>) => {
+        const [message] = warnArgs;
+
+        if (typeof message === 'string' && message.includes(IDENTITY_FUNCTION_CHECK_MESSAGE)) {
+            throw new Error(IDENTITY_FUNCTION_CHECK_ERROR);
+        }
+
+        return originalWarn(...warnArgs);
+    };
+
+    globalScope.__trezorReselectIdentityWarnPatched__ = true;
+}
+
+module.exports = actualReselect;

--- a/suite-native/test-utils/src/mocks/reselectMock.ts
+++ b/suite-native/test-utils/src/mocks/reselectMock.ts
@@ -13,6 +13,9 @@ type GlobalWithReselectWarnPatch = typeof globalThis & {
 const globalScope = globalThis as GlobalWithReselectWarnPatch;
 
 if (!globalScope.__trezorReselectIdentityWarnPatched__) {
+    // We cannot mock reselect's internal `runIdentityFunctionCheck` directly here because the
+    // published CommonJS build bundles that helper into the main module. Patching `console.warn`
+    // lets tests fail on that specific warning without modifying production code.
     const originalWarn = console.warn.bind(console);
 
     globalScope.__trezorReselectOriginalWarn__ = originalWarn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12050,6 +12050,8 @@ __metadata:
     "@suite-common/formatters": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
+    "@suite-common/suite-sync-storage": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"


### PR DESCRIPTION
This is a attempt to catch badly memoized selectors early. Its a nasty hack, but its just for tests.


<img width="1651" height="756" alt="image" src="https://github.com/user-attachments/assets/af84c0a8-dfac-4a5c-9389-7e69910d3ed3" />

<img width="1978" height="1061" alt="image" src="https://github.com/user-attachments/assets/4da917b4-b830-4b2f-b154-c1a70419f15d" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=reselect-warn-to-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=reselect-warn-to-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=reselect-warn-to-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T10:21:19.612Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T18:07:21.672Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->