### PR TITLE
Feat/connect compose psbt tx

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -75,6 +75,7 @@ const connectPublicCallableMethodGroups = {
     bitcoin: [
         'sendTransaction',
         'signTransaction',
+        'composePsbt',
         'composeTransaction',
         'authorizeCoinjoin',
         'cancelCoinjoinAuthorization',

--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -516,6 +516,33 @@ export const sendTransaction = async (api: TrezorConnect) => {
     }
 };
 
+export const composePsbt = async (api: TrezorConnect) => {
+    const precompose = await api.composePsbt({
+        account: {
+            addresses: {
+                used: [],
+                unused: [],
+                change: [],
+            },
+            utxo: [],
+        },
+        coin: 'btc',
+        psbtData: '70736274ff01000a0000000000000000000000',
+    });
+
+    if (precompose.success) {
+        const { payload } = precompose;
+        const tx = payload;
+        if (tx.type === 'final') {
+            tx.inputs.map(a => a.prev_index.toFixed());
+            tx.outputs.map(a => a.amount.toString());
+        }
+    } else {
+        precompose.error.message.toLowerCase();
+        precompose.error.code.toLowerCase();
+    }
+};
+
 export const composeTransaction = async (api: TrezorConnect) => {
     const precompose = await api.composeTransaction({
         outputs: [],
@@ -530,8 +557,6 @@ export const composeTransaction = async (api: TrezorConnect) => {
         },
         feeLevels: [{ feePerUnit: '1' }],
         coin: 'btc',
-        // @ts-expect-error
-        push: true,
     });
 
     if (precompose.success) {
@@ -544,16 +569,15 @@ export const composeTransaction = async (api: TrezorConnect) => {
         if (tx.type === 'nonfinal') {
             tx.bytes.toFixed();
             tx.feePerByte.toLowerCase();
-            tx.inputs.map((a: any) => a);
+            tx.inputs.map(a => a.prev_index.toFixed());
         }
         if (tx.type === 'final') {
-            tx.inputs.map((a: any) => a);
-            tx.outputs.map((a: any) => a);
+            tx.inputs.map(a => a.prev_index.toFixed());
+            tx.outputs.map(a => a.amount.toString());
         }
     } else {
         precompose.error.message.toLowerCase();
-        // @ts-expect-error
-        precompose.payload.type.toLowerCase();
+        precompose.error.code.toLowerCase();
     }
 };
 

--- a/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composePsbt.ts
@@ -1,0 +1,24 @@
+import type { AccountAddresses, Utxo as AccountUtxo } from '@trezor/blockchain-link';
+import type { ComposeInput as ComposeInputBase } from '@trezor/utxo-lib';
+
+import type { PrecomposeResultFinal } from './composeTransaction';
+import { type CoinSymbol } from '../../coinInfo';
+import type { Params, Response } from '../../params';
+
+export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
+
+export type ComposePsbtParams = {
+    account: {
+        addresses: AccountAddresses;
+        utxo: ComposeUtxo[];
+    };
+    coin: CoinSymbol;
+    psbtData: string;
+};
+
+export type ComposePsbtResult = PrecomposeResultFinal & {
+    version: number;
+    locktime: number;
+};
+
+export declare function composePsbt(params: Params<ComposePsbtParams>): Response<ComposePsbtResult>;

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -3,6 +3,7 @@ import { Type } from '@trezor/schema-utils';
 
 import type { authorizeCoinjoin } from './authorizeCoinjoin';
 import type { cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
+import type { composePsbt } from './composePsbt';
 import type { composeTransaction } from './composeTransaction';
 import type { sendTransaction } from './sendTransaction';
 import type { signTransaction } from './signTransaction';
@@ -11,6 +12,7 @@ import type { signTransaction } from './signTransaction';
 export const TrezorConnectBitcoin = Type.Object({
     signTransaction: Type.Unsafe<typeof signTransaction>(),
     sendTransaction: Type.Unsafe<typeof sendTransaction>(),
+    composePsbt: Type.Unsafe<typeof composePsbt>(),
     composeTransaction: Type.Unsafe<typeof composeTransaction>(),
     authorizeCoinjoin: Type.Unsafe<typeof authorizeCoinjoin>(),
     cancelCoinjoinAuthorization: Type.Unsafe<typeof cancelCoinjoinAuthorization>(),

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -22,6 +22,7 @@ export * from './api/tron/common';
 export * from './api/nostr/common';
 
 // types used in @trezor/suite. if you need a type, reexport it from ./api/<method>
+export type { ComposePsbtParams, ComposePsbtResult } from './api/bitcoin/composePsbt';
 export type {
     PrecomposeResultError,
     PrecomposeResultNonFinal,

--- a/packages/connect/e2e/__fixtures__/composePsbt.ts
+++ b/packages/connect/e2e/__fixtures__/composePsbt.ts
@@ -1,0 +1,109 @@
+const composePsbt: TestCase = {
+    method: 'composePsbt',
+    setup: {
+        mnemonic: 'mnemonic_all',
+    },
+    tests: [
+        {
+            description: 'Bitcoin (P2PKH)',
+            params: {
+                account: {
+                    utxo: [
+                        {
+                            txid: '50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d',
+                            vout: 1,
+                            amount: '50000',
+                            blockHeight: 343014,
+                            path: "m/44'/0'/0'/0/5",
+                            address: '1GA9u9TfCG7SWmKCveBumdA1TZpfom6ZdJ',
+                        },
+                    ],
+                    addresses: {
+                        used: [],
+                        unused: [],
+                        change: [
+                            {
+                                address: '1EcL6AyfQTyWKGvXwNSfsWoYnD3whzVFdu',
+                                path: "m/44'/0'/0'/1/3",
+                            },
+                        ],
+                    },
+                },
+                psbtData:
+                    '70736274ff01007701000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f6500100000000ffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000100e101000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006a47304402203429bd3ce7b38c5c1e8a15340edd79ced41a2939aae62e259d2e3d18e0c5ee7602201b83b10ebc4d6dcee3f9eb42ba8f1ef8a059a05397e0c1b9223d1565a3e6ec01012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff0230750000000000001976a914954820f1de627a703596ac0396f986d958e3de4c88ac10270000000000001976a91405427736705cfbfaff76b1cff48283707fb1037088ac00000000000000',
+                coin: 'btc',
+            },
+            result: {
+                type: 'final',
+                bytes: 226,
+                fee: '10000',
+                feePerByte: '44.24778761061947',
+                totalSpent: '20000',
+                inputs: [{ script_type: 'SPENDADDRESS' }],
+                outputs: [
+                    {
+                        amount: '30000',
+                        script_type: 'PAYTOADDRESS',
+                        address_n: [2147483692, 2147483648, 2147483648, 1, 3],
+                    },
+                    {
+                        amount: '10000',
+                        script_type: 'PAYTOADDRESS',
+                        address: '1Up15Msx4sbvUCGm8Xgo2Zp5FQim3wE59',
+                    },
+                ],
+            },
+        },
+        {
+            description: 'Testnet (Bech32/P2WPKH)',
+            params: {
+                account: {
+                    utxo: [
+                        {
+                            txid: 'ae0949b1b050ac6f92c7d9c1570f2f06c21a997eef8be9ef5edc2a38cb92a879',
+                            vout: 1,
+                            amount: '7802513',
+                            blockHeight: 343014,
+                            path: "m/84'/1'/0'/1/4",
+                            address: 'tb1qguznsd2hyl69gjx2axd6f5qu9k274qj9waffqy',
+                        },
+                    ],
+                    addresses: {
+                        used: [],
+                        unused: [],
+                        change: [
+                            {
+                                address: 'tb1q8zx9dlztqz9apm7y5gtx8a0tlz57fhncx343ya',
+                                path: "m/84'/1'/0'/1/5",
+                            },
+                        ],
+                    },
+                },
+                psbtData:
+                    '70736274ff010061010000000179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7800000000000100cf0100000000010179a892cb382adc5eefe98bef7e991ac2062f0f57c1d9c7926fac50b0b14909ae010000000000000000020000000000000000066a04deadbeeffb0d770000000000160014388c56fc4b008bd0efc4a21663f5ebf8a9e4de7802483045022100a87aa2338d0e7401d26b67b76a6446052ef148186893fe4bdceba467b00b5c2c022073159df4b4bb4514d23c8f9b0566098da47da383a829a941b54e95068beba491012102e7477af80286177f60fbf529b8bd3004dd2f0f407ce9f852b3e88fbe295c0f2700000000000000',
+                coin: 'test',
+            },
+            result: {
+                type: 'final',
+                bytes: 125,
+                fee: '150',
+                feePerByte: '1.2',
+                totalSpent: '150',
+                inputs: [{ script_type: 'SPENDWITNESS' }],
+                outputs: [
+                    {
+                        amount: '0',
+                        script_type: 'PAYTOOPRETURN',
+                        op_return_data: 'deadbeef',
+                    },
+                    {
+                        amount: '7802363',
+                        script_type: 'PAYTOWITNESS',
+                    },
+                ],
+            },
+        },
+    ],
+};
+
+export default composePsbt;

--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -7,6 +7,7 @@ export { default as cardanoGetPublicKey } from './cardanoGetPublicKey';
 export { default as cardanoSignTransaction } from './cardanoSignTransaction';
 export { default as cardanoSignMessage } from './cardanoSignMessage';
 export { default as changeLanguage } from './changeLanguage';
+export { default as composePsbt } from './composePsbt';
 export { default as composeTransaction } from './composeTransaction';
 export { default as ethereumGetAddress } from './ethereumGetAddress';
 export { default as ethereumGetPublicKey } from './ethereumGetPublicKey';

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -8,7 +8,8 @@ import type {
     ProtoWithDerivationPath,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { ComposeOutput as ComposeOutputBase } from '@trezor/utxo-lib';
+import type { ComposeOutput as ComposeOutputBase, Network } from '@trezor/utxo-lib';
+import { address as BitcoinJsAddress, payments as BitcoinJsPayments } from '@trezor/utxo-lib';
 
 import { isValidAddress } from '../../utils/addressUtils';
 import { convertMultisigPubKey } from '../../utils/hdnodeUtils';
@@ -163,4 +164,21 @@ export const outputToTrezor = (
         amount: output.amount,
         script_type: 'PAYTOADDRESS',
     };
+};
+
+export const parseOutputScript = (output: Buffer, network?: Network) => {
+    try {
+        const address = BitcoinJsAddress.fromOutputScript(output, network);
+
+        return { type: 'address', address } as const;
+    } catch {
+        try {
+            const { data: embedScript } = BitcoinJsPayments.embed({ output }, { validate: true });
+            const data = embedScript?.shift()?.toString('hex'); // shift OP code
+
+            return { type: 'data', data } as const;
+        } catch {
+            return { type: 'unknown' } as const;
+        }
+    }
 };

--- a/packages/connect/src/api/bitcoin/parsePsbt.ts
+++ b/packages/connect/src/api/bitcoin/parsePsbt.ts
@@ -1,0 +1,126 @@
+import type {
+    AccountAddresses,
+    AccountUtxo,
+    BitcoinNetworkInfo,
+    ComposePsbtResult,
+} from '@trezor/connect-common';
+import { TypedError } from '@trezor/connect-common/src/constants/errors';
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { bufferUtils } from '@trezor/utils';
+import { Psbt } from '@trezor/utxo-lib';
+
+import { parseOutputScript } from './outputs';
+import { getTransactionVbytes } from './transactionBytes';
+import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
+
+type ParsePsbtParams = {
+    psbtTransactionData: string;
+    coinInfo: BitcoinNetworkInfo;
+    addresses: AccountAddresses;
+    utxos: AccountUtxo[];
+};
+
+export const parsePsbt = ({
+    psbtTransactionData,
+    coinInfo,
+    addresses,
+    utxos,
+}: ParsePsbtParams): ComposePsbtResult => {
+    const psbt = Psbt.fromHex(psbtTransactionData, { network: coinInfo.network });
+
+    const inputs: PROTO.TxInputType[] = [];
+    const outputs: PROTO.TxOutputType[] = [];
+
+    let totalSpent = BigInt(0);
+    let sumOfInputs = BigInt(0);
+    let sumOfOutputs = BigInt(0);
+
+    for (const [index, input] of psbt.unsignedTx.ins.entries()) {
+        const txid = bufferUtils.reverseBuffer(input.hash).toString('hex');
+        const utxo = utxos.find(u => u.vout === input.index && u.txid === txid);
+        if (!utxo) {
+            // TODO: external utxo
+            throw TypedError('Method_InvalidParameter', `parsePsbt: Utxo [${index}] not found`);
+        }
+
+        const address_n = getHDPath(utxo.path);
+        inputs.push({
+            prev_hash: utxo.txid,
+            prev_index: input.index,
+            amount: utxo.amount,
+            address_n,
+            script_type: getScriptType(address_n),
+            sequence: input.sequence,
+        });
+
+        sumOfInputs += BigInt(utxo.amount);
+    }
+
+    const knownAddresses = addresses.used.concat(addresses.unused).concat(addresses.change);
+
+    for (const [index, output] of psbt.unsignedTx.outs.entries()) {
+        const outputScript = parseOutputScript(output.script, coinInfo.network);
+        if (outputScript.type === 'address') {
+            const changeAddress = knownAddresses.find(a => a.address === outputScript.address);
+            if (changeAddress) {
+                const address_n = getHDPath(changeAddress.path);
+                outputs.push({
+                    script_type: getOutputScriptType(address_n),
+                    address_n,
+                    amount: output.value,
+                });
+            } else {
+                outputs.push({
+                    script_type: 'PAYTOADDRESS',
+                    address: outputScript.address,
+                    amount: output.value,
+                });
+                totalSpent += BigInt(output.value);
+            }
+
+            sumOfOutputs += BigInt(output.value);
+        } else if (outputScript.type === 'data') {
+            if (typeof outputScript.data !== 'string') {
+                throw TypedError(
+                    'Method_InvalidParameter',
+                    `parsePsbt: Invalid op_return_data at [${index}]`,
+                );
+            }
+            outputs.push({
+                script_type: 'PAYTOOPRETURN',
+                amount: '0',
+                op_return_data: outputScript.data,
+            });
+            totalSpent += BigInt(output.value);
+            sumOfOutputs += BigInt(output.value);
+        } else {
+            throw TypedError(
+                'Method_InvalidParameter',
+                `parsePsbt: Unknown output type at [${index}]`,
+            );
+        }
+    }
+
+    const fee = sumOfInputs - sumOfOutputs;
+    if (fee <= 0n) {
+        throw TypedError('Method_InvalidParameter', 'parsePsbt: Transaction fee is non-positive');
+    }
+    const bytes = getTransactionVbytes(inputs, outputs, coinInfo);
+    if (!bytes) {
+        throw TypedError('Method_InvalidParameter', 'parsePsbt: Invalid transaction size');
+    }
+    const feePerByte = Number(fee) / bytes;
+
+    return {
+        type: 'final',
+        version: psbt.unsignedTx.version,
+        locktime: psbt.unsignedTx.locktime,
+        totalSpent: (totalSpent + fee).toString(),
+        fee: fee.toString(),
+        feePerByte: feePerByte.toString(),
+        bytes,
+        inputs,
+        outputs,
+        outputsPermutation: Array.from(outputs.keys()),
+    };
+};

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -13,14 +13,13 @@ import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 import { bufferUtils } from '@trezor/utils';
 import {
-    address as BitcoinJsAddress,
     type TxInput as BitcoinJsInput,
     type TxOutput as BitcoinJsOutput,
-    payments as BitcoinJsPayments,
     Transaction as BitcoinJsTransaction,
     type Network,
 } from '@trezor/utxo-lib';
 
+import { parseOutputScript } from './outputs';
 import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
 
 // Referenced transactions are not required if:
@@ -90,22 +89,6 @@ const enhanceTransaction = (refTx: RefTransaction, srcTx: BitcoinJsTransaction):
     return refTx;
 };
 
-const parseOutputScript = (output: Buffer, network?: Network) => {
-    try {
-        const address = BitcoinJsAddress.fromOutputScript(output, network);
-
-        return { type: 'address', address } as const;
-    } catch {
-        try {
-            const { data } = BitcoinJsPayments.embed({ output }, { validate: true });
-
-            return { type: 'data', data } as const;
-        } catch {
-            return { type: 'unknown' } as const;
-        }
-    }
-};
-
 // Transform orig transactions from Blockbook (blockchain-link) to Trezor format
 const transformOrigTransaction = (
     tx: BitcoinJsTransaction,
@@ -149,8 +132,7 @@ const transformOrigTransaction = (
         const parsed = parseOutputScript(output.script, coinInfo.network);
         switch (parsed.type) {
             case 'data': {
-                const op_return_data = parsed.data?.shift()?.toString('hex'); // shift OP code
-                if (typeof op_return_data !== 'string') {
+                if (typeof parsed.data !== 'string') {
                     throw TypedError(
                         'Method_InvalidParameter',
                         `transformOrigTransactions: invalid op_return_data at ${tx.getId()} [${i}]`,
@@ -160,7 +142,7 @@ const transformOrigTransaction = (
                 return {
                     script_type: 'PAYTOOPRETURN',
                     amount: '0',
-                    op_return_data,
+                    op_return_data: parsed.data,
                 };
             }
             case 'address': {

--- a/packages/connect/src/api/composePsbt.ts
+++ b/packages/connect/src/api/composePsbt.ts
@@ -1,0 +1,60 @@
+import {
+    type BitcoinNetworkInfo,
+    type ComposePsbtParams,
+    type PermissionRequest,
+} from '@trezor/connect-common';
+
+import type { MethodMessage } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getBitcoinNetworkOrThrow } from '../data/coinInfo';
+import { parsePsbt } from './bitcoin/parsePsbt';
+import { validateParams } from './common/paramsValidator';
+
+type Params = Omit<ComposePsbtParams, 'coin'> & {
+    coinInfo: BitcoinNetworkInfo;
+};
+
+export default class ComposePsbt extends AbstractMethod<'composePsbt', Params> {
+    constructor(message: MethodMessage<'composePsbt'>) {
+        const { payload } = message;
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'account', type: 'object', required: true },
+            { name: 'psbtData', type: 'string', required: true },
+            { name: 'coin', type: 'string', required: true },
+        ]);
+
+        const coinInfo = getBitcoinNetworkOrThrow(payload.coin);
+
+        const params = {
+            account: payload.account,
+            psbtData: payload.psbtData,
+            coinInfo,
+        };
+
+        super(message, params);
+
+        this.useDevice = false;
+        this.useUi = false;
+        this.requiredFirmwareCoins = [coinInfo];
+    }
+
+    get requiredPermissions(): PermissionRequest[] {
+        return [];
+    }
+
+    get info() {
+        return `Compose PSBT transaction`;
+    }
+
+    run() {
+        const tx = parsePsbt({
+            psbtTransactionData: this.params.psbtData,
+            coinInfo: this.params.coinInfo,
+            addresses: this.params.account.addresses,
+            utxos: this.params.account.utxo,
+        });
+
+        return Promise.resolve(tx);
+    }
+}

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -30,6 +30,7 @@ export { default as evoluSignRegistrationRequest } from './evoluSignRegistration
 export { default as evoluGetDelegatedIdentityKey } from './evoluGetDelegatedIdentityKey';
 export { default as nostrGetPublicKey } from './nostr/nostrGetPublicKey';
 export { default as nostrSignEvent } from './nostr/nostrSignEvent';
+export { default as composePsbt } from './composePsbt';
 export { default as composeTransaction } from './composeTransaction';
 export { default as discoverAccounts } from './discoverAccounts';
 export { default as getAccountInfo } from './getAccountInfo';

--- a/packages/utxo-lib/src/__fixtures__/psbt.ts
+++ b/packages/utxo-lib/src/__fixtures__/psbt.ts
@@ -1,0 +1,24 @@
+export const PSBT_FIXTURES = [
+    {
+        description: 'parses the BIP174 valid vector with 0 inputs and 2 outputs',
+        source: 'BIP174 test vector "PSBT with 0 inputs" from https://en.bitcoin.it/wiki/BIP_0174#Test_Vectors.',
+        hex: '70736274ff01004c020000000002d3dff505000000001976a914d0c59903c5bac2868760e90fd521a4665aa7652088ac00e1f5050000000017a9143545e6e33b832c47050f24d3eeb93c9c03948bc787b32e1300000000',
+        inputCount: 0,
+        outputCount: 2,
+    },
+    {
+        description: 'parses the bitcoinjs/bip174 addInputOutput round-trip vector',
+        source: 'bitcoinjs/bip174 ts_src/tests/addInputOutput.ts from https://github.com/bitcoinjs/bip174.',
+        hex: '70736274ff01009c0100000002d4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5d860300000000ffffffffd4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5dff0100000000ffffffff02d20296490000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87b168de3a0000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87000000000000000000',
+        inputCount: 2,
+        outputCount: 2,
+    },
+    {
+        description:
+            'parses a variant of the bitcoinjs/bip174 round-trip vector with the first output set to the suite fixture funded utxo address',
+        source: 'Derived from bitcoinjs/bip174 ts_src/tests/addInputOutput.ts by replacing the first output script with bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk and resizing outputs to 4000 and 8000 sats.',
+        hex: '70736274ff01009b0100000002d4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5d860300000000ffffffffd4a76ff95de1f4c0161a3e53ea876a91ed95331ae8d012d81f97138498ce5dff0100000000ffffffff02a00f000000000000160014ece6935b2a5a5b5ff997c87370b16fa10f164410401f00000000000017a914e18870f2c297fbfca54c5c6f645c7745a5b66eda87000000000000000000',
+        inputCount: 2,
+        outputCount: 2,
+    },
+] as const;

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -12,6 +12,7 @@ import * as script from './script';
 import { TxWeightCalculator } from './txWeightCalculator';
 
 export { Transaction } from './transaction';
+export { Psbt } from './psbt';
 
 export {
     address,

--- a/packages/utxo-lib/src/psbt.test.ts
+++ b/packages/utxo-lib/src/psbt.test.ts
@@ -1,0 +1,146 @@
+import { address, networks } from '../src';
+import { BufferWriter, varIntSize } from '../src/bufferutils';
+import { PSBT_MAGIC, Psbt } from '../src/psbt';
+import { PSBT_FIXTURES } from './__fixtures__/psbt';
+
+const UNSIGNED_TX_KEY = Buffer.from([0x00]);
+const MAP_SEPARATOR = Buffer.from([0x00]);
+
+const UNSIGNED_TX_HEX =
+    '0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a010000000000';
+const SIGNED_TX_HEX =
+    '0200000001ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000100ffffffff010000000000000000036a010000000000';
+const WITNESS_TX_HEX =
+    '02000000000101ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000ffffffff010000000000000000036a0101010000000000';
+
+function toVarSlice(buffer: Buffer) {
+    const out = Buffer.allocUnsafe(varIntSize(buffer.length) + buffer.length);
+    const writer = new BufferWriter(out);
+    writer.writeVarSlice(buffer);
+
+    return out;
+}
+
+function getSimplePsbtBuffer(unsignedTxHex: string) {
+    const unsignedTx = Buffer.from(unsignedTxHex, 'hex');
+
+    const globalUnsignedTx = Buffer.concat([toVarSlice(UNSIGNED_TX_KEY), toVarSlice(unsignedTx)]);
+
+    return Buffer.concat([
+        PSBT_MAGIC,
+        globalUnsignedTx,
+        MAP_SEPARATOR,
+        MAP_SEPARATOR,
+        MAP_SEPARATOR,
+    ]);
+}
+
+describe('Psbt', () => {
+    it.each(PSBT_FIXTURES)('$description', ({ hex, inputCount, outputCount, source }) => {
+        const psbt = Psbt.fromHex(hex);
+
+        expect(psbt.inputs).toHaveLength(inputCount);
+        expect(psbt.outputs).toHaveLength(outputCount);
+        expect(psbt.unsignedTx.ins).toHaveLength(inputCount);
+        expect(psbt.unsignedTx.outs).toHaveLength(outputCount);
+        expect(psbt.toHex()).toEqual(hex);
+
+        expect(source).toBeTruthy();
+    });
+
+    it('parses a minimal synthetic PSBT and extracts unsigned transaction', () => {
+        const psbtHex = getSimplePsbtBuffer(UNSIGNED_TX_HEX).toString('hex');
+
+        const psbt = Psbt.fromHex(psbtHex);
+
+        expect(psbt.unsignedTx.toHex()).toEqual(UNSIGNED_TX_HEX);
+        expect(psbt.inputs).toHaveLength(1);
+        expect(psbt.outputs).toHaveLength(1);
+        expect(psbt.toHex()).toEqual(psbtHex);
+    });
+
+    it('serializes current unsigned transaction state after mutation', () => {
+        const psbtHex = getSimplePsbtBuffer(UNSIGNED_TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.unsignedTx.locktime = 123;
+
+        const reparsed = Psbt.fromBuffer(psbt.toBuffer());
+
+        expect(reparsed.unsignedTx.locktime).toEqual(123);
+        expect(reparsed.inputs).toHaveLength(1);
+        expect(reparsed.outputs).toHaveLength(1);
+    });
+
+    it('serializes added unsigned transaction outputs with empty PSBT output maps', () => {
+        const psbtHex = getSimplePsbtBuffer(UNSIGNED_TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.unsignedTx.outs.push({
+            value: '500',
+            script: address.toOutputScript('1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL', networks.bitcoin),
+        });
+
+        const reparsed = Psbt.fromBuffer(psbt.toBuffer(), { network: networks.bitcoin });
+
+        expect(reparsed.unsignedTx.outs).toHaveLength(2);
+        expect(reparsed.outputs).toHaveLength(2);
+        expect(reparsed.outputs[1]).toEqual([]);
+        expect(reparsed.unsignedTx.outs[1]?.value).toEqual('500');
+    });
+
+    it('throws when there are more PSBT output maps than unsigned transaction outputs', () => {
+        const psbtHex = getSimplePsbtBuffer(UNSIGNED_TX_HEX).toString('hex');
+        const psbt = Psbt.fromHex(psbtHex);
+
+        psbt.outputs.push([]);
+
+        expect(() => psbt.toBuffer()).toThrow(
+            'PSBT has more output maps than unsigned transaction outputs.',
+        );
+    });
+
+    it('throws when global map is missing unsigned transaction', () => {
+        const missingUnsignedTx = Buffer.concat([PSBT_MAGIC, MAP_SEPARATOR]);
+
+        expect(() => Psbt.fromBuffer(missingUnsignedTx)).toThrow(
+            'PSBT must contain exactly one unsigned transaction.',
+        );
+    });
+
+    it('throws when unsigned transaction contains scriptSigs', () => {
+        const psbtBuffer = getSimplePsbtBuffer(SIGNED_TX_HEX);
+
+        expect(() => Psbt.fromBuffer(psbtBuffer)).toThrow(
+            'PSBT unsigned transaction must not contain scriptSigs.',
+        );
+    });
+
+    it('throws when unsigned transaction contains witnesses', () => {
+        const psbtBuffer = getSimplePsbtBuffer(WITNESS_TX_HEX);
+
+        expect(() => Psbt.fromBuffer(psbtBuffer)).toThrow(
+            'PSBT unsigned transaction must not contain witnesses.',
+        );
+    });
+
+    it('throws on trailing data in strict mode', () => {
+        const psbtBuffer = Buffer.concat([
+            getSimplePsbtBuffer(UNSIGNED_TX_HEX),
+            Buffer.from([0xaa]),
+        ]);
+
+        expect(() => Psbt.fromBuffer(psbtBuffer)).toThrow('PSBT has unexpected data.');
+    });
+
+    it('allows trailing data with nostrict', () => {
+        const psbtBuffer = Buffer.concat([
+            getSimplePsbtBuffer(UNSIGNED_TX_HEX),
+            Buffer.from([0xaa]),
+        ]);
+
+        const psbt = Psbt.fromBuffer(psbtBuffer, { nostrict: true });
+
+        expect(psbt.unsignedTx.toHex()).toEqual(UNSIGNED_TX_HEX);
+    });
+});

--- a/packages/utxo-lib/src/psbt.ts
+++ b/packages/utxo-lib/src/psbt.ts
@@ -1,0 +1,208 @@
+// Minimal BIP-174 (PSBTv0) parser/serializer.
+//
+// Handles the raw key-value map structure and the unsigned transaction.
+// Field-level interpretation is left to consumers.
+//
+// Spec: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
+//
+
+import { BufferReader, BufferWriter, varIntSize } from './bufferutils';
+import { Transaction, type TransactionOptions } from './transaction';
+
+// 5-byte header: ASCII "psbt" followed by 0xff separator.
+export const PSBT_MAGIC = Buffer.from('70736274ff', 'hex');
+
+// BIP-174 global key type for the unsigned transaction (key 0x00, no key data).
+export const UNSIGNED_TX_KEY = 0x00;
+
+export type PsbtKeyValue = {
+    key: Buffer;
+    value: Buffer;
+};
+
+export type PsbtOptions = TransactionOptions;
+
+// Read key-value pairs from a single map section until the 0x00 separator.
+// Each pair is encoded as: <varint key_len> <key> <varint value_len> <value>.
+// Duplicate keys within a map are rejected per BIP-174.
+function readMap(bufferReader: BufferReader): PsbtKeyValue[] {
+    const map: PsbtKeyValue[] = [];
+    const keySet = new Set<string>();
+
+    while (true) {
+        const key = bufferReader.readVarSlice();
+        if (key.length === 0) {
+            return map;
+        }
+
+        const keyHex = key.toString('hex');
+        if (keySet.has(keyHex)) {
+            throw new Error('PSBT map has duplicate key.');
+        }
+        keySet.add(keyHex);
+
+        map.push({
+            key,
+            value: bufferReader.readVarSlice(),
+        });
+    }
+}
+
+function getUnsignedTx(map: PsbtKeyValue[], options: PsbtOptions) {
+    const unsignedTxEntries = map.filter(
+        kv => kv.key.length === 1 && kv.key[0] === UNSIGNED_TX_KEY,
+    );
+
+    if (unsignedTxEntries.length !== 1 || !unsignedTxEntries[0]) {
+        throw new Error('PSBT must contain exactly one unsigned transaction.');
+    }
+
+    const unsignedTx = Transaction.fromBuffer(unsignedTxEntries[0].value, {
+        network: options.network,
+        nostrict: false,
+    });
+
+    if (unsignedTx.ins.some(input => input.script.length !== 0)) {
+        throw new Error('PSBT unsigned transaction must not contain scriptSigs.');
+    }
+
+    if (unsignedTx.hasWitnesses()) {
+        throw new Error('PSBT unsigned transaction must not contain witnesses.');
+    }
+
+    return unsignedTx;
+}
+
+function getMapByteLength(map: PsbtKeyValue[]) {
+    return map.reduce(
+        (size, { key, value }) =>
+            size + varIntSize(key.length) + key.length + varIntSize(value.length) + value.length,
+        1,
+    );
+}
+
+// Serialize key-value pairs and terminate the map with a 0x00 byte.
+function writeMap(bufferWriter: BufferWriter, map: PsbtKeyValue[]) {
+    map.forEach(({ key, value }) => {
+        bufferWriter.writeVarSlice(key);
+        bufferWriter.writeVarSlice(value);
+    });
+
+    bufferWriter.writeUInt8(0);
+}
+
+export class Psbt {
+    readonly unsignedTx: Transaction;
+    readonly globalMap: PsbtKeyValue[];
+    readonly inputs: PsbtKeyValue[][];
+    readonly outputs: PsbtKeyValue[][];
+
+    private constructor({
+        unsignedTx,
+        globalMap,
+        inputs,
+        outputs,
+    }: {
+        unsignedTx: Transaction;
+        globalMap: PsbtKeyValue[];
+        inputs: PsbtKeyValue[][];
+        outputs: PsbtKeyValue[][];
+    }) {
+        this.unsignedTx = unsignedTx;
+        this.globalMap = globalMap;
+        this.inputs = inputs;
+        this.outputs = outputs;
+    }
+
+    static fromBuffer(buffer: Buffer, options: PsbtOptions = {}) {
+        const bufferReader = new BufferReader(buffer);
+        if (!bufferReader.readSlice(PSBT_MAGIC.length).equals(PSBT_MAGIC)) {
+            throw new Error('Invalid PSBT magic bytes.');
+        }
+
+        const globalMap = readMap(bufferReader);
+        const unsignedTx = getUnsignedTx(globalMap, options);
+
+        const inputs: PsbtKeyValue[][] = [];
+        for (let i = 0; i < unsignedTx.ins.length; i++) {
+            inputs.push(readMap(bufferReader));
+        }
+
+        const outputs: PsbtKeyValue[][] = [];
+        for (let i = 0; i < unsignedTx.outs.length; i++) {
+            outputs.push(readMap(bufferReader));
+        }
+
+        if (!options.nostrict && bufferReader.offset !== buffer.length) {
+            throw new Error('PSBT has unexpected data.');
+        }
+
+        return new Psbt({
+            unsignedTx,
+            globalMap,
+            inputs,
+            outputs,
+        });
+    }
+
+    static fromHex(hex: string, options: PsbtOptions = {}) {
+        return this.fromBuffer(Buffer.from(hex, 'hex'), { ...options, nostrict: false });
+    }
+
+    toBuffer() {
+        const unsignedTxBuffer = this.unsignedTx.toBuffer();
+        const globalMap = this.globalMap.map(keyValue => {
+            if (keyValue.key.length === 1 && keyValue.key[0] === UNSIGNED_TX_KEY) {
+                return {
+                    ...keyValue,
+                    value: unsignedTxBuffer,
+                };
+            }
+
+            return keyValue;
+        });
+
+        const globalUnsignedTxEntries = globalMap.filter(
+            ({ key }) => key.length === 1 && key[0] === UNSIGNED_TX_KEY,
+        );
+
+        if (globalUnsignedTxEntries.length !== 1) {
+            throw new Error('PSBT must contain exactly one unsigned transaction.');
+        }
+
+        if (this.inputs.length > this.unsignedTx.ins.length) {
+            throw new Error('PSBT has more input maps than unsigned transaction inputs.');
+        }
+
+        if (this.outputs.length > this.unsignedTx.outs.length) {
+            throw new Error('PSBT has more output maps than unsigned transaction outputs.');
+        }
+
+        const inputMaps = Array.from({ length: this.unsignedTx.ins.length }, (_, index) =>
+            this.inputs[index] ? this.inputs[index].map(keyValue => ({ ...keyValue })) : [],
+        );
+        const outputMaps = Array.from({ length: this.unsignedTx.outs.length }, (_, index) =>
+            this.outputs[index] ? this.outputs[index].map(keyValue => ({ ...keyValue })) : [],
+        );
+
+        const byteLength =
+            PSBT_MAGIC.length +
+            getMapByteLength(globalMap) +
+            inputMaps.reduce((size, map) => size + getMapByteLength(map), 0) +
+            outputMaps.reduce((size, map) => size + getMapByteLength(map), 0);
+
+        const buffer = Buffer.allocUnsafe(byteLength);
+        const bufferWriter = new BufferWriter(buffer);
+
+        bufferWriter.writeSlice(PSBT_MAGIC);
+        writeMap(bufferWriter, globalMap);
+        inputMaps.forEach(map => writeMap(bufferWriter, map));
+        outputMaps.forEach(map => writeMap(bufferWriter, map));
+
+        return buffer;
+    }
+
+    toHex() {
+        return this.toBuffer().toString('hex');
+    }
+}

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -38,7 +38,7 @@ const groups = {
         name: 'btc-others',
         pattern: 'methods',
         includeFilter:
-            'getAccountInfo,getAddress,getPublicKey,signMessage,verifyMessage,composeTransaction,getOwnershipId,getOwnershipProof',
+            'getAccountInfo,getAddress,getPublicKey,signMessage,verifyMessage,composePsbt,composeTransaction,getOwnershipId,getOwnershipProof',
     },
     stellar: {
         name: 'stellar',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- add `PSBT` minimal parser
- add `composePsbt` method.
  When requested parse psbt data and map inputs/outputs to trezor protobuf format, find tx inputs in known account utxos set, find tx outputs in known account addresses set.

Resolve <!--- link the issue here -->
#22565

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-psbt&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-psbt&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-psbt&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T10:46:42.092Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T10:46:18.906Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes concentrate on Connect's Bitcoin/PSBT transaction construction (outputs, refTx, parsePsbt, composePsbt) and utxo-lib PSBT utilities, so the highest regression risk is in any flow that builds or signs a Bitcoin transaction. The recommended tests target Suite send forms with custom outputs, CSV imports, multi-output sends, trading BTC sell/swap flows, and TrezorConnect.signTransaction. The new composePsbt method, its fixtures, and the type/script files are not covered by existing Suite E2E tests and should be validated by the corresponding Connect unit/e2e suite.

<details><summary><b>Changed files (17)</b></summary>

- `packages/connect-common/src/callableMethods.ts`
- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect-common/src/types/api/bitcoin/composePsbt.ts`
- `packages/connect-common/src/types/api/bitcoin/index.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/connect/e2e/__fixtures__/composePsbt.ts`
- `packages/connect/e2e/__fixtures__/index.ts`
- `packages/connect/src/api/bitcoin/outputs.ts`
- `packages/connect/src/api/bitcoin/parsePsbt.ts`
- `packages/connect/src/api/bitcoin/refTx.ts`
- `packages/connect/src/api/composePsbt.ts`
- `packages/connect/src/api/index.ts`
- `packages/utxo-lib/src/__fixtures__/psbt.ts`
- `packages/utxo-lib/src/index.ts`
- `packages/utxo-lib/src/psbt.test.ts`
- `packages/utxo-lib/src/psbt.ts`
- `scripts/ci/connect-test-matrix-generator.js`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test signs and broadcasts a real Bitcoin sell transaction through the trading flow, exercising Connect's BTC output construction, reference transaction handling, and device prompt serialization that are touched by the changed files.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — The test signs a Bitcoin swap transaction after reviewing amounts and fees on the device prompt, directly stress-testing the BTC transaction composition and PSBT/utxo-lib signing path affected by the changes.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — It performs a BTC swap with custom fee settings and verifies fee/total amounts on both the app prompt and the hardware device, making it a strong end-to-end check of Bitcoin transaction construction logic.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test drives TrezorConnect.signTransaction for a BTC transaction through the desktop Connect flow, hitting the exact Connect API layer (outputs, refTx, parsePsbt, utxo-lib PSBT) that was modified.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — CSV import creates multiple Bitcoin transaction outputs with metadata labels, which directly exercises output parsing/creation and the send-form signing path impacted by the Bitcoin API changes.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — The test sends multi-output Bitcoin regtest transactions and verifies pending/confirmed state, relying on correct BTC transaction construction and broadcast through the modified Connect Bitcoin stack.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — It covers advanced Bitcoin send form behavior including multiple outputs, locktime, OP_RETURN data, and unit switching, all of which depend on the Bitcoin output and PSBT parsing logic in the changed files.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This test exercises a Dogecoin send flow and device confirmation of outputs/totals/fees; DOGE shares the Bitcoin-like transaction building code, so it provides a reasonable cross-coin sanity check.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — It signs an LTC transaction spending a MimbleWimble peg-out output, testing handling of non-standard outputs and backend-based discovery that shares the modified transaction-building infrastructure.

</details>

⚠️ **Changes with no test coverage (11)**
- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect-common/src/types/api/bitcoin/composePsbt.ts`
- `packages/connect-common/src/types/api/bitcoin/index.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/connect/e2e/__fixtures__/composePsbt.ts`
- `packages/connect/e2e/__fixtures__/index.ts`
- `packages/utxo-lib/src/__fixtures__/psbt.ts`
- `packages/utxo-lib/src/psbt.test.ts`
- `packages/utxo-lib/src/index.ts`
- `packages/connect/src/api/composePsbt.ts`
- `scripts/ci/connect-test-matrix-generator.js`

_Updated: 2026-09-09T10:44:50.420Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-psbt/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-psbt/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->