### PR TITLE
refactor(suite): fix circulars in component props

### DIFF
--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipAccount.tsx
@@ -8,10 +8,10 @@ import { Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import type { CryptoGraphProps } from 'src/components/suite/graph/types';
 import { type CommonAggregatedHistory, type GraphRange } from 'src/types/wallet/graph';
 
 import { GraphTooltipBase } from './GraphTooltipBase';
-import type { CryptoGraphProps } from './TransactionsGraph';
 
 const formatAmount = (
     amount: string | undefined,

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipDashboard.tsx
@@ -3,10 +3,10 @@ import { type TooltipProps } from 'recharts';
 import { useFormatters } from '@suite-common/formatters';
 import { BASE_CURRENCY_ZERO } from '@suite-common/wallet-utils';
 
+import type { FiatGraphProps } from 'src/components/suite/graph/types';
 import { type CommonAggregatedHistory, type GraphRange } from 'src/types/wallet/graph';
 
 import { GraphTooltipBase } from './GraphTooltipBase';
-import type { FiatGraphProps } from './TransactionsGraph';
 
 interface GraphTooltipDashboardProps extends TooltipProps<number, any> {
     selectedRange: GraphRange;

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.tsx
@@ -4,20 +4,15 @@ import { Bar, CartesianGrid, Cell, ComposedChart, Line, Tooltip, XAxis, YAxis } 
 import styled, { useTheme } from 'styled-components';
 
 import { selectAccountTransactionsWithNulls } from '@suite-common/wallet-core';
-import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { isPending } from '@suite-common/wallet-utils';
 import { Icon } from '@trezor/components';
 import { typography, zIndices } from '@trezor/theme';
 
 import { GraphRangeSelector } from 'src/components/suite/graph/GraphRangeSelector';
 import { GraphSkeleton } from 'src/components/suite/graph/GraphSkeleton';
+import type { TransactionsGraphProps } from 'src/components/suite/graph/types';
 import { useGraph, useSelector } from 'src/hooks/suite';
 import { type Account, type WalletAccountTransaction } from 'src/types/wallet';
-import {
-    type AggregatedAccountHistory,
-    type AggregatedDashboardHistory,
-    type GraphRange,
-} from 'src/types/wallet/graph';
 import { calcFakeGraphDataForTimestamps, calcXDomain, calcYDomain } from 'src/utils/wallet/graph';
 
 import { GraphBar } from './GraphBar';
@@ -64,47 +59,17 @@ const Description = styled.div`
     flex: 1;
 `;
 
-interface CommonProps {
-    isLoading?: boolean;
-    selectedRange: GraphRange;
-    xTicks: number[];
-    localCurrency: string;
-    minMaxValues: [number, number];
-    hideToolbar?: boolean;
-    onRefresh?: (abortController?: AbortController) => Promise<any>;
-}
-
-export interface CryptoGraphProps extends CommonProps {
-    variant: 'one-asset';
-    account: Account;
-    data: AggregatedAccountHistory[];
-    receivedValueFn: (data: AggregatedAccountHistory) => string | undefined;
-    sentValueFn: (data: AggregatedAccountHistory) => string | undefined;
-    balanceValueFn: (data: AggregatedAccountHistory) => string | undefined;
-}
-
-export interface FiatGraphProps extends CommonProps {
-    variant: 'all-assets';
-    data: AggregatedDashboardHistory[];
-    receivedValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
-    sentValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
-    balanceValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
-    account?: never;
-}
-
-export type TransactionsGraphProps = CryptoGraphProps | FiatGraphProps;
-
 const emptyList: ReturnType<typeof selectAccountTransactionsWithNulls>[] = [];
 const useTransactionGraphUpdater = ({
     onRequestGraphUpdate,
     account,
 }: {
-    onRequestGraphUpdate: (abortController: AbortController) => Promise<any> | undefined;
+    onRequestGraphUpdate: (abortController: AbortController) => Promise<unknown> | undefined;
     account: Account | undefined;
 }) => {
     const [currentPromise, setCurrentPromise] = useState<{
         promiseId: string;
-        promise: Promise<any>;
+        promise: Promise<unknown>;
         abortController: AbortController;
     } | null>(null);
 

--- a/packages/suite/src/components/suite/graph/types.ts
+++ b/packages/suite/src/components/suite/graph/types.ts
@@ -1,0 +1,38 @@
+import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
+
+import { type Account } from 'src/types/wallet';
+import {
+    type AggregatedAccountHistory,
+    type AggregatedDashboardHistory,
+    type GraphRange,
+} from 'src/types/wallet/graph';
+
+export interface CommonGraphProps {
+    isLoading?: boolean;
+    selectedRange: GraphRange;
+    xTicks: number[];
+    localCurrency: string;
+    minMaxValues: [number, number];
+    hideToolbar?: boolean;
+    onRefresh?: (abortController?: AbortController) => Promise<unknown>;
+}
+
+export interface CryptoGraphProps extends CommonGraphProps {
+    variant: 'one-asset';
+    account: Account;
+    data: AggregatedAccountHistory[];
+    receivedValueFn: (data: AggregatedAccountHistory) => string | undefined;
+    sentValueFn: (data: AggregatedAccountHistory) => string | undefined;
+    balanceValueFn: (data: AggregatedAccountHistory) => string | undefined;
+}
+
+export interface FiatGraphProps extends CommonGraphProps {
+    variant: 'all-assets';
+    data: AggregatedDashboardHistory[];
+    receivedValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
+    sentValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
+    balanceValueFn: (data: AggregatedDashboardHistory) => BaseCurrencyAmount | undefined;
+    account?: never;
+}
+
+export type TransactionsGraphProps = CryptoGraphProps | FiatGraphProps;


### PR DESCRIPTION
## Description

Fix type-only circular imports in product components by extracting types.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-component-props-circulars&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-component-props-circulars&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T11:09:47.553Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-03-20T11:08:01.767Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->