### PR TITLE
fix(suite-native): show device switcher icon also during Connect init

### DIFF
--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemIcon.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemIcon.tsx
@@ -9,7 +9,7 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { DeviceModelIcon, Icon, type IconSize } from '@suite-native/icons';
 
 type DeviceItemIconProps = {
-    deviceId: TrezorDevice['id'];
+    deviceId?: TrezorDevice['id'];
     iconSize?: IconSize | number;
 };
 

--- a/suite-native/device-manager/src/components/DeviceSwitchContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitchContent.tsx
@@ -1,12 +1,14 @@
+import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectDeviceState, selectNumberOfDeviceInstances } from '@suite-common/device';
-import { Text } from '@suite-native/atoms';
+import { HStack, Text } from '@suite-native/atoms';
 import { selectShouldFactoryResetBeVisible } from '@suite-native/device';
 import { Translation } from '@suite-native/intl';
 
 import { BootloaderModeItemContent } from './BootloaderModeItemContent';
 import { DeviceItemContent } from './DeviceItem/DeviceItemContent';
+import { DeviceItemIcon } from './DeviceItem/DeviceItemIcon';
 
 export const DeviceSwitchContent = () => {
     const deviceState = useSelector(selectDeviceState);
@@ -29,8 +31,11 @@ export const DeviceSwitchContent = () => {
     }
 
     return (
-        <Text variant="body-md-strong">
-            <Translation id="deviceManager.defaultHeader" />
-        </Text>
+        <HStack alignItems="center">
+            <DeviceItemIcon />
+            <Text variant="body-md-strong">
+                <Translation id="deviceManager.defaultHeader" />
+            </Text>
+        </HStack>
     );
 };


### PR DESCRIPTION
Icon added to the fallback content in `DeviceSwitchContent`.

## Videos

### Before

https://github.com/user-attachments/assets/49a6811d-6d7a-4e1e-8858-aba37e921a1f

### After

https://github.com/user-attachments/assets/f5ead7a4-506f-4a36-8de4-4e4d21b4671c


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/device-switcher-icon&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->