### PR TITLE
fix(e2e-suite): split 'confirm on device' text assertions

### DIFF
--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -5,6 +5,7 @@ import { DeviceFixture } from '../device';
 
 export class DevicePrompt {
     readonly confirmOnDevicePrompt: Locator;
+    readonly confirmOnDevicePromptSuccess: Locator;
     readonly connectDevicePrompt: Locator;
     readonly modal: Locator;
     readonly modalCloseButton: Locator;
@@ -39,6 +40,7 @@ export class DevicePrompt {
         private device: DeviceFixture,
     ) {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
+        this.confirmOnDevicePromptSuccess = page.getByTestId('@prompts/confirm-on-device/success');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
         this.modalCloseButton = page.getByTestId('@modal/close-button');
         this.modal = page.modal;
@@ -73,7 +75,8 @@ export class DevicePrompt {
     @step()
     async confirmOnDeviceIsCompleted() {
         await this.confirmOnDevicePromptIsShown();
-        await expect(this.confirmOnDevicePrompt).toHaveText('Confirm on TrezorConfirmed');
+        await expect(this.confirmOnDevicePrompt).toContainText('Confirm on Trezor');
+        await expect(this.confirmOnDevicePromptSuccess).toHaveText('Confirmed');
     }
 
     @step()


### PR DESCRIPTION
## Description

Fix the test sell-bitcoin.test.ts, which fails on the 'confirm on device' assertion, by splitting text verification into two parts

## Related Issue

[Currents - ignored 'Trading - Sell BTC > Sell Bitcoin for best offer' ](https://app.currents.dev/instance/35e35c055051e515/test/7be789b9cefa049f9dad-62b8cdd1c79fb4eb0113)



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/test-sell-bitcoin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/test-sell-bitcoin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T14:20:58.979Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T14:19:50.996Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->