### PR TITLE
fix(ci): exclude husky from shellcheck

### DIFF
--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -7,4 +7,12 @@ set -o pipefail
 
 shellcheck --version
 # lint all *.sh files
-find . -type f -name '*.sh' ! -path './node_modules/*' ! -path './yarn/*' ! -path './suite-native/app/ios/*' ! -path './submodules/*' -print0 | xargs -0 shellcheck
+find . -type f \
+    -name '*.sh' \
+    ! -path './node_modules/*' \
+    ! -path './yarn/*' \
+    ! -path './suite-native/app/ios/*' \
+    ! -path './submodules/*' \
+    ! -path './.husky/_/*' \
+    -print0 |
+    xargs -0 shellcheck


### PR DESCRIPTION
## Description

Exclude `/.husky/_` folder from shellcheck, because that's an autogenerated folder.
Also format the command to multiple lines for clarity.

To be sure I tested it by `cp .husky/_/husky.sh ./.husky && yarn lint:shellcheck` (still fails :heavy_check_mark: )

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/shellcheck&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/shellcheck&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T15:36:17.777Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T15:34:22.332Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->