### PR TITLE
Fix EVM address chunking in Suite and e2e helpers

### DIFF
--- a/packages/suite/src/components/suite/Address.tsx
+++ b/packages/suite/src/components/suite/Address.tsx
@@ -10,7 +10,7 @@ import { copyAddressToClipboard } from 'src/actions/suite/copyAddressActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectAddressDisplayType } from 'src/selectors/suite/suiteSelectors';
 
-const TRUNCATION_PLACEHOLDER = ' ... ';
+const TRUNCATION_PLACEHOLDER = '...';
 const REGEXP_ADDRESS = /^(0x)?((.{8})(?:.{4})*(.{5,8}))$/;
 const REGEXP_ADDRESS_CHUNKS = /((?:\S+\s){3}\S+)\s/g;
 
@@ -38,19 +38,17 @@ const AddressWrapper = styled.p<{ $device?: DeviceModelInternal }>`
         $device &&
         css`
             ${mapDeviceModelToFontStyle($device)};
-            white-space: pre-line;
+            white-space: pre-wrap;
         `};
 `;
 
-const addSpacing = (value: string) => value?.match(/.{1,4}/g)?.join(' ') ?? value;
+const addSpacing = (value?: string) => value?.match(/.{1,4}/g)?.join(' ') ?? value;
 const addNewlineAfterEveryFourthChunk = (value: string) =>
     value?.replace(REGEXP_ADDRESS_CHUNKS, '$1\n') ?? value;
 
-export type AddressProps = {
+type AddressBaseProps = {
     value: string;
-    isTruncated?: boolean;
     isChunked?: boolean;
-    isDeviceRendered?: boolean;
     'data-testid'?: string;
     typographyStyle?: TypographyStyle;
     intent?: TextProps['intent'];
@@ -59,6 +57,18 @@ export type AddressProps = {
     isCopyAllowed?: boolean;
     onCopy?: () => void;
 };
+
+type AddressDisplayProps =
+    | {
+          isTruncated?: boolean;
+          isDeviceRendered?: false;
+      }
+    | {
+          isTruncated?: false;
+          isDeviceRendered: true;
+      };
+
+export type AddressProps = AddressBaseProps & AddressDisplayProps;
 
 export const Address = ({
     value,
@@ -78,18 +88,21 @@ export const Address = ({
     const deviceModelInternal = selectedDevice?.features?.internal_model || DEFAULT_FLAGSHIP_MODEL;
     const isChunkedSettings = useSelector(selectAddressDisplayType);
     const isAddressChunked = isChunked ?? isChunkedSettings === 'chunked';
-    const placeholder = isAddressChunked ? TRUNCATION_PLACEHOLDER : TRUNCATION_PLACEHOLDER.trim();
+    const separator = isAddressChunked ? ' ' : '';
 
-    const [, prefix = '', rest, beginning, end] = (value.match(REGEXP_ADDRESS) || []).map(part =>
+    const [, prefix, rest, beginning, end] = (value.match(REGEXP_ADDRESS) || []).map(part =>
         isAddressChunked ? addSpacing(part) : part,
     );
 
-    const formattedValueBase = prefix + (isTruncated ? beginning + placeholder + end : rest);
-    const formattedValueFull = prefix + rest;
-    const formattedValue =
-        isAddressChunked && isDeviceRendered && !isTruncated
-            ? addNewlineAfterEveryFourthChunk(formattedValueBase)
-            : formattedValueBase;
+    const formattedValueTruncated = [prefix, beginning, TRUNCATION_PLACEHOLDER, end]
+        .filter(Boolean)
+        .join(separator);
+    const formattedValueFull = [prefix, rest].filter(Boolean).join(separator);
+    const formattedValue = isTruncated ? formattedValueTruncated : formattedValueFull;
+
+    const deviceRenderedIndent = isAddressChunked && prefix ? '  ' : '';
+    const deviceRenderedValue =
+        deviceRenderedIndent + addNewlineAfterEveryFourthChunk(formattedValueFull);
 
     const onManualCopy = (e: React.ClipboardEvent) => {
         const selection = window.getSelection()?.toString();
@@ -137,7 +150,7 @@ export const Address = ({
                     id={value}
                     $device={isDeviceRendered ? deviceModelInternal : undefined}
                 >
-                    {formattedValue}
+                    {isDeviceRendered ? deviceRenderedValue : formattedValue}
                 </AddressWrapper>
             </Text>
         </Tooltip>

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -47,15 +47,21 @@ export const isEqualWithOmit = (param: { object1: any; object2: any; mask: strin
 export const formatAddress = (address: string) => splitStringEveryNCharacters(address, 4).join(' ');
 
 const REGEXP_ADDRESS_CHUNKS = /((?:\S+\s){3}\S+)\s/g;
+const EVM_ADDRESS_PREFIX = '0x';
+const DEVICE_RENDERED_EVM_INDENT = '  ';
 
 const formatEvmAddress = (address: string) => {
-    if (!address.startsWith('0x')) {
+    if (!address.startsWith(EVM_ADDRESS_PREFIX)) {
         return formatAddress(address);
     }
 
     const spacedBody = splitStringEveryNCharacters(address.slice(2), 4).join(' ');
 
-    return spacedBody ? `0x${spacedBody}` : address;
+    if (!spacedBody) {
+        return address;
+    }
+
+    return `${DEVICE_RENDERED_EVM_INDENT}${EVM_ADDRESS_PREFIX} ${spacedBody}`;
 };
 
 export const formatAddressWithNewlines = (address: string) =>


### PR DESCRIPTION
**Notes for QA**
- update Suite address formatting so chunked EVM addresses render `0x` as a separate prefix before 4-character groups
- preserve the two-space indent for device-rendered chunked addresses and switch device rendering to `white-space: pre-wrap`
- tighten `AddressProps` so `isDeviceRendered` cannot be combined with truncated output
- align e2e address formatting helpers with the new EVM display format
- non EVM addresses should be the same

**Screenshots**

***Before***
<img width="621" height="318" alt="image" src="https://github.com/user-attachments/assets/82eb59e4-b19a-469e-90c7-fc23a86e98b7" />

<img width="448" height="179" alt="image" src="https://github.com/user-attachments/assets/7be190eb-9a0b-4c60-b179-1d41af0932d2" />


***After***
<img width="621" height="318" alt="image" src="https://github.com/user-attachments/assets/21663b60-9d20-476d-8ecb-c8aecacf40b1" />

<img width="500" height="184" alt="image" src="https://github.com/user-attachments/assets/2dbb54e0-fe03-4ef5-ab4c-9865f3e3daa7" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/evm-address-chunking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/evm-address-chunking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T11:45:40.635Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-18T11:43:54.340Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->