### PR TITLE
fix(trade): refresh trading offers after app visibility restore

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -36,25 +36,43 @@ export const useTradingInitializer = ({
         (callback: () => Promise<void>) => {
             if (isLoading) return;
 
-            if (!timer.isLoading && !timer.isStopped) {
-                if (timer.resetCount >= 40) {
-                    timer.stop();
-                }
-
-                if (pageType === 'confirm' || pageType === 'retry') {
-                    timer.stop();
-
-                    return;
-                }
-
-                if (
-                    isWindowVisible &&
-                    timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS
-                ) {
-                    dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
-                    callback();
-                }
+            if (timer.isLoading) {
+                return;
             }
+
+            if (timer.resetCount >= 40) {
+                timer.stop();
+
+                return;
+            }
+
+            if (pageType === 'confirm' || pageType === 'retry') {
+                timer.stop();
+
+                return;
+            }
+
+            const hasRefreshIntervalElapsed =
+                timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
+
+            if (!hasRefreshIntervalElapsed) {
+                return;
+            }
+
+            if (!isWindowVisible) {
+                if (!timer.isStopped) {
+                    timer.stop();
+                }
+
+                return;
+            }
+
+            if (timer.isStopped) {
+                timer.reset();
+            }
+
+            dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
+            callback();
         },
         [timer, isWindowVisible, pageType, isLoading, dispatch],
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingRefreshTime.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingRefreshTime.tsx
@@ -2,6 +2,7 @@ import { type ReactElement } from 'react';
 
 import styled from 'styled-components';
 
+import { clamp } from '@suite-common/trading';
 import { Paragraph, ProgressPie, Spinner } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
 
@@ -44,8 +45,8 @@ export const TradingRefreshTime = ({
     refetchInterval,
     label,
 }: TradingRefreshTimeProps) => {
-    const remaining = refetchInterval - seconds;
-    const progress = (remaining / refetchInterval) * 100;
+    const remaining = Math.max(refetchInterval - seconds, 0);
+    const progress = refetchInterval > 0 ? clamp((remaining / refetchInterval) * 100, 0, 100) : 0;
 
     return (
         <>

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -31,6 +31,7 @@ export * from './utils/exchange/exchangeUtils';
 export * from './utils/sell/sellUtils';
 export * from './utils/signature/signatureUtils';
 export * from './utils/countryUtils';
+export * from './utils/numberUtils';
 export { getOtcProvidersByCountry, useFetchOtc } from './queries';
 export * from './invityAPI';
 export * from './utils/currencyUtils';

--- a/suite-common/trading/src/utils/__tests__/numberUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/numberUtils.test.ts
@@ -1,0 +1,29 @@
+import { clamp } from '../numberUtils';
+
+describe('numberUtils', () => {
+    it('clamp - value within bounds', () => {
+        expect(clamp(5, 0, 10)).toBe(5);
+    });
+
+    it('clamp - value below min', () => {
+        expect(clamp(-5, 0, 10)).toBe(0);
+    });
+
+    it('clamp - value above max', () => {
+        expect(clamp(15, 0, 10)).toBe(10);
+    });
+
+    it('clamp - default bounds', () => {
+        expect(clamp(0)).toBe(0);
+        expect(clamp(-100)).toBe(-100);
+        expect(clamp(100)).toBe(100);
+    });
+
+    it('clamp - value below custom min', () => {
+        expect(clamp(5, 10, 20)).toBe(10);
+    });
+
+    it('clamp - value above custom max', () => {
+        expect(clamp(25, 10, 20)).toBe(20);
+    });
+});

--- a/suite-common/trading/src/utils/numberUtils.ts
+++ b/suite-common/trading/src/utils/numberUtils.ts
@@ -1,0 +1,8 @@
+/**
+ * Clamps a number between min and max bounds
+ */
+export const clamp = (
+    value: number,
+    min = Number.NEGATIVE_INFINITY,
+    max = Number.POSITIVE_INFINITY,
+) => Math.min(Math.max(value, min), max);


### PR DESCRIPTION
## Description
Fixes a trading offers refresh regression where the countdown could go below zero and offers did not refresh after the timer elapsed while the app window was not visible.

Changes included:
- stop the trading refresh timer when the refresh interval has elapsed while app visibility is false
- when visibility is restored and the interval is already elapsed, trigger quote refresh immediately
- clamp the refresh countdown/progress UI to prevent rendering negative values

## Notes for QA
Please verify in Buy/Sell/Exchange offers flows:
1. Open offers and wait for the refresh countdown.
2. Hide/minimize the app (or switch tab) before countdown reaches zero, wait until interval elapses, then return.
3. Confirm offers refresh after returning to visible state.
4. Confirm the timer never shows negative values.
5. Confirm no regressions on confirm/retry pages (timer should remain stopped there).

## Related Issue
Resolve #19124

## Screenshots:
N/A (behavioral fix)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-offers-refresh-19124&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-offers-refresh-19124&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-offers-refresh-19124&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T09:23:15.459Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T06:43:47.767Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->