### PR TITLE
fix(trading): improve type safety for transaction signing timeout handling

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -261,8 +261,7 @@ export const signAndPushSendFormTransactionThunk = createThunk(
 
             // Do not close the modal if the transaction signing timed out
             if (signResponse.payload?.error === 'sign-transaction-timeout') {
-                // TODO: this is some kinda bizarre hack
-                return { type: signResponse.error.message } as any;
+                return { type: 'sign-transaction-timeout' as const };
             }
 
             // Close the modal manually since UI.CLOSE_UI.WINDOW was

--- a/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/__tests__/recomposeAndSignTxThunk.test.ts
@@ -448,6 +448,44 @@ describe('recomposeAndSignTxThunk', () => {
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(0);
     });
 
+    it('should reject with sign-transaction-timeout when signAndPushSendFormTransaction returns timeout signal', async () => {
+        const { store, account, tradingFormState } = getMocks();
+
+        const mockSignAndPushSendFormTransaction = jest
+            .fn()
+            .mockResolvedValueOnce({ type: 'sign-transaction-timeout' });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            outputs: [{ amount: '10000000' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('rejected');
+        expect(response.payload).toEqual({
+            type: 'sign-transaction-timeout',
+            error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+        });
+        expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(1);
+    });
+
     it('should return successful recomposed and signed transaction', async () => {
         const { store, account, tradingFormState } = getMocks({
             composedTransactionInfo: {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -27,6 +27,7 @@ import type {
     TradingFulfillValue,
     TradingSendRejectedProps,
     TradingSignAndPushSendFormTransactionProps,
+    TradingSignTimeoutResult,
 } from '../../types';
 
 export type RecomposeAndSignTxThunkProps = {
@@ -52,6 +53,9 @@ export type RecomposeAndSignTxThunkProps = {
         paymentRequests,
     }: TradingSignAndPushSendFormTransactionProps) => Promise<TradingFulfillValue>;
 };
+
+const isSignTimeoutResult = (value: TradingFulfillValue): value is TradingSignTimeoutResult =>
+    value != null && 'type' in value && value.type === 'sign-transaction-timeout';
 
 /**
  * This thunk is particularly useful for scenarios where transaction details (e.g., fees, outputs) need to be recalculated
@@ -269,6 +273,13 @@ export const recomposeAndSignTxThunk = createThunk<
             selectedAccount: account,
             paymentRequests,
         });
+
+        if (isSignTimeoutResult(resultOfSignedTransaction)) {
+            return rejectWithValue({
+                type: resultOfSignedTransaction.type,
+                error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+            });
+        }
 
         return fulfillWithValue(resultOfSignedTransaction);
     },

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -27,6 +27,7 @@ import type {
     TradingFulfillValue,
     TradingSendRejectedProps,
     TradingSignAndPushSendFormTransactionProps,
+    TradingSignResult,
     TradingSignTimeoutResult,
 } from '../../types';
 
@@ -51,10 +52,10 @@ export type RecomposeAndSignTxThunkProps = {
         precomposedTransaction,
         selectedAccount,
         paymentRequests,
-    }: TradingSignAndPushSendFormTransactionProps) => Promise<TradingFulfillValue>;
+    }: TradingSignAndPushSendFormTransactionProps) => Promise<TradingSignResult>;
 };
 
-const isSignTimeoutResult = (value: TradingFulfillValue): value is TradingSignTimeoutResult =>
+const isSignTimeoutResult = (value: TradingSignResult): value is TradingSignTimeoutResult =>
     value != null && 'type' in value && value.type === 'sign-transaction-timeout';
 
 /**

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -113,6 +113,13 @@ describe('sendDexTransactionThunk', () => {
             ['when payload is undefined', undefined],
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
+            [
+                'when sign transaction timed out',
+                {
+                    type: 'sign-transaction-timeout',
+                    error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+                },
+            ],
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account } = getMocks();
 

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -234,6 +234,13 @@ describe('sendTransactionThunk', () => {
             ['when payload is undefined', undefined],
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
+            [
+                'when sign transaction timed out',
+                {
+                    type: 'sign-transaction-timeout',
+                    error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+                },
+            ],
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account, trade } = getMocks();
 

--- a/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/sendSellTransactionThunk.test.ts
@@ -142,6 +142,13 @@ describe('sendSellTransactionThunk', () => {
             ['when payload is undefined', undefined],
             ['when payload contains error', { type: 'error', error: { id: 'TR_ERROR' } }],
             ['when payload is not successful', { success: false }],
+            [
+                'when sign transaction timed out',
+                {
+                    type: 'sign-transaction-timeout',
+                    error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
+                },
+            ],
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, account, formValues, trade, mockNextStep } = getMocks();
 

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -342,4 +342,10 @@ export type TradingVerifiedAddress =
       }
     | undefined;
 
-export type TradingFulfillValue = Ok<{ txid: string }> | Err<SerializedError> | undefined;
+export type TradingSignTimeoutResult = { type: 'sign-transaction-timeout' };
+
+export type TradingFulfillValue =
+    | Ok<{ txid: string }>
+    | Err<SerializedError>
+    | TradingSignTimeoutResult
+    | undefined;

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -344,8 +344,6 @@ export type TradingVerifiedAddress =
 
 export type TradingSignTimeoutResult = { type: 'sign-transaction-timeout' };
 
-export type TradingFulfillValue =
-    | Ok<{ txid: string }>
-    | Err<SerializedError>
-    | TradingSignTimeoutResult
-    | undefined;
+export type TradingFulfillValue = Ok<{ txid: string }> | Err<SerializedError> | undefined;
+
+export type TradingSignResult = TradingFulfillValue | TradingSignTimeoutResult;


### PR DESCRIPTION
## Description

- Replace untyped timeout return in send flow with explicit typed result (`{ type: 'sign-transaction-timeout' }`) in `signAndPushSendFormTransactionThunk`.
- Introduce `TradingSignTimeoutResult` and extend `TradingFulfillValue` so timeout is represented as a first-class type.
- Add `isSignTimeoutResult` type guard in `recomposeAndSignTxThunk` and reject with stable trading error payload when signing times out.
- Add regression tests for timeout propagation in trading thunks.

## Notes for QA

- Verify normal trading send flow still succeeds when signing and push succeed.
- Verify when signing times out, trading flow is rejected with:
  - `type: sign-transaction-timeout`
  - `error.id: TR_TRADING_CANNOT_SEND_TRANSACTION`
- Focus on:
  - `recomposeAndSignTxThunk` timeout branch
  - send/sell/dex thunk behavior on timeout path
- No UI/visual changes expected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25963

## Screenshots:

<img width="600" height="493" alt="image" src="https://github.com/user-attachments/assets/78358495-f23b-415a-a46b-e2082e061167" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-sign-tx-timeout-type-safety&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-sign-tx-timeout-type-safety&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-sign-tx-timeout-type-safety&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T15:29:08.178Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T15:28:02.911Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->