### PR TITLE
Test/unpair forget

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
@@ -8,7 +8,7 @@ const ConfirmationContent = ({
     isBluetoothDevice: boolean;
     isBluetoothConnectedDevice: boolean;
 }) => (
-    <Card paddingType="normal">
+    <Card paddingType="normal" data-testid="@settings/device/forget/confirm-content">
         <List gap={24}>
             <List.Item
                 bulletComponent={
@@ -70,10 +70,18 @@ export const ConfirmationModal = ({
         width={680}
         bottomContent={
             <>
-                <Modal.Button onClick={onConfirm}>
+                <Modal.Button
+                    data-testid="@settings/device/forget-button-confirm"
+                    onClick={onConfirm}
+                >
                     <Translation id="TR_FORGET_DEVICE_MODAL_CONFIRM" />
                 </Modal.Button>
-                <Modal.Button intent="neutral" priority="secondary" onClick={onCancel}>
+                <Modal.Button
+                    data-testid="@settings/device/forget-button-cancel"
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={onCancel}
+                >
                     <Translation id="TR_CANCEL" />
                 </Modal.Button>
             </>

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDevice.tsx
@@ -25,7 +25,7 @@ export const ForgetDevice = () => {
     return (
         <>
             {isModalOpen && <ForgetDeviceModal onCancel={handleModalCancel} />}
-            <SectionItem data-test="@settings/device/forget">
+            <SectionItem data-testid="@settings/device/forget">
                 <TextColumn
                     title={<Translation id="TR_FORGET_DEVICE_HEADING" />}
                     description={<Translation id="TR_FORGET_DEVICE_DESCRIPTION" />}
@@ -35,6 +35,7 @@ export const ForgetDevice = () => {
                         onClick={handleClick}
                         intent="warning"
                         isDisabled={hasRunningDiscovery}
+                        data-testid="@settings/device/forget-button"
                     >
                         <Translation id="TR_FORGET" />
                     </ActionButton>

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
@@ -55,6 +55,7 @@ export const OsAndTrezorCleanupModal = ({
                             intent="brand"
                             onClick={() => setOsRemovalConfirmed(true)}
                             size="large"
+                            data-testid="@settings/device/ive-removed-it-button"
                         >
                             <Translation id="TR_FORGET_DEVICE_MODAL_IVE_REMOVED_IT" />
                         </Button>
@@ -74,7 +75,12 @@ export const OsAndTrezorCleanupModal = ({
                         />
                     }
                     actions={
-                        <Button intent="brand" onClick={onTrezorRemovalConfirm} size="large">
+                        <Button
+                            intent="brand"
+                            onClick={onTrezorRemovalConfirm}
+                            size="large"
+                            data-testid="@settings/device/ive-removed-it-button-trezor"
+                        >
                             <Translation id="TR_FORGET_DEVICE_MODAL_IVE_REMOVED_IT" />
                         </Button>
                     }

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/UnplugDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/UnplugDeviceModal.tsx
@@ -33,14 +33,23 @@ export const UnplugDeviceModal = ({
     }, [onCancel, onDisconnect]);
 
     return (
-        <Modal width={400} height={420}>
+        <Modal width={400} height={420} data-testid="@settings/device/unplug-device-modal">
             <Column gap={24} alignItems="center">
                 <Illustration name="disconnectTrezor" width={224} />
                 <Column gap={8} alignItems="center">
-                    <Paragraph typographyStyle="headline-md" align="center">
+                    <Paragraph
+                        typographyStyle="headline-md"
+                        align="center"
+                        data-testid="@settings/device/unplug-device-modal/heading"
+                    >
                         <Translation id="TR_FORGET_DEVICE_MODAL_FINISH_FORGETTING_HEADING" />
                     </Paragraph>
-                    <Paragraph align="center" typographyStyle="body-md" color="contentSecondary">
+                    <Paragraph
+                        align="center"
+                        typographyStyle="body-md"
+                        color="contentSecondary"
+                        data-testid="@settings/device/unplug-device-modal/subtitle"
+                    >
                         <Translation id="TR_FORGET_DEVICE_MODAL_DISCONNECT_SUBTITLE" />
                     </Paragraph>
                 </Column>

--- a/suite/e2e/support/pageObjects/settings/deviceTab.ts
+++ b/suite/e2e/support/pageObjects/settings/deviceTab.ts
@@ -1,6 +1,9 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
+
+import { TranslationKey } from '@suite/intl';
 
 import { step } from '../../common';
+import { expect } from '../../testExtends/customMatchers';
 
 export class DeviceTab {
     readonly createMultiShareBackupButton: Locator;
@@ -14,6 +17,17 @@ export class DeviceTab {
     readonly firmwareConfirmSeedButton: Locator;
     readonly firmwareReconnectDevice: Locator;
     readonly autoconnectSwitch: Locator;
+    readonly deviceForgetButton: Locator;
+    readonly deviceForgetConfirmContent: Locator;
+    readonly deviceForgetConfirmButton: Locator;
+    readonly deviceForgetCancelButton: Locator;
+    readonly deviceForgetIveRemovedItButton: Locator;
+    readonly deviceForgetIveRemovedItTrezorButton: Locator;
+    readonly toastDeviceForgotten: Locator;
+    readonly toastDeviceWillBeForgotten: Locator;
+    readonly unplugDeviceModal: Locator;
+    readonly unplugDeviceHeading: Locator;
+    readonly unplugDeviceSubtitle: Locator;
 
     constructor(private readonly page: Page) {
         this.createMultiShareBackupButton = page.getByTestId(
@@ -35,6 +49,25 @@ export class DeviceTab {
         this.firmwareConfirmSeedButton = page.getByTestId('@firmware/confirm-seed-button');
         this.firmwareReconnectDevice = page.getByTestId('@firmware/reconnect-device');
         this.autoconnectSwitch = page.getByTestId('@settings/device/thp-autoconnect');
+        this.deviceForgetButton = page.getByTestId('@settings/device/forget-button');
+        this.deviceForgetConfirmButton = page.getByTestId('@settings/device/forget-button-confirm');
+        this.deviceForgetConfirmContent = page.getByTestId(
+            '@settings/device/forget/confirm-content',
+        );
+        this.deviceForgetCancelButton = page.getByTestId('@settings/device/forget-button-cancel');
+        this.deviceForgetIveRemovedItButton = page.getByTestId(
+            '@settings/device/ive-removed-it-button',
+        );
+        this.deviceForgetIveRemovedItTrezorButton = page.getByTestId(
+            '@settings/device/ive-removed-it-button-trezor',
+        );
+        this.toastDeviceForgotten = page.getByTestId('@toast/device-forgotten');
+        this.toastDeviceWillBeForgotten = page.getByTestId('@toast/device-will-be-forgotten');
+        this.unplugDeviceModal = page.getByTestId('@settings/device/unplug-device-modal');
+        this.unplugDeviceHeading = page.getByTestId('@settings/device/unplug-device-modal/heading');
+        this.unplugDeviceSubtitle = page.getByTestId(
+            '@settings/device/unplug-device-modal/subtitle',
+        );
     }
 
     @step()
@@ -64,5 +97,39 @@ export class DeviceTab {
         await this.firmwareInstallButton.click();
         await this.firmwareConfirmSeedCheckbox.click();
         await this.firmwareConfirmSeedButton.click();
+    }
+
+    @step()
+    async completeBluetoothForgetFlow() {
+        await this.deviceForgetIveRemovedItButton.click();
+        await this.deviceForgetIveRemovedItTrezorButton.click();
+    }
+
+    @step()
+    async verifyFinishForgettingDeviceModal() {
+        await expect(this.unplugDeviceModal).toBeVisible();
+        await expect(this.unplugDeviceHeading).toHaveTranslation(
+            'TR_FORGET_DEVICE_MODAL_FINISH_FORGETTING_HEADING',
+        );
+        await expect(this.unplugDeviceSubtitle).toHaveTranslation(
+            'TR_FORGET_DEVICE_MODAL_DISCONNECT_SUBTITLE',
+        );
+    }
+
+    @step()
+    async verifyToastDeviceForgotten() {
+        await expect(this.toastDeviceForgotten).toBeVisible();
+        await expect(this.toastDeviceForgotten).toHaveTranslation('TR_DEVICE_HAS_BEEN_FORGOTTEN');
+    }
+
+    @step()
+    async verifyForgetDeviceModal(translation: TranslationKey) {
+        await expect(this.page.modal).toBeVisible();
+        await expect(this.page.modalHeader).toHaveTranslation(translation);
+    }
+
+    @step()
+    async verifyForgetDeviceContent(translation: TranslationKey[]) {
+        await expect(this.deviceForgetConfirmContent.locator('li')).toHaveTranslation(translation);
     }
 }

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -261,7 +261,7 @@ export const expect = baseExpect.extend({
 
     async toHaveTranslation(
         locator: Locator,
-        translationKey: TranslationKey,
+        translationKey: TranslationKey | TranslationKey[],
         // Use ICU values for placeholders (e.g., { amount, symbol, days })
         options?: {
             isValueElement?: boolean;
@@ -269,24 +269,46 @@ export const expect = baseExpect.extend({
             timeout?: number;
         },
     ) {
-        const template = messages[translationKey].defaultMessage;
-        const values = options?.values;
-        const expectedTranslation =
-            values && Object.keys(values).length > 0
-                ? String(
-                      intlEn.formatMessage(
-                          { id: translationKey, defaultMessage: template },
-                          options.values,
-                      ),
-                  )
+        // Helper to resolve a translation key into its formatted string
+        const translate = (key: TranslationKey) => {
+            const message = messages[key];
+            if (!message)
+                throw new Error(`[toHaveTranslation] Could not resolve translation key: ${key}`);
+
+            const template = message.defaultMessage;
+            const values = options?.values;
+
+            return values && Object.keys(values).length > 0
+                ? String(intlEn.formatMessage({ id: key, defaultMessage: template }, values))
                 : template;
+        };
+
+        /*
+         * Resolve all keys into translated strings.
+         * If an array is provided, 'expected' will be an array of strings,
+         * enabling the locator to match multiple elements simultaneously.
+         */
+        const expected = Array.isArray(translationKey)
+            ? translationKey.map(translate)
+            : translate(translationKey);
 
         if (options?.isValueElement) {
-            await baseExpect(locator).toHaveValue(expectedTranslation, {
-                timeout: options?.timeout,
-            });
+            if (Array.isArray(expected)) {
+                await baseExpect(locator).toHaveCount(expected.length, {
+                    timeout: options?.timeout,
+                });
+                for (let i = 0; i < expected.length; i++) {
+                    await baseExpect(locator.nth(i)).toHaveValue(expected[i], {
+                        timeout: options?.timeout,
+                    });
+                }
+            } else {
+                await baseExpect(locator).toHaveValue(expected, {
+                    timeout: options?.timeout,
+                });
+            }
         } else {
-            await baseExpect(locator).toHaveText(expectedTranslation, {
+            await baseExpect(locator).toHaveText(expected, {
                 timeout: options?.timeout,
             });
         }

--- a/suite/e2e/support/testExtends/enhancePage.ts
+++ b/suite/e2e/support/testExtends/enhancePage.ts
@@ -3,6 +3,12 @@ import { writeFileSync } from 'fs';
 import { get, isMatch, set } from 'lodash';
 import { join } from 'path';
 
+import {
+    DeviceStateMock,
+    ExpectDeviceStateOptions,
+    MockBluetoothOptions,
+} from './mocks/deviceStateMock';
+
 declare module '@playwright/test' {
     interface Page {
         // Locators
@@ -10,6 +16,13 @@ declare module '@playwright/test' {
         modalHeader: Locator;
         modalCloseButton: Locator;
 
+        // External Mocks
+        /**
+         * Mocks a Bluetooth device context by synchronizing the Device Manager and Bluetooth Manager state.
+         * @see {@link DeviceStateMock.mockBluetooth} for detailed description.
+         */
+        mockDeviceBluetoothState(options?: MockBluetoothOptions): Promise<void>;
+        expectDeviceState(expected: ExpectDeviceStateOptions): Promise<void>;
         // Methods
         discoveryShouldFinish(): Promise<void>;
         /**
@@ -47,21 +60,31 @@ declare module '@playwright/test' {
 // These properties and methods have general use across the whole test suite.
 // It is not specific to any particular test or feature.
 export const enhancePage = (page: Page): Page => {
+    const deviceStateMock = new DeviceStateMock(page);
+
     // Locators
     page.modal = page.getByTestId('@modal');
     page.modalHeader = page.getByTestId('@modal/header');
     page.modalCloseButton = page.getByTestId('@modal/close-button');
 
-    // Methods
+    // External Mocks
+    page.mockDeviceBluetoothState = options => deviceStateMock.mockBluetooth(options);
+    page.expectDeviceState = expected => deviceStateMock.expectDeviceState(expected);
+
+    // High-Level Helpers
     page.discoveryShouldFinish = async function () {
         const discoveryBar = page.getByTestId('@wallet/discovery-progress-bar');
         await test.step('Wait for discovery to finish', async () => {
-            await expect(discoveryBar, 'discovery bar should be visible').toBeVisible({
-                timeout: 15_000,
-            });
-            await discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
+            await expect(async () => {
+                if (await discoveryBar.isVisible()) {
+                    await discoveryBar.waitFor({ state: 'detached', timeout: 120_000 });
+                }
+                await expect(discoveryBar).toBeHidden();
+            }).toPass({ timeout: 120_000 });
         });
     };
+
+    // Low-Level Infrastructure (Redux utils, Retry mechanisms, etc.)
 
     //Retry mechanism for settings dropdowns which tend to be flaky in automation
     page.selectDropdownOptionWithRetry = async function (dropdown: Locator, option: Locator) {

--- a/suite/e2e/support/testExtends/mocks/deviceStateMock.ts
+++ b/suite/e2e/support/testExtends/mocks/deviceStateMock.ts
@@ -1,0 +1,169 @@
+import { Page, expect, test } from '@playwright/test';
+
+/**
+ * Mocks a Bluetooth device context by synchronizing the Device Manager and Bluetooth Manager state.
+ *
+ * This class provides a "State-Level Mock" that forces a Trezor device into a specific connection
+ * state (USB or Bluetooth) and injects a simulated pairing history into the application.
+ *
+ * --- WHY THIS IS NECESSARY ---
+ * Trezor Suite's state is divided into multiple "Silos" (Reducers). To simulate a Bluetooth device,
+ * you must simultaneously update the active device status, the Bluetooth pairing history,
+ * and the persistence layer.
+ *
+ * --- HARDWARE CONFLICT ---
+ * When testing with a live USB emulator, the transport layer will attempt to overwrite the
+ * Redux state with the "Physical Reality" (resetting apiType back to 'usb').
+ *
+ * To test a "Disconnected" state successfully:
+ * 1. Call `await device.powerOff()` first to stop the hardware signal.
+ * 2. THEN call `await page.mockDeviceBluetoothState({ isConnected: false })`.
+ *
+ * --- USE CASES ---
+ * - Forget Device Flow: Verifies "Unplug" vs "Bluetooth Cleanup" modal transitions.
+ * - Header Icons: Verifies that the correct Bluetooth/USB status icons are shown.
+ * - Device Selector: Verifies that "Remembered" Bluetooth devices are displayed correctly.
+ */
+
+export interface MockBluetoothOptions {
+    bluetoothId?: string;
+    isConnected?: boolean;
+    apiType?: 'bluetooth' | 'usb';
+}
+
+export interface ExpectDeviceStateOptions {
+    connected: boolean;
+    apiType: 'bluetooth' | 'usb';
+}
+
+interface EvaluatePayload {
+    id: string;
+    connected: boolean;
+    type: 'bluetooth' | 'usb';
+}
+
+export class DeviceStateMock {
+    constructor(private page: Page) {}
+
+    /**
+     * Mocks a Bluetooth device context by synchronizing the Device Manager and Bluetooth Manager.
+     *
+     * @param options configuration for the mock
+     * @param options.bluetoothId The simulated MAC address (e.g., '00:11:22...').
+     * @param options.apiType The active protocol. Use 'usb' to test devices plugged in that have BT history.
+     * @param options.isConnected Current connection status. Note: 'false' may be overwritten by a live emulator unless device.powerOff() is called first.
+     */
+    async mockBluetooth(options: MockBluetoothOptions = {}) {
+        const {
+            bluetoothId = '00:11:22:33:44:55',
+            isConnected = true,
+            apiType = 'bluetooth',
+        } = options;
+
+        const payload: EvaluatePayload = {
+            id: bluetoothId,
+            connected: isConnected,
+            type: apiType,
+        };
+
+        await test.step(`Mock Bluetooth Device State (${apiType}, ${isConnected ? 'Connected' : 'Disconnected'})`, async () => {
+            await this.page.ensureStoreOnDesktop();
+            await this.page.evaluate(this.syncDeviceAndBluetoothState, payload);
+        });
+    }
+
+    /**
+     * Verifies the core connection state of the selected device in Redux.
+     * Note: For disconnected devices, apiType is often reset to 'usb' by the hardware
+     * layer even if the mock tried to set it to 'bluetooth'.
+     */
+    async expectDeviceState(expected: ExpectDeviceStateOptions) {
+        await test.step(`Verify Device State (connected: ${expected.connected}, type: ${expected.apiType})`, async () => {
+            const device = await this.page.getReduxObject('device.selectedDevice');
+
+            expect(device.connected, 'Device connection status mismatch').toBe(expected.connected);
+
+            // For disconnected ones, we accept 'usb' due to hardware reset reality.
+            if (expected.connected) {
+                expect(device.descriptor.apiType, 'Device API type mismatch').toBe(
+                    expected.apiType,
+                );
+            }
+        });
+    }
+
+    /**
+     * Performs the internal Redux synchronization to mock a Bluetooth device context.
+     *
+     * This method requires three separate dispatches to satisfy the app's internal logic
+     * and ensure a consistent state across different "Silos" (Reducers):
+     *
+     * 1. '@device/update-selected-device': Updates the primary Device Reducer (UI State).
+     *    This ensures the 'thp' property exists (forcing modern TS7 flows) and sets
+     *    the initial 'apiType' and 'connected' status.
+     *
+     * 2. '@suite/bluetooth/known-devices-update': Populates the Bluetooth Reducer (History).
+     *    This injects the "Pairing Footprint" into the computer's simulated OS settings,
+     *    which is what triggers the "Bluetooth Cleanup" modals during the Forget flow.
+     *
+     * 3. '@device/device-changed': Updates the Persistence Layer (Background Logic).
+     *    This ensures the app "remembers" the connection type and prevents the device
+     *    from being immediately overwritten or forgotten by background transport tasks.
+     *
+     * @param payload Internal state mapping for the browser execution context.
+     */
+    private syncDeviceAndBluetoothState(payload: EvaluatePayload) {
+        const { id, connected, type } = payload;
+        const { store } = window;
+        const state = store.getState();
+        const { selectedDevice } = state.device;
+
+        if (!selectedDevice) {
+            throw new Error('DeviceStateMock: No device selected.');
+        }
+
+        // Update DEVICE REDUCER
+        const modifiedDevice = {
+            ...selectedDevice,
+            thp: selectedDevice.thp ?? {},
+            remember: true,
+            connected,
+            descriptor: {
+                ...selectedDevice.descriptor,
+                apiType: type,
+                id: type === 'bluetooth' ? id : selectedDevice.descriptor.id,
+            },
+        };
+
+        // Update BLUETOOTH REDUCER (THE HISTORY)
+        const mockKnownDevice = {
+            id,
+            deviceId: selectedDevice.id,
+            name: selectedDevice.name,
+            connectionStatus: { type: connected ? 'connected' : 'disconnected' },
+            manufacturerData: {
+                deviceModel: selectedDevice.features.internal_model,
+                deviceColor: selectedDevice.features.unit_color,
+            },
+            lastUpdatedTimestamp: Date.now(),
+        };
+
+        // 1. Update UI state for the selected device
+        store.dispatch({
+            type: '@device/update-selected-device',
+            payload: modifiedDevice,
+        });
+
+        // 2. Mock Bluetooth pairing history in the Bluetooth manager
+        store.dispatch({
+            type: '@suite/bluetooth/known-devices-update',
+            payload: { knownDevices: [mockKnownDevice] },
+        });
+
+        // 3. Update persistence layer so the app "remembers" the device and its connection type
+        store.dispatch({
+            type: '@device/device-changed',
+            payload: modifiedDevice,
+        });
+    }
+}

--- a/suite/e2e/tests/settings/forget-device.test.ts
+++ b/suite/e2e/tests/settings/forget-device.test.ts
@@ -1,0 +1,347 @@
+import { NetworkSymbol } from '@suite-common/wallet-config';
+import { TestCategory, TestPriority, TestStream, createTestAnnotation } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../support/fixtures';
+
+test.describe('Device Settings - Forget TS7', { tag: ['@T3W1'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('device');
+    });
+
+    test(
+        'Confirm forget disconnected TS7 with BT history',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a disconnected TS7 device with Bluetooth history successfully unpairs and is forgotten, skipping the "Unplug" step.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+            tag: ['@desktopOnly'],
+        },
+        async ({ page, device, onboardingPage, settingsPage, walletPage }) => {
+            await test.step('Disconnect device', async () => {
+                await device.powerOff();
+
+                await expect(walletPage.deviceDisconnectedStatus).toBeVisible();
+            });
+
+            // Mock device Bluetooth state
+            await page.mockDeviceBluetoothState({ isConnected: false });
+            await page.expectDeviceState({ connected: false, apiType: 'bluetooth' });
+
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BLUETOOTH_REMOVED',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_FINISH_HEADING',
+                );
+            });
+
+            await test.step('Confirm Bluetooth removal', async () => {
+                await settingsPage.deviceTab.completeBluetoothForgetFlow();
+
+                await expect(onboardingPage.welcomeBody).toBeVisible();
+                await settingsPage.deviceTab.verifyToastDeviceForgotten();
+            });
+        },
+    );
+
+    test(
+        'Confirm forget device TS7 connected via USB with BT history',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a USB-connected TS7 device with Bluetooth history is unpaired and forgotten successfully.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+            tag: ['@desktopOnly'],
+        },
+        async ({ page, device, onboardingPage, settingsPage }) => {
+            // Mock device bluetooth state
+            await page.mockDeviceBluetoothState({ isConnected: true, apiType: 'usb' });
+            await page.expectDeviceState({ connected: true, apiType: 'usb' });
+
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BLUETOOTH_REMOVED',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_FINISH_HEADING',
+                );
+            });
+
+            await test.step('Confirm Bluetooth removal', async () => {
+                await settingsPage.deviceTab.completeBluetoothForgetFlow();
+
+                await settingsPage.deviceTab.verifyFinishForgettingDeviceModal();
+            });
+
+            await test.step('Complete the process by disconnecting device', async () => {
+                await device.powerOff();
+
+                await expect(settingsPage.deviceTab.unplugDeviceModal).toBeHidden();
+                await expect(onboardingPage.welcomeBody).toBeVisible();
+                await settingsPage.deviceTab.verifyToastDeviceForgotten();
+            });
+        },
+    );
+
+    test(
+        'Confirm forget device TS7 connected via USB',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a USB-connected TS7 device has been unpaired and forgotten successfully.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ device, settingsPage }) => {
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await settingsPage.deviceTab.verifyFinishForgettingDeviceModal();
+            });
+
+            await test.step('Complete the process by disconnecting device', async () => {
+                await device.powerOff();
+
+                await expect(settingsPage.deviceTab.unplugDeviceModal).toBeHidden();
+                await settingsPage.deviceTab.verifyToastDeviceForgotten();
+            });
+        },
+    );
+
+    test(
+        'Confirm forget disconnected device TS7',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a disconnected TS7 device has been unpaired and forgotten successfully',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ device, settingsPage, walletPage, onboardingPage }) => {
+            await test.step('Disconnect device', async () => {
+                await device.powerOff();
+
+                await expect(walletPage.deviceDisconnectedStatus).toBeVisible();
+            });
+
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await expect(onboardingPage.welcomeBody).toBeVisible();
+            });
+        },
+    );
+
+    test(
+        'Cancel forget device TS7',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verify that the TS7 device "Forget" process was cancelled successfully.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ page, settingsPage }) => {
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+            });
+
+            await test.step('Cancel the forget device modal', async () => {
+                await settingsPage.deviceTab.deviceForgetCancelButton.click();
+
+                await expect(page.modal).toBeHidden();
+            });
+        },
+    );
+
+    test(
+        'Forget button is disabled during discovery process',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that the "Forget" button is disabled during the discovery process and enabled once discovery finishes.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ page, settingsPage }) => {
+            const coins: NetworkSymbol[] = ['eth', 'ada', 'sol'];
+
+            await test.step('Enable few coins', async () => {
+                await settingsPage.navigateTo('coins');
+
+                for (const coin of coins) {
+                    await settingsPage.coinsTab.enableNetwork(coin);
+                }
+
+                await settingsPage.coinsTab.activateCoinsButton.click();
+            });
+
+            await test.step('Verify "Forget" button is disabled', async () => {
+                await settingsPage.navigateTo('device');
+
+                await expect(settingsPage.deviceTab.deviceForgetButton).toBeDisabled();
+            });
+
+            await test.step('Verify "Forget" button is enabled when discovery finished', async () => {
+                await page.discoveryShouldFinish();
+
+                await expect(settingsPage.deviceTab.deviceForgetButton).toBeEnabled();
+            });
+        },
+    );
+});
+
+test.describe('Device Settings - Forget TS5', { tag: ['@T3T1', '@smoke'] }, () => {
+    test.beforeEach(async ({ onboardingPage, settingsPage }) => {
+        await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('device');
+    });
+
+    test(
+        'Confirm forget device TS5',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that the TS5 device has been unpaired and forgotten successfully.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ device, settingsPage }) => {
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await settingsPage.deviceTab.verifyFinishForgettingDeviceModal();
+            });
+
+            await test.step('Complete the process by disconnecting device', async () => {
+                await device.powerOff();
+
+                await expect(settingsPage.deviceTab.unplugDeviceModal).toBeHidden();
+                await settingsPage.deviceTab.verifyToastDeviceForgotten();
+            });
+        },
+    );
+
+    test(
+        'Confirm forget disconnected device TS5',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a disconnected TS5 device has been unpaired and forgotten successfully.',
+                category: TestCategory.Device,
+                priority: TestPriority.Low,
+                stream: TestStream.Growth,
+            }),
+        },
+        async ({ device, settingsPage }) => {
+            await test.step('Disconnect device', async () => {
+                await device.powerOff();
+            });
+
+            await test.step('Forget device', async () => {
+                await settingsPage.deviceTab.deviceForgetButton.click();
+
+                await settingsPage.deviceTab.verifyForgetDeviceModal(
+                    'TR_FORGET_DEVICE_MODAL_HEADING',
+                );
+                await settingsPage.deviceTab.verifyForgetDeviceContent([
+                    'TR_FORGET_DEVICE_MODAL_BULLET_FORGET',
+                    'TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE',
+                ]);
+            });
+
+            await test.step('Confirm device forgetting', async () => {
+                await settingsPage.deviceTab.deviceForgetConfirmButton.click();
+
+                await settingsPage.deviceTab.verifyFinishForgettingDeviceModal();
+            });
+
+            await test.step('Complete the process by disconnecting device', async () => {
+                await expect(settingsPage.deviceTab.unplugDeviceModal).toBeHidden();
+                await settingsPage.deviceTab.verifyToastDeviceForgotten();
+            });
+        },
+    );
+});


### PR DESCRIPTION
## Description

## Related Issue

https://github.com/trezor/trezor-suite/pull/25148

https://github.com/trezor/trezor-suite/issues/26422?reload=1

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/unpair-forget&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/unpair-forget&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/unpair-forget&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T11:21:25.941Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T11:20:10.291Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/unpair-forget/web/](https://dev.suite.sldev.cz/suite-web/test/unpair-forget/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->