### PR TITLE
refactor(product-components): fix circular type imports

### DIFF
--- a/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
@@ -6,7 +6,7 @@ import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { Badge, Column, Row, Text } from '@trezor/components';
 import { spacings, spacingsPx } from '@trezor/theme';
 
-import { type AssetOptionBaseProps } from './SelectAssetModal';
+import { type AssetOptionBaseProps } from './types';
 import { isCoinSymbol } from '../../constants/coins';
 import { AssetLogo } from '../AssetLogo/AssetLogo';
 import { CoinLogo } from '../CoinLogo/CoinLogo';
@@ -30,11 +30,11 @@ const BadgeWrapper = styled.div`
     flex: none;
 `;
 
-interface AssetItemProps extends AssetOptionBaseProps {
+type AssetItemProps = AssetOptionBaseProps & {
     handleClick: (selectedAsset: AssetOptionBaseProps) => void;
     'data-testid'?: string;
     balance?: ReactNode;
-}
+};
 
 export const AssetItem = ({
     cryptoName,

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.stories.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.stories.tsx
@@ -6,12 +6,9 @@ import { ThemeProvider } from 'styled-components';
 
 import { Modal, intermediaryTheme } from '@trezor/components';
 
-import {
-    type AssetProps,
-    ITEM_HEIGHT,
-    SelectAssetModal as SelectAssetModalComponent,
-} from './SelectAssetModal';
+import { ITEM_HEIGHT, SelectAssetModal as SelectAssetModalComponent } from './SelectAssetModal';
 import { selectAssetModalOptions } from './SelectAssetModal.storiesData';
+import { type AssetProps } from './types';
 
 const meta = {
     title: 'SelectAssetModal',

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.storiesData.ts
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.storiesData.ts
@@ -1,19 +1,19 @@
-import { type AssetOptionBaseProps } from './SelectAssetModal';
+import { type AssetOptionBaseProps } from './types';
 
-interface SelectAssetOptionCurrencyProps extends AssetOptionBaseProps {
+type SelectAssetOptionCurrencyProps = AssetOptionBaseProps & {
     type: 'currency';
     label?: string;
     balance?: string;
     networkName?: string;
     value: string;
-}
+};
 
-interface SelectAssetOptionGroupProps {
+type SelectAssetOptionGroupProps = {
     type: 'group';
     label: string;
     networkName?: string;
     coingeckoId?: string;
-}
+};
 
 export const selectAssetModalOptions: (
     | SelectAssetOptionCurrencyProps

--- a/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/SelectAssetModal.tsx
@@ -1,49 +1,24 @@
-import { type ReactNode, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useIntl } from 'react-intl';
 
-import type { NetworkSymbolExtended } from '@suite-common/wallet-config';
-import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Column, Modal, VirtualizedList, useScrollShadow } from '@trezor/components';
 import { mapElevationToBackgroundToken, spacings } from '@trezor/theme';
 
 import { AssetItem } from './AssetItem';
 import { AssetItemNotFound } from './AssetItemNotFound';
+import type { AssetProps, SelectAssetModalProps } from './types';
 
-export interface AssetTokenBalance {
-    baseSymbol?: string; // TokenInfo['symbol'];
-    baseAmount: string;
-    fiatAmount: BaseCurrencyAmount | null;
-}
-
-export interface AssetProps {
-    ticker: string;
-    badge?: ReactNode;
-    symbol: NetworkSymbolExtended;
-    cryptoName?: string;
-    coingeckoId?: string;
-    contractAddress: string | null;
-    height: number;
-    shouldTryToFetch?: boolean;
-    tokenBalance?: AssetTokenBalance;
-}
-
-export type AssetOptionBaseProps = Omit<AssetProps, 'height' | 'formattedBalance'>;
+export type {
+    AssetOptionBaseProps,
+    AssetProps,
+    AssetTokenBalance,
+    SelectAssetModalProps,
+} from './types';
 
 export const ITEM_HEIGHT = 60;
 const LIST_MIN_HEIGHT = 200;
 const HEADER_HEIGHT = 267;
 const LIST_HEIGHT = `calc(80vh - ${HEADER_HEIGHT}px)`;
-
-export interface SelectAssetModalProps {
-    options: AssetProps[];
-    onSelectAsset: (selectedAsset: AssetOptionBaseProps) => Promise<void> | void;
-    onClose: () => void;
-    searchInput?: ReactNode;
-    filterTabs?: ReactNode;
-    noItemsAvailablePlaceholder: { heading: ReactNode; body?: ReactNode };
-    'data-testid'?: string;
-    renderOptionBalance: (assetProps: AssetProps) => ReactNode;
-}
 
 export const SelectAssetModal = ({
     options,

--- a/packages/product-components/src/components/SelectAssetModal/types.ts
+++ b/packages/product-components/src/components/SelectAssetModal/types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+import type { NetworkSymbolExtended } from '@suite-common/wallet-config';
+import type { BaseCurrencyAmount } from '@suite-common/wallet-types';
+
+export type AssetTokenBalance = {
+    baseSymbol?: string; // TokenInfo['symbol'];
+    baseAmount: string;
+    fiatAmount: BaseCurrencyAmount | null;
+};
+
+export type AssetProps = {
+    ticker: string;
+    badge?: ReactNode;
+    symbol: NetworkSymbolExtended;
+    cryptoName?: string;
+    coingeckoId?: string;
+    contractAddress: string | null;
+    height: number;
+    shouldTryToFetch?: boolean;
+    tokenBalance?: AssetTokenBalance;
+};
+
+export type AssetOptionBaseProps = Omit<AssetProps, 'height' | 'formattedBalance'>;
+
+export type SelectAssetModalProps = {
+    options: AssetProps[];
+    onSelectAsset: (selectedAsset: AssetOptionBaseProps) => Promise<void> | void;
+    onClose: () => void;
+    searchInput?: ReactNode;
+    filterTabs?: ReactNode;
+    noItemsAvailablePlaceholder: { heading: ReactNode; body?: ReactNode };
+    'data-testid'?: string;
+    renderOptionBalance: (assetProps: AssetProps) => ReactNode;
+};


### PR DESCRIPTION
## Description

Fix type-only circular imports in product components by extracting types.

Also, change `interface` to `type` while I'm at it.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/fix-product-component-circulars&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/fix-product-component-circulars&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T08:10:40.006Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-20T08:08:58.617Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->