### PR TITLE
Suite native render with store async removal

### DIFF
--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.test.tsx
@@ -3,7 +3,7 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { AppTabNavigator } from '../AppTabNavigator';
@@ -12,7 +12,7 @@ jest.mock('@suite-common/tx-simulation', () => ({}));
 
 describe('AppTabNavigator', () => {
     const renderTabs = (preloadedState?: PreloadedState) =>
-        renderWithStoreProviderAsync(<AppTabNavigator />, { preloadedState });
+        renderWithStoreProvider(<AppTabNavigator />, { preloadedState });
 
     beforeEach(() => {
         global.fetch = jest.fn().mockResolvedValue({
@@ -21,16 +21,16 @@ describe('AppTabNavigator', () => {
         });
     });
 
-    it('should render 3 buttons', async () => {
-        const { getByText } = await renderTabs();
+    it('should render 3 buttons', () => {
+        const { getByText } = renderTabs();
 
         expect(getByText('Home')).toBeTruthy();
         expect(getByText('My assets')).toBeTruthy();
         expect(getByText('Settings')).toBeTruthy();
     });
 
-    it('should not render Trade tab when all trading flags are disabled', async () => {
-        const { queryByText } = await renderTabs({
+    it('should not render Trade tab when all trading flags are disabled', () => {
+        const { queryByText } = renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
                 [FeatureFlag.IsTradingBuyEnabled]: false,
@@ -77,7 +77,7 @@ describe('AppTabNavigator', () => {
     });
 
     it('should render Trade tab when at least one trading flag is enabled', async () => {
-        const { getByText, getByTestId } = await renderTabs({
+        const { getByText, getByTestId } = renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
                 [FeatureFlag.IsTradingBuyEnabled]: true,
@@ -94,8 +94,8 @@ describe('AppTabNavigator', () => {
         expect(getByTestId('@screen/Trading')).toBeTruthy();
     });
 
-    it('should not render Earn tab when the Earn flag is disabled', async () => {
-        const { queryByText } = await renderTabs({
+    it('should not render Earn tab when the Earn flag is disabled', () => {
+        const { queryByText } = renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
                 [FeatureFlag.IsEarnEnabled]: false,
@@ -105,8 +105,8 @@ describe('AppTabNavigator', () => {
         expect(queryByText('Earn')).toBe(null);
     });
 
-    it('should render Earn tab when the Earn flag is enabled', async () => {
-        const { queryByText } = await renderTabs({
+    it('should render Earn tab when the Earn flag is enabled', () => {
+        const { queryByText } = renderTabs({
             featureFlags: {
                 ...featureFlagsInitialState,
                 [FeatureFlag.IsEarnEnabled]: true,

--- a/suite-native/formatters/src/components/__tests__/TokenAmountFormatter.test.tsx
+++ b/suite-native/formatters/src/components/__tests__/TokenAmountFormatter.test.tsx
@@ -1,22 +1,22 @@
 import { type TokenSymbol } from '@suite-common/wallet-types';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TokenAmountFormatter, type TokenAmountFormatterProps } from '../TokenAmountFormatter';
 
 describe('TokenAmountFormatter', () => {
     const renderTokenAmountFormatter = (props: Partial<TokenAmountFormatterProps>) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TokenAmountFormatter tokenSymbol={'USDC' as TokenSymbol} value="1234.56" {...props} />,
         );
 
-    it('should render formatted value', async () => {
-        const { getByTestId } = await renderTokenAmountFormatter({});
+    it('should render formatted value', () => {
+        const { getByTestId } = renderTokenAmountFormatter({});
 
         expect(getByTestId('plain-text')).toHaveTextContent('1,234.56 USDC');
     });
 
-    it('should render phishing transaction with empty value as discreet text', async () => {
-        const { getByTestId } = await renderTokenAmountFormatter({
+    it('should render phishing transaction with empty value as discreet text', () => {
+        const { getByTestId } = renderTokenAmountFormatter({
             value: '',
             isPhishingTransaction: true,
         });

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.test.tsx
@@ -1,6 +1,6 @@
 import { Context, type ContextDomain } from '@suite-common/message-system';
 import { type Action, type Message } from '@suite-common/suite-types';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ContextMessage } from '../ContextMessage';
 
@@ -56,7 +56,7 @@ const stateWithTradeContextMessage = {
 
 jest.mock('@suite-common/message-system', () => ({
     ...jest.requireActual('@suite-common/message-system'),
-    initMessageSystemThunk: async () => {},
+    initMessageSystemThunk: () => {},
 }));
 
 describe('ContextMessage', () => {
@@ -67,30 +67,30 @@ describe('ContextMessage', () => {
         context: ContextDomain;
         preloadedState?: PreloadedState;
     }) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ContextMessage context={context} accessibilityHint={contextActionId} />,
             {
                 preloadedState,
             },
         );
 
-    it('should render content when there is message of given context', async () => {
-        const { queryByText } = await render({
+    it('should render content when there is message of given context', () => {
+        const { queryByText } = render({
             context: Context.getTrading('buy'),
             preloadedState: stateWithTradeContextMessage,
         });
         expect(queryByText(contentText)).toBeTruthy();
     });
 
-    it('should return null when there is no message fetched', async () => {
-        const { queryByHintText } = await render({
+    it('should return null when there is no message fetched', () => {
+        const { queryByHintText } = render({
             context: Context.getTrading('buy'),
         });
         expect(queryByHintText(contextActionId)).toBeNull();
     });
 
-    it('should render content in English when locale is en-US', async () => {
-        const { queryByText } = await render({
+    it('should render content in English when locale is en-US', () => {
+        const { queryByText } = render({
             context: Context.getTrading('buy'),
             preloadedState: {
                 ...stateWithTradeContextMessage,
@@ -104,8 +104,8 @@ describe('ContextMessage', () => {
         expect(queryByText(contentTextCs)).toBeNull();
     });
 
-    it('should render content in Czech when locale is cs-CZ - different from en-US', async () => {
-        const { queryByText } = await render({
+    it('should render content in Czech when locale is cs-CZ - different from en-US', () => {
+        const { queryByText } = render({
             context: Context.getTrading('buy'),
             preloadedState: {
                 ...stateWithTradeContextMessage,

--- a/suite-native/module-accounts-import/src/components/__tests__/SelectableNetworkList.test.tsx
+++ b/suite-native/module-accounts-import/src/components/__tests__/SelectableNetworkList.test.tsx
@@ -1,5 +1,5 @@
 import { type PreloadedState } from '@suite-native/state';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { SelectableNetworkList } from '../SelectableNetworkList';
 
@@ -10,9 +10,9 @@ const getMockPreloadedState = (areTestnetsEnabled: boolean): PreloadedState => (
 });
 
 describe('SelectableNetworkList', () => {
-    it('should render mainnet and testnet sections when testnets are enabled', async () => {
+    it('should render mainnet and testnet sections when testnets are enabled', () => {
         const onSelectItem = jest.fn();
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
@@ -21,9 +21,9 @@ describe('SelectableNetworkList', () => {
         expect(getByText('Testnet coins (have no value – for testing purposes only)')).toBeTruthy();
     });
 
-    it('should split networks into mainnet and testnet sections correctly', async () => {
+    it('should split networks into mainnet and testnet sections correctly', () => {
         const onSelectItem = jest.fn();
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
@@ -34,9 +34,9 @@ describe('SelectableNetworkList', () => {
         expect(getByText('Ethereum Sepolia')).toBeTruthy();
     });
 
-    it('should call onSelectItem with correct network symbol when item is pressed', async () => {
+    it('should call onSelectItem with correct network symbol when item is pressed', () => {
         const onSelectItem = jest.fn();
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(true) },
         );
@@ -47,9 +47,9 @@ describe('SelectableNetworkList', () => {
         expect(onSelectItem).toHaveBeenCalledWith('test');
     });
 
-    it('should not render testnet section when testnets are disabled', async () => {
+    it('should not render testnet section when testnets are disabled', () => {
         const onSelectItem = jest.fn();
-        const { getByText, queryByText } = await renderWithStoreProviderAsync(
+        const { getByText, queryByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
             { preloadedState: getMockPreloadedState(false) },
         );

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
@@ -1,17 +1,13 @@
 import { PORTFOLIO_TRACKER_DEVICE_ID } from '@suite-common/device';
 import { getTranslation } from '@suite-native/intl';
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    screen,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { EmptyHomeRenderer } from '../EmptyHomeRenderer';
 
 describe('EmptyHomeRenderer', () => {
     const renderEmptyHomeRenderer = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(<EmptyHomeRenderer />, { preloadedState });
+        renderWithStoreProvider(<EmptyHomeRenderer />, { preloadedState });
 
     const expectUninitializedConnectedDeviceState = () => {
         expect(
@@ -31,8 +27,8 @@ describe('EmptyHomeRenderer', () => {
         ).toBeTruthy();
     };
 
-    it('should display UninitializedConnectedDeviceState when device is connected but not initialized', async () => {
-        await renderEmptyHomeRenderer({
+    it('should display UninitializedConnectedDeviceState when device is connected but not initialized', () => {
+        renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: true,
@@ -45,8 +41,8 @@ describe('EmptyHomeRenderer', () => {
         expectUninitializedConnectedDeviceState();
     });
 
-    it('should not display UninitializedConnectedDeviceState when device is connected, not initialized, but model does not support setup', async () => {
-        await renderEmptyHomeRenderer({
+    it('should not display UninitializedConnectedDeviceState when device is connected, not initialized, but model does not support setup', () => {
+        renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: true,
@@ -59,8 +55,8 @@ describe('EmptyHomeRenderer', () => {
         expectEmptyPortfolioCrossroadsState();
     });
 
-    it('should display EmptyPortfolioCrossroadsState when only portfolio tracker is allowed', async () => {
-        await renderEmptyHomeRenderer({
+    it('should display EmptyPortfolioCrossroadsState when only portfolio tracker is allowed', () => {
+        renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: false,
@@ -74,8 +70,8 @@ describe('EmptyHomeRenderer', () => {
         expectEmptyPortfolioCrossroadsState();
     });
 
-    it('should display EmptyPortfolioCrossroadsState when device is not authorized', async () => {
-        await renderEmptyHomeRenderer({
+    it('should display EmptyPortfolioCrossroadsState when device is not authorized', () => {
+        renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: false,
@@ -89,8 +85,8 @@ describe('EmptyHomeRenderer', () => {
         expectEmptyPortfolioCrossroadsState();
     });
 
-    it('should display EmptyConnectedDeviceState when device is connected and authorized', async () => {
-        await renderEmptyHomeRenderer({
+    it('should display EmptyConnectedDeviceState when device is connected and authorized', () => {
+        renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: true,

--- a/suite-native/module-onboarding/src/hooks/__tests__/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/__tests__/useExitOnboardingFlow.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { useExitOnboardingFlow } from '../useExitOnboardingFlow';
@@ -29,16 +29,16 @@ describe('useExitOnboardingFlow', () => {
     let store: TestStore;
 
     const renderUseExitOnboardingFlow = () =>
-        renderHookWithStoreProviderAsync(() => useExitOnboardingFlow(), { store });
+        renderHookWithStoreProvider(() => useExitOnboardingFlow(), { store });
 
     beforeEach(() => {
         store = initStore().store;
         jest.clearAllMocks();
     });
 
-    it('should set onboarding flag and navigate', async () => {
+    it('should set onboarding flag and navigate', () => {
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result } = await renderUseExitOnboardingFlow();
+        const { result } = renderUseExitOnboardingFlow();
 
         // call the returned callback
         act(() => {

--- a/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
@@ -2,7 +2,7 @@ import { OnboardingStackRoutes } from '@suite-native/navigation';
 import {
     type TestStore,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 
@@ -29,7 +29,7 @@ describe('BiometricsScreen', () => {
     let store: TestStore;
 
     const renderBiometricsScreen = () =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <BiometricsScreen
                 navigation={
                     { navigate: mockNavigate } as unknown as BiometricsScreenProps['navigation']
@@ -49,7 +49,7 @@ describe('BiometricsScreen', () => {
                 isTradingResidenceCheckEnabled: true,
             },
         }).store;
-        const { getByText } = await renderBiometricsScreen();
+        const { getByText } = renderBiometricsScreen();
 
         await userEvent.press(getByText('Not now'));
 
@@ -62,7 +62,7 @@ describe('BiometricsScreen', () => {
                 isTradingResidenceCheckEnabled: false,
             },
         }).store;
-        const { getByText } = await renderBiometricsScreen();
+        const { getByText } = renderBiometricsScreen();
 
         await userEvent.press(getByText('Not now'));
 

--- a/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.test.tsx
@@ -3,7 +3,7 @@ import { type RouteProp } from '@react-navigation/native';
 import { events } from '@suite-native/analytics';
 import { type TradingStackParamList, type TradingStackRoutes } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
-import { renderWithStoreProviderAsync, screen, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen, userEvent } from '@suite-native/test-utils';
 
 import { TradingLocationScreen } from '../TradingLocationScreen';
 
@@ -33,8 +33,7 @@ jest.mock('../../hooks/useExitOnboardingFlow', () => ({
 }));
 
 describe('TradingLocationOnboardingScreen', () => {
-    const renderTradingLocationScreen = () =>
-        renderWithStoreProviderAsync(<TradingLocationScreen />);
+    const renderTradingLocationScreen = () => renderWithStoreProvider(<TradingLocationScreen />);
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -48,8 +47,8 @@ describe('TradingLocationOnboardingScreen', () => {
         screen.unmount();
     });
 
-    it('should render all components', async () => {
-        const { getByText, getByLabelText } = await renderTradingLocationScreen();
+    it('should render all components', () => {
+        const { getByText, getByLabelText } = renderTradingLocationScreen();
 
         expect(getByText('Trading is now available')).toBeOnTheScreen();
         expect(getByText('Confirm location')).toBeOnTheScreen();
@@ -59,7 +58,7 @@ describe('TradingLocationOnboardingScreen', () => {
     });
 
     it('should log analytics event on country change', async () => {
-        const { getByText } = await renderTradingLocationScreen();
+        const { getByText } = renderTradingLocationScreen();
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText('Argentina'));
@@ -75,7 +74,7 @@ describe('TradingLocationOnboardingScreen', () => {
     });
 
     it('should use exitOnboardingFlow on button press', async () => {
-        const { getByText } = await renderTradingLocationScreen();
+        const { getByText } = renderTradingLocationScreen();
         await userEvent.press(getByText('Not now'));
 
         expect(mockExitOnboardingFlow).toHaveBeenCalledTimes(1);

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { SendUtxoScreenFooter } from '../SendUtxoScreenFooter';
 
@@ -7,8 +7,8 @@ jest.mock('../../../hooks/useUtxoSelection', () => ({
 }));
 
 describe('SendUtxosScreenFooter', () => {
-    it('should render footer with selected total and continue button', async () => {
-        const { getByText } = await renderWithStoreProviderAsync(
+    it('should render footer with selected total and continue button', () => {
+        const { getByText } = renderWithStoreProvider(
             <SendUtxoScreenFooter symbol="btc" selectedTotal="800000000" onSubmit={jest.fn()} />,
         );
 
@@ -17,8 +17,8 @@ describe('SendUtxosScreenFooter', () => {
         expect(getByText('Confirm selection')).toBeTruthy();
     });
 
-    it('should show remaining amount when amount is provided and selected total is less than amount', async () => {
-        const { getByText } = await renderWithStoreProviderAsync(
+    it('should show remaining amount when amount is provided and selected total is less than amount', () => {
+        const { getByText } = renderWithStoreProvider(
             <SendUtxoScreenFooter
                 symbol="btc"
                 selectedTotal="500000000"
@@ -31,8 +31,8 @@ describe('SendUtxosScreenFooter', () => {
         expect(getByText('3 BTC')).toBeTruthy(); // 800000000 - 500000000 = 300000000 (3 BTC)
     });
 
-    it('should not show remaining amount when selected total is equal to or greater than amount', async () => {
-        const { queryByText } = await renderWithStoreProviderAsync(
+    it('should not show remaining amount when selected total is equal to or greater than amount', () => {
+        const { queryByText } = renderWithStoreProvider(
             <SendUtxoScreenFooter
                 symbol="btc"
                 selectedTotal="800000000"

--- a/suite-native/module-send/src/hooks/__tests__/useRequestDelayedNavigationToOutputsReview.test.ts
+++ b/suite-native/module-send/src/hooks/__tests__/useRequestDelayedNavigationToOutputsReview.test.ts
@@ -1,5 +1,5 @@
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useRequestDelayedNavigationToOutputsReview } from '../useRequestDelayedNavigationToOutputsReview';
 
@@ -20,7 +20,7 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('useRequestDelayedNavigationToOutputsReview', () => {
     const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProviderAsync(() =>
+        renderHookWithStoreProvider(() =>
             useRequestDelayedNavigationToOutputsReview({
                 accountKey: 'accountKey' as AccountKey,
                 tokenContract: 'tokenContract' as TokenAddress,
@@ -31,8 +31,8 @@ describe('useRequestDelayedNavigationToOutputsReview', () => {
         jest.clearAllMocks();
     });
 
-    it('should call navigate once there are any button requests', async () => {
-        const { result, rerender } = await renderUseRequestDelayedNavigationToOutputsReview();
+    it('should call navigate once there are any button requests', () => {
+        const { result, rerender } = renderUseRequestDelayedNavigationToOutputsReview();
 
         act(() => {
             result.current();

--- a/suite-native/module-settings/src/components/__tests__/FaqCard.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/FaqCard.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { FaqCard } from '../FaqCard';
 
@@ -17,7 +17,7 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('FaqCard', () => {
     const renderFaqCard = (preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(<FaqCard />, { preloadedState });
+        renderWithStoreProvider(<FaqCard />, { preloadedState });
 
     beforeEach(() => {
         mockIsTradingEnabled = true;
@@ -28,8 +28,8 @@ describe('FaqCard', () => {
             mockIsAndroid = true;
         });
 
-        it('should render appropriate sections when BT is enabled', async () => {
-            const { getByText } = await renderFaqCard();
+        it('should render appropriate sections when BT is enabled', () => {
+            const { getByText } = renderFaqCard();
 
             // Android BT-specific info
             expect(getByText('For wireless connections:')).toBeOnTheScreen();
@@ -38,10 +38,10 @@ describe('FaqCard', () => {
             expect(getByText('What trading features are available?')).toBeOnTheScreen();
         });
 
-        it('should not render trading section when trading is disabled', async () => {
+        it('should not render trading section when trading is disabled', () => {
             mockIsTradingEnabled = false;
 
-            const { queryByText } = await renderFaqCard();
+            const { queryByText } = renderFaqCard();
 
             expect(queryByText('What trading features are available?')).toBeNull();
         });
@@ -52,8 +52,8 @@ describe('FaqCard', () => {
             mockIsAndroid = false;
         });
 
-        it('should render appropriate sections when BT is enabled', async () => {
-            const { getByText } = await renderFaqCard();
+        it('should render appropriate sections when BT is enabled', () => {
+            const { getByText } = renderFaqCard();
 
             // iOS BT-specific info
             expect(
@@ -64,10 +64,10 @@ describe('FaqCard', () => {
             expect(getByText('What trading features are available?')).toBeOnTheScreen();
         });
 
-        it('should not render trading section when trading is disabled', async () => {
+        it('should not render trading section when trading is disabled', () => {
             mockIsTradingEnabled = false;
 
-            const { queryByText } = await renderFaqCard();
+            const { queryByText } = renderFaqCard();
 
             expect(queryByText('What trading features are available?')).toBeNull();
         });

--- a/suite-native/module-settings/src/components/__tests__/GeneralSettings.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/GeneralSettings.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { GeneralSettings } from '../GeneralSettings';
 
@@ -9,14 +9,14 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 
 describe('GeneralSettings', () => {
-    const renderGeneralSettings = () => renderWithStoreProviderAsync(<GeneralSettings />);
+    const renderGeneralSettings = () => renderWithStoreProvider(<GeneralSettings />);
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render trading settings button', async () => {
-        const { getByTestId } = await renderGeneralSettings();
+    it('should render trading settings button', () => {
+        const { getByTestId } = renderGeneralSettings();
 
         expect(getByTestId('@settings/trading')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
@@ -1,7 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     renderWithBasicProvider,
 } from '@suite-native/test-utils';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -12,15 +12,15 @@ import { BuyAlert } from '../BuyAlert';
 describe('BuyAlert', () => {
     let form: BuyFormType;
 
-    const renderFormHook = () => renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderFormHook = () => renderHookWithStoreProvider(() => useBuyForm());
 
     const renderTradingAlert = () =>
         renderWithBasicProvider(<BuyAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderFormHook();
+    beforeEach(() => {
+        const { result } = renderFormHook();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
 import { BuyConfirmation } from '../BuyConfirmation';
@@ -17,11 +17,11 @@ describe('BuyConfirmation', () => {
     const mockUseBuyFlow = require('../../../hooks/buy/useBuyFlow').useBuyFlow;
 
     const renderConfirmation = () =>
-        renderWithStoreProviderAsync(<BuyConfirmation />, {
+        renderWithStoreProvider(<BuyConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
-    it('should render continue button when canProceed is true', async () => {
+    it('should render continue button when canProceed is true', () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -30,11 +30,11 @@ describe('BuyConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
         expect(getByText('Continue')).toBeTruthy();
     });
 
-    it('should not render continue button when canProceed is false', async () => {
+    it('should not render continue button when canProceed is false', () => {
         mockUseBuyFlow.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
@@ -43,7 +43,7 @@ describe('BuyConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { queryByText } = await renderConfirmation();
+        const { queryByText } = renderConfirmation();
 
         expect(queryByText('Continue')).toBeNull();
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
@@ -2,8 +2,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { btcAsset, getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -19,15 +19,15 @@ describe('BuyCryptoAmountInput', () => {
         form: BuyFormType,
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <BuyCryptoAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
             { preloadedState },
         );
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
@@ -35,28 +35,28 @@ describe('BuyCryptoAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You get'), '100');
 
         expect(form.getValues('cryptoValue')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', async () => {
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', () => {
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         expect(getByLabelText('You get')).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You get'));
 
@@ -65,11 +65,11 @@ describe('BuyCryptoAmountInput', () => {
 
     it('should not call showAssetsSheet when enabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You get'));
 
@@ -77,11 +77,11 @@ describe('BuyCryptoAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You get'), 'asd1.123');
 
@@ -93,11 +93,11 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You get'), 'asd1.123');
 
@@ -109,11 +109,11 @@ describe('BuyCryptoAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You get'), 'asd');
 
@@ -121,35 +121,35 @@ describe('BuyCryptoAmountInput', () => {
         expect(getByLabelText('You get')).toHaveDisplayValue('');
     });
 
-    it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
+    it('should display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         preloadedState.wallet.trading.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
 
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 
-    it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
+    it('should not display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         preloadedState.wallet.trading.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { queryByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { queryByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         expect(queryByLabelText('Fetching offers...')).toBeNull();
     });
 
     it('should limit value to 9 decimals', async () => {
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('asset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You get'), '1.0123456789');
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
@@ -2,8 +2,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -14,15 +14,15 @@ import { BuyFiatAmountInput } from '../BuyFiatAmountInput';
 
 describe('BuyFiatAmountInput', () => {
     const renderFiatAmountInput = (form: BuyFormType, preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <BuyFiatAmountInput />
             </Form>,
             { preloadedState },
         );
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
@@ -30,8 +30,8 @@ describe('BuyFiatAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), '100');
 
@@ -39,8 +39,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should format input value to be decimal', async () => {
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
@@ -49,8 +49,8 @@ describe('BuyFiatAmountInput', () => {
     });
 
     it('should always escape non-numeric characters', async () => {
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd');
 
@@ -58,32 +58,32 @@ describe('BuyFiatAmountInput', () => {
         expect(getByLabelText('You pay')).toHaveDisplayValue('');
     });
 
-    it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', async () => {
+    it('should display loading skeleton while amountInCrypto is true and buyInfo is loading', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         preloadedState.wallet.trading.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
         act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { getByLabelText } = await renderFiatAmountInput(form, preloadedState);
+        const { getByLabelText } = renderFiatAmountInput(form, preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 
-    it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', async () => {
+    it('should not display loading skeleton while amountInCrypto is false and buyInfo is loading', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         preloadedState.wallet.trading.buy.isLoading = true;
-        const form = await renderUseTradingBuyForm();
+        const form = renderUseTradingBuyForm();
 
-        const { queryByLabelText } = await renderFiatAmountInput(form, preloadedState);
+        const { queryByLabelText } = renderFiatAmountInput(form, preloadedState);
 
         expect(queryByLabelText('Fetching offers...')).toBeNull();
     });
 
     it('should limit value to 3 decimals', async () => {
-        const form = await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingBuyForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You pay'), '1.0123456789');
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
@@ -3,8 +3,8 @@ import { Form } from '@suite-native/forms';
 import {
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -25,13 +25,13 @@ describe('BuyFiatCurrencyPicker', () => {
         mockUseListDataFilter = jest.requireActual('@suite-common/trading').useListDataFilter;
     });
 
-    const renderFiatCurrencyPicker = async () => {
+    const renderFiatCurrencyPicker = () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <Form form={result.current}>
                 <BuyFiatCurrencyPicker />
             </Form>,
@@ -45,14 +45,14 @@ describe('BuyFiatCurrencyPicker', () => {
         screen.unmount();
     });
 
-    it('should display selected currency', async () => {
-        const { getByLabelText } = await renderFiatCurrencyPicker();
+    it('should display selected currency', () => {
+        const { getByLabelText } = renderFiatCurrencyPicker();
 
         expect(getByLabelText('Select fiat currency')).toHaveTextContent(/CZK/);
     });
 
     it('should allow to select currency', async () => {
-        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
 
         fireEvent.press(getByLabelText('Select fiat currency'));
         fireEvent.press(getByText('USD'));
@@ -63,14 +63,14 @@ describe('BuyFiatCurrencyPicker', () => {
         expect(getByLabelText('Select fiat currency')).toHaveTextContent(/USD/);
     });
 
-    it('should display empty component when filtered data is empty', async () => {
+    it('should display empty component when filtered data is empty', () => {
         mockUseListDataFilter = () => ({
             filteredData: [],
             setFilterValue: jest.fn(),
             filterValue: 'test-key',
         });
 
-        const { getByText } = await renderFiatCurrencyPicker();
+        const { getByText } = renderFiatCurrencyPicker();
 
         expect(getByText('Currency not found')).toBeTruthy();
         expect(

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.test.tsx
@@ -1,11 +1,11 @@
-import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { BuyFiatCurrencySheet } from '../BuyFiatCurrencySheet';
 
 describe('BuyFiatCurrencySheet', () => {
     const renderBuyFiatCurrencySheet = () =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <BuyFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) } },
         );
@@ -14,8 +14,8 @@ describe('BuyFiatCurrencySheet', () => {
         screen.unmount();
     });
 
-    it('should render items based on buy state', async () => {
-        const { getByText } = await renderBuyFiatCurrencySheet();
+    it('should render items based on buy state', () => {
+        const { getByText } = renderBuyFiatCurrencySheet();
 
         expect(getByText('USD')).toBeOnTheScreen();
         expect(getByText('EUR')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
@@ -2,8 +2,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import {
@@ -22,10 +22,10 @@ jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
 
 describe('BuyForm', () => {
     const renderFormHook = (preloadedState: PreloadedState) =>
-        renderHookWithStoreProviderAsync(() => useBuyForm(), { preloadedState });
+        renderHookWithStoreProvider(() => useBuyForm(), { preloadedState });
 
     const renderBuyForm = (preloadedState: PreloadedState, form: BuyFormType) =>
-        renderWithStoreProviderAsync(<BuyForm />, {
+        renderWithStoreProvider(<BuyForm />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -34,9 +34,9 @@ describe('BuyForm', () => {
         screen.unmount();
     });
 
-    it('should render when buy data are not preloaded', async () => {
-        const { result } = await renderFormHook(residenceCheckDisabledState);
-        const { queryByText, getByText, getByLabelText } = await renderBuyForm(
+    it('should render when buy data are not preloaded', () => {
+        const { result } = renderFormHook(residenceCheckDisabledState);
+        const { queryByText, getByText, getByLabelText } = renderBuyForm(
             residenceCheckDisabledState,
             result.current,
         );
@@ -59,16 +59,13 @@ describe('BuyForm', () => {
             ...residenceCheckDisabledState,
         };
 
-        beforeEach(async () => {
-            const { result } = await renderFormHook(preloadedState);
+        beforeEach(() => {
+            const { result } = renderFormHook(preloadedState);
             form = result.current;
         });
 
-        it('should render with default values', async () => {
-            const { queryByText, getByLabelText, getByText } = await renderBuyForm(
-                preloadedState,
-                form,
-            );
+        it('should render with default values', () => {
+            const { queryByText, getByLabelText, getByText } = renderBuyForm(preloadedState, form);
 
             expect(getByText('You pay')).toBeTruthy();
 
@@ -84,11 +81,11 @@ describe('BuyForm', () => {
             expect(queryByText('Continue')).toBeNull();
         });
 
-        it('should render only BuyCard and Done when amount input is active', async () => {
+        it('should render only BuyCard and Done when amount input is active', () => {
             act(() => {
                 form.setValue('focusedValue', 'fiatValue');
             });
-            const { queryByText, getByText } = await renderBuyForm(preloadedState, form);
+            const { queryByText, getByText } = renderBuyForm(preloadedState, form);
 
             expect(getByText('You pay')).toBeTruthy();
             expect(getByText('You get')).toBeTruthy();
@@ -99,8 +96,8 @@ describe('BuyForm', () => {
             expect(queryByText('Continue')).toBeNull();
         });
 
-        it('should not render receive account when assets is not selected', async () => {
-            const { queryByText, getByTestId } = await renderBuyForm(preloadedState, form);
+        it('should not render receive account when assets is not selected', () => {
+            const { queryByText, getByTestId } = renderBuyForm(preloadedState, form);
 
             expect(queryByText('Receive account')).toBeNull();
             expect(getByTestId('@trading/buyCard/fiatSection')).toHaveStyle({
@@ -111,11 +108,11 @@ describe('BuyForm', () => {
             });
         });
 
-        it('should render receive account once asset is selected', async () => {
+        it('should render receive account once asset is selected', () => {
             act(() => {
                 form.setValue('asset', btcAsset);
             });
-            const { getByText, getByTestId } = await renderBuyForm(preloadedState, form);
+            const { getByText, getByTestId } = renderBuyForm(preloadedState, form);
 
             expect(getByText('Receive account')).toBeTruthy();
             expect(getByTestId('@trading/buyCard/fiatSection')).toHaveStyle({

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -9,8 +9,8 @@ import {
     act,
     fireEvent,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { buyQuotes, getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
@@ -33,14 +33,14 @@ jest.mock('@suite-native/services', () => {
 describe('BuyPaymentMethodPicker', () => {
     let form: BuyFormType;
 
-    const renderPaymentMethodPicker = async (
+    const renderPaymentMethodPicker = (
         preloadedState: PreloadedState | undefined = {},
         store?: EnhancedStore,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+        const { result } = renderHookWithStoreProvider(() => useBuyForm());
         form = result.current;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <Form form={form}>
                 <BuyPaymentMethodPicker />
             </Form>,
@@ -60,18 +60,18 @@ describe('BuyPaymentMethodPicker', () => {
         screen.unmount();
     });
 
-    it('should not render when there are no payment methods', async () => {
-        const { toJSON } = await renderPaymentMethodPicker();
+    it('should not render when there are no payment methods', () => {
+        const { toJSON } = renderPaymentMethodPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display loader when loading initial quotes', async () => {
+    it('should display loader when loading initial quotes', () => {
         const preloadedState: PreloadedState = {
             wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         };
 
-        const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
+        const { getByLabelText } = renderPaymentMethodPicker(preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
@@ -83,13 +83,13 @@ describe('BuyPaymentMethodPicker', () => {
             preloadedState = { wallet: { trading: getInitializedTradingStateWithQuotes() } };
         });
 
-        it('should display "Not selected" when no method is selected in form', async () => {
-            const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
+        it('should display "Not selected" when no method is selected in form', () => {
+            const { getByLabelText } = renderPaymentMethodPicker(preloadedState);
             expect(getByLabelText('No payment method selected')).toHaveTextContent('Not selected');
         });
 
-        it('should allow to select payment method', async () => {
-            const { getByText, getByLabelText } = await renderPaymentMethodPicker(preloadedState);
+        it('should allow to select payment method', () => {
+            const { getByText, getByLabelText } = renderPaymentMethodPicker(preloadedState);
 
             fireEvent.press(getByText('Payment method'));
             fireEvent.press(getByText('Credit Card'));
@@ -97,17 +97,17 @@ describe('BuyPaymentMethodPicker', () => {
             expect(getByLabelText('Selected payment method')).toHaveTextContent('Credit Card');
         });
 
-        it('should display loader while quotes are fetched', async () => {
+        it('should display loader while quotes are fetched', () => {
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
-            const { getByLabelText } = await renderPaymentMethodPicker(preloadedState);
+            const { getByLabelText } = renderPaymentMethodPicker(preloadedState);
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
         });
 
-        it('should display sheet even while quotes are fetched', async () => {
+        it('should display sheet even while quotes are fetched', () => {
             const { store } = initStore();
             store.dispatch(tradingBuyActions.saveQuotes(buyQuotes));
-            const { getByText } = await renderPaymentMethodPicker(undefined, store);
+            const { getByText } = renderPaymentMethodPicker(undefined, store);
 
             fireEvent.press(getByText('Payment method'));
             act(() => {
@@ -122,8 +122,8 @@ describe('BuyPaymentMethodPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on payment method select', async () => {
-                const { getByText } = await renderPaymentMethodPicker(preloadedState);
+            it('should fire analytics event on payment method select', () => {
+                const { getByText } = renderPaymentMethodPicker(preloadedState);
 
                 fireEvent.press(getByText('Payment method'));
                 fireEvent.press(getByText('Credit Card'));
@@ -137,8 +137,8 @@ describe('BuyPaymentMethodPicker', () => {
                 });
             });
 
-            it('should fire analytics event on payment method change', async () => {
-                const { getByText } = await renderPaymentMethodPicker(preloadedState);
+            it('should fire analytics event on payment method change', () => {
+                const { getByText } = renderPaymentMethodPicker(preloadedState);
 
                 act(() => {
                     form.setValue('quote', buyQuotes[1]);
@@ -150,8 +150,8 @@ describe('BuyPaymentMethodPicker', () => {
                 expect(reportMock).toHaveBeenCalledTimes(1);
             });
 
-            it('should not fire analytics event when same payment method is selected', async () => {
-                const { getByText, getAllByText } = await renderPaymentMethodPicker(preloadedState);
+            it('should not fire analytics event when same payment method is selected', () => {
+                const { getByText, getAllByText } = renderPaymentMethodPicker(preloadedState);
 
                 act(() => {
                     form.setValue('quote', buyQuotes[1]);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
@@ -5,8 +5,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import {
@@ -35,8 +35,8 @@ jest.mock('@suite-native/services', () => {
 describe('BuyProviderPicker', () => {
     let form: BuyFormType;
 
-    const renderUseTradingBuyForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    const renderUseTradingBuyForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
         });
         form = result.current;
@@ -45,7 +45,7 @@ describe('BuyProviderPicker', () => {
     };
 
     const renderTradingProviderPicker = (preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <BuyProviderPicker />
             </Form>,
@@ -64,19 +64,19 @@ describe('BuyProviderPicker', () => {
         });
     });
 
-    it('should display nothing when in default state', async () => {
-        await renderUseTradingBuyForm();
-        const { toJSON } = await renderTradingProviderPicker();
+    it('should display nothing when in default state', () => {
+        renderUseTradingBuyForm();
+        const { toJSON } = renderTradingProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display loader while quotes are fetched', async () => {
+    it('should display loader while quotes are fetched', () => {
         const preloadedState: PreloadedState = {
             wallet: { trading: { buy: { isLoading: true, quotes: [] } } },
         };
-        await renderUseTradingBuyForm();
-        const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
+        renderUseTradingBuyForm();
+        const { getByLabelText } = renderTradingProviderPicker(preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
@@ -97,8 +97,8 @@ describe('BuyProviderPicker', () => {
             };
         });
 
-        it('should allow to select provider', async () => {
-            const { getByText, getByLabelText } = await renderTradingProviderPicker(preloadedState);
+        it('should allow to select provider', () => {
+            const { getByText, getByLabelText } = renderTradingProviderPicker(preloadedState);
 
             fireEvent.press(getByText('Provider'));
             fireEvent.press(getByText('Mercuryo'));
@@ -106,31 +106,31 @@ describe('BuyProviderPicker', () => {
             expect(getByLabelText('Selected provider')).toHaveTextContent('Mercuryo');
         });
 
-        it('should display loader while quotes are re-fetched', async () => {
+        it('should display loader while quotes are re-fetched', () => {
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
-            const { getByLabelText } = await renderTradingProviderPicker(preloadedState);
+            const { getByLabelText } = renderTradingProviderPicker(preloadedState);
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
         });
 
-        it('should display sheet even while quotes are fetched', async () => {
+        it('should display sheet even while quotes are fetched', () => {
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
-            const { getByText } = await renderTradingProviderPicker(preloadedState);
+            const { getByText } = renderTradingProviderPicker(preloadedState);
 
             fireEvent.press(getByText('Provider'));
 
             expect(getByText('Mercuryo')).toBeOnTheScreen();
         });
 
-        it('should display kyc warning when not loading', async () => {
-            const { getByText } = await renderTradingProviderPicker(preloadedState);
+        it('should display kyc warning when not loading', () => {
+            const { getByText } = renderTradingProviderPicker(preloadedState);
 
             expect(getByText('This provider requires to know your identity.')).toBeOnTheScreen();
         });
 
-        it('should not display kyc warning when loading', async () => {
+        it('should not display kyc warning when loading', () => {
             preloadedState!.wallet!.trading!.buy!.isLoading = true;
-            const { queryByText } = await renderTradingProviderPicker(preloadedState);
+            const { queryByText } = renderTradingProviderPicker(preloadedState);
             expect(
                 queryByText('This provider requires to know your identity.'),
             ).not.toBeOnTheScreen();
@@ -141,8 +141,8 @@ describe('BuyProviderPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on provider select', async () => {
-                const { getByText } = await renderTradingProviderPicker(preloadedState);
+            it('should fire analytics event on provider select', () => {
+                const { getByText } = renderTradingProviderPicker(preloadedState);
 
                 fireEvent.press(getByText('Provider'));
                 fireEvent.press(getByText('Mercuryo'));
@@ -163,8 +163,8 @@ describe('BuyProviderPicker', () => {
                 });
             });
 
-            it('should fire analytics event on provider change', async () => {
-                const { getByText } = await renderTradingProviderPicker(preloadedState);
+            it('should fire analytics event on provider change', () => {
+                const { getByText } = renderTradingProviderPicker(preloadedState);
 
                 fireEvent.press(getByText('Provider'));
                 fireEvent.press(getByText('Mercuryo'));
@@ -172,9 +172,8 @@ describe('BuyProviderPicker', () => {
                 expect(reportMock).toHaveBeenCalledTimes(2);
             });
 
-            it('should not fire analytics event when same provider is selected', async () => {
-                const { getByText, getAllByText } =
-                    await renderTradingProviderPicker(preloadedState);
+            it('should not fire analytics event when same provider is selected', () => {
+                const { getByText, getAllByText } = renderTradingProviderPicker(preloadedState);
 
                 fireEvent.press(getByText('Provider'));
                 fireEvent.press(getAllByText('Cexdirect')[1]);
@@ -188,9 +187,9 @@ describe('BuyProviderPicker', () => {
                 });
             });
 
-            it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
+            it('should not call analytics when user tries to open sheet while quotes are loading', () => {
                 preloadedState!.wallet!.trading!.buy!.isLoading = true;
-                const { getByText } = await renderTradingProviderPicker(preloadedState);
+                const { getByText } = renderTradingProviderPicker(preloadedState);
 
                 fireEvent.press(getByText('Provider'));
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -16,31 +16,31 @@ import {
 describe('BuyReceiveAccountCryptoBalance', () => {
     let buyForm: BuyFormType;
 
-    const renderBuyForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderBuyForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm());
 
         return result.current;
     };
 
     const renderComponent = () =>
-        renderWithStoreProviderAsync(<BuyReceiveAccountCryptoBalance />, {
+        renderWithStoreProvider(<BuyReceiveAccountCryptoBalance />, {
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        buyForm = await renderBuyForm();
+    beforeEach(() => {
+        buyForm = renderBuyForm();
     });
 
-    it('should use asset form field as default symbol', async () => {
+    it('should use asset form field as default symbol', () => {
         act(() => {
             buyForm.setValue('asset', btcAsset);
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use receiveAccount form field to obtain account', async () => {
+    it('should use receiveAccount form field to obtain account', () => {
         act(() => {
             buyForm.setValue('asset', btcAsset);
         });
@@ -49,7 +49,7 @@ describe('BuyReceiveAccountCryptoBalance', () => {
                 account: getBtcAccount(),
             });
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
@@ -3,8 +3,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { tradingInitialState } from '@suite-native/trading-state';
@@ -45,14 +45,14 @@ const getTradingState = (selectedReceiveAccount: ReceiveAccount | undefined) => 
 describe('BuyReceiveAccountPicker', () => {
     let buyForm: BuyFormType;
 
-    const renderBuyForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderBuyForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm());
 
         return result.current;
     };
 
     const renderPicker = ({ preloadedState }: { preloadedState?: PreloadedState } = {}) =>
-        renderWithStoreProviderAsync(<BuyReceiveAccountPicker />, {
+        renderWithStoreProvider(<BuyReceiveAccountPicker />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
         });
@@ -63,29 +63,29 @@ describe('BuyReceiveAccountPicker', () => {
         });
     };
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.resetAllMocks();
-        buyForm = await renderBuyForm();
+        buyForm = renderBuyForm();
     });
 
-    it('should display nothing when selectedSymbol is not specified', async () => {
-        const { toJSON } = await renderPicker();
+    it('should display nothing when selectedSymbol is not specified', () => {
+        const { toJSON } = renderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when asset is not specified', async () => {
+    it('should display "Not selected" when asset is not specified', () => {
         setSelectedAsset(btcAsset);
-        const { getByText } = await renderPicker();
+        const { getByText } = renderPicker();
 
         expect(getByText('Not selected')).toBeTruthy();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should display selected account name and address', async () => {
+    it.skip('should display selected account name and address', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
-        const { getByText } = await renderPicker({
+        const { getByText } = renderPicker({
             preloadedState: getTradingState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],
@@ -96,10 +96,10 @@ describe('BuyReceiveAccountPicker', () => {
         expect(getByText(btcAddressAddress)).toBeTruthy();
     });
 
-    it('should call navigate with correct params on press', async () => {
+    it('should call navigate with correct params on press', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
-        const { getByText } = await renderPicker({
+        const { getByText } = renderPicker({
             preloadedState: getTradingState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
@@ -1,7 +1,7 @@
 import {
     type PreloadedState,
     act,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     screen,
     userEvent,
 } from '@suite-native/test-utils';
@@ -31,7 +31,7 @@ describe('BuyTab', () => {
     });
 
     const renderBuyTab = (preloadedState?: PreloadedState) =>
-        renderWithStoreProviderAsync(<BuyTab />, { preloadedState });
+        renderWithStoreProvider(<BuyTab />, { preloadedState });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -45,50 +45,50 @@ describe('BuyTab', () => {
         expect(screen.getByText("It's not you, it's us.")).toBeTruthy();
     };
 
-    it('should render Buy skeleton when isLoading is true', async () => {
+    it('should render Buy skeleton when isLoading is true', () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderBuyTab();
+        renderBuyTab();
 
         expectSkeleton();
     });
 
-    it('should render Buy skeleton when lastLoadedTimestamp is 0', async () => {
+    it('should render Buy skeleton when lastLoadedTimestamp is 0', () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        await renderBuyTab();
+        renderBuyTab();
 
         expectSkeleton();
     });
 
-    it('should render Buy form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
+    it('should render Buy form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        await renderBuyTab();
+        renderBuyTab();
 
         expectBuyForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
         mockUseTradingBuyData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderBuyTab();
+        renderBuyTab();
 
         expectServerOffline();
     });
@@ -106,7 +106,7 @@ describe('BuyTab', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = await renderBuyTab();
+        const { getByText } = renderBuyTab();
 
         const reloadButton = getByText('Try again');
 
@@ -120,9 +120,9 @@ describe('BuyTab', () => {
         expect(mockUseTradingBuyData).toHaveBeenCalledWith(1);
     });
 
-    it('should render disabled info when buy is disabled by FFs', async () => {
+    it('should render disabled info when buy is disabled by FFs', () => {
         (selectIsTradingBuyEnabled as jest.Mock).mockReturnValue(false);
-        const { getByText } = await renderBuyTab();
+        const { getByText } = renderBuyTab();
 
         expect(getByText('Buy disabled')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -4,8 +4,8 @@ import { Form } from '@suite-native/forms';
 import {
     fireEvent,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -25,8 +25,8 @@ describe('BuyTradeableAssetPicker', () => {
             wallet: { trading: getInitializedTradingState() },
         });
 
-    const renderFormHook = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useBuyForm(), {
+    const renderFormHook = () => {
+        const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             store,
         });
 
@@ -34,7 +34,7 @@ describe('BuyTradeableAssetPicker', () => {
     };
 
     const renderTradeableAssetPicker = () =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <BuyTradeableAssetPicker />
             </Form>,
@@ -46,19 +46,19 @@ describe('BuyTradeableAssetPicker', () => {
     });
 
     describe('with regular firmware', () => {
-        beforeEach(async () => {
-            store = (await initPreloadedStore(FirmwareType.Universal)).store;
-            form = await renderFormHook();
+        beforeEach(() => {
+            store = initPreloadedStore(FirmwareType.Universal).store;
+            form = renderFormHook();
         });
 
-        it('should render "Select asset" button with caret', async () => {
-            const { getByLabelText } = await renderTradeableAssetPicker();
+        it('should render "Select asset" button with caret', () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
 
             expect(getByLabelText('Select asset')).toHaveTextContent(/^Select asset.$/);
         });
 
-        it('should render bottom sheet with all assets', async () => {
-            const { getByLabelText } = await renderTradeableAssetPicker();
+        it('should render bottom sheet with all assets', () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
 
             expect(getByLabelText('Bitcoin')).toBeTruthy();
             expect(getByLabelText('USDC')).toBeTruthy();
@@ -66,25 +66,25 @@ describe('BuyTradeableAssetPicker', () => {
     });
 
     describe('with BTC-only firmware', () => {
-        beforeEach(async () => {
-            store = (await initPreloadedStore(FirmwareType.BitcoinOnly)).store;
-            form = await renderFormHook();
+        beforeEach(() => {
+            store = initPreloadedStore(FirmwareType.BitcoinOnly).store;
+            form = renderFormHook();
         });
 
-        it('should preselect BTC and do not render caret', async () => {
-            const { getByLabelText } = await renderTradeableAssetPicker();
+        it('should preselect BTC and do not render caret', () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
 
             expect(getByLabelText('Select asset')).toHaveTextContent('BTC');
         });
 
-        it('should not render bottom sheet at all', async () => {
-            const { queryByLabelText } = await renderTradeableAssetPicker();
+        it('should not render bottom sheet at all', () => {
+            const { queryByLabelText } = renderTradeableAssetPicker();
 
             expect(queryByLabelText('Bitcoin')).toBeNull();
         });
 
-        it('should do nothing on button or input press', async () => {
-            const { getByLabelText } = await renderTradeableAssetPicker();
+        it('should do nothing on button or input press', () => {
+            const { getByLabelText } = renderTradeableAssetPicker();
 
             // no need to act as there should be no action
             fireEvent.press(getByLabelText('Select asset'));

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { ExchangeApprovalLimitSheet } from '../ExchangeApprovalLimitSheet';
@@ -25,7 +25,7 @@ const renderSheet = (
     quote = testQuote,
     selectedApprovalType: 'INFINITE' | 'MINIMAL' = 'INFINITE',
 ) =>
-    renderWithStoreProviderAsync(
+    renderWithStoreProvider(
         <ExchangeApprovalLimitSheet
             isVisible={isVisible}
             onDismiss={mockOnDismiss}
@@ -41,15 +41,15 @@ describe('ExchangeApprovalLimitSheet', () => {
         jest.clearAllMocks();
     });
 
-    it('should render the sheet when visible', async () => {
-        const { getByText } = await renderSheet();
+    it('should render the sheet when visible', () => {
+        const { getByText } = renderSheet();
 
         expect(getByText('Unlimited')).toBeTruthy();
         expect(getByText('100 USDC')).toBeTruthy();
     });
 
-    it('should render unlimited approval option with correct details', async () => {
-        const { getByText } = await renderSheet();
+    it('should render unlimited approval option with correct details', () => {
+        const { getByText } = renderSheet();
 
         expect(getByText('Unlimited')).toBeTruthy();
         expect(
@@ -59,8 +59,8 @@ describe('ExchangeApprovalLimitSheet', () => {
         ).toBeTruthy();
     });
 
-    it('should render limited approval option with correct amount', async () => {
-        const { getByText } = await renderSheet();
+    it('should render limited approval option with correct amount', () => {
+        const { getByText } = renderSheet();
 
         expect(getByText('100 USDC')).toBeTruthy();
         expect(
@@ -70,15 +70,15 @@ describe('ExchangeApprovalLimitSheet', () => {
         ).toBeTruthy();
     });
 
-    it('should render crypto icons for both cards', async () => {
-        const { getAllByLabelText } = await renderSheet();
+    it('should render crypto icons for both cards', () => {
+        const { getAllByLabelText } = renderSheet();
 
         const cryptoIcons = getAllByLabelText('eth0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
         expect(cryptoIcons).toHaveLength(2);
     });
 
-    it('should render provider company name in unlimited card description', async () => {
-        const { getByText } = await renderSheet();
+    it('should render provider company name in unlimited card description', () => {
+        const { getByText } = renderSheet();
 
         expect(
             getByText(
@@ -87,24 +87,24 @@ describe('ExchangeApprovalLimitSheet', () => {
         ).toBeTruthy();
     });
 
-    it('should display quote sendStringAmount in limited approval option', async () => {
+    it('should display quote sendStringAmount in limited approval option', () => {
         const customQuote = {
             ...testQuote,
             sendStringAmount: '250',
         };
-        const { getByText } = await renderSheet(true, customQuote);
+        const { getByText } = renderSheet(true, customQuote);
 
         expect(getByText('250 USDC')).toBeTruthy();
     });
 
-    it('should pass correct props when INFINITE is selected', async () => {
-        await renderSheet(true, testQuote, 'INFINITE');
+    it('should pass correct props when INFINITE is selected', () => {
+        renderSheet(true, testQuote, 'INFINITE');
 
         expect(mockOnApprovalTypeSelect).toBeDefined();
     });
 
-    it('should pass correct props when MINIMAL is selected', async () => {
-        await renderSheet(true, testQuote, 'MINIMAL');
+    it('should pass correct props when MINIMAL is selected', () => {
+        renderSheet(true, testQuote, 'MINIMAL');
 
         expect(mockOnApprovalTypeSelect).toBeDefined();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
@@ -3,7 +3,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import {
     type TestStore,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
@@ -23,7 +23,7 @@ describe('ApprovalButton', () => {
     let store: TestStore;
 
     const renderApprovalButton = (props: ApprovalButtonProps) =>
-        renderWithStoreProviderAsync(<ApprovalButton {...props} />, { store });
+        renderWithStoreProvider(<ApprovalButton {...props} />, { store });
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -39,20 +39,20 @@ describe('ApprovalButton', () => {
         store = initStore(preloadedState).store;
     });
 
-    it('should render continue button when isReady is true', async () => {
-        const { getByText } = await renderApprovalButton({ isReady: true });
+    it('should render continue button when isReady is true', () => {
+        const { getByText } = renderApprovalButton({ isReady: true });
 
         expect(getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should render nothing when isReady is false', async () => {
-        const { toJSON } = await renderApprovalButton({ isReady: false });
+    it('should render nothing when isReady is false', () => {
+        const { toJSON } = renderApprovalButton({ isReady: false });
 
         expect(toJSON()).toBeNull();
     });
 
     it('should navigate to TradingExchangeOutputsReview on press', async () => {
-        const { getByText } = await renderApprovalButton({ isReady: true });
+        const { getByText } = renderApprovalButton({ isReady: true });
 
         await userEvent.press(getByText('Continue'));
 
@@ -63,10 +63,10 @@ describe('ApprovalButton', () => {
         });
     });
 
-    it('should render nothing when no selected quote is provided', async () => {
+    it('should render nothing when no selected quote is provided', () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = await renderApprovalButton({ isReady: true });
+        const { toJSON } = renderApprovalButton({ isReady: true });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetailsCard.test.tsx
@@ -1,5 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { ExchangeApprovalDetailsCard } from '../ExchangeApprovalDetailsCard';
@@ -12,7 +12,7 @@ describe('ExchangeApprovalDetailsCard', () => {
         isLoading = false,
         networkSymbol: NetworkSymbol | undefined,
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ExchangeApprovalDetailsCard
                 fee={fee}
                 isLoading={isLoading}
@@ -29,10 +29,10 @@ describe('ExchangeApprovalDetailsCard', () => {
         };
     });
 
-    it('should render card', async () => {
+    it('should render card', () => {
         preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
 
-        const { getByText } = await renderExchangeApprovalDetailsCard('100000', false, 'eth');
+        const { getByText } = renderExchangeApprovalDetailsCard('100000', false, 'eth');
 
         expect(getByText('Approval details')).toBeTruthy();
         expect(getByText('Provider')).toBeTruthy();
@@ -40,16 +40,16 @@ describe('ExchangeApprovalDetailsCard', () => {
         expect(getByText('Fee')).toBeTruthy();
     });
 
-    it('should render nothing without quote', async () => {
-        const { toJSON } = await renderExchangeApprovalDetailsCard('100000', false, 'eth');
+    it('should render nothing without quote', () => {
+        const { toJSON } = renderExchangeApprovalDetailsCard('100000', false, 'eth');
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing without networkSymbol', async () => {
+    it('should render nothing without networkSymbol', () => {
         preloadedState!.wallet!.trading!.exchange!.preselectedQuote = exchangeQuotes[0];
 
-        const { toJSON } = await renderExchangeApprovalDetailsCard('100000', false, undefined);
+        const { toJSON } = renderExchangeApprovalDetailsCard('100000', false, undefined);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalForCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalForCard.test.tsx
@@ -1,18 +1,18 @@
 import { type AccountKey } from '@suite-common/wallet-types';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { ExchangeApprovalForCard } from '../ExchangeApprovalForCard';
 
 describe('ExchangeApprovalForCard', () => {
     const renderExchangeApprovalForCard = (preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(<ExchangeApprovalForCard />, { preloadedState });
+        renderWithStoreProvider(<ExchangeApprovalForCard />, { preloadedState });
 
-    it('should render text based on redux state', async () => {
+    it('should render text based on redux state', () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
         preloadedState.wallet.trading.exchange.tradingAccountKey = 'eth-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
-        const { getByText } = await renderExchangeApprovalForCard(preloadedState);
+        const { getByText } = renderExchangeApprovalForCard(preloadedState);
 
         expect(getByText('For')).toBeOnTheScreen();
         expect(getByText('Ethereum')).toBeOnTheScreen();
@@ -20,10 +20,10 @@ describe('ExchangeApprovalForCard', () => {
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
     });
 
-    it('should render nothing when account is not found', async () => {
+    it('should render nothing when account is not found', () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
 
-        const { toJSON } = await renderExchangeApprovalForCard(preloadedState);
+        const { toJSON } = renderExchangeApprovalForCard(preloadedState);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -2,7 +2,7 @@ import { selectTradingExchangeSelectedQuote, tradingExchangeActions } from '@sui
 import {
     type TestStore,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     userEvent,
     within,
 } from '@suite-native/test-utils';
@@ -13,7 +13,7 @@ import { LimitPicker } from '../LimitPicker';
 describe('LimitPicker', () => {
     let store: TestStore;
 
-    const renderLimitPicker = () => renderWithStoreProviderAsync(<LimitPicker />, { store });
+    const renderLimitPicker = () => renderWithStoreProvider(<LimitPicker />, { store });
 
     beforeEach(() => {
         const preloadedState = {
@@ -27,8 +27,8 @@ describe('LimitPicker', () => {
         store = initStore(preloadedState).store;
     });
 
-    it('should render Unlimited when no limit is specified', async () => {
-        const { getByTestId } = await renderLimitPicker();
+    it('should render Unlimited when no limit is specified', () => {
+        const { getByTestId } = renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
 
@@ -42,7 +42,7 @@ describe('LimitPicker', () => {
     });
 
     it('should update limit when users selects new value', async () => {
-        const { getByTestId } = await renderLimitPicker();
+        const { getByTestId } = renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
         const sheet = getByTestId('ExchangeApproval/LimitSheet');
@@ -58,10 +58,10 @@ describe('LimitPicker', () => {
         );
     });
 
-    it('should render nothing without quote', async () => {
+    it('should render nothing without quote', () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
 
-        const { toJSON } = await renderLimitPicker();
+        const { toJSON } = renderLimitPicker();
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { ExchangeFeePickerCard, type ExchangeFeePickerCardProps } from '../ExchangeFeePickerCard';
@@ -14,14 +14,13 @@ describe('ExchangeFeePickerCard', () => {
         preloadedState.wallet!.trading!.composedTransactionInfo = { composed: { fee: '1000' } };
         preloadedState.wallet!.trading!.exchange!.tradingAccountKey = tradingAccountKey;
 
-        return renderWithStoreProviderAsync(
-            <ExchangeFeePickerCard isTxnError={false} {...props} />,
-            { preloadedState },
-        );
+        return renderWithStoreProvider(<ExchangeFeePickerCard isTxnError={false} {...props} />, {
+            preloadedState,
+        });
     };
 
-    it('should render nothing when isTxnError', async () => {
-        const { toJSON } = await renderExchangeFeePickerCard({
+    it('should render nothing when isTxnError', () => {
+        const { toJSON } = renderExchangeFeePickerCard({
             quote: exchangeQuotes[0],
             isTxnError: true,
         });
@@ -29,14 +28,14 @@ describe('ExchangeFeePickerCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderExchangeFeePickerCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderExchangeFeePickerCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', async () => {
-        const { toJSON } = await renderExchangeFeePickerCard(
+    it('should render nothing when account is not found', () => {
+        const { toJSON } = renderExchangeFeePickerCard(
             { quote: exchangeQuotes[0] },
             'unknown-account-key',
         );
@@ -44,8 +43,8 @@ describe('ExchangeFeePickerCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render FeePickerCard otherwise', async () => {
-        const { getByText } = await renderExchangeFeePickerCard({ quote: exchangeQuotes[0] });
+    it('should render FeePickerCard otherwise', () => {
+        const { getByText } = renderExchangeFeePickerCard({ quote: exchangeQuotes[0] });
 
         expect(getByText('Fee')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
@@ -2,11 +2,7 @@ import {
     type AccountKey,
     type GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -28,7 +24,7 @@ describe('ExchangePreviewContinueButton', () => {
         props: Partial<ExchangePreviewContinueButtonProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ExchangePreviewContinueButton
                 isDisabled={false}
                 quote={exchangeQuotes[0]}
@@ -57,24 +53,24 @@ describe('ExchangePreviewContinueButton', () => {
         return preloadedState;
     };
 
-    it('should render nothing when precomposed transaction is not in final state', async () => {
+    it('should render nothing when precomposed transaction is not in final state', () => {
         const preloadedState = getPreloadedState();
         preloadedState!.wallet!.send!.precomposedTx = {
             type: 'composing',
         } as any;
-        const { toJSON } = await renderExchangePreviewContinueButton({}, preloadedState);
+        const { toJSON } = renderExchangePreviewContinueButton({}, preloadedState);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render continue button', async () => {
-        const { getByText } = await renderExchangePreviewContinueButton({}, getPreloadedState());
+    it('should render continue button', () => {
+        const { getByText } = renderExchangePreviewContinueButton({}, getPreloadedState());
 
         expect(getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should render disabled button when isDisabled prop is specified', async () => {
-        const { getByText } = await renderExchangePreviewContinueButton(
+    it('should render disabled button when isDisabled prop is specified', () => {
+        const { getByText } = renderExchangePreviewContinueButton(
             { isDisabled: true },
             getPreloadedState(),
         );
@@ -85,7 +81,7 @@ describe('ExchangePreviewContinueButton', () => {
     it('should fire console.warn and do not navigate when quote is not specified', async () => {
         const mockOnSignTransactionNavigation = jest.fn();
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { getByText } = await renderExchangePreviewContinueButton(
+        const { getByText } = renderExchangePreviewContinueButton(
             { quote: undefined, onSignTransactionNavigation: mockOnSignTransactionNavigation },
             getPreloadedState(),
         );
@@ -105,7 +101,7 @@ describe('ExchangePreviewContinueButton', () => {
         const preloadedState = getPreloadedState();
         preloadedState!.wallet!.trading!.exchange!.tradingAccountKey = 'non-existing-key';
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = await renderExchangePreviewContinueButton(
+        const { getByText } = renderExchangePreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             preloadedState,
         );
@@ -123,7 +119,7 @@ describe('ExchangePreviewContinueButton', () => {
     it('should navigate to TradingExchangeOutputsReview on continue press', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = await renderExchangePreviewContinueButton(
+        const { getByText } = renderExchangePreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             getPreloadedState(),
         );

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { ExchangePreviewView, type ExchangePreviewViewProps } from '../ExchangePreviewView';
@@ -13,15 +13,15 @@ describe('ExchangePreviewView', () => {
         preloadedState.wallet!.trading!.exchange!.receiveAccountKey = 'eth-account-1';
         preloadedState.wallet!.trading!.exchange!.lastErrorMessage = 'ERROR_MESSAGE';
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <ExchangePreviewView quote={exchangeQuotes[0]} txnErrorString={null} {...props} />,
             { preloadedState },
         );
     };
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render all sections except alert', async () => {
-        const { getByText } = await renderExchangePreviewView({});
+    it.skip('should render all sections except alert', () => {
+        const { getByText } = renderExchangePreviewView({});
 
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
@@ -30,8 +30,8 @@ describe('ExchangePreviewView', () => {
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should render txnErrorString but no fee picker when isTxnError is true', async () => {
-        const { getByText, queryByText } = await renderExchangePreviewView({
+    it.skip('should render txnErrorString but no fee picker when isTxnError is true', () => {
+        const { getByText, queryByText } = renderExchangePreviewView({
             txnErrorString: 'txnErrorString',
         });
 
@@ -41,18 +41,18 @@ describe('ExchangePreviewView', () => {
         expect(queryByText('Fee')).toBeNull();
     });
 
-    it('should render 1Inch Fusion+ info when exchange is 1inchfusionplus', async () => {
+    it('should render 1Inch Fusion+ info when exchange is 1inchfusionplus', () => {
         const fusionQuote = exchangeQuotes.find(q => q.exchange === '1inchfusionplus');
-        const { getByText } = await renderExchangePreviewView({
+        const { getByText } = renderExchangePreviewView({
             quote: fusionQuote,
         });
 
         expect(getByText('You are swapping with 1Inch Fusion+')).toBeOnTheScreen();
     });
 
-    it('should not render 1Inch Fusion+ info when exchange is not 1inchfusionplus', async () => {
+    it('should not render 1Inch Fusion+ info when exchange is not 1inchfusionplus', () => {
         const nonFusionQuote = exchangeQuotes.find(q => q.exchange === 'mercuryo');
-        const { queryByText } = await renderExchangePreviewView({
+        const { queryByText } = renderExchangePreviewView({
             quote: nonFusionQuote,
         });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
@@ -1,7 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     renderWithBasicProvider,
 } from '@suite-native/test-utils';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -12,15 +12,15 @@ import { ExchangeAlert } from '../ExchangeAlert';
 describe('ExchangeAlert', () => {
     let form: ExchangeFormType;
 
-    const renderFormHook = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderFormHook = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderTradingAlert = () =>
         renderWithBasicProvider(<ExchangeAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderFormHook();
+    beforeEach(() => {
+        const { result } = renderFormHook();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
 import { ExchangeConfirmation } from '../ExchangeConfirmation';
@@ -26,7 +26,7 @@ describe('ExchangeConfirmation', () => {
         require('../../../hooks/exchange/useExchangeSelectQuote').useExchangeSelectQuote;
 
     const renderConfirmation = () =>
-        renderWithStoreProviderAsync(<ExchangeConfirmation />, {
+        renderWithStoreProvider(<ExchangeConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
@@ -35,7 +35,7 @@ describe('ExchangeConfirmation', () => {
         mockQuote.preapprovedStringAmount = undefined;
     });
 
-    it('should render "Swap" button when canProceed is true and approval not needed', async () => {
+    it('should render "Swap" button when canProceed is true and approval not needed', () => {
         mockUseExchangeSelectQuote.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -44,11 +44,11 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
         expect(getByText('Swap')).toBeTruthy();
     });
 
-    it('should render "Approve and swap" button when canProceed is true and approval needed', async () => {
+    it('should render "Approve and swap" button when canProceed is true and approval needed', () => {
         mockQuote.isDex = true;
 
         mockUseExchangeSelectQuote.mockReturnValue({
@@ -59,11 +59,11 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
         expect(getByText('Approve and swap')).toBeTruthy();
     });
 
-    it('should render "Swap" button when canProceed is true and approval status is approved', async () => {
+    it('should render "Swap" button when canProceed is true and approval status is approved', () => {
         mockQuote.isDex = false;
 
         mockUseExchangeSelectQuote.mockReturnValue({
@@ -74,11 +74,11 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
         expect(getByText('Swap')).toBeTruthy();
     });
 
-    it('should render "Swap" button when canProceed is true and approval status is null', async () => {
+    it('should render "Swap" button when canProceed is true and approval status is null', () => {
         mockQuote.isDex = false;
 
         mockUseExchangeSelectQuote.mockReturnValue({
@@ -89,11 +89,11 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
         expect(getByText('Swap')).toBeTruthy();
     });
 
-    it('should not render button when canProceed is false', async () => {
+    it('should not render button when canProceed is false', () => {
         mockQuote.isDex = false;
 
         mockUseExchangeSelectQuote.mockReturnValue({
@@ -104,7 +104,7 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { queryByText } = await renderConfirmation();
+        const { queryByText } = renderConfirmation();
 
         expect(queryByText('Swap')).toBeNull();
         expect(queryByText('Approve and swap')).toBeNull();

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import {
@@ -22,18 +22,18 @@ jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
 describe('ExchangeForm', () => {
     let form: ExchangeFormType;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm(), {});
+    const renderForm = () => renderHookWithStoreProvider(() => useExchangeForm(), {});
 
     const renderExchangeForm = () =>
-        renderWithStoreProviderAsync(<ExchangeForm />, {
+        renderWithStoreProvider(<ExchangeForm />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState: {
                 wallet: { trading: getInitializedTradingState() },
             },
         });
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
@@ -41,8 +41,8 @@ describe('ExchangeForm', () => {
         screen.unmount();
     });
 
-    it('should render form', async () => {
-        const { getByText, queryByText } = await renderExchangeForm();
+    it('should render form', () => {
+        const { getByText, queryByText } = renderExchangeForm();
 
         expect(getByText('You get')).toBeOnTheScreen();
         expect(queryByText('Done')).toBeNull();
@@ -56,19 +56,19 @@ describe('ExchangeForm', () => {
             });
         });
 
-        it('should display Receive account picker', async () => {
-            const { getByText, queryByText } = await renderExchangeForm();
+        it('should display Receive account picker', () => {
+            const { getByText, queryByText } = renderExchangeForm();
 
             expect(getByText('You get')).toBeOnTheScreen();
             expect(queryByText('Done')).toBeNull();
             expect(getByText('Receive account')).toBeOnTheScreen();
         });
 
-        it('should display Done button when any input is active', async () => {
+        it('should display Done button when any input is active', () => {
             act(() => {
                 form.setValue('focusedValue', 'sendCryptoAmount');
             });
-            const { getByText, queryByText } = await renderExchangeForm();
+            const { getByText, queryByText } = renderExchangeForm();
 
             expect(getByText('You get')).toBeOnTheScreen();
             expect(getByText('Done')).toBeOnTheScreen();
@@ -82,8 +82,8 @@ describe('ExchangeForm', () => {
                 });
             });
 
-            it('should display provider', async () => {
-                const { getByText } = await renderExchangeForm();
+            it('should display provider', () => {
+                const { getByText } = renderExchangeForm();
 
                 expect(getByText('Provider')).toBeOnTheScreen();
             });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -10,7 +10,7 @@ describe('ExchangeProviderPicker', () => {
     let preloadedState: PreloadedState;
 
     const renderExchangeProviderPicker = (props: Partial<ExchangeProviderPickerProps>) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ExchangeProviderPicker
                 isLoading={false}
                 selectedValue={undefined}
@@ -26,14 +26,14 @@ describe('ExchangeProviderPicker', () => {
         preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
     });
 
-    it('should render nothing when no quote is selected and isLoading is false', async () => {
-        const { toJSON } = await renderExchangeProviderPicker({});
+    it('should render nothing when no quote is selected and isLoading is false', () => {
+        const { toJSON } = renderExchangeProviderPicker({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render skeleton when quotes are being fetched', async () => {
-        const { getByText, getByLabelText } = await renderExchangeProviderPicker({
+    it('should render skeleton when quotes are being fetched', () => {
+        const { getByText, getByLabelText } = renderExchangeProviderPicker({
             isLoading: true,
         });
 
@@ -41,8 +41,8 @@ describe('ExchangeProviderPicker', () => {
         expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
 
-    it('should render provider when quote is selected', async () => {
-        const { getByText } = await renderExchangeProviderPicker({
+    it('should render provider when quote is selected', () => {
+        const { getByText } = renderExchangeProviderPicker({
             selectedValue: exchangeQuotes[0],
         });
 
@@ -50,16 +50,16 @@ describe('ExchangeProviderPicker', () => {
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render KYC warning for provider with "KYC-required"', async () => {
-        const { getByText } = await renderExchangeProviderPicker({
+    it('should render KYC warning for provider with "KYC-required"', () => {
+        const { getByText } = renderExchangeProviderPicker({
             selectedValue: exchangeQuotes[2],
         });
 
         expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
     });
 
-    it('should not render KYC provider warning for providers with "noKYC"', async () => {
-        const { queryByText } = await renderExchangeProviderPicker({
+    it('should not render KYC provider warning for providers with "noKYC"', () => {
+        const { queryByText } = renderExchangeProviderPicker({
             selectedValue: exchangeQuotes[0],
         });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
@@ -4,8 +4,8 @@ import { useAnalytics } from '@suite-native/services';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
     userEvent,
 } from '@suite-native/test-utils';
@@ -30,22 +30,22 @@ describe('ExchangeRateAndProviderPicker', () => {
     let exchangeForm: ExchangeFormType;
     let preloadedState: PreloadedState;
 
-    const renderExchangeForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderExchangeForm = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderExchangeRateAndProviderPicker = () =>
-        renderWithStoreProviderAsync(<ExchangeRateAndProviderPicker />, {
+        renderWithStoreProvider(<ExchangeRateAndProviderPicker />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
 
         (useAnalytics as jest.Mock).mockReturnValue({
             report: reportMock,
         });
 
-        const { result } = await renderExchangeForm();
+        const { result } = renderExchangeForm();
         exchangeForm = result.current;
 
         preloadedState = { wallet: getWalletState({ tradeType: 'exchange' }) };
@@ -55,26 +55,26 @@ describe('ExchangeRateAndProviderPicker', () => {
         screen.unmount();
     });
 
-    it('should render nothing when no quote is selected and quotes are not loading', async () => {
-        const { toJSON } = await renderExchangeRateAndProviderPicker();
+    it('should render nothing when no quote is selected and quotes are not loading', () => {
+        const { toJSON } = renderExchangeRateAndProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render provider picker when no quote is selected and quotes are loading', async () => {
+    it('should render provider picker when no quote is selected and quotes are loading', () => {
         preloadedState!.wallet!.trading!.exchange!.isLoading = true;
 
-        const { getByText } = await renderExchangeRateAndProviderPicker();
+        const { getByText } = renderExchangeRateAndProviderPicker();
 
         expect(getByText('Provider')).toBeOnTheScreen();
     });
 
-    it('should render provider when quote is selected', async () => {
+    it('should render provider when quote is selected', () => {
         act(() => {
             exchangeForm.setValue('quote', exchangeQuotes[0]);
         });
 
-        const { getByText } = await renderExchangeRateAndProviderPicker();
+        const { getByText } = renderExchangeRateAndProviderPicker();
 
         expect(getByText('Provider')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
@@ -90,7 +90,7 @@ describe('ExchangeRateAndProviderPicker', () => {
         });
 
         it('should fire analytics event on provider select', async () => {
-            const { getByText } = await renderExchangeRateAndProviderPicker();
+            const { getByText } = renderExchangeRateAndProviderPicker();
 
             await userEvent.press(getByText('Provider'));
             await userEvent.press(getByText('Cexdirect'));
@@ -112,7 +112,7 @@ describe('ExchangeRateAndProviderPicker', () => {
         });
 
         it('should not fire analytics event when same provider is selected', async () => {
-            const { getByText, getAllByText } = await renderExchangeRateAndProviderPicker();
+            const { getByText, getAllByText } = renderExchangeRateAndProviderPicker();
 
             await userEvent.press(getByText('Provider'));
             await userEvent.press(getAllByText('Mercuryo')[1]);

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ExchangeTab } from '../ExchangeTab';
 
@@ -29,7 +29,7 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('ExchangeTab', () => {
     const renderExchangeTab = (preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(<ExchangeTab />, { preloadedState });
+        renderWithStoreProvider(<ExchangeTab />, { preloadedState });
 
     beforeEach(() => {
         mockIsDeviceInViewOnlyMode = false;
@@ -38,41 +38,41 @@ describe('ExchangeTab', () => {
         mockIsTradingExchangeEnabled = true;
     });
 
-    it('should render exchange form', async () => {
-        const { getByText } = await renderExchangeTab();
+    it('should render exchange form', () => {
+        const { getByText } = renderExchangeTab();
 
         expect(getByText('You pay')).toBeOnTheScreen();
         expect(getByText('You get')).toBeOnTheScreen();
     });
 
-    it('should render disabled info when exchange FF is not enabled', async () => {
+    it('should render disabled info when exchange FF is not enabled', () => {
         mockIsTradingExchangeEnabled = false;
-        const { getByText, queryByText } = await renderExchangeTab();
+        const { getByText, queryByText } = renderExchangeTab();
 
         expect(getByText('Swap disabled')).toBeOnTheScreen();
         expect(queryByText('You pay')).toBeNull();
     });
 
-    it('should display BTC only firmware info with BTC only wallet connected', async () => {
+    it('should display BTC only firmware info with BTC only wallet connected', () => {
         mockHasBitcoinOnlyFirmware = true;
-        const { getByText } = await renderExchangeTab();
+        const { getByText } = renderExchangeTab();
 
         expect(getByText('Bitcoin-only firmware')).toBeOnTheScreen();
     });
 
-    it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', async () => {
+    it('should display Portfolio Tracker info with Portfolio Tracker "wallet" selected', () => {
         // Portfolio Tracker sets both selectors to true
         mockIsPortfolioTrackerDevice = true;
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText, queryByText } = await renderExchangeTab();
+        const { getByText, queryByText } = renderExchangeTab();
 
         expect(getByText('Portfolio Tracker')).toBeOnTheScreen();
         expect(queryByText('View-only wallet')).toBeNull();
     });
 
-    it('should display exchange form for view-only wallet', async () => {
+    it('should display exchange form for view-only wallet', () => {
         mockIsDeviceInViewOnlyMode = true;
-        const { getByText } = await renderExchangeTab();
+        const { getByText } = renderExchangeTab();
 
         expect(getByText('You pay')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
@@ -1,7 +1,7 @@
 import {
     type PreloadedState,
     act,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     screen,
     userEvent,
 } from '@suite-native/test-utils';
@@ -29,7 +29,7 @@ describe('ExchangeTab', () => {
     });
 
     const renderExchangeTab = (preloadedState?: PreloadedState) =>
-        renderWithStoreProviderAsync(<ExchangeTabContent />, { preloadedState });
+        renderWithStoreProvider(<ExchangeTabContent />, { preloadedState });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -44,50 +44,50 @@ describe('ExchangeTab', () => {
         expect(screen.getByText("It's not you, it's us.")).toBeOnTheScreen();
     };
 
-    it('should render Exchange skeleton when isLoading is true', async () => {
+    it('should render Exchange skeleton when isLoading is true', () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderExchangeTab();
+        renderExchangeTab();
 
         expectSkeleton();
     });
 
-    it('should render Exchange skeleton when lastLoadedTimestamp is 0', async () => {
+    it('should render Exchange skeleton when lastLoadedTimestamp is 0', () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        await renderExchangeTab();
+        renderExchangeTab();
 
         expectSkeleton();
     });
 
-    it('should render Exchange form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
+    it('should render Exchange form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        await renderExchangeTab();
+        renderExchangeTab();
 
         expectExchangeForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
         mockUseTradingExchangeData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderExchangeTab();
+        renderExchangeTab();
 
         expectServerOffline();
     });
@@ -105,7 +105,7 @@ describe('ExchangeTab', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = await renderExchangeTab();
+        const { getByText } = renderExchangeTab();
 
         const reloadButton = getByText('Try again');
 

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -16,38 +16,38 @@ import {
 describe('ExchangeReceiveAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;
 
-    const renderExchangeForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderExchangeForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeForm());
 
         return result.current;
     };
 
     const renderComponent = () =>
-        renderWithStoreProviderAsync(<ExchangeReceiveAccountCryptoBalance />, {
+        renderWithStoreProvider(<ExchangeReceiveAccountCryptoBalance />, {
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        exchangeForm = await renderExchangeForm();
+    beforeEach(() => {
+        exchangeForm = renderExchangeForm();
     });
 
-    it('should use asset form field as default symbol', async () => {
+    it('should use asset form field as default symbol', () => {
         act(() => {
             exchangeForm.setValue('receiveAsset', btcAsset);
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use receiveAccount form field to obtain account', async () => {
+    it('should use receiveAccount form field to obtain account', () => {
         act(() => {
             exchangeForm.setValue('receiveAsset', btcAsset);
         });
         act(() => {
             exchangeForm.setValue('receiveAccount', { account: getBtcAccount() });
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(RECEIVE_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
@@ -3,8 +3,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { tradingInitialState } from '@suite-native/trading-state';
@@ -45,14 +45,14 @@ const getExchangeState = (selectedReceiveAccount: ReceiveAccount | undefined) =>
 describe('ExchangeReceiveAccountPicker', () => {
     let exchangeForm: ExchangeFormType;
 
-    const renderExchangeForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderExchangeForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeForm());
 
         return result.current;
     };
 
     const renderPicker = ({ preloadedState }: { preloadedState?: PreloadedState } = {}) =>
-        renderWithStoreProviderAsync(<ExchangeReceiveAccountPicker />, {
+        renderWithStoreProvider(<ExchangeReceiveAccountPicker />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
@@ -63,29 +63,29 @@ describe('ExchangeReceiveAccountPicker', () => {
         });
     };
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.resetAllMocks();
-        exchangeForm = await renderExchangeForm();
+        exchangeForm = renderExchangeForm();
     });
 
-    it('should display nothing when selectedSymbol is not specified', async () => {
-        const { toJSON } = await renderPicker();
+    it('should display nothing when selectedSymbol is not specified', () => {
+        const { toJSON } = renderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should display "Not selected" when asset is not specified', async () => {
+    it('should display "Not selected" when asset is not specified', () => {
         setSelectedAsset(btcAsset);
-        const { getByText } = await renderPicker();
+        const { getByText } = renderPicker();
 
         expect(getByText('Not selected')).toBeTruthy();
     });
 
     // Todo: https://github.com/trezor/trezor-suite/issues/24906
-    it.skip('should display selected account name and address', async () => {
+    it.skip('should display selected account name and address', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
-        const { getByText } = await renderPicker({
+        const { getByText } = renderPicker({
             preloadedState: getExchangeState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],
@@ -96,10 +96,10 @@ describe('ExchangeReceiveAccountPicker', () => {
         expect(getByText(btcAddressAddress)).toBeTruthy();
     });
 
-    it('should call navigate with correct params on press', async () => {
+    it('should call navigate with correct params on press', () => {
         setSelectedAsset(btcAsset);
         const btcAccount = getBtcAccount();
-        const { getByText } = await renderPicker({
+        const { getByText } = renderPicker({
             preloadedState: getExchangeState({
                 account: btcAccount,
                 address: btcAccount.addresses?.used[0],

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
@@ -3,8 +3,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     exchangeQuotes,
@@ -22,36 +22,36 @@ import {
 describe('ExchangeReceiveAmountInput', () => {
     let form: ExchangeFormType;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderExchangeReceiveAmountInput = (
         props: Partial<ExchangeReceiveAmountInputProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ExchangeReceiveAmountInput showAssetsSheet={jest.fn()} {...props} />,
             { preloadedState, wrapper: ({ children }) => <Form form={form}>{children}</Form> },
         );
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
-    it('should render receiveCryptoAmount form value', async () => {
+    it('should render receiveCryptoAmount form value', () => {
         act(() => {
             form.setValue('receiveAsset', usdcAsset);
             form.setValue('quote', exchangeQuotes[0]);
         });
 
-        const { getByLabelText } = await renderExchangeReceiveAmountInput();
+        const { getByLabelText } = renderExchangeReceiveAmountInput();
 
         expect(getByLabelText('You get')).toHaveDisplayValue('0.00083554');
     });
 
-    it('should call showAssetsSheet callback on press', async () => {
+    it('should call showAssetsSheet callback on press', () => {
         const showAssetsSheetMock = jest.fn();
-        const { getByLabelText } = await renderExchangeReceiveAmountInput({
+        const { getByLabelText } = renderExchangeReceiveAmountInput({
             showAssetsSheet: showAssetsSheetMock,
         });
 
@@ -60,11 +60,11 @@ describe('ExchangeReceiveAmountInput', () => {
         expect(showAssetsSheetMock).toHaveBeenCalled();
     });
 
-    it('should display loading skeleton when quotes are being fetched', async () => {
+    it('should display loading skeleton when quotes are being fetched', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         preloadedState.wallet.trading.exchange.isLoading = true;
 
-        const { getByLabelText } = await renderExchangeReceiveAmountInput({}, preloadedState);
+        const { getByLabelText } = renderExchangeReceiveAmountInput({}, preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveCard.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -13,24 +13,24 @@ import { ExchangeReceiveCard } from '../ExchangeReceiveCard';
 describe('ExchangeReceiveCard', () => {
     let form: ExchangeFormType;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderExchangeBuyCard = () =>
-        renderWithStoreProviderAsync(<ExchangeReceiveCard />, {
+        renderWithStoreProvider(<ExchangeReceiveCard />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
-    it('should render all components', async () => {
+    it('should render all components', () => {
         act(() => {
             form.setValue('receiveAsset', usdcAsset);
             form.setValue('quote', exchangeQuotes[0]);
         });
-        const { getByText, getByLabelText } = await renderExchangeBuyCard();
+        const { getByText, getByLabelText } = renderExchangeBuyCard();
 
         expect(getByText('You get')).toBeOnTheScreen();
         expect(getByLabelText('Select asset')).toHaveTextContent(/USDC/);

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -3,8 +3,8 @@ import { type EnhancedStore } from '@reduxjs/toolkit';
 import { Form } from '@suite-native/forms';
 import {
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
@@ -24,8 +24,8 @@ describe('ExchangeTradeableAssetPicker', () => {
             wallet: { trading: getInitializedTradingState() },
         });
 
-    const renderFormHook = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useExchangeForm(), {
+    const renderFormHook = () => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeForm(), {
             store,
         });
 
@@ -33,28 +33,28 @@ describe('ExchangeTradeableAssetPicker', () => {
     };
 
     const renderTradeableAssetPicker = () =>
-        renderWithStoreProviderAsync(<ExchangeTradeableAssetPicker />, {
+        renderWithStoreProvider(<ExchangeTradeableAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        store = (await initPreloadedStore(FirmwareType.Universal)).store;
-        form = await renderFormHook();
+    beforeEach(() => {
+        store = initPreloadedStore(FirmwareType.Universal).store;
+        form = renderFormHook();
     });
 
     afterEach(() => {
         screen.unmount();
     });
 
-    it('should render "Select asset" button with caret', async () => {
-        const { getByLabelText } = await renderTradeableAssetPicker();
+    it('should render "Select asset" button with caret', () => {
+        const { getByLabelText } = renderTradeableAssetPicker();
 
         expect(getByLabelText('Select asset')).toHaveTextContent(/^Select asset.$/);
     });
 
-    it('should render bottom sheet with all assets', async () => {
-        const { getAllByText } = await renderTradeableAssetPicker();
+    it('should render bottom sheet with all assets', () => {
+        const { getAllByText } = renderTradeableAssetPicker();
 
         expect(getAllByText('Bitcoin')).toBeTruthy();
         expect(getAllByText('USDC')).toBeTruthy();

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAccountCryptoBalance.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -16,38 +16,38 @@ import {
 describe('ExchangeSendAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;
 
-    const renderExchangeForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderExchangeForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeForm());
 
         return result.current;
     };
 
     const renderComponent = () =>
-        renderWithStoreProviderAsync(<ExchangeSendAccountCryptoBalance />, {
+        renderWithStoreProvider(<ExchangeSendAccountCryptoBalance />, {
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        exchangeForm = await renderExchangeForm();
+    beforeEach(() => {
+        exchangeForm = renderExchangeForm();
     });
 
-    it('should use asset form field as default symbol', async () => {
+    it('should use asset form field as default symbol', () => {
         act(() => {
             exchangeForm.setValue('sendAsset', btcAsset);
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use sendAccount form field to obtain account', async () => {
+    it('should use sendAccount form field to obtain account', () => {
         act(() => {
             exchangeForm.setValue('sendAsset', btcAsset);
         });
         act(() => {
             exchangeForm.setValue('sendAccount', getBtcAccount());
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
@@ -2,8 +2,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getWalletState } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -19,21 +19,21 @@ describe('ExchangeSendAmountBadge', () => {
         wallet: getWalletState({ tradeType: 'exchange', bitcoinAmountUnit }),
     });
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderExchangeSendAmountBadge = (preloadedState: PreloadedState = getPreloadedState()) =>
-        renderWithStoreProviderAsync(<ExchangeSendAmountBadge />, {
+        renderWithStoreProvider(<ExchangeSendAmountBadge />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
-    it('should display nothing when asset is not selected', async () => {
-        const { toJSON } = await renderExchangeSendAmountBadge();
+    it('should display nothing when asset is not selected', () => {
+        const { toJSON } = renderExchangeSendAmountBadge();
 
         expect(toJSON()).toBeNull();
     });
@@ -45,33 +45,33 @@ describe('ExchangeSendAmountBadge', () => {
             });
         });
 
-        it('should display nothing when amount is not set', async () => {
-            const { toJSON } = await renderExchangeSendAmountBadge();
+        it('should display nothing when amount is not set', () => {
+            const { toJSON } = renderExchangeSendAmountBadge();
 
             expect(toJSON()).toBeNull();
         });
 
-        it('should display formatted value when amount is 0', async () => {
+        it('should display formatted value when amount is 0', () => {
             act(() => {
                 form.setValue('sendCryptoAmount', '0');
             });
 
-            const { getByText } = await renderExchangeSendAmountBadge();
+            const { getByText } = renderExchangeSendAmountBadge();
 
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should display formatted value when amount is set', async () => {
+        it('should display formatted value when amount is set', () => {
             act(() => {
                 form.setValue('sendCryptoAmount', '1234567');
             });
 
-            const { getByText } = await renderExchangeSendAmountBadge();
+            const { getByText } = renderExchangeSendAmountBadge();
 
             expect(getByText('$1,234.57')).toBeOnTheScreen();
         });
 
-        it('should display error message when field has error', async () => {
+        it('should display error message when field has error', () => {
             act(() => {
                 form.setError('sendCryptoAmount', {
                     type: 'manual',
@@ -80,13 +80,13 @@ describe('ExchangeSendAmountBadge', () => {
                 form.setValue('sendCryptoAmount', '1000');
             });
 
-            const { getByText, queryByText } = await renderExchangeSendAmountBadge();
+            const { getByText, queryByText } = renderExchangeSendAmountBadge();
 
             expect(queryByText('$1.00')).toBeNull();
             expect(getByText('VALIDATION_ERROR')).toBeOnTheScreen();
         });
 
-        it('should display formatted fiat value when field has error, but quotes are loading', async () => {
+        it('should display formatted fiat value when field has error, but quotes are loading', () => {
             act(() => {
                 form.setError('sendCryptoAmount', {
                     type: 'manual',
@@ -97,18 +97,18 @@ describe('ExchangeSendAmountBadge', () => {
             const preloadedState = getPreloadedState();
             preloadedState!.wallet!.trading!.exchange!.isLoading = true;
 
-            const { getByText, queryByText } = await renderExchangeSendAmountBadge(preloadedState);
+            const { getByText, queryByText } = renderExchangeSendAmountBadge(preloadedState);
 
             expect(queryByText('VALIDATION_ERROR')).toBeNull();
             expect(getByText('$1.00')).toBeOnTheScreen();
         });
 
-        it('should display correct value when using sats', async () => {
+        it('should display correct value when using sats', () => {
             act(() => {
                 form.setValue('sendCryptoAmount', '1234567123456');
             });
 
-            const { getByText } = await renderExchangeSendAmountBadge(
+            const { getByText } = renderExchangeSendAmountBadge(
                 getPreloadedState(PROTO.AmountUnit.SATOSHI),
             );
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
@@ -3,8 +3,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
@@ -33,15 +33,15 @@ describe('ExchangeSendAmountInput', () => {
         form: ExchangeFormType,
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <ExchangeSendAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
             { preloadedState },
         );
 
-    const renderUseTradingExchangeForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useExchangeForm(), {
+    const renderUseTradingExchangeForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
         });
 
@@ -53,28 +53,28 @@ describe('ExchangeSendAmountInput', () => {
     });
 
     it('should set send value in form', async () => {
-        const form = await renderUseTradingExchangeForm();
+        const form = renderUseTradingExchangeForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), '100');
 
         expect(form.getValues('sendCryptoAmount')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', async () => {
-        const form = await renderUseTradingExchangeForm();
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', () => {
+        const form = renderUseTradingExchangeForm();
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         expect(getByLabelText('You pay')).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingExchangeForm();
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const form = renderUseTradingExchangeForm();
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You pay'));
 
@@ -83,11 +83,11 @@ describe('ExchangeSendAmountInput', () => {
 
     it('should not call showAssetsSheet when enabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingExchangeForm();
+        const form = renderUseTradingExchangeForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You pay'));
 
@@ -95,11 +95,11 @@ describe('ExchangeSendAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = await renderUseTradingExchangeForm();
+        const form = renderUseTradingExchangeForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
@@ -111,11 +111,11 @@ describe('ExchangeSendAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingExchangeForm(preloadedState);
+        const form = renderUseTradingExchangeForm(preloadedState);
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
@@ -127,11 +127,11 @@ describe('ExchangeSendAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingExchangeForm(preloadedState);
+        const form = renderUseTradingExchangeForm(preloadedState);
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You pay'), 'asd');
 
@@ -140,7 +140,7 @@ describe('ExchangeSendAmountInput', () => {
     });
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
-        const form = await renderUseTradingExchangeForm();
+        const form = renderUseTradingExchangeForm();
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
@@ -148,7 +148,7 @@ describe('ExchangeSendAmountInput', () => {
                 symbol: 'eth',
             } as Account);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), '1.0123456789');
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
@@ -5,8 +5,8 @@ import { Form } from '@suite-native/forms';
 import {
     type TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import {
@@ -68,17 +68,17 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     const renderExchangeForm = () =>
-        renderHookWithStoreProviderAsync(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), { store });
 
     const renderExchangeSendAssetPicker = () =>
-        renderWithStoreProviderAsync(<ExchangeSendAssetPicker />, {
+        renderWithStoreProvider(<ExchangeSendAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         store = initStore(getPreloadedState()).store;
-        const { result } = await renderExchangeForm();
+        const { result } = renderExchangeForm();
         form = result.current;
 
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
@@ -87,7 +87,7 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     it('should select asset on item press', async () => {
-        const { getByText } = await renderExchangeSendAssetPicker();
+        const { getByText } = renderExchangeSendAssetPicker();
 
         await userEvent.press(getByText('BTC'));
 
@@ -101,7 +101,7 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     it('should select account on item press', async () => {
-        const { getByText } = await renderExchangeSendAssetPicker();
+        const { getByText } = renderExchangeSendAssetPicker();
 
         await userEvent.press(getByText('BTC'));
 

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendCard.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -13,28 +13,25 @@ import { ExchangeSendCard } from '../ExchangeSendCard';
 describe('ExchangeSendCard', () => {
     let form: ExchangeFormType;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useExchangeForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useExchangeForm());
 
     const renderExchangeSendCard = (isAmountInputActive: boolean) =>
-        renderWithStoreProviderAsync(
-            <ExchangeSendCard isAmountInputActive={isAmountInputActive} />,
-            {
-                wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-                preloadedState: { wallet: getWalletState() },
-            },
-        );
+        renderWithStoreProvider(<ExchangeSendCard isAmountInputActive={isAmountInputActive} />, {
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            preloadedState: { wallet: getWalletState() },
+        });
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
-    it('should render all components', async () => {
+    it('should render all components', () => {
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendCryptoAmount', '100');
         });
-        const { getByText, getByLabelText } = await renderExchangeSendCard(false);
+        const { getByText, getByLabelText } = renderExchangeSendCard(false);
 
         expect(getByText('You pay')).toBeOnTheScreen();
         expect(getByText('$99.00')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/fees/__tests__/FeePicker.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePicker.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 import { FEE_PICKER_TEST_ID, FeePicker } from '../FeePicker';
 
@@ -21,24 +21,24 @@ describe('FeePicker', () => {
         onPress: jest.fn(),
     };
 
-    const renderFeePicker = async (props = {}) => {
+    const renderFeePicker = (props = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return await renderWithStoreProviderAsync(<FeePicker {...finalProps} />);
+        return renderWithStoreProvider(<FeePicker {...finalProps} />);
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should render fee label', async () => {
-        const { getByText } = await renderFeePicker();
+    it('should render fee label', () => {
+        const { getByText } = renderFeePicker();
 
         expect(getByText('Fee')).toBeTruthy();
     });
 
-    it('should render fee value with correct symbol', async () => {
-        const { getByText } = await renderFeePicker({
+    it('should render fee value with correct symbol', () => {
+        const { getByText } = renderFeePicker({
             fee: '5000',
             symbol: 'eth' as NetworkSymbol,
             isLoading: false,
@@ -48,8 +48,8 @@ describe('FeePicker', () => {
         expect(getByText('$0.00')).toBeTruthy();
     });
 
-    it('should render caret right icon', async () => {
-        const { getByTestId } = await renderFeePicker();
+    it('should render caret right icon', () => {
+        const { getByTestId } = renderFeePicker();
 
         const icon = getByTestId('caret-right-icon');
         expect(icon).toBeTruthy();
@@ -57,7 +57,7 @@ describe('FeePicker', () => {
 
     it('should render clickable component', async () => {
         const mockOnPress = jest.fn();
-        const { getByTestId } = await renderFeePicker({
+        const { getByTestId } = renderFeePicker({
             onPress: mockOnPress,
             isLoading: false,
         });
@@ -67,23 +67,23 @@ describe('FeePicker', () => {
         expect(mockOnPress).toHaveBeenCalledTimes(1);
     });
 
-    it('should show loading state when isLoading is true', async () => {
-        const { getByTestId } = await renderFeePicker({ isLoading: true });
+    it('should show loading state when isLoading is true', () => {
+        const { getByTestId } = renderFeePicker({ isLoading: true });
 
         // When loading, should show skeleton
         const skeleton = getByTestId('BoxSkeleton');
         expect(skeleton).toBeTruthy();
     });
 
-    it('should not show loading state when isLoading is false', async () => {
-        const { getByText } = await renderFeePicker({ isLoading: false });
+    it('should not show loading state when isLoading is false', () => {
+        const { getByText } = renderFeePicker({ isLoading: false });
 
         // When not loading, should show the formatted fee value
         expect(getByText('$0.50')).toBeTruthy();
     });
 
-    it('should not show loading state when isLoading is undefined', async () => {
-        const { getByText } = await renderFeePicker();
+    it('should not show loading state when isLoading is undefined', () => {
+        const { getByText } = renderFeePicker();
 
         // When isLoading is undefined, should show the formatted fee value
         expect(getByText('$0.50')).toBeTruthy();
@@ -91,8 +91,8 @@ describe('FeePicker', () => {
 
     it.each(['btc', 'eth', 'ltc', 'bch', 'doge'])(
         'should render with %s network symbol',
-        async symbol => {
-            const { getByText } = await renderFeePicker({
+        symbol => {
+            const { getByText } = renderFeePicker({
                 symbol: symbol as NetworkSymbol,
                 isLoading: false,
             });
@@ -103,8 +103,8 @@ describe('FeePicker', () => {
 
     it.each(['100', '1000', '10000', '0.001', '0.00000001'])(
         'should render with fee value %s',
-        async fee => {
-            const { getByText } = await renderFeePicker({
+        fee => {
+            const { getByText } = renderFeePicker({
                 fee,
                 isLoading: false,
             });
@@ -113,8 +113,8 @@ describe('FeePicker', () => {
         },
     );
 
-    it('should render the approximate symbol', async () => {
-        const { getByText } = await renderFeePicker();
+    it('should render the approximate symbol', () => {
+        const { getByText } = renderFeePicker();
 
         expect(getByText('≈')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { type TradingExchangeType, type TradingSellType } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { renderWithStoreProviderAsync, userEvent } from '@suite-native/test-utils';
+import { renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 import { FeePickerCard } from '../FeePickerCard';
 
@@ -45,10 +45,10 @@ describe('FeePickerCard', () => {
         },
     });
 
-    const renderFeePickerCard = async (props = {}, preloadedState = {}) => {
+    const renderFeePickerCard = (props = {}, preloadedState = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return await renderWithStoreProviderAsync(<FeePickerCard {...finalProps} />, {
+        return renderWithStoreProvider(<FeePickerCard {...finalProps} />, {
             preloadedState,
         });
     };
@@ -58,20 +58,20 @@ describe('FeePickerCard', () => {
         mockNavigate.mockClear();
     });
 
-    it('should render the details title', async () => {
-        const { getByText } = await renderFeePickerCard({}, createPreloadedState('1000'));
+    it('should render the details title', () => {
+        const { getByText } = renderFeePickerCard({}, createPreloadedState('1000'));
 
         expect(getByText('Transaction details')).toBeTruthy();
     });
 
-    it('should render fee label', async () => {
-        const { getByText } = await renderFeePickerCard({}, createPreloadedState('1000'));
+    it('should render fee label', () => {
+        const { getByText } = renderFeePickerCard({}, createPreloadedState('1000'));
 
         expect(getByText('Fee')).toBeTruthy();
     });
 
-    it('should render fee value with correct symbol', async () => {
-        const { getByText } = await renderFeePickerCard(
+    it('should render fee value with correct symbol', () => {
+        const { getByText } = renderFeePickerCard(
             {
                 symbol: 'eth' as NetworkSymbol,
             },
@@ -82,23 +82,23 @@ describe('FeePickerCard', () => {
         expect(getByText('$0.00')).toBeTruthy();
     });
 
-    it('should show loading state when fee is undefined', async () => {
-        const { getByTestId } = await renderFeePickerCard({}, {});
+    it('should show loading state when fee is undefined', () => {
+        const { getByTestId } = renderFeePickerCard({}, {});
 
         // When fee is undefined, should show skeleton
         const skeleton = getByTestId('BoxSkeleton');
         expect(skeleton).toBeTruthy();
     });
 
-    it('should not show loading state when fee is defined', async () => {
-        const { getByText } = await renderFeePickerCard({}, createPreloadedState('1000'));
+    it('should not show loading state when fee is defined', () => {
+        const { getByText } = renderFeePickerCard({}, createPreloadedState('1000'));
 
         // When fee is defined, should show the formatted fee value
         expect(getByText('$0.50')).toBeTruthy();
     });
 
     it('should handle fee picker press and navigate to fees screen', async () => {
-        const { getByText } = await renderFeePickerCard({}, createPreloadedState('1000'));
+        const { getByText } = renderFeePickerCard({}, createPreloadedState('1000'));
 
         await userEvent.press(getByText('Fee'));
 
@@ -109,7 +109,7 @@ describe('FeePickerCard', () => {
     });
 
     it('should not navigate when actualFee is undefined', async () => {
-        const { getByText } = await renderFeePickerCard({}, {});
+        const { getByText } = renderFeePickerCard({}, {});
 
         await userEvent.press(getByText('Fee'));
 

--- a/suite-native/module-trading/src/components/fees/__tests__/TradingFeesForm.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/TradingFeesForm.test.tsx
@@ -4,8 +4,8 @@ import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     getBtcAccount,
@@ -45,11 +45,11 @@ describe('TradingFeesForm', () => {
         },
     };
 
-    const renderUseFeesForm = async (
+    const renderUseFeesForm = (
         accountKey: AccountKey = mockAccountKey,
         preloadedState?: PreloadedState,
     ) => {
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () =>
                 useFeesForm({
                     accountKey,
@@ -64,13 +64,13 @@ describe('TradingFeesForm', () => {
         return result.current;
     };
 
-    const renderTradingFeesForm = async (props: {
+    const renderTradingFeesForm = (props: {
         accountKey: AccountKey;
         tokenContract?: TokenAddress;
     }) => {
-        const form = await renderUseFeesForm(props.accountKey);
+        const form = renderUseFeesForm(props.accountKey);
 
-        return await renderWithStoreProviderAsync(<TradingFeesForm {...props} />, {
+        return renderWithStoreProvider(<TradingFeesForm {...props} />, {
             preloadedState: defaultState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -80,22 +80,22 @@ describe('TradingFeesForm', () => {
         jest.clearAllMocks();
     });
 
-    it('should render TradingFeesForm with FeesContent component', async () => {
-        const { getByText } = await renderTradingFeesForm({ accountKey: mockAccountKey });
+    it('should render TradingFeesForm with FeesContent component', () => {
+        const { getByText } = renderTradingFeesForm({ accountKey: mockAccountKey });
 
         expect(getByText('Transaction fee')).toBeTruthy();
     });
 
-    it('should render with fees footer when total amount and fee are available', async () => {
-        const { getByText } = await renderTradingFeesForm({ accountKey: mockAccountKey });
+    it('should render with fees footer when total amount and fee are available', () => {
+        const { getByText } = renderTradingFeesForm({ accountKey: mockAccountKey });
 
         // FeesFooter should be rendered if totalAmount and fee are present
         // This test validates the integration between TradingFeesForm and its child components
         expect(getByText('Transaction fee')).toBeTruthy();
     });
 
-    it('should work with token contract for Ethereum accounts', async () => {
-        const { getByText } = await renderTradingFeesForm({
+    it('should work with token contract for Ethereum accounts', () => {
+        const { getByText } = renderTradingFeesForm({
             accountKey: 'eth1' as AccountKey, // Todo: create properly via `createAccountKey()`
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
@@ -103,9 +103,9 @@ describe('TradingFeesForm', () => {
         expect(getByText('Maximum fee')).toBeTruthy();
     });
 
-    it('should not render anything when account is not available', async () => {
+    it('should not render anything when account is not available', () => {
         const accountKey = 'nonexistent-account' as AccountKey;
-        const { queryByText } = await renderTradingFeesForm({ accountKey });
+        const { queryByText } = renderTradingFeesForm({ accountKey });
 
         // Should not render when account doesn't exist
         expect(queryByText('Transaction fee')).toBeFalsy();

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
@@ -5,7 +5,7 @@ import {
     type TestStore,
     fireEvent,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import {
@@ -84,7 +84,7 @@ describe('AccountList', () => {
     ) => {
         store = initStore(preloadedState).store;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <AccountList
                 symbol="btc"
                 pickerMode="account"
@@ -102,8 +102,8 @@ describe('AccountList', () => {
             screen.unmount();
         });
 
-        it('should display all accounts for given symbol', async () => {
-            const { getByText } = await renderComponent({
+        it('should display all accounts for given symbol', () => {
+            const { getByText } = renderComponent({
                 symbol: 'btc',
                 pickerMode: 'account',
             });
@@ -112,8 +112,8 @@ describe('AccountList', () => {
             expect(getByText('BTC Account #2')).toBeTruthy();
         });
 
-        it('should display addresses when picker mode is set and account is selected', async () => {
-            const { getByText } = await renderComponent(
+        it('should display addresses when picker mode is set and account is selected', () => {
+            const { getByText } = renderComponent(
                 {
                     symbol: 'btc',
                     pickerMode: 'address',
@@ -131,10 +131,10 @@ describe('AccountList', () => {
             screen.unmount();
         });
 
-        it('should call onSetPickerMode when account is selected in account mode', async () => {
+        it('should call onSetPickerMode when account is selected in account mode', () => {
             (useNavigation as jest.Mock).mockReturnValue({ popToTop });
 
-            const { getByText } = await renderComponent({
+            const { getByText } = renderComponent({
                 symbol: 'btc',
                 pickerMode: 'account',
                 onSetPickerMode: onSetPickerModeMock,
@@ -149,10 +149,10 @@ describe('AccountList', () => {
             expect(popToTop).not.toHaveBeenCalled();
         });
 
-        it('should popToTop when account is selected in account mode and there are no addresses', async () => {
+        it('should popToTop when account is selected in account mode and there are no addresses', () => {
             (useNavigation as jest.Mock).mockReturnValue({ popToTop });
 
-            const { getByText } = await renderComponent({
+            const { getByText } = renderComponent({
                 symbol: 'eth',
                 pickerMode: 'account',
                 onSetPickerMode: onSetPickerModeMock,
@@ -166,9 +166,9 @@ describe('AccountList', () => {
             expect(popToTop).toHaveBeenCalled();
         });
 
-        it('should handle address selection in address mode', async () => {
+        it('should handle address selection in address mode', () => {
             (useNavigation as jest.Mock).mockReturnValue({ popToTop });
-            const { getByText } = await renderComponent(
+            const { getByText } = renderComponent(
                 {
                     symbol: 'btc',
                     pickerMode: 'address',
@@ -185,8 +185,8 @@ describe('AccountList', () => {
             expect(popToTop).toHaveBeenCalled();
         });
 
-        it('should set correct state with tradingType set to "buy"', async () => {
-            const { getByText } = await renderComponent({
+        it('should set correct state with tradingType set to "buy"', () => {
+            const { getByText } = renderComponent({
                 symbol: 'btc',
                 pickerMode: 'account',
             });
@@ -200,8 +200,8 @@ describe('AccountList', () => {
             expect(selectTradingBuyReceiveAccountKey(store.getState())).toBe(btc1NormalAccount.key);
         });
 
-        it('should set correct state with tradingType set to "exchange"', async () => {
-            const { getByText } = await renderComponent({
+        it('should set correct state with tradingType set to "exchange"', () => {
+            const { getByText } = renderComponent({
                 symbol: 'btc',
                 pickerMode: 'account',
                 tradingType: 'exchange',
@@ -215,9 +215,9 @@ describe('AccountList', () => {
             });
         });
 
-        it('should handle address selection in address mode for "exchange"', async () => {
+        it('should handle address selection in address mode for "exchange"', () => {
             (useNavigation as jest.Mock).mockReturnValue({ popToTop });
-            const { getByText } = await renderComponent(
+            const { getByText } = renderComponent(
                 {
                     symbol: 'btc',
                     pickerMode: 'address',
@@ -241,8 +241,8 @@ describe('AccountList', () => {
             screen.unmount();
         });
 
-        it('should display footer with "Add new" button in "account" mode', async () => {
-            const { getByText } = await renderComponent({
+        it('should display footer with "Add new" button in "account" mode', () => {
+            const { getByText } = renderComponent({
                 symbol: 'btc',
                 pickerMode: 'account',
             });
@@ -250,8 +250,8 @@ describe('AccountList', () => {
             expect(getByText('Add new')).toBeTruthy();
         });
 
-        it('should NOT display footer with "Add new" button in "address" mode', async () => {
-            const { queryByText } = await renderComponent(
+        it('should NOT display footer with "Add new" button in "address" mode', () => {
+            const { queryByText } = renderComponent(
                 {
                     symbol: 'btc',
                     pickerMode: 'address',

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -1,5 +1,5 @@
 import { type Account, type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 
 import { AccountListAddressItem } from '../AccountListAddressItem';
@@ -50,7 +50,7 @@ describe(AccountListAddressItem.name, () => {
     const onPressMock = jest.fn();
 
     const renderAccountListAddressItem = (receiveAccount: ReceiveAccount) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <AccountListAddressItem receiveAccount={receiveAccount} onPress={onPressMock} />,
         );
 
@@ -58,7 +58,7 @@ describe(AccountListAddressItem.name, () => {
         jest.resetAllMocks();
     });
 
-    it('should call onPress callback when pressed', async () => {
+    it('should call onPress callback when pressed', () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -75,14 +75,14 @@ describe(AccountListAddressItem.name, () => {
                 received: '',
             },
         };
-        const { getByText } = await renderAccountListAddressItem(receiveAccount);
+        const { getByText } = renderAccountListAddressItem(receiveAccount);
 
         fireEvent.press(getByText('BTC_address'));
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
-    it('should not display caret for address addresses', async () => {
+    it('should not display caret for address addresses', () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -100,13 +100,13 @@ describe(AccountListAddressItem.name, () => {
             },
         };
         const { getByText, queryByAccessibilityHint } =
-            await renderAccountListAddressItem(receiveAccount);
+            renderAccountListAddressItem(receiveAccount);
 
         expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
     });
 
-    it('should display address', async () => {
+    it('should display address', () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -124,7 +124,7 @@ describe(AccountListAddressItem.name, () => {
             },
         };
         const { getByText, queryByText, queryByAccessibilityHint, getByLabelText } =
-            await renderAccountListAddressItem(receiveAccount);
+            renderAccountListAddressItem(receiveAccount);
 
         expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByText('My BTC account')).toBeNull();
@@ -133,7 +133,7 @@ describe(AccountListAddressItem.name, () => {
         expect(getByLabelText('Balance in crypto')).toHaveTextContent('0.05 BTC');
     });
 
-    it('should display zero balance', async () => {
+    it('should display zero balance', () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -150,13 +150,13 @@ describe(AccountListAddressItem.name, () => {
                 received: '',
             },
         };
-        const { getByLabelText } = await renderAccountListAddressItem(receiveAccount);
+        const { getByLabelText } = renderAccountListAddressItem(receiveAccount);
 
         expect(getByLabelText('Balance in fiat')).toHaveTextContent('$0.00');
         expect(getByLabelText('Balance in crypto')).toHaveTextContent('0 BTC');
     });
 
-    it('should render nothing when no address is specified', async () => {
+    it('should render nothing when no address is specified', () => {
         const receiveAccount: ReceiveAccount = {
             account: createAccount({
                 key: 'btc1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -166,7 +166,7 @@ describe(AccountListAddressItem.name, () => {
             }),
             address: undefined,
         };
-        const { toJSON } = await renderAccountListAddressItem(receiveAccount);
+        const { toJSON } = renderAccountListAddressItem(receiveAccount);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
@@ -4,7 +4,7 @@ import {
     type TestStore,
     fireEvent,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type StaticSessionId } from '@trezor/connect';
@@ -67,7 +67,7 @@ describe('AccountListItem', () => {
     ) => {
         store = initStore(preloadedState).store;
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <AccountListItem onPress={onPressMock} receiveAccount={receiveAccount} />,
             { store },
         );
@@ -77,23 +77,23 @@ describe('AccountListItem', () => {
         jest.resetAllMocks();
     });
 
-    it('should call onPress callback when pressed', async () => {
+    it('should call onPress callback when pressed', () => {
         const receiveAccount: ReceiveAccount = {
             account: btc10000000Account,
         };
-        const { getByText } = await renderAccountListItem(receiveAccount);
+        const { getByText } = renderAccountListItem(receiveAccount);
 
         fireEvent.press(getByText('My BTC account'));
 
         expect(onPressMock).toHaveBeenCalled();
     });
 
-    it('should render account name', async () => {
+    it('should render account name', () => {
         const receiveAccount: ReceiveAccount = {
             account: btc10000000Account,
         };
         const { getByText, queryByAccessibilityHint, getByLabelText } =
-            await renderAccountListItem(receiveAccount);
+            renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
         expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
@@ -101,7 +101,7 @@ describe('AccountListItem', () => {
         expect(getByLabelText('Balance in crypto')).toHaveTextContent('0.1 BTC');
     });
 
-    it('should display caret when account defines addresses', async () => {
+    it('should display caret when account defines addresses', () => {
         const receiveAccount: ReceiveAccount = {
             account: {
                 ...btc10000000Account,
@@ -112,7 +112,7 @@ describe('AccountListItem', () => {
                 },
             },
         };
-        const { getByText, getByAccessibilityHint } = await renderAccountListItem(receiveAccount);
+        const { getByText, getByAccessibilityHint } = renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
         expect(getByAccessibilityHint('Select to display account addresses')).toBeTruthy();

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { NoAccountsComponent } from '../NoAccountsComponent';
 
@@ -10,7 +10,7 @@ describe('NoAccountsComponent', () => {
         isConnected: boolean;
         id?: string;
     }) =>
-        renderWithStoreProviderAsync(<NoAccountsComponent isBottomRounded />, {
+        renderWithStoreProvider(<NoAccountsComponent isBottomRounded />, {
             preloadedState: {
                 device: {
                     selectedDevice: {
@@ -22,22 +22,22 @@ describe('NoAccountsComponent', () => {
             },
         });
 
-    it('should render for not connected device', async () => {
-        const { queryByText } = await renderNoAccountsComponent({ isConnected: false });
+    it('should render for not connected device', () => {
+        const { queryByText } = renderNoAccountsComponent({ isConnected: false });
 
         expect(queryByText('You need to connect your device to add new account.')).toBeTruthy();
     });
 
-    it('should render for no account but connected device', async () => {
-        const { queryByText } = await renderNoAccountsComponent({ isConnected: true });
+    it('should render for no account but connected device', () => {
+        const { queryByText } = renderNoAccountsComponent({ isConnected: true });
 
         expect(
             queryByText('It seems that you don’t have any account matching selected asset.'),
         ).toBeTruthy();
     });
 
-    it('should render for portfolio tracker', async () => {
-        const { queryByText } = await renderNoAccountsComponent({
+    it('should render for portfolio tracker', () => {
+        const { queryByText } = renderNoAccountsComponent({
             isConnected: false,
             id: 'hiddenDeviceWithImportedAccounts',
         });

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
@@ -6,7 +6,7 @@ import {
     type TestStore,
     fireEvent,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { type TradingRootState } from '@suite-native/trading-state';
 
@@ -43,8 +43,8 @@ describe('Header', () => {
         },
     });
 
-    const renderWithStoreProviderAsyncWithReportMock = async (
-        ...args: Parameters<typeof renderWithStoreProviderAsync>
+    const renderWithStoreProviderWithReportMock = (
+        ...args: Parameters<typeof renderWithStoreProvider>
     ) => {
         const reportMock = jest.fn();
         (useAnalytics as jest.Mock).mockReturnValue({
@@ -52,7 +52,7 @@ describe('Header', () => {
         });
 
         return {
-            renderer: await renderWithStoreProviderAsync(...args),
+            renderer: renderWithStoreProvider(...args),
             reportMock,
         };
     };
@@ -114,7 +114,7 @@ describe('Header', () => {
             ...tradingPreloadedState,
         } as unknown as PreloadedState;
 
-        return renderWithStoreProviderAsyncWithReportMock(<Header />, { preloadedState });
+        return renderWithStoreProviderWithReportMock(<Header />, { preloadedState });
     };
 
     it.each([
@@ -143,16 +143,16 @@ describe('Header', () => {
             sellEnabled: false,
             exchangeEnabled: true,
         },
-    ])('should display Header tabs with Buy, Swap and Sell tabs, case %#', async config => {
-        const { renderer } = await renderHeader(config);
+    ])('should display Header tabs with Buy, Swap and Sell tabs, case %#', config => {
+        const { renderer } = renderHeader(config);
 
         expect(renderer.getByText('Buy')).toBeOnTheScreen();
         expect(renderer.getByText('Swap')).toBeOnTheScreen();
         expect(renderer.getByText('Sell')).toBeOnTheScreen();
     });
 
-    it('should display nothing when isAmountInputActive is true', async () => {
-        const { renderer } = await renderHeader({
+    it('should display nothing when isAmountInputActive is true', () => {
+        const { renderer } = renderHeader({
             buyEnabled: true,
             tradingPreloadedState: {
                 wallet: {
@@ -166,14 +166,14 @@ describe('Header', () => {
         expect(renderer.toJSON()).toBeNull();
     });
 
-    it('should set state on tab button press', async () => {
+    it('should set state on tab button press', () => {
         const { store } = initStore(
             getFFPreloadedState({
                 buyEnabled: true,
                 exchangeEnabled: true,
             }),
         );
-        const { renderer } = await renderWithStoreProviderAsyncWithReportMock(<Header />, {
+        const { renderer } = renderWithStoreProviderWithReportMock(<Header />, {
             store,
         });
 
@@ -182,8 +182,8 @@ describe('Header', () => {
         expect(store.getState().wallet.trading.activeTradingType).toBe('exchange');
     });
 
-    it('should display trade settings button', async () => {
-        const { renderer } = await renderHeader({
+    it('should display trade settings button', () => {
+        const { renderer } = renderHeader({
             buyEnabled: true,
             exchangeEnabled: true,
         });
@@ -191,8 +191,8 @@ describe('Header', () => {
         expect(renderer.getByLabelText('Advanced settings')).toBeOnTheScreen();
     });
 
-    it('should not display settings wheel when AreTradingExchangeDexesEnabled is disabled', async () => {
-        const { renderer } = await renderHeader({
+    it('should not display settings wheel when AreTradingExchangeDexesEnabled is disabled', () => {
+        const { renderer } = renderHeader({
             buyEnabled: true,
             exchangeEnabled: true,
             areTradingExchangeDexesEnabled: false,
@@ -214,11 +214,10 @@ describe('Header', () => {
             ).store;
         });
 
-        it('should report TradingNavigate event on tab change', async () => {
-            const { renderer, reportMock } = await renderWithStoreProviderAsyncWithReportMock(
-                <Header />,
-                { store },
-            );
+        it('should report TradingNavigate event on tab change', () => {
+            const { renderer, reportMock } = renderWithStoreProviderWithReportMock(<Header />, {
+                store,
+            });
 
             fireEvent.press(renderer.getByText('Swap'));
 
@@ -232,11 +231,10 @@ describe('Header', () => {
             });
         });
 
-        it('should not report TradingNavigate event when tab was not changed', async () => {
-            const { renderer, reportMock } = await renderWithStoreProviderAsyncWithReportMock(
-                <Header />,
-                { store },
-            );
+        it('should not report TradingNavigate event when tab was not changed', () => {
+            const { renderer, reportMock } = renderWithStoreProviderWithReportMock(<Header />, {
+                store,
+            });
 
             fireEvent.press(renderer.getByText('Swap'));
             reportMock.mockClear();
@@ -246,11 +244,10 @@ describe('Header', () => {
             expect(reportMock).not.toHaveBeenCalled();
         });
 
-        it('should report TradingNavigate event when tab was changed to buy', async () => {
-            const { renderer, reportMock } = await renderWithStoreProviderAsyncWithReportMock(
-                <Header />,
-                { store },
-            );
+        it('should report TradingNavigate event when tab was changed to buy', () => {
+            const { renderer, reportMock } = renderWithStoreProviderWithReportMock(<Header />, {
+                store,
+            });
 
             fireEvent.press(renderer.getByText('Swap'));
             reportMock.mockClear();

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
@@ -6,7 +6,7 @@ import {
     type TokenSymbol,
     asBaseCurrencyAmount,
 } from '@suite-common/wallet-types';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getBtcAccount, getEthAccount } from '@suite-native/trading-fixtures';
 import { type MyAsset } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
@@ -79,13 +79,13 @@ describe('MyAssetListItem', () => {
         }: Partial<MyAssetListItemProps> = {},
         preloadedState = getPreloadedState(),
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <MyAssetListItem asset={asset} account={account} onPress={onPress} />,
             { preloadedState },
         );
 
-    it('should render with correct labels', async () => {
-        const { getAllByText } = await renderComponent({
+    it('should render with correct labels', () => {
+        const { getAllByText } = renderComponent({
             asset: mockUsdcTokenAsset,
             account: getEthAccount(),
         });
@@ -94,9 +94,9 @@ describe('MyAssetListItem', () => {
         expect(getAllByText('100,000,000 USDC').length).toBeGreaterThan(0);
     });
 
-    it('should call onPress callback when clicked', async () => {
+    it('should call onPress callback when clicked', () => {
         const onPress = jest.fn();
-        const { getAllByText } = await renderComponent({ asset: mockBtcAsset, onPress });
+        const { getAllByText } = renderComponent({ asset: mockBtcAsset, onPress });
 
         fireEvent.press(getAllByText('Bitcoin')[0]);
 
@@ -110,16 +110,16 @@ describe('MyAssetListItem', () => {
         );
     });
 
-    it('should render Bitcoin asset with correct labels and balance', async () => {
-        const { getAllByText } = await renderComponent({ asset: mockBtcAsset });
+    it('should render Bitcoin asset with correct labels and balance', () => {
+        const { getAllByText } = renderComponent({ asset: mockBtcAsset });
 
         expect(getAllByText('Bitcoin')[0]).toBeTruthy();
         expect(getAllByText('1,000,000 BTC')[0]).toBeTruthy();
         expect(getAllByText('$42,000.00')[0]).toBeTruthy();
     });
 
-    it('should render Ethereum asset with correct labels and balance', async () => {
-        const { getAllByText } = await renderComponent({
+    it('should render Ethereum asset with correct labels and balance', () => {
+        const { getAllByText } = renderComponent({
             asset: mockEthAsset,
             account: getEthAccount(),
         });
@@ -129,8 +129,8 @@ describe('MyAssetListItem', () => {
         expect(getAllByText('$2,500.00')[0]).toBeTruthy();
     });
 
-    it('should render token asset with token formatter', async () => {
-        const { getAllByText } = await renderComponent({
+    it('should render token asset with token formatter', () => {
+        const { getAllByText } = renderComponent({
             asset: mockUsdcTokenAsset,
             account: getEthAccount(),
         });
@@ -140,7 +140,7 @@ describe('MyAssetListItem', () => {
         expect(getAllByText('100,000,000 USDC')[0]).toBeTruthy();
     });
 
-    it('should render as no pair when not enabled', async () => {
+    it('should render as no pair when not enabled', () => {
         const preloadedState = {
             ...getPreloadedState(),
             appSettings: {
@@ -149,7 +149,7 @@ describe('MyAssetListItem', () => {
             },
         };
 
-        const { getByText } = await renderComponent(
+        const { getByText } = renderComponent(
             { asset: { ...mockEthAsset, isEnabled: false } },
             preloadedState,
         );
@@ -157,13 +157,13 @@ describe('MyAssetListItem', () => {
         expect(getByText('No pair')).toBeTruthy();
     });
 
-    it('should render without fiat balance when not available', async () => {
+    it('should render without fiat balance when not available', () => {
         const assetWithoutFiat: MyAsset = {
             ...mockBtcAsset,
             fiatBalance: null,
         };
 
-        const { getAllByText, queryByText } = await renderComponent({
+        const { getAllByText, queryByText } = renderComponent({
             asset: assetWithoutFiat,
         });
 
@@ -172,8 +172,8 @@ describe('MyAssetListItem', () => {
         expect(queryByText('$42,000.00')).toBeNull();
     });
 
-    it('should handle token assets with contract address correctly', async () => {
-        const { getByText, getAllByText } = await renderComponent({
+    it('should handle token assets with contract address correctly', () => {
+        const { getByText, getAllByText } = renderComponent({
             asset: mockUsdcTokenAsset,
             account: getEthAccount(),
         });
@@ -184,9 +184,9 @@ describe('MyAssetListItem', () => {
     });
 
     describe('handlePress functionality', () => {
-        it('should call onPress when asset is enabled and tradeableAsset exists', async () => {
+        it('should call onPress when asset is enabled and tradeableAsset exists', () => {
             const onPress = jest.fn();
-            const { getAllByText } = await renderComponent({
+            const { getAllByText } = renderComponent({
                 asset: mockBtcAsset,
                 onPress,
             });
@@ -205,10 +205,10 @@ describe('MyAssetListItem', () => {
             );
         });
 
-        it('should  not call onPress when asset is not enabled', async () => {
+        it('should  not call onPress when asset is not enabled', () => {
             const onPress = jest.fn();
             const disabledAsset = { ...mockBtcAsset, isEnabled: false };
-            const { getAllByText } = await renderComponent({
+            const { getAllByText } = renderComponent({
                 asset: disabledAsset,
                 onPress,
             });
@@ -218,10 +218,10 @@ describe('MyAssetListItem', () => {
             expect(onPress).not.toHaveBeenCalled();
         });
 
-        it('should  not call onPress when tradeableAsset does not exist (no cryptoId)', async () => {
+        it('should  not call onPress when tradeableAsset does not exist (no cryptoId)', () => {
             const onPress = jest.fn();
             const assetWithoutCryptoId = { ...mockBtcAsset, cryptoId: undefined };
-            const { getAllByText } = await renderComponent({
+            const { getAllByText } = renderComponent({
                 asset: assetWithoutCryptoId,
                 onPress,
             });
@@ -231,7 +231,7 @@ describe('MyAssetListItem', () => {
             expect(onPress).not.toHaveBeenCalled();
         });
 
-        it('should  not call onPress when coinInfo does not exist in store', async () => {
+        it('should  not call onPress when coinInfo does not exist in store', () => {
             const onPress = jest.fn();
             const preloadedStateWithoutCoinInfo = {
                 wallet: {
@@ -249,7 +249,7 @@ describe('MyAssetListItem', () => {
                 },
             };
 
-            const { getAllByText } = await renderComponent(
+            const { getAllByText } = renderComponent(
                 {
                     asset: mockBtcAsset,
                     onPress,
@@ -262,14 +262,14 @@ describe('MyAssetListItem', () => {
             expect(onPress).not.toHaveBeenCalled();
         });
 
-        it('should not call onPress when asset is not enabled and tradeableAsset does not exist', async () => {
+        it('should not call onPress when asset is not enabled and tradeableAsset does not exist', () => {
             const onPress = jest.fn();
             const disabledAssetWithoutCryptoId = {
                 ...mockBtcAsset,
                 isEnabled: false,
                 cryptoId: undefined,
             };
-            const { getAllByText } = await renderComponent({
+            const { getAllByText } = renderComponent({
                 asset: disabledAssetWithoutCryptoId,
                 onPress,
             });

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
@@ -2,7 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { selectFormattedAccountType } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
-import { fireEvent, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import {
     btc1NormalAccount,
     eth1NormalAccount,
@@ -66,7 +66,7 @@ describe('MyAssetSheet', () => {
     });
 
     const renderMyAssetsSheet = (props?: Partial<MyAssetSheetProps>) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <MyAssetSheet
                 onAssetSelect={jest.fn}
                 onClose={jest.fn}
@@ -87,33 +87,33 @@ describe('MyAssetSheet', () => {
         screen.unmount();
     });
 
-    it('should render account information correctly', async () => {
+    it('should render account information correctly', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
             defaultAccounts,
         );
 
-        const { getByText } = await renderMyAssetsSheet();
+        const { getByText } = renderMyAssetsSheet();
 
         expect(getByText('BTC Account #1')).toBeTruthy();
         expect(getByText('ETH Account #1')).toBeTruthy();
     });
 
-    it('should render correct empty component', async () => {
+    it('should render correct empty component', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue([]);
-        const { getByText } = await renderMyAssetsSheet();
+        const { getByText } = renderMyAssetsSheet();
 
         expect(getByText('No assets found')).toBeTruthy();
         expect(getByText('You do not have any assets available for this operation.')).toBeTruthy();
     });
 
-    it('should select asset and close on asset item press', async () => {
+    it('should select asset and close on asset item press', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
             defaultAccounts,
         );
         const onAssetSelect = jest.fn();
         const onClose = jest.fn();
 
-        const { getByText } = await renderMyAssetsSheet({ onAssetSelect, onClose });
+        const { getByText } = renderMyAssetsSheet({ onAssetSelect, onClose });
 
         fireEvent.press(getByText('BTC'));
 
@@ -127,7 +127,7 @@ describe('MyAssetSheet', () => {
         expect(onClose).toHaveBeenCalledWith(false);
     });
 
-    it('should render formatted account type badge when defined', async () => {
+    it('should render formatted account type badge when defined', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
             defaultAccounts,
         );
@@ -137,12 +137,12 @@ describe('MyAssetSheet', () => {
             accountKey === btcAccount.key ? 'SegWit' : null,
         );
 
-        const { getByText } = await renderMyAssetsSheet();
+        const { getByText } = renderMyAssetsSheet();
 
         expect(getByText('SegWit')).toBeTruthy();
     });
 
-    it('should not render badge when formatted account type is null', async () => {
+    it('should not render badge when formatted account type is null', () => {
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
             defaultAccounts,
         );
@@ -150,7 +150,7 @@ describe('MyAssetSheet', () => {
         // Mock the selector to return null for all accounts
         mockedSelectFormattedAccountType.mockReturnValue(null);
 
-        const { queryByTestId } = await renderMyAssetsSheet();
+        const { queryByTestId } = renderMyAssetsSheet();
 
         expect(queryByTestId(TEST_ID_ACCOUNT_TYPE_BADGE)).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
@@ -1,10 +1,6 @@
 import { type TradingTradeType, type TradingType } from '@suite-common/trading';
 import { FeatureFlag } from '@suite-native/feature-flags';
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    screen,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { buyQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { ProviderSheet, type ProviderSheetProps } from '../ProviderSheet';
@@ -14,7 +10,7 @@ describe('ProviderSheet', () => {
         props: Partial<ProviderSheetProps<TradingType, TradingTradeType>> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ProviderSheet
                 onClose={jest.fn()}
                 isVisible={true}
@@ -30,22 +26,22 @@ describe('ProviderSheet', () => {
         screen.unmount();
     });
 
-    it('should render empty providers placeholder and no section header and for buy', async () => {
-        const { queryByText, getByText } = await renderProviderSheet({}, {});
+    it('should render empty providers placeholder and no section header and for buy', () => {
+        const { queryByText, getByText } = renderProviderSheet({}, {});
 
         expect(getByText('No offers available.')).toBeOnTheScreen();
         expect(queryByText('Fixed-rate CEX')).toBeNull();
     });
 
-    it('should render section header and empty placeholder for exchange', async () => {
-        const { getByText } = await renderProviderSheet({ tradingType: 'exchange' }, {});
+    it('should render section header and empty placeholder for exchange', () => {
+        const { getByText } = renderProviderSheet({ tradingType: 'exchange' }, {});
 
         expect(getByText('No offers available.')).toBeOnTheScreen();
         expect(getByText('Fixed-rate CEX')).toBeOnTheScreen();
     });
 
-    it('should render all section headers for exchange', async () => {
-        const { getByText } = await renderProviderSheet(
+    it('should render all section headers for exchange', () => {
+        const { getByText } = renderProviderSheet(
             { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
             { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: true } },
         );
@@ -55,8 +51,8 @@ describe('ProviderSheet', () => {
         expect(getByText('DEX')).toBeOnTheScreen();
     });
 
-    it('should not render DEX section header for exchange when DEXes are disabled', async () => {
-        const { queryByText, getByText } = await renderProviderSheet(
+    it('should not render DEX section header for exchange when DEXes are disabled', () => {
+        const { queryByText, getByText } = renderProviderSheet(
             { tradingType: 'exchange', quotes: { fixed: [], float: [], dex: [] } },
             { featureFlags: { [FeatureFlag.AreTradingExchangeDexesEnabled]: false } },
         );
@@ -66,8 +62,8 @@ describe('ProviderSheet', () => {
         expect(queryByText('DEX')).toBeNull();
     });
 
-    it('should render provided quotes', async () => {
-        const { queryByText, getByText } = await renderProviderSheet(
+    it('should render provided quotes', () => {
+        const { queryByText, getByText } = renderProviderSheet(
             { quotes: { fixed: [buyQuotes[0]] } },
             { wallet: getWalletState() },
         );

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
@@ -1,8 +1,4 @@
-import {
-    type PreloadedState,
-    fireEvent,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type PreloadedState, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ProviderSheetHandle, type ProviderSheetHandleProps } from '../ProviderSheetHandle';
 
@@ -24,7 +20,7 @@ describe('ProviderSheetHandle', () => {
         props: Partial<ProviderSheetHandleProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ProviderSheetHandle
                 onClose={jest.fn()}
                 shouldShowFilters={true}
@@ -40,8 +36,8 @@ describe('ProviderSheetHandle', () => {
             { preloadedState },
         );
 
-    it('should render component with title and filter', async () => {
-        const { getByText } = await renderProviderSheetHandle({}, {});
+    it('should render component with title and filter', () => {
+        const { getByText } = renderProviderSheetHandle({}, {});
 
         expect(getByText('Providers')).toBeOnTheScreen();
         expect(getByText('All')).toBeOnTheScreen();
@@ -49,8 +45,8 @@ describe('ProviderSheetHandle', () => {
         expect(getByText('DEX')).toBeOnTheScreen();
     });
 
-    it('should not render filters when shouldShowFilters is false', async () => {
-        const { getByText, queryByText } = await renderProviderSheetHandle(
+    it('should not render filters when shouldShowFilters is false', () => {
+        const { getByText, queryByText } = renderProviderSheetHandle(
             { shouldShowFilters: false },
             {},
         );
@@ -61,26 +57,26 @@ describe('ProviderSheetHandle', () => {
         expect(queryByText('DEX')).toBeNull();
     });
 
-    it('should call onClose when close button is pressed', async () => {
+    it('should call onClose when close button is pressed', () => {
         const onClose = jest.fn();
-        const { getByLabelText } = await renderProviderSheetHandle({ onClose }, {});
+        const { getByLabelText } = renderProviderSheetHandle({ onClose }, {});
 
         fireEvent.press(getByLabelText('Close'));
 
         expect(onClose).toHaveBeenCalled();
     });
 
-    it('should setSelectedFilter when filter item is pressed', async () => {
+    it('should setSelectedFilter when filter item is pressed', () => {
         const setSelectedFilter = jest.fn();
-        const { getByText } = await renderProviderSheetHandle({ setSelectedFilter }, {});
+        const { getByText } = renderProviderSheetHandle({ setSelectedFilter }, {});
 
         fireEvent.press(getByText('CEX'));
 
         expect(setSelectedFilter).toHaveBeenCalledWith('cex');
     });
 
-    it('should display context message', async () => {
-        const { getByText } = await renderProviderSheetHandle(
+    it('should display context message', () => {
+        const { getByText } = renderProviderSheetHandle(
             {},
             {
                 wallet: {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { type QuotesCategory } from '@suite-native/trading-types';
 
 import {
@@ -8,14 +8,14 @@ import {
 
 describe('ProviderSheetSectionHeader', () => {
     const renderProviderSheetSectionHeader = (props: ProviderSheetSectionHeaderProps) =>
-        renderWithStoreProviderAsync(<ProviderSheetSectionHeader {...props} />);
+        renderWithStoreProvider(<ProviderSheetSectionHeader {...props} />);
 
     it.each<[QuotesCategory, string]>([
         ['fixed', 'Fixed-rate CEX'],
         ['float', 'Floating-rate CEX'],
         ['dex', 'DEX'],
-    ])('should render correct section based on category [%s]', async (category, expectedTitle) => {
-        const { getByText } = await renderProviderSheetSectionHeader({ category });
+    ])('should render correct section based on category [%s]', (category, expectedTitle) => {
+        const { getByText } = renderProviderSheetSectionHeader({ category });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { ProviderInfoRow, type ProviderInfoRowProps } from '../ProviderInfoRow';
@@ -11,20 +11,20 @@ describe('ProviderInfoRow', () => {
             }),
         };
 
-        return renderWithStoreProviderAsync(<ProviderInfoRow exchange="mercuryo" {...props} />, {
+        return renderWithStoreProvider(<ProviderInfoRow exchange="mercuryo" {...props} />, {
             preloadedState,
         });
     };
 
-    it('should render provider', async () => {
-        const { getByText } = await renderProviderInfoRow({});
+    it('should render provider', () => {
+        const { getByText } = renderProviderInfoRow({});
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
         expect(getByText('Provider')).toBeOnTheScreen();
     });
 
-    it('should render nothing when no provider is found', async () => {
-        const { toJSON } = await renderProviderInfoRow({ exchange: 'non-existing-provider' });
+    it('should render nothing when no provider is found', () => {
+        const { toJSON } = renderProviderInfoRow({ exchange: 'non-existing-provider' });
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
@@ -1,5 +1,5 @@
 import { type Network } from '@suite-common/wallet-config';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TradeableAssetFilterTabs } from '../TradeableAssetFilterTabs';
 
@@ -23,7 +23,7 @@ jest.mock('@suite-native/discovery', () => {
 
 describe('TradeableAssetFilterTabs', () => {
     const renderComponent = (onSelectedNetworkFilter = jest.fn()) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeableAssetFilterTabs
                 visible={true}
                 animationDuration={300}
@@ -31,16 +31,16 @@ describe('TradeableAssetFilterTabs', () => {
             />,
         );
 
-    it('should render all filter tabs including "All" option', async () => {
-        const { getByText } = await renderComponent();
+    it('should render all filter tabs including "All" option', () => {
+        const { getByText } = renderComponent();
 
         expect(getByText('All')).toBeTruthy();
         expect(getByText('Bitcoin')).toBeTruthy();
         expect(getByText('Ethereum')).toBeTruthy();
     });
 
-    it('should not render anything when visible is false', async () => {
-        const { queryByText } = await renderWithStoreProviderAsync(
+    it('should not render anything when visible is false', () => {
+        const { queryByText } = renderWithStoreProvider(
             <TradeableAssetFilterTabs
                 visible={false}
                 animationDuration={300}
@@ -53,18 +53,18 @@ describe('TradeableAssetFilterTabs', () => {
         expect(queryByText('Ethereum')).toBeNull();
     });
 
-    it('should call onSelectedNetworkFilter with undefined when "All" is selected', async () => {
+    it('should call onSelectedNetworkFilter with undefined when "All" is selected', () => {
         const onSelectedNetworkFilter = jest.fn();
-        const { getByText } = await renderComponent(onSelectedNetworkFilter);
+        const { getByText } = renderComponent(onSelectedNetworkFilter);
 
         fireEvent.press(getByText('All'));
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith(undefined);
     });
 
-    it('should call onSelectedNetworkFilter with network symbol when network tab is selected', async () => {
+    it('should call onSelectedNetworkFilter with network symbol when network tab is selected', () => {
         const onSelectedNetworkFilter = jest.fn();
-        const { getByText } = await renderComponent(onSelectedNetworkFilter);
+        const { getByText } = renderComponent(onSelectedNetworkFilter);
 
         fireEvent.press(getByText('Bitcoin'));
 

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetListItem.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 
 import {
@@ -11,34 +11,34 @@ describe('TradeableAssetListItem', () => {
         onPress = jest.fn(),
         asset = btcAsset,
     }: Partial<TradeableAssetListItemProps>) =>
-        renderWithStoreProviderAsync(<TradeableAssetListItem asset={asset} onPress={onPress} />);
+        renderWithStoreProvider(<TradeableAssetListItem asset={asset} onPress={onPress} />);
 
-    it('should render with correct labels', async () => {
-        const { getAllByText } = await renderComponent({ asset: usdcAsset });
+    it('should render with correct labels', () => {
+        const { getAllByText } = renderComponent({ asset: usdcAsset });
 
         expect(getAllByText('USDC').length).toBeGreaterThan(0);
         expect(getAllByText('Ethereum').length).toBeGreaterThan(0);
     });
 
-    it('should call onPress callback when clicked', async () => {
+    it('should call onPress callback when clicked', () => {
         const onPress = jest.fn();
-        const { getByText } = await renderComponent({ asset: btcAsset, onPress });
+        const { getByText } = renderComponent({ asset: btcAsset, onPress });
 
         fireEvent.press(getByText('BTC'));
 
         expect(onPress).toHaveBeenCalledWith();
     });
 
-    it('should add asset to favourites on star click', async () => {
-        const { getByAccessibilityHint } = await renderComponent({ asset: btcAsset });
+    it('should add asset to favourites on star click', () => {
+        const { getByAccessibilityHint } = renderComponent({ asset: btcAsset });
 
         fireEvent.press(getByAccessibilityHint('Add to favourites'));
 
         expect(getByAccessibilityHint('Remove from favourites')).toBeTruthy();
     });
 
-    it('should remove asset from favourites on star click', async () => {
-        const { getByAccessibilityHint } = await renderComponent({ asset: btcAsset });
+    it('should remove asset from favourites on star click', () => {
+        const { getByAccessibilityHint } = renderComponent({ asset: btcAsset });
 
         fireEvent.press(getByAccessibilityHint('Add to favourites'));
         fireEvent.press(getByAccessibilityHint('Remove from favourites'));

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
@@ -8,7 +8,7 @@ describe('TradeableAssetSheet', () => {
     const defaultAssets: TradeableAsset[] = [btcAsset, usdcAsset, adaAsset];
 
     const renderTradeableAssetsSheet = (props: Partial<TradeableAssetsSheetProps>) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeableAssetSheet
                 assets={defaultAssets}
                 onAssetSelect={jest.fn}
@@ -25,11 +25,11 @@ describe('TradeableAssetSheet', () => {
         screen.unmount();
     });
 
-    it('should call onAssetSelect and onClose when an item is pressed', async () => {
+    it('should call onAssetSelect and onClose when an item is pressed', () => {
         const closeMock = jest.fn();
         const selectMock = jest.fn();
 
-        const { getByText } = await renderTradeableAssetsSheet({
+        const { getByText } = renderTradeableAssetsSheet({
             onClose: closeMock,
             onAssetSelect: selectMock,
         });
@@ -41,11 +41,11 @@ describe('TradeableAssetSheet', () => {
         expect(closeMock).toHaveBeenCalledWith(undefined);
     });
 
-    it('should call onAssetSelect with hideKeyboardOnAssetSelect=true when an item is pressed', async () => {
+    it('should call onAssetSelect with hideKeyboardOnAssetSelect=true when an item is pressed', () => {
         const closeMock = jest.fn();
         const selectMock = jest.fn();
 
-        const { getByText } = await renderTradeableAssetsSheet({
+        const { getByText } = renderTradeableAssetsSheet({
             onClose: closeMock,
             onAssetSelect: selectMock,
             hideKeyboardOnAssetSelect: true,
@@ -58,8 +58,8 @@ describe('TradeableAssetSheet', () => {
         expect(closeMock).toHaveBeenCalledWith(true);
     });
 
-    it('should render correct empty component', async () => {
-        const { getByText } = await renderTradeableAssetsSheet({
+    it('should render correct empty component', () => {
+        const { getByText } = renderTradeableAssetsSheet({
             assets: [],
         });
 

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
@@ -1,5 +1,5 @@
 import { type Network } from '@suite-common/wallet-config';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TradeableAssetSheetHeader } from '../TradeableAssetSheetHeader';
 
@@ -14,7 +14,7 @@ jest.mock('@suite-native/discovery', () => {
 
 describe('TradeableAssetSheetHeader', () => {
     const renderComponent = (onClose = jest.fn()) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeableAssetSheetHeader
                 onClose={onClose}
                 onFilterChange={jest.fn()}
@@ -22,15 +22,15 @@ describe('TradeableAssetSheetHeader', () => {
             />,
         );
 
-    it('should display "Coins" and do not display tabs by default', async () => {
-        const { getByText, queryByText } = await renderComponent();
+    it('should display "Coins" and do not display tabs by default', () => {
+        const { getByText, queryByText } = renderComponent();
 
         expect(getByText('Assets')).toBeTruthy();
         expect(queryByText('All')).toBeNull();
     });
 
-    it('should display tabs after focusing search input', async () => {
-        const { getByPlaceholderText, getByText, queryByText } = await renderComponent();
+    it('should display tabs after focusing search input', () => {
+        const { getByPlaceholderText, getByText, queryByText } = renderComponent();
 
         fireEvent(getByPlaceholderText(/Search/), 'focus');
 
@@ -38,23 +38,23 @@ describe('TradeableAssetSheetHeader', () => {
         expect(queryByText('Coins')).toBeNull();
     });
 
-    it('should not display cancel button by default', async () => {
-        const { queryByText } = await renderComponent();
+    it('should not display cancel button by default', () => {
+        const { queryByText } = renderComponent();
 
         expect(queryByText('Cancel')).toBeNull();
     });
 
-    it('should display cancel button after focusing search input', async () => {
-        const { getByPlaceholderText, getByText } = await renderComponent();
+    it('should display cancel button after focusing search input', () => {
+        const { getByPlaceholderText, getByText } = renderComponent();
 
         fireEvent(getByPlaceholderText(/Search/), 'focus');
 
         expect(getByText('Cancel')).toBeTruthy();
     });
 
-    it('should call onClose when close button is pressed ', async () => {
+    it('should call onClose when close button is pressed ', () => {
         const onClose = jest.fn();
-        const { getByLabelText } = await renderComponent(onClose);
+        const { getByLabelText } = renderComponent(onClose);
 
         fireEvent.press(getByLabelText('Close'));
 

--- a/suite-native/module-trading/src/components/general/__tests__/ActiveTab.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ActiveTab.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingType } from '@suite-common/trading';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ActiveTab } from '../ActiveTab';
 
@@ -13,22 +13,22 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('ActiveTab', () => {
     const renderActiveTab = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(<ActiveTab />, { preloadedState });
+        renderWithStoreProvider(<ActiveTab />, { preloadedState });
 
     it.each<[TradingType, string]>([
         ['buy', 'Buy disabled'],
         ['exchange', 'Swap disabled'],
         ['sell', 'Sell disabled'],
-    ])('should display correct trading type tab for %s', async (tradingType, expectedTitle) => {
-        const { getByText } = await renderActiveTab({
+    ])('should display correct trading type tab for %s', (tradingType, expectedTitle) => {
+        const { getByText } = renderActiveTab({
             wallet: { trading: { activeTradingType: tradingType } },
         });
 
         expect(getByText(expectedTitle)).toBeOnTheScreen();
     });
 
-    it('should render nothing when no active tab is specified', async () => {
-        const { toJSON } = await renderActiveTab({
+    it('should render nothing when no active tab is specified', () => {
+        const { toJSON } = renderActiveTab({
             wallet: { trading: { activeTradingType: undefined } },
         });
 

--- a/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithStoreProviderAsync, within } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider, within } from '@suite-native/test-utils';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
 describe('FilterTabs', () => {
@@ -13,7 +13,7 @@ describe('FilterTabs', () => {
         value = 'all',
         keyExtractor?: (item: FilterItem<string>) => string,
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <FilterTabs
                 items={items}
                 onChange={onChange}
@@ -22,17 +22,17 @@ describe('FilterTabs', () => {
             />,
         );
 
-    it('should render all filter tabs', async () => {
-        const { getByText } = await renderComponent();
+    it('should render all filter tabs', () => {
+        const { getByText } = renderComponent();
 
         expect(getByText('All')).toBeTruthy();
         expect(getByText('Bitcoin')).toBeTruthy();
         expect(getByText('Ethereum')).toBeTruthy();
     });
 
-    it('should call onChange with the correct value when a tab is pressed', async () => {
+    it('should call onChange with the correct value when a tab is pressed', () => {
         const onChange = jest.fn();
-        const { getByText } = await renderComponent(onChange);
+        const { getByText } = renderComponent(onChange);
 
         const bitcoinTab = getByText('Bitcoin');
         expect(bitcoinTab).toBeTruthy();
@@ -41,8 +41,8 @@ describe('FilterTabs', () => {
         expect(onChange).toHaveBeenCalledWith('btc');
     });
 
-    it('should have the correct tab active based on the value prop', async () => {
-        const { getByRole } = await renderComponent(jest.fn(), 'btc');
+    it('should have the correct tab active based on the value prop', () => {
+        const { getByRole } = renderComponent(jest.fn(), 'btc');
 
         const activeTab = getByRole('tab', { selected: true });
         expect(within(activeTab).getByText('Bitcoin')).toBeTruthy();
@@ -51,9 +51,9 @@ describe('FilterTabs', () => {
         expect(within(inactiveTab).getByText('All')).toBeTruthy();
     });
 
-    it('should use custom keyExtractor if provided', async () => {
+    it('should use custom keyExtractor if provided', () => {
         const keyExtractor = jest.fn(item => item.label);
-        await renderComponent(jest.fn(), 'all', keyExtractor);
+        renderComponent(jest.fn(), 'all', keyExtractor);
         expect(keyExtractor).toHaveBeenCalledWith(items[0]);
         expect(keyExtractor).toHaveBeenCalledWith(items[1]);
         expect(keyExtractor).toHaveBeenCalledWith(items[2]);

--- a/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
@@ -1,9 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
-import {
-    type PreloadedState,
-    fireEvent,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type PreloadedState, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
 import { HistoryButton } from '../HistoryButton';
@@ -25,13 +21,13 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('HistoryButton', () => {
     const renderHistoryButton = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(<HistoryButton />, {
+        renderWithStoreProvider(<HistoryButton />, {
             preloadedState,
         });
 
-    it('should render nothing where no trades are available', async () => {
+    it('should render nothing where no trades are available', () => {
         mockSelectDeviceTradingTrades = [];
-        const { toJSON } = await renderHistoryButton({});
+        const { toJSON } = renderHistoryButton({});
 
         expect(toJSON()).toBeNull();
     });
@@ -42,14 +38,14 @@ describe('HistoryButton', () => {
             mockNavigate = jest.fn();
         });
 
-        it('should render button when at least one trade is specified', async () => {
-            const { getByText } = await renderHistoryButton({});
+        it('should render button when at least one trade is specified', () => {
+            const { getByText } = renderHistoryButton({});
 
             expect(getByText('Trade history')).toBeOnTheScreen();
         });
 
-        it('should render nothing when isAmountInputActive is true', async () => {
-            const { toJSON } = await renderHistoryButton({
+        it('should render nothing when isAmountInputActive is true', () => {
+            const { toJSON } = renderHistoryButton({
                 wallet: {
                     trading: {
                         isAmountInputActive: true,
@@ -60,8 +56,8 @@ describe('HistoryButton', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should navigate on press', async () => {
-            const { getByText } = await renderHistoryButton({});
+        it('should navigate on press', () => {
+            const { getByText } = renderHistoryButton({});
 
             fireEvent.press(getByText('Trade history'));
 

--- a/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { LegalGatewayContextMessage } from '../LegalGatewayContextMessage';
 
@@ -15,10 +15,10 @@ jest.mock('@suite-common/message-system', () => {
 
 describe('LegalGatewayContextMessage', () => {
     const renderLegalGatewayContextMessage = () =>
-        renderWithStoreProviderAsync(<LegalGatewayContextMessage />);
+        renderWithStoreProvider(<LegalGatewayContextMessage />);
 
-    it('should render legal.gateway context message', async () => {
-        const { getByText } = await renderLegalGatewayContextMessage();
+    it('should render legal.gateway context message', () => {
+        const { getByText } = renderLegalGatewayContextMessage();
 
         expect(getByText('Legal gateway message')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
 import { type AccountKey } from '@suite-common/wallet-types';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     exchangeMercuryo,
     exchangeQuotes,
@@ -26,7 +26,7 @@ describe('ProviderReceiveAddress', () => {
         destinationAddress: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', // Add destination address
     };
 
-    const renderProviderReceiveAddress = async (
+    const renderProviderReceiveAddress = (
         trade: ExchangeTrade | SellFiatTrade,
         tradeType: 'exchange' | 'sell' = 'exchange',
         accountKey: AccountKey = 'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -48,7 +48,7 @@ describe('ProviderReceiveAddress', () => {
             walletState.trading.sell.tradingAccountKey = accountKey;
         }
 
-        return await renderWithStoreProviderAsync(<ProviderReceiveAddress trade={trade} />, {
+        return renderWithStoreProvider(<ProviderReceiveAddress trade={trade} />, {
             preloadedState: { wallet: walletState },
         });
     };
@@ -57,8 +57,8 @@ describe('ProviderReceiveAddress', () => {
         jest.clearAllMocks();
     });
 
-    it('should display provider name and receive address for exchange trade', async () => {
-        const { getByText } = await renderProviderReceiveAddress(mockExchangeTrade, 'exchange');
+    it('should display provider name and receive address for exchange trade', () => {
+        const { getByText } = renderProviderReceiveAddress(mockExchangeTrade, 'exchange');
 
         // User should see the provider name in the label
         expect(getByText("Mercuryo's receive address")).toBeTruthy();
@@ -66,8 +66,8 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeTruthy();
     });
 
-    it('should display provider name and destination address for sell fiat trade', async () => {
-        const { getByText } = await renderProviderReceiveAddress(mockSellFiatTrade, 'sell');
+    it('should display provider name and destination address for sell fiat trade', () => {
+        const { getByText } = renderProviderReceiveAddress(mockSellFiatTrade, 'sell');
 
         // User should see the provider name in the label
         expect(getByText("Banxa's receive address")).toBeTruthy();
@@ -75,12 +75,12 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1BvB MSEY stWe tqTF n5Au 4m4G Fg7x JaNV N2')).toBeTruthy();
     });
 
-    it('should show fallback text when provider info is not available', async () => {
+    it('should show fallback text when provider info is not available', () => {
         const walletState = getWalletState({ tradeType: 'exchange' });
         // Don't set provider info to simulate missing provider
         walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { queryByText } = await renderWithStoreProviderAsync(
+        const { queryByText } = renderWithStoreProvider(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
             { preloadedState: { wallet: walletState } },
         );
@@ -89,12 +89,12 @@ describe('ProviderReceiveAddress', () => {
         expect(queryByText("Provider's receive address")).toBeFalsy();
     });
 
-    it('should show fallback text when provider company name is not available', async () => {
+    it('should show fallback text when provider company name is not available', () => {
         const walletState = getWalletState({ tradeType: 'exchange' });
         // Don't set provider info to simulate missing provider
         walletState.trading.exchange.exchangeInfo!.providerInfos = {};
 
-        const { queryByText } = await renderWithStoreProviderAsync(
+        const { queryByText } = renderWithStoreProvider(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
             { preloadedState: { wallet: walletState } },
         );
@@ -103,26 +103,26 @@ describe('ProviderReceiveAddress', () => {
         expect(queryByText("Provider's receive address")).toBeFalsy();
     });
 
-    it('should not render anything when receive address is missing for exchange trade', async () => {
+    it('should not render anything when receive address is missing for exchange trade', () => {
         const tradeWithoutAddress = { ...mockExchangeTrade, sendAddress: undefined };
 
-        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress, 'exchange');
+        const { queryByText } = renderProviderReceiveAddress(tradeWithoutAddress, 'exchange');
 
         // User should not see any address information when address is missing
         expect(queryByText("Mercuryo's receive address")).toBeFalsy();
     });
 
-    it('should not render anything when destination address is missing for sell fiat trade', async () => {
+    it('should not render anything when destination address is missing for sell fiat trade', () => {
         const tradeWithoutAddress = { ...mockSellFiatTrade, destinationAddress: undefined };
 
-        const { queryByText } = await renderProviderReceiveAddress(tradeWithoutAddress, 'sell');
+        const { queryByText } = renderProviderReceiveAddress(tradeWithoutAddress, 'sell');
 
         // User should not see any address information when address is missing
         expect(queryByText("Banxa's receive address")).toBeFalsy();
     });
 
-    it('should display solana address as-is without splitting', async () => {
-        const { getByText } = await renderProviderReceiveAddress(
+    it('should display solana address as-is without splitting', () => {
+        const { getByText } = renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
             'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -132,8 +132,8 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')).toBeTruthy();
     });
 
-    it('should display ethereum address with chunking for non-solana networks', async () => {
-        const { getByText } = await renderProviderReceiveAddress(
+    it('should display ethereum address with chunking for non-solana networks', () => {
+        const { getByText } = renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
             'eth-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -143,8 +143,8 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeTruthy();
     });
 
-    it('should display bitcoin address with chunking for non-solana networks', async () => {
-        const { getByText } = await renderProviderReceiveAddress(
+    it('should display bitcoin address with chunking for non-solana networks', () => {
+        const { getByText } = renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
             'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -154,13 +154,13 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('1A1z P1eP 5QGe fi2D MPTf TL5S Lmv7 Divf Na')).toBeTruthy();
     });
 
-    it('should handle solana network type correctly', async () => {
+    it('should handle solana network type correctly', () => {
         const solanaTrade = {
             ...mockExchangeTrade,
             sendAddress: '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM', // Real Solana address
         };
 
-        const { getByText } = await renderProviderReceiveAddress(
+        const { getByText } = renderProviderReceiveAddress(
             solanaTrade,
             'exchange',
             'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
@@ -170,8 +170,8 @@ describe('ProviderReceiveAddress', () => {
         expect(getByText('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')).toBeTruthy();
     });
 
-    it('should handle undefined network symbol gracefully', async () => {
-        const { queryByText } = await renderProviderReceiveAddress(
+    it('should handle undefined network symbol gracefully', () => {
+        const { queryByText } = renderProviderReceiveAddress(
             mockExchangeTrade,
             'exchange',
             'unknown-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     btcAsset,
     ethAsset,
@@ -19,7 +19,7 @@ describe('TradeableAssetAccountBalance', () => {
         props: Partial<TradeableAssetAccountBalanceProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeableAssetAccountBalance
                 asset={undefined}
                 account={undefined}
@@ -29,8 +29,8 @@ describe('TradeableAssetAccountBalance', () => {
             { preloadedState },
         );
 
-    it('should render nothing without asset selected', async () => {
-        const { toJSON } = await renderTradeableAssetAccountBalance({});
+    it('should render nothing without asset selected', () => {
+        const { toJSON } = renderTradeableAssetAccountBalance({});
 
         expect(toJSON()).toBeNull();
     });
@@ -42,23 +42,23 @@ describe('TradeableAssetAccountBalance', () => {
         [usdcAsset, 'USDC'],
     ])(
         'should render empty balance when account is not selected, case %#',
-        async (asset, expectedSymbol) => {
-            const { getByText } = await renderTradeableAssetAccountBalance({ asset });
+        (asset, expectedSymbol) => {
+            const { getByText } = renderTradeableAssetAccountBalance({ asset });
 
             expect(getByText('Balance:')).toBeDefined();
             expect(getByText(`- ${expectedSymbol}`)).toBeDefined();
         },
     );
 
-    it('should use correct TestIDs when no balance is displayed', async () => {
-        const { getByTestId } = await renderTradeableAssetAccountBalance({ asset: btcAsset });
+    it('should use correct TestIDs when no balance is displayed', () => {
+        const { getByTestId } = renderTradeableAssetAccountBalance({ asset: btcAsset });
 
         expect(getByTestId('TEST_ID')).toHaveTextContent('Balance:- BTC');
         expect(getByTestId('TEST_ID/no-value')).toHaveTextContent('- BTC');
     });
 
-    it('should render without TestID', async () => {
-        const { getByText } = await renderTradeableAssetAccountBalance({
+    it('should render without TestID', () => {
+        const { getByText } = renderTradeableAssetAccountBalance({
             asset: btcAsset,
             testID: undefined,
         });
@@ -78,8 +78,8 @@ describe('TradeableAssetAccountBalance', () => {
             [ethAsset, '0.00000081 ETH'],
             [usdcAsset, '1 USDC'],
             [usdtAsset, '0 USDT'],
-        ])('should display correct balance for asset, case %s', async (asset, expectedBalance) => {
-            const { getByText, getByTestId } = await renderTradeableAssetAccountBalance(
+        ])('should display correct balance for asset, case %s', (asset, expectedBalance) => {
+            const { getByText, getByTestId } = renderTradeableAssetAccountBalance(
                 {
                     asset,
                     account: getEthAccount(),

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.test.tsx
@@ -1,6 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { btcAsset, getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
 
 import {
@@ -12,12 +12,12 @@ describe('TradingCoinAmountFormatter', () => {
     const renderTradingCoinAmountFormatter = (
         props: Partial<TradingCoinAmountFormatterProps> = {},
     ) =>
-        renderWithStoreProviderAsync(<TradingCoinAmountFormatter {...props} />, {
+        renderWithStoreProvider(<TradingCoinAmountFormatter {...props} />, {
             preloadedState: { wallet: getWalletState() },
         });
 
-    it('should render formatted value for network', async () => {
-        const { getByText } = await renderTradingCoinAmountFormatter({
+    it('should render formatted value for network', () => {
+        const { getByText } = renderTradingCoinAmountFormatter({
             amount: '123456',
             cryptoId: btcAsset.cryptoId,
         });
@@ -25,8 +25,8 @@ describe('TradingCoinAmountFormatter', () => {
         expect(getByText('123,456 BTC')).toBeOnTheScreen();
     });
 
-    it('should render formatted value for token', async () => {
-        const { getByText } = await renderTradingCoinAmountFormatter({
+    it('should render formatted value for token', () => {
+        const { getByText } = renderTradingCoinAmountFormatter({
             amount: '123456',
             cryptoId: usdcAsset.cryptoId,
         });
@@ -34,22 +34,22 @@ describe('TradingCoinAmountFormatter', () => {
         expect(getByText('123,456 USDC')).toBeOnTheScreen();
     });
 
-    it('should render null when cryptoId is undefined', async () => {
-        const { toJSON } = await renderTradingCoinAmountFormatter();
+    it('should render null when cryptoId is undefined', () => {
+        const { toJSON } = renderTradingCoinAmountFormatter();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render null when cryptoId is unknown', async () => {
-        const { toJSON } = await renderTradingCoinAmountFormatter({
+    it('should render null when cryptoId is unknown', () => {
+        const { toJSON } = renderTradingCoinAmountFormatter({
             cryptoId: 'unknown-crypto-id' as CryptoId,
         });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render 0 value when amount is undefined', async () => {
-        const { getByText } = await renderTradingCoinAmountFormatter({
+    it('should render 0 value when amount is undefined', () => {
+        const { getByText } = renderTradingCoinAmountFormatter({
             cryptoId: btcAsset.cryptoId,
         });
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
@@ -7,8 +7,8 @@ import { useAnalytics } from '@suite-native/services';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
     userEvent,
 } from '@suite-native/test-utils';
@@ -34,28 +34,25 @@ describe('TradingCountryOfResidencePicker', () => {
     let form: UseFormReturn<{ country: TradingCountryOption }>;
 
     const renderForm = () =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             () => useForm<{ country: TradingCountryOption }>({ validation: yup.object() }),
             { preloadedState: residenceCheckDisabledState },
         );
 
     const renderCountryOfResidencePicker = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(
-            <TradingCountryOfResidencePicker testID="testID" context="buy" />,
-            {
-                wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-                preloadedState,
-            },
-        );
+        renderWithStoreProvider(<TradingCountryOfResidencePicker testID="testID" context="buy" />, {
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            preloadedState,
+        });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
 
         (useAnalytics as jest.Mock).mockReturnValue({
             report: reportMock,
         });
 
-        const { result } = await renderForm();
+        const { result } = renderForm();
         form = result.current;
     });
 
@@ -63,7 +60,7 @@ describe('TradingCountryOfResidencePicker', () => {
         screen.unmount();
     });
 
-    it('should use country from form', async () => {
+    it('should use country from form', () => {
         act(() => {
             form.setValue('country', {
                 value: 'US',
@@ -75,13 +72,13 @@ describe('TradingCountryOfResidencePicker', () => {
             });
         });
 
-        const { getByTestId } = await renderCountryOfResidencePicker(residenceCheckDisabledState);
+        const { getByTestId } = renderCountryOfResidencePicker(residenceCheckDisabledState);
 
         expect(getByTestId('testID/value')).toHaveTextContent('🇺🇸 USA');
     });
 
     it('should call analytics on country change', async () => {
-        const { getByText } = await renderCountryOfResidencePicker(residenceCheckDisabledState);
+        const { getByText } = renderCountryOfResidencePicker(residenceCheckDisabledState);
 
         await userEvent.press(getByText('Country of residence'));
         await userEvent.press(getByText(/Algeria/));
@@ -95,8 +92,8 @@ describe('TradingCountryOfResidencePicker', () => {
         });
     });
 
-    it('should render nothing when isTradingResidenceCheckEnabled FF is true', async () => {
-        const { toJSON } = await renderCountryOfResidencePicker(residenceCheckEnabledState);
+    it('should render nothing when isTradingResidenceCheckEnabled FF is true', () => {
+        const { toJSON } = renderCountryOfResidencePicker(residenceCheckEnabledState);
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { tradingInitialState } from '@suite-native/trading-state';
 
 import { TradingTabContent } from '../TradingTabContent';
@@ -21,7 +21,7 @@ jest.mock('../../../hooks/buy/useBuyData', () => ({
 
 describe('TradingTabContent', () => {
     const renderTradingTabContent = (isBlacklisted: boolean = false) =>
-        renderWithStoreProviderAsync(<TradingTabContent />, {
+        renderWithStoreProvider(<TradingTabContent />, {
             preloadedState: {
                 wallet: {
                     trading: {
@@ -73,32 +73,32 @@ describe('TradingTabContent', () => {
         mockIsInternetReachable = true;
     });
 
-    it('should render error screen when isInternetReachable is false', async () => {
+    it('should render error screen when isInternetReachable is false', () => {
         mockIsInternetReachable = false;
 
-        await renderTradingTabContent();
+        renderTradingTabContent();
 
         expectDeviceOffline();
     });
 
-    it('should render trading not allowed in your country warning when ff is set up', async () => {
-        await renderTradingTabContent(true);
+    it('should render trading not allowed in your country warning when ff is set up', () => {
+        renderTradingTabContent(true);
 
         expectTradingNotAllowedInCountry();
     });
 
-    it('trading not allowed should have priority over offline notice', async () => {
+    it('trading not allowed should have priority over offline notice', () => {
         mockIsInternetReachable = false;
 
-        await renderTradingTabContent(true);
+        renderTradingTabContent(true);
 
         expectTradingNotAllowedInCountry();
     });
 
-    it('should render form even when isInternetReachable is null', async () => {
+    it('should render form even when isInternetReachable is null', () => {
         mockIsInternetReachable = null;
 
-        await renderTradingTabContent();
+        renderTradingTabContent();
 
         expectBuyForm();
     });

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingType } from '@suite-common/trading';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TradingTypeAwareContextMessage } from '../TradingTypeAwareContextMessage';
 
@@ -32,7 +32,7 @@ describe('TradingTypeAwareContextMessage', () => {
     });
 
     const renderTradingTypeAwareContextMessage = (preloadedState: PreloadedState) =>
-        renderWithStoreProviderAsync(<TradingTypeAwareContextMessage />, { preloadedState });
+        renderWithStoreProvider(<TradingTypeAwareContextMessage />, { preloadedState });
 
     it.each<[TradingType, string]>([
         ['buy', 'Trading buy message'],
@@ -40,8 +40,8 @@ describe('TradingTypeAwareContextMessage', () => {
         ['sell', 'Trading sell message'],
     ])(
         'should render correct context message for trading type %s',
-        async (tradingType, expectedMessage) => {
-            const { getByText } = await renderTradingTypeAwareContextMessage(
+        (tradingType, expectedMessage) => {
+            const { getByText } = renderTradingTypeAwareContextMessage(
                 getPreloadedState(tradingType),
             );
 
@@ -49,8 +49,8 @@ describe('TradingTypeAwareContextMessage', () => {
         },
     );
 
-    it('should render nothing when trading type is not specified', async () => {
-        const { toJSON } = await renderTradingTypeAwareContextMessage(getPreloadedState(undefined));
+    it('should render nothing when trading type is not specified', () => {
+        const { toJSON } = renderTradingTypeAwareContextMessage(getPreloadedState(undefined));
 
         expect(toJSON()).toBeNull();
     });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
@@ -5,7 +5,7 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     buyMercuryo,
@@ -105,7 +105,7 @@ describe('TradeDetailAlert', () => {
 
         const alertType = getTradeStatusStep(trade);
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <TradeDetailAlert
                 alertType={alertType}
                 provider={TEST_PROVIDER}
@@ -118,15 +118,15 @@ describe('TradeDetailAlert', () => {
     };
 
     describe('Error Alert', () => {
-        it('should render error alert with support button for buy trades', async () => {
-            const { getByText } = await renderAlert('ERROR', 'buy', TEST_PROVIDER_STATUS_URL);
+        it('should render error alert with support button for buy trades', () => {
+            const { getByText } = renderAlert('ERROR', 'buy', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Transaction failed')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
         });
 
-        it('should render error alert with support button for sell trades', async () => {
-            const { getByText } = await renderAlert('ERROR', 'sell', TEST_PROVIDER_STATUS_URL);
+        it('should render error alert with support button for sell trades', () => {
+            const { getByText } = renderAlert('ERROR', 'sell', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Transaction failed')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
@@ -134,15 +134,15 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('Waiting Alert', () => {
-        it('should render waiting alert with payment button when orderId is provided', async () => {
-            const { getByText } = await renderAlert('SUBMITTED', 'buy', undefined, 'test-order-id');
+        it('should render waiting alert with payment button when orderId is provided', () => {
+            const { getByText } = renderAlert('SUBMITTED', 'buy', undefined, 'test-order-id');
 
             expect(getByText('Waiting for your payment ...')).toBeTruthy();
             expect(getByText('Proceed to pay')).toBeTruthy();
         });
 
-        it('should render button but not navigate when trade is not found in store', async () => {
-            const { getByText } = await renderWithStoreProviderAsync(
+        it('should render button but not navigate when trade is not found in store', () => {
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="waiting"
                     provider={TEST_PROVIDER}
@@ -166,8 +166,8 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('KYC Alert', () => {
-        it('should render kyc alert with support button when orderId is provided', async () => {
-            const { getByText } = await renderAlert('KYC', 'exchange', undefined, 'test-order-id');
+        it('should render kyc alert with support button when orderId is provided', () => {
+            const { getByText } = renderAlert('KYC', 'exchange', undefined, 'test-order-id');
 
             expect(getByText('Identity verification required')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
@@ -175,12 +175,8 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('Converting Alert', () => {
-        it('should render converting alert with support button', async () => {
-            const { getByText } = await renderAlert(
-                'CONVERTING',
-                'exchange',
-                TEST_PROVIDER_STATUS_URL,
-            );
+        it('should render converting alert with support button', () => {
+            const { getByText } = renderAlert('CONVERTING', 'exchange', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Converting your crypto...')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
@@ -188,12 +184,8 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('Sending Alert', () => {
-        it('should render sending alert with support button', async () => {
-            const { getByText } = await renderAlert(
-                'SENDING',
-                'exchange',
-                TEST_PROVIDER_STATUS_URL,
-            );
+        it('should render sending alert with support button', () => {
+            const { getByText } = renderAlert('SENDING', 'exchange', TEST_PROVIDER_STATUS_URL);
 
             expect(getByText('Sending your crypto...')).toBeTruthy();
             expect(getByText('Go to provider support')).toBeTruthy();
@@ -201,8 +193,8 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('Sell Trade Alerts', () => {
-        it('should not render alert for sell trades with SUCCESS status', async () => {
-            const { toJSON } = await renderWithStoreProviderAsync(
+        it('should not render alert for sell trades with SUCCESS status', () => {
+            const { toJSON } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="success"
                     provider={TEST_PROVIDER}
@@ -216,8 +208,8 @@ describe('TradeDetailAlert', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render alert for sell trades with SEND_CRYPTO status (pending)', async () => {
-            const { toJSON } = await renderAlert('SEND_CRYPTO', 'sell');
+        it('should not render alert for sell trades with SEND_CRYPTO status (pending)', () => {
+            const { toJSON } = renderAlert('SEND_CRYPTO', 'sell');
 
             expect(toJSON()).toBeNull();
         });
@@ -233,12 +225,8 @@ describe('TradeDetailAlert', () => {
             ['SENDING', 'exchange', TEST_PROVIDER_STATUS_URL],
         ])(
             'should call openLink with status URL when support button is pressed for %s %s trades',
-            async (status, tradeType, expectedUrl) => {
-                const { getByText } = await renderAlert(
-                    status as any,
-                    tradeType as any,
-                    expectedUrl,
-                );
+            (status, tradeType, expectedUrl) => {
+                const { getByText } = renderAlert(status as any, tradeType as any, expectedUrl);
 
                 act(() => {
                     fireEvent.press(getByText('Go to provider support'));
@@ -250,8 +238,8 @@ describe('TradeDetailAlert', () => {
     });
 
     describe('Edge Cases', () => {
-        it('should not render when alertType is undefined', async () => {
-            const { toJSON } = await renderWithStoreProviderAsync(
+        it('should not render when alertType is undefined', () => {
+            const { toJSON } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType={undefined as any}
                     provider={TEST_PROVIDER}
@@ -265,8 +253,8 @@ describe('TradeDetailAlert', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render when alertType is success for non-exchange trades', async () => {
-            const { toJSON } = await renderWithStoreProviderAsync(
+        it('should not render when alertType is success for non-exchange trades', () => {
+            const { toJSON } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="success"
                     provider={TEST_PROVIDER}
@@ -280,14 +268,14 @@ describe('TradeDetailAlert', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render error alert without button when trade and provider info is missing', async () => {
+        it('should render error alert without button when trade and provider info is missing', () => {
             const tradingState = getInitializedTradingStateWithQuotes();
             tradingState.trades = [];
             if (tradingState.buy.buyInfo?.providerInfos) {
                 delete tradingState.buy.buyInfo.providerInfos[TEST_PROVIDER];
             }
 
-            const { getByText, queryByText } = await renderWithStoreProviderAsync(
+            const { getByText, queryByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="error"
                     provider={TEST_PROVIDER}
@@ -302,8 +290,8 @@ describe('TradeDetailAlert', () => {
             expect(queryByText('Go to provider support')).toBeNull();
         });
 
-        it('should render waiting alert with support fallback when statusUrl is missing', async () => {
-            const { getByText } = await renderWithStoreProviderAsync(
+        it('should render waiting alert with support fallback when statusUrl is missing', () => {
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="waiting"
                     provider={TEST_PROVIDER}
@@ -321,12 +309,12 @@ describe('TradeDetailAlert', () => {
             expect(mockOpenLink).toHaveBeenCalledWith(buyMercuryo.supportUrl);
         });
 
-        it('should render button but not navigate when partnerData is missing for buy trades', async () => {
+        it('should render button but not navigate when partnerData is missing for buy trades', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             // Remove partnerData to test missing url for browser navigation
             delete buyTrade.data.partnerData;
 
-            const { getByText } = await renderWithStoreProviderAsync(
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="waiting"
                     provider={TEST_PROVIDER}
@@ -346,11 +334,11 @@ describe('TradeDetailAlert', () => {
             expect(mockOnOpenedBrowser).not.toHaveBeenCalled();
         });
 
-        it('should fall back to support URL when partnerData is missing for exchange trades', async () => {
+        it('should fall back to support URL when partnerData is missing for exchange trades', () => {
             const exchangeTrade = getExchangeTrade({ status: 'KYC' });
             // Exchange trades don't have partnerData, so they always fall back to support URL
 
-            const { getByText } = await renderWithStoreProviderAsync(
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="kyc"
                     provider={TEST_PROVIDER}
@@ -370,7 +358,7 @@ describe('TradeDetailAlert', () => {
             expect(mockNavigation.navigate).not.toHaveBeenCalled();
         });
 
-        it('should render button but not navigate when neither URL for browser auth nor support URL is available', async () => {
+        it('should render button but not navigate when neither URL for browser auth nor support URL is available', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
             // Remove partnerData to test missing url for browser navigation
             delete buyTrade.data.partnerData;
@@ -383,7 +371,7 @@ describe('TradeDetailAlert', () => {
                 delete tradingState.buy.buyInfo.providerInfos[TEST_PROVIDER];
             }
 
-            const { getByText } = await renderWithStoreProviderAsync(
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="waiting"
                     provider={TEST_PROVIDER}
@@ -404,12 +392,12 @@ describe('TradeDetailAlert', () => {
             expect(mockOpenLink).not.toHaveBeenCalled();
         });
 
-        it('should handle sell trades with browser navigation when partnerData is available', async () => {
+        it('should handle sell trades with browser navigation when partnerData is available', () => {
             const sellTrade = getSellTrade({ status: 'ERROR' });
             // Ensure partnerData is present for browser navigation
             sellTrade.data.partnerData = 'https://sell.mercuryo.io/test';
 
-            const { getByText } = await renderWithStoreProviderAsync(
+            const { getByText } = renderWithStoreProvider(
                 <TradeDetailAlert
                     alertType="error"
                     provider={TEST_PROVIDER}

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
-import { fireEvent, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingState, getSellTrade } from '@suite-native/trading-fixtures';
 
 import { TradeDetailFooter } from '../TradeDetailFooter';
@@ -24,10 +24,10 @@ describe('TradeDetailFooter', () => {
         jest.resetAllMocks();
     });
 
-    it('should not render when trade is not found', async () => {
+    it('should not render when trade is not found', () => {
         const preloadedState = getPreloadedState([]);
 
-        const { toJSON } = await renderWithStoreProviderAsync(
+        const { toJSON } = renderWithStoreProvider(
             <TradeDetailFooter orderId="nonexistent_order_id" />,
             { preloadedState },
         );
@@ -35,11 +35,11 @@ describe('TradeDetailFooter', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should handle copy order ID press', async () => {
+    it('should handle copy order ID press', () => {
         const sellTrade = getSellTrade({ status: 'ERROR' });
         const preloadedState = getPreloadedState([sellTrade]);
 
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { getByText } = renderWithStoreProvider(
             <TradeDetailFooter orderId={sellTrade.data.orderId!} />,
             { preloadedState },
         );

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     getBuyTrade,
     getExchangeTrade,
@@ -24,67 +24,67 @@ describe('TradeDetailHeader', () => {
     });
 
     const renderHeader = (orderId: string, trades: TradingTransaction[] = []) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeDetailHeader orderId={orderId} onOpenedBrowser={jest.fn()} />,
             { preloadedState: createPreloadedState(trades) },
         );
 
     describe('Trade Not Found', () => {
-        it('should not render when trade is not found', async () => {
-            const { toJSON } = await renderHeader('nonexistent_order_id');
+        it('should not render when trade is not found', () => {
+            const { toJSON } = renderHeader('nonexistent_order_id');
 
             expect(toJSON()).toBeNull();
         });
     });
 
     describe('Success Status', () => {
-        it('should render header with spinner for in-progress pending trade', async () => {
+        it('should render header with spinner for in-progress pending trade', () => {
             const sellTrade = getSellTrade({ status: 'PENDING' });
-            const { getByTestId } = await renderHeader(sellTrade.data.orderId!, [sellTrade]);
+            const { getByTestId } = renderHeader(sellTrade.data.orderId!, [sellTrade]);
 
             expect(getByTestId('@circular-spinner')).toBeTruthy();
         });
 
-        it('should render header without spinner for final success status', async () => {
+        it('should render header without spinner for final success status', () => {
             const sellTrade = getSellTrade({ status: 'SUCCESS' });
-            const { queryByTestId } = await renderHeader(sellTrade.data.orderId!, [sellTrade]);
+            const { queryByTestId } = renderHeader(sellTrade.data.orderId!, [sellTrade]);
 
             expect(queryByTestId('@circular-spinner')).toBeNull();
         });
     });
 
     describe('Alert Rendering', () => {
-        it('should render error alert for buy trade error status', async () => {
+        it('should render error alert for buy trade error status', () => {
             const buyTrade = getBuyTrade({ status: 'ERROR' });
-            const { getByText } = await renderHeader(buyTrade.data.orderId!, [buyTrade]);
+            const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
             expect(getByText('Transaction failed')).toBeTruthy();
         });
 
-        it('should render waiting alert for buy trade submitted status', async () => {
+        it('should render waiting alert for buy trade submitted status', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const { getByText } = await renderHeader(buyTrade.data.orderId!, [buyTrade]);
+            const { getByText } = renderHeader(buyTrade.data.orderId!, [buyTrade]);
 
             expect(getByText('Waiting for your payment ...')).toBeTruthy();
         });
 
-        it('should render converting alert for exchange converting status', async () => {
+        it('should render converting alert for exchange converting status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
-            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(getByText('Converting your crypto...')).toBeTruthy();
         });
 
-        it('should render kyc alert for exchange kyc status', async () => {
+        it('should render kyc alert for exchange kyc status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'KYC' });
-            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(getByText('Identity verification required')).toBeTruthy();
         });
 
-        it('should render sending alert for exchange sending status', async () => {
+        it('should render sending alert for exchange sending status', () => {
             const exchangeTrade = getExchangeTrade({ status: 'SENDING' });
-            const { getByText } = await renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
+            const { getByText } = renderHeader(exchangeTrade.data.orderId!, [exchangeTrade]);
 
             expect(getByText('Sending your crypto...')).toBeTruthy();
         });

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingTransaction } from '@suite-common/trading';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     getBuyTrade,
     getExchangeTrade,
@@ -18,10 +18,10 @@ const getPreloadedState = (trades: TradingTransaction[]) => ({
 });
 
 describe('TradeDetailInfo', () => {
-    it('should not render when trade is not found', async () => {
+    it('should not render when trade is not found', () => {
         const preloadedState = getPreloadedState([]);
 
-        const { toJSON } = await renderWithStoreProviderAsync(
+        const { toJSON } = renderWithStoreProvider(
             <TradeDetailInfo orderId="nonexistent_order_id" />,
             { preloadedState },
         );
@@ -29,12 +29,12 @@ describe('TradeDetailInfo', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render buy trade info correctly', async () => {
+    it('should render buy trade info correctly', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
         const preloadedState = getPreloadedState([buyTrade]);
 
-        const { getByText } = await renderWithStoreProviderAsync(
+        const { getByText } = renderWithStoreProvider(
             <TradeDetailInfo orderId={buyTrade.data.orderId!} />,
             { preloadedState },
         );
@@ -46,12 +46,12 @@ describe('TradeDetailInfo', () => {
         expect(getByText(/[0-9]{1,2}:21/)).toBeTruthy();
     });
 
-    it('should render exchange trade info correctly', async () => {
+    it('should render exchange trade info correctly', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
 
         const preloadedState = getPreloadedState([exchangeTrade]);
 
-        const { getByText, queryByText } = await renderWithStoreProviderAsync(
+        const { getByText, queryByText } = renderWithStoreProvider(
             <TradeDetailInfo orderId={exchangeTrade.data.orderId!} />,
             { preloadedState },
         );

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
@@ -1,20 +1,20 @@
 import { type TradingTransaction } from '@suite-common/trading';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { TradeHistoryListItem } from '../TradeHistoryListItem';
 
 describe('TradeHistoryListItem', () => {
     const renderTradeHistoryListItem = (transaction: TradingTransaction) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <TradeHistoryListItem transaction={transaction} onPress={jest.fn()} />,
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
 
-    it('should render trade correctly', async () => {
+    it('should render trade correctly', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByText } = await renderTradeHistoryListItem(buyTrade);
+        const { getByText } = renderTradeHistoryListItem(buyTrade);
 
         expect(getByText('Mercuryo')).toBeTruthy();
         expect(getByText('$1,234.00')).toBeTruthy();
@@ -23,10 +23,10 @@ describe('TradeHistoryListItem', () => {
         expect(getByText('Submitted')).toBeTruthy();
     });
 
-    it('should render date and time', async () => {
+    it('should render date and time', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
 
-        const { getByText } = await renderTradeHistoryListItem(buyTrade);
+        const { getByText } = renderTradeHistoryListItem(buyTrade);
 
         expect(getByText(/0[45]\/10\/2025 at [0-9]{1,2}:21/)).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
+++ b/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
@@ -1,16 +1,14 @@
 import { type TradingTransactionStatus } from '@suite-common/trading';
 import { type BadgeVariant } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '@suite-native/trading-fixtures';
 
 import { TradeStatusBadge, getBadgeIconName, getBadgeVariant } from '../TradeStatusBadge';
 
 describe('TradeStatusBadge', () => {
-    it('should render nothing when status is undefined', async () => {
-        const { toJSON } = await renderWithStoreProviderAsync(
-            <TradeStatusBadge status={undefined} />,
-        );
+    it('should render nothing when status is undefined', () => {
+        const { toJSON } = renderWithStoreProvider(<TradeStatusBadge status={undefined} />);
 
         expect(toJSON()).toBeNull();
     });
@@ -26,9 +24,9 @@ describe('TradeStatusBadge', () => {
         ['WAITING_FOR_USER', 'waitingForUser'],
     ] as const)(
         'should render badge with correct text for buy trade and status %s',
-        async (status, statusKey) => {
+        (status, statusKey) => {
             const buyTrade = getBuyTrade({ status });
-            const { getByAccessibilityHint } = await renderWithStoreProviderAsync(
+            const { getByAccessibilityHint } = renderWithStoreProvider(
                 <TradeStatusBadge status={buyTrade.data.status} />,
             );
             const expectedText = new RegExp(
@@ -52,9 +50,9 @@ describe('TradeStatusBadge', () => {
         ['SIGN_DATA', 'signData'],
     ] as const)(
         'should render badge with correct text for exchange trade and status %s',
-        async (status, statusKey) => {
+        (status, statusKey) => {
             const exchangeTrade = getExchangeTrade({ status });
-            const { getByAccessibilityHint } = await renderWithStoreProviderAsync(
+            const { getByAccessibilityHint } = renderWithStoreProvider(
                 <TradeStatusBadge status={exchangeTrade.data.status} />,
             );
             const expectedText = new RegExp(
@@ -76,9 +74,9 @@ describe('TradeStatusBadge', () => {
         ['SUBMITTED', 'submitted'],
     ] as const)(
         'should render badge with correct text for sell trade and status %s',
-        async (status, statusKey) => {
+        (status, statusKey) => {
             const sellTrade = getSellTrade({ status });
-            const { getByAccessibilityHint } = await renderWithStoreProviderAsync(
+            const { getByAccessibilityHint } = renderWithStoreProvider(
                 <TradeStatusBadge status={sellTrade.data.status} />,
             );
             const expectedText = new RegExp(

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.test.tsx
@@ -1,5 +1,5 @@
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { ReviewOutputsContent, type ReviewOutputsContentProps } from '../ReviewOutputsContent';
 
@@ -27,7 +27,7 @@ jest.mock('../../../hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag', 
 
 describe('ReviewOutputsContent', () => {
     const renderReviewOutputsContent = (props: Partial<ReviewOutputsContentProps>) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ReviewOutputsContent
                 orderId="ORDER_ID"
                 accountKey={
@@ -52,33 +52,33 @@ describe('ReviewOutputsContent', () => {
         });
     });
 
-    it('should display loading skeleton when mockDelayedReviewOutputListDisplayFlag is falsy', async () => {
+    it('should display loading skeleton when mockDelayedReviewOutputListDisplayFlag is falsy', () => {
         mockDelayedReviewOutputListDisplayFlag = false;
-        const { getByTestId } = await renderReviewOutputsContent({});
+        const { getByTestId } = renderReviewOutputsContent({});
 
         expect(getByTestId('@trading/outputs-review/skeleton')).toBeOnTheScreen();
     });
 
-    it('should display output item list if mockDelayedReviewOutputListDisplayFlag is truthy', async () => {
-        const { getByText, queryByTestId } = await renderReviewOutputsContent({});
+    it('should display output item list if mockDelayedReviewOutputListDisplayFlag is truthy', () => {
+        const { getByText, queryByTestId } = renderReviewOutputsContent({});
 
         // invalid account id is provided, expect error
         expect(getByText(/Account not found/)).toBeOnTheScreen();
         expect(queryByTestId('@trading/outputs-review/skeleton')).not.toBeOnTheScreen();
     });
 
-    it('should not display sign button if transaction is not signed yet', async () => {
-        const { queryByTestId } = await renderReviewOutputsContent({});
+    it('should not display sign button if transaction is not signed yet', () => {
+        const { queryByTestId } = renderReviewOutputsContent({});
 
         expect(queryByTestId('@trading/outputs-review/footer')).not.toBeOnTheScreen();
     });
 
-    it('should display sign button if transaction is signed', async () => {
+    it('should display sign button if transaction is signed', () => {
         mockUseTradingOutputsReviewScreenControls.mockReturnValue({
             isTransactionAlreadySigned: true,
             confirmOnTrezorRef: { current: null },
         });
-        const { getByTestId } = await renderReviewOutputsContent({});
+        const { getByTestId } = renderReviewOutputsContent({});
 
         expect(getByTestId('@trading/outputs-review/footer')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
@@ -1,8 +1,4 @@
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 
 import { ReviewOutputsFooter, type ReviewOutputsFooterProps } from '../ReviewOutputsFooter';
 
@@ -11,7 +7,7 @@ describe('ReviewOutputsFooter', () => {
         props: Partial<ReviewOutputsFooterProps>,
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <ReviewOutputsFooter
                 resolveConsent={jest.fn()}
                 isConsentRequested={true}
@@ -21,21 +17,21 @@ describe('ReviewOutputsFooter', () => {
             { preloadedState },
         );
 
-    it('should display "Send transaction" button', async () => {
-        const { getByTestId } = await renderReviewOutputsFooter({});
+    it('should display "Send transaction" button', () => {
+        const { getByTestId } = renderReviewOutputsFooter({});
 
         expect(getByTestId('TEST_ID/submit-button')).toHaveTextContent('Send transaction');
         expect(getByTestId('TEST_ID/submit-button')).toBeEnabled();
     });
 
-    it('should be disabled when isConsentRequested is false', async () => {
-        const { getByText } = await renderReviewOutputsFooter({ isConsentRequested: false });
+    it('should be disabled when isConsentRequested is false', () => {
+        const { getByText } = renderReviewOutputsFooter({ isConsentRequested: false });
 
         expect(getByText('Send transaction')).toBeDisabled();
     });
 
-    it('should display "all set" info when transaction is signed', async () => {
-        const { getByText } = await renderReviewOutputsFooter(
+    it('should display "all set" info when transaction is signed', () => {
+        const { getByText } = renderReviewOutputsFooter(
             { isConsentRequested: true },
             {
                 wallet: {
@@ -56,7 +52,7 @@ describe('ReviewOutputsFooter', () => {
 
     it('should resolveConsent on press', async () => {
         const resolveConsent = jest.fn();
-        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
+        const { getByTestId } = renderReviewOutputsFooter({ resolveConsent });
 
         await userEvent.press(getByTestId('TEST_ID/submit-button'));
 
@@ -66,7 +62,7 @@ describe('ReviewOutputsFooter', () => {
 
     it('should resolveConsent only once', async () => {
         const resolveConsent = jest.fn();
-        const { getByTestId } = await renderReviewOutputsFooter({ resolveConsent });
+        const { getByTestId } = renderReviewOutputsFooter({ resolveConsent });
 
         await userEvent.press(getByTestId('TEST_ID/submit-button'));
         await userEvent.press(getByTestId('TEST_ID/submit-button'));

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { bankAccounts, getWalletState } from '@suite-native/trading-fixtures';
 
 import { SellBankAccountPicker } from '../SellBankAccountPicker';
@@ -18,7 +18,7 @@ describe('SellBankAccountPicker', () => {
     });
 
     describe('Conditional Rendering', () => {
-        it('should not render when no bank accounts are available', async () => {
+        it('should not render when no bank accounts are available', () => {
             const preloadedState: PreloadedState = {
                 wallet: getWalletState({ tradeType: 'sell' }),
             };
@@ -34,7 +34,7 @@ describe('SellBankAccountPicker', () => {
                 },
             ];
 
-            const { queryByTestId } = await renderWithStoreProviderAsync(
+            const { queryByTestId } = renderWithStoreProvider(
                 <SellBankAccountPicker
                     orderId="order_id_1"
                     selectedBankAccountIban=""
@@ -46,7 +46,7 @@ describe('SellBankAccountPicker', () => {
             expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
         });
 
-        it('should not render when bankAccounts is undefined', async () => {
+        it('should not render when bankAccounts is undefined', () => {
             const preloadedState: PreloadedState = {
                 wallet: getWalletState({ tradeType: 'sell' }),
             };
@@ -62,7 +62,7 @@ describe('SellBankAccountPicker', () => {
                 },
             ];
 
-            const { queryByTestId } = await renderWithStoreProviderAsync(
+            const { queryByTestId } = renderWithStoreProvider(
                 <SellBankAccountPicker
                     orderId="order_id_1"
                     selectedBankAccountIban=""
@@ -74,7 +74,7 @@ describe('SellBankAccountPicker', () => {
             expect(queryByTestId('@trading/sell/bank-account-item')).not.toBeOnTheScreen();
         });
 
-        it('should not render when orderId is undefined', async () => {
+        it('should not render when orderId is undefined', () => {
             const preloadedState: PreloadedState = {
                 wallet: getWalletState({ tradeType: 'sell' }),
             };
@@ -90,7 +90,7 @@ describe('SellBankAccountPicker', () => {
                 },
             ];
 
-            const { queryByTestId } = await renderWithStoreProviderAsync(
+            const { queryByTestId } = renderWithStoreProvider(
                 <SellBankAccountPicker
                     orderId={undefined}
                     selectedBankAccountIban={bankAccounts[0].bankAccount}

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 import type { ProviderConfirmationStatus } from '@suite-native/trading-types';
 
@@ -17,13 +17,13 @@ describe('SellFeePickerCard', () => {
         preloadedState.wallet!.trading!.sell!.tradingAccountKey = tradingAccountKey;
         preloadedState.wallet!.trading!.providerConfirmationStatus = providerConfirmationStatus;
 
-        return renderWithStoreProviderAsync(<SellFeePickerCard isTxnError={false} {...props} />, {
+        return renderWithStoreProvider(<SellFeePickerCard isTxnError={false} {...props} />, {
             preloadedState,
         });
     };
 
-    it('should render nothing when isTxnError', async () => {
-        const { toJSON } = await renderSellFeePickerCard({
+    it('should render nothing when isTxnError', () => {
+        const { toJSON } = renderSellFeePickerCard({
             quote: sellQuotes[0],
             isTxnError: true,
         });
@@ -31,35 +31,32 @@ describe('SellFeePickerCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderSellFeePickerCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderSellFeePickerCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when quote has no cryptoCurrency', async () => {
+    it('should render nothing when quote has no cryptoCurrency', () => {
         const quoteWithoutCrypto = {
             ...sellQuotes[0],
             cryptoCurrency: undefined,
         };
-        const { toJSON } = await renderSellFeePickerCard({
+        const { toJSON } = renderSellFeePickerCard({
             quote: quoteWithoutCrypto as (typeof sellQuotes)[0],
         });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when account is not found', async () => {
-        const { toJSON } = await renderSellFeePickerCard(
-            { quote: sellQuotes[0] },
-            'unknown-account-key',
-        );
+    it('should render nothing when account is not found', () => {
+        const { toJSON } = renderSellFeePickerCard({ quote: sellQuotes[0] }, 'unknown-account-key');
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when providerConfirmationStatus is not in "confirmation_success" state', async () => {
-        const { toJSON } = await renderSellFeePickerCard(
+    it('should render nothing when providerConfirmationStatus is not in "confirmation_success" state', () => {
+        const { toJSON } = renderSellFeePickerCard(
             { quote: sellQuotes[0] },
             'eth-account-1',
             'window_closed_with_success',
@@ -68,8 +65,8 @@ describe('SellFeePickerCard', () => {
         expect(toJSON()).toBeNull();
     });
 
-    it('should render FeePickerCard otherwise', async () => {
-        const { getByText } = await renderSellFeePickerCard({ quote: sellQuotes[0] });
+    it('should render FeePickerCard otherwise', () => {
+        const { getByText } = renderSellFeePickerCard({ quote: sellQuotes[0] });
 
         expect(getByText('Fee')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
@@ -2,11 +2,7 @@ import {
     type AccountKey,
     type GeneralPrecomposedTransactionFinal,
 } from '@suite-common/wallet-types';
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    userEvent,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, userEvent } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import {
@@ -28,7 +24,7 @@ describe('SellPreviewContinueButton', () => {
         props: Partial<SellPreviewContinueButtonProps> = {},
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <SellPreviewContinueButton
                 isDisabled={false}
                 quote={sellQuotes[0]}
@@ -56,24 +52,24 @@ describe('SellPreviewContinueButton', () => {
         return preloadedState;
     };
 
-    it('should render nothing when precomposed transaction is not in final state', async () => {
+    it('should render nothing when precomposed transaction is not in final state', () => {
         const preloadedState = getPreloadedState();
         preloadedState!.wallet!.send!.precomposedTx = {
             type: 'composing',
         } as any;
-        const { toJSON } = await renderSellPreviewContinueButton({}, preloadedState);
+        const { toJSON } = renderSellPreviewContinueButton({}, preloadedState);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render continue button', async () => {
-        const { getByText } = await renderSellPreviewContinueButton({}, getPreloadedState());
+    it('should render continue button', () => {
+        const { getByText } = renderSellPreviewContinueButton({}, getPreloadedState());
 
         expect(getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should render disabled button when isDisabled prop is specified', async () => {
-        const { getByText } = await renderSellPreviewContinueButton(
+    it('should render disabled button when isDisabled prop is specified', () => {
+        const { getByText } = renderSellPreviewContinueButton(
             { isDisabled: true },
             getPreloadedState(),
         );
@@ -84,7 +80,7 @@ describe('SellPreviewContinueButton', () => {
     it('should fire console.warn and do not navigate when quote is not specified', async () => {
         const mockOnSignTransactionNavigation = jest.fn();
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { getByText } = await renderSellPreviewContinueButton(
+        const { getByText } = renderSellPreviewContinueButton(
             { quote: undefined, onSignTransactionNavigation: mockOnSignTransactionNavigation },
             getPreloadedState(),
         );
@@ -104,7 +100,7 @@ describe('SellPreviewContinueButton', () => {
         const preloadedState = getPreloadedState();
         preloadedState!.wallet!.trading!.sell!.tradingAccountKey = 'non-existing-key';
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = await renderSellPreviewContinueButton(
+        const { getByText } = renderSellPreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             preloadedState,
         );
@@ -122,7 +118,7 @@ describe('SellPreviewContinueButton', () => {
     it('should navigate to TradingOutputsReview on continue press', async () => {
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
         const mockOnSignTransactionNavigation = jest.fn();
-        const { getByText } = await renderSellPreviewContinueButton(
+        const { getByText } = renderSellPreviewContinueButton(
             { onSignTransactionNavigation: mockOnSignTransactionNavigation },
             getPreloadedState(),
         );

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
@@ -1,13 +1,13 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { SellPreviewScreenHeader } from '../SellPreviewScreenHeader';
 
 describe('SellPreviewScreenHeader', () => {
     const renderSellPreviewScreenHeader = () =>
-        renderWithStoreProviderAsync(<SellPreviewScreenHeader />);
+        renderWithStoreProvider(<SellPreviewScreenHeader />);
 
-    it('should render screen header with correct title', async () => {
-        const { getByText } = await renderSellPreviewScreenHeader();
+    it('should render screen header with correct title', () => {
+        const { getByText } = renderSellPreviewScreenHeader();
 
         expect(getByText('Sell')).toBeOnTheScreen();
     });

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getSellTrade, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import { BANK_ACCOUNT_ITEM_TEST_ID } from '../BankAccount/SellBankAccountItem';
@@ -35,7 +35,7 @@ describe('SellPreviewView', () => {
     ) => {
         const preloadedState = getPreloadedSellState(preloadedStateOverrides ?? {});
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <SellPreviewView quote={sellQuotes[1]} txnErrorString={null} {...props} />,
             {
                 preloadedState,
@@ -43,8 +43,8 @@ describe('SellPreviewView', () => {
         );
     };
 
-    it('should render all sections except alert', async () => {
-        const { getByText } = await renderSellPreviewView({});
+    it('should render all sections except alert', () => {
+        const { getByText } = renderSellPreviewView({});
 
         expect(getByText('From')).toBeOnTheScreen();
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
@@ -53,8 +53,8 @@ describe('SellPreviewView', () => {
         expect(getByText('Fee')).toBeOnTheScreen();
     });
 
-    it('should render txnErrorString when isTxnError is true', async () => {
-        const { getByText, queryByText } = await renderSellPreviewView({
+    it('should render txnErrorString when isTxnError is true', () => {
+        const { getByText, queryByText } = renderSellPreviewView({
             txnErrorString: 'Transaction error occurred',
         });
 
@@ -67,8 +67,8 @@ describe('SellPreviewView', () => {
         expect(queryByText('Fee')).not.toBeOnTheScreen();
     });
 
-    it('should not render bank account picker when form step is not BANK_ACCOUNT', async () => {
-        const { queryByTestId } = await renderSellPreviewView(
+    it('should not render bank account picker when form step is not BANK_ACCOUNT', () => {
+        const { queryByTestId } = renderSellPreviewView(
             {},
             {
                 formStep: 'SEND_TRANSACTION', // Not BANK_ACCOUNT
@@ -78,8 +78,8 @@ describe('SellPreviewView', () => {
         expect(queryByTestId(BANK_ACCOUNT_ITEM_TEST_ID)).not.toBeOnTheScreen();
     });
 
-    it('should render bank account picker when form step is BANK_ACCOUNT', async () => {
-        const { getAllByTestId } = await renderSellPreviewView(
+    it('should render bank account picker when form step is BANK_ACCOUNT', () => {
+        const { getAllByTestId } = renderSellPreviewView(
             {},
             {
                 formStep: 'BANK_ACCOUNT',
@@ -89,9 +89,9 @@ describe('SellPreviewView', () => {
         expect(getAllByTestId(BANK_ACCOUNT_ITEM_TEST_ID).length).toBeGreaterThan(0);
     });
 
-    it('should use quote prop instead of selector', async () => {
+    it('should use quote prop instead of selector', () => {
         const differentQuote = sellQuotes[0];
-        const { getByText } = await renderSellPreviewView({
+        const { getByText } = renderSellPreviewView({
             quote: differentQuote,
         });
 
@@ -101,12 +101,12 @@ describe('SellPreviewView', () => {
         expect(getByText('Fee')).toBeOnTheScreen();
     });
 
-    it('should not render fee picker when quote has no cryptoCurrency', async () => {
+    it('should not render fee picker when quote has no cryptoCurrency', () => {
         const quoteWithoutCrypto = {
             ...sellQuotes[0],
             cryptoCurrency: undefined,
         };
-        const { queryByText } = await renderSellPreviewView({
+        const { queryByText } = renderSellPreviewView({
             quote: quoteWithoutCrypto as (typeof sellQuotes)[0],
         });
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
@@ -1,4 +1,4 @@
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
 import {
@@ -14,37 +14,37 @@ describe('SellToFiatTradePreviewCard', () => {
             wallet: getWalletState({ tradeType: 'sell' }),
         };
 
-        return renderWithStoreProviderAsync(<SellToFiatTradePreviewCard {...props} />, {
+        return renderWithStoreProvider(<SellToFiatTradePreviewCard {...props} />, {
             preloadedState,
         });
     };
 
-    it('should render nothing when there is no quote', async () => {
-        const { toJSON } = await renderSellToFiatTradePreviewCard({});
+    it('should render nothing when there is no quote', () => {
+        const { toJSON } = renderSellToFiatTradePreviewCard({});
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when quote has no fiatCurrency', async () => {
+    it('should render nothing when quote has no fiatCurrency', () => {
         const quoteWithoutFiat = { ...sellQuotes[0], fiatCurrency: undefined };
-        const { toJSON } = await renderSellToFiatTradePreviewCard({
+        const { toJSON } = renderSellToFiatTradePreviewCard({
             quote: quoteWithoutFiat,
         });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render nothing when quote has no paymentMethod', async () => {
+    it('should render nothing when quote has no paymentMethod', () => {
         const quoteWithoutPaymentMethod = { ...sellQuotes[0], paymentMethod: undefined };
-        const { toJSON } = await renderSellToFiatTradePreviewCard({
+        const { toJSON } = renderSellToFiatTradePreviewCard({
             quote: quoteWithoutPaymentMethod,
         });
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render TradeFiatSideCard otherwise', async () => {
-        const { getByText } = await renderSellToFiatTradePreviewCard({
+    it('should render TradeFiatSideCard otherwise', () => {
+        const { getByText } = renderSellToFiatTradePreviewCard({
             quote: sellQuotes[0],
         });
 
@@ -53,8 +53,8 @@ describe('SellToFiatTradePreviewCard', () => {
         expect(getByText('+$90.17')).toBeOnTheScreen();
     });
 
-    it('should render bank transfer payment method', async () => {
-        const { getByText } = await renderSellToFiatTradePreviewCard({
+    it('should render bank transfer payment method', () => {
+        const { getByText } = renderSellToFiatTradePreviewCard({
             quote: sellQuotes[1], // This quote has bankTransfer payment method
         });
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
@@ -1,7 +1,7 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     renderWithBasicProvider,
 } from '@suite-native/test-utils';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -12,15 +12,15 @@ import { SellAlert } from '../SellAlert';
 describe('SellAlert', () => {
     let form: SellFormType;
 
-    const renderFormHook = () => renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderFormHook = () => renderHookWithStoreProvider(() => useSellForm());
 
     const renderTradingAlert = () =>
         renderWithBasicProvider(<SellAlert />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderFormHook();
+    beforeEach(() => {
+        const { result } = renderFormHook();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes, usdcAsset } from '@suite-native/trading-fixtures';
@@ -14,23 +14,20 @@ import { SellCard } from '../SellCard';
 describe('SellCard', () => {
     let form: SellFormType;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useSellForm());
 
     const renderSellCard = (isAmountInputActive: boolean) => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
         preloadedState.wallet!.trading!.sell!.quotes = sellQuotes;
 
-        return renderWithStoreProviderAsync(
-            <SellCard isAmountInputActive={isAmountInputActive} />,
-            {
-                wrapper: ({ children }) => <Form form={form}>{children}</Form>,
-                preloadedState,
-            },
-        );
+        return renderWithStoreProvider(<SellCard isAmountInputActive={isAmountInputActive} />, {
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            preloadedState,
+        });
     };
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
     });
 
@@ -38,13 +35,13 @@ describe('SellCard', () => {
         screen.unmount();
     });
 
-    it('should render all components for "you pay" part', async () => {
+    it('should render all components for "you pay" part', () => {
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('amountInCrypto', true);
             form.setValue('cryptoStringAmount', '100');
         });
-        const { getByText, getByLabelText } = await renderSellCard(false);
+        const { getByText, getByLabelText } = renderSellCard(false);
 
         expect(getByText('You pay')).toBeOnTheScreen();
         expect(getByText('$99.00')).toBeOnTheScreen();
@@ -66,8 +63,8 @@ describe('SellCard', () => {
             });
         });
 
-        it('should render receive method', async () => {
-            const { getByText } = await renderSellCard(false);
+        it('should render receive method', () => {
+            const { getByText } = renderSellCard(false);
 
             expect(getByText('Receive method')).toBeOnTheScreen();
         });

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
 import { SellConfirmation } from '../SellConfirmation';
@@ -30,11 +30,11 @@ describe('SellConfirmation', () => {
         require('../../../hooks/sell/useSellSelectQuote').useSellSelectQuote;
 
     const renderConfirmation = () =>
-        renderWithStoreProviderAsync(<SellConfirmation />, {
+        renderWithStoreProvider(<SellConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
-    it('should render continue button when canProceed is true', async () => {
+    it('should render continue button when canProceed is true', () => {
         mockUseSellSelectQuote.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -43,12 +43,12 @@ describe('SellConfirmation', () => {
             cancelLegalTermsConsent: jest.fn(),
         });
 
-        const { getByText } = await renderConfirmation();
+        const { getByText } = renderConfirmation();
 
         expect(getByText('Continue')).toBeTruthy();
     });
 
-    it('should not render continue button when canProceed is false', async () => {
+    it('should not render continue button when canProceed is false', () => {
         mockUseSellSelectQuote.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
@@ -57,7 +57,7 @@ describe('SellConfirmation', () => {
             cancelLegalTermsConsent: jest.fn(),
         });
 
-        const { queryByText } = await renderConfirmation();
+        const { queryByText } = renderConfirmation();
 
         expect(queryByText('Continue')).toBeNull();
     });

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
@@ -4,8 +4,8 @@ import { useAnalytics } from '@suite-native/services';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import {
@@ -37,10 +37,10 @@ jest.mock('@suite-native/services', () => {
 
 describe('SellForm', () => {
     const renderFormHook = (preloadedState: PreloadedState) =>
-        renderHookWithStoreProviderAsync(() => useSellForm(), { preloadedState });
+        renderHookWithStoreProvider(() => useSellForm(), { preloadedState });
 
     const renderSellForm = (preloadedState: PreloadedState, form: SellFormType) =>
-        renderWithStoreProviderAsync(<SellForm />, {
+        renderWithStoreProvider(<SellForm />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
@@ -56,9 +56,9 @@ describe('SellForm', () => {
         screen.unmount();
     });
 
-    it('should render when sell data are not preloaded', async () => {
-        const { result } = await renderFormHook({});
-        const { getByText, getByLabelText } = await renderSellForm({}, result.current);
+    it('should render when sell data are not preloaded', () => {
+        const { result } = renderFormHook({});
+        const { getByText, getByLabelText } = renderSellForm({}, result.current);
 
         expect(getByText('You pay')).toBeOnTheScreen();
         expect(getByText('You get')).toBeOnTheScreen();
@@ -69,14 +69,14 @@ describe('SellForm', () => {
         let form: SellFormType;
         let preloadedState: PreloadedState;
 
-        beforeEach(async () => {
+        beforeEach(() => {
             preloadedState = {
                 wallet: { trading: getInitializedTradingState() },
                 ...residenceCheckDisabledState,
             };
             preloadedState.wallet!.trading!.sell!.quotes = sellQuotes;
 
-            const { result } = await renderFormHook(preloadedState);
+            const { result } = renderFormHook(preloadedState);
             form = result.current;
             act(() => {
                 form.setValue('sendAsset', btcAsset);
@@ -87,8 +87,8 @@ describe('SellForm', () => {
             });
         });
 
-        it('should render with default values', async () => {
-            const { getByLabelText, getByText } = await renderSellForm(preloadedState, form);
+        it('should render with default values', () => {
+            const { getByLabelText, getByText } = renderSellForm(preloadedState, form);
 
             expect(getByText('You pay')).toBeOnTheScreen();
             expect(getByLabelText('Select fiat currency')).toBeOnTheScreen();
@@ -97,11 +97,11 @@ describe('SellForm', () => {
             expect(getByText('Provider')).toBeOnTheScreen();
         });
 
-        it('should render only SellCard and Done when amount input is active', async () => {
+        it('should render only SellCard and Done when amount input is active', () => {
             act(() => {
                 form.setValue('focusedValue', 'fiatStringAmount');
             });
-            const { queryByText, getByText } = await renderSellForm(preloadedState, form);
+            const { queryByText, getByText } = renderSellForm(preloadedState, form);
 
             expect(getByText('You pay')).toBeOnTheScreen();
             expect(getByText('You get')).toBeOnTheScreen();
@@ -112,9 +112,9 @@ describe('SellForm', () => {
         });
     });
 
-    it('should report to analytics on mount', async () => {
-        const { result } = await renderFormHook({});
-        await renderSellForm({}, result.current);
+    it('should report to analytics on mount', () => {
+        const { result } = renderFormHook({});
+        renderSellForm({}, result.current);
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingSellEvent.name,

--- a/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.test.tsx
@@ -2,8 +2,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -18,8 +18,8 @@ import {
 describe('SellFormFieldErrorBadge', () => {
     let tradingForm: SellFormType;
 
-    const renderUseTradingSellForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useSellForm(), {
+    const renderUseTradingSellForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
@@ -35,20 +35,20 @@ describe('SellFormFieldErrorBadge', () => {
         form: SellFormType,
         preloadedState: PreloadedState = getPreloadedState(),
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <SellFormFieldErrorBadge {...props} />
             </Form>,
             { preloadedState },
         );
 
-    beforeEach(async () => {
-        tradingForm = await renderUseTradingSellForm();
+    beforeEach(() => {
+        tradingForm = renderUseTradingSellForm();
     });
 
     describe('for fiatStringAmount', () => {
-        it('should render nothing where there is no error in form', async () => {
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+        it('should render nothing where there is no error in form', () => {
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -56,14 +56,14 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should render error when field has error', async () => {
+        it('should render error when field has error', () => {
             act(() => {
                 tradingForm.setError('fiatStringAmount', {
                     type: 'manual',
                     message: 'Error message',
                 });
             });
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -73,8 +73,8 @@ describe('SellFormFieldErrorBadge', () => {
     });
 
     describe('for cryptoStringAmount', () => {
-        it('should display nothing when asset is not selected', async () => {
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+        it('should display nothing when asset is not selected', () => {
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -89,8 +89,8 @@ describe('SellFormFieldErrorBadge', () => {
                 });
             });
 
-            it('should display nothing when amount is not set', async () => {
-                const { toJSON } = await renderSellFormFieldErrorBadge(
+            it('should display nothing when amount is not set', () => {
+                const { toJSON } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -98,12 +98,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(toJSON()).toBeNull();
             });
 
-            it('should display formatted value when amount is 0', async () => {
+            it('should display formatted value when amount is 0', () => {
                 act(() => {
                     tradingForm.setValue('cryptoStringAmount', '0');
                 });
 
-                const { getByText } = await renderSellFormFieldErrorBadge(
+                const { getByText } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -111,12 +111,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$0.00')).toBeOnTheScreen();
             });
 
-            it('should display formatted value when amount is set', async () => {
+            it('should display formatted value when amount is set', () => {
                 act(() => {
                     tradingForm.setValue('cryptoStringAmount', '1234567');
                 });
 
-                const { getByText } = await renderSellFormFieldErrorBadge(
+                const { getByText } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -124,7 +124,7 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$1,234.57')).toBeOnTheScreen();
             });
 
-            it('should display error message when field has error', async () => {
+            it('should display error message when field has error', () => {
                 act(() => {
                     tradingForm.setError('cryptoStringAmount', {
                         type: 'manual',
@@ -133,7 +133,7 @@ describe('SellFormFieldErrorBadge', () => {
                     tradingForm.setValue('cryptoStringAmount', '1000');
                 });
 
-                const { getByText, queryByText } = await renderSellFormFieldErrorBadge(
+                const { getByText, queryByText } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                 );
@@ -142,7 +142,7 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('VALIDATION_ERROR')).toBeOnTheScreen();
             });
 
-            it('should display formatted fiat value when field has error, but quotes are loading', async () => {
+            it('should display formatted fiat value when field has error, but quotes are loading', () => {
                 act(() => {
                     tradingForm.setError('cryptoStringAmount', {
                         type: 'manual',
@@ -155,7 +155,7 @@ describe('SellFormFieldErrorBadge', () => {
                 };
                 preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-                const { getByText, queryByText } = await renderSellFormFieldErrorBadge(
+                const { getByText, queryByText } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                     preloadedState,
@@ -165,12 +165,12 @@ describe('SellFormFieldErrorBadge', () => {
                 expect(getByText('$1.00')).toBeOnTheScreen();
             });
 
-            it('should display correct value when using sats', async () => {
+            it('should display correct value when using sats', () => {
                 act(() => {
                     tradingForm.setValue('cryptoStringAmount', '1234567123456');
                 });
 
-                const { getByText } = await renderSellFormFieldErrorBadge(
+                const { getByText } = renderSellFormFieldErrorBadge(
                     { fieldName: 'cryptoStringAmount' },
                     tradingForm,
                     getPreloadedState(PROTO.AmountUnit.SATOSHI),
@@ -189,7 +189,7 @@ describe('SellFormFieldErrorBadge', () => {
             });
         });
 
-        it('should render badge when quote has different crypto value than requested', async () => {
+        it('should render badge when quote has different crypto value than requested', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -197,7 +197,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0235');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -205,7 +205,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('Provider offer: 0.0233 BTC')).toBeOnTheScreen();
         });
 
-        it('should render $ value badge when crypto amount does not differ', async () => {
+        it('should render $ value badge when crypto amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -213,7 +213,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0233');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -221,7 +221,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render $ value badge when crypto amount does not differ but contains trailing zeros', async () => {
+        it('should render $ value badge when crypto amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -229,7 +229,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.023300');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -237,7 +237,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render $ value badge while quotes are loading', async () => {
+        it('should render $ value badge while quotes are loading', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -247,7 +247,7 @@ describe('SellFormFieldErrorBadge', () => {
             const preloadedState = getPreloadedState();
             preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 preloadedState,
@@ -256,12 +256,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should render badge when quote has different fiat value than requested', async () => {
+        it('should render badge when quote has different fiat value than requested', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '91');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -269,12 +269,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('Provider offer: $90.17')).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ', async () => {
+        it('should not render badge when fiat amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '90.17');
             });
 
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -282,7 +282,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for cryptoStringAmount when rendering different form field badge', async () => {
+        it('should not render badge for cryptoStringAmount when rendering different form field badge', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -290,7 +290,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0006');
             });
 
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -298,12 +298,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge for fiatStringAmount when rendering different form field badge', async () => {
+        it('should not render badge for fiatStringAmount when rendering different form field badge', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '11.0');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -311,12 +311,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '90.170');
             });
 
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -324,7 +324,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should correctly compare with amount in sats', async () => {
+        it('should correctly compare with amount in sats', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -332,7 +332,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '2330000');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 getPreloadedState(PROTO.AmountUnit.SATOSHI),
@@ -341,7 +341,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should correctly display amount in sats', async () => {
+        it('should correctly display amount in sats', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -349,7 +349,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '2330001');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
                 getPreloadedState(PROTO.AmountUnit.SATOSHI),
@@ -371,7 +371,7 @@ describe('SellFormFieldErrorBadge', () => {
             });
         });
 
-        it('should not render badge when crypto amount does not differ', async () => {
+        it('should not render badge when crypto amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -379,7 +379,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0005');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -387,7 +387,7 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when crypto amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when crypto amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('amountInCrypto', true);
             });
@@ -395,7 +395,7 @@ describe('SellFormFieldErrorBadge', () => {
                 tradingForm.setValue('cryptoStringAmount', '0.0005000');
             });
 
-            const { getByText } = await renderSellFormFieldErrorBadge(
+            const { getByText } = renderSellFormFieldErrorBadge(
                 { fieldName: 'cryptoStringAmount' },
                 tradingForm,
             );
@@ -403,12 +403,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(getByText('$0.00')).toBeOnTheScreen();
         });
 
-        it('should not render badge when fiat amount does not differ', async () => {
+        it('should not render badge when fiat amount does not differ', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '10.0');
             });
 
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );
@@ -416,12 +416,12 @@ describe('SellFormFieldErrorBadge', () => {
             expect(toJSON()).toBeNull();
         });
 
-        it('should not render badge when fiat amount does not differ but contains trailing zeros', async () => {
+        it('should not render badge when fiat amount does not differ but contains trailing zeros', () => {
             act(() => {
                 tradingForm.setValue('fiatStringAmount', '10.000');
             });
 
-            const { toJSON } = await renderSellFormFieldErrorBadge(
+            const { toJSON } = renderSellFormFieldErrorBadge(
                 { fieldName: 'fiatStringAmount' },
                 tradingForm,
             );

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlag } from '@suite-native/feature-flags';
-import { type PreloadedState, act, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, act, renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { SellTab } from '../SellTab';
 
@@ -22,7 +22,7 @@ jest.mock('../../../hooks/sell/useSellData', () => ({
 
 describe('SellTab', () => {
     const renderSellTab = async (preloadedState: PreloadedState = {}) => {
-        const result = await renderWithStoreProviderAsync(<SellTab />, { preloadedState });
+        const result = renderWithStoreProvider(<SellTab />, { preloadedState });
 
         // wait for form reactions to run
         await act(() => Promise.resolve());

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
@@ -1,7 +1,7 @@
 import {
     type PreloadedState,
     act,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     screen,
     userEvent,
 } from '@suite-native/test-utils';
@@ -28,7 +28,7 @@ describe('SellTabContent', () => {
     });
 
     const renderSellTabContent = (preloadedState?: PreloadedState) =>
-        renderWithStoreProviderAsync(<SellTabContent />, { preloadedState });
+        renderWithStoreProvider(<SellTabContent />, { preloadedState });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);
@@ -42,50 +42,50 @@ describe('SellTabContent', () => {
         expect(screen.getByText("It's not you, it's us.")).toBeOnTheScreen();
     };
 
-    it('should render Sell skeleton when isLoading is true', async () => {
+    it('should render Sell skeleton when isLoading is true', () => {
         mockUseSellData.mockReturnValue({
             isLoading: true,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderSellTabContent();
+        renderSellTabContent();
 
         expectSkeleton();
     });
 
-    it('should render Sell skeleton when lastLoadedTimestamp is 0', async () => {
+    it('should render Sell skeleton when lastLoadedTimestamp is 0', () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 0,
             isFullyLoaded: false,
         });
 
-        await renderSellTabContent();
+        renderSellTabContent();
 
         expectSkeleton();
     });
 
-    it('should render Sell form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', async () => {
+    it('should render Sell form when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded true', () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: true,
         });
 
-        await renderSellTabContent();
+        renderSellTabContent();
 
         expectSellForm();
     });
 
-    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', async () => {
+    it('should render server error info when isLoading is false, lastLoadedTimestamp is greater than 0 and isFullyLoaded false', () => {
         mockUseSellData.mockReturnValue({
             isLoading: false,
             lastLoadedTimestamp: 1,
             isFullyLoaded: false,
         });
 
-        await renderSellTabContent();
+        renderSellTabContent();
 
         expectServerOffline();
     });
@@ -103,7 +103,7 @@ describe('SellTabContent', () => {
                 isFullyLoaded: true,
             });
 
-        const { getByText } = await renderSellTabContent();
+        const { getByText } = renderSellTabContent();
 
         const reloadButton = getByText('Try again');
 

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -12,15 +12,15 @@ import { SellFiatAmountInput } from '../SellFiatAmountInput';
 
 describe('SellFiatAmountInput', () => {
     const renderFiatAmountInput = (form: SellFormType, preloadedState: PreloadedState = {}) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <SellFiatAmountInput />
             </Form>,
             { preloadedState },
         );
 
-    const renderUseTradingSellForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useSellForm(), {
+    const renderUseTradingSellForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
@@ -28,8 +28,8 @@ describe('SellFiatAmountInput', () => {
     };
 
     it('should set fiat value in form', async () => {
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You get'), '100');
 
@@ -37,8 +37,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should format input value to be decimal', async () => {
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You get'), 'asd1.123');
 
@@ -47,8 +47,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should always escape non-numeric characters', async () => {
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You get'), 'asd');
 
@@ -57,8 +57,8 @@ describe('SellFiatAmountInput', () => {
     });
 
     it('should limit value to 3 decimals', async () => {
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderFiatAmountInput(form);
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderFiatAmountInput(form);
 
         await userEvent.type(getByLabelText('You get'), '1.0123456789');
 

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -3,8 +3,8 @@ import { Form } from '@suite-native/forms';
 import {
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
@@ -29,13 +29,13 @@ describe('SellFiatCurrencyPicker', () => {
         screen.unmount();
     });
 
-    const renderFiatCurrencyPicker = async () => {
+    const renderFiatCurrencyPicker = () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
-        const { result } = await renderHookWithStoreProviderAsync(() => useSellForm(), {
+        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
-        return renderWithStoreProviderAsync(
+        return renderWithStoreProvider(
             <Form form={result.current}>
                 <SellFiatCurrencyPicker />
             </Form>,
@@ -45,14 +45,14 @@ describe('SellFiatCurrencyPicker', () => {
         );
     };
 
-    it('should display selected currency', async () => {
-        const { getByLabelText } = await renderFiatCurrencyPicker();
+    it('should display selected currency', () => {
+        const { getByLabelText } = renderFiatCurrencyPicker();
 
         expect(getByLabelText('Select fiat currency')).toHaveTextContent(/USD/);
     });
 
     it('should allow to select currency', async () => {
-        const { getByText, getByLabelText } = await renderFiatCurrencyPicker();
+        const { getByText, getByLabelText } = renderFiatCurrencyPicker();
 
         fireEvent.press(getByLabelText('Select fiat currency'));
         fireEvent.press(getByText('PLN'));
@@ -63,14 +63,14 @@ describe('SellFiatCurrencyPicker', () => {
         expect(getByLabelText('Select fiat currency')).toHaveTextContent(/PLN/);
     });
 
-    it('should display empty component when filtered data is empty', async () => {
+    it('should display empty component when filtered data is empty', () => {
         mockUseListDataFilter = () => ({
             filteredData: [],
             setFilterValue: jest.fn(),
             filterValue: 'test-key',
         });
 
-        const { getByText } = await renderFiatCurrencyPicker();
+        const { getByText } = renderFiatCurrencyPicker();
 
         expect(getByText('Currency not found')).toBeTruthy();
         expect(

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.test.tsx
@@ -1,11 +1,11 @@
-import { renderWithStoreProviderAsync, screen } from '@suite-native/test-utils';
+import { renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import { SellFiatCurrencySheet } from '../SellFiatCurrencySheet';
 
 describe('SellFiatCurrencySheet', () => {
     const renderSellFiatCurrencySheet = () =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <SellFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
             { preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) } },
         );
@@ -14,8 +14,8 @@ describe('SellFiatCurrencySheet', () => {
         screen.unmount();
     });
 
-    it('should render items based on Sell state', async () => {
-        const { getByText } = await renderSellFiatCurrencySheet();
+    it('should render items based on Sell state', () => {
+        const { getByText } = renderSellFiatCurrencySheet();
 
         expect(getByText('USD')).toBeOnTheScreen();
         expect(getByText('EUR')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -5,8 +5,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
@@ -30,15 +30,15 @@ describe('SellReceiveMethodPicker', () => {
     let form: SellFormType;
     let preloadedState: PreloadedState;
 
-    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm());
 
     const renderSellReceiveMethodPicker = () =>
-        renderWithStoreProviderAsync(<SellReceiveMethodPicker />, {
+        renderWithStoreProvider(<SellReceiveMethodPicker />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
 
         (useAnalytics as jest.Mock).mockReturnValue({
@@ -47,7 +47,7 @@ describe('SellReceiveMethodPicker', () => {
 
         preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
 
-        const { result } = await renderSellForm();
+        const { result } = renderSellForm();
         form = result.current;
     });
 
@@ -55,24 +55,24 @@ describe('SellReceiveMethodPicker', () => {
         screen.unmount();
     });
 
-    it('should render nothing when no quotes are loaded', async () => {
-        const { toJSON } = await renderSellReceiveMethodPicker();
+    it('should render nothing when no quotes are loaded', () => {
+        const { toJSON } = renderSellReceiveMethodPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
+    it('should render loading skeleton when no quotes are loaded and new quotes are loading', () => {
         preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-        const { getByLabelText } = await renderSellReceiveMethodPicker();
+        const { getByLabelText } = renderSellReceiveMethodPicker();
 
         expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
 
-    it('should render "Not selected" when no quote is selected', async () => {
+    it('should render "Not selected" when no quote is selected', () => {
         preloadedState!.wallet!.trading!.sell!.quotes = sellQuotes;
 
-        const { getByLabelText } = await renderSellReceiveMethodPicker();
+        const { getByLabelText } = renderSellReceiveMethodPicker();
 
         expect(getByLabelText('No receive method selected')).toHaveTextContent('Not selected');
     });
@@ -85,22 +85,22 @@ describe('SellReceiveMethodPicker', () => {
             });
         });
 
-        it('should render selected receive method', async () => {
-            const { getByLabelText } = await renderSellReceiveMethodPicker();
+        it('should render selected receive method', () => {
+            const { getByLabelText } = renderSellReceiveMethodPicker();
 
             expect(getByLabelText('Selected receive method')).toHaveTextContent('Bank Transfer');
         });
 
-        it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
+        it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {
             preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-            const { getByLabelText } = await renderSellReceiveMethodPicker();
+            const { getByLabelText } = renderSellReceiveMethodPicker();
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
         });
 
-        it('should allow to select receive method', async () => {
-            const { getByText, getByLabelText } = await renderSellReceiveMethodPicker();
+        it('should allow to select receive method', () => {
+            const { getByText, getByLabelText } = renderSellReceiveMethodPicker();
 
             fireEvent.press(getByText('Receive method'));
             fireEvent.press(getByText('Credit Card'));
@@ -113,8 +113,8 @@ describe('SellReceiveMethodPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on receive method select', async () => {
-                const { getByText } = await renderSellReceiveMethodPicker();
+            it('should fire analytics event on receive method select', () => {
+                const { getByText } = renderSellReceiveMethodPicker();
 
                 fireEvent.press(getByText('Receive method'));
                 fireEvent.press(getByText('Credit Card'));
@@ -128,8 +128,8 @@ describe('SellReceiveMethodPicker', () => {
                 });
             });
 
-            it('should not fire analytics event when same receive method is selected', async () => {
-                const { getAllByText } = await renderSellReceiveMethodPicker();
+            it('should not fire analytics event when same receive method is selected', () => {
+                const { getAllByText } = renderSellReceiveMethodPicker();
 
                 fireEvent.press(getAllByText('Bank Transfer')[0]);
                 fireEvent.press(getAllByText('Bank Transfer')[1]);

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
@@ -5,8 +5,8 @@ import {
     type PreloadedState,
     act,
     fireEvent,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     screen,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
@@ -30,15 +30,15 @@ describe('SellProviderPicker', () => {
     let form: SellFormType;
     let preloadedState: PreloadedState;
 
-    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm());
 
     const renderSellProviderPicker = () =>
-        renderWithStoreProviderAsync(<SellProviderPicker />, {
+        renderWithStoreProvider(<SellProviderPicker />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
 
         (useAnalytics as jest.Mock).mockReturnValue({
@@ -47,7 +47,7 @@ describe('SellProviderPicker', () => {
 
         preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
 
-        const { result } = await renderSellForm();
+        const { result } = renderSellForm();
         form = result.current;
     });
 
@@ -55,16 +55,16 @@ describe('SellProviderPicker', () => {
         screen.unmount();
     });
 
-    it('should render nothing when no quotes are loaded', async () => {
-        const { toJSON } = await renderSellProviderPicker();
+    it('should render nothing when no quotes are loaded', () => {
+        const { toJSON } = renderSellProviderPicker();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render loading skeleton when no quotes are loaded and new quotes are loading', async () => {
+    it('should render loading skeleton when no quotes are loaded and new quotes are loading', () => {
         preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-        const { getByLabelText } = await renderSellProviderPicker();
+        const { getByLabelText } = renderSellProviderPicker();
 
         expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
     });
@@ -77,37 +77,37 @@ describe('SellProviderPicker', () => {
             });
         });
 
-        it('should render loading skeleton when quotes are loaded and new quotes are loading', async () => {
+        it('should render loading skeleton when quotes are loaded and new quotes are loading', () => {
             preloadedState!.wallet!.trading!.sell!.isLoading = true;
 
-            const { getByLabelText } = await renderSellProviderPicker();
+            const { getByLabelText } = renderSellProviderPicker();
 
             expect(getByLabelText('Fetching offers...')).toBeOnTheScreen();
         });
 
-        it('should render selected payment provider', async () => {
-            const { getByLabelText } = await renderSellProviderPicker();
+        it('should render selected payment provider', () => {
+            const { getByLabelText } = renderSellProviderPicker();
 
             expect(getByLabelText('Selected provider')).toHaveTextContent('Banxa');
         });
 
-        it('should display kyc warning when not loading', async () => {
-            const { getByText } = await renderSellProviderPicker();
+        it('should display kyc warning when not loading', () => {
+            const { getByText } = renderSellProviderPicker();
 
             expect(getByText('This provider requires to know your identity.')).toBeOnTheScreen();
         });
 
-        it('should not display kyc warning when loading', async () => {
+        it('should not display kyc warning when loading', () => {
             preloadedState!.wallet!.trading!.sell!.isLoading = true;
-            const { queryByText } = await renderSellProviderPicker();
+            const { queryByText } = renderSellProviderPicker();
 
             expect(
                 queryByText('This provider requires to know your identity.'),
             ).not.toBeOnTheScreen();
         });
 
-        it('should allow to select provider', async () => {
-            const { getByText, getByLabelText } = await renderSellProviderPicker();
+        it('should allow to select provider', () => {
+            const { getByText, getByLabelText } = renderSellProviderPicker();
 
             fireEvent.press(getByText('Provider'));
             fireEvent.press(getByText('MoonPay'));
@@ -120,8 +120,8 @@ describe('SellProviderPicker', () => {
                 reportMock.mockClear();
             });
 
-            it('should fire analytics event on provider select', async () => {
-                const { getByText } = await renderSellProviderPicker();
+            it('should fire analytics event on provider select', () => {
+                const { getByText } = renderSellProviderPicker();
 
                 fireEvent.press(getByText('Provider'));
                 fireEvent.press(getByText('MoonPay'));
@@ -142,8 +142,8 @@ describe('SellProviderPicker', () => {
                 });
             });
 
-            it('should not fire analytics event when same provider is selected', async () => {
-                const { getAllByText } = await renderSellProviderPicker();
+            it('should not fire analytics event when same provider is selected', () => {
+                const { getAllByText } = renderSellProviderPicker();
 
                 fireEvent.press(getAllByText('Banxa')[0]);
                 fireEvent.press(getAllByText('Banxa')[1]);
@@ -157,9 +157,9 @@ describe('SellProviderPicker', () => {
                 });
             });
 
-            it('should not call analytics when user tries to open sheet while quotes are loading', async () => {
+            it('should not call analytics when user tries to open sheet while quotes are loading', () => {
                 preloadedState!.wallet!.trading!.sell!.isLoading = true;
-                const { getByText } = await renderSellProviderPicker();
+                const { getByText } = renderSellProviderPicker();
 
                 fireEvent.press(getByText('Provider'));
 

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAccountCryptoBalance.test.tsx
@@ -1,8 +1,8 @@
 import { Form } from '@suite-native/forms';
 import {
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -16,38 +16,38 @@ import {
 describe('SellSendAccountCryptoBalance', () => {
     let sellForm: SellFormType;
 
-    const renderSellForm = async () => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderSellForm = () => {
+        const { result } = renderHookWithStoreProvider(() => useSellForm());
 
         return result.current;
     };
 
     const renderComponent = () =>
-        renderWithStoreProviderAsync(<SellSendAccountCryptoBalance />, {
+        renderWithStoreProvider(<SellSendAccountCryptoBalance />, {
             wrapper: ({ children }) => <Form form={sellForm}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        sellForm = await renderSellForm();
+    beforeEach(() => {
+        sellForm = renderSellForm();
     });
 
-    it('should use asset form field as default symbol', async () => {
+    it('should use asset form field as default symbol', () => {
         act(() => {
             sellForm.setValue('sendAsset', btcAsset);
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:- BTC');
     });
 
-    it('should use sendAccount form field to obtain account', async () => {
+    it('should use sendAccount form field to obtain account', () => {
         act(() => {
             sellForm.setValue('sendAsset', btcAsset);
         });
         act(() => {
             sellForm.setValue('sendAccount', getBtcAccount());
         });
-        const { getByTestId } = await renderComponent();
+        const { getByTestId } = renderComponent();
 
         expect(getByTestId(SEND_ACCOUNT_BALANCE_TEST_ID)).toHaveTextContent('Balance:0.01 BTC');
     });

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -3,8 +3,8 @@ import { Form } from '@suite-native/forms';
 import {
     type PreloadedState,
     act,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import { btcAsset, getWalletState, usdcAsset } from '@suite-native/trading-fixtures';
@@ -30,15 +30,15 @@ describe('SellSendAmountInput', () => {
         form: SellFormType,
         preloadedState: PreloadedState = {},
     ) =>
-        renderWithStoreProviderAsync(
+        renderWithStoreProvider(
             <Form form={form}>
                 <SellSendAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
             { preloadedState },
         );
 
-    const renderUseTradingSellForm = async (preloadedState: PreloadedState = {}) => {
-        const { result } = await renderHookWithStoreProviderAsync(() => useSellForm(), {
+    const renderUseTradingSellForm = (preloadedState: PreloadedState = {}) => {
+        const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
         });
 
@@ -50,28 +50,28 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should set send value in form', async () => {
-        const form = await renderUseTradingSellForm();
+        const form = renderUseTradingSellForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), '100');
 
         expect(form.getValues('cryptoStringAmount')).toEqual('100');
     });
 
-    it('should be disabled when asset is not selected', async () => {
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+    it('should be disabled when asset is not selected', () => {
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         expect(getByLabelText('You pay')).toBeDisabled();
     });
 
     it('should call showAssetsSheet when disabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingSellForm();
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const form = renderUseTradingSellForm();
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You pay'));
 
@@ -80,11 +80,11 @@ describe('SellSendAmountInput', () => {
 
     it('should not call showAssetsSheet when enabled and pressed', async () => {
         const showAssetsSheet = jest.fn();
-        const form = await renderUseTradingSellForm();
+        const form = renderUseTradingSellForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({ showAssetsSheet }, form);
+        const { getByLabelText } = renderCryptoAmountInput({ showAssetsSheet }, form);
 
         await userEvent.press(getByLabelText('You pay'));
 
@@ -92,11 +92,11 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should format input value to be decimal by default', async () => {
-        const form = await renderUseTradingSellForm();
+        const form = renderUseTradingSellForm();
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
@@ -108,11 +108,11 @@ describe('SellSendAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingSellForm(preloadedState);
+        const form = renderUseTradingSellForm(preloadedState);
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You pay'), 'asd1.123');
 
@@ -124,11 +124,11 @@ describe('SellSendAmountInput', () => {
         const preloadedState = {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
-        const form = await renderUseTradingSellForm(preloadedState);
+        const form = renderUseTradingSellForm(preloadedState);
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         await userEvent.type(getByLabelText('You pay'), 'asd');
 
@@ -137,7 +137,7 @@ describe('SellSendAmountInput', () => {
     });
 
     it('should limit value to decimals based on useAmountInputDecimals return value', async () => {
-        const form = await renderUseTradingSellForm();
+        const form = renderUseTradingSellForm();
         act(() => {
             form.setValue('sendAsset', usdcAsset);
             form.setValue('sendAccount', {
@@ -145,7 +145,7 @@ describe('SellSendAmountInput', () => {
                 symbol: 'eth',
             } as Account);
         });
-        const { getByLabelText } = await renderCryptoAmountInput({}, form);
+        const { getByLabelText } = renderCryptoAmountInput({}, form);
 
         await userEvent.type(getByLabelText('You pay'), '1.0123456789');
 
@@ -156,30 +156,30 @@ describe('SellSendAmountInput', () => {
         );
     });
 
-    it('should display loading skeleton while amountInCrypto is false and quotes are loading', async () => {
+    it('should display loading skeleton while amountInCrypto is false and quotes are loading', () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
         preloadedState.wallet!.trading!.sell!.isLoading = true;
-        const form = await renderUseTradingSellForm(preloadedState);
+        const form = renderUseTradingSellForm(preloadedState);
 
         act(() => {
             form.setValue('amountInCrypto', false);
         });
 
-        const { getByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { getByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         expect(getByLabelText('Fetching offers...')).toBeTruthy();
     });
 
-    it('should not display loading skeleton when amountInCrypto is true', async () => {
+    it('should not display loading skeleton when amountInCrypto is true', () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
         preloadedState.wallet!.trading!.sell!.isLoading = true;
-        const form = await renderUseTradingSellForm(preloadedState);
+        const form = renderUseTradingSellForm(preloadedState);
 
         act(() => {
             form.setValue('amountInCrypto', true);
         });
 
-        const { queryByLabelText } = await renderCryptoAmountInput({}, form, preloadedState);
+        const { queryByLabelText } = renderCryptoAmountInput({}, form, preloadedState);
 
         expect(queryByLabelText('Fetching offers...')).toBeNull();
     });

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -5,8 +5,8 @@ import { Form } from '@suite-native/forms';
 import {
     type TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
-    renderWithStoreProviderAsync,
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 import {
@@ -66,17 +66,17 @@ describe('SellSendAssetPicker', () => {
         },
     });
 
-    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm(), { store });
+    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
 
     const renderSellSendAssetPicker = () =>
-        renderWithStoreProviderAsync(<SellSendAssetPicker />, {
+        renderWithStoreProvider(<SellSendAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         store = initStore(getPreloadedState()).store;
-        const { result } = await renderSellForm();
+        const { result } = renderSellForm();
         form = result.current;
 
         mockedSelectAccountsWithTokensToSellSectionListByTradingType.mockReturnValue(
@@ -85,7 +85,7 @@ describe('SellSendAssetPicker', () => {
     });
 
     it('should select asset on item press', async () => {
-        const { getByText } = await renderSellSendAssetPicker();
+        const { getByText } = renderSellSendAssetPicker();
 
         await userEvent.press(getByText('BTC'));
 
@@ -99,7 +99,7 @@ describe('SellSendAssetPicker', () => {
     });
 
     it('should select account on item press', async () => {
-        const { getByText } = await renderSellSendAssetPicker();
+        const { getByText } = renderSellSendAssetPicker();
 
         await userEvent.press(getByText('BTC'));
 

--- a/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
+++ b/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
@@ -1,8 +1,9 @@
 import { selectTradingMaxSlippagePercentage } from '@suite-common/trading';
 import {
     type TestStore,
+    act,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     userEvent,
 } from '@suite-native/test-utils';
 
@@ -13,10 +14,19 @@ import {
 } from '../MaxSlippageForm';
 
 describe('MaxSlippageForm', () => {
-    const renderMaxSlippageForm = (props: Partial<MaxSlippageFormProps>, store: TestStore) =>
-        renderWithStoreProviderAsync(<MaxSlippageForm onSubmit={jest.fn()} {...props} />, {
+    const renderMaxSlippageForm = async (
+        props: Partial<MaxSlippageFormProps>,
+        store: TestStore,
+    ) => {
+        const ret = renderWithStoreProvider(<MaxSlippageForm onSubmit={jest.fn()} {...props} />, {
             store,
         });
+
+        // wait for validators to run
+        await act(() => Promise.resolve());
+
+        return ret;
+    };
 
     it('should render value based on store', async () => {
         const { store } = initStore();

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
@@ -5,7 +5,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
@@ -37,14 +37,19 @@ describe('useBuyData', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderUseBuyData = (reloadRequestOrdinalInitialValue: number, store: TestStore) =>
-        renderHookWithStoreProviderAsync(
+    const renderUseBuyData = async (reloadRequestOrdinalInitialValue: number, store: TestStore) => {
+        const ret = renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useBuyData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store,
             },
         );
+
+        await act(() => Promise.resolve()); // Wait for all effects to run
+
+        return ret;
+    };
 
     beforeEach(() => {
         jest.resetAllMocks();
@@ -117,7 +122,7 @@ describe('useBuyData', () => {
         });
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
-            const store = await getInitializedStore(undefined);
+            const store = getInitializedStore(undefined);
             await renderUseBuyData(0, store);
 
             // Clear the initial call
@@ -139,7 +144,7 @@ describe('useBuyData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore(btc2AccountKey);
+            const store = getInitializedStore(btc2AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call
@@ -158,7 +163,7 @@ describe('useBuyData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
-            const store = await getInitializedStore(btc1AccountKey);
+            const store = getInitializedStore(btc1AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call
@@ -181,7 +186,7 @@ describe('useBuyData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
-            const store = await getInitializedStore(btc1AccountKey);
+            const store = getInitializedStore(btc1AccountKey);
             await renderUseBuyData(0, store);
 
             // Clear the initial call

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -3,7 +3,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     buyQuotes,
@@ -44,30 +44,30 @@ describe('useBuyFlow', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderBuyForm = () => renderHookWithStoreProviderAsync(() => useBuyForm(), { store });
+    const renderBuyForm = () => renderHookWithStoreProvider(() => useBuyForm(), { store });
 
     const renderUseTradingBuyFlow = () =>
-        renderHookWithStoreProviderAsync(() => useBuyFlow(buyForm), { store });
+        renderHookWithStoreProvider(() => useBuyFlow(buyForm), { store });
 
     describe('while loading quotes', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({ isLoading: true });
+        beforeEach(() => {
+            store = getInitializedStore({ isLoading: true });
 
-            const { result } = await renderBuyForm();
+            const { result } = renderBuyForm();
             buyForm = result.current;
         });
 
-        it('should canProceed be false when loading', async () => {
-            const { result } = await renderUseTradingBuyFlow();
+        it('should canProceed be false when loading', () => {
+            const { result } = renderUseTradingBuyFlow();
             expect(result.current.canProceed).toBe(false);
         });
     });
 
     describe('with quote loaded and selected', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({ isLoading: false });
+        beforeEach(() => {
+            store = getInitializedStore({ isLoading: false });
 
-            const { result } = await renderBuyForm();
+            const { result } = renderBuyForm();
             buyForm = result.current;
 
             act(() => {
@@ -75,8 +75,8 @@ describe('useBuyFlow', () => {
             });
         });
 
-        it('should canProceed be true when not loading and orderId filters one in quotes', async () => {
-            const { result } = await renderUseTradingBuyFlow();
+        it('should canProceed be true when not loading and orderId filters one in quotes', () => {
+            const { result } = renderUseTradingBuyFlow();
 
             expect(result.current.canProceed).toBe(true);
         });
@@ -92,13 +92,13 @@ describe('useBuyFlow', () => {
                 });
             });
 
-            it('should call nextStep callback with correct address', async () => {
+            it('should call nextStep callback with correct address', () => {
                 const btcAccount = getBtcAccount();
                 const dispatchSpy = jest.spyOn(store, 'dispatch');
                 const expectedAddress =
                     btcAccount.addresses?.used?.[0]?.address ?? btcAccount.descriptor;
 
-                const { result } = await renderUseTradingBuyFlow();
+                const { result } = renderUseTradingBuyFlow();
                 dispatchSpy.mockClear();
 
                 act(() => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
@@ -1,8 +1,5 @@
 import { Form } from '@suite-native/forms';
-import {
-    renderHookWithBasicProvider,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { renderHookWithBasicProvider, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { useBuyForm } from '../useBuyForm';
@@ -11,15 +8,15 @@ import { useBuyInputFormControls } from '../useBuyInputFormControls';
 describe('useBuyInputFormControls', () => {
     let form: BuyFormType;
 
-    const renderBuyFormHook = () => renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderBuyFormHook = () => renderHookWithStoreProvider(() => useBuyForm());
 
     const renderUseBuyInputFormControls = () =>
         renderHookWithBasicProvider(() => useBuyInputFormControls('fiatValue'), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderBuyFormHook();
+    beforeEach(() => {
+        const { result } = renderBuyFormHook();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
@@ -5,7 +5,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
@@ -15,7 +15,7 @@ describe('useApprovalTypeControls', () => {
     let store: TestStore;
 
     const renderUseApprovalTypeControls = () =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             () => {
                 const quote = useSelector(selectTradingExchangeActiveQuote);
 
@@ -34,8 +34,8 @@ describe('useApprovalTypeControls', () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(exchangeQuotes[0]));
     });
 
-    it('should use INFINITE as default', async () => {
-        const { result } = await renderUseApprovalTypeControls();
+    it('should use INFINITE as default', () => {
+        const { result } = renderUseApprovalTypeControls();
 
         expect(result.current).toEqual({
             approvalType: 'INFINITE',
@@ -49,8 +49,8 @@ describe('useApprovalTypeControls', () => {
         );
     });
 
-    it('should set new value with handleApprovalTypeChange', async () => {
-        const { result } = await renderUseApprovalTypeControls();
+    it('should set new value with handleApprovalTypeChange', () => {
+        const { result } = renderUseApprovalTypeControls();
 
         act(() => {
             result.current.handleApprovalTypeChange('MINIMAL');
@@ -66,9 +66,9 @@ describe('useApprovalTypeControls', () => {
         );
     });
 
-    it('should do nothing when no quote is provided', async () => {
+    it('should do nothing when no quote is provided', () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
-        const { result } = await renderUseApprovalTypeControls();
+        const { result } = renderUseApprovalTypeControls();
 
         expect(result.current).toEqual({
             approvalType: 'INFINITE',

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
@@ -4,7 +4,7 @@ import {
     type PreloadedState,
     type TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
     waitFor,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
@@ -50,10 +50,10 @@ describe('useEvmApprovalFees', () => {
     });
 
     const renderUseEvmApprovalFees = (params?: Parameters<typeof useEvmApprovalFees>[0]) =>
-        renderHookWithStoreProviderAsync(() => useEvmApprovalFees(params), { store });
+        renderHookWithStoreProvider(() => useEvmApprovalFees(params), { store });
 
-    it('should return isLoading true when fee is undefined', async () => {
-        const { result } = await renderUseEvmApprovalFees();
+    it('should return isLoading true when fee is undefined', () => {
+        const { result } = renderUseEvmApprovalFees();
 
         expect(result.current).toEqual(
             expect.objectContaining({
@@ -65,7 +65,7 @@ describe('useEvmApprovalFees', () => {
         );
     });
 
-    it('should return fee and isLoading false when composed transaction info is available', async () => {
+    it('should return fee and isLoading false when composed transaction info is available', () => {
         preloadedState!.wallet!.trading!.exchange!.selectedQuote = undefined;
         store = initStore(preloadedState).store;
 
@@ -76,7 +76,7 @@ describe('useEvmApprovalFees', () => {
             }),
         );
 
-        const { result } = await renderUseEvmApprovalFees();
+        const { result } = renderUseEvmApprovalFees();
 
         expect(result.current.fee).toBe('50000');
         expect(result.current.error).toBeNull();
@@ -103,7 +103,7 @@ describe('useEvmApprovalFees', () => {
         };
         store = initStore(preloadedState).store;
 
-        const { result } = await renderUseEvmApprovalFees();
+        const { result } = renderUseEvmApprovalFees();
 
         await waitFor(() => {
             expect(result.current.error).toBe(
@@ -114,8 +114,8 @@ describe('useEvmApprovalFees', () => {
         expect(result.current.isLoading).toBe(false);
     });
 
-    it('should accept approvalTypeOverride parameter', async () => {
-        const { result } = await renderUseEvmApprovalFees({ approvalTypeOverride: 'ZERO' });
+    it('should accept approvalTypeOverride parameter', () => {
+        const { result } = renderUseEvmApprovalFees({ approvalTypeOverride: 'ZERO' });
 
         expect(result.current).toEqual(
             expect.objectContaining({

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
@@ -5,7 +5,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
@@ -37,17 +37,22 @@ describe('useExchangeData', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderUseExchangeData = (
+    const renderUseExchangeData = async (
         reloadRequestOrdinalInitialValue: number = 0,
         store?: TestStore,
-    ) =>
-        renderHookWithStoreProviderAsync(
+    ) => {
+        const ret = renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useExchangeData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store,
             },
         );
+
+        await act(() => Promise.resolve()); // Wait for all effects to run
+
+        return ret;
+    };
 
     beforeEach(() => {
         jest.resetAllMocks();
@@ -116,7 +121,7 @@ describe('useExchangeData', () => {
         });
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
-            const store = await getInitializedStore(undefined);
+            const store = getInitializedStore(undefined);
             await renderUseExchangeData(0, store);
 
             // Clear the initial call
@@ -138,7 +143,7 @@ describe('useExchangeData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore(btc2AccountKey);
+            const store = getInitializedStore(btc2AccountKey);
             await renderUseExchangeData(0, store);
 
             // Clear the initial call
@@ -157,7 +162,7 @@ describe('useExchangeData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = getInitializedStore('btc-account-1');
             await renderUseExchangeData(0, store);
 
             // Clear the initial call
@@ -180,7 +185,7 @@ describe('useExchangeData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
-            const store = await getInitializedStore('btc-account-1');
+            const store = getInitializedStore('btc-account-1');
             await renderUseExchangeData(0, store);
 
             // Clear the initial call

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -6,7 +6,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     getBtcAccount,
@@ -64,7 +64,7 @@ describe('useExchangeFlow', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderUseExchangeFlow = async ({ store }: { store: TestStore }) => {
+    const renderUseExchangeFlow = ({ store }: { store: TestStore }) => {
         const reportMock = jest.fn();
 
         (useAnalytics as jest.Mock).mockReturnValue({
@@ -73,8 +73,7 @@ describe('useExchangeFlow', () => {
 
         return {
             reportMock,
-            result: (await renderHookWithStoreProviderAsync(() => useExchangeFlow(), { store }))
-                .result,
+            result: renderHookWithStoreProvider(() => useExchangeFlow(), { store }).result,
         };
     };
 
@@ -86,11 +85,11 @@ describe('useExchangeFlow', () => {
 
     describe('confirmTrade', () => {
         it('should call confirmTradeThunk when confirmTrade is called', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result } = await renderUseExchangeFlow({ store });
+            const { result } = renderUseExchangeFlow({ store });
 
             const mockTrade = {
                 exchange: 'test-exchange',
@@ -127,7 +126,7 @@ describe('useExchangeFlow', () => {
         });
 
         it('should return false when confirmTradeThunk returns false', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
 
             const originalConfirmTradeThunk =
                 require('@suite-common/trading').exchangeThunks.confirmTradeThunk;
@@ -136,7 +135,7 @@ describe('useExchangeFlow', () => {
                 unwrap: () => Promise.resolve(false),
             });
 
-            const { result } = await renderUseExchangeFlow({ store });
+            const { result } = renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -157,10 +156,10 @@ describe('useExchangeFlow', () => {
         });
 
         it('should return false when trade is missing', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
 
-            const { result } = await renderUseExchangeFlow({ store });
+            const { result } = renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -193,7 +192,7 @@ describe('useExchangeFlow', () => {
             };
 
             const { store } = initStore(preloadedState);
-            const { result } = await renderUseExchangeFlow({ store });
+            const { result } = renderUseExchangeFlow({ store });
 
             const confirmResult = await act(() =>
                 result.current.confirmTrade({
@@ -216,11 +215,11 @@ describe('useExchangeFlow', () => {
 
     describe('analytics', () => {
         it('should call analytics event when confirmTrade is called', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result, reportMock } = await renderUseExchangeFlow({ store });
+            const { result, reportMock } = renderUseExchangeFlow({ store });
 
             const mockTrade = {
                 exchange: 'test-exchange',

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -9,7 +9,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     btcAsset,
@@ -92,10 +92,10 @@ describe('useExchangeSelectQuote', () => {
     };
 
     const renderExchangeForm = () =>
-        renderHookWithStoreProviderAsync(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), { store });
 
-    const renderUseExchangeSelectQuote = async () => {
-        const hook = await renderHookWithStoreProviderAsync(
+    const renderUseExchangeSelectQuote = () => {
+        const hook = renderHookWithStoreProvider(
             () => useExchangeSelectQuoteWithReportSpy(exchangeForm),
             { store },
         );
@@ -111,24 +111,24 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('while loading quotes', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({ isLoading: true });
+        beforeEach(() => {
+            store = getInitializedStore({ isLoading: true });
 
-            const { result } = await renderExchangeForm();
+            const { result } = renderExchangeForm();
             exchangeForm = result.current;
         });
 
-        it('should canProceed be false when loading', async () => {
-            const { result } = await renderUseExchangeSelectQuote();
+        it('should canProceed be false when loading', () => {
+            const { result } = renderUseExchangeSelectQuote();
             expect(result.current.canProceed).toBe(false);
         });
     });
 
     describe('with quote loaded and selected', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({ isLoading: false });
+        beforeEach(() => {
+            store = getInitializedStore({ isLoading: false });
 
-            const { result } = await renderExchangeForm();
+            const { result } = renderExchangeForm();
             exchangeForm = result.current;
 
             act(() => {
@@ -137,17 +137,17 @@ describe('useExchangeSelectQuote', () => {
         });
 
         it('should canProceed be true when not loading and quote exists', async () => {
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(true);
         });
 
-        it('should call selectQuoteThunk when selectQuote is called', async () => {
+        it('should call selectQuoteThunk when selectQuote is called', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             act(() => {
                 result.current.selectQuote();
@@ -164,12 +164,12 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should call selectQuoteThunk with correct maxSlippage value', async () => {
+        it('should call selectQuoteThunk with correct maxSlippage value', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             act(() => {
                 store.dispatch(tradingSettingsActions.setMaxSlippagePercentage('1.5'));
             });
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             act(() => {
                 result.current.selectQuote();
@@ -186,7 +186,7 @@ describe('useExchangeSelectQuote', () => {
             );
         });
 
-        it('should not call selectQuoteThunk when account is not fully selected', async () => {
+        it('should not call selectQuoteThunk when account is not fully selected', () => {
             act(() => {
                 [
                     tradingExchangeActions.setReceiveAccountKey(
@@ -200,7 +200,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result, reportMock } = await renderUseExchangeSelectQuote();
+            const { result, reportMock } = renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
             act(() => {
@@ -223,10 +223,10 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangePreview when nextStep callback is executed', async () => {
+        it('should navigate to TradingExchangePreview when nextStep callback is executed', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {
@@ -245,14 +245,14 @@ describe('useExchangeSelectQuote', () => {
     });
 
     describe('navigation based on approval status', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({ isLoading: false });
+        beforeEach(() => {
+            store = getInitializedStore({ isLoading: false });
 
-            const { result } = await renderExchangeForm();
+            const { result } = renderExchangeForm();
             exchangeForm = result.current;
         });
 
-        it('should navigate to TradingExchangePreview when approval status is "approved"', async () => {
+        it('should navigate to TradingExchangePreview when approval status is "approved"', () => {
             jest.spyOn(approvalStatusUtils, 'getApprovalStatus').mockReturnValue('approved');
 
             act(() => {
@@ -260,7 +260,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {
@@ -281,7 +281,7 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangePreview when approval status is "not_needed"', async () => {
+        it('should navigate to TradingExchangePreview when approval status is "not_needed"', () => {
             jest.spyOn(approvalStatusUtils, 'getApprovalStatus').mockReturnValue('not_needed');
 
             act(() => {
@@ -289,7 +289,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {
@@ -306,7 +306,7 @@ describe('useExchangeSelectQuote', () => {
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview', {});
         });
 
-        it('should navigate to TradingExchangeApproval when approval status is "needs_approval"', async () => {
+        it('should navigate to TradingExchangeApproval when approval status is "needs_approval"', () => {
             jest.spyOn(approvalStatusUtils, 'getApprovalStatus').mockReturnValue('needs_approval');
 
             act(() => {
@@ -314,7 +314,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {
@@ -336,7 +336,7 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when approval status is "needs_increase" and token supports increasing allowance', async () => {
+        it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when approval status is "needs_increase" and token supports increasing allowance', () => {
             jest.spyOn(approvalStatusUtils, 'getApprovalStatus').mockReturnValue('needs_increase');
             mockTokenSupportsIncreasingAllowance.mockReturnValue(true);
 
@@ -345,7 +345,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {
@@ -368,7 +368,7 @@ describe('useExchangeSelectQuote', () => {
             });
         });
 
-        it('should navigate to TradingExchangeRevoke when approval status is "needs_increase" and token does not support increasing allowance', async () => {
+        it('should navigate to TradingExchangeRevoke when approval status is "needs_increase" and token does not support increasing allowance', () => {
             jest.spyOn(approvalStatusUtils, 'getApprovalStatus').mockReturnValue('needs_increase');
             mockTokenSupportsIncreasingAllowance.mockReturnValue(false);
 
@@ -377,7 +377,7 @@ describe('useExchangeSelectQuote', () => {
             });
 
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
             dispatchSpy.mockClear();
 
             act(() => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useActiveTradingTypeReaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useActiveTradingTypeReaction.test.ts
@@ -1,9 +1,5 @@
 import { type TradingType } from '@suite-common/trading';
-import {
-    type TestStore,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { selectActiveTradingType, selectEnabledTradingTypes } from '@suite-native/trading-state';
 
 import { useActiveTradingTypeReaction } from '../useActiveTradingTypeReaction';
@@ -28,36 +24,36 @@ describe('useActiveTradingTypeReaction', () => {
     const castedSelectEnabledTradingTypes = selectEnabledTradingTypes as unknown as jest.Mock;
 
     const renderUseActiveTradingTypeReaction = (store: TestStore) =>
-        renderHookWithStoreProviderAsync(() => useActiveTradingTypeReaction(), { store });
+        renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), { store });
 
     beforeEach(() => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy', 'exchange', 'sell']);
         mockUseRouteParams = {};
     });
 
-    it('should set buy active when only buy is allowed', async () => {
+    it('should set buy active when only buy is allowed', () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
         const { store } = initStore();
 
-        await renderUseActiveTradingTypeReaction(store);
+        renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('buy');
     });
 
-    it('should set exchange active when only exchange is allowed', async () => {
+    it('should set exchange active when only exchange is allowed', () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['exchange']);
         const { store } = initStore();
 
-        await renderUseActiveTradingTypeReaction(store);
+        renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('exchange');
     });
 
-    it('should set sell active when only sell is allowed', async () => {
+    it('should set sell active when only sell is allowed', () => {
         castedSelectEnabledTradingTypes.mockReturnValue(['sell']);
         const { store } = initStore();
 
-        await renderUseActiveTradingTypeReaction(store);
+        renderUseActiveTradingTypeReaction(store);
 
         expect(selectActiveTradingType(store.getState())).toBe('sell');
     });
@@ -69,9 +65,9 @@ describe('useActiveTradingTypeReaction', () => {
         expect(() => renderUseActiveTradingTypeReaction(store)).not.toThrow();
     });
 
-    it('should clear activeTradingType on unmount', async () => {
+    it('should clear activeTradingType on unmount', () => {
         const { store } = initStore();
-        const { unmount } = await renderUseActiveTradingTypeReaction(store);
+        const { unmount } = renderUseActiveTradingTypeReaction(store);
 
         unmount();
 
@@ -79,49 +75,49 @@ describe('useActiveTradingTypeReaction', () => {
     });
 
     describe('with trading type specified by navigation params', () => {
-        it('should set buy active when buy is specified', async () => {
+        it('should set buy active when buy is specified', () => {
             mockUseRouteParams.tradingType = 'buy';
             const { store } = initStore();
 
-            await renderUseActiveTradingTypeReaction(store);
+            renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });
 
-        it('should set exchange active when exchange is specified', async () => {
+        it('should set exchange active when exchange is specified', () => {
             mockUseRouteParams.tradingType = 'exchange';
             const { store } = initStore();
 
-            await renderUseActiveTradingTypeReaction(store);
+            renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('exchange');
         });
 
-        it('should set sell active when sell is specified', async () => {
+        it('should set sell active when sell is specified', () => {
             mockUseRouteParams.tradingType = 'sell';
             const { store } = initStore();
 
-            await renderUseActiveTradingTypeReaction(store);
+            renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('sell');
         });
 
-        it('should fallback to buy when navigating to exchange but exchange is disabled', async () => {
+        it('should fallback to buy when navigating to exchange but exchange is disabled', () => {
             castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
             mockUseRouteParams.tradingType = 'exchange';
             const { store } = initStore();
 
-            await renderUseActiveTradingTypeReaction(store);
+            renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });
 
-        it('should fallback to buy when navigating to sell but sell is disabled', async () => {
+        it('should fallback to buy when navigating to sell but sell is disabled', () => {
             mockUseRouteParams.tradingType = 'sell';
             castedSelectEnabledTradingTypes.mockReturnValue(['buy']);
             const { store } = initStore();
 
-            await renderUseActiveTradingTypeReaction(store);
+            renderUseActiveTradingTypeReaction(store);
 
             expect(selectActiveTradingType(store.getState())).toBe('buy');
         });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
@@ -3,7 +3,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     getBuyTrade,
@@ -85,9 +85,9 @@ describe('useAllTradesReloadTimer', () => {
     };
 
     const renderUseAllTradesReloadTimer = (store: TestStore) =>
-        renderHookWithStoreProviderAsync(() => useAllTradesReloadTimer(), { store });
+        renderHookWithStoreProvider(() => useAllTradesReloadTimer(), { store });
 
-    it('should enable reload timer when there are trades to watch', async () => {
+    it('should enable reload timer when there are trades to watch', () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -105,8 +105,8 @@ describe('useAllTradesReloadTimer', () => {
             resetCount: 0,
         });
 
-        const store = await getInitializedStore({ trades: tradesWithAccounts });
-        await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: tradesWithAccounts });
+        renderUseAllTradesReloadTimer(store);
 
         expect(mockUseReloadTimer).toHaveBeenCalledWith({
             isEnabled: true, // Should be true when there are trades to watch
@@ -114,7 +114,7 @@ describe('useAllTradesReloadTimer', () => {
         });
     });
 
-    it('should return selected trades', async () => {
+    it('should return selected trades', () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }), // Should be watched
             getBuyTrade({ status: 'SUCCESS' }), // Should not be watched (final status)
@@ -127,8 +127,8 @@ describe('useAllTradesReloadTimer', () => {
             selectedAccountKey: 'btc1',
         }));
 
-        const store = await getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: tradesWithAccounts });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         expect(result.current.tradesToWatch).toHaveLength(2);
         expect(result.current.tradesToWatch[0].data.status).toBe('SUBMITTED');
@@ -154,8 +154,8 @@ describe('useAllTradesReloadTimer', () => {
             selectedAccountKey: 'btc1',
         }));
 
-        const store = await getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: tradesWithAccounts });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         // Call the refreshAllTrades function
         await act(async () => {
@@ -180,8 +180,8 @@ describe('useAllTradesReloadTimer', () => {
             getExchangeTrade({ status: 'ERROR' }),
         ];
 
-        const store = await getInitializedStore({ trades: mockTrades });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: mockTrades });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         await act(async () => {
             await result.current.refreshAllTrades();
@@ -205,8 +205,8 @@ describe('useAllTradesReloadTimer', () => {
             selectedAccountKey: 'btc1',
         }));
 
-        const store = await getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: tradesWithAccounts });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         // Initially should be false
         expect(result.current.hasFetchedInitialTrades).toBe(false);
@@ -228,8 +228,8 @@ describe('useAllTradesReloadTimer', () => {
             resetCount: 0,
         });
 
-        const store = await getInitializedStore({ trades: [] });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: [] });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         expect(result.current.tradesToWatch).toHaveLength(0);
         expect(result.current.tradesByAccount).toHaveLength(0);
@@ -239,7 +239,7 @@ describe('useAllTradesReloadTimer', () => {
         expect(mockReset).not.toHaveBeenCalled();
     });
 
-    it('should handle trades with different trade types', async () => {
+    it('should handle trades with different trade types', () => {
         const mockTrades = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -251,16 +251,16 @@ describe('useAllTradesReloadTimer', () => {
             selectedAccountKey: 'btc1',
         }));
 
-        const store = await getInitializedStore({ trades: tradesWithAccounts });
-        const { result } = await renderUseAllTradesReloadTimer(store);
+        const store = getInitializedStore({ trades: tradesWithAccounts });
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         // All trades should be watched as they have non-final statuses
         expect(result.current.tradesToWatch).toHaveLength(3);
     });
 
-    it('should provide setIsFetching function', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseAllTradesReloadTimer(store);
+    it('should provide setIsFetching function', () => {
+        const store = getInitializedStore();
+        const { result } = renderUseAllTradesReloadTimer(store);
 
         expect(typeof result.current.setIsFetching).toBe('function');
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
@@ -1,5 +1,5 @@
 import { type Account, type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { type TokensRootState } from '@suite-native/tokens';
 
 import { useAmountInputDecimals } from '../useAmountInputDecimals';
@@ -23,48 +23,48 @@ jest.mock('@suite-native/tokens', () => ({
 
 describe('useAmountInputDecimals', () => {
     const renderUseAmountInputDecimals = (account?: Account, contractAddress?: TokenAddress) =>
-        renderHookWithStoreProviderAsync(() => useAmountInputDecimals(account, contractAddress));
+        renderHookWithStoreProvider(() => useAmountInputDecimals(account, contractAddress));
 
     beforeEach(() => {
         jest.clearAllMocks();
         mockSelectAccountTokenDecimals.mockReturnValue(6);
     });
 
-    it('should be undefined when account is not set', async () => {
-        const { result } = await renderUseAmountInputDecimals(undefined, undefined);
+    it('should be undefined when account is not set', () => {
+        const { result } = renderUseAmountInputDecimals(undefined, undefined);
 
         expect(result.current).toBeUndefined();
     });
 
-    it('should limit value to decimals based on network.decimals value for networks', async () => {
+    it('should limit value to decimals based on network.decimals value for networks', () => {
         const account = {
             key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
-        const { result } = await renderUseAmountInputDecimals(account, undefined);
+        const { result } = renderUseAmountInputDecimals(account, undefined);
 
         expect(result.current).toEqual(18);
     });
 
-    it('should limit value to decimals based on selectAccountTokenDecimals return value', async () => {
+    it('should limit value to decimals based on selectAccountTokenDecimals return value', () => {
         const account = {
             key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
-        const { result } = await renderUseAmountInputDecimals(account, contractAddress);
+        const { result } = renderUseAmountInputDecimals(account, contractAddress);
 
         expect(result.current).toEqual(6);
     });
 
-    it('should return undefined when selectAccountTokenDecimals returns nullish value', async () => {
+    it('should return undefined when selectAccountTokenDecimals returns nullish value', () => {
         mockSelectAccountTokenDecimals.mockReturnValue(null);
         const account = {
             key: 'account_key' as AccountKey, // Todo: create properly via `createAccountKey()`
             symbol: 'eth',
         } as Account;
         const contractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress;
-        const { result } = await renderUseAmountInputDecimals(account, contractAddress);
+        const { result } = renderUseAmountInputDecimals(account, contractAddress);
 
         expect(result.current).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
@@ -1,5 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { PROTO } from '@trezor/connect';
 
 import { useConvertFormValueToBaseUnit } from '../useConvertFormValueToBaseUnit';
@@ -8,14 +8,14 @@ describe('useConvertFormValueToBaseUnit', () => {
     const renderUseConvertApiToAppAmount = (bitcoinAmountUnit: PROTO.AmountUnit) => {
         const preloadedState = { wallet: { settings: { bitcoinAmountUnit } } };
 
-        return renderHookWithStoreProviderAsync(() => useConvertFormValueToBaseUnit(), {
+        return renderHookWithStoreProvider(() => useConvertFormValueToBaseUnit(), {
             preloadedState,
         });
     };
 
     describe('convertStrToBaseUnit', () => {
-        it('should return undefined when amount is undefined', async () => {
-            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+        it('should return undefined when amount is undefined', () => {
+            const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
             expect(result.current.convertStrToBaseUnit(undefined, 'btc')).toEqual(undefined);
         });
@@ -25,8 +25,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', '1', '1'],
         ])(
             'should correctly convert %s with BTC as app unit',
-            async (symbol, amountFromApi, expectedAmount) => {
-                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+            (symbol, amountFromApi, expectedAmount) => {
+                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
 
                 expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -39,8 +39,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', '1', '1'],
         ])(
             'should correctly convert %s with SAT as app unit',
-            async (symbol, amountFromApi, expectedAmount) => {
-                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+            (symbol, amountFromApi, expectedAmount) => {
+                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
                 expect(result.current.convertStrToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -50,8 +50,8 @@ describe('useConvertFormValueToBaseUnit', () => {
     });
 
     describe('convertNumberToBaseUnit', () => {
-        it('should return undefined when amount is undefined', async () => {
-            const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+        it('should return undefined when amount is undefined', () => {
+            const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
             expect(result.current.convertNumberToBaseUnit(undefined, 'btc')).toEqual(undefined);
         });
@@ -61,8 +61,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', 1, 1],
         ])(
             'should correctly convert %s with BTC as app unit',
-            async (symbol, amountFromApi, expectedAmount) => {
-                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
+            (symbol, amountFromApi, expectedAmount) => {
+                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.BITCOIN);
 
                 expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,
@@ -75,8 +75,8 @@ describe('useConvertFormValueToBaseUnit', () => {
             ['eth', 1, 1],
         ])(
             'should correctly convert %s with SAT as app unit',
-            async (symbol, amountFromApi, expectedAmount) => {
-                const { result } = await renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
+            (symbol, amountFromApi, expectedAmount) => {
+                const { result } = renderUseConvertApiToAppAmount(PROTO.AmountUnit.SATOSHI);
 
                 expect(result.current.convertNumberToBaseUnit(amountFromApi, symbol)).toEqual(
                     expectedAmount,

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
@@ -3,7 +3,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { selectIsAmountInputActive } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -17,31 +17,31 @@ describe('useFocusedValueWatch', () => {
     let form: BuyFormType;
     let store: TestStore;
 
-    const renderForm = () => renderHookWithStoreProviderAsync(() => useBuyForm());
+    const renderForm = () => renderHookWithStoreProvider(() => useBuyForm());
 
     const renderUseFocusedValueWatch = () =>
-        renderHookWithStoreProviderAsync(({ watch }) => useFocusedValueWatch(watch), {
+        renderHookWithStoreProvider(({ watch }) => useFocusedValueWatch(watch), {
             initialProps: { watch: form.watch },
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderForm();
+    beforeEach(() => {
+        const { result } = renderForm();
         form = result.current;
 
         store = initStore().store;
     });
 
-    it('should return false by default', async () => {
-        const { result } = await renderUseFocusedValueWatch();
+    it('should return false by default', () => {
+        const { result } = renderUseFocusedValueWatch();
 
         expect(result.current).toEqual(false);
         expect(selectIsAmountInputActive(store.getState())).toBe(false);
     });
 
     it('should be false right after input is focused', async () => {
-        const { result, rerender } = await renderUseFocusedValueWatch();
+        const { result, rerender } = renderUseFocusedValueWatch();
 
         act(() => {
             form.setValue('focusedValue', 'fiatValue');
@@ -56,7 +56,7 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should be true after 300ms of input focus', async () => {
-        const { result, rerender } = await renderUseFocusedValueWatch();
+        const { result, rerender } = renderUseFocusedValueWatch();
 
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
@@ -73,7 +73,7 @@ describe('useFocusedValueWatch', () => {
     });
 
     it('should set isAmountInputActive to false on unmount', async () => {
-        const { rerender, unmount } = await renderUseFocusedValueWatch();
+        const { rerender, unmount } = renderUseFocusedValueWatch();
         await act(() => {
             form.setValue('focusedValue', 'fiatValue');
         });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
@@ -1,9 +1,5 @@
 import { geolocationActions, selectCountryCode } from '@suite-common/geolocation';
-import {
-    type TestStore,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useGeolocationCountryCode } from '../useGeolocationCountryCode';
 
@@ -20,21 +16,21 @@ jest.mock('@suite-common/geolocation', () => {
 
 describe('useGeolocationCountryCode', () => {
     const renderUseGeolocationCountryCode = (store: TestStore) =>
-        renderHookWithStoreProviderAsync(() => useGeolocationCountryCode(), { store });
+        renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store });
 
-    it('should call geolocation thunk on mount', async () => {
+    it('should call geolocation thunk on mount', () => {
         const { store } = initStore();
 
-        await renderUseGeolocationCountryCode(store);
+        renderUseGeolocationCountryCode(store);
 
         expect(selectCountryCode(store.getState())).toBe('US');
     });
 
-    it('should not call geolocation thunk if country code is already known', async () => {
+    it('should not call geolocation thunk if country code is already known', () => {
         const { store } = initStore();
         store.dispatch(geolocationActions.setCountryCode('CZ'));
 
-        await renderUseGeolocationCountryCode(store);
+        renderUseGeolocationCountryCode(store);
 
         expect(selectCountryCode(store.getState())).toBe('CZ');
     });

--- a/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
@@ -1,10 +1,6 @@
 import { type ActionCreatorWithoutPayload } from '@reduxjs/toolkit';
 
-import {
-    type TestStore,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { type AbortablePromise } from '@suite-native/trading-types';
 
 import { type UseQuotesInvalidatorProps, useQuotesInvalidator } from '../useQuotesInvalidator';
@@ -23,7 +19,7 @@ describe('useQuotesInvalidator', () => {
         })) as ActionCreatorWithoutPayload,
         getClearStateAction = (() => ({ type: 'clearStateAction' })) as ActionCreatorWithoutPayload,
     }: Partial<UseQuotesInvalidatorProps>) =>
-        renderHookWithStoreProviderAsync(props => useQuotesInvalidator(props), {
+        renderHookWithStoreProvider(props => useQuotesInvalidator(props), {
             store,
             initialProps: {
                 isFormValid,
@@ -40,18 +36,18 @@ describe('useQuotesInvalidator', () => {
         store = initStore().store;
     });
 
-    it('should call debounce with empty method when form is not valid', async () => {
+    it('should call debounce with empty method when form is not valid', () => {
         const debounceMock = jest.fn();
-        await renderUseQuotesInvalidator({
+        renderUseQuotesInvalidator({
             debounce: debounceMock,
         });
 
         expect(debounceMock).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    it('should not call debounce when form is valid', async () => {
+    it('should not call debounce when form is valid', () => {
         const debounceMock = jest.fn();
-        await renderUseQuotesInvalidator({
+        renderUseQuotesInvalidator({
             debounce: debounceMock,
             isFormValid: true,
         });
@@ -60,12 +56,12 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('promise aborting', () => {
-        it('should abort quotesPromise when form is invalid and quotes are loading', async () => {
+        it('should abort quotesPromise when form is invalid and quotes are loading', () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: false,
                 isLoading: true,
                 quotesPromiseRef,
@@ -74,12 +70,12 @@ describe('useQuotesInvalidator', () => {
             expect(abortMock).toHaveBeenCalledWith('Invalidating quotes');
         });
 
-        it('should abort quotesPromise on unmount', async () => {
+        it('should abort quotesPromise on unmount', () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            const { unmount } = await renderUseQuotesInvalidator({
+            const { unmount } = renderUseQuotesInvalidator({
                 isFormValid: true,
                 quotesPromiseRef,
             });
@@ -89,12 +85,12 @@ describe('useQuotesInvalidator', () => {
             expect(abortMock).toHaveBeenCalledWith('Component unmounted');
         });
 
-        it('should not abort quotesPromise when form is valid', async () => {
+        it('should not abort quotesPromise when form is valid', () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: true,
                 quotesPromiseRef,
             });
@@ -102,12 +98,12 @@ describe('useQuotesInvalidator', () => {
             expect(abortMock).not.toHaveBeenCalled();
         });
 
-        it('should not abort quotesPromise when form is invalid but quotes are not loading', async () => {
+        it('should not abort quotesPromise when form is invalid but quotes are not loading', () => {
             const abortMock = jest.fn();
             const quotesPromiseRef = {
                 current: { abort: abortMock } as unknown as AbortablePromise,
             };
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: false,
                 isLoading: false,
                 quotesPromiseRef,
@@ -118,9 +114,9 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('getClearRequestAction', () => {
-        it('should dispatch clear request action', async () => {
+        it('should dispatch clear request action', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: false,
                 anyQuotesLoaded: true,
             });
@@ -128,9 +124,9 @@ describe('useQuotesInvalidator', () => {
             expect(dispatchSpy).toHaveBeenCalledWith({ type: 'clearRequestAction' });
         });
 
-        it('should not dispatch clear request when no quotes are loaded', async () => {
+        it('should not dispatch clear request when no quotes are loaded', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: false,
                 anyQuotesLoaded: false,
             });
@@ -138,9 +134,9 @@ describe('useQuotesInvalidator', () => {
             expect(dispatchSpy).not.toHaveBeenCalledWith({ type: 'clearStateAction' });
         });
 
-        it('should not dispatch clear request when form is valid', async () => {
+        it('should not dispatch clear request when form is valid', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            await renderUseQuotesInvalidator({
+            renderUseQuotesInvalidator({
                 isFormValid: true,
                 anyQuotesLoaded: true,
             });
@@ -150,9 +146,9 @@ describe('useQuotesInvalidator', () => {
     });
 
     describe('getClearStateAction', () => {
-        it('should dispatch clear state action on unmount', async () => {
+        it('should dispatch clear state action on unmount', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { unmount } = await renderUseQuotesInvalidator({});
+            const { unmount } = renderUseQuotesInvalidator({});
 
             unmount();
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { type PreloadedState, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
     accounts,
@@ -35,7 +35,7 @@ describe('useReceiveAccountsListData', () => {
         initialMode: ReceiveAccountsListMode,
         preloadedState: PreloadedState = defaultPreloadedState,
     ) =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             ({ symbol, selectedAccount, mode }) =>
                 useReceiveAccountsListData({ symbol, selectedAccount, mode }),
             {
@@ -49,12 +49,8 @@ describe('useReceiveAccountsListData', () => {
         );
 
     describe('without account selected', () => {
-        it('should display all accounts for given symbol', async () => {
-            const { result } = await renderUseReceiveAccountsListDataHook(
-                'btc',
-                undefined,
-                'account',
-            );
+        it('should display all accounts for given symbol', () => {
+            const { result } = renderUseReceiveAccountsListDataHook('btc', undefined, 'account');
 
             expect(result.current).toEqual([
                 {
@@ -68,8 +64,8 @@ describe('useReceiveAccountsListData', () => {
             ]);
         });
 
-        it('should react to symbol change', async () => {
-            const { result, rerender } = await renderUseReceiveAccountsListDataHook(
+        it('should react to symbol change', () => {
+            const { result, rerender } = renderUseReceiveAccountsListDataHook(
                 'btc',
                 undefined,
                 'account',
@@ -89,24 +85,19 @@ describe('useReceiveAccountsListData', () => {
             ]);
         });
 
-        it('should render empty array when wallet accounts are not initialized', async () => {
-            const { result } = await renderUseReceiveAccountsListDataHook(
-                'btc',
-                undefined,
-                'account',
-                {
-                    ...defaultPreloadedState,
-                    wallet: undefined,
-                },
-            );
+        it('should render empty array when wallet accounts are not initialized', () => {
+            const { result } = renderUseReceiveAccountsListDataHook('btc', undefined, 'account', {
+                ...defaultPreloadedState,
+                wallet: undefined,
+            });
 
             expect(result.current).toEqual([]);
         });
     });
 
     describe('with account selected', () => {
-        it('should be empty array for non BTC like assets', async () => {
-            const { result } = await renderUseReceiveAccountsListDataHook(
+        it('should be empty array for non BTC like assets', () => {
+            const { result } = renderUseReceiveAccountsListDataHook(
                 'eth',
                 eth1NormalAccount,
                 'address',
@@ -115,8 +106,8 @@ describe('useReceiveAccountsListData', () => {
             expect(result.current).toEqual([]);
         });
 
-        it('should return 1 unused address and all used addresses for BTC like assets', async () => {
-            const { result } = await renderUseReceiveAccountsListDataHook(
+        it('should return 1 unused address and all used addresses for BTC like assets', () => {
+            const { result } = renderUseReceiveAccountsListDataHook(
                 'btc',
                 btc1NormalAccount,
                 'address',
@@ -167,8 +158,8 @@ describe('useReceiveAccountsListData', () => {
             ]);
         });
 
-        it('should not return empty sections', async () => {
-            const { result } = await renderUseReceiveAccountsListDataHook(
+        it('should not return empty sections', () => {
+            const { result } = renderUseReceiveAccountsListDataHook(
                 'btc',
                 btc2legacyAccount,
                 'address',
@@ -177,7 +168,7 @@ describe('useReceiveAccountsListData', () => {
             expect(result.current).toEqual([]);
         });
 
-        it('should not display not visible accounts', async () => {
+        it('should not display not visible accounts', () => {
             const preloadedState = {
                 device: {
                     selectedDevice: {
@@ -199,7 +190,7 @@ describe('useReceiveAccountsListData', () => {
                     ] as unknown as Account[],
                 },
             };
-            const { result } = await renderUseReceiveAccountsListDataHook(
+            const { result } = renderUseReceiveAccountsListDataHook(
                 'eth',
                 undefined,
                 'account',

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     getBtcAccount,
@@ -92,7 +92,7 @@ describe('useTradingTransaction', () => {
     };
 
     const renderUseTradingTransaction = ({ store }: { store: TestStore }) =>
-        renderHookWithStoreProviderAsync(() => useTradingTransaction({ tradeType: 'exchange' }), {
+        renderHookWithStoreProvider(() => useTradingTransaction({ tradeType: 'exchange' }), {
             store,
         });
 
@@ -129,7 +129,7 @@ describe('useTradingTransaction', () => {
 
     describe('composeRequest', () => {
         it('should call composeTradingTransactionThunk with correct parameters', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             // Mock the networkFeeInfo selector to return proper data
@@ -145,7 +145,7 @@ describe('useTradingTransaction', () => {
                 'selectConvertedNetworkFeeInfo',
             ).mockReturnValue(mockNetworkFeeInfo);
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.composeRequest({
@@ -173,7 +173,7 @@ describe('useTradingTransaction', () => {
         });
 
         it('should call composeTradingTransactionThunk with minimal parameters', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             // Mock the networkFeeInfo selector to return proper data
@@ -188,7 +188,7 @@ describe('useTradingTransaction', () => {
                 'selectConvertedNetworkFeeInfo',
             ).mockReturnValue(mockNetworkFeeInfo);
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.composeRequest({});
@@ -214,7 +214,7 @@ describe('useTradingTransaction', () => {
 
     describe('fetchFeesAndCompose', () => {
         it('should call updateFeeInfoThunk and then composeRequest with draft fee values', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             // Mock the networkFeeInfo selector to return proper data
@@ -239,7 +239,7 @@ describe('useTradingTransaction', () => {
                 feeLimit: '30000',
             });
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.fetchFeesAndCompose();
@@ -273,7 +273,7 @@ describe('useTradingTransaction', () => {
         });
 
         it('should handle undefined draft values', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
 
             // Mock the networkFeeInfo selector to return proper data
@@ -294,7 +294,7 @@ describe('useTradingTransaction', () => {
                 'selectDeepCopyOfFormDraft',
             ).mockReturnValue(undefined);
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.fetchFeesAndCompose();
@@ -330,11 +330,11 @@ describe('useTradingTransaction', () => {
 
     describe('signAndSendTransaction', () => {
         it('should call sendTransactionThunk with correct parameters', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
             const dispatchSpy = jest.spyOn(store, 'dispatch');
             const mockNextStep = jest.fn();
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             await act(async () => {
                 await result.current.signAndSendTransaction({
@@ -365,9 +365,9 @@ describe('useTradingTransaction', () => {
 
     describe('resolveConsent', () => {
         it('should set isConsentRequested to false and resolve the promise', async () => {
-            const store = await getInitializedStore();
+            const store = getInitializedStore();
 
-            const { result } = await renderUseTradingTransaction({ store });
+            const { result } = renderUseTradingTransaction({ store });
 
             // First, trigger the signAndSendTransaction to set up the promise
             const originalSendTransactionThunk =
@@ -398,9 +398,9 @@ describe('useTradingTransaction', () => {
     });
 
     describe('useEffect cleanup', () => {
-        it('should call TrezorConnect.cancel on unmount', async () => {
-            const store = await getInitializedStore();
-            const { unmount } = await renderUseTradingTransaction({ store });
+        it('should call TrezorConnect.cancel on unmount', () => {
+            const store = getInitializedStore();
+            const { unmount } = renderUseTradingTransaction({ store });
 
             // Get the mocked TrezorConnect.cancel function
             const TrezorConnect = require('@trezor/connect');

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
@@ -2,7 +2,7 @@ import {
     type PreloadedState,
     type TestStore,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import {
     MOCK_ACCOUNT_DEVICE_SESSION_ID,
@@ -96,11 +96,11 @@ describe('useWatchAllTrades', () => {
     };
 
     const renderUseWatchAllTrades = (store: TestStore) =>
-        renderHookWithStoreProviderAsync(() => useWatchAllTrades(), { store });
+        renderHookWithStoreProvider(() => useWatchAllTrades(), { store });
 
-    it('should return empty arrays when no trades', async () => {
-        const store = await getInitializedStore();
-        const { result } = await renderUseWatchAllTrades(store);
+    it('should return empty arrays when no trades', () => {
+        const store = getInitializedStore();
+        const { result } = renderUseWatchAllTrades(store);
 
         expect(result.current.allTrades).toEqual([]);
         expect(result.current.tradesToWatch).toEqual([]);
@@ -108,21 +108,21 @@ describe('useWatchAllTrades', () => {
         expect(result.current.tradesWatching).toBe(0);
     });
 
-    it('should return trades for the current device', async () => {
+    it('should return trades for the current device', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const exchangeTrade = getExchangeTrade({ status: 'CONVERTING' });
         const sellTrade = getSellTrade({ status: 'SEND_CRYPTO' });
 
-        const store = await getInitializedStore({
+        const store = getInitializedStore({
             trades: [buyTrade, exchangeTrade, sellTrade],
         });
-        const { result } = await renderUseWatchAllTrades(store);
+        const { result } = renderUseWatchAllTrades(store);
 
         expect(result.current.allTrades).toHaveLength(3);
         expect(result.current.totalTrades).toBe(3);
     });
 
-    it('should return trades to watch from useAllTradesReloadTimer', async () => {
+    it('should return trades to watch from useAllTradesReloadTimer', () => {
         const mockTradesToWatch = [
             getBuyTrade({ status: 'SUBMITTED' }),
             getExchangeTrade({ status: 'CONVERTING' }),
@@ -137,8 +137,8 @@ describe('useWatchAllTrades', () => {
             tradesToWatch: mockTradesToWatch,
         });
 
-        const store = await getInitializedStore();
-        const { result } = await renderUseWatchAllTrades(store);
+        const store = getInitializedStore();
+        const { result } = renderUseWatchAllTrades(store);
 
         expect(result.current.tradesToWatch).toEqual(mockTradesToWatch);
         expect(result.current.tradesWatching).toBe(2);
@@ -157,8 +157,8 @@ describe('useWatchAllTrades', () => {
             tradesToWatch: [],
         });
 
-        const store = await getInitializedStore();
-        await renderUseWatchAllTrades(store);
+        const store = getInitializedStore();
+        renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));
@@ -180,8 +180,8 @@ describe('useWatchAllTrades', () => {
             tradesToWatch: [],
         });
 
-        const store = await getInitializedStore();
-        await renderUseWatchAllTrades(store);
+        const store = getInitializedStore();
+        renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));
@@ -202,8 +202,8 @@ describe('useWatchAllTrades', () => {
             tradesToWatch: [],
         });
 
-        const store = await getInitializedStore();
-        await renderUseWatchAllTrades(store);
+        const store = getInitializedStore();
+        renderUseWatchAllTrades(store);
 
         // Wait for the effect to run
         await new Promise(resolve => setTimeout(resolve, 0));

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
@@ -5,7 +5,7 @@ import { useAnalytics } from '@suite-native/services';
 import {
     type PreloadedState,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBuyTrade, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
@@ -98,22 +98,18 @@ describe('useWatchTrade', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderUseWatchTrade = async (
+    const renderUseWatchTrade = (
         store: any,
         props: { accountKey?: AccountKey; orderId?: string; isInProgress?: boolean },
-    ) => {
-        const hook = await renderHookWithStoreProviderAsync(
-            () => useWatchTradeWithReportSpy(props),
-            { store },
-        );
-
-        return hook;
-    };
+    ) =>
+        renderHookWithStoreProvider(() => useWatchTradeWithReportSpy(props), {
+            store,
+        });
 
     describe('Trade Watching Behavior', () => {
-        it('should not dispatch watch trade thunk when no trade is found', async () => {
-            const store = await getInitializedStore();
-            await renderUseWatchTrade(store, {
+        it('should not dispatch watch trade thunk when no trade is found', () => {
+            const store = getInitializedStore();
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: 'non-existent-order',
             });
@@ -121,13 +117,13 @@ describe('useWatchTrade', () => {
             expect(mockWatchTradeThunk).not.toHaveBeenCalled();
         });
 
-        it('should not dispatch watch trade thunk when no account is found', async () => {
+        it('should not dispatch watch trade thunk when no account is found', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: 'non-existent-account' as AccountKey, // Todo: create properly via `createAccountKey()`
                 orderId: buyTrade.data.orderId,
             });
@@ -135,13 +131,13 @@ describe('useWatchTrade', () => {
             expect(mockWatchTradeThunk).not.toHaveBeenCalled();
         });
 
-        it('should dispatch watch trade thunk when trade and account are found', async () => {
+        it('should dispatch watch trade thunk when trade and account are found', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey as AccountKey, // Todo: create properly via `createAccountKey()`
                 orderId: buyTrade.data.orderId,
             });
@@ -153,9 +149,9 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should dispatch watch trade thunk when shouldReload is true', async () => {
+        it('should dispatch watch trade thunk when shouldReload is true', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
@@ -167,7 +163,7 @@ describe('useWatchTrade', () => {
                 resetCount: 1,
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
@@ -179,13 +175,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should not dispatch watch trade thunk when trade is in final status', async () => {
+        it('should not dispatch watch trade thunk when trade is in final status', () => {
             const buyTrade = getBuyTrade({ status: 'SUCCESS' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });
@@ -195,13 +191,13 @@ describe('useWatchTrade', () => {
     });
 
     describe('Timer Management', () => {
-        it('should use faster refresh rate when trade is in progress', async () => {
+        it('should use faster refresh rate when trade is in progress', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: true,
@@ -213,13 +209,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should use slower refresh rate when trade is not in progress', async () => {
+        it('should use slower refresh rate when trade is not in progress', () => {
             const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
                 isInProgress: false,
@@ -231,13 +227,13 @@ describe('useWatchTrade', () => {
             });
         });
 
-        it('should disable timer when trade is in final status', async () => {
+        it('should disable timer when trade is in final status', () => {
             const buyTrade = getBuyTrade({ status: 'SUCCESS' });
-            const store = await getInitializedStore({
+            const store = getInitializedStore({
                 trades: [buyTrade],
             });
 
-            await renderUseWatchTrade(store, {
+            renderUseWatchTrade(store, {
                 accountKey: btc1AccountKey,
                 orderId: buyTrade.data.orderId,
             });

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useContextForTradingForm.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useContextForTradingForm.test.ts
@@ -1,9 +1,5 @@
 import { type TradingAmountLimitProps } from '@suite-common/trading';
-import {
-    type PreloadedState,
-    act,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type PreloadedState, act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useContextForTradingForm } from '../useContextForTradingForm';
 
@@ -12,12 +8,12 @@ describe('useContextForTradingForm', () => {
         limits: TradingAmountLimitProps | undefined,
         preloadedState: PreloadedState = {},
     ) =>
-        renderHookWithStoreProviderAsync(() => useContextForTradingForm(limits), {
+        renderHookWithStoreProvider(() => useContextForTradingForm(limits), {
             preloadedState,
         });
 
-    it('should return base context without limits and balance on initial render', async () => {
-        const { result } = await renderUseContextForTradingForm(undefined);
+    it('should return base context without limits and balance on initial render', () => {
+        const { result } = renderUseContextForTradingForm(undefined);
 
         expect(result.current.context).toEqual({
             translate: expect.any(Function),
@@ -27,7 +23,7 @@ describe('useContextForTradingForm', () => {
         });
     });
 
-    it('should append limits to context when specified', async () => {
+    it('should append limits to context when specified', () => {
         const limits: TradingAmountLimitProps = {
             minCrypto: '0.0001',
             maxCrypto: '1',
@@ -36,13 +32,13 @@ describe('useContextForTradingForm', () => {
             currency: 'BTC',
         };
 
-        const { result } = await renderUseContextForTradingForm(limits);
+        const { result } = renderUseContextForTradingForm(limits);
 
         expect(result.current.context).toEqual(expect.objectContaining(limits));
     });
 
-    it('should append balance and sendSymbol when specified', async () => {
-        const { result } = await renderUseContextForTradingForm(undefined);
+    it('should append balance and sendSymbol when specified', () => {
+        const { result } = renderUseContextForTradingForm(undefined);
 
         act(() => {
             result.current.setBalance('0.5');

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
@@ -1,9 +1,5 @@
 import { type TradingCountryCode, type TradingCountryOption } from '@suite-common/trading';
-import {
-    type TestStore,
-    initStore,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { selectTradingResidenceCountry } from '@suite-native/trading-state';
 
 import { type CountryFormWatch, useCountryChangeEffect } from '../useCountryChangeEffect';
@@ -12,14 +8,14 @@ describe('useCountryChangeEffect', () => {
     let store: TestStore;
 
     const renderUseCountryChangeEffect = (watch: CountryFormWatch) =>
-        renderHookWithStoreProviderAsync(() => useCountryChangeEffect(watch), { store });
+        renderHookWithStoreProvider(() => useCountryChangeEffect(watch), { store });
 
     beforeEach(() => {
         store = initStore().store;
     });
 
-    it('should do nothing on mount', async () => {
-        await renderUseCountryChangeEffect(() => ({
+    it('should do nothing on mount', () => {
+        renderUseCountryChangeEffect(() => ({
             codeAlpha3: 'USA',
             flag: '🇺🇸',
             name: 'United States of America',
@@ -31,7 +27,7 @@ describe('useCountryChangeEffect', () => {
         expect(selectTradingResidenceCountry(store.getState())).toBeUndefined();
     });
 
-    it('should update trading residence country on country change', async () => {
+    it('should update trading residence country on country change', () => {
         let countryValue: TradingCountryCode = 'US';
         const watch: CountryFormWatch = () => ({
             value: countryValue,
@@ -42,7 +38,7 @@ describe('useCountryChangeEffect', () => {
             shortLabel: 'Short label',
         });
 
-        const { rerender } = await renderUseCountryChangeEffect(watch);
+        const { rerender } = renderUseCountryChangeEffect(watch);
 
         countryValue = 'CA';
         rerender({});
@@ -50,7 +46,7 @@ describe('useCountryChangeEffect', () => {
         expect(selectTradingResidenceCountry(store.getState())).toBe('CA');
     });
 
-    it('should not update when country becomes undefined', async () => {
+    it('should not update when country becomes undefined', () => {
         let countryOption: TradingCountryOption | undefined = {
             codeAlpha3: 'USA',
             flag: '🇺🇸',
@@ -60,7 +56,7 @@ describe('useCountryChangeEffect', () => {
             shortLabel: '🇺🇸 USA',
         };
         const watch: CountryFormWatch = () => countryOption;
-        const { rerender } = await renderUseCountryChangeEffect(watch);
+        const { rerender } = renderUseCountryChangeEffect(watch);
 
         countryOption = undefined;
         rerender({});

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedReceiveAccount } from '@suite-native/trading-state';
@@ -16,7 +16,7 @@ describe('useReceiveAccountChangeEffect', () => {
     let setValue: jest.Mock;
 
     const renderUseReceiveAccountChangeEffect = () =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             () => useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount),
             { store },
         );
@@ -27,15 +27,15 @@ describe('useReceiveAccountChangeEffect', () => {
         setValue = jest.fn();
     });
 
-    it('should set receiveAccount based on store value', async () => {
-        await renderUseReceiveAccountChangeEffect();
+    it('should set receiveAccount based on store value', () => {
+        renderUseReceiveAccountChangeEffect();
 
         expect(setValue).toHaveBeenCalledTimes(1);
         expect(setValue).toHaveBeenCalledWith('receiveAccount', undefined);
     });
 
-    it('should set receiveAccount on change', async () => {
-        await renderUseReceiveAccountChangeEffect();
+    it('should set receiveAccount on change', () => {
+        renderUseReceiveAccountChangeEffect();
 
         setValue.mockClear();
         act(() => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
@@ -1,5 +1,5 @@
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { btcAsset, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import {
     type ExchangeFormType,
@@ -17,7 +17,7 @@ type HookProps = {
 };
 describe('useSendAccountAssetBalance', () => {
     const renderUseSendAccountAssetBalance = (initialProps: HookProps) =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             ({ form, setBalance, setSendSymbol, setContractAddress }) =>
                 useSendAccountAssetBalance(form, setBalance, setSendSymbol, setContractAddress),
             {
@@ -31,12 +31,12 @@ describe('useSendAccountAssetBalance', () => {
             watch: () => [sendAccount, sendAsset],
         }) as unknown as SellFormType;
 
-    it('should watch for balance and asset symbol', async () => {
+    it('should watch for balance and asset symbol', () => {
         const setBalance = jest.fn();
         const setSendSymbol = jest.fn();
         const setContractAddress = jest.fn();
 
-        await renderUseSendAccountAssetBalance({
+        renderUseSendAccountAssetBalance({
             form: getFormMock(getBtcAccount(), btcAsset),
             setBalance,
             setSendSymbol,
@@ -47,12 +47,12 @@ describe('useSendAccountAssetBalance', () => {
         expect(setSendSymbol).toHaveBeenCalledWith('btc');
     });
 
-    it('should set balance to undefined when account is undefined', async () => {
+    it('should set balance to undefined when account is undefined', () => {
         const setBalance = jest.fn();
         const setSendSymbol = jest.fn();
         const setContractAddress = jest.fn();
 
-        await renderUseSendAccountAssetBalance({
+        renderUseSendAccountAssetBalance({
             form: getFormMock(undefined, btcAsset),
             setBalance,
             setSendSymbol,
@@ -62,12 +62,12 @@ describe('useSendAccountAssetBalance', () => {
         expect(setBalance).toHaveBeenCalledWith(undefined);
     });
 
-    it('should set balance to undefined when symbol is undefined', async () => {
+    it('should set balance to undefined when symbol is undefined', () => {
         const setBalance = jest.fn();
         const setSendSymbol = jest.fn();
         const setContractAddress = jest.fn();
 
-        await renderUseSendAccountAssetBalance({
+        renderUseSendAccountAssetBalance({
             form: getFormMock(getBtcAccount(), undefined),
             setBalance,
             setSendSymbol,

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
@@ -19,7 +19,7 @@ describe('useSendAccountChangeEffect', () => {
     let setValue: jest.Mock;
 
     const renderUseSendAccountChangeEffect = () =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             () => {
                 useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
             },
@@ -32,16 +32,16 @@ describe('useSendAccountChangeEffect', () => {
         setValue = jest.fn();
     });
 
-    it('should set sendAccount and sendAsset to undefined initially', async () => {
-        await renderUseSendAccountChangeEffect();
+    it('should set sendAccount and sendAsset to undefined initially', () => {
+        renderUseSendAccountChangeEffect();
 
         expect(setValue).toHaveBeenCalledTimes(2);
         expect(setValue).toHaveBeenCalledWith('sendAccount', undefined);
         expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
     });
 
-    it('should set sendAccount when account is changed in store', async () => {
-        await renderUseSendAccountChangeEffect();
+    it('should set sendAccount when account is changed in store', () => {
+        renderUseSendAccountChangeEffect();
 
         setValue.mockClear();
         act(() => {
@@ -52,8 +52,8 @@ describe('useSendAccountChangeEffect', () => {
         expect(setValue).toHaveBeenCalledWith('sendAccount', getBtcAccount(btc1AccountKey));
     });
 
-    it('should set sendAsset to undefined when no trading account is selected', async () => {
-        await renderUseSendAccountChangeEffect();
+    it('should set sendAsset to undefined when no trading account is selected', () => {
+        renderUseSendAccountChangeEffect();
         act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
         });
@@ -68,8 +68,8 @@ describe('useSendAccountChangeEffect', () => {
         expect(setValue).toHaveBeenCalledWith('sendAsset', undefined);
     });
 
-    it('should not change sendAsset when trading account key changed', async () => {
-        await renderUseSendAccountChangeEffect();
+    it('should not change sendAsset when trading account key changed', () => {
+        renderUseSendAccountChangeEffect();
         act(() => {
             store.dispatch(tradingExchangeActions.setTradingAccountKey(btc1AccountKey));
         });

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -1,4 +1,4 @@
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     getBuyTrade,
     getExchangeTrade,
@@ -9,9 +9,9 @@ import {
 import { useChangeStringsExtractor } from '../useChangeStringsExtractor';
 
 describe('useChangeStringsExtractor', () => {
-    it('should extract strings for buy trade', async () => {
+    it('should extract strings for buy trade', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () => useChangeStringsExtractor(buyTrade.data),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -28,9 +28,9 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should extract strings for sell trade', async () => {
+    it('should extract strings for sell trade', () => {
         const sellTrade = getSellTrade({ status: 'SUBMITTED' });
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () => useChangeStringsExtractor(sellTrade.data),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -47,9 +47,9 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should extract strings for exchange trade', async () => {
+    it('should extract strings for exchange trade', () => {
         const exchangeTrade = getExchangeTrade({ status: 'CONFIRM' });
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () => useChangeStringsExtractor(exchangeTrade.data),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -66,11 +66,10 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should handle undefined trade', async () => {
-        const { result } = await renderHookWithStoreProviderAsync(
-            () => useChangeStringsExtractor(undefined),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+    it('should handle undefined trade', () => {
+        const { result } = renderHookWithStoreProvider(() => useChangeStringsExtractor(undefined), {
+            preloadedState: { wallet: { trading: getInitializedTradingState() } },
+        });
 
         expect(result.current).toEqual({
             fromCurrency: undefined,
@@ -84,7 +83,7 @@ describe('useChangeStringsExtractor', () => {
         });
     });
 
-    it('should handle trade with missing values', async () => {
+    it('should handle trade with missing values', () => {
         const buyTrade = getBuyTrade({ status: 'SUBMITTED' });
         const tradeWithMissingValues = {
             ...buyTrade.data,
@@ -92,7 +91,7 @@ describe('useChangeStringsExtractor', () => {
             receiveStringAmount: undefined,
         };
 
-        const { result } = await renderHookWithStoreProviderAsync(
+        const { result } = renderHookWithStoreProvider(
             () => useChangeStringsExtractor(tradeWithMissingValues),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );

--- a/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
@@ -1,13 +1,13 @@
 import type { CryptoId } from 'invity-api';
 
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { useSymbolExtractor } from '../useSymbolExtractor';
 
 describe('useSymbolExtractor', () => {
-    it('should return symbol for known cryptoId', async () => {
-        const { result } = await renderHookWithStoreProviderAsync(
+    it('should return symbol for known cryptoId', () => {
+        const { result } = renderHookWithStoreProvider(
             () => useSymbolExtractor('bitcoin' as CryptoId),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -15,8 +15,8 @@ describe('useSymbolExtractor', () => {
         expect(result.current).toBe('BTC');
     });
 
-    it('should return original cryptoId for unknown cryptoId', async () => {
-        const { result } = await renderHookWithStoreProviderAsync(
+    it('should return original cryptoId for unknown cryptoId', () => {
+        const { result } = renderHookWithStoreProvider(
             () => useSymbolExtractor('unknown-crypto' as CryptoId),
             { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
         );
@@ -24,11 +24,10 @@ describe('useSymbolExtractor', () => {
         expect(result.current).toBe('unknown-crypto');
     });
 
-    it('should handle undefined cryptoId', async () => {
-        const { result } = await renderHookWithStoreProviderAsync(
-            () => useSymbolExtractor(undefined),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
-        );
+    it('should handle undefined cryptoId', () => {
+        const { result } = renderHookWithStoreProvider(() => useSymbolExtractor(undefined), {
+            preloadedState: { wallet: { trading: getInitializedTradingState() } },
+        });
 
         expect(result.current).toBeUndefined();
     });

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useDelayedReviewOutputListDisplayFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useDelayedReviewOutputListDisplayFlag.test.ts
@@ -1,4 +1,4 @@
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 
 import { useDelayedReviewOutputListDisplayFlag } from '../useDelayedReviewOutputListDisplayFlag';
 
@@ -11,14 +11,14 @@ jest.mock('@suite-common/device', () => ({
 
 describe('useDelayedReviewOutputListDisplayFlag', () => {
     const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProviderAsync(() => useDelayedReviewOutputListDisplayFlag());
+        renderHookWithStoreProvider(() => useDelayedReviewOutputListDisplayFlag());
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('should became once there are any button requests', async () => {
-        const { result, rerender } = await renderUseRequestDelayedNavigationToOutputsReview();
+    it('should became once there are any button requests', () => {
+        const { result, rerender } = renderUseRequestDelayedNavigationToOutputsReview();
 
         expect(result.current).toBe(false);
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
@@ -3,7 +3,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
@@ -21,7 +21,7 @@ describe('useTradingOutputsReviewErrorAlert', () => {
     let store: TestStore;
 
     const renderUseTradingOutputsReviewErrorAlert = (accountKey: AccountKey) =>
-        renderHookWithStoreProviderAsync(() => useTradingOutputsReviewErrorAlert(accountKey), {
+        renderHookWithStoreProvider(() => useTradingOutputsReviewErrorAlert(accountKey), {
             store,
         });
 
@@ -30,10 +30,10 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         store = initStore({ wallet: getWalletState({ tradeType: 'exchange' }) }).store;
     });
 
-    it('should show alert', async () => {
+    it('should show alert', () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = await renderUseTradingOutputsReviewErrorAlert(
+        const { result } = renderUseTradingOutputsReviewErrorAlert(
             'btc-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 
@@ -56,10 +56,10 @@ describe('useTradingOutputsReviewErrorAlert', () => {
         });
     });
 
-    it('should show special text fort solana', async () => {
+    it('should show special text fort solana', () => {
         const mockOnRetry = jest.fn();
         const mockOnCancel = jest.fn();
-        const { result } = await renderUseTradingOutputsReviewErrorAlert(
+        const { result } = renderUseTradingOutputsReviewErrorAlert(
             'sol-account-1' as AccountKey, // Todo: create properly via `createAccountKey()`
         );
 

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { transactionManagementActions } from '@suite-native/transaction-management';
@@ -55,7 +55,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
     let store: TestStore;
 
     const renderUseTradingOutputsReviewScreenControls = () =>
-        renderHookWithStoreProviderAsync(
+        renderHookWithStoreProvider(
             () =>
                 useTradingOutputsReviewScreenControls({
                     orderId: 'orderId',
@@ -73,8 +73,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
         store = initStore({ wallet: getWalletState({ tradeType: 'exchange' }) }).store;
     });
 
-    it('should return confirmOnTrezorRef', async () => {
-        const { result } = await renderUseTradingOutputsReviewScreenControls();
+    it('should return confirmOnTrezorRef', () => {
+        const { result } = renderUseTradingOutputsReviewScreenControls();
 
         expect(result.current.confirmOnTrezorRef).toBe(
             mockUseConfirmOnTrezorController.confirmOnTrezorRef,
@@ -82,20 +82,20 @@ describe('useTradingOutputsReviewScreenControls', () => {
     });
 
     describe('without signed transaction', () => {
-        it('should call signAndSendTransaction on mount', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should call signAndSendTransaction on mount', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(1);
         });
 
-        it('should not call closeSheet', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should not call closeSheet', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockUseConfirmOnTrezorController.closeSheet).not.toHaveBeenCalled();
         });
 
-        it('should navigate to trade detail', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should navigate to trade detail', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -117,9 +117,9 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'continue');
         });
 
-        it('should navigate to trade detail and report sell analytics', async () => {
-            store = (await initStore({ wallet: getWalletState({ tradeType: 'sell' }) })).store;
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should navigate to trade detail and report sell analytics', () => {
+            store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -141,8 +141,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenLastCalledWith('sign-and-send', 'continue');
         });
 
-        it('should display alert on thunk error', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should display alert on thunk error', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -170,9 +170,9 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
         });
 
-        it('should offer pop and popToTop action on thunk error', async () => {
+        it('should offer pop and popToTop action on thunk error', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            await renderUseTradingOutputsReviewScreenControls();
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -227,22 +227,22 @@ describe('useTradingOutputsReviewScreenControls', () => {
             });
         });
 
-        it('should not call signAndSendTransaction', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should not call signAndSendTransaction', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).not.toHaveBeenCalled();
         });
 
-        it('should closeSheet', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should closeSheet', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             expect(mockUseConfirmOnTrezorController.closeSheet).toHaveBeenCalledTimes(1);
         });
     });
 
     describe('useOutputsReviewBackInterceptor', () => {
-        it('should be initialized with popToTop navigation callback and report cancel for exchange', async () => {
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should be initialized with popToTop navigation callback and report cancel for exchange', () => {
+            renderUseTradingOutputsReviewScreenControls();
 
             act(() => {
                 const onReviewCanceled = mockUseOutputsReviewBackInterceptor.mock.lastCall?.[0];
@@ -253,9 +253,9 @@ describe('useTradingOutputsReviewScreenControls', () => {
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'cancel');
         });
 
-        it('should report cancel for sell', async () => {
-            store = (await initStore({ wallet: getWalletState({ tradeType: 'sell' }) })).store;
-            await renderUseTradingOutputsReviewScreenControls();
+        it('should report cancel for sell', () => {
+            store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
+            renderUseTradingOutputsReviewScreenControls();
 
             act(() => {
                 const onReviewCanceled = mockUseOutputsReviewBackInterceptor.mock.lastCall?.[0];
@@ -267,8 +267,8 @@ describe('useTradingOutputsReviewScreenControls', () => {
         });
     });
 
-    it('should report visit to analytics on mount for exchange', async () => {
-        await renderUseTradingOutputsReviewScreenControls();
+    it('should report visit to analytics on mount for exchange', () => {
+        renderUseTradingOutputsReviewScreenControls();
 
         expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'visit');
     });

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
@@ -5,7 +5,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getBtcAccount, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
@@ -37,14 +37,22 @@ describe('useSellData', () => {
         return initStore(preloadedState).store;
     };
 
-    const renderUseSellData = (reloadRequestOrdinalInitialValue: number = 0, store?: TestStore) =>
-        renderHookWithStoreProviderAsync(
+    const renderUseSellData = async (
+        reloadRequestOrdinalInitialValue: number = 0,
+        store?: TestStore,
+    ) => {
+        const ret = renderHookWithStoreProvider(
             ({ reloadRequestOrdinal }) => useSellData(reloadRequestOrdinal),
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store,
             },
         );
+
+        await act(() => Promise.resolve()); // Wait for all effects to run
+
+        return ret;
+    };
 
     beforeEach(() => {
         jest.resetAllMocks();
@@ -113,7 +121,7 @@ describe('useSellData', () => {
         });
 
         it('should dispatch loadInitialDataThunk when account is changed with descriptor', async () => {
-            const store = await getInitializedStore(undefined);
+            const store = getInitializedStore(undefined);
             await renderUseSellData(0, store);
 
             // Clear the initial call
@@ -135,7 +143,7 @@ describe('useSellData', () => {
         });
 
         it('should not dispatch loadInitialDataThunk when descriptor is not changed', async () => {
-            const store = await getInitializedStore(btc2AccountKey);
+            const store = getInitializedStore(btc2AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call
@@ -154,7 +162,7 @@ describe('useSellData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is empty string', async () => {
-            const store = await getInitializedStore(btc1AccountKey);
+            const store = getInitializedStore(btc1AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call
@@ -177,7 +185,7 @@ describe('useSellData', () => {
         });
 
         it('should dispatch loadInitialDataThunk with random string when descriptor is undefined', async () => {
-            const store = await getInitializedStore(btc1AccountKey);
+            const store = getInitializedStore(btc1AccountKey);
             await renderUseSellData(0, store);
 
             // Clear the initial call

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -7,7 +7,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { bankAccounts, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 
@@ -69,8 +69,7 @@ const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly v
 describe('useSellFlow', () => {
     let store: TestStore;
 
-    const renderUseSellFlow = () =>
-        renderHookWithStoreProviderAsync(() => useSellFlow(), { store });
+    const renderUseSellFlow = () => renderHookWithStoreProvider(() => useSellFlow(), { store });
 
     beforeEach(() => {
         store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
@@ -92,7 +91,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -123,7 +122,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -147,7 +146,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);
@@ -175,7 +174,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -206,7 +205,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -230,7 +229,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.setTradingAccountKey(undefined));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.confirmTrade(bankAccount);
@@ -254,7 +253,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -277,7 +276,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -301,7 +300,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -322,7 +321,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(undefined));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doBankAccountVerificationCheck();
@@ -345,7 +344,7 @@ describe('useSellFlow', () => {
                 store.dispatch(tradingSellActions.saveSelectedQuote(trade));
             });
 
-            const { result } = await renderUseSellFlow();
+            const { result } = renderUseSellFlow();
 
             await act(async () => {
                 await result.current.doSellTrade(trade);

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
@@ -1,8 +1,5 @@
 import { Form } from '@suite-native/forms';
-import {
-    renderHookWithBasicProvider,
-    renderHookWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { renderHookWithBasicProvider, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { type SellFormType } from '@suite-native/trading-types';
 
 import { useSellForm } from '../useSellForm';
@@ -11,15 +8,15 @@ import { useSellInputFormControls } from '../useSellInputFormControls';
 describe('useSellInputFormControls', () => {
     let form: SellFormType;
 
-    const renderSellFormHook = () => renderHookWithStoreProviderAsync(() => useSellForm());
+    const renderSellFormHook = () => renderHookWithStoreProvider(() => useSellForm());
 
     const renderUseSellInputFormControls = () =>
         renderHookWithBasicProvider(() => useSellInputFormControls('fiatStringAmount'), {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
-    beforeEach(async () => {
-        const { result } = await renderSellFormHook();
+    beforeEach(() => {
+        const { result } = renderSellFormHook();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -4,7 +4,7 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 import { getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -23,37 +23,37 @@ describe('useSellSelectQuote', () => {
     let store: TestStore;
     let sellForm: SellFormType;
 
-    const renderSellForm = () => renderHookWithStoreProviderAsync(() => useSellForm(), { store });
+    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
 
     const renderUseSellSelectQuote = () =>
-        renderHookWithStoreProviderAsync(() => useSellSelectQuote(sellForm), { store });
+        renderHookWithStoreProvider(() => useSellSelectQuote(sellForm), { store });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         store = initStore({ wallet: getWalletState({ tradeType: 'sell' }) }).store;
 
-        const { result } = await renderSellForm();
+        const { result } = renderSellForm();
         sellForm = result.current;
     });
 
     describe('canProceed', () => {
-        it('should be false when no quote is selected in form', async () => {
-            const { result } = await renderUseSellSelectQuote();
+        it('should be false when no quote is selected in form', () => {
+            const { result } = renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(false);
         });
 
-        it('should be false when quotes are being fetched', async () => {
+        it('should be false when quotes are being fetched', () => {
             act(() => {
                 sellForm.setValue('quote', sellQuotes[0]);
                 store.dispatch(tradingSellActions.setIsLoading(true));
             });
 
-            const { result } = await renderUseSellSelectQuote();
+            const { result } = renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(false);
         });
 
-        it('should be false when form contains error', async () => {
+        it('should be false when form contains error', () => {
             act(() => {
                 store.dispatch(
                     tradingSellActions.setTradingAccountKey(
@@ -67,12 +67,12 @@ describe('useSellSelectQuote', () => {
                 });
             });
 
-            const { result } = await renderUseSellSelectQuote();
+            const { result } = renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(false);
         });
 
-        it('should be true when quote is selected', async () => {
+        it('should be true when quote is selected', () => {
             act(() => {
                 sellForm.setValue('quote', sellQuotes[0]);
                 store.dispatch(
@@ -82,7 +82,7 @@ describe('useSellSelectQuote', () => {
                 );
             });
 
-            const { result } = await renderUseSellSelectQuote();
+            const { result } = renderUseSellSelectQuote();
 
             expect(result.current.canProceed).toEqual(true);
         });

--- a/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
+++ b/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
@@ -2,18 +2,18 @@ import {
     type TestStore,
     act,
     initStore,
-    renderHookWithStoreProviderAsync,
+    renderHookWithStoreProvider,
 } from '@suite-native/test-utils';
 
 import { useMaxSlippageForm } from '../useMaxSlippageForm';
 
 describe('useMaxSlippageForm', () => {
     const renderUseMaxSlippageForm = (store: TestStore) =>
-        renderHookWithStoreProviderAsync(() => useMaxSlippageForm(), { store });
+        renderHookWithStoreProvider(() => useMaxSlippageForm(), { store });
 
-    it('should have default value from store', async () => {
+    it('should have default value from store', () => {
         const { store } = initStore();
-        const { result } = await renderUseMaxSlippageForm(store);
+        const { result } = renderUseMaxSlippageForm(store);
 
         expect(result.current.getValues()).toEqual({
             maxSlippage: '1',
@@ -24,7 +24,7 @@ describe('useMaxSlippageForm', () => {
         'should error validation for value %s',
         async slippage => {
             const { store } = initStore();
-            const { result } = await renderUseMaxSlippageForm(store);
+            const { result } = renderUseMaxSlippageForm(store);
 
             await act(async () => {
                 result.current.setValue('maxSlippage', slippage, { shouldValidate: true });
@@ -38,9 +38,9 @@ describe('useMaxSlippageForm', () => {
         },
     );
 
-    it.each(['0.01', '1', '12.34', '50'])('should pass validation for value %s', async slippage => {
+    it.each(['0.01', '1', '12.34', '50'])('should pass validation for value %s', slippage => {
         const { store } = initStore();
-        const { result } = await renderUseMaxSlippageForm(store);
+        const { result } = renderUseMaxSlippageForm(store);
 
         act(() => {
             result.current.setValue('maxSlippage', slippage, { shouldValidate: true });

--- a/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.test.tsx
+++ b/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.test.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 
 import { TradingStackNavigator } from '../TradingStackNavigator';
 
@@ -12,8 +12,8 @@ jest.mock('../../hooks/buy/useBuyData', () => ({
 }));
 
 describe('TradingStackNavigator', () => {
-    it('should render', async () => {
-        const { getByTestId } = await renderWithStoreProviderAsync(<TradingStackNavigator />, {
+    it('should render', () => {
+        const { getByTestId } = renderWithStoreProvider(<TradingStackNavigator />, {
             preloadedState: {
                 featureFlags: {
                     ...featureFlagsInitialState,

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -7,7 +7,7 @@ import {
     type TestStore,
     fireEvent,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
 } from '@suite-native/test-utils';
 import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
@@ -58,8 +58,8 @@ describe('TradingExchangeApprovalScreen', () => {
     let store: TestStore;
     let unmount: (() => void) | undefined;
 
-    const renderScreen = async () => {
-        const result = await renderWithStoreProviderAsync(
+    const renderScreen = () => {
+        const result = renderWithStoreProvider(
             <TradingExchangeApprovalScreen route={{ params: {} } as any} navigation={{} as any} />,
             { store },
         );
@@ -94,27 +94,27 @@ describe('TradingExchangeApprovalScreen', () => {
         }
     });
 
-    it('should render the approval screen with quote details', async () => {
-        const { getByText } = await renderScreen();
+    it('should render the approval screen with quote details', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Ethereum #1')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should show network information when network symbol is available', async () => {
-        const { getByText } = await renderScreen();
+    it('should show network information when network symbol is available', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Ethereum')).toBeOnTheScreen();
     });
 
-    it('should display provider information correctly', async () => {
-        const { getByText } = await renderScreen();
+    it('should display provider information correctly', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
     it('should open bottom sheet when limit row is pressed', async () => {
-        const { findByText } = await renderScreen();
+        const { findByText } = renderScreen();
 
         const pressableElement = await findByText('Limit');
 
@@ -122,25 +122,25 @@ describe('TradingExchangeApprovalScreen', () => {
         expect(mockShowSheet).toHaveBeenCalledTimes(1);
     });
 
-    it('should render continue button', async () => {
-        const { getByText } = await renderScreen();
+    it('should render continue button', () => {
+        const { getByText } = renderScreen();
 
         const buttons = getByText('Continue');
         expect(buttons).toBeTruthy();
     });
 
-    it('should render nothing when no quote is provided', async () => {
+    it('should render nothing when no quote is provided', () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
         store.dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
 
-        const { toJSON } = await renderScreen();
+        const { toJSON } = renderScreen();
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should clear selected quote on unmount', async () => {
+    it('should clear selected quote on unmount', () => {
         store.dispatch(tradingExchangeActions.saveSelectedQuote(testQuote));
-        const { unmount: localUnmount } = await renderScreen();
+        const { unmount: localUnmount } = renderScreen();
 
         localUnmount();
         unmount = undefined;

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -13,7 +13,7 @@ import {
     type PreloadedState,
     type TestStore,
     initStore,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     userEvent,
     waitFor,
 } from '@suite-native/test-utils';
@@ -126,7 +126,7 @@ describe('TradingExchangePreviewScreen', () => {
     let consoleErrorSpy: jest.SpyInstance;
     let unmount: (() => void) | undefined;
 
-    const renderTradingExchangePreviewScreen = async (
+    const renderTradingExchangePreviewScreen = (
         isApproved: boolean = false,
         customStore?: TestStore,
     ) => {
@@ -137,7 +137,7 @@ describe('TradingExchangePreviewScreen', () => {
             report: reportMock,
         });
 
-        const result = await renderWithStoreProviderAsync(
+        const result = renderWithStoreProvider(
             <TradingExchangePreviewScreen
                 navigation={createNavigationProps()}
                 route={createRouteProps(isApproved)}
@@ -169,35 +169,35 @@ describe('TradingExchangePreviewScreen', () => {
         }
     });
 
-    it('should display device guard when device is not connected', async () => {
+    it('should display device guard when device is not connected', () => {
         mockIsDeviceConnected = false;
-        const { result } = await renderTradingExchangePreviewScreen();
+        const { result } = renderTradingExchangePreviewScreen();
         expect(
             result.getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
         ).toBeOnTheScreen();
     });
 
-    it('should render continue button', async () => {
-        const { result } = await renderTradingExchangePreviewScreen();
+    it('should render continue button', () => {
+        const { result } = renderTradingExchangePreviewScreen();
 
         expect(result.getByText('Continue')).toBeOnTheScreen();
     });
 
-    it('should render screen title correctly', async () => {
-        const { result } = await renderTradingExchangePreviewScreen();
+    it('should render screen title correctly', () => {
+        const { result } = renderTradingExchangePreviewScreen();
 
         expect(result.getByText('Swap')).toBeOnTheScreen();
     });
 
-    it('should render from and to account labels', async () => {
-        const { result } = await renderTradingExchangePreviewScreen();
+    it('should render from and to account labels', () => {
+        const { result } = renderTradingExchangePreviewScreen();
 
         expect(result.getByText('From')).toBeOnTheScreen();
         expect(result.getByText('To')).toBeOnTheScreen();
     });
 
-    it('should render transaction details section', async () => {
-        const { result } = await renderTradingExchangePreviewScreen();
+    it('should render transaction details section', () => {
+        const { result } = renderTradingExchangePreviewScreen();
 
         expect(result.getByText('Transaction details')).toBeOnTheScreen();
         expect(result.getByText('Fee')).toBeOnTheScreen();
@@ -207,7 +207,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should show error alert when trade confirmation errors', async () => {
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
 
-            await renderTradingExchangePreviewScreen();
+            renderTradingExchangePreviewScreen();
 
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalledTimes(1);
@@ -223,7 +223,7 @@ describe('TradingExchangePreviewScreen', () => {
                 .mockRejectedValueOnce(new Error('Trade confirmation failed'))
                 .mockResolvedValueOnce(true);
 
-            const { reportMock } = await renderTradingExchangePreviewScreen();
+            const { reportMock } = renderTradingExchangePreviewScreen();
 
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalled();
@@ -247,7 +247,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should navigate to top when cancel button is pressed', async () => {
             mockConfirmTrade.mockRejectedValueOnce(new Error('Trade confirmation failed'));
 
-            const { reportMock } = await renderTradingExchangePreviewScreen();
+            const { reportMock } = renderTradingExchangePreviewScreen();
 
             await waitFor(() => {
                 expect(mockShowAlert).toHaveBeenCalled();
@@ -271,7 +271,7 @@ describe('TradingExchangePreviewScreen', () => {
         it('should not show error alert when trade confirmation succeeds', async () => {
             mockConfirmTrade.mockResolvedValue(true);
 
-            await renderTradingExchangePreviewScreen();
+            renderTradingExchangePreviewScreen();
 
             await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -279,8 +279,8 @@ describe('TradingExchangePreviewScreen', () => {
         });
     });
 
-    it('should report to analytics on mount', async () => {
-        const { reportMock } = await renderTradingExchangePreviewScreen();
+    it('should report to analytics on mount', () => {
+        const { reportMock } = renderTradingExchangePreviewScreen();
 
         expect(reportMock).toHaveBeenCalledTimes(1);
         expect(reportMock).toHaveBeenCalledWith({
@@ -293,7 +293,7 @@ describe('TradingExchangePreviewScreen', () => {
     });
 
     it('should report to analytics on Continue press', async () => {
-        const { result, reportMock } = await renderTradingExchangePreviewScreen();
+        const { result, reportMock } = renderTradingExchangePreviewScreen();
         reportMock.mockClear();
 
         await userEvent.press(result.getByText('Continue'));
@@ -309,15 +309,15 @@ describe('TradingExchangePreviewScreen', () => {
     });
 
     describe('Error String Fallback Logic', () => {
-        it('should use txnErrorString when provided', async () => {
+        it('should use txnErrorString when provided', () => {
             mockTxnErrorString = 'Transaction error occurred';
 
-            const { result } = await renderTradingExchangePreviewScreen();
+            const { result } = renderTradingExchangePreviewScreen();
 
             expect(result.getByText('Transaction error occurred')).toBeOnTheScreen();
         });
 
-        it('should fall back to quote.error when txnErrorString is null', async () => {
+        it('should fall back to quote.error when txnErrorString is null', () => {
             mockTxnErrorString = null;
 
             const quoteWithError = {
@@ -327,12 +327,12 @@ describe('TradingExchangePreviewScreen', () => {
 
             const preloadedState = createPreloadedState(quoteWithError);
             const testStore = initStore(preloadedState).store;
-            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.getByText('Quote error message')).toBeOnTheScreen();
         });
 
-        it('should not show error when both txnErrorString and quote.error are null', async () => {
+        it('should not show error when both txnErrorString and quote.error are null', () => {
             mockTxnErrorString = null;
 
             const quoteWithoutError = {
@@ -342,13 +342,13 @@ describe('TradingExchangePreviewScreen', () => {
 
             const preloadedState = createPreloadedState(quoteWithoutError);
             const testStore = initStore(preloadedState).store;
-            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.queryByText('Transaction error occurred')).toBeNull();
             expect(result.queryByText('Quote error message')).toBeNull();
         });
 
-        it('should prioritize txnErrorString over quote.error', async () => {
+        it('should prioritize txnErrorString over quote.error', () => {
             mockTxnErrorString = 'Transaction error takes priority';
 
             const quoteWithError = {
@@ -358,7 +358,7 @@ describe('TradingExchangePreviewScreen', () => {
 
             const preloadedState = createPreloadedState(quoteWithError);
             const testStore = initStore(preloadedState).store;
-            const { result } = await renderTradingExchangePreviewScreen(false, testStore);
+            const { result } = renderTradingExchangePreviewScreen(false, testStore);
 
             expect(result.getByText('Transaction error takes priority')).toBeOnTheScreen();
             expect(result.queryByText('Quote error message')).toBeNull();

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -209,9 +209,12 @@ describe('TradingExchangePreviewScreen', () => {
 
             renderTradingExchangePreviewScreen();
 
-            await waitFor(() => {
-                expect(mockShowAlert).toHaveBeenCalledTimes(1);
-            });
+            await waitFor(
+                () => {
+                    expect(mockShowAlert).toHaveBeenCalledTimes(1);
+                },
+                { timeout: 30_000 },
+            );
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 'Failed to confirm trade',
                 new Error('Trade confirmation failed'),

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
@@ -1,7 +1,7 @@
 import { type RouteProp } from '@react-navigation/native';
 
 import { type TradingStackParamList, type TradingStackRoutes } from '@suite-native/navigation';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     accounts,
     exchangeQuotes,
@@ -37,8 +37,8 @@ const preloadedState = {
 describe('TradingExchangeRevokeScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderScreen = async () => {
-        const result = await renderWithStoreProviderAsync(
+    const renderScreen = () => {
+        const result = renderWithStoreProvider(
             <TradingExchangeRevokeScreen
                 route={
                     { params: { quote: testQuote } } as RouteProp<
@@ -65,28 +65,28 @@ describe('TradingExchangeRevokeScreen', () => {
         }
     });
 
-    it('should render the revoke screen with quote details', async () => {
-        const { getByText } = await renderScreen();
+    it('should render the revoke screen with quote details', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('BTC Account #1')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
         expect(getByText('$4.76')).toBeOnTheScreen(); // Fixed fee TODO value
     });
 
-    it('should show network information when network symbol is available', async () => {
-        const { getByText } = await renderScreen();
+    it('should show network information when network symbol is available', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Ethereum')).toBeOnTheScreen();
     });
 
-    it('should display provider information correctly', async () => {
-        const { getByText } = await renderScreen();
+    it('should display provider information correctly', () => {
+        const { getByText } = renderScreen();
 
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should show current limit and new limit with crypto icon', async () => {
-        const { getByText, getAllByText } = await renderScreen();
+    it('should show current limit and new limit with crypto icon', () => {
+        const { getByText, getAllByText } = renderScreen();
 
         expect(getByText('Current limit')).toBeOnTheScreen();
         expect(getByText('New limit')).toBeOnTheScreen();
@@ -94,15 +94,15 @@ describe('TradingExchangeRevokeScreen', () => {
         expect(usdcElements).toHaveLength(2);
     });
 
-    it('should render continue button', async () => {
-        const { getByText } = await renderScreen();
+    it('should render continue button', () => {
+        const { getByText } = renderScreen();
 
         const buttons = getByText('Continue');
         expect(buttons).toBeTruthy();
     });
 
-    it('should display warning alert about revoking permissions', async () => {
-        const { getByText } = await renderScreen();
+    it('should display warning alert about revoking permissions', () => {
+        const { getByText } = renderScreen();
 
         expect(
             getByText(

--- a/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingFeesScreen.test.tsx
@@ -1,6 +1,6 @@
 import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
-import { renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
     accounts,
     btc1NormalAccount,
@@ -52,7 +52,7 @@ const preloadedState = {
 describe('TradingFeesScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderScreen = async (state = preloadedState) => {
+    const renderScreen = (state = preloadedState) => {
         const reportMock = jest.fn();
         jest.clearAllMocks();
 
@@ -60,7 +60,7 @@ describe('TradingFeesScreen', () => {
             report: reportMock,
         });
 
-        const result = await renderWithStoreProviderAsync(<TradingFeesScreen />, {
+        const result = renderWithStoreProvider(<TradingFeesScreen />, {
             preloadedState: state,
         });
 
@@ -83,40 +83,40 @@ describe('TradingFeesScreen', () => {
         }
     });
 
-    it('should render the screen without crashing', async () => {
-        const { result } = await renderScreen();
+    it('should render the screen without crashing', () => {
+        const { result } = renderScreen();
 
         expect(result.root).toBeTruthy();
     });
 
-    it('should render TradingFeesForm with correct accountKey', async () => {
-        await renderScreen();
+    it('should render TradingFeesForm with correct accountKey', () => {
+        renderScreen();
 
         expect(mockTradingFeesForm).toHaveBeenCalledWith({
             accountKey: btc1NormalAccount.key,
         });
     });
 
-    it('should call useSubscribeForSolanaBlockUpdates with the account', async () => {
-        await renderScreen();
+    it('should call useSubscribeForSolanaBlockUpdates with the account', () => {
+        renderScreen();
 
         expect(mockUseSubscribeForSolanaBlockUpdates).toHaveBeenCalled();
     });
 
-    it('should not render anything when account is not found', async () => {
+    it('should not render anything when account is not found', () => {
         mockUseRoute.mockReturnValue({
             name: 'TradingFeesScreen',
             params: { accountKey: 'nonexistent-account' },
         });
 
-        const { result } = await renderScreen();
+        const { result } = renderScreen();
 
         expect(result.queryByTestId('trading-fees-form')).not.toBeOnTheScreen();
         expect(mockTradingFeesForm).not.toHaveBeenCalled();
     });
 
-    it('should report to analytics on mount for exchange (default)', async () => {
-        const { reportMock } = await renderScreen();
+    it('should report to analytics on mount for exchange (default)', () => {
+        const { reportMock } = renderScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingExchangeEvent.name,
@@ -127,13 +127,13 @@ describe('TradingFeesScreen', () => {
         });
     });
 
-    it('should report to analytics on mount for exchange when explicitly set', async () => {
+    it('should report to analytics on mount for exchange when explicitly set', () => {
         mockUseRoute.mockReturnValue({
             name: 'TradingFeesScreen',
             params: { accountKey: btc1NormalAccount.key, tradingType: 'exchange' },
         });
 
-        const { reportMock } = await renderScreen();
+        const { reportMock } = renderScreen();
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingExchangeEvent.name,
@@ -144,7 +144,7 @@ describe('TradingFeesScreen', () => {
         });
     });
 
-    it('should report to analytics on mount for sell', async () => {
+    it('should report to analytics on mount for sell', () => {
         const sellPreloadedState = {
             wallet: {
                 trading: getInitializedTradingState('sell'),
@@ -156,7 +156,7 @@ describe('TradingFeesScreen', () => {
             params: { accountKey: btc1NormalAccount.key, tradingType: 'sell' },
         });
 
-        const { reportMock } = await renderScreen(sellPreloadedState);
+        const { reportMock } = renderScreen(sellPreloadedState);
 
         expect(reportMock).toHaveBeenCalledWith({
             type: events.tradingSellEvent.name,

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.test.tsx
@@ -1,11 +1,7 @@
 import { type RouteProp } from '@react-navigation/native';
 
 import { type TradingStackParamList, type TradingStackRoutes } from '@suite-native/navigation';
-import {
-    type PreloadedState,
-    fireEvent,
-    renderWithStoreProviderAsync,
-} from '@suite-native/test-utils';
+import { type PreloadedState, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils';
 import { accounts, getBuyTrade, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { TradingHistoryScreen } from '../TradingHistoryScreen';
@@ -59,8 +55,8 @@ const getPreloadedState = (): PreloadedState => ({
 describe('TradingHistoryScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderScreen = async (preloadedState: PreloadedState) => {
-        const result = await renderWithStoreProviderAsync(<TradingHistoryScreen />, {
+    const renderScreen = (preloadedState: PreloadedState) => {
+        const result = renderWithStoreProvider(<TradingHistoryScreen />, {
             preloadedState,
         });
 
@@ -79,16 +75,16 @@ describe('TradingHistoryScreen', () => {
         }
     });
 
-    it('should render list of trades', async () => {
-        const { getByText } = await renderScreen(getPreloadedState());
+    it('should render list of trades', () => {
+        const { getByText } = renderScreen(getPreloadedState());
 
         expect(getByText('Mercuryo')).toBeTruthy();
         expect(getByText('$1,234.00')).toBeTruthy();
         expect(getByText('0.462586 ETH')).toBeTruthy();
     });
 
-    it('should show bottom sheet when trade item is clicked', async () => {
-        const { getByText, queryAllByText } = await renderScreen(getPreloadedState());
+    it('should show bottom sheet when trade item is clicked', () => {
+        const { getByText, queryAllByText } = renderScreen(getPreloadedState());
 
         fireEvent.press(getByText('Trans. ID: d3ef3451-8f68-4250-9e08-580ece5e7d12'));
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.test.tsx
@@ -6,7 +6,7 @@ import type {
     TradingStackParamList,
     TradingStackRoutes,
 } from '@suite-native/navigation';
-import { type TestStore, initStore, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type TestStore, initStore, renderWithStoreProvider } from '@suite-native/test-utils';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
 import {
@@ -128,13 +128,13 @@ describe('TradingSellOutputsReviewScreen', () => {
     });
 
     describe('TradingSellOutputsReviewScreen', () => {
-        const renderScreen = async (
+        const renderScreen = (
             route: StackProps<
                 TradingStackParamList,
                 TradingStackRoutes.TradingSellOutputsReview
             >['route'],
         ) => {
-            const result = await renderWithStoreProviderAsync(
+            const result = renderWithStoreProvider(
                 <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
                 { store },
             );
@@ -152,11 +152,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             mockNavigation.popToTop.mockClear();
         });
 
-        it('should render TradingSellOutputsReviewScreen', async () => {
+        it('should render TradingSellOutputsReviewScreen', () => {
             const params = createSellRouteParams();
             const route = createSellRoute(params);
 
-            const { toJSON } = await renderScreen(route);
+            const { toJSON } = renderScreen(route);
 
             expect(toJSON()).not.toBeNull();
             expect(mockUseSellFlowFn).toHaveBeenCalled();
@@ -171,13 +171,13 @@ describe('TradingSellOutputsReviewScreen', () => {
     });
 
     describe('TradingExchangeOutputsReviewScreen', () => {
-        const renderScreen = async (
+        const renderScreen = (
             route: StackProps<
                 TradingStackParamList,
                 TradingStackRoutes.TradingExchangeOutputsReview
             >['route'],
         ) => {
-            const result = await renderWithStoreProviderAsync(
+            const result = renderWithStoreProvider(
                 <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
                 { store },
             );
@@ -195,11 +195,11 @@ describe('TradingSellOutputsReviewScreen', () => {
             mockNavigation.popToTop.mockClear();
         });
 
-        it('should render TradingExchangeOutputsReviewScreen', async () => {
+        it('should render TradingExchangeOutputsReviewScreen', () => {
             const params = createExchangeRouteParams();
             const route = createExchangeRoute(params);
 
-            const { toJSON } = await renderScreen(route);
+            const { toJSON } = renderScreen(route);
 
             expect(toJSON()).not.toBeNull();
             expect(mockUseExchangeFlowFn).toHaveBeenCalled();

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
@@ -3,7 +3,7 @@ import { type RouteProp } from '@react-navigation/native';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { type TradingStackParamList, type TradingStackRoutes } from '@suite-native/navigation';
-import { type PreloadedState, renderWithStoreProviderAsync } from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import { accounts, getInitializedTradingState } from '@suite-native/trading-fixtures';
 
 import { TradingReceiveAccountsPickerScreen } from '../TradingReceiveAccountsPickerScreen';
@@ -43,8 +43,8 @@ const getPreloadedState = (preloadedAccounts: Account[]): PreloadedState => ({
 describe('TradingReceiveAccountsPickerScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderScreen = async (preloadedState: PreloadedState) => {
-        const result = await renderWithStoreProviderAsync(<TradingReceiveAccountsPickerScreen />, {
+    const renderScreen = (preloadedState: PreloadedState) => {
+        const result = renderWithStoreProvider(<TradingReceiveAccountsPickerScreen />, {
             preloadedState,
         });
 
@@ -60,42 +60,42 @@ describe('TradingReceiveAccountsPickerScreen', () => {
         }
     });
 
-    it('should render account list with correct title', async () => {
+    it('should render account list with correct title', () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = await renderScreen(getPreloadedState([]));
+        const { getByText } = renderScreen(getPreloadedState([]));
 
         expect(getByText('Select account')).toBeTruthy();
     });
 
-    it('should render account list with accounts', async () => {
+    it('should render account list with accounts', () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = await renderScreen(getPreloadedState(accounts));
+        const { getByText } = renderScreen(getPreloadedState(accounts));
 
         expect(getByText(accounts[0].accountLabel!)).toBeTruthy();
     });
 
-    it('should render account list with accounts for exchange', async () => {
+    it('should render account list with accounts for exchange', () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'exchange' };
 
-        const { getByText } = await renderScreen(getPreloadedState(accounts));
+        const { getByText } = renderScreen(getPreloadedState(accounts));
 
         expect(getByText(accounts[0].accountLabel!)).toBeTruthy();
     });
 
-    it('should render empty state when no account exist', async () => {
+    it('should render empty state when no account exist', () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = await renderScreen(getPreloadedState([]));
+        const { getByText } = renderScreen(getPreloadedState([]));
 
         expect(getByText('Account not found')).toBeTruthy();
     });
 
-    it('should render add account button', async () => {
+    it('should render add account button', () => {
         mockRouteParams = { symbol: 'btc', tradingType: 'buy' };
 
-        const { getByText } = await renderScreen(getPreloadedState([]));
+        const { getByText } = renderScreen(getPreloadedState([]));
 
         expect(getByText('Add new')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
@@ -1,9 +1,5 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
-import {
-    type PreloadedState,
-    renderWithStoreProviderAsync,
-    screen,
-} from '@suite-native/test-utils';
+import { type PreloadedState, renderWithStoreProvider, screen } from '@suite-native/test-utils';
 
 import { TradingScreen } from '../TradingScreen';
 
@@ -95,8 +91,8 @@ const stateWithDisabledTrading = {
 describe('TradingScreen', () => {
     let unmount: (() => void) | undefined;
 
-    const renderTradingScreen = async (preloadedState?: PreloadedState) => {
-        const result = await renderWithStoreProviderAsync(<TradingScreen />, { preloadedState });
+    const renderTradingScreen = (preloadedState?: PreloadedState) => {
+        const result = renderWithStoreProvider(<TradingScreen />, { preloadedState });
 
         ({ unmount } = result);
 
@@ -114,14 +110,14 @@ describe('TradingScreen', () => {
         expect(screen.getByText('You pay')).toBeOnTheScreen();
     };
 
-    it('should render nothing when trading feature flag is not enabled', async () => {
-        const { toJSON } = await renderTradingScreen(stateWithDisabledTrading);
+    it('should render nothing when trading feature flag is not enabled', () => {
+        const { toJSON } = renderTradingScreen(stateWithDisabledTrading);
 
         expect(toJSON()).toBeNull();
     });
 
-    it('should render Buy form by default', async () => {
-        await renderTradingScreen(stateWithEnabledBuy);
+    it('should render Buy form by default', () => {
+        renderTradingScreen(stateWithEnabledBuy);
 
         expectBuyForm();
     });

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
@@ -3,7 +3,7 @@ import { getTranslation } from '@suite-native/intl';
 import {
     type PreloadedState,
     act,
-    renderWithStoreProviderAsync,
+    renderWithStoreProvider,
     waitFor,
 } from '@suite-native/test-utils';
 import { getSellTrade, getWalletState, sellQuotes } from '@suite-native/trading-fixtures';
@@ -55,7 +55,7 @@ describe('TradingSellPreviewScreen', () => {
     let unmount: (() => void) | undefined;
 
     const renderTradingSellPreviewScreen = async (preloadedState?: PreloadedState) => {
-        const result = await renderWithStoreProviderAsync(<TradingSellPreviewScreen />, {
+        const result = renderWithStoreProvider(<TradingSellPreviewScreen />, {
             preloadedState,
         });
 

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -1,7 +1,7 @@
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { type TradingAssetOption } from '@suite-common/trading';
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     btcAsset,
     buyQuotes,
@@ -17,12 +17,12 @@ describe('quotesUtils', () => {
     let form: BuyFormType;
 
     const renderUseTradingBuyForm = () =>
-        renderHookWithStoreProviderAsync(() => useBuyForm(), {
+        renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: { wallet: { trading: getInitializedTradingState() } },
         });
 
-    beforeEach(async () => {
-        const { result } = await renderUseTradingBuyForm();
+    beforeEach(() => {
+        const { result } = renderUseTradingBuyForm();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -4,7 +4,7 @@ import type { CryptoId } from 'invity-api';
 
 import { type MinimalExchangeFormProps } from '@suite-common/trading';
 import type { TokenAddress } from '@suite-common/wallet-types';
-import { renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { renderHookWithStoreProvider } from '@suite-native/test-utils';
 import {
     btcAsset,
     ethAsset,
@@ -22,12 +22,12 @@ describe('quotesUtils', () => {
     let form: ExchangeFormType;
 
     const renderUseTradingBuyForm = () =>
-        renderHookWithStoreProviderAsync(() => useExchangeForm(), {
+        renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState: { wallet: { trading: getInitializedTradingState() } },
         });
 
-    beforeEach(async () => {
-        const { result } = await renderUseTradingBuyForm();
+    beforeEach(() => {
+        const { result } = renderUseTradingBuyForm();
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
+++ b/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
@@ -1,7 +1,7 @@
 import { type CryptoId } from 'invity-api';
 
 import { type MinimalSellFormProps } from '@suite-common/trading';
-import { act, renderHookWithStoreProviderAsync } from '@suite-native/test-utils';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils';
 import { btcAsset, getWalletState } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 
@@ -12,12 +12,12 @@ describe('quoteUtils', () => {
     let form: SellFormType;
 
     const renderUseTradingSellForm = () =>
-        renderHookWithStoreProviderAsync(() => useSellForm(), {
+        renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
         });
 
-    beforeEach(async () => {
-        const { result } = await renderUseTradingSellForm();
+    beforeEach(() => {
+        const { result } = renderUseTradingSellForm();
         form = result.current;
     });
 

--- a/suite-native/test-utils/src/renderWithStore.tsx
+++ b/suite-native/test-utils/src/renderWithStore.tsx
@@ -5,7 +5,6 @@ import {
     type RenderOptions,
     render,
     renderHook,
-    waitFor,
 } from '@testing-library/react-native';
 
 import type { PreloadedState } from '@suite-native/state';
@@ -35,20 +34,6 @@ export const renderWithStoreProvider = <Props,>(
         ...options,
     });
 
-/**
- * @deprecated Use renderWithStoreProvider instead
- */
-export const renderWithStoreProviderAsync = async <Props,>(
-    element: ReactElement<Props>,
-    options?: RenderOptionsExtended,
-) => {
-    const ret = renderWithStoreProvider(element, options);
-    // There is no need to wait anymore, but keep the async logic here to maintain async behavior.
-    await waitFor(() => expect(true).toBeTruthy());
-
-    return ret;
-};
-
 export const renderHookWithStoreProvider = <Result, Props>(
     callback: (props: Props) => Result,
     { preloadedState, wrapper: Wrapper, store, ...options }: RenderHookOptionsExtended<Props> = {},
@@ -61,17 +46,3 @@ export const renderHookWithStoreProvider = <Result, Props>(
         ),
         ...options,
     });
-
-/**
- * @deprecated Use renderHookWithStoreProvider instead
- */
-export const renderHookWithStoreProviderAsync = async <Result, Props>(
-    callback: (props: Props) => Result,
-    options?: RenderHookOptionsExtended<Props>,
-) => {
-    const ret = renderHookWithStoreProvider(callback, options);
-    // There is no need to wait anymore, but keep the async logic here to maintain async behavior.
-    await waitFor(() => expect(ret.result.current).not.toBeNull());
-
-    return ret;
-};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove deprecated test functions `renderWithStoreAsync` and `renderHookWithStoreAsync`.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native-renderWithStoreAsync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->