### PR TITLE
fix(suite-native): allow isDisabled to be passed to useTapGesture

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -82,7 +82,7 @@ export const CompactCardWithIconLayout = ({
     const { caretColor, iconColor, titleColor, subtitleColor, iconWrapperBackgroundColor } =
         cardVariantToColorsMap[variant];
 
-    const { tapGesture, animatedStyle } = useTapGesture(onPress);
+    const { tapGesture, animatedStyle } = useTapGesture({ onPress, isDisabled });
 
     return (
         <GestureDetector gesture={tapGesture}>

--- a/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
@@ -29,7 +29,7 @@ export const PressableCardWithIconLayout = ({
     description,
     onPress,
 }: PressableCardWithIconLayoutProps) => {
-    const { tapGesture, animatedStyle } = useTapGesture(onPress);
+    const { tapGesture, animatedStyle } = useTapGesture({ onPress });
     const { applyStyle } = useNativeStyles();
 
     return (

--- a/suite-native/atoms/src/useTapGesture.ts
+++ b/suite-native/atoms/src/useTapGesture.ts
@@ -1,7 +1,13 @@
 import { Gesture } from 'react-native-gesture-handler';
 import { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
-export const useTapGesture = (onPress: () => void) => {
+export const useTapGesture = ({
+    onPress,
+    isDisabled = false,
+}: {
+    onPress: () => void;
+    isDisabled?: boolean;
+}) => {
     const isPressed = useSharedValue(false);
 
     const tapGesture = Gesture.Tap()
@@ -19,7 +25,8 @@ export const useTapGesture = (onPress: () => void) => {
             if (onPress) {
                 runOnJS(onPress)();
             }
-        });
+        })
+        .enabled(!isDisabled);
 
     const animatedStyle = useAnimatedStyle(() => ({
         opacity: withTiming(isPressed.value ? 0.5 : 1, { duration: 100 }),


### PR DESCRIPTION
It was possible to tap cards in _Device settings_ while discovery was in progress (and loader shown).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/tap-gesture-disabled&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->