### PR TITLE
chore: add a jest-runner for VSCode

### DIFF
--- a/scripts/vscode-jest-runner.cjs
+++ b/scripts/vscode-jest-runner.cjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+
+/**
+ * This runner is for:
+ * @link the https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest
+ * 
+ * You need to add:
+ * ```
+ * {
+ *   "jest.runMode": "deferred",
+ *   "jest.jestCommandLine": "node ./scripts/vscode-jest-runner.cjs"
+ * }
+ * ```
+ * 
+ * Into the `.vscode/settings.json` to make it work.
+ */
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const forwardedArgs = process.argv.slice(2);
+const yarnRcPath = path.join(repoRoot, '.yarnrc.yml');
+
+const getYarnExecutable = () => {
+    if (fs.existsSync(yarnRcPath)) {
+        const yarnRcContent = fs.readFileSync(yarnRcPath, 'utf8');
+        const yarnPathMatch = yarnRcContent.match(/^yarnPath:\s+(.+)$/m);
+
+        if (yarnPathMatch) {
+            const yarnPath = yarnPathMatch[1].trim();
+
+            return {
+                command: process.execPath,
+                baseArgs: [path.resolve(repoRoot, yarnPath)],
+            };
+        }
+    }
+
+    return {
+        command: 'yarn',
+        baseArgs: [],
+    };
+};
+
+const runYarn = (args, options = {}) => {
+    const yarn = getYarnExecutable();
+
+    return spawnSync(yarn.command, [...yarn.baseArgs, ...args], {
+        cwd: repoRoot,
+        env: process.env,
+        ...options,
+    });
+};
+
+const parseWorkspaceList = () =>
+    runYarn(['workspaces', 'list', '--json'], { encoding: 'utf8' }).stdout
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map(line => JSON.parse(line));
+
+const readPackageJson = workspaceLocation => {
+    const packageJsonPath = path.join(repoRoot, workspaceLocation, 'package.json');
+
+    if (!fs.existsSync(packageJsonPath)) {
+        return undefined;
+    }
+
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+};
+
+const getTestableWorkspaces = () =>
+    parseWorkspaceList()
+        .filter(workspace => workspace.location !== '.')
+        .map(workspace => ({
+            ...workspace,
+            packageJson: readPackageJson(workspace.location),
+        }))
+        .filter(workspace => workspace.packageJson?.scripts?.['test:unit'])
+        .map(({ packageJson, ...workspace }) => workspace)
+        .sort((left, right) => right.location.length - left.location.length);
+
+const normalizePathLikeArg = value => {
+    if (!value || value.startsWith('-')) {
+        return undefined;
+    }
+
+    if (path.isAbsolute(value)) {
+        return path.relative(repoRoot, value).split(path.sep).join('/');
+    }
+
+    const resolvedFromRepoRoot = path.resolve(repoRoot, value);
+
+    if (fs.existsSync(resolvedFromRepoRoot)) {
+        return path.relative(repoRoot, resolvedFromRepoRoot).split(path.sep).join('/');
+    }
+
+    return value.split(path.sep).join('/');
+};
+
+const collectCandidateValues = args => {
+    const values = [];
+
+    for (let index = 0; index < args.length; index++) {
+        const currentArg = args[index];
+        const separatorIndex = currentArg.indexOf('=');
+        const flag = separatorIndex === -1 ? currentArg : currentArg.slice(0, separatorIndex);
+        const inlineValue =
+            separatorIndex === -1 ? undefined : currentArg.slice(separatorIndex + 1);
+
+        if (
+            flag === '--runTestsByPath' ||
+            flag === '--findRelatedTests' ||
+            flag === '--testPathPattern' ||
+            flag === '--testPathPatterns'
+        ) {
+            if (inlineValue) {
+                values.push(inlineValue);
+            } else if (args[index + 1]) {
+                values.push(args[index + 1]);
+                index += 1;
+            }
+
+            continue;
+        }
+
+        values.push(currentArg);
+    }
+
+    return values.map(normalizePathLikeArg).filter(Boolean);
+};
+
+const findTargetWorkspace = args => {
+    const candidates = collectCandidateValues(args);
+
+    return getTestableWorkspaces().find(workspace =>
+        candidates.some(
+            candidate =>
+                candidate === workspace.location ||
+                candidate.startsWith(`${workspace.location}/`) ||
+                candidate.includes(`/${workspace.location}/`),
+        ),
+    );
+};
+
+const rewriteArgForWorkspace = (value, workspace) => {
+    const normalizedValue = normalizePathLikeArg(value);
+
+    if (!normalizedValue) {
+        return value;
+    }
+
+    if (normalizedValue === workspace.location) {
+        return '.';
+    }
+
+    if (normalizedValue.startsWith(`${workspace.location}/`)) {
+        return normalizedValue.slice(workspace.location.length + 1);
+    }
+
+    return value;
+};
+
+const rewriteArgsForWorkspace = (args, workspace) =>
+    args.map(currentArg => {
+        const separatorIndex = currentArg.indexOf('=');
+
+        if (separatorIndex === -1) {
+            return rewriteArgForWorkspace(currentArg, workspace);
+        }
+
+        const flag = currentArg.slice(0, separatorIndex);
+        const value = currentArg.slice(separatorIndex + 1);
+
+        if (
+            flag === '--runTestsByPath' ||
+            flag === '--findRelatedTests' ||
+            flag === '--testPathPattern' ||
+            flag === '--testPathPatterns'
+        ) {
+            return `${flag}=${rewriteArgForWorkspace(value, workspace)}`;
+        }
+
+        return currentArg;
+    });
+
+const targetWorkspace = findTargetWorkspace(forwardedArgs);
+const delegatedArgs = targetWorkspace
+    ? rewriteArgsForWorkspace(forwardedArgs, targetWorkspace)
+    : forwardedArgs;
+const yarnArgs = targetWorkspace
+    ? ['workspace', targetWorkspace.name, 'test:unit', ...delegatedArgs]
+    : ['test:unit', ...delegatedArgs];
+
+if (process.env.TREZOR_VSCODE_JEST_DEBUG === '1') {
+    const yarn = getYarnExecutable();
+    const targetLabel = targetWorkspace
+        ? `${targetWorkspace.name} (${targetWorkspace.location})`
+        : 'repo root';
+    console.error(`[vscode-jest-runner] target: ${targetLabel}`);
+    console.error(
+        `[vscode-jest-runner] command: ${[yarn.command, ...yarn.baseArgs, ...yarnArgs].join(' ')}`,
+    );
+}
+
+const result = runYarn(yarnArgs, {
+    stdio: 'inherit',
+});
+
+if (result.error) {
+    throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
The code is pure AI Slop.


You need to add: 
```json
{
    "jest.runMode": "deferred",
    "jest.jestCommandLine": "node ./scripts/vscode-jest-runner.cjs"
}
```

Into the `.vscode/settings.json` to make it work.



<img width="1978" height="1061" alt="image" src="https://github.com/user-attachments/assets/350655e6-06af-4ec5-9791-875fd50e48b6" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=vscode-test-jest&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=vscode-test-jest&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T11:00:53.231Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T10:59:17.596Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->