### PR TITLE
feat(suite-native): allow .onion Electrum server addresses

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1419,9 +1419,11 @@ export const messages = {
                     connectButton: 'Connect',
                     invalidFormat:
                         'Incorrect format. Please enter the server address in such a way: host:port:[t|s]',
-                    torNotSupported: 'Tor not supported, use a clearnet address instead.',
-                    unableToConnect:
-                        'Unable to connect to server. Check for typos and server disruptions.',
+                    unableToConnect: {
+                        clearnet:
+                            'Unable to connect to server. Check for typos and server disruptions.',
+                        tor: 'Unable to connect to server. Check for typos and ensure Orbot is running on your device.',
+                    },
                 },
                 closeAction: {
                     title: 'Discard changes?',

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -72,17 +72,13 @@ export const useBackendServersForm = () => {
                     'format',
                     translate('moduleSettings.advanced.bitcoinBackends.servers.invalidFormat'),
                     value => !!value && !!parseElectrumUrl(value),
-                )
-                .test(
-                    'tor',
-                    translate('moduleSettings.advanced.bitcoinBackends.servers.torNotSupported'),
-                    value => !!value && !value.includes('.onion:'),
                 ),
         }),
         defaultValues,
         mode: 'onSubmit',
     });
 
+    const isOnionAddress = form.watch('serverAddress').includes('.onion:');
     const [isConnecting, setIsConnecting] = useState(false);
 
     const setBackend = ({ serverType, serverAddress }: FormValues) => {
@@ -120,13 +116,15 @@ export const useBackendServersForm = () => {
             if (e.code === 'Backend_Error') {
                 form.setError('serverAddress', {
                     message: translate(
-                        'moduleSettings.advanced.bitcoinBackends.servers.unableToConnect',
+                        isOnionAddress
+                            ? 'moduleSettings.advanced.bitcoinBackends.servers.unableToConnect.tor'
+                            : 'moduleSettings.advanced.bitcoinBackends.servers.unableToConnect.clearnet',
                     ),
                 });
                 setIsConnecting(false);
             }
         },
-        [form, translate],
+        [form, isOnionAddress, translate],
     );
 
     useFocusEffect(


### PR DESCRIPTION
Make sure `.onion` Electrum server address may be configured by users using [Orbot](https://orbot.app/en/).

## Related Issue

Follow-up for #26004

## Screenshots

| Clearnet | Tor |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/c5ff29be-f8fa-4de7-aedc-cb9d8236fb7f" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/406074bd-6120-45af-9915-65b3b52258d8" /> |


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/bitcoin-backends-onion-addresses&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->