### PR TITLE
fix(alerts): await async button handlers before closing sheet

### DIFF
--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -93,12 +93,12 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
     } = alert;
 
     const handlePressPrimaryButton = async () => {
-        onPressPrimaryButton?.();
+        await onPressPrimaryButton?.();
         await closeSheetAnimated();
     };
 
     const handlePressSecondaryButton = async () => {
-        onPressSecondaryButton?.();
+        await onPressSecondaryButton?.();
         await closeSheetAnimated();
     };
 

--- a/suite-native/module-settings/src/components/useContactSupportAlert.tsx
+++ b/suite-native/module-settings/src/components/useContactSupportAlert.tsx
@@ -23,10 +23,10 @@ export const useContactSupportAlert = () => {
                 <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.primaryButton" />
             ),
             primaryButtonViewRight: 'arrowLineUpRight',
-            onPressPrimaryButton: () => {
+            onPressPrimaryButton: async () => {
                 if (appendixRef.current) {
                     // We need to access the URL via a ref to ensure it's always up to date, even if the value changes while the alert is already displayed.
-                    openLink(appendixRef.current.getSupportChatUrl());
+                    await openLink(appendixRef.current.getSupportChatUrl());
                 }
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,


### PR DESCRIPTION
## Description

Allow alert button handlers to return a `Promise` and `await` them before the sheet close animation runs. Without this, async handlers (e.g. opening a link) would not complete before the sheet dismissed.

## Notes for QA

Open the "Contact Support" alert in Settings and tap the primary button — the sheet should wait for the link to open before dismissing.

## Screenshots:

### BEFORE

https://github.com/user-attachments/assets/12c60fd1-fb03-4517-9596-d61ce1e43a74


### AFTER

https://github.com/user-attachments/assets/e3e64e7b-eedc-4025-af4e-b19c30c84cb5


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native/alert-async-button-handlers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->