### PR TITLE
Chore: more package json requirements

### DIFF
--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -5,7 +5,8 @@ Simple checks for repository requirements on Nx-affected workspaces.
 ## What it does 🧩
 
 - Verifies required repo rules.
-- Can auto-fix supported issues.
+- Can auto-fix issues, if the rule supports it.
+    - If the rule doesn't support auto-fix, it will only verify _(similarly to eslint)_.
 
 ## Usage 🚀
 

--- a/packages/requirements/src/__tests__/getAffectedWorkspaces.test.ts
+++ b/packages/requirements/src/__tests__/getAffectedWorkspaces.test.ts
@@ -12,6 +12,7 @@ const createTestGetAffectedWorkspaces = (options: CreateTestGetAffectedWorkspace
             .fn()
             .mockResolvedValueOnce(options.workspaceListResult)
             .mockResolvedValueOnce(options.affectedResult),
+        requirementsWorkspaceName: '@trezor/requirements',
     });
 
 describe(createGetAffectedWorkspaces.name, () => {
@@ -46,6 +47,37 @@ describe(createGetAffectedWorkspaces.name, () => {
             workspaces: [
                 { name: '@trezor/connect', dir: '/repo/packages/connect' },
                 { name: '@trezor/suite', dir: '/repo/packages/suite' },
+            ],
+        });
+    });
+
+    it('returns all workspaces when @trezor/requirements is affected', async () => {
+        const getAffectedWorkspaces = createTestGetAffectedWorkspaces({
+            workspaceListResult: {
+                exitCode: 0,
+                stderr: '',
+                stdout: [
+                    '{"name":"trezor-suite","location":"."}',
+                    '{"name":"@trezor/connect","location":"packages/connect"}',
+                    '{"name":"@trezor/suite","location":"packages/suite"}',
+                    '{"name":"@trezor/requirements","location":"packages/requirements"}',
+                ].join('\n'),
+            },
+            affectedResult: {
+                exitCode: 0,
+                stderr: '',
+                stdout: '["@trezor/requirements"]',
+            },
+        });
+
+        const result = await getAffectedWorkspaces('/repo/packages/requirements');
+
+        expect(result).toEqual({
+            repoRoot: '/repo',
+            workspaces: [
+                { name: '@trezor/connect', dir: '/repo/packages/connect' },
+                { name: '@trezor/suite', dir: '/repo/packages/suite' },
+                { name: '@trezor/requirements', dir: '/repo/packages/requirements' },
             ],
         });
     });
@@ -128,6 +160,7 @@ describe(createGetAffectedWorkspaces.name, () => {
                     stderr: 'boom',
                 }),
             ),
