### PR TITLE
Validate yield.xyz api tx data

### DIFF
--- a/suite-common/calldata/README.md
+++ b/suite-common/calldata/README.md
@@ -2,21 +2,22 @@
 
 ## Overview
 
-Type-safe calldata builder for blockchain transactions. Validates inputs, normalizes values, applies configurable policies (error/warning/ignore), and encodes transaction data.
+Type-safe calldata builder and verifier for blockchain transactions. The builder validates inputs, normalizes values, and encodes transaction data. The verifier decodes externally-provided calldata and checks it against expected params. Built with a chain-agnostic core — currently implements EVM using viem.
 
-Built with chain-agnostic core - add validators and encoders for any chain. Currently implements EVM using viem.
+---
 
-## Usage
+## Builder
+
+### Usage
 
 ```typescript
 import { Calldata } from '@suite-common/calldata';
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 const result = Calldata.evm.erc20.approve(
     {
         spender: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
-        amount: asAmountSubunit(new BigNumber('1000000')),
+        amount: new BigNumber('1000000'),
     },
     { sender: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3' },
 );
@@ -30,9 +31,7 @@ if (result.isValid) {
 
 The second argument is context - additional data for validation (e.g., sender address for self-transfer detection). Required fields depend on the builder.
 
-## Architecture
-
-### Flow
+### Architecture
 
 ```
 Input → Validate → Normalize → Inspect → Policy → Encode → Calldata
