### PR TITLE
test-utils - load init store only when actually requested

### DIFF
--- a/suite-native/formatters/src/hooks/__tests__/useFormattedGraphHeaderValues.test.ts
+++ b/suite-native/formatters/src/hooks/__tests__/useFormattedGraphHeaderValues.test.ts
@@ -3,7 +3,7 @@ import {
     PreloadedState,
     TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { AmountUnit } from '@trezor/protobuf/src/messages';
 
@@ -19,7 +19,7 @@ const setNewStoreMockup = (preloadedState: PreloadedState) => {
 
 describe(useFormattedGraphHeaderValues.name, () => {
     const renderUseFormattedGraphHeaderValues = (value?: string) =>
-        renderHookWithStoreProviderAsync(() => useFormattedGraphHeaderValues(value), {
+        renderHookWithStoreProvider(() => useFormattedGraphHeaderValues(value), {
             store,
         });
 
@@ -27,12 +27,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         jest.clearAllMocks();
     });
 
-    it('should parse balance amount correctly with valid input - english locale + USD', async () => {
+    it('should parse balance amount correctly with valid input - english locale + USD', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'usd' } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: '$',
             wholeNumber: '1,234',
@@ -40,12 +40,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input - english locale + CZK', async () => {
+    it('parses balance amount correctly with valid input - english locale + CZK', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: 'CZK',
             wholeNumber: '1,234',
@@ -53,12 +53,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input - czech locale + CZK', async () => {
+    it('parses balance amount correctly with valid input - czech locale + CZK', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'cs-CZ' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('1234.56');
+        const { result } = renderUseFormattedGraphHeaderValues('1234.56');
         expect(result.current).toEqual({
             currencySymbol: 'Kč',
             wholeNumber: '1\u00a0234', // non-breaking space
@@ -66,12 +66,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input and no decimal part', async () => {
+    it('parses balance amount correctly with valid input and no decimal part', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'eur' } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('2000');
+        const { result } = renderUseFormattedGraphHeaderValues('2000');
         expect(result.current).toEqual({
             currencySymbol: '€',
             wholeNumber: '2,000',
@@ -79,12 +79,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses balance amount correctly with valid input and only decimal part', async () => {
+    it('parses balance amount correctly with valid input and only decimal part', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'czk' } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('0.99');
+        const { result } = renderUseFormattedGraphHeaderValues('0.99');
         expect(result.current).toEqual({
             currencySymbol: 'CZK',
             wholeNumber: '0',
@@ -92,12 +92,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('handles BTC BaseCurrency correctly', async () => {
+    it('handles BTC BaseCurrency correctly', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.BITCOIN } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('0.01');
+        const { result } = renderUseFormattedGraphHeaderValues('0.01');
         expect(result.current).toEqual({
             currencySymbol: 'BTC',
             wholeNumber: '0',
@@ -105,12 +105,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('rounds BTC Crypto value correctly', async () => {
+    it('rounds BTC Crypto value correctly', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.BITCOIN } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('0.00124009');
+        const { result } = renderUseFormattedGraphHeaderValues('0.00124009');
         expect(result.current).toEqual({
             currencySymbol: 'BTC',
             wholeNumber: '0',
@@ -118,12 +118,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses satoshis value correctly - english locale', async () => {
+    it('parses satoshis value correctly - english locale', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'en-US' },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.SATOSHI } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('0.01477571');
+        const { result } = renderUseFormattedGraphHeaderValues('0.01477571');
         expect(result.current).toEqual({
             currencySymbol: 'sat',
             wholeNumber: '1,477,571',
@@ -131,12 +131,12 @@ describe(useFormattedGraphHeaderValues.name, () => {
         });
     });
 
-    it('parses satoshis value correctly - spanish locale', async () => {
+    it('parses satoshis value correctly - spanish locale', () => {
         setNewStoreMockup({
             locale: { appLocaleCode: 'es-ES' as SupportedLocaleCode },
             wallet: { settings: { localCurrency: 'btc', bitcoinAmountUnit: AmountUnit.SATOSHI } },
         });
-        const { result } = await renderUseFormattedGraphHeaderValues('0.01477571');
+        const { result } = renderUseFormattedGraphHeaderValues('0.01477571');
         expect(result.current).toEqual({
             currencySymbol: 'sat',
             wholeNumber: '1.477.571',

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -5,7 +5,7 @@ import { Form } from '@suite-native/forms';
 import {
     PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     waitFor,
 } from '@suite-native/test-utils';
 import TrezorConnect from '@trezor/connect';
@@ -91,7 +91,7 @@ describe('useAddressValidationAlerts', () => {
         preloadedState: PreloadedState = defaultPreloadedState,
         { inputIndex = 0 } = {},
     ) => {
-        const result = await renderHookWithStoreProviderAsync(
+        const result = renderHookWithStoreProvider(
             () => useAddressValidationAlerts({ inputIndex }),
             {
                 preloadedState,

--- a/suite-native/test-utils/src/StoreProviderForTests.tsx
+++ b/suite-native/test-utils/src/StoreProviderForTests.tsx
@@ -2,9 +2,10 @@ import { type ReactNode, useMemo } from 'react';
 import { Provider } from 'react-redux';
 
 import { useFormattersConfig } from '@suite-native/formatters-config';
-import { PreloadedState, Store, initStore } from '@suite-native/state';
+import type { PreloadedState, Store } from '@suite-native/state';
 
 import { BasicProviderForTests } from './BasicProviderForTests';
+import { initStore } from './initStore';
 
 export type TestStore = Store;
 

--- a/suite-native/test-utils/src/index.tsx
+++ b/suite-native/test-utils/src/index.tsx
@@ -1,6 +1,6 @@
 export * from '@testing-library/react-native';
 
-export { type PreloadedState, type FullAppState, initStore } from '@suite-native/state';
+export type { PreloadedState, FullAppState } from '@suite-native/state';
 
 export * from './BasicProviderForTests';
 export * from './StoreProviderForTests';
@@ -8,3 +8,4 @@ export { extraDependenciesNativeMock } from './extraDependenciesNative.mock';
 
 export * from './renderBasic';
 export * from './renderWithStore';
+export { initStore } from './initStore';

--- a/suite-native/test-utils/src/initStore.ts
+++ b/suite-native/test-utils/src/initStore.ts
@@ -1,0 +1,14 @@
+import type { PreloadedState, StoreWithExtra } from '@suite-native/state';
+
+type InitStore = (preloadedState?: PreloadedState) => StoreWithExtra;
+
+let lazyLoadedInitStore: InitStore | null = null;
+
+export const initStore = (preloadedState?: PreloadedState) => {
+    if (!lazyLoadedInitStore) {
+        const { initStore: localInitStore } = require('@suite-native/state');
+        lazyLoadedInitStore = localInitStore as InitStore;
+    }
+
+    return lazyLoadedInitStore(preloadedState);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This should safe some memory usage (and therefore time) for tests, that do not need store. Note that in only helps until store is requested for the first time. After that there is no advantage over using `initStore` from `state` package directly.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:
<img width="1095" height="339" alt="Screenshot 2026-03-17 at 9 04 32" src="https://github.com/user-attachments/assets/dff27c96-8308-4e45-9d60-1018522d8a56" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native-test-lazy-load&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->