### PR TITLE
fix(scripts): don't use nx in pre-commit hook eslint

### DIFF
--- a/.husky/eslint.sh
+++ b/.husky/eslint.sh
@@ -26,7 +26,7 @@ else
 
   # No quotes to pass as separate arguments (files)
   # shellcheck disable=SC2086
-  if ! yarn lint:js:fix-files $STAGED_FILES; then
+  if ! yarn g:eslint --fix $STAGED_FILES; then
     echo "Eslint failed! Please fix the errors and try again. You can also use --no-verify to skip pre-commit checks."
     exit 1
   fi


### PR DESCRIPTION
## Description

After https://github.com/trezor/trezor-suite/pull/26006, `yarn lint:js` now uses Nx

That is not viable in pre-commit hook, there we want to use eslint directly with list of staged files

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/pre-commit-eslint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-18T11:33:05.564Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->