### PR TITLE
chore(suite): routerThunks unit test tweak

### DIFF
--- a/suite/router/src/__tests__/routerThunks.test.ts
+++ b/suite/router/src/__tests__/routerThunks.test.ts
@@ -73,9 +73,10 @@ describe('Router thunks', () => {
             if (f.result) {
                 expect(store.getState().router).toEqual(f.result);
             } else {
-                expect(
-                    store.getActions().filter(a => !a.type.startsWith('@router/init')).length,
-                ).toEqual(0);
+                const actionsWithoutThunkLifecycleEvents = store
+                    .getActions()
+                    .filter(a => !a.type.startsWith(routerInit.typePrefix));
+                expect(actionsWithoutThunkLifecycleEvents.length).toEqual(0);
             }
         });
     });
@@ -109,9 +110,10 @@ describe('Router thunks', () => {
         });
         const { store } = initStore(state);
         store.dispatch(onLocationChange({ pathname: '/' }));
-        expect(
-            store.getActions().filter(a => !a.type.startsWith('@router/onLocationChange')).length,
-        ).toEqual(0);
+        const actionsWithoutThunkLifecycleEvents = store
+            .getActions()
+            .filter(a => !a.type.startsWith(onLocationChange.typePrefix));
+        expect(actionsWithoutThunkLifecycleEvents.length).toEqual(0);
     });
 
     it('closeModalApp', () => {


### PR DESCRIPTION
## Description

Small unit test tweak for #25830 :

use thunk.typePrefix instead of repeating the thunk's name

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/typePrefix-in-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/typePrefix-in-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-16T19:30:33.094Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-16T19:29:44.964Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->