### PR TITLE
refactor(suite-common): extract forgetDeviceThunk from desktop code

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 
 import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
-import { deviceActions, selectDevices, selectSelectedDevice } from '@suite-common/device';
+import { selectSelectedDevice } from '@suite-common/device';
 import * as deviceUtils from '@suite-common/suite-utils';
-import { forgetSingleDevicePersistentDataThunk } from '@suite-common/wallet-core';
+import { forgetDeviceThunk } from '@suite-common/wallet-core';
 import { Card, Icon, List, Modal, type ModalProps, Paragraph } from '@trezor/components';
 
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
@@ -14,7 +14,6 @@ import { useAnalytics } from 'src/support/useAnalytics';
 export const ForgetDeviceModal = ({ onCancel }: ModalProps) => {
     const dispatch = useDispatch();
     const selectedDevice = useSelector(selectSelectedDevice);
-    const devices = useSelector(selectDevices);
     const analytics = useAnalytics();
     if (!selectedDevice) {
         return null;
@@ -24,13 +23,7 @@ export const ForgetDeviceModal = ({ onCancel }: ModalProps) => {
     const isBluetoothConnectedDevice = selectedDevice?.descriptor.apiType === 'bluetooth';
 
     const handleConfirmClick = async () => {
-        const instances = deviceUtils.getDeviceInstances(selectedDevice, devices);
-
-        await dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: selectedDevice.id }));
-
-        instances.forEach(instance => {
-            dispatch(deviceActions.forgetDevice({ device: instance }));
-        });
+        await dispatch(forgetDeviceThunk());
 
         analytics.report({ type: events.switchDeviceForgetEvent.name });
         onCancel?.();

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -435,6 +435,23 @@ export const forgetSingleDevicePersistentDataThunk = createThunk(
     },
 );
 
+export const forgetDeviceThunk = createThunk(
+    `${DEVICE_MODULE_PREFIX}/forgetDevice`,
+    async (_, { dispatch, getState }) => {
+        const device = selectSelectedDevice(getState());
+        if (!device) return;
+
+        const devices = selectDevices(getState());
+        const deviceInstances = getDeviceInstances(device, devices);
+
+        await dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device.id }));
+
+        deviceInstances.forEach(instance => {
+            dispatch(deviceActions.forgetDevice({ device: instance }));
+        });
+    },
+);
+
 /**
  * Handles the necessary cleanup after a device has been wiped.
  * This includes forgetting old/new device instances, clearing persistent data,


### PR DESCRIPTION
Extracted `forgetDeviceThunk` so that it may be used in `suite-native` code as well.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/forget-device-thunk&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/forget-device-thunk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/forget-device-thunk&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T11:56:26.889Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-18T11:54:29.878Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->