### PR TITLE
fix(trading): prevent cross-network trading receive address restore

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { type CryptoId } from 'invity-api';
@@ -90,6 +90,13 @@ export const useTradingReceiveAddress = ({
     const [selectedAccount, setSelectedAccount] = useState<Account | null | undefined>(undefined);
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState<boolean | undefined>(undefined);
+    const initialSymbolRef = useRef<typeof symbol>(undefined);
+
+    useEffect(() => {
+        if (initialSymbolRef.current === undefined && symbol !== undefined) {
+            initialSymbolRef.current = symbol;
+        }
+    }, [symbol]);
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,
@@ -180,7 +187,12 @@ export const useTradingReceiveAddress = ({
             }
         }
 
-        if (isPreviousRouteFromTradeSection && persistedReceiveAddress && canUseNonSuiteAccount) {
+        if (
+            isPreviousRouteFromTradeSection &&
+            persistedReceiveAddress &&
+            canUseNonSuiteAccount &&
+            symbol === initialSymbolRef.current
+        ) {
             selectNonSuiteAddress(persistedReceiveAddress);
 
             return;


### PR DESCRIPTION
## Description

Prevent restoring a stale trading receive address after a network/symbol change in `useTradingReceiveAddress`.

This change introduces `initialSymbolRef` to track the initial symbol context and avoid cross-network address reuse when form state updates.

## Notes for QA

1. Open trading flow and select a receive account/address on network A; continue until the address is populated.
2. Change to network/symbol B and verify an address from network A is not restored or reused.
3. Switch back and forth between symbols/networks and confirm receive address handling remains consistent and no stale address appears.
4. Regression check: on a single unchanged network/symbol, receive address restore behavior still works as before.

## Related Issue

Resolve #25711

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25711-trading-receive-address-network-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25711-trading-receive-address-network-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T12:08:03.634Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-18T12:06:21.498Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->