### PR TITLE
Fix/erase qm data when ss off

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import {
     enforceQuotaManagerUpdated,
-    eraseFetchedDataDebug,
+    eraseFetchedData,
     selectEnforceQuotaManager,
     selectOwnersAllowance,
     selectQuotaManagerBaseUrl,
@@ -40,7 +40,7 @@ export const QuotaManagerSettings = () => {
         }, 300);
     };
 
-    const onEraseFetchedData = () => dispatch(eraseFetchedDataDebug());
+    const onEraseFetchedData = () => dispatch(eraseFetchedData());
 
     const onToggleEnforceQuotaManager = () =>
         dispatch(

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -20,7 +20,7 @@ export {
     quotaManagerDeviceFetched,
     quotaManagerFetchError,
     suiteSyncQuotaManagerActions,
-    eraseFetchedData as eraseFetchedDataDebug,
+    eraseFetchedData,
     noQuotaLeftWarningDismissed,
     enforceQuotaManagerUpdated,
 } from './quotaManagerActions';

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -28,7 +28,6 @@ export const createTurnOffSuiteSync =
         }
 
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: false }));
-        deps.dispatch(eraseFetchedData());
 
         const deviceStaticSessionIds = deps.getAllDeviceSessionIds();
 
@@ -41,6 +40,8 @@ export const createTurnOffSuiteSync =
         if (params.ensureSettingsPersisted) {
             await params.ensureSettingsPersisted();
         }
+
+        deps.dispatch(eraseFetchedData());
 
         // NOTE: this is TEMPORARY solution until https://github.com/trezor/trezor-suite/issues/23641 is resolved
         deps.reloadApp();

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { eraseFetchedDataDebug } from '@suite-common/suite-sync-quota-manager';
+import { eraseFetchedData } from '@suite-common/suite-sync-quota-manager';
 import {
     type SuiteSyncAppReloaderDep,
     type TurnOffSuiteSync,
@@ -28,7 +28,7 @@ export const createTurnOffSuiteSync =
         }
 
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: false }));
-        deps.dispatch(eraseFetchedDataDebug());
+        deps.dispatch(eraseFetchedData());
 
         const deviceStaticSessionIds = deps.getAllDeviceSessionIds();
 

--- a/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
+++ b/suite-native/module-dev-utils/src/components/SuiteSyncQuotaManager.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
     enforceQuotaManagerUpdated,
-    eraseFetchedDataDebug,
+    eraseFetchedData,
     selectEnforceQuotaManager,
     selectOwnersAllowance,
     selectQuotaManagerBaseUrl,
@@ -23,7 +23,7 @@ export const SuiteSyncQuotaManager = () => {
     const ownersAllowance = useSelector(selectOwnersAllowance);
     const enforceQuotaManager = useSelector(selectEnforceQuotaManager);
 
-    const onEraseFetchedData = () => dispatch(eraseFetchedDataDebug());
+    const onEraseFetchedData = () => dispatch(eraseFetchedData());
 
     const onToggleEnforceQuotaManager = () =>
         dispatch(


### PR DESCRIPTION
dispatching eraseFetchedData from QM was too early in the case of turning SS off.

**changes**:
- fixed action name
- fix and dispatched the action later in the flow 

## Notes for QA

- should clear fetched data correctly when turning SS off

resolves https://github.com/trezor/trezor-suite/issues/25341

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/erase-qm-data-when-ss-off&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/erase-qm-data-when-ss-off&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/erase-qm-data-when-ss-off&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T01:04:39.980Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Account transactions overview > Check graph span and search a transaction by BTC address | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T01:02:34.727Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->