### PR TITLE
fix(suite-native): remove limit for evm accounts

### DIFF
--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -85,7 +85,7 @@ export const accountTypeTranslationKeys: Record<
     },
 };
 
-const LIMIT = 10; // or maybe find another place to put it if needed
+const LIMIT = 10; // Maximum number of manually added accounts per non-EVM network type.
 
 export const useAddCoinAccount = () => {
     const dispatch = useDispatch();
@@ -269,15 +269,16 @@ export const useAddCoinAccount = () => {
             return false;
         }
 
-        // Do not allow adding more than 10 accounts of the same type
+        // EVM networks have no manual-add limit. Users can add accounts beyond
+        if (isEvmNetwork(networkSymbol)) {
+            return true;
+        }
+
+        // Do not allow adding more than 10 accounts of the same type.
         if (accounts.filter(account => account.visible).length >= LIMIT) {
             showTooManyAccountsAlert();
 
             return false;
-        }
-
-        if (isEvmNetwork(networkSymbol)) {
-            return true;
         }
 
         const hasVisibleEmptyAccount = accounts.some(account => account.empty && account.visible);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- remove EVM account limit for manual addition

## Notes for QA

- except EVM acc's it should not be possible to add more than 10 accs

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25988

## Screenshots:

https://github.com/user-attachments/assets/7ba9815a-e82f-4c83-9820-6a321c0fe9f5


https://github.com/user-attachments/assets/eb773ec8-a646-45c8-b9f1-ca2a0d8c76c3


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/evm-acc-limit&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->