### PR TITLE
fix(suite): navigate to correct network when clicking stake on dashboard

### DIFF
--- a/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
@@ -5,24 +5,27 @@ import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-commo
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
 
 import { useAccountSearch, useDispatch, useSelector } from 'src/hooks/suite';
 
-type TradingButtonProps = {
+type AssetActionButtonRoute = Extract<Route['name'], 'wallet-staking' | 'wallet-trading-buy'>;
+
+type AssetActionButtonProps = {
     children: ReactNode;
     onClick?: () => void;
     symbol: NetworkSymbol;
-    routeName: Route['name'];
+    routeName: AssetActionButtonRoute;
     'data-testid'?: string;
 };
 
-export const TradingButton = ({
+export const AssetActionButton = ({
     children,
     onClick: onButtonClick,
     symbol,
     routeName,
     'data-testid': dataTest,
-}: TradingButtonProps) => {
+}: AssetActionButtonProps) => {
     const dispatch = useDispatch();
     const { toggleCoinFilter, setSearchString } = useAccountSearch();
     const accounts = useSelector(selectVisibleDeviceAccounts);
@@ -34,15 +37,32 @@ export const TradingButton = ({
             a => a.symbol === symbol && a.accountType === 'normal' && a.index === 0,
         );
 
-        if (account) {
-            dispatch(
-                tradingActions.setTradingFromPrefilledAccount(
-                    getTradingPrefilledFromAccountData(account),
-                ),
-            );
+        switch (routeName) {
+            case 'wallet-staking':
+                dispatch(
+                    goto({
+                        routeName,
+                        params: {
+                            symbol,
+                            accountIndex: account?.index ?? 0,
+                            accountType: account?.accountType ?? 'normal',
+                        },
+                    }),
+                );
+                break;
+            case 'wallet-trading-buy':
+                if (account) {
+                    dispatch(
+                        tradingActions.setTradingFromPrefilledAccount(
+                            getTradingPrefilledFromAccountData(account),
+                        ),
+                    );
+                }
+                dispatch(goto({ routeName }));
+                break;
+            default:
+                exhaustive(routeName);
         }
-
-        dispatch(goto({ routeName }));
         toggleCoinFilter(symbol);
         setSearchString(undefined);
 

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -35,7 +35,7 @@ import { useAnalytics } from 'src/support/useAnalytics';
 
 import { AssetCardInfo, AssetCardInfoSkeleton } from './AssetCardInfo';
 import { AssetCardTokensAndStakingInfo } from './AssetCardTokensAndStakingInfo';
-import { TradingButton } from '../TradingButton';
+import { AssetActionButton } from '../AssetActionButton';
 import { handleTokensAndStakingData } from '../assetsViewUtils';
 
 type AmountComponentProps = {
@@ -209,24 +209,24 @@ export const AssetCard = ({
 
                             <Row gap={8}>
                                 {isStakeNetwork && (
-                                    <TradingButton
+                                    <AssetActionButton
                                         symbol={symbol}
                                         data-testid={`@dashboard/asset/${symbol}/stake-button`}
                                         onClick={onStakeButtonClick}
                                         routeName="wallet-staking"
                                     >
                                         <Translation id="TR_STAKE_STAKE" />
-                                    </TradingButton>
+                                    </AssetActionButton>
                                 )}
 
-                                <TradingButton
+                                <AssetActionButton
                                     symbol={symbol}
                                     routeName="wallet-trading-buy"
                                     data-testid={`@dashboard/asset/${symbol}/buy-button`}
                                     onClick={onBuyButtonClick}
                                 >
                                     <Translation id="TR_BUY_BUY" />
-                                </TradingButton>
+                                </AssetActionButton>
                             </Row>
                         </Row>
                     </Card>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -11,7 +11,6 @@ import { type Account, type RatesByKey } from '@suite-common/wallet-types';
 import { type AmountUnit, isTestnet } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
 import { Column, Icon, IconButton, Row, Table, Text } from '@trezor/components';
-import { spacings } from '@trezor/theme';
 
 import {
     AmountUnitSwitchWrapper,
@@ -29,7 +28,7 @@ import { AssetCoinName } from '../AssetCoinName';
 import { AssetStakingRow } from './AssetStakingRow';
 import { AssetTableExtraRowsSection as Section } from './AssetTableExtraRowsSection';
 import { AssetTokenRow } from './AssetTokenRow';
-import { TradingButton } from '../TradingButton';
+import { AssetActionButton } from '../AssetActionButton';
 import { handleTokensAndStakingData } from '../assetsViewUtils';
 
 export interface AssetTableRowProps {
@@ -139,7 +138,7 @@ export const AssetRow = memo(
                             />
                         </Section>
                     </Table.Cell>
-                    <Table.Cell padding={{ left: spacings.zero }}>
+                    <Table.Cell padding={{ left: 0 }}>
                         <AssetCoinName network={network} />
                     </Table.Cell>
                     <Table.Cell>
@@ -147,7 +146,7 @@ export const AssetRow = memo(
                             <Column
                                 alignItems="flex-start"
                                 justifyContent="center"
-                                gap={spacings.xxxs}
+                                gap={2}
                                 data-testid={`@dashboard/asset/${symbol}/fiat-amount`}
                             >
                                 <BaseCurrencyValue
@@ -172,7 +171,7 @@ export const AssetRow = memo(
                             </Column>
                         ) : (
                             <Text intent="critical" typographyStyle="body-sm" textWrap="nowrap">
-                                <Row gap={spacings.xxs}>
+                                <Row gap={4}>
                                     <Icon name="warning" intent="critical" size={14} />
                                     <Translation id="TR_DASHBOARD_ASSET_FAILED" />
                                 </Row>
@@ -187,26 +186,26 @@ export const AssetRow = memo(
                         {shallDisplayBaseCurrency && <TrendTicker symbol={symbol} />}
                     </Table.Cell>
                     <Table.Cell align="end" colSpan={2}>
-                        <Row gap={spacings.md}>
+                        <Row gap={16}>
                             {isStakeNetwork && (
-                                <TradingButton
+                                <AssetActionButton
                                     symbol={symbol}
                                     onClick={onStakeButtonClick}
                                     routeName="wallet-staking"
                                 >
                                     <Translation id="TR_STAKE_STAKE" />
-                                </TradingButton>
+                                </AssetActionButton>
                             )}
 
                             {!isTestnet(symbol) && (
-                                <TradingButton
+                                <AssetActionButton
                                     symbol={symbol}
                                     routeName="wallet-trading-buy"
                                     data-testid={`@dashboard/asset/${symbol}/buy-button`}
                                     onClick={onBuyButtonClick}
                                 >
                                     <Translation id="TR_BUY_BUY" />
-                                </TradingButton>
+                                </AssetActionButton>
                             )}
                             <IconButton icon="arrowRight" intent="neutral" priority="secondary" />
                         </Row>

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -30,7 +30,7 @@ import {
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode, TokenInfo } from '@trezor/blockchain-link-types';
 import { Button, Card, Icon, IconButton, LoadingContent, Row } from '@trezor/components';
-import { spacings, spacingsPx, typography } from '@trezor/theme';
+import { spacingsPx, typography } from '@trezor/theme';
 import { type PartialRecord } from '@trezor/type-utils';
 import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
@@ -190,7 +190,7 @@ export const AssetsView = () => {
                 isBelowTablet ? (
                     <></>
                 ) : (
-                    <Row justifyContent="space-around" gap={spacings.sm}>
+                    <Row justifyContent="space-around" gap={12}>
                         {hasMainnetNetworksToEnable && (
                             <Button
                                 intent="neutral"
@@ -250,7 +250,7 @@ export const AssetsView = () => {
                                     name="warning"
                                     intent="critical"
                                     size={14}
-                                    margin={{ right: spacings.xxs }}
+                                    margin={{ right: 4 }}
                                 />
                                 <Translation id="TR_DASHBOARD_ASSETS_ERROR" />
                             </InfoMessage>
@@ -273,7 +273,7 @@ export const AssetsView = () => {
                                 name="warning"
                                 intent="critical"
                                 size={14}
-                                margin={{ right: spacings.xxs }}
+                                margin={{ right: 4 }}
                             />
                             <Translation id="TR_DASHBOARD_ASSETS_ERROR" />
                         </InfoMessage>


### PR DESCRIPTION
## Description

When clicking the staking button on the dashboard, the app was navigating to `wallet-staking` without explicit route params, which caused the staking page to open for the last active account instead of the selected cryptocurrency.

Fix passes explicit `symbol`, `accountIndex`, and `accountType` params when navigating to `wallet-staking` from `TradingButton`.

Also:
- Restricts `routeName` prop to a `TradingButtonRoute` union type (`wallet-staking | wallet-trading-buy`) for type safety
- Replaces deprecated `spacings.*` token usage with literal values in `AssetRow` and `AssetsView`

## Notes for QA

On the dashboard, click the Stake button for a cryptocurrency that is **not** the currently active account. Verify the staking page opens for the correct cryptocurrency.

## Related Issue

Resolve #25995

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dashboard-staking-button-wrong-network&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dashboard-staking-button-wrong-network&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T17:08:55.613Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T17:07:00.428Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->