### PR TITLE
Feat/protobuf manager

### DIFF
--- a/packages/protobuf/src/bufbuild-loader.ts
+++ b/packages/protobuf/src/bufbuild-loader.ts
@@ -1,0 +1,61 @@
+import * as bitcoinProto from './definitions/messages-bitcoin_pb';
+import * as bleProto from './definitions/messages-ble_pb';
+import * as bootloaderProto from './definitions/messages-bootloader_pb';
+import * as cardanoProto from './definitions/messages-cardano_pb';
+import * as commonProto from './definitions/messages-common_pb';
+import * as cryptoProto from './definitions/messages-crypto_pb';
+import * as debugProto from './definitions/messages-debug_pb';
+import * as definitionsProto from './definitions/messages-definitions_pb';
+import * as eosProto from './definitions/messages-eos_pb';
+import * as ethereumEip712Proto from './definitions/messages-ethereum-eip712_pb';
+import * as ethereumProto from './definitions/messages-ethereum_pb';
+import * as evoluProto from './definitions/messages-evolu_pb';
+import * as managementProto from './definitions/messages-management_pb';
+import * as moneroProto from './definitions/messages-monero_pb';
+import * as rippleProto from './definitions/messages-ripple_pb';
+import * as solanaProto from './definitions/messages-solana_pb';
+import * as stellarProto from './definitions/messages-stellar_pb';
+import * as telemetryProto from './definitions/messages-telemetry_pb';
+import * as tezosProto from './definitions/messages-tezos_pb';
+import * as thpProto from './definitions/messages-thp_pb';
+import * as tronProto from './definitions/messages-tron_pb';
+import * as messagesProto from './definitions/messages_pb';
+import * as optionsProto from './definitions/options_pb';
+import { ProtobufManager } from './manager';
+
+const bufbuildDebugEnvValue =
+    typeof process !== 'undefined' && typeof process.env !== 'undefined'
+        ? process.env.BUFBUILD_DEBUG
+        : undefined;
+
+export const isBufbuildDebugEnabled =
+    bufbuildDebugEnvValue !== '0' && bufbuildDebugEnvValue !== 'false';
+
+const protobufManager = isBufbuildDebugEnabled ? ProtobufManager() : undefined;
+protobufManager?.load([
+    bitcoinProto,
+    bleProto,
+    bootloaderProto,
+    cardanoProto,
+    commonProto,
+    cryptoProto,
+    debugProto,
+    definitionsProto,
+    eosProto,
+    ethereumEip712Proto,
+    ethereumProto,
+    evoluProto,
+    managementProto,
+    moneroProto,
+    rippleProto,
+    solanaProto,
+    stellarProto,
+    telemetryProto,
+    tezosProto,
+    thpProto,
+    tronProto,
+    messagesProto,
+    optionsProto,
+]);
+
+export { protobufManager };

--- a/packages/protobuf/src/decode.ts
+++ b/packages/protobuf/src/decode.ts
@@ -1,5 +1,6 @@
 import type * as protobuf from 'protobufjs/light';
 
+import { protobufManager } from './bufbuild-loader';
 import type { MessageResponse } from './messages';
 import { createMessageFromType, isPrimitiveField } from './utils';
 
@@ -88,6 +89,18 @@ export const decodeMessage = (
 ) => {
     const { Message, messageName } = createMessageFromType(messages, messageType);
     const message = decode(Message, data);
+
+    // This should be removed once we have confidence in the new implementation.
+    if (protobufManager) {
+        try {
+            const bufbuildResult = protobufManager.decode(messageName, data);
+            if (JSON.stringify(message) !== JSON.stringify(bufbuildResult.message)) {
+                console.error(`[bufbuild] decode mismatch for "${messageName}"`);
+            }
+        } catch (error) {
+            console.error(`[bufbuild] bufbuild decode failed for "${messageName}":`, error);
+        }
+    }
 
     return { type: messageName, message } as MessageResponse;
 };

--- a/packages/protobuf/src/encode.ts
+++ b/packages/protobuf/src/encode.ts
@@ -1,5 +1,6 @@
 import * as protobuf from 'protobufjs/light';
 
