### PR TITLE
fix(trading): guard fee shortfall validation by min amount

### DIFF
--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -101,7 +101,7 @@ export const validateCryptoLimits =
             }
 
             if (amountLimits.maxCrypto && new BigNumber(value).gt(maxCrypto)) {
-                if (minCrypto.lte(new BigNumber(value))) {
+                if (minCrypto.gt(0) && minCrypto.lte(new BigNumber(value))) {
                     const missingAmount = new BigNumber(value).minus(maxCrypto);
 
                     return translationString(
@@ -170,7 +170,11 @@ export const validateFiatLimits =
             }
 
             if (amountLimits.maxFiat && new BigNumber(value).gt(amountLimits.maxFiat)) {
-                if (new BigNumber(amountLimits.minCrypto ?? '0').lte(new BigNumber(value))) {
+                if (
+                    amountLimits.minCrypto &&
+                    new BigNumber(amountLimits.minCrypto).gt(0) &&
+                    new BigNumber(amountLimits.minCrypto).lte(new BigNumber(cryptoAmount ?? '0'))
+                ) {
                     const missingAmount = new BigNumber(value).minus(amountLimits.maxFiat);
 
                     return translationString(


### PR DESCRIPTION
## Description

Fixes trading fiat max validation so the "not enough for fees" message is shown only when the computed crypto amount is at least the configured minimum crypto threshold.

Previously, the condition used `amountLimits.minCrypto` directly, which can represent a value in a different network precision/context. This could trigger an incorrect fee shortfall validation path. The check now compares against the already computed `cryptoAmount` value, keeping the comparison in the same unit context.

## Notes for QA

Reproduce steps described in the bug and verify, that error message is correct

## Related Issue

Resolve #24384

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-validation-min-crypto-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-validation-min-crypto-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T14:06:49.790Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T05:35:14.266Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->