@@ -109,7 +108,7 @@ const buildApprove = createBuilder({
 
 Parameter names (`spender`, `amount`) are derived directly from the ABI - TypeScript will error on wrong param names or types.
 
-## Adding New Calls
+### Adding New Builders
 
 1. **Add ABI to constants**
 
@@ -153,6 +152,50 @@ export const Calldata = {
     evm: {
         myContract: {
             myMethod: buildMyMethod,
+        },
+    },
+};
+```
+
+---
+
+## Verifier
+
+Validates externally-provided calldata against expected params. Accepts an optional `fields` array for partial validation — only the specified fields are checked. If omitted, all fields must match.
+
+### Usage
+
+```typescript
+import { Verifier } from '@suite-common/calldata';
+
+// Full validation — all params must match
+const result = Verifier.evm.erc4626.deposit(externalCalldata, {
+    assets: expectedAmount,
+    receiver: userAddress,
+});
+
+// Partial validation — only check specific fields
+const result = Verifier.evm.erc20.approve(
+    externalCalldata,
+    { spender: expectedSpender, amount: expectedAmount },
+    ['spender'],
+);
+
+if (!result.isValid) {
+    console.log(result.issues);
+}
+```
+
+Parameter names and types in `params` and `fields` are inferred from the ABI — TypeScript will error on wrong names or types.
+
+### Adding New Verifiers
+
+```typescript
+// verifier.ts
+export const Verifier = {
+    evm: {
+        myContract: {
+            myMethod: createVerifier({ abi: EVM_ABI.myContract.myMethod }),
         },
     },
 };

--- a/suite-common/calldata/package.json
+++ b/suite-common/calldata/package.json
@@ -12,8 +12,6 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@suite-common/suite-constants": "workspace:*",
-        "@suite-common/wallet-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "viem": "^2.46.3"

--- a/suite-common/calldata/src/builder/createBuilder.ts
+++ b/suite-common/calldata/src/builder/createBuilder.ts
@@ -3,20 +3,23 @@ import { typedObjectFromEntries } from '@trezor/utils';
 import {
     type BuildResult,
     type Builder,
-    type BuilderConfig,
     type Encoder,
     type ExtractContext,
     type ExtractEncoderOutput,
     type ExtractInputs,
     type ExtractParamNames,
-    type ParamsConfig,
 } from '../types/builder';
+import { type Param } from '../types/param';
 
 export const createBuilder = <
     E extends Encoder<string, unknown>,
-    Config extends ParamsConfig<ExtractParamNames<E>>,
+    Config extends Record<ExtractParamNames<E>, Param<any, any, any>>,
 >(
-    config: BuilderConfig<E> & { params: ParamsConfig<ExtractParamNames<E>, Config> },
+    config: { params: Config; encode: E } & ([Exclude<keyof Config, ExtractParamNames<E>>] extends [
+        never,
+    ]
+        ? unknown
+        : { params: Record<Exclude<keyof Config & string, ExtractParamNames<E>>, never> }),
 ): Builder<
     ExtractInputs<ExtractParamNames<E>, Config>,
     ExtractContext<Config>,

--- a/suite-common/calldata/src/builder/evm/approve.ts
+++ b/suite-common/calldata/src/builder/evm/approve.ts
@@ -1,4 +1,4 @@
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { type BigNumber } from '@trezor/utils';
 
 import { EVM_ABI } from '../../constants/evm';
 import { createEvmEncoder } from '../../encoder/evm';
@@ -18,7 +18,7 @@ const spenderParam = createParam<string, EvmAddress, ApproveContext>({
     policy: createPolicy({ ZERO_ADDRESS: 'warning', SELF_ADDRESS: 'warning' }),
 });
 
-const amountParam = createParam<AmountSubunit, bigint, ApproveContext>({
+const amountParam = createParam<BigNumber, bigint, ApproveContext>({
     validate: validateUint256,
 });
 

--- a/suite-common/calldata/src/builder/evm/deposit.ts
+++ b/suite-common/calldata/src/builder/evm/deposit.ts
@@ -1,4 +1,4 @@
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { type BigNumber } from '@trezor/utils';
 
 import { EVM_ABI } from '../../constants/evm';
 import { createEvmEncoder } from '../../encoder/evm';
@@ -14,7 +14,7 @@ type DepositContext = {
     balance?: bigint;
 };
 
-const assetsParam = createParam<AmountSubunit, bigint, DepositContext>({
+const assetsParam = createParam<BigNumber, bigint, DepositContext>({
     validate: validateUint256,
     policy: createPolicy({ ZERO_AMOUNT: 'error' }),
 });

--- a/suite-common/calldata/src/builder/evm/redeem.ts
+++ b/suite-common/calldata/src/builder/evm/redeem.ts
@@ -1,4 +1,4 @@
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { type BigNumber } from '@trezor/utils';
 
 import { EVM_ABI } from '../../constants/evm';
 import { createEvmEncoder } from '../../encoder/evm';
@@ -14,7 +14,7 @@ type RedeemContext = {
     balance?: bigint;
 };
 
-const sharesParam = createParam<AmountSubunit, bigint, RedeemContext>({
+const sharesParam = createParam<BigNumber, bigint, RedeemContext>({
     validate: validateUint256,
     policy: createPolicy({ ZERO_AMOUNT: 'error' }),
 });

--- a/suite-common/calldata/src/builder/evm/transfer.ts
+++ b/suite-common/calldata/src/builder/evm/transfer.ts
@@ -1,4 +1,4 @@
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { type BigNumber } from '@trezor/utils';
 
 import { EVM_ABI } from '../../constants/evm';
 import { createEvmEncoder } from '../../encoder/evm';
@@ -19,7 +19,7 @@ const toParam = createParam<string, EvmAddress, TransferContext>({
     policy: createPolicy({ ZERO_ADDRESS: 'warning', SELF_ADDRESS: 'warning' }),
 });
 
-const amountParam = createParam<AmountSubunit, bigint, TransferContext>({
+const amountParam = createParam<BigNumber, bigint, TransferContext>({
     validate: validateUint256,
 });
 

--- a/suite-common/calldata/src/builder/evm/withdraw.ts
+++ b/suite-common/calldata/src/builder/evm/withdraw.ts
@@ -1,4 +1,4 @@
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { type BigNumber } from '@trezor/utils';
 
 import { EVM_ABI } from '../../constants/evm';
 import { createEvmEncoder } from '../../encoder/evm';
@@ -14,7 +14,7 @@ type WithdrawContext = {
     balance?: bigint;
 };
 
-const assetsParam = createParam<AmountSubunit, bigint, WithdrawContext>({
+const assetsParam = createParam<BigNumber, bigint, WithdrawContext>({
     validate: validateUint256,
     policy: createPolicy({ ZERO_AMOUNT: 'error' }),
 });

--- a/suite-common/calldata/src/encoder/evm.ts
+++ b/suite-common/calldata/src/encoder/evm.ts
@@ -1,15 +1,7 @@
-import { type Abi, type AbiFunction, type AbiParameter, encodeFunctionData } from 'viem';
+import { type Abi, type AbiFunction, encodeFunctionData } from 'viem';
 
+import { type AbiParamName } from '../types/abi';
 import { type Encoder } from '../types/encoder';
-
-type ExtractAbiFunction<T extends Abi> = Extract<T[number], AbiFunction>;
-
-type NamedAbiParameter = AbiParameter & { name: string };
-
-type AbiParamName<T extends Abi> =
-    ExtractAbiFunction<T> extends infer F extends AbiFunction
-        ? Extract<F['inputs'][number], NamedAbiParameter>['name']
-        : never;
 
 export const createEvmEncoder = <const T extends Abi>(
     abi: T,

--- a/suite-common/calldata/src/fixtures/validation/evm/address.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/address.fixture.ts
@@ -1,4 +1,4 @@
-import { type EvmAddress } from '../../../types/evm';
+import { type EvmAddress, asEvmAddress } from '../../../types/evm';
 import { type IssueCode } from '../../../types/validation';
 
 type IsValidAddressTestCase = {
@@ -20,7 +20,7 @@ type IsSameAsSenderTestCase = {
     expected: IssueCode | null;
 };
 
-const SENDER = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress;
+const SENDER = asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
 
 export const isValidAddressTestCases: IsValidAddressTestCase[] = [
     {
@@ -63,12 +63,12 @@ export const isValidAddressTestCases: IsValidAddressTestCase[] = [
 export const isZeroAddressTestCases: IsZeroAddressTestCase[] = [
     {
         description: 'zero address returns ZERO_ADDRESS',
-        input: '0x0000000000000000000000000000000000000000' as EvmAddress,
+        input: asEvmAddress('0x0000000000000000000000000000000000000000'),
         expected: 'ZERO_ADDRESS',
     },
     {
         description: 'non-zero address returns null',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         expected: null,
     },
 ];
@@ -76,25 +76,25 @@ export const isZeroAddressTestCases: IsZeroAddressTestCase[] = [
 export const isSameAsSenderTestCases: IsSameAsSenderTestCase[] = [
     {
         description: 'same address same case returns SELF_ADDRESS',
-        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        input: asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         context: { sender: SENDER },
         expected: 'SELF_ADDRESS',
     },
     {
         description: 'same address different case returns SELF_ADDRESS',
-        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        input: asEvmAddress('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'),
         context: { sender: SENDER },
         expected: 'SELF_ADDRESS',
     },
     {
         description: 'different address returns null',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         context: { sender: SENDER },
         expected: null,
     },
     {
         description: 'no sender in context returns null',
-        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        input: asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         context: {},
         expected: null,
     },
@@ -103,25 +103,25 @@ export const isSameAsSenderTestCases: IsSameAsSenderTestCase[] = [
 export const isNotSameAsSenderTestCases: IsSameAsSenderTestCase[] = [
     {
         description: 'different address returns NOT_SAME_AS_SENDER',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         context: { sender: SENDER },
         expected: 'NOT_SAME_AS_SENDER',
     },
     {
         description: 'same address different case returns null',
-        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        input: asEvmAddress('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'),
         context: { sender: SENDER },
         expected: null,
     },
     {
         description: 'same address returns null',
-        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        input: asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         context: { sender: SENDER },
         expected: null,
     },
     {
         description: 'no sender in context returns null',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         context: {},
         expected: null,
     },
@@ -135,38 +135,38 @@ type IsNotWhitelistedTestCase = {
 };
 
 const WHITELIST: EvmAddress[] = [
-    '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
-    '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as EvmAddress,
+    asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
+    asEvmAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
 ];
 
 export const isNotWhitelistedTestCases: IsNotWhitelistedTestCase[] = [
     {
         description: 'address in whitelist returns null',
-        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        input: asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         context: { addressWhitelist: WHITELIST },
         expected: null,
     },
     {
         description: 'address not in whitelist returns ADDRESS_NOT_WHITELISTED',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         context: { addressWhitelist: WHITELIST },
         expected: 'ADDRESS_NOT_WHITELISTED',
     },
     {
         description: 'address in whitelist different case returns null',
-        input: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as EvmAddress,
+        input: asEvmAddress('0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'),
         context: { addressWhitelist: WHITELIST },
         expected: null,
     },
     {
         description: 'no whitelist in context returns null',
-        input: '0x1111111111111111111111111111111111111111' as EvmAddress,
+        input: asEvmAddress('0x1111111111111111111111111111111111111111'),
         context: {},
         expected: null,
     },
     {
         description: 'empty whitelist rejects all addresses',
-        input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress,
+        input: asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
         context: { addressWhitelist: [] },
         expected: 'ADDRESS_NOT_WHITELISTED',
     },

--- a/suite-common/calldata/src/fixtures/validation/evm/uint256.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/uint256.fixture.ts
@@ -1,12 +1,11 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
-import { type AmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { type IssueCode } from '../../../types/validation';
+import { UINT256_MAX } from '../../../validation/evm/uint256';
 
 type ValidateFnTestCase = {
     description: string;
-    input: AmountSubunit;
+    input: BigNumber;
     expected: IssueCode | null;
 };
 
@@ -26,17 +25,17 @@ type HasBalanceTestCase = {
 export const isNegativeTestCases: ValidateFnTestCase[] = [
     {
         description: 'positive number returns null',
-        input: new BigNumber('100') as AmountSubunit,
+        input: new BigNumber('100'),
         expected: null,
     },
     {
         description: 'zero returns null',
-        input: new BigNumber('0') as AmountSubunit,
+        input: new BigNumber('0'),
         expected: null,
     },
     {
         description: 'negative number returns NEGATIVE_AMOUNT',
-        input: new BigNumber('-1') as AmountSubunit,
+        input: new BigNumber('-1'),
         expected: 'NEGATIVE_AMOUNT',
     },
 ];
@@ -44,12 +43,12 @@ export const isNegativeTestCases: ValidateFnTestCase[] = [
 export const isNotIntegerTestCases: ValidateFnTestCase[] = [
     {
         description: 'integer returns null',
-        input: new BigNumber('100') as AmountSubunit,
+        input: new BigNumber('100'),
         expected: null,
     },
     {
         description: 'decimal returns NOT_INTEGER',
-        input: new BigNumber('1.5') as AmountSubunit,
+        input: new BigNumber('1.5'),
         expected: 'NOT_INTEGER',
     },
 ];
@@ -57,17 +56,17 @@ export const isNotIntegerTestCases: ValidateFnTestCase[] = [
 export const exceedsUint256TestCases: ValidateFnTestCase[] = [
     {
         description: 'value within range returns null',
-        input: new BigNumber('100') as AmountSubunit,
+        input: new BigNumber('100'),
         expected: null,
     },
     {
         description: 'value equal to UINT256_MAX returns null',
-        input: new BigNumber(UINT256_MAX) as AmountSubunit,
+        input: UINT256_MAX,
         expected: null,
     },
     {
         description: 'value exceeding UINT256_MAX returns EXCEEDS_UINT256',
-        input: new BigNumber(UINT256_MAX).plus(1) as AmountSubunit,
+        input: UINT256_MAX.plus(1),
         expected: 'EXCEEDS_UINT256',
     },
 ];

--- a/suite-common/calldata/src/fixtures/validation/evm/validateAddress.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/validateAddress.fixture.ts
@@ -1,4 +1,4 @@
-import { type EvmAddress } from '../../../types/evm';
+import { type EvmAddress, asEvmAddress } from '../../../types/evm';
 import { type ValidationResult } from '../../../types/validation';
 
 interface ValidateAddressTestCase {
@@ -8,8 +8,8 @@ interface ValidateAddressTestCase {
     expected: ValidationResult<EvmAddress>;
 }
 
-const VALID_ADDRESS = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as EvmAddress;
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as EvmAddress;
+const VALID_ADDRESS = asEvmAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+const ZERO_ADDRESS = asEvmAddress('0x0000000000000000000000000000000000000000');
 
 export const validateAddressTestCases: ValidateAddressTestCase[] = [
     {
@@ -59,7 +59,7 @@ export const validateAddressTestCases: ValidateAddressTestCase[] = [
     {
         description: 'address different from sender returns NOT_SAME_AS_SENDER issue',
         input: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        context: { sender: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as EvmAddress },
+        context: { sender: asEvmAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb') },
         expected: {
             value: VALID_ADDRESS,
             issues: [{ code: 'NOT_SAME_AS_SENDER', path: 'to' }],
@@ -70,7 +70,7 @@ export const validateAddressTestCases: ValidateAddressTestCase[] = [
         input: '0xcccccccccccccccccccccccccccccccccccccccc',
         context: { addressWhitelist: [VALID_ADDRESS] },
         expected: {
-            value: '0xcccccccccccccccccccccccccccccccccccccccc' as EvmAddress,
+            value: asEvmAddress('0xcccccccccccccccccccccccccccccccccccccccc'),
             issues: [{ code: 'ADDRESS_NOT_WHITELISTED', path: 'to' }],
         },
     },

--- a/suite-common/calldata/src/fixtures/validation/evm/validateUint256.fixture.ts
+++ b/suite-common/calldata/src/fixtures/validation/evm/validateUint256.fixture.ts
@@ -1,12 +1,11 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
-import { type AmountSubunit, asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { type ValidationResult } from '../../../types/validation';
+import { UINT256_MAX } from '../../../validation/evm/uint256';
 
 interface ValidateUint256TestCase {
     description: string;
-    input: AmountSubunit;
+    input: BigNumber;
     context?: { balance?: bigint };
     expected: ValidationResult<bigint>;
 }
@@ -14,7 +13,7 @@ interface ValidateUint256TestCase {
 export const validateUint256TestCases: ValidateUint256TestCase[] = [
     {
         description: 'valid amount returns normalized bigint with no issues',
-        input: asAmountSubunit(new BigNumber('1000000000000000000')),
+        input: new BigNumber('1000000000000000000'),
         expected: {
             value: 1000000000000000000n,
             issues: [],
@@ -22,7 +21,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'negative amount returns NEGATIVE_AMOUNT issue',
-        input: asAmountSubunit(new BigNumber('-1')),
+        input: new BigNumber('-1'),
         expected: {
             value: null,
             issues: [{ code: 'NEGATIVE_AMOUNT', path: 'amount' }],
@@ -30,7 +29,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'non-integer amount returns NOT_INTEGER issue',
-        input: asAmountSubunit(new BigNumber('1.5')),
+        input: new BigNumber('1.5'),
         expected: {
             value: null,
             issues: [{ code: 'NOT_INTEGER', path: 'amount' }],
@@ -38,7 +37,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'negative decimal returns NEGATIVE_AMOUNT (first validation)',
-        input: asAmountSubunit(new BigNumber('-1.5')),
+        input: new BigNumber('-1.5'),
         expected: {
             value: null,
             issues: [{ code: 'NEGATIVE_AMOUNT', path: 'amount' }],
@@ -46,15 +45,15 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'exact UINT256_MAX is valid',
-        input: asAmountSubunit(new BigNumber(UINT256_MAX)),
+        input: UINT256_MAX,
         expected: {
-            value: BigInt(UINT256_MAX),
+            value: BigInt('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
             issues: [],
         },
     },
     {
         description: 'amount exceeding uint256 returns EXCEEDS_UINT256 issue',
-        input: asAmountSubunit(new BigNumber(UINT256_MAX).plus(1)),
+        input: UINT256_MAX.plus(1),
         expected: {
             value: null,
             issues: [{ code: 'EXCEEDS_UINT256', path: 'amount' }],
@@ -62,7 +61,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'zero amount returns ZERO_AMOUNT issue',
-        input: asAmountSubunit(new BigNumber('0')),
+        input: new BigNumber('0'),
         expected: {
             value: 0n,
             issues: [{ code: 'ZERO_AMOUNT', path: 'amount' }],
@@ -70,7 +69,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'amount exceeding balance returns INSUFFICIENT_BALANCE issue',
-        input: asAmountSubunit(new BigNumber('1000')),
+        input: new BigNumber('1000'),
         context: { balance: 500n },
         expected: {
             value: 1000n,
@@ -79,7 +78,7 @@ export const validateUint256TestCases: ValidateUint256TestCase[] = [
     },
     {
         description: 'no context provided works without INSUFFICIENT_BALANCE issue',
-        input: asAmountSubunit(new BigNumber('1000')),
+        input: new BigNumber('1000'),
         expected: {
             value: 1000n,
             issues: [],

--- a/suite-common/calldata/src/index.ts
+++ b/suite-common/calldata/src/index.ts
@@ -1,1 +1,5 @@
 export { Calldata } from './calldata';
+export { Verifier } from './verifier';
+export type { EvmAddress } from './types/evm';
+export { asEvmAddress } from './types/evm';
+export type { VerifyIssue } from './types/verifier';

--- a/suite-common/calldata/src/tests/builder/evm/approve.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/approve.test.ts
@@ -1,18 +1,18 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { buildApprove } from '../../../builder/evm/approve';
+import { asEvmAddress } from '../../../types/evm';
+import { UINT256_MAX } from '../../../validation/evm/uint256';
 
-const SPENDER = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
-const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
+const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 
 describe('buildApprove', () => {
     it('encodes valid approve calldata', () => {
         const result = buildApprove(
             {
                 spender: SPENDER,
-                amount: asAmountSubunit(new BigNumber('1000000')),
+                amount: new BigNumber('1000000'),
             },
             { sender: SENDER },
         );
@@ -29,7 +29,7 @@ describe('buildApprove', () => {
         const result = buildApprove(
             {
                 spender: SPENDER,
-                amount: asAmountSubunit(new BigNumber(UINT256_MAX)),
+                amount: UINT256_MAX,
             },
             { sender: SENDER },
         );
@@ -46,7 +46,7 @@ describe('buildApprove', () => {
         const result = buildApprove(
             {
                 spender: 'invalid-address',
-                amount: asAmountSubunit(new BigNumber('1000000')),
+                amount: new BigNumber('1000000'),
             },
             { sender: SENDER },
         );
@@ -63,7 +63,7 @@ describe('buildApprove', () => {
         const result = buildApprove(
             {
                 spender: SPENDER,
-                amount: asAmountSubunit(new BigNumber('0')),
+                amount: new BigNumber('0'),
             },
             { sender: SENDER },
         );

--- a/suite-common/calldata/src/tests/builder/evm/deposit.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/deposit.test.ts
@@ -1,15 +1,15 @@
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { buildDeposit } from '../../../builder/evm/deposit';
+import { asEvmAddress } from '../../../types/evm';
 
-const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 
 describe('buildDeposit', () => {
     it('encodes valid deposit calldata', () => {
         const result = buildDeposit(
             {
-                assets: asAmountSubunit(new BigNumber('5000000')),
+                assets: new BigNumber('5000000'),
                 receiver: SENDER,
             },
             { sender: SENDER },
@@ -26,7 +26,7 @@ describe('buildDeposit', () => {
     it('returns error for zero address receiver', () => {
         const result = buildDeposit(
             {
-                assets: asAmountSubunit(new BigNumber('5000000')),
+                assets: new BigNumber('5000000'),
                 receiver: '0x0000000000000000000000000000000000000000',
             },
             { sender: SENDER },
@@ -44,7 +44,7 @@ describe('buildDeposit', () => {
     it('returns error when receiver is different from sender', () => {
         const result = buildDeposit(
             {
-                assets: asAmountSubunit(new BigNumber('5000000')),
+                assets: new BigNumber('5000000'),
                 receiver: '0x1111111111111111111111111111111111111111',
             },
             { sender: SENDER },
@@ -61,7 +61,7 @@ describe('buildDeposit', () => {
     it('returns error for zero assets', () => {
         const result = buildDeposit(
             {
-                assets: asAmountSubunit(new BigNumber('0')),
+                assets: new BigNumber('0'),
                 receiver: SENDER,
             },
             { sender: SENDER },

--- a/suite-common/calldata/src/tests/builder/evm/redeem.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/redeem.test.ts
@@ -1,15 +1,15 @@
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { buildRedeem } from '../../../builder/evm/redeem';
+import { asEvmAddress } from '../../../types/evm';
 
-const SENDER = '0x44Ab691a7492C3dCb88241AF8aC5371d84B61BB6';
+const SENDER = asEvmAddress('0x44Ab691a7492C3dCb88241AF8aC5371d84B61BB6');
 
 describe('buildRedeem', () => {
     it('encodes valid redeem calldata', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: SENDER,
                 owner: SENDER,
             },
@@ -27,7 +27,7 @@ describe('buildRedeem', () => {
     it('returns error for zero address receiver', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: '0x0000000000000000000000000000000000000000',
                 owner: SENDER,
             },
@@ -46,7 +46,7 @@ describe('buildRedeem', () => {
     it('returns error for zero address owner', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: SENDER,
                 owner: '0x0000000000000000000000000000000000000000',
             },
@@ -65,7 +65,7 @@ describe('buildRedeem', () => {
     it('returns error when receiver is different from sender', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: '0x1111111111111111111111111111111111111111',
                 owner: SENDER,
             },
@@ -83,7 +83,7 @@ describe('buildRedeem', () => {
     it('returns error when owner is different from sender', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: SENDER,
                 owner: '0x1111111111111111111111111111111111111111',
             },
@@ -101,7 +101,7 @@ describe('buildRedeem', () => {
     it('returns errors when owner and receiver are different from sender', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('9999586934321')),
+                shares: new BigNumber('9999586934321'),
                 receiver: '0x1111111111111111111111111111111111111111',
                 owner: '0x1111111111111111111111111111111111111111',
             },
@@ -120,7 +120,7 @@ describe('buildRedeem', () => {
     it('returns error for zero shares', () => {
         const result = buildRedeem(
             {
-                shares: asAmountSubunit(new BigNumber('0')),
+                shares: new BigNumber('0'),
                 receiver: SENDER,
                 owner: SENDER,
             },

--- a/suite-common/calldata/src/tests/builder/evm/transfer.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/transfer.test.ts
@@ -1,17 +1,17 @@
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { buildTransfer } from '../../../builder/evm/transfer';
+import { asEvmAddress } from '../../../types/evm';
 
-const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
-const RECIPIENT = '0xB836472D21991eB9842e15BEaE1AF6c8B63D6a96';
+const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
+const RECIPIENT = asEvmAddress('0xB836472D21991eB9842e15BEaE1AF6c8B63D6a96');
 
 describe('buildTransfer', () => {
     it('encodes valid transfer calldata', () => {
         const result = buildTransfer(
             {
                 to: RECIPIENT,
-                amount: asAmountSubunit(new BigNumber('1000000')),
+                amount: new BigNumber('1000000'),
             },
             { sender: SENDER },
         );

--- a/suite-common/calldata/src/tests/builder/evm/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/withdraw.test.ts
@@ -1,15 +1,15 @@
-import { asAmountSubunit } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { buildWithdraw } from '../../../builder/evm/withdraw';
+import { asEvmAddress } from '../../../types/evm';
 
-const SENDER = '0x22E228AdE324185123A54Ad25F3459a99CF51E7a';
+const SENDER = asEvmAddress('0x22E228AdE324185123A54Ad25F3459a99CF51E7a');
 
 describe('buildWithdraw', () => {
     it('encodes valid withdraw calldata', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('1507906')),
+                assets: new BigNumber('1507906'),
                 receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
                 owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
             },
@@ -27,7 +27,7 @@ describe('buildWithdraw', () => {
     it('returns error for zero address receiver', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('1507906')),
+                assets: new BigNumber('1507906'),
                 receiver: '0x0000000000000000000000000000000000000000',
                 owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
             },
@@ -46,7 +46,7 @@ describe('buildWithdraw', () => {
     it('returns error for zero address owner', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('1507906')),
+                assets: new BigNumber('1507906'),
                 receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
                 owner: '0x0000000000000000000000000000000000000000',
             },
@@ -65,7 +65,7 @@ describe('buildWithdraw', () => {
     it('returns error when receiver is different from sender', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('1507906')),
+                assets: new BigNumber('1507906'),
                 receiver: '0x1111111111111111111111111111111111111111',
                 owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
             },
@@ -83,7 +83,7 @@ describe('buildWithdraw', () => {
     it('returns error when owner is different from sender', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('1507906')),
+                assets: new BigNumber('1507906'),
                 receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
                 owner: '0x1111111111111111111111111111111111111111',
             },
@@ -101,7 +101,7 @@ describe('buildWithdraw', () => {
     it('returns error for zero assets', () => {
         const result = buildWithdraw(
             {
-                assets: asAmountSubunit(new BigNumber('0')),
+                assets: new BigNumber('0'),
                 receiver: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
                 owner: '0x22E228AdE324185123A54Ad25F3459a99CF51E7a',
             },

--- a/suite-common/calldata/src/tests/verifier/createVerifier.test.ts
+++ b/suite-common/calldata/src/tests/verifier/createVerifier.test.ts
@@ -1,0 +1,118 @@
+import { parseAbi } from 'viem';
+
+import { BigNumber } from '@trezor/utils';
+
+import { buildApprove } from '../../builder/evm/approve';
+import { EVM_ABI } from '../../constants/evm';
+import { asEvmAddress } from '../../types/evm';
+import { createVerifier } from '../../verifier/createVerifier';
+
+const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
+const SPENDER_CHECKSUMMED = asEvmAddress('0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE');
+const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const AMOUNT = 1000000n;
+
+const approveHex = buildApprove(
+    { spender: SPENDER, amount: new BigNumber(AMOUNT.toString()) },
+    { sender: SENDER },
+).data!;
+
+describe('createVerifier', () => {
+    describe('factory', () => {
+        it('throws when ABI has no functions', () => {
+            expect(() =>
+                createVerifier({
+                    // @ts-expect-error
+                    abi: parseAbi([]),
+                }),
+            ).toThrow('No function in ABI');
+        });
+
+        it('throws when ABI has multiple functions', () => {
+            expect(() =>
+                createVerifier({ abi: parseAbi(['function foo()', 'function bar()']) }),
+            ).toThrow('ABI must contain exactly one function');
+        });
+    });
+
+    describe('verifier', () => {
+        const verifyApprove = createVerifier({ abi: EVM_ABI.erc20.approve });
+
+        it('returns isValid true with no issues on full match', () => {
+            expect(verifyApprove(approveHex, { spender: SPENDER, amount: AMOUNT })).toEqual({
+                isValid: true,
+                issues: [],
+            });
+        });
+
+        it('returns VALUE_MISMATCH for a single mismatched field', () => {
+            expect(
+                verifyApprove(approveHex, {
+                    spender: '0x0000000000000000000000000000000000000001',
+                    amount: AMOUNT,
+                }),
+            ).toEqual({
+                isValid: false,
+                issues: [{ code: 'VALUE_MISMATCH', field: 'spender' }],
+            });
+        });
+
+        it('returns VALUE_MISMATCH for each mismatched field', () => {
+            expect(
+                verifyApprove(approveHex, {
+                    spender: '0x0000000000000000000000000000000000000001',
+                    amount: 999n,
+                }),
+            ).toEqual({
+                isValid: false,
+                issues: [
+                    { code: 'VALUE_MISMATCH', field: 'spender' },
+                    { code: 'VALUE_MISMATCH', field: 'amount' },
+                ],
+            });
+        });
+
+        it('returns isValid true when checked partial fields match even if unchecked fields differ', () => {
+            expect(
+                verifyApprove(approveHex, { spender: SPENDER, amount: 999n }, ['spender']),
+            ).toEqual({ isValid: true, issues: [] });
+        });
+
+        it('returns VALUE_MISMATCH when checked partial field does not match', () => {
+            expect(
+                verifyApprove(
+                    approveHex,
+                    { spender: '0x0000000000000000000000000000000000000001', amount: AMOUNT },
+                    ['spender'],
+                ),
+            ).toEqual({
+                isValid: false,
+                issues: [{ code: 'VALUE_MISMATCH', field: 'spender' }],
+            });
+        });
+
+        it('returns SIGNATURE_MISMATCH when selector does not match', () => {
+            const verifyTransfer = createVerifier({ abi: EVM_ABI.erc20.transfer });
+
+            expect(verifyTransfer(approveHex, { to: SPENDER, amount: AMOUNT })).toEqual({
+                isValid: false,
+                issues: [{ code: 'SIGNATURE_MISMATCH', field: null }],
+            });
+        });
+
+        it('returns DECODING_FAILED when calldata is malformed', () => {
+            const malformedHex = `${approveHex.slice(0, 10)}deadbeef` as `0x${string}`;
+
+            expect(verifyApprove(malformedHex, { spender: SPENDER, amount: AMOUNT })).toEqual({
+                isValid: false,
+                issues: [{ code: 'DECODING_FAILED', field: null }],
+            });
+        });
+
+        it('compares addresses case-insensitively', () => {
+            expect(
+                verifyApprove(approveHex, { spender: SPENDER_CHECKSUMMED, amount: AMOUNT }),
+            ).toEqual({ isValid: true, issues: [] });
+        });
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/approve.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/approve.test.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildApprove } from '../../../builder/evm/approve';
+import { asEvmAddress } from '../../../types/evm';
+import { Verifier } from '../../../verifier';
+
+const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
+const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const AMOUNT = 1000000n;
+
+const approveHex = buildApprove(
+    { spender: SPENDER, amount: new BigNumber(AMOUNT.toString()) },
+    { sender: SENDER },
+).data!;
+
+describe('verifyApprove', () => {
+    it('returns isValid true on full match', () => {
+        expect(
+            Verifier.evm.erc20.approve(approveHex, { spender: SPENDER, amount: AMOUNT }),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('returns VALUE_MISMATCH on full mismatch', () => {
+        expect(
+            Verifier.evm.erc20.approve(approveHex, {
+                spender: '0x0000000000000000000000000000000000000001',
+                amount: AMOUNT,
+            }),
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'spender' }] });
+    });
+
+    it('returns isValid true when partial checked fields match', () => {
+        expect(
+            Verifier.evm.erc20.approve(approveHex, { spender: SPENDER, amount: 999n }, ['spender']),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/deposit.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/deposit.test.ts
@@ -1,0 +1,41 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildDeposit } from '../../../builder/evm/deposit';
+import { asEvmAddress } from '../../../types/evm';
+import { Verifier } from '../../../verifier';
+
+const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const RECEIVER = SENDER;
+const ASSETS = 1000000n;
+
+const depositHex = buildDeposit(
+    { assets: new BigNumber(ASSETS.toString()), receiver: RECEIVER },
+    { sender: SENDER },
+).data!;
+
+describe('verifyDeposit', () => {
+    it('returns isValid true on full match', () => {
+        expect(
+            Verifier.evm.erc4626.deposit(depositHex, { assets: ASSETS, receiver: RECEIVER }),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('returns VALUE_MISMATCH on full mismatch', () => {
+        expect(
+            Verifier.evm.erc4626.deposit(depositHex, {
+                assets: ASSETS,
+                receiver: '0x0000000000000000000000000000000000000001',
+            }),
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'receiver' }] });
+    });
+
+    it('returns isValid true when partial checked fields match', () => {
+        expect(
+            Verifier.evm.erc4626.deposit(
+                depositHex,
+                { assets: ASSETS, receiver: '0x0000000000000000000000000000000000000001' },
+                ['assets'],
+            ),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/redeem.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/redeem.test.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildRedeem } from '../../../builder/evm/redeem';
+import { asEvmAddress } from '../../../types/evm';
+import { Verifier } from '../../../verifier';
+
+const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const RECEIVER = SENDER;
+const OWNER = SENDER;
+const SHARES = 1000000n;
+
+const redeemHex = buildRedeem(
+    {
+        shares: new BigNumber(SHARES.toString()),
+        receiver: RECEIVER,
+        owner: OWNER,
+    },
+    { sender: SENDER },
+).data!;
+
+describe('verifyRedeem', () => {
+    it('returns isValid true on full match', () => {
+        expect(
+            Verifier.evm.erc4626.redeem(redeemHex, {
+                shares: SHARES,
+                receiver: RECEIVER,
+                owner: OWNER,
+            }),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('returns VALUE_MISMATCH on shares mismatch', () => {
+        expect(
+            Verifier.evm.erc4626.redeem(redeemHex, {
+                shares: 999n,
+                receiver: RECEIVER,
+                owner: OWNER,
+            }),
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'shares' }] });
+    });
+
+    it('returns isValid true when partial checked fields match', () => {
+        expect(
+            Verifier.evm.erc4626.redeem(
+                redeemHex,
+                { shares: 999n, receiver: RECEIVER, owner: OWNER },
+                ['receiver', 'owner'],
+            ),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/withdraw.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/withdraw.test.ts
@@ -1,0 +1,51 @@
+import { BigNumber } from '@trezor/utils';
+
+import { buildWithdraw } from '../../../builder/evm/withdraw';
+import { asEvmAddress } from '../../../types/evm';
+import { Verifier } from '../../../verifier';
+
+const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const RECEIVER = SENDER;
+const OWNER = SENDER;
+const ASSETS = 1000000n;
+
+const withdrawHex = buildWithdraw(
+    {
+        assets: new BigNumber(ASSETS.toString()),
+        receiver: RECEIVER,
+        owner: OWNER,
+    },
+    { sender: SENDER },
+).data!;
+
+describe('verifyWithdraw', () => {
+    it('returns isValid true on full match', () => {
+        expect(
+            Verifier.evm.erc4626.withdraw(withdrawHex, {
+                assets: ASSETS,
+                receiver: RECEIVER,
+                owner: OWNER,
+            }),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('returns VALUE_MISMATCH on full mismatch', () => {
+        expect(
+            Verifier.evm.erc4626.withdraw(withdrawHex, {
+                assets: 999n,
+                receiver: RECEIVER,
+                owner: OWNER,
+            }),
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'assets' }] });
+    });
+
+    it('returns isValid true when partial checked fields match', () => {
+        expect(
+            Verifier.evm.erc4626.withdraw(
+                withdrawHex,
+                { assets: 999n, receiver: RECEIVER, owner: OWNER },
+                ['receiver', 'owner'],
+            ),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+});

--- a/suite-common/calldata/src/types/abi.ts
+++ b/suite-common/calldata/src/types/abi.ts
@@ -1,0 +1,10 @@
+import { type Abi, type AbiFunction, type AbiParameter } from 'viem';
+
+export type NamedAbiParameter = AbiParameter & { name: string };
+
+export type ExtractAbiFunction<T extends Abi> = Extract<T[number], AbiFunction>;
+
+export type AbiParamName<T extends Abi> =
+    ExtractAbiFunction<T> extends infer F extends AbiFunction
+        ? Extract<F['inputs'][number], NamedAbiParameter>['name']
+        : never;

--- a/suite-common/calldata/src/types/builder.ts
+++ b/suite-common/calldata/src/types/builder.ts
@@ -4,31 +4,20 @@ import type { IssueWithSeverity } from './policy';
 
 export type { Encoder };
 
-export type ParamsConfig<
-    ParamNames extends string,
-    Config = Record<ParamNames, Param<any, any, any>>,
-> = {
-    [K in ParamNames]: Param<any, any, any>;
-} & (Exclude<keyof Config, ParamNames> extends never
-    ? unknown
-    : { [K in Exclude<keyof Config, ParamNames>]: never });
-
 type ExtractParamInput<T> = T extends Param<infer I, any, any> ? I : never;
 export type ExtractParamNames<E> = E extends Encoder<infer P, unknown> ? P : never;
 
 export type ExtractEncoderOutput<E> = E extends Encoder<string, infer O> ? O : never;
 
-export type ExtractInputs<ParamNames extends string, Config extends ParamsConfig<ParamNames>> = {
+export type ExtractInputs<
+    ParamNames extends string,
+    Config extends Record<ParamNames, Param<any, any, any>>,
+> = {
     [K in ParamNames]: ExtractParamInput<Config[K]>;
 };
 
 export type ExtractContext<Config> =
     Config extends Record<string, Param<any, any, infer C>> ? C : void;
-
-export interface BuilderConfig<E extends Encoder> {
-    params: ParamsConfig<ExtractParamNames<E>>;
-    encode: E;
-}
 
 interface BuildResultBase {
     issues: IssueWithSeverity[];

--- a/suite-common/calldata/src/types/evm.ts
+++ b/suite-common/calldata/src/types/evm.ts
@@ -1,3 +1,4 @@
 import { type Branded } from '@trezor/type-utils';
 
 export type EvmAddress = `0x${string}` & Branded<'EvmAddress'>;
+export const asEvmAddress = (address: string): EvmAddress => address as EvmAddress;

--- a/suite-common/calldata/src/types/verifier.ts
+++ b/suite-common/calldata/src/types/verifier.ts
@@ -1,0 +1,24 @@
+import { type Abi, type AbiFunction, type AbiParameterToPrimitiveType } from 'viem';
+
+import { type AbiParamName, type ExtractAbiFunction, type NamedAbiParameter } from './abi';
+
+type AbiParamByName<T extends Abi, N extends string> =
+    ExtractAbiFunction<T> extends infer F extends AbiFunction
+        ? Extract<Extract<F['inputs'][number], NamedAbiParameter>, { name: N }>
+        : never;
+
+export type AbiParams<T extends Abi> = {
+    [K in AbiParamName<T>]: AbiParameterToPrimitiveType<AbiParamByName<T, K>>;
+};
+
+export type VerifyIssueCode = 'DECODING_FAILED' | 'SIGNATURE_MISMATCH' | 'VALUE_MISMATCH';
+
+export type VerifyIssue = {
+    code: VerifyIssueCode;
+    field: string | null;
+};
+
+export type VerifyResult = {
+    isValid: boolean;
+    issues: VerifyIssue[];
+};

--- a/suite-common/calldata/src/validation/evm/uint256.ts
+++ b/suite-common/calldata/src/validation/evm/uint256.ts
@@ -1,16 +1,19 @@
-import { UINT256_MAX } from '@suite-common/suite-constants';
-import { type AmountSubunit } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { type ContextWith } from '../../types/validation';
 import { type InspectFn, type ValidateFn, createValidator } from '../createValidator';
 
-export const isNegative: ValidateFn<AmountSubunit> = input =>
+export const UINT256_MAX = new BigNumber(
+    '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+);
+
+export const isNegative: ValidateFn<BigNumber> = input =>
     input.isNegative() ? 'NEGATIVE_AMOUNT' : null;
 
-export const isNotInteger: ValidateFn<AmountSubunit> = input =>
+export const isNotInteger: ValidateFn<BigNumber> = input =>
     input.isInteger() ? null : 'NOT_INTEGER';
 
-export const exceedsUint256: ValidateFn<AmountSubunit> = input =>
+export const exceedsUint256: ValidateFn<BigNumber> = input =>
     input.gt(UINT256_MAX) ? 'EXCEEDS_UINT256' : null;
 
 export const isZero: InspectFn<bigint> = input => (input === 0n ? 'ZERO_AMOUNT' : null);
@@ -20,7 +23,7 @@ type BalanceContext = ContextWith<{ balance?: bigint }>;
 export const hasBalance: InspectFn<bigint, BalanceContext> = (input, context) =>
     context?.balance !== undefined && input > context.balance ? 'INSUFFICIENT_BALANCE' : null;
 
-export const validateUint256 = createValidator<AmountSubunit, bigint, BalanceContext>({
+export const validateUint256 = createValidator<BigNumber, bigint, BalanceContext>({
     validate: [isNegative, isNotInteger, exceedsUint256],
     normalize: input => BigInt(input.toFixed(0)),
     inspect: [isZero, hasBalance],

--- a/suite-common/calldata/src/verifier.ts
+++ b/suite-common/calldata/src/verifier.ts
@@ -1,0 +1,15 @@
+import { EVM_ABI } from './constants/evm';
+import { createVerifier } from './verifier/createVerifier';
+
+export const Verifier = {
+    evm: {
+        erc20: {
+            approve: createVerifier({ abi: EVM_ABI.erc20.approve }),
+        },
+        erc4626: {
+            deposit: createVerifier({ abi: EVM_ABI.erc4626.deposit }),
+            withdraw: createVerifier({ abi: EVM_ABI.erc4626.withdraw }),
+            redeem: createVerifier({ abi: EVM_ABI.erc4626.redeem }),
+        },
+    },
+} as const;

--- a/suite-common/calldata/src/verifier/createVerifier.ts
+++ b/suite-common/calldata/src/verifier/createVerifier.ts
@@ -1,0 +1,59 @@
+import { type Abi, type AbiFunction, decodeFunctionData, toFunctionSelector } from 'viem';
+
+import { type AbiParamName } from '../types/abi';
+import { type AbiParams, type VerifyIssue, type VerifyResult } from '../types/verifier';
+
+export const createVerifier = <const T extends Abi>(config: { abi: T }) => {
+    const functions = config.abi.filter((item): item is AbiFunction => item.type === 'function');
+
+    if (functions.length === 0) throw new Error('No function in ABI');
+    if (functions.length > 1) throw new Error('ABI must contain exactly one function');
+
+    const fn = functions[0];
+    const selector = toFunctionSelector(fn);
+    const paramNames = fn.inputs
+        .filter((input): input is typeof input & { name: string } => !!input.name)
+        .map(input => input.name);
+
+    return (
+        externalHex: `0x${string}`,
+        params: AbiParams<T>,
+        fields?: AbiParamName<T>[],
+    ): VerifyResult => {
+        if (externalHex.slice(0, 10).toLowerCase() !== selector.toLowerCase()) {
+            return { isValid: false, issues: [{ code: 'SIGNATURE_MISMATCH', field: null }] };
+        }
+
+        try {
+            const decoded = decodeFunctionData({ abi: config.abi, data: externalHex });
+
+            if (!Array.isArray(decoded.args)) {
+                return { isValid: false, issues: [{ code: 'DECODING_FAILED', field: null }] };
+            }
+
+            const fieldsToCheck = fields ?? (paramNames as AbiParamName<T>[]);
+            const issues: VerifyIssue[] = [];
+
+            for (const field of fieldsToCheck) {
+                const index = paramNames.indexOf(field);
+
+                if (index === -1) {
+                    throw new Error(
+                        `Field '${field}' not found in ABI params: ${paramNames.join(', ')}`,
+                    );
+                }
+
+                const decodedValue = decoded.args[index];
+                const expectedValue = params[field];
+
+                if (String(decodedValue).toLowerCase() !== String(expectedValue).toLowerCase()) {
+                    issues.push({ code: 'VALUE_MISMATCH', field });
+                }
+            }
+
+            return { isValid: issues.length === 0, issues };
+        } catch {
+            return { isValid: false, issues: [{ code: 'DECODING_FAILED', field: null }] };
+        }
+    };
+};

--- a/suite-common/calldata/tsconfig.json
+++ b/suite-common/calldata/tsconfig.json
@@ -2,8 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../suite-constants" },
-        { "path": "../wallet-utils" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/utils" }
     ]

--- a/suite-common/earn-api/jest.config.js
+++ b/suite-common/earn-api/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/earn-api/package.json
+++ b/suite-common/earn-api/package.json
@@ -13,13 +13,17 @@
         "orval": "orval --config ./orval.config.ts",
         "api:fetch": "node ./scripts/fetchSpec.mjs",
         "api:generate": "yarn orval",
-        "api:update": "yarn api:fetch && yarn api:generate && yarn lint:js --fix && yarn format"
+        "api:update": "yarn api:fetch && yarn api:generate && yarn lint:js --fix && yarn format",
+        "test:unit": "yarn g:jest"
     },
     "devDependencies": {
         "orval": "8.5.0",
         "prettier": "3.8.1"
     },
     "dependencies": {
-        "@suite-common/react-query": "workspace:^"
+        "@suite-common/calldata": "workspace:^",
+        "@suite-common/react-query": "workspace:^",
+        "@trezor/utils": "workspace:^",
+        "zod": "4.3.6"
     }
 }

--- a/suite-common/earn-api/src/constants/vaults.ts
+++ b/suite-common/earn-api/src/constants/vaults.ts
@@ -1,0 +1,14 @@
+// Temporary, it'll come from the API in the future,
+// but for now to be able to validate Yield.xyz data we need it hardcoded
+export const EVM_VAULT_ADDRESSES: Record<string, `0x${string}`> = {
+    'ethereum-usdc-steakusdc-0xbeef01735c132ada46aa9aa4c54623caa92a64cb-4626-vault':
+        '0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB',
+    'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault':
+        '0xbEef047a543E45807105E51A8BBEFCc5950fcfBa',
+    'arbitrum-usdc-steakusdc-0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca-4626-vault':
+        '0x250CF7c82bAc7cB6cf899b6052979d4B5BA1f9ca',
+    'base-usdc-steakusdc-0xbeefe94c8ad530842bfe7d8b397938ffc1cb83b2-4626-vault':
+        '0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2',
+    'ethereum-usdc-wgtusdc-0x8fee7605f78195379a977426ee5e0bab1eac2aec-third-party-oav':
+        '0x8fee7605f78195379a977426ee5E0BAb1eAc2aeC',
+};

--- a/suite-common/earn-api/src/hooks/useEnterYieldOpportunity.ts
+++ b/suite-common/earn-api/src/hooks/useEnterYieldOpportunity.ts
@@ -1,9 +1,17 @@
 import { desktopMutationKeys, useMutation } from '@suite-common/react-query';
 
 import { type CreateActionDto, type EnterYieldResponseSuccess, enterYield } from '../api';
+import { verifyEnterTransactions } from '../verification/enter';
+import { type VerificationStatus } from '../verification/shared';
 
 type EnterYieldOpportunityVariables = Pick<CreateActionDto, 'yieldId' | 'address'> & {
     amount: string;
+    decimals: number;
+};
+
+type EnterYieldOpportunityResult = {
+    response: EnterYieldResponseSuccess;
+    verification: VerificationStatus;
 };
 
 /**
@@ -11,14 +19,23 @@ type EnterYieldOpportunityVariables = Pick<CreateActionDto, 'yieldId' | 'address
  * @url https://docs.yield.xyz/reference/actionscontroller_enteryield
  */
 export function useEnterYieldOpportunity() {
-    return useMutation<EnterYieldResponseSuccess, Error, EnterYieldOpportunityVariables>({
+    return useMutation<EnterYieldOpportunityResult, Error, EnterYieldOpportunityVariables>({
         mutationKey: desktopMutationKeys.enterYieldOpportunity,
-        mutationFn({ yieldId, address, amount }) {
-            return enterYield({
+        async mutationFn({ yieldId, address, amount, decimals }) {
+            const response = await enterYield({
                 yieldId,
                 address,
                 arguments: { amount },
             });
+
+            const verification = verifyEnterTransactions(response, {
+                yieldId,
+                address,
+                amount,
+                decimals,
+            });
+
+            return { response, verification };
         },
     });
 }

--- a/suite-common/earn-api/src/hooks/useExitYieldOpportunity.ts
+++ b/suite-common/earn-api/src/hooks/useExitYieldOpportunity.ts
@@ -1,0 +1,35 @@
+import { desktopMutationKeys, useMutation } from '@suite-common/react-query';
+
+import { type CreateActionDto, type ExitYieldResponseSuccess, exitYield } from '../api';
+import { verifyExitTransactions } from '../verification/exit';
+import { type VerificationStatus } from '../verification/shared';
+
+type ExitYieldOpportunityVariables = Pick<CreateActionDto, 'yieldId' | 'address'> & {
+    amount: string;
+};
+
+type ExitYieldOpportunityResult = {
+    response: ExitYieldResponseSuccess;
+    verification: VerificationStatus;
+};
+
+/**
+ * Generate the transactions needed to exit a yield position
+ * @url https://docs.yield.xyz/reference/actionscontroller_exityield
+ */
+export function useExitYieldOpportunity() {
+    return useMutation<ExitYieldOpportunityResult, Error, ExitYieldOpportunityVariables>({
+        mutationKey: desktopMutationKeys.exitYieldOpportunity,
+        async mutationFn({ yieldId, address, amount }) {
+            const response = await exitYield({
+                yieldId,
+                address,
+                arguments: { amount },
+            });
+
+            const verification = verifyExitTransactions(response, { yieldId, address });
+
+            return { response, verification };
+        },
+    });
+}

--- a/suite-common/earn-api/src/index.ts
+++ b/suite-common/earn-api/src/index.ts
@@ -3,4 +3,6 @@ export * from './config';
 export * from './hooks/useAllYieldOpportunities';
 export * from './hooks/useGetYieldOpportunities';
 export * from './hooks/useEnterYieldOpportunity';
+export * from './hooks/useExitYieldOpportunity';
 export * from './hooks/useSubmitTxHash';
+export * from './constants/vaults';

--- a/suite-common/earn-api/src/tests/verification/enter.test.ts
+++ b/suite-common/earn-api/src/tests/verification/enter.test.ts
@@ -1,0 +1,98 @@
+import { type EnterYieldResponseSuccess, TransactionDtoType } from '../../api';
+import { verifyEnterTransactions } from '../../verification/enter';
+
+const YIELD_ID = 'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault';
+const ADDRESS = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const AMOUNT = '1';
+const DECIMALS = 6;
+
+const APPROVAL_UNSIGNED_TX =
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0xe563","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","data":"0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+
+const SUPPLY_UNSIGNED_TX =
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x124f80","to":"0xbEef047a543E45807105E51A8BBEFCc5950fcfBa","data":"0x6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+
+const mockResponse = (transactions: { type: TransactionDtoType; unsignedTransaction: unknown }[]) =>
+    ({ data: { transactions } }) as unknown as EnterYieldResponseSuccess;
+
+describe('verifyEnterTransactions', () => {
+    it('returns success when all transactions are verified', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.APPROVAL, unsignedTransaction: APPROVAL_UNSIGNED_TX },
+            { type: TransactionDtoType.SUPPLY, unsignedTransaction: SUPPLY_UNSIGNED_TX },
+        ]);
+
+        expect(
+            verifyEnterTransactions(response, {
+                yieldId: YIELD_ID,
+                address: ADDRESS,
+                amount: AMOUNT,
+                decimals: DECIMALS,
+            }),
+        ).toBe('success');
+    });
+
+    it('returns failure when supply to address does not match vault', () => {
+        const tx = JSON.parse(SUPPLY_UNSIGNED_TX);
+        tx.to = '0x0000000000000000000000000000000000000001';
+        const response = mockResponse([
+            { type: TransactionDtoType.SUPPLY, unsignedTransaction: JSON.stringify(tx) },
+        ]);
+
+        expect(
+            verifyEnterTransactions(response, {
+                yieldId: YIELD_ID,
+                address: ADDRESS,
+                amount: AMOUNT,
+                decimals: DECIMALS,
+            }),
+        ).toBe('failure');
+    });
+
+    it('returns skipped when transaction type is unknown', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.STAKE, unsignedTransaction: APPROVAL_UNSIGNED_TX },
+        ]);
+
+        expect(
+            verifyEnterTransactions(response, {
+                yieldId: YIELD_ID,
+                address: ADDRESS,
+                amount: AMOUNT,
+                decimals: DECIMALS,
+            }),
+        ).toBe('skipped');
+    });
+
+    it('returns skipped when vault is not in constants', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.APPROVAL, unsignedTransaction: APPROVAL_UNSIGNED_TX },
+            { type: TransactionDtoType.SUPPLY, unsignedTransaction: SUPPLY_UNSIGNED_TX },
+        ]);
+
+        expect(
+            verifyEnterTransactions(response, {
+                yieldId: 'unknown-yield-id',
+                address: ADDRESS,
+                amount: AMOUNT,
+                decimals: DECIMALS,
+            }),
+        ).toBe('skipped');
+    });
+
+    it('returns failure when amount does not match', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.APPROVAL, unsignedTransaction: APPROVAL_UNSIGNED_TX },
+            { type: TransactionDtoType.SUPPLY, unsignedTransaction: SUPPLY_UNSIGNED_TX },
+        ]);
+
+        expect(
+            verifyEnterTransactions(response, {
+                yieldId: YIELD_ID,
+                address: ADDRESS,
+                amount: '999',
+                decimals: DECIMALS,
+            }),
+        ).toBe('failure');
+    });
+});

--- a/suite-common/earn-api/src/tests/verification/exit.test.ts
+++ b/suite-common/earn-api/src/tests/verification/exit.test.ts
@@ -1,0 +1,70 @@
+import { type ExitYieldResponseSuccess, TransactionDtoType } from '../../api';
+import { verifyExitTransactions } from '../../verification/exit';
+
+const YIELD_ID = 'ethereum-usdt-steakusdt-0xbeef047a543e45807105e51a8bbefcc5950fcfba-4626-vault';
+const ADDRESS = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+
+const WITHDRAW_UNSIGNED_TX =
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x071918","to":"0xbEef047a543E45807105E51A8BBEFCc5950fcfBa","data":"0xba0876520000000000000000000000000000000000000000000000000c7a27dbf69bc4850000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae30000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":667,"type":2,"maxFeePerGas":"0x17d78400","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+
+const mockResponse = (transactions: { type: TransactionDtoType; unsignedTransaction: unknown }[]) =>
+    ({ data: { transactions } }) as unknown as ExitYieldResponseSuccess;
+
+describe('verifyExitTransactions', () => {
+    it('returns success when all transactions are verified', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.WITHDRAW, unsignedTransaction: WITHDRAW_UNSIGNED_TX },
+        ]);
+
+        expect(verifyExitTransactions(response, { yieldId: YIELD_ID, address: ADDRESS })).toBe(
+            'success',
+        );
+    });
+
+    it('returns failure when to address does not match vault', () => {
+        const tx = JSON.parse(WITHDRAW_UNSIGNED_TX);
+        tx.to = '0x0000000000000000000000000000000000000001';
+        const response = mockResponse([
+            { type: TransactionDtoType.WITHDRAW, unsignedTransaction: JSON.stringify(tx) },
+        ]);
+
+        expect(verifyExitTransactions(response, { yieldId: YIELD_ID, address: ADDRESS })).toBe(
+            'failure',
+        );
+    });
+
+    it('returns failure when receiver does not match address', () => {
+        const tx = JSON.parse(WITHDRAW_UNSIGNED_TX);
+        tx.data = tx.data.replace(
+            /9ea3721b5bf3b64b4418c38b603154d2d597fae3/g,
+            '0000000000000000000000000000000000000001',
+        );
+        const response = mockResponse([
+            { type: TransactionDtoType.WITHDRAW, unsignedTransaction: JSON.stringify(tx) },
+        ]);
+
+        expect(verifyExitTransactions(response, { yieldId: YIELD_ID, address: ADDRESS })).toBe(
+            'failure',
+        );
+    });
+
+    it('returns skipped when transaction type is unknown', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.STAKE, unsignedTransaction: WITHDRAW_UNSIGNED_TX },
+        ]);
+
+        expect(verifyExitTransactions(response, { yieldId: YIELD_ID, address: ADDRESS })).toBe(
+            'skipped',
+        );
+    });
+
+    it('returns skipped when vault is not in constants', () => {
+        const response = mockResponse([
+            { type: TransactionDtoType.WITHDRAW, unsignedTransaction: WITHDRAW_UNSIGNED_TX },
+        ]);
+
+        expect(
+            verifyExitTransactions(response, { yieldId: 'unknown-yield-id', address: ADDRESS }),
+        ).toBe('skipped');
+    });
+});

--- a/suite-common/earn-api/src/tests/verification/schema.test.ts
+++ b/suite-common/earn-api/src/tests/verification/schema.test.ts
@@ -1,0 +1,58 @@
+import { parseUnsignedEvmTransaction } from '../../verification/schema';
+
+const APPROVAL_UNSIGNED_TX =
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0xe563","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","data":"0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+
+const SUPPLY_UNSIGNED_TX =
+    '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0x124f80","to":"0xbEef047a543E45807105E51A8BBEFCc5950fcfBa","data":"0x6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';
+
+describe('parseUnsignedEvmTransaction', () => {
+    it('parses a valid approval transaction', () => {
+        const result = parseUnsignedEvmTransaction(APPROVAL_UNSIGNED_TX);
+
+        expect(result).toEqual({
+            from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+            to: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            data: '0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240',
+            chainId: 1,
+        });
+    });
+
+    it('parses a valid supply transaction', () => {
+        const result = parseUnsignedEvmTransaction(SUPPLY_UNSIGNED_TX);
+
+        expect(result).toEqual({
+            from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
+            to: '0xbEef047a543E45807105E51A8BBEFCc5950fcfBa',
+            data: '0x6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3',
+            chainId: 1,
+        });
+    });
+
+    it('returns null for non-string input', () => {
+        expect(parseUnsignedEvmTransaction(null)).toBeNull();
+        expect(parseUnsignedEvmTransaction(undefined)).toBeNull();
+        expect(parseUnsignedEvmTransaction(1)).toBeNull();
+    });
+
+    it('returns null for invalid JSON', () => {
+        expect(parseUnsignedEvmTransaction('not-json')).toBeNull();
+        expect(parseUnsignedEvmTransaction('{invalid')).toBeNull();
+    });
+
+    it.each(['from', 'to', 'data'])('returns null when %s field missing 0x prefix', field => {
+        const tx = JSON.parse(APPROVAL_UNSIGNED_TX);
+        tx[field] = tx[field].slice(2);
+        const result = parseUnsignedEvmTransaction(JSON.stringify(tx));
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null when required field is missing', () => {
+        const tx = JSON.parse(APPROVAL_UNSIGNED_TX);
+        delete tx.chainId;
+        const result = parseUnsignedEvmTransaction(JSON.stringify(tx));
+
+        expect(result).toBeNull();
+    });
+});

--- a/suite-common/earn-api/src/verification/enter.ts
+++ b/suite-common/earn-api/src/verification/enter.ts
@@ -1,0 +1,74 @@
+import { Verifier, asEvmAddress } from '@suite-common/calldata';
+import { BigNumber } from '@trezor/utils';
+
+import { type EnterYieldResponseSuccess, TransactionDtoType } from '../api';
+import { parseUnsignedEvmTransaction } from './schema';
+import {
+    type TransactionVerificationStatus,
+    type VerificationStatus,
+    aggregateStatuses,
+    toStatus,
+} from './shared';
+import { EVM_VAULT_ADDRESSES } from '../constants/vaults';
+
+type VerifyEnterTransactionsParams = {
+    yieldId: string;
+    address: string;
+    amount: string;
+    decimals: number;
+};
+
+const verifyApproval = (
+    calldata: `0x${string}`,
+    spender: `0x${string}`,
+    amount: bigint,
+): TransactionVerificationStatus =>
+    toStatus(Verifier.evm.erc20.approve(calldata, { spender, amount }).isValid);
+
+const verifySupply = (
+    calldata: `0x${string}`,
+    to: `0x${string}`,
+    vaultAddress: `0x${string}`,
+    receiver: `0x${string}`,
+    assets: bigint,
+): TransactionVerificationStatus => {
+    if (to.toLowerCase() !== vaultAddress.toLowerCase()) return 'failed';
+
+    return toStatus(Verifier.evm.erc4626.deposit(calldata, { assets, receiver }).isValid);
+};
+
+const getTransactionStatus = (
+    tx: EnterYieldResponseSuccess['data']['transactions'][number],
+    vaultAddress: `0x${string}` | undefined,
+    address: `0x${string}`,
+    amountBigInt: bigint,
+): TransactionVerificationStatus => {
+    const parsed = parseUnsignedEvmTransaction(tx.unsignedTransaction);
+
+    if (!parsed || !vaultAddress) return 'skipped';
+
+    switch (tx.type) {
+        case TransactionDtoType.APPROVAL:
+            return verifyApproval(parsed.data, vaultAddress, amountBigInt);
+        case TransactionDtoType.SUPPLY:
+            return verifySupply(parsed.data, parsed.to, vaultAddress, address, amountBigInt);
+        default:
+            return 'skipped';
+    }
+};
+
+export const verifyEnterTransactions = (
+    response: EnterYieldResponseSuccess,
+    { yieldId, address, amount, decimals }: VerifyEnterTransactionsParams,
+): VerificationStatus => {
+    const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
+    const amountBigInt = BigInt(
+        new BigNumber(amount).times(new BigNumber(10).pow(decimals)).toFixed(0),
+    );
+
+    const statuses = response.data.transactions.map(tx =>
+        getTransactionStatus(tx, vaultAddress, asEvmAddress(address), amountBigInt),
+    );
+
+    return aggregateStatuses(statuses);
+};

--- a/suite-common/earn-api/src/verification/exit.ts
+++ b/suite-common/earn-api/src/verification/exit.ts
@@ -1,0 +1,67 @@
+import { Verifier, asEvmAddress } from '@suite-common/calldata';
+
+import { type ExitYieldResponseSuccess, TransactionDtoType } from '../api';
+import { parseUnsignedEvmTransaction } from './schema';
+import {
+    type TransactionVerificationStatus,
+    type VerificationStatus,
+    aggregateStatuses,
+    toStatus,
+} from './shared';
+import { EVM_VAULT_ADDRESSES } from '../constants/vaults';
+
+type VerifyExitTransactionsParams = {
+    yieldId: string;
+    address: string;
+};
+
+const verifyRedeem = (
+    calldata: `0x${string}`,
+    to: `0x${string}`,
+    vaultAddress: `0x${string}`,
+    address: string,
+): TransactionVerificationStatus => {
+    if (to.toLowerCase() !== vaultAddress.toLowerCase()) return 'failed';
+
+    const result = Verifier.evm.erc4626.redeem(
+        calldata,
+        {
+            shares: 0n,
+            receiver: asEvmAddress(address),
+            owner: asEvmAddress(address),
+        },
+        ['receiver', 'owner'],
+    );
+
+    return toStatus(result.isValid);
+};
+
+const getTransactionStatus = (
+    tx: ExitYieldResponseSuccess['data']['transactions'][number],
+    vaultAddress: `0x${string}` | undefined,
+    address: string,
+): TransactionVerificationStatus => {
+    const parsed = parseUnsignedEvmTransaction(tx.unsignedTransaction);
+
+    if (!parsed || !vaultAddress) return 'skipped';
+
+    switch (tx.type) {
+        case TransactionDtoType.WITHDRAW:
+            return verifyRedeem(parsed.data, parsed.to, vaultAddress, address);
+        default:
+            return 'skipped';
+    }
+};
+
+export const verifyExitTransactions = (
+    response: ExitYieldResponseSuccess,
+    { yieldId, address }: VerifyExitTransactionsParams,
+): VerificationStatus => {
+    const vaultAddress = EVM_VAULT_ADDRESSES[yieldId];
+
+    const statuses = response.data.transactions.map(tx =>
+        getTransactionStatus(tx, vaultAddress, address),
+    );
+
+    return aggregateStatuses(statuses);
+};

--- a/suite-common/earn-api/src/verification/index.ts
+++ b/suite-common/earn-api/src/verification/index.ts
@@ -1,0 +1,4 @@
+export * from './schema';
+export * from './shared';
+export * from './enter';
+export * from './exit';

--- a/suite-common/earn-api/src/verification/schema.ts
+++ b/suite-common/earn-api/src/verification/schema.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+const evmHexString = z
+    .string()
+    .startsWith('0x')
+    .transform(s => s as `0x${string}`);
+
+export const UnsignedEvmTransactionSchema = z.object({
+    from: evmHexString,
+    to: evmHexString,
+    data: evmHexString,
+    chainId: z.number(),
+});
+
+export type UnsignedEvmTransaction = z.infer<typeof UnsignedEvmTransactionSchema>;
+
+export const parseUnsignedEvmTransaction = (raw: unknown): UnsignedEvmTransaction | null => {
+    if (typeof raw !== 'string') {
+        return null;
+    }
+
+    try {
+        const result = UnsignedEvmTransactionSchema.safeParse(JSON.parse(raw));
+
+        return result.success ? result.data : null;
+    } catch {
+        return null;
+    }
+};

--- a/suite-common/earn-api/src/verification/shared.ts
+++ b/suite-common/earn-api/src/verification/shared.ts
@@ -1,0 +1,15 @@
+export type VerificationStatus = 'success' | 'failure' | 'skipped';
+export type TransactionVerificationStatus = 'verified' | 'failed' | 'skipped';
+
+export const toStatus = (isValid: boolean): TransactionVerificationStatus =>
+    isValid ? 'verified' : 'failed';
+
+export const aggregateStatuses = (
+    statuses: TransactionVerificationStatus[],
+): VerificationStatus => {
+    if (statuses.length === 0) return 'skipped';
+    if (statuses.some(s => s === 'failed')) return 'failure';
+    if (statuses.every(s => s === 'verified')) return 'success';
+
+    return 'skipped';
+};

--- a/suite-common/earn-api/tsconfig.json
+++ b/suite-common/earn-api/tsconfig.json
@@ -1,5 +1,9 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../react-query" }]
+    "references": [
+        { "path": "../calldata" },
+        { "path": "../react-query" },
+        { "path": "../../packages/utils" }
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11083,12 +11083,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/calldata@workspace:suite-common/calldata":
+"@suite-common/calldata@workspace:^, @suite-common/calldata@workspace:suite-common/calldata":
   version: 0.0.0-use.local
   resolution: "@suite-common/calldata@workspace:suite-common/calldata"
   dependencies:
-    "@suite-common/suite-constants": "workspace:*"
-    "@suite-common/wallet-utils": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     viem: "npm:^2.46.3"
@@ -11228,9 +11226,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/earn-api@workspace:suite-common/earn-api"
   dependencies:
+    "@suite-common/calldata": "workspace:^"
     "@suite-common/react-query": "workspace:^"
+    "@trezor/utils": "workspace:^"
     orval: "npm:8.5.0"
     prettier: "npm:3.8.1"
+    zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

### @suite-common/calldata

Adds a Verifier alongside the existing Calldata builder. The verifier decodes externally-provided calldata using the ABI and checks decoded field values against expected params. Supports full and partial validation via an optional fields array.

### @suite-common/earn-api

Verifies transaction calldata returned by the yield.xyz API before the user signs. For the enter flow, verifies **ERC-20 approve (spender + amount)** and **ERC-4626 deposit (assets + receiver)**. For the exit flow, verifies **ERC-4626 redeem (receiver + owner)**. Verification result (success | failure | skipped) is returned from the `useEnterYieldOpportunity` and `useExitYieldOpportunity` hooks.

## Notes for QA

Nothing to test here, this is just a prerequisite for supply/exit flow development.

## Related Issue

Resolve #25024

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-tx-data-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-tx-data-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-tx-data-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T07:26:21.329Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T07:25:00.359Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->