+import { protobufManager } from './bufbuild-loader';
 import { createMessageFromName, isPrimitiveField } from './utils';
 
 type Type = protobuf.Type;
@@ -105,6 +106,18 @@ export const encodeMessage = (
 ) => {
     const { Message, messageType } = createMessageFromName(messages, messageName);
     const message = encode(Message, data);
+
+    // This should be removed once we have confidence in the new implementation.
+    if (protobufManager) {
+        try {
+            const bufbuildResult = protobufManager.encode(messageName, data);
+            if (message.compare(bufbuildResult.message) !== 0) {
+                console.error(`[bufbuild] encode mismatch for "${messageName}"`);
+            }
+        } catch (error) {
+            console.error(`[bufbuild] encode failed for "${messageName}":`, error);
+        }
+    }
 
     return { messageType, message };
 };

--- a/packages/protobuf/src/manager.ts
+++ b/packages/protobuf/src/manager.ts
@@ -1,0 +1,310 @@
+import {
+    type AnyDesc,
+    type DescEnum,
+    type DescExtension,
+    type DescField,
+    type DescMessage,
+    ScalarType,
+    fromBinary,
+    fromJson,
+    toBinary,
+    toJson,
+} from '@bufbuild/protobuf';
+
+import type { MessageResponse } from './messages';
+
+const patchLongValue = (value: unknown) => {
+    if (typeof value === 'number') {
+        return value;
+    }
+
+    const numericValue = Number(value);
+    if (typeof value === 'bigint') {
+        return Number.isSafeInteger(numericValue) ? numericValue : value.toString();
+    }
+
+    if (typeof value === 'string') {
+        if (Number.isSafeInteger(numericValue)) {
+            try {
+                if (BigInt(value) === BigInt(numericValue)) {
+                    return numericValue;
+                }
+            } catch {
+                return value;
+            }
+        }
+
+        return value;
+    }
+
+    return value;
+};
+
+const patchFieldForEncode = (field: DescField, value: unknown) => {
+    if (value === undefined) {
+        return value;
+    }
+
+    if (field.scalar === ScalarType.STRING) {
+        if (typeof value === 'number') {
+            return value.toString(); // Features.model
+        }
+
+        return value;
+    }
+
+    if (field.scalar === ScalarType.BYTES) {
+        // Protobuf bytes fields are represented as hex strings in Suite payloads.
+        // Convert to raw bytes before calling fromJson().
+        if (typeof value === 'string') {
+            return value.length === 0 ? Buffer.alloc(0) : Buffer.from(value, 'hex');
+        }
+
+        return Buffer.from(value as Uint8Array | number[]);
+    }
+
+    return value;
+};
+
+const patchFieldForDecode = (field: DescField, value: unknown) => {
+    // [compatibility]: optional undefined keys should be null. Example: Features.fw_major.
+    if (value === undefined) {
+        return null;
+    }
+
+    if (field.scalar === ScalarType.BYTES) {
+        // Keep backward compatibility: consumers expect bytes as lower-level hex strings.
+        if (typeof value === 'string') {
+            return Buffer.from(value, 'base64').toString('hex');
+        }
+
+        return Buffer.from(value as Uint8Array | number[]).toString('hex');
+    }
+
+    if (field.scalar === ScalarType.UINT32 || field.scalar === ScalarType.SINT32) {
+        return Number(value);
+    }
+
+    if (
+        field.scalar === ScalarType.INT64 ||
+        field.scalar === ScalarType.UINT64 ||
+        field.scalar === ScalarType.SINT64 ||
+        field.scalar === ScalarType.FIXED64 ||
+        field.scalar === ScalarType.SFIXED64
+    ) {
+        return patchLongValue(value);
+    }
+
+    return value;
+};
+
+const transformSchemaFields = (
+    schema: DescMessage,
+    sourceData: Record<string, unknown> | undefined,
+    transformField: (field: DescField, value: unknown) => unknown,
+) => {
+    const transformedData: Record<string, unknown> = {};
+
+    schema.fields.forEach(schemaField => {
+        const fieldValue = sourceData?.[schemaField.name];
+
+        if (schemaField.fieldKind === 'list') {
+            if (!Array.isArray(fieldValue)) {
+                transformedData[schemaField.name] = [];
+            } else if (schemaField.listKind === 'message') {
+                transformedData[schemaField.name] = fieldValue.map(item =>
+                    transformSchemaFields(
+                        schemaField.message,
+                        item as Record<string, unknown> | undefined,
+                        transformField,
+                    ),
+                );
+            } else if (schemaField.listKind === 'scalar') {
+                transformedData[schemaField.name] = fieldValue.map(item =>
+                    transformField(schemaField, item),
+                );
+            } else {
+                transformedData[schemaField.name] = fieldValue; // enum
+            }
+        } else if (schemaField.fieldKind === 'message') {
+            transformedData[schemaField.name] = fieldValue
+                ? transformSchemaFields(
+                      schemaField.message,
+                      fieldValue as Record<string, unknown>,
+                      transformField,
+                  )
+                : undefined;
+        } else if (schemaField.fieldKind === 'scalar') {
+            transformedData[schemaField.name] = transformField(schemaField, fieldValue);
+        } else if (schemaField.fieldKind === 'enum') {
+            transformedData[schemaField.name] = fieldValue;
+        } else {
+            transformedData[schemaField.name] = fieldValue; // map
+        }
+
+        if (transformedData[schemaField.name] === undefined) {
+            delete transformedData[schemaField.name];
+        }
+    });
+
+    return transformedData;
+};
+
+export const ProtobufManager = () => {
+    const messages: Record<string, DescMessage | undefined> = {};
+    const extensions: Record<string, DescExtension | undefined> = {};
+    const enums: Record<string, DescEnum | undefined> = {};
+
+    const load = (modules: Record<string, AnyDesc> | Record<string, AnyDesc>[]) => {
+        if (Array.isArray(modules)) {
+            modules.forEach(m => load(m));
+        } else {
+            Object.keys(modules).forEach(key => {
+                const def = modules[key];
+                if (def.kind && def.kind !== 'file') {
+                    if (def.kind === 'message') {
+                        messages[key] = def;
+                    } else if (def.kind === 'extension') {
+                        extensions[key] = def;
+                    } else if (def.kind === 'enum') {
+                        enums[def.name] = def;
+                    }
+                }
+            });
+        }
+    };
+
+    // (wire_type) is a custom option this is why it is to be found in '$unknown' options
+    // as { no: option_id, data: Uint8Array }
+    const getWireTypeOverride = (schema: AnyDesc) => {
+        const unknownOptions = schema.proto.options?.['$unknown'] ?? [];
+        if (unknownOptions.length === 0) {
+            return;
+        }
+
+        const wireTypeExtension = extensions['wire_type'];
+        const wireTypeOption = unknownOptions.find(o => o.no === wireTypeExtension?.number);
+
+        return wireTypeOption ? wireTypeOption.data[0] : undefined;
+    };
+
+    const findEnum = (enumName: string) => enums[enumName];
+
+    const findSchema = (nameOrId: number | string) => {
+        const messageTypeEnum = findEnum('MessageType');
+        const thpMessageTypeEnum = findEnum('ThpMessageType');
+
+        if (typeof nameOrId === 'string') {
+            const schemaKey = `${nameOrId}Schema`;
+            const schema = messages[schemaKey];
+
+            if (!schema) {
+                throw new Error(`Schema ${nameOrId} not found`);
+            }
+
+            // Try to find message type enum value
+            // -1 is expected for ThpMessageType and other non-standard messages
+            let messageType = -1;
+            if (thpMessageTypeEnum) {
+                const thpEnum = thpMessageTypeEnum.values.find(
+                    k => k.name === 'ThpMessageType_' + schema.name,
+                );
+                if (thpEnum) {
+                    messageType = thpEnum.number;
+                }
+            }
+
+            if (messageType === -1 && messageTypeEnum) {
+                const mtEnum = messageTypeEnum.values.find(
+                    k => k.name === 'MessageType_' + schema.name,
+                );
+                if (mtEnum) {
+                    messageType = mtEnum.number;
+                }
+            }
+
+            return {
+                schema,
+                messageType: getWireTypeOverride(schema) || messageType,
+                messageName: nameOrId,
+            };
+        }
+
+        // Lookup by numeric ID
+        let matchedMessageType = messageTypeEnum?.value[nameOrId];
+        if (!matchedMessageType && thpMessageTypeEnum) {
+            matchedMessageType = thpMessageTypeEnum.value[nameOrId];
+        }
+
+        if (!matchedMessageType) {
+            throw new Error(
+                `MessageType with ID ${nameOrId} not found. Check MessageType and ThpMessageType enums.`,
+            );
+        }
+
+        const messageName = matchedMessageType.name
+            .replace('ThpMessageType_', '')
+            .replace('MessageType_', '');
+        const schemaKey = messageName + 'Schema';
+        const schema = messages[schemaKey];
+
+        if (!schema) {
+            throw new Error(
+                `Schema "${messageName}" (from ID ${nameOrId}) not found. Available: ${Object.keys(messages).length}`,
+            );
+        }
+
+        return {
+            schema,
+            messageType: getWireTypeOverride(schema) || nameOrId,
+            messageName,
+        };
+    };
+
+    const encode = (messageName: string, data: Record<string, unknown>) => {
+        const { schema, messageType } = findSchema(messageName);
+
+        const normalizedPayload = transformSchemaFields(schema, data, patchFieldForEncode);
+        const messageJson = fromJson(schema, normalizedPayload as Parameters<typeof fromJson>[1]);
+        const encodedBytes = toBinary(schema, messageJson);
+
+        return {
+            messageType,
+            message: Buffer.from(encodedBytes),
+        };
+    };
+
+    const decode = (type: string | number, data: Buffer | Uint8Array) => {
+        const { schema, messageName } = findSchema(type);
+        const binaryPayload = Buffer.isBuffer(data) ? data : Buffer.from(data);
+
+        // FW issue: THP codec_v1 sends Failure_InvalidProtocol as 20 bytes instead of 2
+        // https://github.com/trezor/trezor-firmware/pull/6549
+        const patchedPayload =
+            messageName === 'Failure' &&
+            binaryPayload.subarray(0, 2).compare(Buffer.from('0811', 'hex')) === 0
+                ? binaryPayload.subarray(0, 2)
+                : binaryPayload;
+
+        const decoded = fromBinary(schema, patchedPayload, { readUnknownFields: false }); // , { readUnknownFields: true }
+        const json = toJson(schema, decoded, { useProtoFieldName: true });
+        const message = transformSchemaFields(
+            schema,
+            json as Record<string, unknown>,
+            patchFieldForDecode,
+        );
+
+        return {
+            type: messageName,
+            message,
+        } as MessageResponse;
+    };
+
+    return {
+        load,
+        findSchema,
+        findEnum,
+        encode,
+        decode,
+    };
+};

