### PR TITLE
fix(trading): swap displays wrong account after browser back

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -207,6 +207,22 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         }
     };
 
+    useEffect(() => {
+        const selectedAccountKey = sendCryptoSelect?.accountKey;
+
+        if (!selectedAccountKey || selectedAccountKey === account.key) {
+            return;
+        }
+
+        const selectedAccount = accounts.find(item => item.key === selectedAccountKey);
+
+        if (!selectedAccount) {
+            return;
+        }
+
+        setAccountOnChange(selectedAccount);
+    }, [account.key, accounts, sendCryptoSelect?.accountKey, setAccountOnChange]);
+
     const setRatioAmount = (divisor: number) => {
         const amount = tokenData
             ? new BigNumber(tokenData.balance || '0')

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { type FieldErrors, type UseFormReturn } from 'react-hook-form';
+import { type FieldErrors, type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
-import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
+import { selectAccountByKey, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { getNetworkReserve } from '@suite-common/wallet-utils';
 import { NumberInput } from '@trezor/product-components';
 import { useDidUpdate } from '@trezor/react-utils';
@@ -58,16 +58,6 @@ export const TradingFormInputCryptoAmount = ({
     const context = useTradingFormContext();
     const { amountLimits, account, network } = context;
 
-    const feeInUnits =
-        isTradingSellContext(context) || isTradingExchangeContext(context)
-            ? getFeeInUnits({
-                  symbol: account.symbol,
-                  composedLevels: context.composedLevels,
-                  selectedFee: context.composedTransactionInfo?.selectedFee,
-              })
-            : undefined;
-
-    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const {
         control,
@@ -76,6 +66,24 @@ export const TradingFormInputCryptoAmount = ({
         trigger,
         clearErrors,
     } = useTradingFormContext() as UseFormReturn<TradingAllFormProps>;
+
+    const sendCryptoSelect = useWatch({
+        control,
+        name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
+    });
+    const selectedSendAccount = useSelector(state =>
+        selectAccountByKey(state, sendCryptoSelect?.accountKey),
+    );
+    const validationAccount = selectedSendAccount ?? account;
+    const feeInUnits =
+        isTradingSellContext(context) || isTradingExchangeContext(context)
+            ? getFeeInUnits({
+                  symbol: validationAccount.symbol,
+                  composedLevels: context.composedLevels,
+                  selectedFee: context.composedTransactionInfo?.selectedFee,
+              })
+            : undefined;
+    const { shouldSendInSats } = useBitcoinAmountUnit(validationAccount.symbol);
 
     const cryptoSelect = getValues(cryptoSelectName);
     const cryptoInputError =
@@ -121,18 +129,18 @@ export const TradingFormInputCryptoAmount = ({
             ...(!isTradingBuyContext(context)
                 ? {
                       reserveOrBalance: validateReserveOrBalance(translationString, {
-                          account,
+                          account: validationAccount,
                           areSatsUsed: !!shouldSendInSats,
                           contractAddress: getValues('outputs')?.[0]?.token,
                       }),
                       networkReserve: isNetworkReserveEnabled
                           ? validateNetworkReserve(translationString, {
                                 reserve: getNetworkReserve({
-                                    symbol: account.symbol,
+                                    symbol: validationAccount.symbol,
                                     contractAddress,
                                     isEnabled: isNetworkReserveEnabled,
                                 }),
-                                balance: account.formattedBalance,
+                                balance: validationAccount.formattedBalance,
                                 fee: feeInUnits?.toString(),
                             })
                           : () => undefined,
@@ -146,6 +154,10 @@ export const TradingFormInputCryptoAmount = ({
             trigger([cryptoInputName]);
         }
     }, [amountLimits, trigger]);
+
+    useDidUpdate(() => {
+        trigger([cryptoInputName]);
+    }, [cryptoInputName, trigger, validationAccount.key]);
 
     return (
         <NumberInput


### PR DESCRIPTION
## Description

Fixes the swap account mismatch after browser back navigation.

When returning from Manage via browser back, the form could keep stale account data. This change synchronizes the selected send account from form state and uses that account for amount validation and reserve checks so labels and validation data stay consistent.

## Notes for QA

1. Success path
- Open Swap and choose a non-BTC account (for example Solana).
- Enter amount (including Max/ratio button flows).
- Click Manage next to account, then use browser Back.
- Verify the previously selected account is still selected in the form context. 

2. Regression/edge path
- Repeat with token account selection (contract-address based asset) and verify amount validation still works.
- Verify reserve/balance validation messages correspond to the currently selected send account after back navigation.
- Verify no unexpected reset of amount/fiat fields when returning back.

## Related Issue

Resolve #24173

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-swap-displays-wrong-account-24173&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-swap-displays-wrong-account-24173&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T06:58:41.651Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T06:57:52.695Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->