### PR TITLE
test(e2e-suite): enforce local quota manager for suite-sync tests

### DIFF
--- a/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
+++ b/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
@@ -97,16 +97,39 @@ export class BaseEvoluClient {
     }
 }
 
-export const wipeEvoluRelayData = () => {
+// Hardcoded quota data for test environment. The quota manager cannot store keys
+// per-wallet, so these limits must be seeded into the DB before running Suite Sync tests.
+// This will be refactored.
+const QUOTA_OWNER_ID = '0Fco3XDgKR59zX5VBvyyGQ';
+const QUOTA_STORAGE_LIMIT = 10486;
+const QUOTA_PUBLIC_KEY =
+    '0487472eec47aa28fa62ff3231f60b5c89751318a5598af5f93ab2aad9061ca25f53b352a97b855f16b11b795b715249c8dbfb6e47339f677e30d530f0e80bc4bb';
+const QUOTA_TOTAL_STORAGE_SIZE = 1048576;
+const QUOTA_UNSPENT_STORAGE_SIZE = 1038090;
+const QUOTA_DB_CREDENTIALS = '-U suite-sync -d suite-sync-gate';
+
+export const wipeAndRestartEvoluRelayServer = () => {
     execSync(
         'docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T suite-sync rm -rf /app/data',
         { cwd: '../../' },
     );
-};
-
-export const restartEvoluRelayServer = () => {
+    execSync(
+        `docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T quota-db psql ${QUOTA_DB_CREDENTIALS} -c "TRUNCATE challenges, owner_storage_limits, pubkey_storage_limits RESTART IDENTITY CASCADE;"`,
+        { cwd: '../../' },
+    );
     execSync(
         'docker compose -f docker/docker-compose.suite-ci-e2e.yml restart quota-db suite-sync',
+        { cwd: '../../' },
+    );
+};
+
+export const seedQuotaManagerData = () => {
+    execSync(
+        `docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T quota-db psql ${QUOTA_DB_CREDENTIALS} -c "INSERT INTO owner_storage_limits (\\"ownerId\\", \\"storageLimit\\") VALUES ('${QUOTA_OWNER_ID}', ${QUOTA_STORAGE_LIMIT}) ON CONFLICT DO NOTHING;"`,
+        { cwd: '../../' },
+    );
+    execSync(
+        `docker compose -f docker/docker-compose.suite-ci-e2e.yml exec -T quota-db psql ${QUOTA_DB_CREDENTIALS} -c "INSERT INTO pubkey_storage_limits (\\"publicKey\\", \\"totalStorageSize\\", \\"unspentStorageSize\\") VALUES ('${QUOTA_PUBLIC_KEY}', ${QUOTA_TOTAL_STORAGE_SIZE}, ${QUOTA_UNSPENT_STORAGE_SIZE}) ON CONFLICT DO NOTHING;"`,
         { cwd: '../../' },
     );
 };

--- a/suite-common/e2e-evolu-client/src/index.ts
+++ b/suite-common/e2e-evolu-client/src/index.ts
@@ -2,8 +2,8 @@ export {
     BaseEvoluClient,
     RELAY_URL,
     QUOTA_URL,
-    wipeEvoluRelayData,
-    restartEvoluRelayServer,
+    wipeAndRestartEvoluRelayServer,
     checkEvoluRelayServerRunning,
+    seedQuotaManagerData,
 } from './baseEvoluClient';
 export type { EvoluClientInitParams } from './baseEvoluClient';

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -16,7 +16,7 @@
         "github:create:project": "tsx ./support/reporters/scriptCreateProject.ts",
         "git:bisect": "./scripts/bisect-commits.sh",
         "decode:sol:stake": "tsx ./scripts/decode-sol-staking-account.ts",
-        "docker:suite-sync": "docker compose -f ../../docker/docker-compose.suite-ci-e2e.yml up quota-db suite-sync",
+        "docker:suite-sync": "./scripts/docker-suite-sync.sh",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "devDependencies": {

--- a/suite/e2e/scripts/docker-suite-sync.sh
+++ b/suite/e2e/scripts/docker-suite-sync.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="../../docker/docker-compose.suite-ci-e2e.yml"
+IMAGE="ghcr.io/trezor/suite-sync:main"
+SERVICES=(quota-db suite-sync)
+
+LOCAL_ID=$(docker images -q "$IMAGE" 2>/dev/null || echo "")
+
+docker pull "$IMAGE"
+
+NEW_ID=$(docker images -q "$IMAGE")
+echo "📦 Local image ID:  ${LOCAL_ID:-none}"
+echo "📦 Remote image ID: $NEW_ID"
+
+if [ "$LOCAL_ID" != "$NEW_ID" ]; then
+    echo "⬇️  Newer image detected. Removing existing containers..."
+    docker compose -f "$COMPOSE_FILE" rm -f -s "${SERVICES[@]}"
+fi
+
+docker compose -f "$COMPOSE_FILE" up "${SERVICES[@]}"

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -7,8 +7,8 @@ import {
     BaseEvoluClient,
     EvoluClientInitParams,
     checkEvoluRelayServerRunning,
-    restartEvoluRelayServer,
-    wipeEvoluRelayData,
+    seedQuotaManagerData,
+    wipeAndRestartEvoluRelayServer,
 } from '@suite-common/e2e-evolu-client';
 import { Schema } from '@suite-common/suite-sync-evolu';
 
@@ -26,6 +26,11 @@ export class EvoluClient extends BaseEvoluClient {
     @step()
     override writeTo<T extends TableName>(table: T, object: Upsertable<(typeof Schema)[T]>) {
         super.writeTo(table, object as any);
+    }
+
+    @step()
+    seedQuotaManagerData() {
+        seedQuotaManagerData();
     }
 
     @step()
@@ -89,6 +94,5 @@ export class EvoluClient extends BaseEvoluClient {
 
 export const wipeAndRestartEvoluServer = async () => {
     await checkEvoluRelayServerRunning();
-    await test.step('Wipe Evolu Relay data', wipeEvoluRelayData);
-    await test.step('Restart Evolu Relay server', restartEvoluRelayServer);
+    await test.step('Wipe and restart Evolu Relay server', wipeAndRestartEvoluRelayServer);
 };

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -123,6 +123,18 @@ export class DevicePrompt {
         return addressRaw[0].join('').replace(/\n/g, '');
     }
 
+    // This method confirms the Suite Sync device prompt and device provides necessary keys to suite.
+    // E2E limitation is that keys cannot be stored and because of that another prompt is called.
+    // This secondary device prompt for Suite Sync happens on first label change per wallet
+    @step()
+    async confirmSuiteSyncSetup() {
+        await this.device.expectToContainOnDisplay('Sync');
+        await this.confirmOnDevicePromptIsShown();
+        await this.device.pressYes();
+        // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
+        await this.page.waitForTimeout(2_000);
+    }
+
     @step()
     async compareAddressesOnDeviceAndSuite() {
         const addressFromSuite = await this.outputValueOf('address').innerText();

--- a/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/accountMetadata.ts
@@ -18,9 +18,20 @@ export class AccountMetadata extends MetadataBase {
     }
 
     @step()
-    async changeLabel({ accountId, label }: { accountId: string; label: string }) {
+    async changeLabel({
+        accountId,
+        label,
+        confirmSuiteSync,
+    }: {
+        accountId: string;
+        label: string;
+        confirmSuiteSync?: boolean;
+    }) {
         await this.clickEditLabelButton(accountId);
         await this.fillLabelInput(label, { useButton: true });
+        if (confirmSuiteSync) {
+            await this.devicePrompt.confirmSuiteSyncSetup();
+        }
         await this.successIconIsVisible(accountId);
     }
 

--- a/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/addressMetadata.ts
@@ -24,15 +24,26 @@ export class AddressMetadata extends MetadataBase {
     }
 
     @step()
-    async successIconIsVisible(accountId: string) {
-        await expect(this.successLabel(accountId)).toBeVisible();
-        await expect(this.successLabel(accountId)).toBeHidden();
+    async successIconIsVisible(address: string) {
+        await expect(this.successLabel(address)).toBeVisible();
+        await expect(this.successLabel(address)).toBeHidden();
     }
 
     @step()
-    async changeLabel({ address, label }: { address: string; label: string }) {
+    async changeLabel({
+        address,
+        label,
+        confirmSuiteSync,
+    }: {
+        address: string;
+        label: string;
+        confirmSuiteSync?: boolean;
+    }) {
         await this.clickEditLabel(address);
         await this.fillLabelInput(label);
+        if (confirmSuiteSync) {
+            await this.devicePrompt.confirmSuiteSyncSetup();
+        }
         await this.successIconIsVisible(address);
     }
 

--- a/suite/e2e/support/pageObjects/metadata/metadataBase.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataBase.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from '@playwright/test';
 
 import { step } from '../../common';
+import { DevicePrompt } from '../devicePrompt';
 
 interface MetadataSubmitOptions {
     useButton?: boolean;
@@ -15,7 +16,10 @@ export class MetadataBase {
     readonly inputId = '@metadata/input';
     readonly successId = '@metadata/success';
 
-    constructor(protected readonly page: Page) {
+    constructor(
+        protected readonly page: Page,
+        protected readonly devicePrompt: DevicePrompt,
+    ) {
         this.metadataSubmitButton = page.getByTestId('@metadata/submit');
         this.metadataCancelButton = page.getByTestId('@metadata/cancel');
         this.metadataInput = page

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -31,10 +31,10 @@ export class MetadataPage {
         private readonly settingsPage: SettingsPage,
         private readonly devicePrompt: DevicePrompt,
     ) {
-        this.account = new AccountMetadata(page);
-        this.output = new OutputMetadata(page);
-        this.wallet = new WalletMetadata(page);
-        this.address = new AddressMetadata(page);
+        this.account = new AccountMetadata(page, devicePrompt);
+        this.output = new OutputMetadata(page, devicePrompt);
+        this.wallet = new WalletMetadata(page, devicePrompt);
+        this.address = new AddressMetadata(page, devicePrompt);
 
         this.metadataModal = page.getByTestId('@modal/metadata-provider');
         this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
@@ -81,23 +81,16 @@ export class MetadataPage {
     }
 
     @step()
-    async confirmSuiteSyncSetup() {
-        await this.device.expectToContainOnDisplay('Sync');
-        await this.devicePrompt.confirmOnDevicePromptIsShown();
-        await this.device.pressYes();
-        // wait before closing the modal to prevent "Trezor Sync key retrieval failed" error
-        await this.page.waitForTimeout(2_000);
-    }
-
-    @step()
     async enableSuiteSync() {
+        await this.setupQuotaManager();
         await this.initiateSuiteSyncSetup();
-        await this.confirmSuiteSyncSetup();
+        await this.devicePrompt.confirmSuiteSyncSetup();
     }
 
     @step()
     async setupQuotaManager() {
         await this.settingsPage.navigateTo('debug');
+        await this.settingsPage.debugTab.quotaManagerEnforceCheckbox.check();
         await this.settingsPage.debugTab.quotaManagerUrlInput.fill(QUOTA_URL);
         await this.settingsPage.debugTab.quotaManagerUrlSaveButton.click();
     }

--- a/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/outputMetadata.ts
@@ -37,14 +37,19 @@ export class OutputMetadata extends MetadataBase {
         outputId,
         txNumber,
         label,
+        confirmSuiteSync,
     }: {
         outputId: string;
         txNumber: number;
         label: string;
+        confirmSuiteSync?: boolean;
     }) {
         await this.clickAddLabelButton(outputId, txNumber);
         await this.outputMetadataInput(outputId, txNumber).fill(label);
         await this.page.keyboard.press('Enter');
+        if (confirmSuiteSync) {
+            await this.devicePrompt.confirmSuiteSyncSetup();
+        }
         await this.successIconIsVisible(outputId, txNumber);
     }
 

--- a/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
+++ b/suite/e2e/support/pageObjects/metadata/walletMetadata.ts
@@ -28,10 +28,23 @@ export class WalletMetadata extends MetadataBase {
     }
 
     @step()
-    async changeLabel({ index, label }: { index: number; label: string }) {
+    async changeLabel({
+        index,
+        label,
+        confirmSuiteSync,
+    }: {
+        index: number;
+        label: string;
+        confirmSuiteSync?: boolean;
+    }) {
         await this.clickEditLabel(index);
         await this.fillLabelInput(label);
-        await this.successIconIsVisible(index);
+        if (confirmSuiteSync) {
+            await this.devicePrompt.confirmSuiteSyncSetup();
+        } else {
+            // success icon is not visible after device confirms keys on first label change
+            await this.successIconIsVisible(index);
+        }
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -15,6 +15,7 @@ export class DebugTab {
     readonly addMessageButton: Locator;
     readonly quotaManagerUrlInput: Locator;
     readonly quotaManagerUrlSaveButton: Locator;
+    readonly quotaManagerEnforceCheckbox: Locator;
 
     constructor(private readonly page: Page) {
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
@@ -34,6 +35,9 @@ export class DebugTab {
         this.quotaManagerUrlInput = page.getByTestId('@settings/debug/quota-manager-url-input');
         this.quotaManagerUrlSaveButton = page.getByTestId(
             '@settings/debug/quota-manager-url-save-button',
+        );
+        this.quotaManagerEnforceCheckbox = page.getByTestId(
+            '@settings/debug/quota-manager-enforce-for-custom-relay-checkbox',
         );
     }
 

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -11,6 +11,7 @@ test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
         await test.step('Seed Evolu relay server', () => {
             evoluClient.init({ ownerSecret });
             evoluClient.writeTo('account', accountSeed);
+            evoluClient.seedQuotaManagerData();
         });
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
     });

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -60,6 +60,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
             await metadataPage.account.changeLabel({
                 accountId: AccountLabelId.BitcoinDefault1,
                 label: expectedAccount.label,
+                confirmSuiteSync: true,
             });
             await expect
                 .soft(walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }))

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -78,12 +78,14 @@ test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, ()
         dashboardPage,
         metadataPage,
         walletPage,
+        devicePrompt,
     }) => {
         await test.step('Change default wallet label', async () => {
             await dashboardPage.openDeviceSwitcher();
             await metadataPage.wallet.changeLabel({
                 index: 0,
                 label: expectedDefaultWalletLabel.label,
+                confirmSuiteSync: true,
             });
         });
 
@@ -100,6 +102,7 @@ test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, ()
             await metadataPage.wallet.changeLabel({
                 index: walletOne.index,
                 label: expectedWalletOneLabel.label,
+                confirmSuiteSync: true,
             });
         });
 
@@ -127,7 +130,7 @@ test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, ()
             await dashboardPage.openDeviceSwitcher();
             await dashboardPage.openDevice(walletTwo.index);
             await metadataPage.suiteSyncBannerButton.click();
-            await metadataPage.confirmSuiteSyncSetup();
+            await devicePrompt.confirmSuiteSyncSetup();
             await expect(metadataPage.suiteSyncBanner).toBeHidden();
         });
 
@@ -137,6 +140,7 @@ test.describe('Suite Sync - Passphrase wallets', { tag: ['@T3W1', '@T3T1'] }, ()
             await metadataPage.wallet.changeLabel({
                 index: walletTwo.index,
                 label: expectedWalletTwoLabel.label,
+                confirmSuiteSync: true,
             });
         });
 

--- a/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
@@ -21,6 +21,7 @@ test.describe('Suite Sync - Remove Labels', { tag: ['@T3W1', '@T3T1'] }, () => {
             evoluClient.writeTo('account', accountSeed);
             evoluClient.writeTo('address', addressSeed);
             evoluClient.writeTo('output', outputSeed);
+            evoluClient.seedQuotaManagerData();
         });
 
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });

--- a/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts
@@ -20,6 +20,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
             evoluClient.writeTo('account', accountSeed);
             evoluClient.writeTo('address', addressSeed);
             evoluClient.writeTo('output', outputSeed);
+            evoluClient.seedQuotaManagerData();
         });
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
     });
@@ -30,8 +31,10 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
         dashboardPage,
         walletPage,
         metadataPage,
+        devicePrompt,
     }) => {
         await test.step('Enable Suite Sync', async () => {
+            await metadataPage.setupQuotaManager();
             await metadataPage.initiateSuiteSyncSetup();
             if (isWebProject(target)) {
                 // eslint-disable-next-line playwright/no-conditional-expect
@@ -64,7 +67,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
                     },
                 });
             }
-            await metadataPage.confirmSuiteSyncSetup();
+            await devicePrompt.confirmSuiteSyncSetup();
         });
 
         await test.step('Verify BTC account label is synced', async () => {


### PR DESCRIPTION
There was change in our product how quota manager is being handled with suite-sync.
Now it is mandatory to have it setup and our test were missing this configuration.

Changes:
- quota manager is being configured and enforced
- setup now wipes quota manager - atm thru bash exec. I want to change that later to some pg lib
- tests rely on Relay being seeded now also seed Quota db
- new extra verification of keys for quota on first label change in tests - this is unfortunate impact of our product not being able to store keys in our test envs
- adding script that pulls and cleans local Relay server

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-enforce-quota&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-enforce-quota&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-enforce-quota&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T11:40:50.540Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-20T13:03:50.466Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->