### PR TITLE
fix(transport): usb disconnection without serialNumber

### DIFF
--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -84,7 +84,9 @@ export class UsbApi extends AbstractApi {
                 );
 
                 // trezor devices have serial number 468E58AE386B5D2EA8C572A2 or 000000000000000000000000 (for bootloader devices)
-                return this.enumerate();
+                return this.enumerate().then(() => {
+                    this.emit('transport-interface-change', this.devicesToDescriptors());
+                });
             }
 
             const index = this.devices.findIndex(d => d.path === device.serialNumber);

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -1,24 +1,44 @@
+import { createDeferred } from '@trezor/utils';
+
 import { UsbApi } from '../src/api/usb';
 
+const createTransferInResult = (size = 64) =>
+    ({
+        status: 'ok',
+        data: new DataView(new Uint8Array(size).buffer),
+    }) as USBInTransferResult;
+
+const createTransferOutResult = (bytesWritten = 64) =>
+    ({
+        status: 'ok',
+        bytesWritten,
+    }) as USBOutTransferResult;
+
 // create devices otherwise returned from navigator.usb.getDevices
-const createMockedDevice = (optional = {}) => ({
-    vendorId: 0x1209,
-    productId: 0x53c1,
-    serialNumber: '123',
-    open: () => Promise.resolve(),
-    selectConfiguration: () => Promise.resolve(),
-    claimInterface: () => Promise.resolve(),
-    transferOut: () => Promise.resolve({ status: 'ok' }),
-    transferIn: () => Promise.resolve({ data: Buffer.alloc(64) }),
-    releaseInterface: () => Promise.resolve(),
-    close: () => Promise.resolve(),
-    ...optional,
-});
+const createMockedDevice = (optional: Partial<USBDevice> & Record<string, unknown> = {}) =>
+    ({
+        vendorId: 0x1209,
+        productId: 0x53c1,
+        serialNumber: '123',
+        productName: 'Trezor',
+        manufacturerName: 'Trezor',
+        opened: false,
+        open: () => Promise.resolve(),
+        selectConfiguration: () => Promise.resolve(),
+        claimInterface: () => Promise.resolve(),
+        transferOut: () => Promise.resolve(createTransferOutResult()),
+        transferIn: () => Promise.resolve(createTransferInResult()),
+        releaseInterface: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+        ...optional,
+    }) as USBDevice;
 
 // mock of navigator.usb
-const createUsbMock = (optional = {}) =>
+const createUsbMock = (optional: Partial<USB> = {}) =>
     ({
         getDevices: () => Promise.resolve([createMockedDevice()]),
+        onconnect: null,
+        ondisconnect: null,
         ...optional,
     }) as unknown as UsbApi['usbInterface'];
 
@@ -42,7 +62,7 @@ describe('api/usb', () => {
                             transferIn: () =>
                                 new Promise(resolve =>
                                     setTimeout(
-                                        () => resolve({ data: Buffer.alloc(api.chunkSize) }),
+                                        () => resolve(createTransferInResult(api.chunkSize)),
                                         100,
                                     ),
                                 ),
@@ -72,7 +92,7 @@ describe('api/usb', () => {
                             reset,
                             transferOut: () =>
                                 new Promise(resolve =>
-                                    setTimeout(() => resolve({ status: 'ok' }), 100),
+                                    setTimeout(() => resolve(createTransferOutResult()), 100),
                                 ),
                         }),
                     ]),
@@ -113,9 +133,7 @@ describe('api/usb', () => {
                     Promise.resolve([
                         createMockedDevice({
                             open: () =>
-                                new Promise(resolve =>
-                                    setTimeout(() => resolve({ status: 'ok' }), 100),
-                                ),
+                                new Promise<void>(resolve => setTimeout(() => resolve(), 100)),
                         }),
                     ]),
             }),
@@ -186,9 +204,8 @@ describe('api/usb', () => {
                     Promise.resolve([
                         createMockedDevice({
                             reset,
-                            transferIn: () =>
-                                Promise.resolve({ data: Buffer.alloc(api.chunkSize) }),
-                            transferOut: () => new Promise(resolve => resolve({ status: 'ok' })),
+                            transferIn: () => Promise.resolve(createTransferInResult()),
+                            transferOut: () => Promise.resolve(createTransferOutResult()),
                         }),
                     ]),
             }),
@@ -206,5 +223,46 @@ describe('api/usb', () => {
         await api.write('123', Buffer.alloc(0), abortController.signal);
 
         expect(reset).toHaveBeenCalledTimes(0);
+    });
+
+    it.each(['5e81a7', undefined, ''])('disconnect with serialNumber: %p', async serialNumber => {
+        let enumerateCounter = 0;
+        const enumerateDfd = createDeferred<USBDevice[]>();
+        const usbInterface = createUsbMock({
+            getDevices: () => {
+                if (enumerateCounter > 0) {
+                    return enumerateDfd.promise;
+                }
+                enumerateCounter++;
+
+                return Promise.resolve([createMockedDevice({ serialNumber })]);
+            },
+        });
+        const api = new UsbApi({
+            usbInterface,
+        });
+        await api.enumerate();
+
+        const enumerateSpy = jest.spyOn(api, 'enumerate');
+        const listener = jest.fn();
+
+        api.on('transport-interface-change', listener);
+        api.listen();
+
+        // emit change
+        const disconnectPromise = usbInterface.ondisconnect?.({
+            device: createMockedDevice({ serialNumber }),
+        } as any); // partial WebUSB event
+
+        if (!serialNumber) {
+            expect(enumerateSpy).toHaveBeenCalledTimes(1);
+            expect(listener).not.toHaveBeenCalled();
+        }
+
+        enumerateDfd.resolve([]);
+        await disconnectPromise;
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith([]);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
event was never emited if serialNumber was not set


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-usb-disconnect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-usb-disconnect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-19T15:50:59.908Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-19T15:48:28.796Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->