### PR TITLE
chore(workflow): needs qa workflow

### DIFF
--- a/.github/workflows/bot-needs-qa.yml
+++ b/.github/workflows/bot-needs-qa.yml
@@ -1,0 +1,132 @@
+name: "[Bot] Set project status approved/needs-qa on Close/Merge PR & Issue"
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+env:
+  NOQA_LABEL: no-QA
+  PROJECT_ID: PVT_kwDOAD9FD84AAuwj
+  STATUS_FIELD_ID: PVTSSF_lADOAD9FD84AAuwjzgAYi50
+  NEEDS_QA_OPTION_ID: 97926e6f
+  APPROVED_OPTION_ID: 0f23d421
+
+jobs:
+  set-project-status:
+    name: Set project status
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Determine event context
+        id: context
+        run: |
+          if [ "${{ github.event_name }}" == "issues" ]; then
+            echo "content_id=${{ github.event.issue.node_id }}" >> $GITHUB_OUTPUT
+            echo "has_noqa_label=${{ contains(github.event.issue.labels.*.name, env.NOQA_LABEL) }}" >> $GITHUB_OUTPUT
+            echo "is_merged=false" >> $GITHUB_OUTPUT
+            echo "event_type=issue" >> $GITHUB_OUTPUT
+          else
+            echo "content_id=${{ github.event.pull_request.node_id }}" >> $GITHUB_OUTPUT
+            echo "has_noqa_label=${{ contains(github.event.pull_request.labels.*.name, env.NOQA_LABEL) }}" >> $GITHUB_OUTPUT
+            echo "is_merged=${{ github.event.pull_request.merged }}" >> $GITHUB_OUTPUT
+            echo "event_type=pull_request" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if PR closed without merge
+        if: |
+          steps.context.outputs.event_type == 'pull_request' &&
+          steps.context.outputs.is_merged == 'false'
+        run: |
+          echo "PR was closed without merging — skipping."
+          exit 0
+
+      - name: Generate GitHub App token
+        if: |
+          steps.context.outputs.event_type == 'issue' ||
+          steps.context.outputs.is_merged == 'true'
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+      - name: Get project item ID
+        if: |
+          steps.context.outputs.event_type == 'issue' ||
+          steps.context.outputs.is_merged == 'true'
+        id: get-item
+        env:
+          GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: |
+          CONTENT_ID="${{ steps.context.outputs.content_id }}"
+
+          RESPONSE=$(gh api graphql -f query='
+            query($content_id: ID!, $project_id: ID!) {
+              node(id: $content_id) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes { id project { id } }
+                  }
+                }
+                ... on PullRequest {
+                  projectItems(first: 10) {
+                    nodes { id project { id } }
+                  }
+                }
+              }
+            }' \
+            -f content_id="$CONTENT_ID" \
+            -f project_id="${{ env.PROJECT_ID }}")
+
+          ITEM_ID=$(echo "$RESPONSE" | jq -r \
+            ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\") | .id")
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "Item not found in project — it may not be tracked. Skipping."
+            echo "item_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "ITEM_ID=$ITEM_ID" >> $GITHUB_ENV
+          echo "item_found=true" >> $GITHUB_OUTPUT
+
+      - name: Determine target status
+        if: |
+          (steps.context.outputs.event_type == 'issue' || steps.context.outputs.is_merged == 'true') &&
+          steps.get-item.outputs.item_found == 'true'
+        id: target-status
+        run: |
+          if [ "${{ steps.context.outputs.has_noqa_label }}" == "true" ]; then
+            echo "option_id=${{ env.APPROVED_OPTION_ID }}" >> $GITHUB_OUTPUT
+            echo "status_name=Approved" >> $GITHUB_OUTPUT
+          else
+            echo "option_id=${{ env.NEEDS_QA_OPTION_ID }}" >> $GITHUB_OUTPUT
+            echo "status_name=Needs QA" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set project status
+        if: |
+          (steps.context.outputs.event_type == 'issue' || steps.context.outputs.is_merged == 'true') &&
+          steps.get-item.outputs.item_found == 'true'
+        env:
+          GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: |
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field
+                value: { singleSelectOptionId: $value }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project=${{ env.PROJECT_ID }} \
+               -f item=$ITEM_ID \
+               -f field=${{ env.STATUS_FIELD_ID }} \
+               -f value=${{ steps.target-status.outputs.option_id }} \
+
+          echo "✅ Status set to '${{ steps.target-status.outputs.status_name }}' for ${{ steps.context.outputs.event_type }}"


### PR DESCRIPTION
## Description

- Adds a new workflow bot-needs-qa.yml to update status.
- Triggers on:
  - closed issues
  - closed pull requests
  - Skips pull requests that were closed without merge.
- Sets status based on label:
  - Approved when no-QA label is present
  - Needs QA otherwise

Resolves https://github.com/trezor/trezor-suite/issues/26079

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/needs-qa-workflow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/needs-qa-workflow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T12:29:10.706Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-20T12:27:23.418Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->