### PR TITLE
feat(ci): Suite Native tests now have proper nightly gh wf

### DIFF
--- a/.github/workflows/template-suite-native-e2e-android.yml
+++ b/.github/workflows/template-suite-native-e2e-android.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ""
         type: string
+      runner_config:
+        description: "Path to the Detox runner config file"
+        required: false
+        default: e2e/trezorDetoxRunner/config/runner-android-release.config.js
+        type: string
     secrets:
       TREZOR_BOT_APP_ID:
         required: true
@@ -26,8 +31,6 @@ on:
       CURRENTS_RECORD_KEY:
         required: true
       CURRENTS_API_KEY:
-        required: true
-      SLACK_MOBILE_E2E_WEBHOOK:
         required: true
       E2E_TEST_PASSPHRASE:
         required: true
@@ -141,7 +144,7 @@ jobs:
           avd-name: ${{ steps.device.outputs.AVD_NAME }}
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -grpc 8554
           script: |
-            yarn test:e2e --config=e2e/trezorDetoxRunner/config/runner-android-release.config.js --shard=${{ matrix.TEST_GROUP }} --totalShards=4 --headless --quarantine
+            yarn test:e2e --config=${{ inputs.runner_config }} --shard=${{ matrix.TEST_GROUP }} --totalShards=4 --headless --quarantine
 
       - name: Post Currents link
         if: ${{ !cancelled() && github.event_name == 'pull_request' }}
@@ -169,12 +172,3 @@ jobs:
           name: android-tests-${{ matrix.TEST_GROUP }}
           path: suite-native/app/artifacts
           retention-days: 14
-
-  notify_scheduled_failure_to_slack:
-    runs-on: ubuntu-latest
-    if: ${{ failure() && github.event_name == 'schedule' }}
-    needs: run_android_e2e_tests
-    steps:
-      - name: Notify scheduled job failure to Slack
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nightly Android E2E tests failed :pepe_flame: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} "}' "${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}"

--- a/.github/workflows/test-suite-native-e2e-android-nightly.yml
+++ b/.github/workflows/test-suite-native-e2e-android-nightly.yml
@@ -1,0 +1,44 @@
+name: "[Test] suite-native Android E2E Nightly"
+
+permissions:
+  id-token: write # for fetching the OIDC token (needed for aws s3 actions)
+  contents: read # read attached artifacts from tests
+  actions: write # upload/download artifacts
+
+on:
+  schedule:
+    - cron: "0 0 * * 1-5"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare_android_test_app:
+    if: github.repository == 'trezor/trezor-suite'
+    uses: ./.github/workflows/template-suite-native-prepare-test-app-android.yml
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  run_android_e2e_tests:
+    if: github.repository == 'trezor/trezor-suite'
+    uses: ./.github/workflows/template-suite-native-e2e-android.yml
+    needs: [prepare_android_test_app]
+    with:
+      runner_config: e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
+    secrets:
+      TREZOR_BOT_APP_ID: ${{ secrets.TREZOR_BOT_APP_ID }}
+      TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+      CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
+      CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
+      E2E_TEST_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}
+
+  notify_scheduled_failure_to_slack:
+    runs-on: ubuntu-latest
+    if: ${{ failure() }}
+    needs: run_android_e2e_tests
+    steps:
+      - name: Notify scheduled job failure to Slack
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Nightly Android E2E tests failed :pepe_flame: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} "}' "${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}"

--- a/.github/workflows/test-suite-native-e2e-android.yml
+++ b/.github/workflows/test-suite-native-e2e-android.yml
@@ -6,8 +6,6 @@ permissions:
   actions: write # upload/download artifacts
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
   pull_request:
     paths:
       - "suite-native/**"
@@ -76,5 +74,4 @@ jobs:
       TREZOR_BOT_PRIVATE_KEY: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
       CURRENTS_RECORD_KEY: ${{ secrets.CURRENTS_RECORD_KEY }}
       CURRENTS_API_KEY: ${{ secrets.CURRENTS_API_KEY }}
-      SLACK_MOBILE_E2E_WEBHOOK: ${{ secrets.SLACK_MOBILE_E2E_WEBHOOK }}
       E2E_TEST_PASSPHRASE: ${{ secrets.E2E_TEST_PASSPHRASE }}

--- a/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
+++ b/suite-native/app/e2e/tests/entropyCheckFailT3T1.test.ts
@@ -16,7 +16,7 @@ const getPreloadedState = (payload: DeviceReducerState['simulatedEntropyCheckFai
 
 const LONG_RUNNING_TEST_TIMEOUT = 5 * 60 * 1000; // [ms]
 
-describe('Simulated entropy check failure on T3T1 [@androidOnly @T3T1]', () => {
+describe('Simulated entropy check failure on T3T1 [@androidOnly @smoke @T3T1]', () => {
     beforeEach(async () => {
         await prepareTrezorEmulator({ model: Model.T3T1, seed: '' });
     });

--- a/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
+++ b/suite-native/app/e2e/trezorDetoxRunner/config/runner-android-release-nightly.config.js
@@ -1,0 +1,40 @@
+const target = 'android.emu.release';
+
+/*
+ * Android Release Nightly config
+ * This config is used to run all tests nightly, including non-smoke T3T1 tests.
+ * There are projects for all supported device models with the latest firmware versions
+ */
+/** @type {import('../types').RunnerConfig} */
+module.exports = {
+    projects: [
+        {
+            projectName: 'T3W1',
+            target,
+            model: 'T3W1',
+            firmwareVersion: '2-latest',
+            grep: '^(?=.*@T3W1)(?!.*@iosOnly)',
+        },
+        {
+            projectName: 'T3T1',
+            target,
+            model: 'T3T1',
+            firmwareVersion: '2-latest',
+            grep: '^(?=.*@T3T1)(?!.*@iosOnly)',
+        },
+        {
+            projectName: 'T1B1',
+            target,
+            model: 'T1B1',
+            firmwareVersion: '1-latest',
+            grep: '^(?=.*@T1B1)(?!.*@iosOnly)',
+        },
+        {
+            projectName: 'no_device',
+            target,
+            model: undefined,
+            firmwareVersion: undefined,
+            grep: '^(?=.*@noDevice)(?!.*@iosOnly)',
+        },
+    ],
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The nightly scheduled workflow was the same as PR, so the smoke tagging for T3T1 made little sense. Now it actually works as expected. Also added the smoke tag to tests that are T3T1 only so that they run on PRs.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-t3t1-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-t3t1-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-t3t1-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T13:05:30.353Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T13:04:20.859Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->