--- a/packages/protobuf/tests/bufbuild-comprehensive.test.ts
+++ b/packages/protobuf/tests/bufbuild-comprehensive.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Comprehensive Unit Tests for ProtobufManager (@bufbuild implementation)
+ * Tests verify equivalence with protobufjs implementation using REAL messages from messages.json
+ *
+ * This test should be removed once we have confidence in the new implementation and full coverage of all messages and enums.
+ */
+
+import { AnyDesc, ScalarType } from '@bufbuild/protobuf';
+import * as ProtoBuf from 'protobufjs/light';
+
+import * as messagesJson from '../messages.json';
+import { RULE_PATCH } from '../scripts/protobuf-patches';
+import { decode as decodeProtobufJs } from '../src/decode';
+import { encode as encodeProtobufJs } from '../src/encode';
+import { ProtobufManager } from '../src/manager';
+
+type JsonFieldDefinition = {
+    type?: string;
+    rule?: string;
+};
+
+type JsonMessageDefinition = {
+    fields?: Record<string, JsonFieldDefinition>;
+    nested?: Record<string, JsonMessageDefinition | JsonEnumDefinition>;
+};
+
+type JsonEnumDefinition = {
+    values?: Record<string, number>;
+};
+
+type JsonSchema = {
+    nested?: Record<string, JsonMessageDefinition | JsonEnumDefinition>;
+};
+
+type TestPayload = Record<string, unknown>;
+
+const messagesJsonSchema = messagesJson as unknown as JsonSchema;
+
+const isJsonMessageDefinition = (
+    definition: JsonMessageDefinition | JsonEnumDefinition | undefined,
+): definition is JsonMessageDefinition => !!definition && 'fields' in definition;
+
+const getMessageDefinition = (messageName: string): JsonMessageDefinition | undefined => {
+    const definition = messagesJsonSchema.nested?.[messageName];
+    if (!isJsonMessageDefinition(definition)) {
+        return undefined;
+    }
+
+    return definition;
+};
+
+const getErrorMessage = (error: unknown) =>
+    error instanceof Error ? error.message : String(error);
+
+const getDefaultValueForScalarType = (scalarType?: string): unknown => {
+    switch (scalarType) {
+        case 'string':
+            return 'test';
+        case 'bytes':
+            return 'aa';
+        case 'uint32':
+        case 'int32':
+        case 'sint32':
+            return 0;
+        case 'uint64':
+        case 'int64':
+        case 'sint64':
+            return '0';
+        case 'bool':
+            return false;
+        case 'float':
+        case 'double':
+            return 0.0;
+        default:
+            return undefined;
+    }
+};
+
+const getAllProtoModules = () => {
+    const modules: Record<string, Record<string, AnyDesc>> = {};
+
+    // All available proto definition files
+    const protoFiles = [
+        'messages-bitcoin',
+        'messages-ble',
+        'messages-bootloader',
+        'messages-cardano',
+        'messages-common',
+        'messages-crypto',
+        'messages-debug',
+        'messages-definitions',
+        'messages-eos',
+        'messages-ethereum-eip712',
+        'messages-ethereum',
+        'messages-evolu',
+        'messages-management',
+        'messages-monero',
+        'messages',
+        'messages-ripple',
+        'messages-solana',
+        'messages-stellar',
+        'messages-telemetry',
+        'messages-tezos',
+        'messages-thp',
+        'messages-tron',
+        'options',
+    ];
+
+    protoFiles.forEach(name => {
+        modules[name] = require(`../src/definitions/${name}_pb`);
+    });
+
+    return Object.values(modules);
+};
+
+describe('ProtobufManager comprehensive tests', () => {
+    const allProtoModules = getAllProtoModules();
+    const protobufManager = ProtobufManager();
+    protobufManager.load(allProtoModules);
+
+    const protobufJs = ProtoBuf.Root.fromJSON(messagesJson);
+
+    const lookupType = (messageName: string): ProtoBuf.Type => {
+        const reflectionObject = protobufJs.lookup(messageName);
+        if (!(reflectionObject instanceof ProtoBuf.Type)) {
+            throw new Error(`Type ${messageName} not found in protobufjs root.`);
+        }
+
+        return reflectionObject;
+    };
+
+    const buildPayloadFromBufSchema = (schema: { fields?: Array<any> }): TestPayload => {
+        const payload: TestPayload = {};
+
+        schema.fields?.forEach(field => {
+            if (field.fieldKind === 'list') {
+                if (field.name === 'address_n') {
+                    payload[field.name] = [1];
+                } else if (field.listKind === 'message') {
+                    payload[field.name] = [];
+                } else {
+                    payload[field.name] = [];
+                }
+
+                return;
+            }
+
+            if (field.fieldKind === 'message' && field.message) {
+                payload[field.name] = buildPayloadFromBufSchema(field.message);
+
+                return;
+            }
+
+            if (field.fieldKind === 'enum') {
+                payload[field.name] = field.enum.values[0]?.number ?? 0;
+
+                return;
+            }
+
+            if (field.scalar === ScalarType.STRING) {
+                payload[field.name] = 'test';
+            } else if (field.scalar === ScalarType.BYTES) {
+                payload[field.name] = Buffer.from('aa', 'hex');
+            } else if (field.scalar === ScalarType.INT32 || field.scalar === ScalarType.SINT32) {
+                payload[field.name] = 0;
+            } else if (field.scalar === ScalarType.UINT32) {
+                payload[field.name] = 0;
+            } else if (
+                field.scalar === ScalarType.INT64 ||
+                field.scalar === ScalarType.SINT64 ||
+                field.scalar === ScalarType.UINT64
+            ) {
+                payload[field.name] = BigInt(0);
+            } else if (field.scalar === ScalarType.BOOL) {
+                payload[field.name] = false;
+            } else if (field.scalar === ScalarType.FLOAT || field.scalar === ScalarType.DOUBLE) {
+                payload[field.name] = 0.0;
+            } else {
+                payload[field.name] = null;
+            }
+        });
+
+        return payload;
+    };
+
+    const getAllMessageNames = (): string[] => Object.keys(messagesJsonSchema.nested ?? {});
+
+    const getAllEnumNames = () => {
+        const schema = messagesJsonSchema;
+        const enums = new Set<string>();
+
+        Object.keys(schema.nested ?? {}).forEach(key => {
+            const item = schema.nested?.[key];
+            if (item && 'values' in item && !('fields' in item)) {
+                enums.add(key);
+            }
+        });
+
+        return Array.from(enums);
+    };
+
+    const messageExistsInBufbuild = (messageName: string): boolean => {
+        try {
+            protobufManager.findSchema(messageName);
+
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    const enumExistsInBufbuild = (enumName: string): boolean => {
+        const enumDef = protobufManager.findEnum(enumName);
+
+        return enumDef !== undefined;
+    };
+
+    const isFieldRequired = (messageName: string, fieldName: string): boolean => {
+        const patchKey = `${messageName}.${fieldName}`;
+
+        // Check if there's an explicit patch (highest priority)
+        if (patchKey in RULE_PATCH) {
+            return RULE_PATCH[patchKey as keyof typeof RULE_PATCH] === 'required';
+        }
+
+        // Fallback: Check messages.json as primary source for proto2 field rules
+        const messageDef = getMessageDefinition(messageName);
+        if (!messageDef?.fields) {
+            return false;
+        }
+
+        const field = messageDef.fields?.[fieldName];
+        if (!field) {
+            return false;
+        }
+
+        // Repeated fields are always optional
+        if (field.rule === 'repeated') {
+            return false;
+        }
+
+        return field.rule === 'required';
+    };
+
+    const getRequiredFields = (messageName: string): string[] => {
+        const messageDef = getMessageDefinition(messageName);
+        if (!messageDef?.fields) {
+            return [];
+        }
+
+        return Object.keys(messageDef.fields ?? {}).filter(fieldName =>
+            isFieldRequired(messageName, fieldName),
+        );
+    };
+
+    const buildPayloadFromJsonDefinition = (
+        messageName: string,
+        messageDefinition: JsonMessageDefinition,
+        requiredOnly: boolean,
+    ): TestPayload => {
+        const payload: TestPayload = {};
+
+        Object.entries(messageDefinition.fields ?? {}).forEach(([fieldName, field]) => {
+            if (requiredOnly && !isFieldRequired(messageName, fieldName)) {
+                return;
+            }
+
+            if (field.rule === 'repeated') {
+                payload[fieldName] = [];
+
+                return;
+            }
+
+            const scalarValue = getDefaultValueForScalarType(field.type);
+            if (scalarValue !== undefined) {
+                payload[fieldName] = scalarValue;
+
+                return;
+            }
+
+            const nestedTypeName = field.type ?? '';
+            const nestedDefinition = messageDefinition.nested?.[nestedTypeName];
+
+            if (isJsonMessageDefinition(nestedDefinition)) {
+                payload[fieldName] = buildPayloadFromJsonDefinition(
+                    nestedTypeName,
+                    nestedDefinition,
+                    false,
+                );
+
+                return;
+            }
+
+            payload[fieldName] = {};
+        });
+
+        return payload;
+    };
+
+    const buildMinimalTestData = (messageName: string): TestPayload | null => {
+        try {
+            const { schema } = protobufManager.findSchema(messageName);
+            if (!schema?.fields) {
+                return null;
+            }
+
+            return buildPayloadFromBufSchema(schema);
+        } catch {
+            const messageDef = getMessageDefinition(messageName);
+            if (!messageDef?.fields) {
+                return null;
+            }
+
+            return buildPayloadFromJsonDefinition(messageName, messageDef, true);
+        }
+    };
+
+    it('identify all available and missing messages in @bufbuild definitions', () => {
+        const allMessages = getAllMessageNames();
+        const missingMessages: string[] = [];
+        const availableMessages: Array<{ name: string; requirementStatus: string }> = [];
+
+        allMessages.forEach(msgName => {
+            const requiredFields = getRequiredFields(msgName);
+            const hasRequired = requiredFields.length > 0;
+            const requirementStatus = hasRequired
+                ? `required=[${requiredFields.join(', ')}]`
+                : 'optional_only';
+
+            if (messageExistsInBufbuild(msgName)) {
+                availableMessages.push({ name: msgName, requirementStatus });
+            } else {
+                missingMessages.push(msgName);
+            }
+        });
+
+        const allEnums = getAllEnumNames();
+        const missingEnums: string[] = [];
+        const availableEnums: Array<{ name: string; valueCount: number }> = [];
+
+        allEnums.forEach(enumName => {
+            if (enumExistsInBufbuild(enumName)) {
+                const enumDef = protobufManager.findEnum(enumName);
+                const valueCount = enumDef ? Object.keys(enumDef.values || {}).length : 0;
+                availableEnums.push({ name: enumName, valueCount });
+            } else {
+                missingEnums.push(enumName);
+            }
+        });
+        const failures: string[] = [];
+
+        availableMessages.slice(0, 10).forEach(({ name: messageName }) => {
+            const testData = buildMinimalTestData(messageName);
+
+            if (!testData || Object.keys(testData).length === 0) {
+                console.warn(`   ⊘ ${messageName} - skipped (no required fields to test)`);
+
+                return;
+            }
+
+            try {
+                const pbLookup = lookupType(messageName);
+                const newEncoded = protobufManager.encode(messageName, testData);
+                const oldEncoded = encodeProtobufJs(pbLookup, testData);
+                const encodesMatch = newEncoded.message.compare(oldEncoded) === 0;
+
+                const newDecoded = protobufManager.decode(messageName, newEncoded.message);
+                const oldDecoded = decodeProtobufJs(pbLookup, oldEncoded);
+                const decodesMatch =
+                    JSON.stringify(newDecoded.message) === JSON.stringify(oldDecoded);
+
+                if (!encodesMatch || !decodesMatch) {
+                    failures.push(messageName);
+                }
+            } catch {
+                failures.push(messageName);
+            }
+        });
+
+        expect(failures.length).toBe(0);
+        expect(availableMessages.length).toBeGreaterThan(0);
+        expect(availableEnums.length).toBeGreaterThan(0);
+    });
+
+    describe('messages -> JSON round-trip', () => {
+        const allMessages = getAllMessageNames().filter(name => messageExistsInBufbuild(name));
+
+        const samplesToTest = allMessages;
+
+        samplesToTest.forEach(messageName => {
+            const testData = buildMinimalTestData(messageName);
+            const requiredFields = getRequiredFields(messageName);
+
+            if (!testData || Object.keys(testData).length === 0) {
+                return;
+            }
+
+            it(`encode ${messageName} (required: ${requiredFields.join(', ') || 'none'})`, () => {
+                try {
+                    const result = protobufManager.encode(messageName, testData);
+                    expect(result.message).toBeDefined();
+                    expect(result.messageType).toBeDefined();
+                } catch (error) {
+                    console.warn(`${messageName}: ${getErrorMessage(error)}`);
+                    throw error;
+                }
+            });
+
+            it(`decode ${messageName} (required: ${requiredFields.join(', ') || 'none'})`, () => {
+                try {
+                    const encoded = protobufManager.encode(messageName, testData);
+                    const decoded = protobufManager.decode(messageName, encoded.message);
+                    expect(decoded.message).toBeDefined();
+                    expect(decoded.type).toBe(messageName);
+                } catch (error) {
+                    console.warn(`${messageName}: ${getErrorMessage(error)}`);
+                    throw error;
+                }
+            });
+        });
+    });
+
+    describe('nested messages', () => {
+        const compositionTests = [
+            {
+                description: 'GetAddress with multisig (nested)',
+                messageName: 'GetAddress',
+                data: {
+                    address_n: [44, 0, 0],
+                    coin_name: 'Bitcoin',
+                    multisig: {
+                        m: 1,
+                        nodes: [
+                            {
+                                depth: 0,
+                                fingerprint: 0,
+                                child_num: 0,
+                                chain_code: '00',
+                                public_key: '00',
+                            },
+                        ],
+                        pubkeys: [
+                            {
+                                address_n: [1],
+                                node: {
+                                    depth: 1,
+                                    fingerprint: 1,
+                                    child_num: 1,
+                                    chain_code: '11',
+                                    public_key: '11',
+                                },
+                            },
+                        ],
+                        signatures: [''],
+                        address_n: [0],
+                        pubkeys_order: 'LEXICOGRAPHIC',
+                    },
+                },
+            },
+            {
+                description: 'TxAckInput with nested input',
+                messageName: 'TxAckInput',
+                data: {
+                    tx: {
+                        input: {
+                            prev_hash: '00',
+                            prev_index: 0,
+                            amount: 1000,
+                        },
+                    },
+                },
+            },
+        ];
+
+        compositionTests.forEach(({ description, messageName, data }) => {
+            if (!messageExistsInBufbuild(messageName)) {
+                return;
+            }
+
+            it(description, () => {
+                const newResult = protobufManager.encode(messageName, data);
+                const oldResult = encodeProtobufJs(lookupType(messageName), data);
+
+                expect(newResult.message.compare(oldResult)).toEqual(0);
+            });
+        });
+    });
+
+    describe('enum availability', () => {
+        const criticalEnums = [
+            'MessageType',
+            'ThpMessageType',
+            'InputScriptType',
+            'OutputScriptType',
+        ];
+
+        criticalEnums.forEach(enumName => {
+            it(`${enumName} - should exist in @bufbuild definitions`, () => {
+                const exists = enumExistsInBufbuild(enumName);
+                expect(exists).toBe(true);
+
+                const enumDef = protobufManager.findEnum(enumName);
+                const valueCount = enumDef ? Object.keys(enumDef.values || {}).length : 0;
+                expect(enumDef).toBeDefined();
+                expect(valueCount).toBeGreaterThan(0);
+            });
+        });
+    });
+
+    describe('error handling', () => {
+        it('throws error for unknown message type on encode', () => {
+            expect(() => {
+                protobufManager.encode('NonexistentMessage', {});
+            }).toThrow();
+        });
+
+        it('throws error for unknown message type on decode', () => {
+            expect(() => {
+                protobufManager.decode('NonexistentMessage', Buffer.from('00'));
+            }).toThrow();
+        });
+
+        it('throws error for invalid message ID', () => {
+            expect(() => {
+                protobufManager.decode(9999, Buffer.from('00'));
+            }).toThrow();
+        });
+
+        it('findEnum returns undefined for missing enum', () => {
+            const result = protobufManager.findEnum('NonexistentEnum');
+            expect(result).toBeUndefined();
+        });
+
+        [
+            {
+                description: 'matches protobufjs for unsafe uint64 decode',
+                payload: { asset_name_bytes: 'aa', amount: '9223372036854775807' },
+            },
+            {
+                description: 'matches protobufjs for unsafe sint64 decode',
+                payload: { asset_name_bytes: 'aa', mint_amount: '-9223372036854775807' },
+            },
+            {
+                description: 'matches protobufjs for mixed safe and unsafe 64-bit decode',
+                payload: {
+                    asset_name_bytes: 'aa',
+                    amount: 42,
+                    mint_amount: '-9223372036854775807',
+                },
+            },
+        ].forEach(({ description, payload }) => {
+            it(description, () => {
+                const messageType = lookupType('CardanoToken');
+                const encoded = encodeProtobufJs(messageType, payload);
+
+                const protobufJsDecoded = decodeProtobufJs(messageType, encoded);
+                const managerDecoded = protobufManager.decode('CardanoToken', encoded).message;
+
+                expect(managerDecoded).toEqual(protobufJsDecoded);
+            });
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/protobuf-manager&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/protobuf-manager&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-17T18:19:15.506Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-17T18:18:45.191Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->