### PR TITLE
chore(husky): run nx format on staged files in pre-commit

### DIFF
--- a/.husky/format.sh
+++ b/.husky/format.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+if [ "$TREZOR_PRE_COMMIT_FORMAT_SKIP" == "true" ]; then
+  echo "Skipping format pre-commit hook, do: 'export TREZOR_PRE_COMMIT_FORMAT_SKIP=false' to re-enable it."
+  exit 0
+fi
+
+# Get staged files that prettier can format (excluding deleted files)
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=d | grep -E '\.(js|jsx|ts|tsx|md|mdx|html|json|yml|yaml)$')
+
+echo -e "${GREEN}Running prettier pre-commit hook, to disable it do: 'export TREZOR_PRE_COMMIT_FORMAT_SKIP=true'.${NC}"
+
+# Exit if no files. Passing no arguments would format the whole repo.
+if [ -z "$STAGED_FILES" ]; then
+  echo "No staged files to format."
+else
+  echo "$STAGED_FILES"
+  echo ""
+
+  if ! echo "$STAGED_FILES" | xargs ./node_modules/.bin/prettier --write; then
+    echo "prettier --write failed! Please fix the errors and try again. You can also use --no-verify to skip pre-commit checks."
+    exit 1
+  fi
+
+  # Only re-stage if format:write actually changed files
+  REFORMATTED=$(echo "$STAGED_FILES" | xargs git diff --name-only --)
+  if [ -n "$REFORMATTED" ]; then
+    git update-index --again
+  fi
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,3 +5,7 @@ script_dir=$(dirname "$(realpath "$0")")
 if ! bash "$script_dir/eslint.sh"; then
   exit 1
 fi
+
+if ! bash "$script_dir/format.sh"; then
+  exit 1
+fi


### PR DESCRIPTION
## Description

Adds automatic formatting into the pre-commit flow via Nx.

- Introduced a new Husky script that formats only staged files supported by Prettier.
- Added a skip flag via environment variable for local opt-out.
- Prevented accidental full-repo formatting when no relevant files are staged.
- Updated pre-commit pipeline to execute formatting after eslint checks.
- Re-stages files after formatting so the commit includes applied changes.

## Notes for QA

Just DEV thing

## Related Issue

Resolve N/A

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/nx-format-precommit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/nx-format-precommit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T08:19:15.515Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T08:17:11.644Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->