### PR TITLE
fix(blockchain-link): use connect variant available in react-native-tcp-socket

### DIFF
--- a/packages/blockchain-link/src/workers/electrum/sockets/tcp.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tcp.ts
@@ -12,7 +12,8 @@ export class TcpSocket extends SocketBase {
         return new Promise<TCPSocket>((resolve, reject) => {
             const errorHandler = (err: Error) => reject(err);
             socket.on('error', errorHandler);
-            socket.connect(this.port, this.host, () => {
+            // The React Native implementation requires connect(options[, callback]) to be used.
+            socket.connect({ host: this.host, port: this.port }, () => {
                 socket.removeListener('error', errorHandler);
                 resolve(socket);
             });

--- a/packages/blockchain-link/src/workers/electrum/sockets/tls.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/tls.ts
@@ -16,6 +16,7 @@ export class TlsSocket extends SocketBase {
         return new Promise<TLSSocket>((resolve, reject) => {
             const errorHandler = (err: Error) => reject(err);
             socket.on('error', errorHandler);
+            // The React Native implementation requires connect(options[, callback]) to be used.
             socket.connect({ host: this.host, port: this.port }, () => {
                 socket.removeListener('error', errorHandler);
                 resolve(socket);


### PR DESCRIPTION
As described in the [react-native-tcp-socket](https://github.com/Rapsssito/react-native-tcp-socket?tab=readme-ov-file#net) repo, only `connect(options[, callback])` is supported.

## Related Issue

Resolve #25820

## Screenshots:

| iOS | Android |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/bf4dac20-cc09-4f57-9648-17c8359bd19e" /> | <img width="1080" height="2340" alt="Screenshot_20260317_165322" src="https://github.com/user-attachments/assets/3d602a3a-8b40-476e-a96f-fb8ee14cf09a" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link/electrum-native-tcp-connection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link/electrum-native-tcp-connection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T16:08:02.316Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T16:04:37.289Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->