### PR TITLE
fix(trading): fix currency fiat precision issues

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher.ts
@@ -44,7 +44,7 @@ export const useTradingCurrencySwitcher = <T extends TradingAllFormProps>({
 }: TradingUseCurrencySwitcherProps<T>) => {
     const { setValue, getValues, control } =
         methods as unknown as UseFormReturn<TradingAllFormProps>;
-    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const cryptoInputValue = useWatch({ control, name: inputNames.cryptoInput });
     const sendCryptoSelect = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);
     const { getAssetDecimals } = useTradingAssetDecimals();

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -17,7 +17,7 @@ export const useTradingFiatValues = ({
     const { network } = cryptoIdToNetworkAndContractAddress(cryptoId);
     const symbol = network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY;
 
-    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
 
     return useCommonTradingFiatValues({ ...rest, cryptoId, shouldSendInSats });
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -29,6 +29,7 @@ import {
     convertAmountUnitsToSubunits,
     fromBaseCurrencyToCryptoUnit,
     getCryptoAmountWithReserve,
+    getDecimalsForBaseCurrency,
     isZero,
 } from '@suite-common/wallet-utils';
 import { BigNumber, isChanged } from '@trezor/utils';
@@ -68,7 +69,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
 }: TradingUseFormActionsProps<T>): TradingUseFormActionsReturnProps => {
     const dispatch = useDispatch();
     const { symbol } = account;
-    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
     const accounts = useSelector(selectVisibleDeviceAccounts);
     const isNotFormPage = pageType !== 'form';
@@ -140,8 +141,12 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
             formattedAmount.gt(0) // formatAmount() returns '-1' on error
         ) {
             const fiatValueBigNumber = formattedAmount.multipliedBy(rate.rate);
+            const fiatDecimals = getDecimalsForBaseCurrency({
+                code: mappedBaseCurrencyCode,
+                isInSats: false,
+            });
 
-            setValue(TRADING_FORM_OUTPUT_FIAT, fiatValueBigNumber.toFixed(2), {
+            setValue(TRADING_FORM_OUTPUT_FIAT, fiatValueBigNumber.toFixed(fiatDecimals), {
                 shouldValidate: true,
             });
         }

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -91,7 +91,7 @@ export const useTradingBuyForm = ({
 
     const shouldResetOnInitialBuyInfoLoad = useRef(!buyInfo);
 
-    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);
 
     const fiatTradingValuesParams = selectedQuote

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -133,7 +133,7 @@ export const useTradingExchangeForm = ({
     );
 
     const { symbol } = account;
-    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const network = getNetwork(account.symbol);
     const trades = useSelector(selectTradingTrades);
     const trade = useMemo(

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -116,7 +116,7 @@ export const useTradingSellForm = ({
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const network = networks[account.symbol];
-    const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
     const localCurrencyOption = { value: baseCurrencyCode, label: baseCurrencyCode.toUpperCase() };
     const trades = useSelector(selectTradingTrades);
     const trade = trades.find(

--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -19,6 +19,7 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     };
 
     const areSatsDisplayed = bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
+    const isBtcSatsAmountUnit = areSatsDisplayed && symbol === 'btc';
 
     const areUnitsSupportedByDevice = !unavailableCapabilities?.amountUnit;
 
@@ -27,6 +28,7 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
     return {
         bitcoinAmountUnit,
         areSatsDisplayed,
+        isBtcSatsAmountUnit,
         shouldSendInSats:
             areSatsDisplayed && areUnitsSupportedByNetwork && areUnitsSupportedByDevice,
         toggleBitcoinAmountUnits: toggleBitcoinAmountUnitsAction,

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -29,7 +29,7 @@ export const TradingBalance = ({
     amountInCrypto,
     decimals: networkDecimals = getNetworkDecimalsWithFallback(symbol),
 }: TradingBalanceProps) => {
-    const { shouldSendInSats } = useBitcoinAmountUnit(symbol);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const balanceCurrency = tradingGetAccountLabel(displaySymbol ?? '', shouldSendInSats);
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';
     const formattedBalance =

--- a/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
@@ -1,5 +1,7 @@
 import { useFormatters } from '@suite-common/formatters';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
+import { isFiatBaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { HiddenPlaceholder } from 'src/components/suite';
 
@@ -16,9 +18,20 @@ export const TradingFiatAmount = ({
 }: TradingFiatAmountProps) => {
     const { BaseCurrencyAmountFormatter } = useFormatters();
 
+    const formatterOptions =
+        currency && isFiatBaseCurrencyCode(currency)
+            ? {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: getDecimalsForBaseCurrency({
+                      code: currency,
+                      isInSats: false,
+                  }),
+              }
+            : undefined;
+
     const content =
         amount !== undefined ? (
-            <BaseCurrencyAmountFormatter value={amount} currency={currency} />
+            <BaseCurrencyAmountFormatter value={amount} currency={currency} {...formatterOptions} />
         ) : (
             <>{currency?.toUpperCase()}</>
         );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -14,10 +14,9 @@ import {
     isTradingFiatCurrencyOption,
 } from '@suite-common/trading';
 import { buildCurrencyOptions, buildCurrencyShortOption } from '@suite-common/wallet-utils';
-import { isBaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { isFiatBaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import {
     type TradingAllFormProps,
     type TradingFormInputCurrencyProps,
@@ -42,18 +41,24 @@ export const TradingFormInputCurrency = ({
     const currentCurrency = getSelectedTradingCurrency(context);
     const fiatCurrencies = getFiatCurrenciesProps(context);
     const currencies = fiatCurrencies?.supportedFiatCurrencies ?? null;
-    const { areSatsDisplayed } = useBitcoinAmountUnit(context.network.symbol);
+    const selectedBaseCurrencyValue = isFiatBaseCurrencyCode(currentCurrency.value)
+        ? currentCurrency.value
+        : '';
+
     const selectedBaseCurrency = buildCurrencyShortOption({
-        currency: isBaseCurrencyCode(currentCurrency.value) ? currentCurrency.value : '',
-        areSatsDisplayed,
+        currency: selectedBaseCurrencyValue,
+        areSatsDisplayed: false,
     });
 
     const options = useMemo(
         () =>
             currencies
                 ? [...currencies].map(currency => buildTradingFiatOption(currency))
-                : buildCurrencyOptions({ selected: selectedBaseCurrency, areSatsDisplayed }),
-        [currencies, selectedBaseCurrency, areSatsDisplayed],
+                : buildCurrencyOptions({
+                      selected: selectedBaseCurrency,
+                      areSatsDisplayed: false,
+                  }).filter(option => isFiatBaseCurrencyCode(option.value)),
+        [currencies, selectedBaseCurrency],
     );
 
     const onChangeAdditional = (option: TradingFiatCurrencyOption) => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -1,25 +1,35 @@
 import { useEffect } from 'react';
-import { type FieldErrors, type UseControllerProps, useFormContext } from 'react-hook-form';
+import {
+    type FieldErrors,
+    type UseControllerProps,
+    useFormContext,
+    useWatch,
+} from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import {
+    TRADING_FORM_FIAT_CURRENCY_SELECT,
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_CURRENCY,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingBuyFormProps,
+    getNetworkDecimalsWithFallback,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { selectCurrentFiatRates, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import {
     buildCurrencyShortOption,
+    convertAmountSubunitsToUnits,
     findToken,
+    getDecimalsForBaseCurrency,
     getFiatRateKey,
     getNetworkReserve,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
+import { type BaseCurrencyCode, isFiatBaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { NumberInput } from '@trezor/product-components';
 import { useDidUpdate } from '@trezor/react-utils';
 import { BigNumber } from '@trezor/utils';
@@ -38,7 +48,7 @@ import {
     isTradingExchangeContext,
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { getFeeInUnits, tradingGetRoundedFiatAmount } from 'src/utils/wallet/trading/tradingUtils';
+import { getFeeInUnits } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingFormInputCurrency } from 'src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency';
 
 export const TradingFormInputFiat = ({
@@ -52,16 +62,18 @@ export const TradingFormInputFiat = ({
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const context = useTradingFormContext();
-    const { account, amountLimits, network } = context;
+    const { account, amountLimits } = context;
     const {
         control,
         formState: { errors },
         trigger,
         clearErrors,
-        getValues,
     } = useFormContext<TradingAllFormProps>();
 
-    const sendCryptoSelect = getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT);
+    const sendCryptoSelect = useWatch({
+        control,
+        name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
+    });
     const tokenAddress = sendCryptoSelect?.contractAddress as TokenAddress | undefined;
 
     const balance = tokenAddress
@@ -104,13 +116,36 @@ export const TradingFormInputFiat = ({
         rateType: 'current',
     });
 
-    const { areSatsDisplayed } = useBitcoinAmountUnit(network.symbol);
-
     const rates = useSelector(selectCurrentFiatRates);
-    const [currencySelect, cryptoAmount] = getValues([
-        TRADING_FORM_OUTPUT_CURRENCY,
-        cryptoInputName,
-    ]);
+    const outputCurrencySelect = useWatch({ control, name: TRADING_FORM_OUTPUT_CURRENCY });
+    const fiatCurrencySelect = useWatch({ control, name: TRADING_FORM_FIAT_CURRENCY_SELECT });
+    const cryptoAmount = useWatch({ control, name: cryptoInputName });
+    const { areSatsDisplayed } = useBitcoinAmountUnit(account.symbol);
+    const normalizedCryptoAmount =
+        account.symbol === 'btc' && areSatsDisplayed && cryptoAmount
+            ? convertAmountSubunitsToUnits(
+                  cryptoAmount,
+                  getNetworkDecimalsWithFallback(account.symbol),
+              )
+            : cryptoAmount;
+
+    let selectedCurrencyCode: BaseCurrencyCode | '' = '';
+    if (isFiatBaseCurrencyCode(outputCurrencySelect?.value)) {
+        selectedCurrencyCode = outputCurrencySelect.value;
+    } else if (isFiatBaseCurrencyCode(fiatCurrencySelect?.value)) {
+        selectedCurrencyCode = fiatCurrencySelect.value;
+    }
+    const fiatInputDecimals = getDecimalsForBaseCurrency({
+        code: selectedCurrencyCode,
+        isInSats: false,
+    });
+    const selectedCurrencyLabel =
+        buildCurrencyShortOption({
+            currency: selectedCurrencyCode,
+            areSatsDisplayed: false,
+        }).label ||
+        context.amountLimits?.currency ||
+        'USD';
 
     const fiatInputError =
         fiatInputName === TRADING_FORM_OUTPUT_FIAT
@@ -138,7 +173,9 @@ export const TradingFormInputFiat = ({
             ? {
                   validate: {
                       min: validateMin(translationString),
-                      decimals: validateDecimals(translationString, { decimals: 2 }),
+                      decimals: validateDecimals(translationString, {
+                          decimals: fiatInputDecimals,
+                      }),
                       balance: (value: string) => {
                           const valueBigNumber = new BigNumber(value);
                           if (
@@ -157,15 +194,15 @@ export const TradingFormInputFiat = ({
                           : () => undefined,
                       minFiat: () => {
                           if (
-                              cryptoAmount &&
+                              normalizedCryptoAmount &&
                               context.amountLimits?.minCrypto &&
-                              new BigNumber(cryptoAmount).isLessThan(
+                              new BigNumber(normalizedCryptoAmount).isLessThan(
                                   new BigNumber(context.amountLimits.minCrypto),
                               )
                           ) {
                               const fiatRateKey = getFiatRateKey(
                                   account.symbol,
-                                  currencySelect?.value ? currencySelect.value : 'usd',
+                                  selectedCurrencyCode || 'usd',
                                   tokenAddress,
                               );
                               const rate =
@@ -177,16 +214,16 @@ export const TradingFormInputFiat = ({
 
                               if (minFiat) {
                                   return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                      minimum: tradingGetRoundedFiatAmount(minFiat),
-                                      currency: buildCurrencyShortOption({
-                                          currency: currencySelect.value,
-                                          areSatsDisplayed,
-                                      }).label,
+                                      minimum: new BigNumber(minFiat).toFixed(
+                                          fiatInputDecimals,
+                                          BigNumber.ROUND_HALF_UP,
+                                      ),
+                                      currency: selectedCurrencyLabel,
                                   });
                               } else {
                                   return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
                                       minimum: context.amountLimits.minCrypto,
-                                      currency: context.amountLimits.currency,
+                                      currency: selectedCurrencyLabel,
                                   });
                               }
                           }
@@ -196,7 +233,9 @@ export const TradingFormInputFiat = ({
             : {
                   validate: {
                       min: validateMin(translationString),
-                      decimals: validateDecimals(translationString, { decimals: 2 }),
+                      decimals: validateDecimals(translationString, {
+                          decimals: fiatInputDecimals,
+                      }),
                       ...(isTradingSellContext(context)
                           ? {
                                 networkReserve: isNetworkReserveEnabled
@@ -217,8 +256,11 @@ export const TradingFormInputFiat = ({
                               )
                           ) {
                               return translationString('TR_BUY_VALIDATION_ERROR_MINIMUM_FIAT', {
-                                  minimum: context.amountLimits.minFiat,
-                                  currency: context.amountLimits.currency,
+                                  minimum: new BigNumber(context.amountLimits.minFiat).toFixed(
+                                      fiatInputDecimals,
+                                      BigNumber.ROUND_HALF_UP,
+                                  ),
+                                  currency: selectedCurrencyLabel,
                               });
                           }
                       },
@@ -231,8 +273,11 @@ export const TradingFormInputFiat = ({
                               )
                           ) {
                               return translationString('TR_BUY_VALIDATION_ERROR_MAXIMUM_FIAT', {
-                                  maximum: context.amountLimits.maxFiat,
-                                  currency: context.amountLimits.currency,
+                                  maximum: new BigNumber(context.amountLimits.maxFiat).toFixed(
+                                      fiatInputDecimals,
+                                      BigNumber.ROUND_HALF_UP,
+                                  ),
+                                  currency: selectedCurrencyLabel,
                               });
                           }
                       },


### PR DESCRIPTION
## Description
- Restrict trading fiat input currency handling to fiat currencies only, excluding non-fiat/crypto options in the fiat input path.
- Remove BTC/sats-specific handling from fiat amount paths in trading fiat input and fiat-currency change recalculation.
- Apply selected fiat currency decimals for fiat validation and fiat amount formatting instead of fixed 2-decimal behavior.
- Use the selected fiat currency label consistently in minimum/maximum fiat validation messages.

## Notes for QA
- In Trading Buy/Sell/Exchange, open the fiat amount input currency selector and verify only fiat currencies are available (no BTC/XAU/XAG or other non-fiat options).
- Select USD, enter a fiat amount, switch to KRW, and re-enter the amount; verify displayed and validated precision follows the selected fiat currency and is not fixed to 2 decimals.
- Trigger minimum and maximum fiat validation errors and verify the message uses the currently selected fiat currency label and correctly rounded fiat value.

## Related Issue
Resolve #26084

## Screenshots:
N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-currency-fiat-issues-26084&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-currency-fiat-issues-26084&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T07:40:06.029Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T10:55:53.716Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-currency-fiat-issues-26084/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-currency-fiat-issues-26084/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->