+            requirementsWorkspaceName: '@trezor/requirements',
         });
 
         await expect(getAffectedWorkspaces('/repo/packages/requirements')).rejects.toThrow(

--- a/packages/requirements/src/getAffectedWorkspaces.ts
+++ b/packages/requirements/src/getAffectedWorkspaces.ts
@@ -22,7 +22,7 @@ type GetAffectedWorkspacesResult = {
 
 export type GetAffectedWorkspaces = (cwd: string) => Promise<GetAffectedWorkspacesResult>;
 
-export type GetAffectedWorkspacesDeps = ExecCliCommandDep;
+export type GetAffectedWorkspacesDeps = ExecCliCommandDep & { requirementsWorkspaceName: string };
 
 export const createGetAffectedWorkspaces =
     (deps: GetAffectedWorkspacesDeps): GetAffectedWorkspaces =>
@@ -82,6 +82,15 @@ export const createGetAffectedWorkspaces =
             throw new Error('Failed to determine affected projects: invalid Nx output format.');
         }
 
+        // if 'requirements' changed, then we need to recheck all workspaces
+        if (affectedWorkspaceNames.includes(deps.requirementsWorkspaceName)) {
+            return {
+                repoRoot,
+                workspaces: allWorkspaces,
+            };
+        }
+
+        // run only affected workspaces
         const workspaces = allWorkspaces.filter(workspace =>
             affectedWorkspaceNames.includes(workspace.name),
         );

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePackageJsonScripts.test.ts
@@ -7,6 +7,12 @@ import { requirePackageJsonScripts } from '../requirePackageJsonScripts';
 
 const createTempWorkspace = (): string => mkdtempSync(join(tmpdir(), 'package-json-'));
 
+const validScripts = {
+    depcheck: 'yarn g:depcheck',
+    'lint:js': "yarn g:eslint '**/*.{ts,tsx,js}'",
+    'type-check': 'yarn g:tsc --build',
+};
+
 describe(requirePackageJsonScripts.name, () => {
     let workspaceDir: string;
     let context: WorkspaceContext;
@@ -24,10 +30,26 @@ describe(requirePackageJsonScripts.name, () => {
         rmSync(workspaceDir, { recursive: true, force: true });
     });
 
-    it('passes when depcheck script is configured correctly', async () => {
+    it('passes when all required scripts are configured correctly', async () => {
         writeFileSync(
             join(workspaceDir, 'package.json'),
-            JSON.stringify({ scripts: { depcheck: 'yarn g:depcheck' } }),
+            JSON.stringify({ scripts: validScripts }),
+        );
+
+        const errors = await requirePackageJsonScripts.verify(context);
+
+        expect(errors).toEqual([]);
+    });
+
+    it('passes when type-check script matches the configured regex', async () => {
+        writeFileSync(
+            join(workspaceDir, 'package.json'),
+            JSON.stringify({
+                scripts: {
+                    ...validScripts,
+                    'type-check': 'yarn g:tsc --build tsconfig.json',
+                },
+            }),
         );
 
         const errors = await requirePackageJsonScripts.verify(context);
@@ -36,7 +58,15 @@ describe(requirePackageJsonScripts.name, () => {
     });
 
     it('reports missing depcheck script', async () => {
-        writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify({ scripts: {} }));
+        writeFileSync(
+            join(workspaceDir, 'package.json'),
+            JSON.stringify({
+                scripts: {
+                    'lint:js': validScripts['lint:js'],
+                    'type-check': validScripts['type-check'],
+                },
+            }),
+        );
 
         const errors = await requirePackageJsonScripts.verify(context);
 
@@ -48,13 +78,36 @@ describe(requirePackageJsonScripts.name, () => {
     it('reports invalid depcheck value', async () => {
         writeFileSync(
             join(workspaceDir, 'package.json'),
-            JSON.stringify({ scripts: { depcheck: 'depcheck' } }),
+            JSON.stringify({
+                scripts: {
+                    ...validScripts,
+                    depcheck: 'depcheck',
+                },
+            }),
         );
 
         const errors = await requirePackageJsonScripts.verify(context);
 
         expect(errors).toEqual([
             '@trezor/example: scripts.depcheck must be "yarn g:depcheck" in package.json.',
+        ]);
+    });
+
+    it('reports invalid type-check value when it does not match the configured regex', async () => {
+        writeFileSync(
+            join(workspaceDir, 'package.json'),
+            JSON.stringify({
+                scripts: {
+                    ...validScripts,
+                    'type-check': 'tsc --build tsconfig.json',
+                },
+            }),
+        );
+
+        const errors = await requirePackageJsonScripts.verify(context);
+
+        expect(errors).toEqual([
+            '@trezor/example: scripts.type-check must be matching /^yarn g:tsc --build.*$/ in package.json.',
         ]);
     });
 
@@ -84,7 +137,15 @@ describe(requirePackageJsonScripts.name, () => {
             workspaceName: 'connect-example-node',
         };
 
-        writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify({ scripts: {} }));
+        writeFileSync(
+            join(workspaceDir, 'package.json'),
+            JSON.stringify({
+                scripts: {
+                    'lint:js': validScripts['lint:js'],
+                    'type-check': validScripts['type-check'],
+                },
+            }),
+        );
 
         const errors = await requirePackageJsonScripts.verify(context);
 

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -22,6 +22,10 @@ const REQUIRED_SCRIPTS: Record<string, RequiredScriptConfig> = {
             '@trezor/webextension-mv3-sw-ts',
         ],
     },
+    'lint:js': {
+        command: "yarn g:eslint '**/*.{ts,tsx,js}'",
+        ignoredPackages: ['@trezor/eslint', '@suite-common/earn-api'],
+    },
 };
 
 type PackageJson = {

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -8,7 +8,7 @@ import type { Requirement } from '../Requirement';
 const PACKAGE_JSON_FILE = 'package.json';
 
 type RequiredScriptConfig = {
-    readonly command: string;
+    readonly command: string | RegExp;
     readonly ignoredPackages?: ReadonlyArray<string>;
 };
 
@@ -26,11 +26,35 @@ const REQUIRED_SCRIPTS: Record<string, RequiredScriptConfig> = {
         command: "yarn g:eslint '**/*.{ts,tsx,js}'",
         ignoredPackages: ['@trezor/eslint', '@suite-common/earn-api'],
     },
+    'type-check': {
+        command: /^yarn g:tsc --build.*$/,
+        ignoredPackages: [
+            '@trezor/address-validator',
+            '@trezor/suite-desktop',
+            'connect-example-electron-main',
+            'connect-mobile-example',
+            'connect-example-node',
+        ],
+    },
 };
 
 type PackageJson = {
     readonly scripts?: Record<string, string | undefined>;
 };
+
+const matchesScriptCommand = (
+    actualCommand: string | undefined,
+    expectedCommand: string | RegExp,
+) => {
+    if (typeof actualCommand !== 'string') return false;
+
+    if (typeof expectedCommand === 'string') return actualCommand === expectedCommand;
+
+    return new RegExp(expectedCommand.source, expectedCommand.flags).test(actualCommand);
+};
+
+const formatExpectedCommand = (expectedCommand: string | RegExp) =>
+    typeof expectedCommand === 'string' ? `"${expectedCommand}"` : `matching ${expectedCommand}`;
 
 export const requirePackageJsonScripts: Requirement<'workspace'> = {
     name: 'package-json-scripts',
@@ -54,11 +78,11 @@ export const requirePackageJsonScripts: Requirement<'workspace'> = {
                     return false;
                 }
 
-                return parsed.scripts?.[scriptName] !== scriptConfig.command;
+                return !matchesScriptCommand(parsed.scripts?.[scriptName], scriptConfig.command);
             })
             .map(
                 ([scriptName, scriptConfig]) =>
-                    `${context.workspaceName}: scripts.${scriptName} must be "${scriptConfig.command}" in ${PACKAGE_JSON_FILE}.`,
+                    `${context.workspaceName}: scripts.${scriptName} must be ${formatExpectedCommand(scriptConfig.command)} in ${PACKAGE_JSON_FILE}.`,
             );
 
         return Promise.resolve(errors);

--- a/packages/requirements/src/run.ts
+++ b/packages/requirements/src/run.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
 
+import { readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 
 import { createExecCliCommand } from './execCliCommand';
@@ -19,6 +20,12 @@ const getModeFromPositionals = (positionals: ReadonlyArray<string>): Requirement
     throw new Error(`Invalid mode "${mode ?? ''}". Use "verify" or "fix".`);
 };
 
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const requirementsWorkspaceName = pkg.name;
+if (typeof requirementsWorkspaceName !== 'string') {
+    throw new Error('Failed to get name of this workspace (requirements) from package.json.');
+}
+
 /**
  * Runs requirements in selected mode (`verify` or `fix`) for Nx-affected workspaces.
  *
@@ -33,7 +40,10 @@ const getModeFromPositionals = (positionals: ReadonlyArray<string>): Requirement
 const main = async () => {
     // Composition Root
     const execCliCommand = createExecCliCommand({ console });
-    const getAffectedWorkspaces = createGetAffectedWorkspaces({ execCliCommand });
+    const getAffectedWorkspaces = createGetAffectedWorkspaces({
+        execCliCommand,
+        requirementsWorkspaceName,
+    });
     const report = createReport({ console });
 
     // Run

--- a/packages/requirements/src/runRequirements.ts
+++ b/packages/requirements/src/runRequirements.ts
@@ -22,13 +22,21 @@ type RunRequirementsProps = {
     readonly mode: RequirementMode;
 };
 
-const executeRequirement = <T extends RequirementScope>(
-    requirement: Requirement<T>,
-    context: T extends 'workspace' ? WorkspaceContext : RepoContext,
-    mode: RequirementMode,
-): Promise<ReadonlyArray<string>> => {
-    if (mode === 'fix' && requirement.fix !== undefined) {
-        return requirement.fix(context);
+type ExecuteRequirementProps<T extends RequirementScope> = {
+    readonly requirement: Requirement<T>;
+    readonly context: T extends 'workspace' ? WorkspaceContext : RepoContext;
+    readonly mode: RequirementMode;
+};
+
+const executeRequirement = <T extends RequirementScope>({
+    requirement,
+    context,
+    mode,
+}: ExecuteRequirementProps<T>): Promise<ReadonlyArray<string>> => {
+    if (mode === 'fix') {
+        if (requirement.fix !== undefined) {
+            return requirement.fix(context);
+        }
     }
 
     return requirement.verify(context);
@@ -48,7 +56,11 @@ export const runRequirements = async ({
 
     for (const requirement of filtered) {
         if (requirement.scope === 'repo') {
-            const errors = await executeRequirement(requirement, { repoRoot }, mode);
+            const errors = await executeRequirement({
+                requirement,
+                context: { repoRoot },
+                mode,
+            });
 
             results.push({
                 requirement: requirement.name,
@@ -67,7 +79,11 @@ export const runRequirements = async ({
                     continue;
                 }
 
-                const errors = await executeRequirement(requirement, context, mode);
+                const errors = await executeRequirement({
+                    requirement,
+                    context,
+                    mode,
+                });
 
                 results.push({
                     requirement: requirement.name,

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -9,7 +9,7 @@
         "android:clean": "cd android && ./gradlew clean",
         "ios": "expo run:ios",
         "start": "expo start --dev-client",
-        "type-check": "yarn g:tsc -b",
+        "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest src",
         "pods": "npx pod-install",
         "prebuild": "expo prebuild",


### PR DESCRIPTION
## Description

- add more required scripts to the `requirePackageJsonScripts`:
  - enforce `lint:js`
  - enforce `type-check`
 - but for that I needed more features to `@trezor/requirements`:
   - run all workspaces if `@trezor/requirements` is among the affected ones
     - when you change the rules, and package may now fail the new rules, so recheck them all, like with eslint or TS
   - support regex match (because the `type-check` commands differ)
   - small interface cleanup

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/more-package-json-requirements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/more-package-json-requirements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/more-package-json-requirements&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-18T15:19:20.678Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-18T15:17:26.715Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->