### PR TITLE
chore(suite): pre-warm vite ESM cache to speed up dev

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -596,5 +596,15 @@ export default defineConfig({
         watch: {
             ignored: ['**/node_modules/**', '**/dist/**', '**/.nx/**', '**/.git/**'],
         },
+        // Pre-transform app source files into Vite's in-memory cache at startup.
+        // This eliminates per-request esbuild transform latency across the ESM import cascade.
+        warmup: {
+            clientFiles: [
+                './vite-index.ts',
+                '../../packages/*/src/**/*.{ts,tsx}',
+                '../../suite/*/src/**/*.{ts,tsx}',
+                '../../suite-common/*/src/**/*.{ts,tsx}',
+            ],
+        },
     },
 });


### PR DESCRIPTION
**TL;DR:**
- local https (HTTP/2 protocol with fetch concurrency), didn't make it any faster → HTTP/1  is **not** a bottleneck
- prewarming didn't work at all

## Description

Small optimization for local dev app with `vite`: prewarm source code modules.

Theoretically this means a little overhead in starting the node vite process, but in my experience, that is never a bottleneck, it's the browser runtime that freezes up when it has to fetch 6200 JS files over http.
That hasn't changed, but the waterfall is now quicker, because each request is faster to respond (still 6200 http roundabout trips, but vite responses each a bit quicker as it doesn't have to run it through esbuild)


### Perf observations
- Previously, I had problems that sometimes browser freezes during the loading. Idk why, maybe because too many requests are pending, or some timeouts? Idk, but now it seems smoother
- Apx. 20–40% reduction in initial load time = from loading page in browser to final rendered content
    - I mean the actual content, **not** the spinner, because app is still fetching ESM resources when spinner spins.

### Notes

I also tried to overcome the 6 parallel connection limit with HTTP/1.1 (used on `http://localhost`).

<img width="690" height="88" alt="Screenshot from 2026-03-17 13-03-03" src="https://github.com/user-attachments/assets/b2a31174-d314-4d38-81fb-237999b3f6aa" />

That sounds like a clear bottleneck, so I tried `@vitejs/plugin-basic-ssl` – run vite with unverfiied https certificate just for the sake of HTTP/2.
HTTP/2 allows up to 100 streams multiplexing.
vite with https protocol worked, but did not make loading any faster :face_with_diagonal_mouth: 
→ the bottleneck is somewhere else than the http request/response time

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=vite-perf-optimization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=vite-perf-optimization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T12:25:22.357Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T12:23:56.104Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->