### PR TITLE
Replace deprecated renderWithStoreProviderAsync

### DIFF
--- a/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TradingSettingsCard, type TradingSettingsCardProps } from '../TradingSettingsCard';
 
@@ -13,15 +13,15 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('TradingSettingsCard', () => {
     const renderTradingSettingsCard = (props: Partial<TradingSettingsCardProps> = {}) =>
-        renderWithStoreProviderAsync(<TradingSettingsCard onPress={jest.fn()} {...props} />);
+        renderWithStoreProvider(<TradingSettingsCard onPress={jest.fn()} {...props} />);
 
     beforeEach(() => {
         mockIsTradingCountrySet = false;
         mockIsTradingResidenceCheckEnabled = false;
     });
 
-    it('should not render trading settings button when selectIsTradingResidenceCheckEnabled is false', async () => {
-        const { toJSON } = await renderTradingSettingsCard();
+    it('should not render trading settings button when selectIsTradingResidenceCheckEnabled is false', () => {
+        const { toJSON } = renderTradingSettingsCard();
 
         expect(toJSON()).toBeNull();
     });
@@ -31,8 +31,8 @@ describe('TradingSettingsCard', () => {
             mockIsTradingResidenceCheckEnabled = true;
         });
 
-        it('should render "Enable trading" button when selectIsTradingCountrySet is false', async () => {
-            const { getByTestId, getByText } = await renderTradingSettingsCard({
+        it('should render "Enable trading" button when selectIsTradingCountrySet is false', () => {
+            const { getByTestId, getByText } = renderTradingSettingsCard({
                 testID: '@settings/trading',
             });
 
@@ -41,9 +41,9 @@ describe('TradingSettingsCard', () => {
             expect(getByText('Confirm your country of residence')).toBeOnTheScreen();
         });
 
-        it('should render "Trading" button when selectIsTradingCountrySet is true', async () => {
+        it('should render "Trading" button when selectIsTradingCountrySet is true', () => {
             mockIsTradingCountrySet = true;
-            const { getByTestId, getByText } = await renderTradingSettingsCard({
+            const { getByTestId, getByText } = renderTradingSettingsCard({
                 testID: '@settings/trading',
             });
 


### PR DESCRIPTION
replace deprecated renderWithStoreProviderAsync with renderWithStoreProvider in TradingSettingsCard tests

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tests-native-timeout-hotfix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->