### PR TITLE
fix(suite-native): retain amounts after switching off send max

### DIFF
--- a/suite-native/module-send/src/components/AmountInputs.tsx
+++ b/suite-native/module-send/src/components/AmountInputs.tsx
@@ -21,7 +21,7 @@ import { useAnalytics } from '@suite-native/services';
 import { AmountErrorMessage } from './AmountErrorMessage';
 import { CryptoAmountInput } from './CryptoAmountInput';
 import { FiatAmountInput } from './FiatAmountInput';
-import { SendMaxButton } from './SendMaxButton';
+import { SendMaxSwitch } from './SendMaxSwitch';
 
 type AmountInputProps = {
     index: number;
@@ -57,7 +57,7 @@ export const AmountInputs = ({ index }: AmountInputProps) => {
                         <Translation id="moduleSend.outputs.recipients.amountLabel" />
                     </Text>
                 </Animated.View>
-                <SendMaxButton
+                <SendMaxSwitch
                     outputIndex={index}
                     accountKey={accountKey}
                     tokenContract={tokenContract}

--- a/suite-native/module-send/src/components/SendMaxSwitch.tsx
+++ b/suite-native/module-send/src/components/SendMaxSwitch.tsx
@@ -27,13 +27,13 @@ import { useUtxoSelection } from '../hooks/useUtxoSelection';
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { constructFormDraft, getOutputFieldName } from '../utils';
 
-type SendMaxButtonProps = {
+type SendMaxSwitchProps = {
     outputIndex: number;
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
 };
 
-export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMaxButtonProps) => {
+export const SendMaxSwitch = ({ outputIndex, accountKey, tokenContract }: SendMaxSwitchProps) => {
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const { selectedUtxos } = useUtxoSelection(accountKey);
@@ -110,16 +110,6 @@ export const SendMaxButton = ({ outputIndex, accountKey, tokenContract }: SendMa
 
     const disableSendMax = () => {
         setValue('setMaxOutputId', undefined);
-
-        setValue(getOutputFieldName(outputIndex, 'amount'), '', {
-            shouldValidate: true,
-            shouldTouch: true,
-        });
-
-        setValue(getOutputFieldName(outputIndex, 'fiat'), '', {
-            shouldValidate: true,
-            shouldTouch: true,
-        });
     };
 
     const toggleSendMax = (isToggled: boolean) => {


### PR DESCRIPTION
## Description

After turning on and off the send max switch, retain the crypto & fiat amounts in input fields.

## Related Issue

Resolve #20346 

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-03-18 at 14 41 23" src="https://github.com/user-attachments/assets/5f8d6067-21c6-4cdb-99c9-b150a3bf34a9" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-03-18 at 14 41 29" src="https://github.com/user-attachments/assets/06bc7be3-2375-46bd-9f57-b72ca8f65d5c" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/send-max-switch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->