### PR TITLE
chore(connect): use MethodMessage type in method subclasses declarations

### DIFF
--- a/packages/connect/src/api/applyFlags.ts
+++ b/packages/connect/src/api/applyFlags.ts
@@ -3,11 +3,11 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ApplyFlags extends AbstractMethod<'applyFlags', PROTO.ApplyFlags> {
-    constructor(message: { id?: number; payload: Payload<'applyFlags'> }) {
+    constructor(message: MethodMessage<'applyFlags'>) {
         super(message);
         this.useDeviceState = false;
         this.skipFinalReload = false;

--- a/packages/connect/src/api/applySettings.ts
+++ b/packages/connect/src/api/applySettings.ts
@@ -3,12 +3,12 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { ApplySettings as ApplySettingsSchema } from '../types/api/applySettings';
 
 export default class ApplySettings extends AbstractMethod<'applySettings', PROTO.ApplySettings> {
-    constructor(message: { id?: number; payload: Payload<'applySettings'> }) {
+    constructor(message: MethodMessage<'applySettings'>) {
         super(message);
         this.useDeviceState = false;
         this.skipFinalReload = false;

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -8,7 +8,7 @@ import {
 } from '@trezor/device-authenticity';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -18,7 +18,7 @@ export default class AuthenticateDevice extends AbstractMethod<
     'authenticateDevice',
     AuthenticateDeviceParams
 > {
-    constructor(message: { id?: number; payload: Payload<'authenticateDevice'> }) {
+    constructor(message: MethodMessage<'authenticateDevice'>) {
         super(message);
         this.useEmptyPassphrase = true;
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];

--- a/packages/connect/src/api/backupDevice.ts
+++ b/packages/connect/src/api/backupDevice.ts
@@ -3,11 +3,11 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class BackupDevice extends AbstractMethod<'backupDevice', PROTO.BackupDevice> {
-    constructor(message: { id?: number; payload: Payload<'backupDevice'> }) {
+    constructor(message: MethodMessage<'backupDevice'>) {
         super(message);
         this.skipFinalReload = false;
         this.useDeviceState = false;

--- a/packages/connect/src/api/bleUnpair.ts
+++ b/packages/connect/src/api/bleUnpair.ts
@@ -3,12 +3,12 @@ import { Assert } from '@trezor/schema-utils';
 import { TRANSPORT_ERROR } from '@trezor/transport';
 
 import { PROTO } from '../constants';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 
 export default class BleUnpair extends AbstractMethod<'bleUnpair', PROTO.BleUnpair> {
-    constructor(message: { id?: number; payload: Payload<'bleUnpair'> }) {
+    constructor(message: MethodMessage<'bleUnpair'>) {
         super(message);
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.useDeviceState = false;

--- a/packages/connect/src/api/blockchainDisconnect.ts
+++ b/packages/connect/src/api/blockchainDisconnect.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { findBackend, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { CoinInfo } from '../types';
@@ -16,7 +16,7 @@ type Params = {
 };
 
 export default class BlockchainDisconnect extends AbstractMethod<'blockchainDisconnect', Params> {
-    constructor(message: { id?: number; payload: Payload<'blockchainDisconnect'> }) {
+    constructor(message: MethodMessage<'blockchainDisconnect'>) {
         super(message);
 
         this.useDevice = false;

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -2,7 +2,12 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, MethodReturnType, Payload } from '../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+    Payload,
+} from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -17,7 +22,7 @@ type Params = {
 };
 
 export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEstimateFee', Params> {
-    constructor(message: { id?: number; payload: Payload<'blockchainEstimateFee'> }) {
+    constructor(message: MethodMessage<'blockchainEstimateFee'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainEvmRpcCall.ts
+++ b/packages/connect/src/api/blockchainEvmRpcCall.ts
@@ -1,7 +1,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import type { CoinInfo } from '../types';
 import { validateParams } from './common/paramsValidator';
@@ -14,7 +14,7 @@ type Params = {
 };
 
 export default class BlockchainEvmRpcCall extends AbstractMethod<'blockchainEvmRpcCall', Params> {
-    constructor(message: { id?: number; payload: Payload<'blockchainEvmRpcCall'> }) {
+    constructor(message: MethodMessage<'blockchainEvmRpcCall'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
+++ b/packages/connect/src/api/blockchainGetAccountBalanceHistory.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -19,7 +19,7 @@ export default class BlockchainGetAccountBalanceHistory extends AbstractMethod<
     'blockchainGetAccountBalanceHistory',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainGetAccountBalanceHistory'> }) {
+    constructor(message: MethodMessage<'blockchainGetAccountBalanceHistory'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
+++ b/packages/connect/src/api/blockchainGetCurrentFiatRates.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -20,7 +20,7 @@ export default class BlockchainGetCurrentFiatRates extends AbstractMethod<
     'blockchainGetCurrentFiatRates',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainGetCurrentFiatRates'> }) {
+    constructor(message: MethodMessage<'blockchainGetCurrentFiatRates'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
+++ b/packages/connect/src/api/blockchainGetFiatRatesForTimestamps.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -21,7 +21,7 @@ export default class BlockchainGetFiatRatesForTimestamps extends AbstractMethod<
     'blockchainGetFiatRatesForTimestamps',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainGetFiatRatesForTimestamps'> }) {
+    constructor(message: MethodMessage<'blockchainGetFiatRatesForTimestamps'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainGetInfo.ts
+++ b/packages/connect/src/api/blockchainGetInfo.ts
@@ -1,6 +1,6 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -13,7 +13,7 @@ type Params = {
 };
 
 export default class BlockchainGetInfo extends AbstractMethod<'blockchainGetInfo', Params> {
-    constructor(message: { id?: number; payload: Payload<'blockchainGetInfo'> }) {
+    constructor(message: MethodMessage<'blockchainGetInfo'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainGetTransactions.ts
+++ b/packages/connect/src/api/blockchainGetTransactions.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -19,7 +19,7 @@ export default class BlockchainGetTransactions extends AbstractMethod<
     'blockchainGetTransactions',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainGetTransactions'> }) {
+    constructor(message: MethodMessage<'blockchainGetTransactions'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainSetCustomBackend.ts
+++ b/packages/connect/src/api/blockchainSetCustomBackend.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { reconnectAllBackends, setCustomBackend } from '../backend/BlockchainLink';
@@ -17,7 +17,7 @@ export default class BlockchainSetCustomBackend extends AbstractMethod<
     'blockchainSetCustomBackend',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainSetCustomBackend'> }) {
+    constructor(message: MethodMessage<'blockchainSetCustomBackend'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainSubscribe.ts
+++ b/packages/connect/src/api/blockchainSubscribe.ts
@@ -2,8 +2,8 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import type { MethodPermission, Payload, Payload as PayloadType } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import { getCoinInfo } from '../data/coinInfo';
@@ -17,7 +17,7 @@ type Params = {
 };
 
 export default class BlockchainSubscribe extends AbstractMethod<'blockchainSubscribe', Params> {
-    constructor(message: { id?: number; payload: PayloadType<'blockchainSubscribe'> }) {
+    constructor(message: MethodMessage<'blockchainSubscribe'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainSubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainSubscribeFiatRates.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -19,7 +19,7 @@ export default class BlockchainSubscribeFiatRates extends AbstractMethod<
     'blockchainSubscribeFiatRates',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainSubscribeFiatRates'> }) {
+    constructor(message: MethodMessage<'blockchainSubscribeFiatRates'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainUnsubscribe.ts
+++ b/packages/connect/src/api/blockchainUnsubscribe.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, Payload } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -17,7 +17,7 @@ type Params = {
 };
 
 export default class BlockchainUnsubscribe extends AbstractMethod<'blockchainUnsubscribe', Params> {
-    constructor(message: { id?: number; payload: Payload<'blockchainUnsubscribe'> }) {
+    constructor(message: MethodMessage<'blockchainUnsubscribe'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
+++ b/packages/connect/src/api/blockchainUnsubscribeFiatRates.ts
@@ -2,7 +2,7 @@
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
@@ -18,7 +18,7 @@ export default class BlockchainUnsubscribeFiatRates extends AbstractMethod<
     'blockchainUnsubscribeFiatRates',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainUnsubscribeFiatRates'> }) {
+    constructor(message: MethodMessage<'blockchainUnsubscribeFiatRates'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
+++ b/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
@@ -2,7 +2,7 @@ import BlockchainLink from '@trezor/blockchain-link';
 import { MESSAGES } from '@trezor/blockchain-link-types/src/constants';
 import type { ValidateEvmRpc } from '@trezor/blockchain-link-types/src/responses';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { EvmRpcWorker } from '../workers/workers';
 import { validateParams } from './common/paramsValidator';
@@ -16,7 +16,7 @@ export default class BlockchainValidateEvmRpcUrl extends AbstractMethod<
     'blockchainValidateEvmRpcUrl',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'blockchainValidateEvmRpcUrl'> }) {
+    constructor(message: MethodMessage<'blockchainValidateEvmRpcUrl'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -1,7 +1,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 import { CancelCoinjoinAuthorization as CancelCoinjoinAuthorizationSchema } from '../types/api/cancelCoinjoinAuthorization';
@@ -10,7 +10,7 @@ export default class CancelCoinjoinAuthorization extends AbstractMethod<
     'cancelCoinjoinAuthorization',
     PROTO.CancelAuthorization
 > {
-    constructor(message: { id?: number; payload: Payload<'cancelCoinjoinAuthorization'> }) {
+    constructor(message: MethodMessage<'cancelCoinjoinAuthorization'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }

--- a/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoComposeTransaction.ts
@@ -2,7 +2,7 @@ import { CoinSelectionError, trezorUtils } from '@fivebinaries/coin-selection';
 
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import {
     type CardanoComposeTransactionParams,
@@ -15,7 +15,7 @@ export default class CardanoComposeTransaction extends AbstractMethod<
     'cardanoComposeTransaction',
     CardanoComposeTransactionParams
 > {
-    constructor(message: { id?: number; payload: Payload<'cardanoComposeTransaction'> }) {
+    constructor(message: MethodMessage<'cardanoComposeTransaction'>) {
         super(message);
         this.useDevice = false;
         this.useDeviceState = false;

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -4,7 +4,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -27,7 +31,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'cardanoGetAddress'> }) {
+    constructor(message: MethodMessage<'cardanoGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Cardano'];

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -3,7 +3,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { CardanoNativeScript } from '../../../types/api/cardano';
@@ -15,7 +15,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
     'cardanoGetNativeScriptHash',
     PROTO.CardanoGetNativeScriptHash
 > {
-    constructor(message: { id?: number; payload: Payload<'cardanoGetNativeScriptHash'> }) {
+    constructor(message: MethodMessage<'cardanoGetNativeScriptHash'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -3,7 +3,11 @@
 import { Assert } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -18,7 +22,7 @@ interface Params extends PROTO.CardanoGetPublicKey {
 export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPublicKey', Params[]> {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'cardanoGetPublicKey'> }) {
+    constructor(message: MethodMessage<'cardanoGetPublicKey'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { CARDANO, PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { CardanoMessageHeaders, CardanoSignedMessage } from '../../../types/api/cardano';
@@ -32,7 +32,7 @@ export default class CardanoSignMessage extends AbstractMethod<
 > {
     static readonly VERSION = 1;
 
-    constructor(message: { id?: number; payload: Payload<'cardanoSignMessage'> }) {
+    constructor(message: MethodMessage<'cardanoSignMessage'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(
             this.name,

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -8,7 +8,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert, Type } from '@trezor/schema-utils';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import {
@@ -76,7 +76,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
     'cardanoSignTransaction',
     CardanoSignTransactionParams
 > {
-    constructor(message: { id?: number; payload: Payload<'cardanoSignTransaction'> }) {
+    constructor(message: MethodMessage<'cardanoSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/changeLanguage.ts
+++ b/packages/connect/src/api/changeLanguage.ts
@@ -2,14 +2,14 @@
 
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { changeLanguage } from '../device/workflow/changeLanguage';
 import { UI_REQUEST } from '../events';
 import { ChangeLanguage as ChangeLanguageSchema } from '../types/api/changeLanguage';
 
 export default class ChangeLanguage extends AbstractMethod<'changeLanguage', ChangeLanguageSchema> {
-    constructor(message: { id?: number; payload: Payload<'changeLanguage'> }) {
+    constructor(message: MethodMessage<'changeLanguage'>) {
         super(message);
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/changePin.ts
+++ b/packages/connect/src/api/changePin.ts
@@ -3,11 +3,11 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class ChangePin extends AbstractMethod<'changePin', PROTO.ChangePin> {
-    constructor(message: { id?: number; payload: Payload<'changePin'> }) {
+    constructor(message: MethodMessage<'changePin'>) {
         super(message);
         this.useDeviceState = false;
         this.skipFinalReload = false;

--- a/packages/connect/src/api/changeWipeCode.ts
+++ b/packages/connect/src/api/changeWipeCode.ts
@@ -1,11 +1,11 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validateParams } from './common/paramsValidator';
 
 export default class ChangeWipeCode extends AbstractMethod<'changeWipeCode', PROTO.ChangeWipeCode> {
-    constructor(message: { id?: number; payload: Payload<'changeWipeCode'> }) {
+    constructor(message: MethodMessage<'changeWipeCode'>) {
         super(message);
         this.skipFinalReload = false;
         this.useDeviceState = false;

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST, createUiMessage } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -17,7 +17,7 @@ export default class CipherKeyValue extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'cipherKeyValue'> }) {
+    constructor(message: MethodMessage<'cipherKeyValue'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -9,7 +9,7 @@ import {
     DEFAULT_TXS_PER_PAGE,
     SOLANA_TXS_PER_PAGE,
 } from '../constants/paging';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { AccountDescriptor } from '../device/DeviceCommands';
@@ -78,7 +78,7 @@ export default class DiscoverAccounts extends AbstractMethod<
 > {
     disposed = false;
 
-    constructor(message: { id?: number; payload: Payload<'discoverAccounts'> }) {
+    constructor(message: MethodMessage<'discoverAccounts'>) {
         super(message);
         this.useDevice = true;
         this.useDeviceState = true;

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -4,7 +4,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -31,7 +35,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'ethereumGetAddress'> }) {
+    constructor(message: MethodMessage<'ethereumGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -3,7 +3,11 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -20,7 +24,7 @@ type Params = PROTO.EthereumGetPublicKey & {
 export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPublicKey', Params[]> {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'ethereumGetPublicKey'> }) {
+    constructor(message: MethodMessage<'ethereumGetPublicKey'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema, MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
@@ -21,7 +21,7 @@ type Params = PROTO.EthereumSignMessage & {
 };
 
 export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMessage', Params> {
-    constructor(message: { id?: number; payload: Payload<'ethereumSignMessage'> }) {
+    constructor(message: MethodMessage<'ethereumSignMessage'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -4,7 +4,7 @@ import type { MessagesSchema } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 import { BigNumber } from '@trezor/utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import type { EthereumNetworkInfoDefinitionValues, TokenInfo } from '../../../types';
@@ -51,7 +51,7 @@ export default class EthereumSignTransaction extends AbstractMethod<
     'ethereumSignTransaction',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'ethereumSignTransaction'> }) {
+    constructor(message: MethodMessage<'ethereumSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -6,7 +6,7 @@ import { MessagesSchema } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork } from '../../../data/coinInfo';
 import { EthereumNetworkInfo } from '../../../types';
@@ -44,7 +44,7 @@ const Params = Type.Intersect([
 ]);
 
 export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignTypedData', Params> {
-    constructor(message: { id?: number; payload: Payload<'ethereumSignTypedData'> }) {
+    constructor(message: MethodMessage<'ethereumSignTypedData'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
 import { EthereumVerifyMessage as EthereumVerifyMessageSchema } from '../../../types';
@@ -14,7 +14,7 @@ export default class EthereumVerifyMessage extends AbstractMethod<
     'ethereumVerifyMessage',
     PROTO.EthereumVerifyMessage
 > {
-    constructor(message: { id?: number; payload: Payload<'ethereumVerifyMessage'> }) {
+    constructor(message: MethodMessage<'ethereumVerifyMessage'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);

--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -1,6 +1,6 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 
@@ -10,7 +10,7 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'evoluGetDelegatedIdentityKey'> }) {
+    constructor(message: MethodMessage<'evoluGetDelegatedIdentityKey'>) {
         super(message);
         this.useDevice = true;
         this.useUi = true;

--- a/packages/connect/src/api/evoluGetNode.ts
+++ b/packages/connect/src/api/evoluGetNode.ts
@@ -1,14 +1,14 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 
 export default class EvoluGetNode extends AbstractMethod<'evoluGetNode', PROTO.EvoluGetNode> {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'evoluGetNode'> }) {
+    constructor(message: MethodMessage<'evoluGetNode'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }

--- a/packages/connect/src/api/evoluSignRegistrationRequest.ts
+++ b/packages/connect/src/api/evoluSignRegistrationRequest.ts
@@ -1,7 +1,7 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 
@@ -11,7 +11,7 @@ export default class EvoluSignRegistrationRequest extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'evoluSignRegistrationRequest'> }) {
+    constructor(message: MethodMessage<'evoluSignRegistrationRequest'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -2,7 +2,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { getFirmwareRange } from './common/paramsValidator';
-import type { MethodPermission, MethodReturnType, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../events';
@@ -21,7 +21,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
     disposed = false;
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'getAccountDescriptor'> }) {
+    constructor(message: MethodMessage<'getAccountDescriptor'>) {
         super(message);
         this.useDevice = true;
         this.useUi = true;

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodPermission, MethodReturnType, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { UI_REQUEST, UI_RESPONSE, createUiMessage } from '../events';
@@ -22,7 +22,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
     hasBundle?: boolean;
     discovery?: Discovery;
 
-    constructor(message: { id?: number; payload: Payload<'getAccountInfo'> }) {
+    constructor(message: MethodMessage<'getAccountInfo'>) {
         super(message);
         this.useDevice = true;
         this.useUi = true;

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -5,12 +5,11 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../constants';
 import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
-import type { MethodPermission, MethodReturnType, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission, MethodReturnType } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { fixCoinInfoNetwork, getBitcoinNetwork, getUniqueNetworks } from '../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../events';
-import type { BitcoinNetworkInfo } from '../types';
-import { Bundle } from '../types';
+import { type BitcoinNetworkInfo, Bundle } from '../types';
 import { GetAddress as GetAddressSchema } from '../types/api/getAddress';
 import { getLabel, getSerializedPath, validatePath } from '../utils/pathUtils';
 
@@ -24,7 +23,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'getAddress'> }) {
+    constructor(message: MethodMessage<'getAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
     }

--- a/packages/connect/src/api/getCoinInfo.ts
+++ b/packages/connect/src/api/getCoinInfo.ts
@@ -3,7 +3,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { CoinInfo } from '../types';
@@ -14,7 +14,7 @@ type Params = {
 };
 
 export default class GetCoinInfo extends AbstractMethod<'getCoinInfo', Params> {
-    constructor(message: { id?: number; payload: Payload<'getCoinInfo'> }) {
+    constructor(message: MethodMessage<'getCoinInfo'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/getFeatures.ts
+++ b/packages/connect/src/api/getFeatures.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetFeatures.js
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 
 export default class GetFeatures extends AbstractMethod<'getFeatures'> {
-    constructor(message: { id?: number; payload: Payload<'getFeatures'> }) {
+    constructor(message: MethodMessage<'getFeatures'>) {
         super(message);
 
         this.useUi = false;

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -1,7 +1,7 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -10,7 +10,7 @@ export default class GetFirmwareHash extends AbstractMethod<
     'getFirmwareHash',
     PROTO.GetFirmwareHash
 > {
-    constructor(message: { id?: number; payload: Payload<'getFirmwareHash'> }) {
+    constructor(message: MethodMessage<'getFirmwareHash'>) {
         super(message);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;

--- a/packages/connect/src/api/getNonce.ts
+++ b/packages/connect/src/api/getNonce.ts
@@ -1,10 +1,10 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class GetNonce extends AbstractMethod<'getNonce', PROTO.GetNonce> {
-    constructor(message: { id?: number; payload: Payload<'getNonce'> }) {
+    constructor(message: MethodMessage<'getNonce'>) {
         super(message);
         this.useDeviceState = false;
         // TODO should nonce really be always used with useEmptyPassphrase (as it currently is)?

--- a/packages/connect/src/api/getSettings.ts
+++ b/packages/connect/src/api/getSettings.ts
@@ -1,11 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetSettings.js
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 
 export default class GetSettings extends AbstractMethod<'getSettings'> {
-    constructor(message: { id?: number; payload: Payload<'getSettings'> }) {
+    constructor(message: MethodMessage<'getSettings'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -1,13 +1,13 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 
 export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadDevice> {
-    constructor(message: { id?: number; payload: Payload<'loadDevice'> }) {
+    constructor(message: MethodMessage<'loadDevice'>) {
         super(message);
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
         this.useDeviceState = false;

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -2,7 +2,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { Address } from '../../../types/params';
@@ -17,7 +17,7 @@ export default class MoneroGetAddress extends AbstractMethod<'moneroGetAddress',
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'moneroGetAddress'> }) {
+    constructor(message: MethodMessage<'moneroGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Monero'];

--- a/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
+++ b/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
@@ -2,7 +2,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { MoneroWatchKey } from '../../../types/api/monero';
@@ -14,7 +14,7 @@ type Params = PROTO.MoneroGetWatchKey & {
 };
 
 export default class MoneroGetWatchKeyMethod extends AbstractMethod<'moneroGetWatchKey', Params> {
-    constructor(message: { id?: number; payload: Payload<'moneroGetWatchKey'> }) {
+    constructor(message: MethodMessage<'moneroGetWatchKey'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Monero'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
+++ b/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
@@ -4,7 +4,7 @@ import { hexToBytes } from '@noble/hashes/utils.js';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { MoneroExportedKeyImage, MoneroKeyImageSyncResult } from '../../../types/api/monero';
@@ -31,7 +31,7 @@ type Params = {
 };
 
 export default class MoneroKeyImageSyncMethod extends AbstractMethod<'moneroKeyImageSync', Params> {
-    constructor(message: { id?: number; payload: Payload<'moneroKeyImageSync'> }) {
+    constructor(message: MethodMessage<'moneroKeyImageSync'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Monero'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/monero/api/moneroSignTransaction.ts
+++ b/packages/connect/src/api/monero/api/moneroSignTransaction.ts
@@ -1,7 +1,11 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';
@@ -57,7 +61,7 @@ export default class MoneroSignTransactionMethod extends AbstractMethod<
         rsig_parts: [],
     };
 
-    constructor(message: { id?: number; payload: Payload<'moneroSignTransaction'> }) {
+    constructor(message: MethodMessage<'moneroSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Monero'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/pushTransaction.ts
+++ b/packages/connect/src/api/pushTransaction.ts
@@ -4,7 +4,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { CoinInfo } from '../types';
@@ -17,7 +17,7 @@ type Params = {
 };
 
 export default class PushTransaction extends AbstractMethod<'pushTransaction', Params> {
-    constructor(message: { id?: number; payload: Payload<'pushTransaction'> }) {
+    constructor(message: MethodMessage<'pushTransaction'>) {
         super(message);
         this.useUi = false;
         this.useDevice = false;

--- a/packages/connect/src/api/recoveryDevice.ts
+++ b/packages/connect/src/api/recoveryDevice.ts
@@ -3,13 +3,13 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { RecoveryDevice as RecoveryDeviceSchema } from '../types/api/recoveryDevice';
 
 export default class RecoveryDevice extends AbstractMethod<'recoveryDevice', PROTO.RecoveryDevice> {
-    constructor(message: { id?: number; payload: Payload<'recoveryDevice'> }) {
+    constructor(message: MethodMessage<'recoveryDevice'>) {
         super(message);
         this.allowDeviceMode = [...this.allowDeviceMode, UI_REQUEST.INITIALIZE];
         this.useDeviceState = false;

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getFirmwareRange } from './common/paramsValidator';
 import { DataManager } from '../data/DataManager';
@@ -11,7 +11,7 @@ import type { ConnectSettings } from '../types';
 import { RequestLoginSchema } from '../types/api/requestLogin';
 
 export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.SignIdentity> {
-    constructor(message: { id?: number; payload: Payload<'requestLogin'> }) {
+    constructor(message: MethodMessage<'requestLogin'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -6,7 +6,7 @@ import { getRandomInt } from '@trezor/utils';
 
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
 import { PROTO } from '../constants';
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -16,7 +16,7 @@ import { calculateXPubHashes } from './firmware/calculateXPubHash';
 type XPubsPerBip43Path = Record<string, string>; // used only internally, not exported
 
 export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.ResetDevice> {
-    constructor(message: { id?: number; payload: Payload<'resetDevice'> }) {
+    constructor(message: MethodMessage<'resetDevice'>) {
         super(message);
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.useDeviceState = false;

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -4,7 +4,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -21,7 +25,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'rippleGetAddress'> }) {
+    constructor(message: MethodMessage<'rippleGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Ripple'];

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { RippleSignTransaction as RippleSignTransactionSchema } from '../../../types/api/ripple';
@@ -14,7 +14,7 @@ export default class RippleSignTransaction extends AbstractMethod<
     'rippleSignTransaction',
     PROTO.RippleSignTx
 > {
-    constructor(message: { id?: number; payload: Payload<'rippleSignTransaction'> }) {
+    constructor(message: MethodMessage<'rippleSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/setBrightness.ts
+++ b/packages/connect/src/api/setBrightness.ts
@@ -3,11 +3,11 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class SetBrightness extends AbstractMethod<'setBrightness', PROTO.SetBrightness> {
-    constructor(message: { id?: number; payload: Payload<'setBrightness'> }) {
+    constructor(message: MethodMessage<'setBrightness'>) {
         super(message);
         this.skipFinalReload = false;
         this.useDeviceState = false;

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -1,12 +1,12 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DEVICE, createDeviceMessage } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
-    constructor(message: { id?: number; payload: Payload<'setBusy'> }) {
+    constructor(message: MethodMessage<'setBusy'>) {
         super(message);
         this.useDeviceState = false;
         this.skipFinalReload = false;

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -1,6 +1,6 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
@@ -9,7 +9,7 @@ export default class ShowDeviceTutorial extends AbstractMethod<
     'showDeviceTutorial',
     PROTO.ShowDeviceTutorial
 > {
-    constructor(message: { id?: number; payload: Payload<'showDeviceTutorial'> }) {
+    constructor(message: MethodMessage<'showDeviceTutorial'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -3,7 +3,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import { initBlockchain, isBackendSupported } from '../../../backend/BlockchainLink';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getCoinInfo } from '../../../data/coinInfo';
 import type { CoinInfo } from '../../../types';
@@ -23,7 +23,7 @@ export default class SolanaComposeTransaction extends AbstractMethod<
     'solanaComposeTransaction',
     SolanaComposeTransactionParams
 > {
-    constructor(message: { id?: number; payload: Payload<'solanaComposeTransaction'> }) {
+    constructor(message: MethodMessage<'solanaComposeTransaction'>) {
         super(message);
         this.useDevice = false;
         this.useUi = false;

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -2,7 +2,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -19,7 +23,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'solanaGetAddress'> }) {
+    constructor(message: MethodMessage<'solanaGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Solana'];

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -3,7 +3,11 @@ import bs58 from 'bs58';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -17,7 +21,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'solanaGetPublicKey'> }) {
+    constructor(message: MethodMessage<'solanaGetPublicKey'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Solana'];

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -32,7 +32,7 @@ import { Assert } from '@trezor/schema-utils';
 import { BigNumber } from '@trezor/utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { SolanaSignTransaction as SolanaSignTransactionSchema } from '../../../types/api/solana';
@@ -45,7 +45,7 @@ import { SOLANA_BASE_FEE, createTransactionShimFromHex } from '../solanaUtils';
 type Params = PROTO.SolanaSignTx & { serialize: boolean };
 
 export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTransaction', Params> {
-    constructor(message: { id?: number; payload: Payload<'solanaSignTransaction'> }) {
+    constructor(message: MethodMessage<'solanaSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Solana'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -4,7 +4,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -21,7 +25,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'stellarGetAddress'> }) {
+    constructor(message: MethodMessage<'stellarGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Stellar'];

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -3,7 +3,7 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import type { StellarTransaction } from '../../../types/api/stellar';
@@ -27,7 +27,7 @@ export default class StellarSignTransaction extends AbstractMethod<
     'stellarSignTransaction',
     Params
 > {
-    constructor(message: { id?: number; payload: Payload<'stellarSignTransaction'> }) {
+    constructor(message: MethodMessage<'stellarSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/telemetryGet.ts
+++ b/packages/connect/src/api/telemetryGet.ts
@@ -1,11 +1,11 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 
 export default class TelemetryGet extends AbstractMethod<'telemetryGet', PROTO.TelemetryGet> {
-    constructor(message: { id?: number; payload: Payload<'telemetryGet'> }) {
+    constructor(message: MethodMessage<'telemetryGet'>) {
         super(message);
         this.useDeviceState = false;
     }

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -4,7 +4,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -21,7 +25,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'tezosGetAddress'> }) {
+    constructor(message: MethodMessage<'tezosGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Tezos'];

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -3,7 +3,11 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { UI_REQUEST, createUiMessage } from '../../../events';
@@ -17,7 +21,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
 > {
     hasBundle?: boolean;
 
-    constructor(message: { id?: number; payload: Payload<'tezosGetPublicKey'> }) {
+    constructor(message: MethodMessage<'tezosGetPublicKey'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -3,7 +3,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { TezosSignTransaction as TezosSignTransactionSchema } from '../../../types/api/tezos';
@@ -15,7 +15,7 @@ export default class TezosSignTransaction extends AbstractMethod<
     'tezosSignTransaction',
     PROTO.TezosSignTx
 > {
-    constructor(message: { id?: number; payload: Payload<'tezosSignTransaction'> }) {
+    constructor(message: MethodMessage<'tezosSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
         this.firmwareRange = getFirmwareRange(

--- a/packages/connect/src/api/thpGetCredentials.ts
+++ b/packages/connect/src/api/thpGetCredentials.ts
@@ -1,13 +1,13 @@
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 import { getThpCredentials } from '../device/thp';
 import { DEVICE, UI_REQUEST } from '../events';
 
 export default class ThpGetCredentials extends AbstractMethod<'thpGetCredentials'> {
-    constructor(message: { id?: number; payload: Payload<'thpGetCredentials'> }) {
+    constructor(message: MethodMessage<'thpGetCredentials'>) {
         super(message);
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.useDeviceState = false;

--- a/packages/connect/src/api/thpRemoveCredentials.ts
+++ b/packages/connect/src/api/thpRemoveCredentials.ts
@@ -1,10 +1,10 @@
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { DataManager } from '../data/DataManager';
 import { UI_REQUEST } from '../events';
 
 export default class ThpRemoveCredentials extends AbstractMethod<'thpRemoveCredentials'> {
-    constructor(message: { id?: number; payload: Payload<'thpRemoveCredentials'> }) {
+    constructor(message: MethodMessage<'thpRemoveCredentials'>) {
         super(message);
         this.useDevice = this.payload.device !== undefined;
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];

--- a/packages/connect/src/api/tron/api/tronGetAddress.ts
+++ b/packages/connect/src/api/tron/api/tronGetAddress.ts
@@ -2,7 +2,11 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, MethodReturnType, Payload } from '../../../core/AbstractMethod';
+import type {
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { UI_REQUEST, createUiMessage } from '../../../events';
 import { Bundle } from '../../../types';
@@ -17,7 +21,7 @@ export default class TronGetAddress extends AbstractMethod<'tronGetAddress', Par
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'tronGetAddress'> }) {
+    constructor(message: MethodMessage<'tronGetAddress'>) {
         super(message);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Tron'];

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -1,7 +1,7 @@
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
-import type { MethodPermission, Payload } from '../../../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import type { TronContractsParameters, TronContractsTypes } from '../../../types/api/tron';
 import { TronSignTransaction as TronSignTransactionSchema } from '../../../types/api/tron';
@@ -17,7 +17,7 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
     hasBundle?: boolean;
     progress = 0;
 
-    constructor(message: { id?: number; payload: Payload<'tronSignTransaction'> }) {
+    constructor(message: MethodMessage<'tronSignTransaction'>) {
         super(message);
         this.requiredDeviceCapabilities = ['Capability_Tron'];
     }

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -1,14 +1,14 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validatePath } from '../utils/pathUtils';
 import { getFirmwareRange } from './common/paramsValidator';
 import { UnlockPathParams } from '../types/api/unlockPath';
 
 export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.UnlockPath> {
-    constructor(message: { id?: number; payload: Payload<'unlockPath'> }) {
+    constructor(message: MethodMessage<'unlockPath'>) {
         super(message);
         this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
     }

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -1,13 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/WipeDevice.js
 
-import type { MethodPermission, Payload } from '../core/AbstractMethod';
+import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import type { Device } from '../device/Device';
 import { DEVICE, UI_REQUEST } from '../events';
 import { getFirmwareRange } from './common/paramsValidator';
 
 export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
-    constructor(message: { id?: number; payload: Payload<'wipeDevice'> }) {
+    constructor(message: MethodMessage<'wipeDevice'>) {
         super(message);
 
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS, UI_REQUEST.BOOTLOADER];

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -38,6 +38,11 @@ export type MethodInfo = {
     confirmation?: UiRequestConfirmation['payload'];
 };
 
+export type MethodMessage<Name extends CallMethodPayload['method']> = {
+    id?: number;
+    payload: Payload<Name>;
+};
+
 export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
     UNKNOWN: { min: '1.0.0', max: '0' },
     T1B1: { min: '1.0.0', max: '0' },
@@ -160,7 +165,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     public initAsync?(): Promise<void>;
 
-    constructor(message: { id?: number; payload: Payload<Name> }) {
+    constructor(message: MethodMessage<Name>) {
         const { payload } = message;
         this.name = payload.method;
         this.payload = payload;


### PR DESCRIPTION
cherry-picked from #25888, pure refactoring, it only introduces MethodMessage type which reduces friction when adding new properties to method constructor in the future.

```
export type MethodMessage<Name extends CallMethodPayload['method']> = {
    id?: number;
    payload: Payload<Name>;
};
```

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=introduce-method-message-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=introduce-method-message-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T12:40:29.654Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->