### PR TITLE
refactor(analytics-docs): Split LiveLogSidebar into multiple components

### DIFF
--- a/packages/analytics-docs/src/components/LiveLog/EventPayload.tsx
+++ b/packages/analytics-docs/src/components/LiveLog/EventPayload.tsx
@@ -1,0 +1,55 @@
+import { Box, Table, Text } from '@trezor/components';
+
+import { META_KEYS } from './constants';
+import type { LiveLogEvent } from '../../types';
+
+const getPayloadEntries = (event: LiveLogEvent): [string, string][] =>
+    Object.entries(event.payload ?? {});
+
+const getMetaEntries = (event: LiveLogEvent): [string, string][] =>
+    META_KEYS.filter(key => event.meta?.[key] != null).map(key => [key, event.meta[key]!]);
+
+type EventPayloadProps = {
+    event: LiveLogEvent;
+    isPayloadOpen: boolean;
+    showMetaInPayload: boolean;
+};
+
+export const EventPayload = ({ event, isPayloadOpen, showMetaInPayload }: EventPayloadProps) => {
+    const payloadEntries = getPayloadEntries(event);
+    const metaEntries = getMetaEntries(event);
+    const tableEntries = showMetaInPayload ? [...payloadEntries, ...metaEntries] : payloadEntries;
+    const hasPayload = tableEntries.length > 0;
+
+    if (!hasPayload || !isPayloadOpen) return null;
+
+    return (
+        <Box margin={{ top: 8 }} cursor="auto">
+            <>
+                <Table typographyStyle="body-xs">
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.Cell>Key</Table.Cell>
+                            <Table.Cell>Value</Table.Cell>
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {tableEntries.map(([key, value]) => (
+                            <Table.Row key={key}>
+                                <Table.Cell>
+                                    <Text isMonospaced>{key}</Text>
+                                </Table.Cell>
+                                <Table.Cell>
+                                    <Text isMonospaced>{String(value)}</Text>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table>
+            </>
+        </Box>
+    );
+};
+
+export const hasEventPayload = (event: LiveLogEvent, showMetaInPayload: boolean): boolean =>
+    getPayloadEntries(event).length > 0 || (showMetaInPayload && getMetaEntries(event).length > 0);

--- a/packages/analytics-docs/src/components/LiveLog/LiveLogEventItem.tsx
+++ b/packages/analytics-docs/src/components/LiveLog/LiveLogEventItem.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+
+import { format } from 'date-fns';
+import styled from 'styled-components';
+
+import {
+    CardList,
+    Column,
+    IconButton,
+    Row,
+    type SuiteThemeColors,
+    TOOLTIP_DELAY_LONG,
+    Text,
+    Tooltip,
+} from '@trezor/components';
+
+import { EventPayload, hasEventPayload } from './EventPayload';
+import type { LiveLogEvent } from '../../types';
+
+const NewEventDot = styled.div<{ theme: SuiteThemeColors }>`
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.backgroundPrimaryDefault};
+    flex: 0 0 auto;
+`;
+
+type LiveLogEventItemProps = {
+    event: LiveLogEvent;
+    onEventClick: (eventName: string) => void;
+    isNew: boolean;
+    showMetaInPayload: boolean;
+};
+
+export const LiveLogEventItem = ({
+    event,
+    onEventClick,
+    isNew,
+    showMetaInPayload,
+}: LiveLogEventItemProps) => {
+    const [isPayloadOpen, setIsPayloadOpen] = useState(false);
+    const hasPayload = hasEventPayload(event, showMetaInPayload);
+
+    return (
+        <CardList.Item key={event.id} paddingType="small">
+            <Column gap={4} margin={{ vertical: 4 }} alignItems="stretch" width="100%">
+                <Row
+                    onClick={e => {
+                        e.stopPropagation();
+                        setIsPayloadOpen(prev => !prev);
+                    }}
+                    justifyContent="space-between"
+                    alignItems="center"
+                    gap={12}
+                >
+                    <Column gap={2} flex="1" minWidth={0}>
+                        <Text typographyStyle="body-sm-strong">{event.type}</Text>
+                        <Row gap={4} minWidth={0}>
+                            <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
+                                {format(new Date(event.receivedAt), 'HH:mm:ss')}
+                            </Text>
+                            {isNew && <NewEventDot aria-label="New event" />}
+                        </Row>
+                    </Column>
+                    {hasPayload && (
+                        <Tooltip content="Find event" delayShow={TOOLTIP_DELAY_LONG}>
+                            <IconButton
+                                icon="magnifyingGlass"
+                                size="small"
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={e => {
+                                    onEventClick(event.type);
+                                    e.stopPropagation();
+                                }}
+                            />
+                        </Tooltip>
+                    )}
+                </Row>
+                <EventPayload
+                    event={event}
+                    isPayloadOpen={isPayloadOpen}
+                    showMetaInPayload={showMetaInPayload}
+                />
+            </Column>
+        </CardList.Item>
+    );
+};

--- a/packages/analytics-docs/src/components/LiveLog/LiveLogHeader.tsx
+++ b/packages/analytics-docs/src/components/LiveLog/LiveLogHeader.tsx
@@ -1,0 +1,56 @@
+import { Badge, Box, H3, IconButton, Row, Text, Tooltip } from '@trezor/components';
+
+type LiveLogHeaderProps = {
+    connected: boolean;
+    hasEvents: boolean;
+    logServerBaseUrl: string;
+    onClear: () => void;
+    onSettingsClick: () => void;
+};
+
+export const LiveLogHeader = ({
+    connected,
+    hasEvents,
+    logServerBaseUrl,
+    onClear,
+    onSettingsClick,
+}: LiveLogHeaderProps) => (
+    <Box padding={{ horizontal: 20, top: 20, bottom: 8 }}>
+        <Row justifyContent="space-between" alignItems="center" gap={8}>
+            <H3 margin={{ bottom: 0 }}>Live log</H3>
+            <Row gap={8}>
+                {hasEvents && (
+                    <Tooltip content="Clear log">
+                        <IconButton
+                            size="small"
+                            priority="secondary"
+                            intent="critical"
+                            onClick={onClear}
+                            icon="prohibit"
+                        />
+                    </Tooltip>
+                )}
+                <Tooltip content="Settings">
+                    <IconButton
+                        icon="gear"
+                        size="small"
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={onSettingsClick}
+                    />
+                </Tooltip>
+            </Row>
+        </Row>
+        <Box margin={{ bottom: 8 }}>
+            <Badge size="small" intent={connected ? 'brand' : 'warning'}>
+                {connected ? 'Connected' : 'Reconnecting…'}
+            </Badge>
+        </Box>
+        <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
+            In Suite, set Custom Analytics URL (Settings → Debug) to{' '}
+            <Text isMonospaced typographyStyle="inherit">
+                {`${logServerBaseUrl.replace(/\/+$/, '')}/log`}
+            </Text>
+        </Text>
+    </Box>
+);

--- a/packages/analytics-docs/src/components/LiveLog/LiveLogSettings.tsx
+++ b/packages/analytics-docs/src/components/LiveLog/LiveLogSettings.tsx
@@ -1,0 +1,74 @@
+import { createPortal } from 'react-dom';
+
+import { Column, Input, Modal, Row, Switch, Text } from '@trezor/components';
+
+import { getDefaultLogServerBaseUrl } from '../../utils/logServerUrl';
+
+type LiveLogSettingsProps = {
+    isOpen: boolean;
+    logServerInput: string;
+    showMetaInPayloadDraft: boolean;
+    onLogServerInputChange: (value: string) => void;
+    onShowMetaInPayloadChange: (value: boolean) => void;
+    onCancel: () => void;
+    onApply: () => void;
+    onReset: () => void;
+};
+
+export const LiveLogSettings = ({
+    isOpen,
+    logServerInput,
+    showMetaInPayloadDraft,
+    onLogServerInputChange,
+    onShowMetaInPayloadChange,
+    onCancel,
+    onApply,
+    onReset,
+}: LiveLogSettingsProps) => {
+    if (!isOpen) return null;
+
+    return createPortal(
+        <Modal
+            heading="Live log settings"
+            onCancel={onCancel}
+            width={600}
+            bottomContent={<Modal.Button onClick={onApply}>Apply</Modal.Button>}
+        >
+            <Column gap={12} alignItems="stretch">
+                <Row gap={8} alignItems="center">
+                    <Input
+                        size="small"
+                        value={logServerInput}
+                        onChange={e => onLogServerInputChange(e.target.value)}
+                        placeholder="Log server base URL (e.g. https://analytics-log.example.com)"
+                        showClearButton
+                        onClear={() => onLogServerInputChange('')}
+                    />
+
+                    <Modal.Button
+                        priority="secondary"
+                        intent="critical"
+                        onClick={onReset}
+                        size="medium"
+                    >
+                        Reset
+                    </Modal.Button>
+                </Row>
+                <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
+                    This controls where analytics-docs connects for live events (SSE) and where
+                    Suite should send events to{' '}
+                    <Text isMonospaced typographyStyle="inherit">
+                        {`${(logServerInput.trim() || getDefaultLogServerBaseUrl()).replace(/\/+$/, '')}/log`}
+                    </Text>
+                    .
+                </Text>
+                <Switch
+                    isChecked={showMetaInPayloadDraft}
+                    onChange={onShowMetaInPayloadChange}
+                    label="Show metadata in payload table"
+                />
+            </Column>
+        </Modal>,
+        document.body,
+    );
+};

--- a/packages/analytics-docs/src/components/LiveLog/constants.ts
+++ b/packages/analytics-docs/src/components/LiveLog/constants.ts
@@ -1,0 +1,6 @@
+export const META_KEYS = ['version', 'commit', 'instanceId', 'sessionId', 'messageId'] as const;
+export const SHOW_META_IN_PAYLOAD_STORAGE_KEY = 'analytics-docs-live-log-show-meta-in-payload';
+
+export const NEW_EVENT_TIMEOUT = 20_000;
+export const LIVE_LOG_SIDEBAR_MIN_WIDTH = 280;
+export const LIVE_LOG_SIDEBAR_MAX_WIDTH = 800;

--- a/packages/analytics-docs/src/components/LiveLogSidebar.tsx
+++ b/packages/analytics-docs/src/components/LiveLogSidebar.tsx
@@ -1,31 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 
-import { format } from 'date-fns';
 import styled from 'styled-components';
 
 import {
-    Badge,
     Box,
     CardList,
     Column,
-    H3,
-    IconButton,
-    Input,
-    Modal,
-    Row,
     Select,
     type SuiteThemeColors,
-    Switch,
-    TOOLTIP_DELAY_LONG,
-    Table,
     Text,
-    Tooltip,
     variables,
 } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
 
-import type { LiveLogEvent } from '../types';
 import { fuzzyMatch, getEventId } from '../utils/filterUtils';
 import {
     getDefaultLogServerBaseUrl,
@@ -33,13 +20,17 @@ import {
     setLogServerBaseUrl,
 } from '../utils/logServerUrl';
 import { useLiveLogEvents } from '../utils/useLiveLogEvents';
+import { LiveLogEventItem } from './LiveLog/LiveLogEventItem';
+import { LiveLogHeader } from './LiveLog/LiveLogHeader';
+import { LiveLogSettings } from './LiveLog/LiveLogSettings';
+import {
+    LIVE_LOG_SIDEBAR_MAX_WIDTH,
+    LIVE_LOG_SIDEBAR_MIN_WIDTH,
+    NEW_EVENT_TIMEOUT,
+    SHOW_META_IN_PAYLOAD_STORAGE_KEY,
+} from './LiveLog/constants';
 
-const META_KEYS = ['version', 'commit', 'instanceId', 'sessionId', 'messageId'] as const;
-const SHOW_META_IN_PAYLOAD_STORAGE_KEY = 'analytics-docs-live-log-show-meta-in-payload';
-
-export const NEW_EVENT_TIMEOUT = 20_000;
-export const LIVE_LOG_SIDEBAR_MIN_WIDTH = 280;
-export const LIVE_LOG_SIDEBAR_MAX_WIDTH = 800;
+export { LIVE_LOG_SIDEBAR_MIN_WIDTH, LIVE_LOG_SIDEBAR_MAX_WIDTH };
 
 const SidebarWrapper = styled.aside<{ theme: SuiteThemeColors }>`
     width: 100%;
@@ -58,126 +49,6 @@ const SidebarWrapper = styled.aside<{ theme: SuiteThemeColors }>`
         border-bottom: 1px solid ${({ theme }) => theme.borderOnElevation1};
     }
 `;
-
-const NewEventDot = styled.div<{ theme: SuiteThemeColors }>`
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: ${({ theme }) => theme.backgroundPrimaryDefault};
-    flex: 0 0 auto;
-`;
-
-const getPayloadEntries = (event: LiveLogEvent): [string, string][] =>
-    Object.entries(event.payload ?? {});
-
-const getMetaEntries = (event: LiveLogEvent): [string, string][] =>
-    META_KEYS.filter(key => event.meta?.[key] != null).map(key => [key, event.meta[key]!]);
-
-type EventPayloadProps = {
-    event: LiveLogEvent;
-    isPayloadOpen: boolean;
-    showMetaInPayload: boolean;
-};
-
-const EventPayload = ({ event, isPayloadOpen, showMetaInPayload }: EventPayloadProps) => {
-    const payloadEntries = getPayloadEntries(event);
-    const metaEntries = getMetaEntries(event);
-    const tableEntries = showMetaInPayload ? [...payloadEntries, ...metaEntries] : payloadEntries;
-    const hasPayload = tableEntries.length > 0;
-
-    if (!hasPayload || !isPayloadOpen) return null;
-
-    return (
-        <Box margin={{ top: 8 }} cursor="auto">
-            <>
-                <Table typographyStyle="body-xs">
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.Cell>Key</Table.Cell>
-                            <Table.Cell>Value</Table.Cell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {tableEntries.map(([key, value]) => (
-                            <Table.Row key={key}>
-                                <Table.Cell>
-                                    <Text isMonospaced>{key}</Text>
-                                </Table.Cell>
-                                <Table.Cell>
-                                    <Text isMonospaced>{String(value)}</Text>
-                                </Table.Cell>
-                            </Table.Row>
-                        ))}
-                    </Table.Body>
-                </Table>
-            </>
-        </Box>
-    );
-};
-
-type LiveLogEventItemProps = {
-    event: LiveLogEvent;
-    onEventClick: (eventName: string) => void;
-    isNew: boolean;
-    showMetaInPayload: boolean;
-};
-
-const LiveLogEventItem = ({
-    event,
-    onEventClick,
-    isNew,
-    showMetaInPayload,
-}: LiveLogEventItemProps) => {
-    const [isPayloadOpen, setIsPayloadOpen] = useState(false);
-    const hasPayload =
-        getPayloadEntries(event).length > 0 ||
-        (showMetaInPayload && getMetaEntries(event).length > 0);
-
-    return (
-        <CardList.Item key={event.id} paddingType="small">
-            <Column gap={4} margin={{ vertical: 4 }} alignItems="stretch" width="100%">
-                <Row
-                    onClick={e => {
-                        e.stopPropagation();
-                        setIsPayloadOpen(prev => !prev);
-                    }}
-                    justifyContent="space-between"
-                    alignItems="center"
-                    gap={12}
-                >
-                    <Column gap={2} flex="1" minWidth={0}>
-                        <Text typographyStyle="body-sm-strong">{event.type}</Text>
-                        <Row gap={4} minWidth={0}>
-                            <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
-                                {format(new Date(event.receivedAt), 'HH:mm:ss')}
-                            </Text>
-                            {isNew && <NewEventDot aria-label="New event" />}
-                        </Row>
-                    </Column>
-                    {hasPayload && (
-                        <Tooltip content="Find event" delayShow={TOOLTIP_DELAY_LONG}>
-                            <IconButton
-                                icon="magnifyingGlass"
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={e => {
-                                    onEventClick(event.type);
-                                    e.stopPropagation();
-                                }}
-                            />
-                        </Tooltip>
-                    )}
-                </Row>
-                <EventPayload
-                    event={event}
-                    isPayloadOpen={isPayloadOpen}
-                    showMetaInPayload={showMetaInPayload}
-                />
-            </Column>
-        </CardList.Item>
-    );
-};
 
 type LiveLogSidebarProps = {
     onEventClick: (eventName: string) => void;
@@ -262,61 +133,58 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
     }, [events]);
 
     const handleRowClick = (eventName: string) => {
-        const id = getEventId(eventName);
-        window.location.hash = id;
+        window.location.hash = getEventId(eventName);
         onEventClick(eventName);
+    };
+
+    const handleClearLog = async () => {
+        await clear();
+        seenEventIdsRef.current.clear();
+        for (const timeoutId of timeoutsRef.current.values()) {
+            window.clearTimeout(timeoutId);
+        }
+        timeoutsRef.current.clear();
+        setNewEventIds({});
+    };
+
+    const handleSettingsApply = () => {
+        const next = logServerInput.trim() || getDefaultLogServerBaseUrl();
+        setLogServerBaseUrl(next);
+        setLogServerBaseUrlState(next);
+        setLogServerInput(next);
+        setShowMetaInPayload(showMetaInPayloadDraft);
+        if (showMetaInPayloadDraft) {
+            window.localStorage.setItem(SHOW_META_IN_PAYLOAD_STORAGE_KEY, '1');
+        } else {
+            window.localStorage.removeItem(SHOW_META_IN_PAYLOAD_STORAGE_KEY);
+        }
+        setIsSettingsOpen(false);
+    };
+
+    const handleSettingsReset = () => {
+        const def = getDefaultLogServerBaseUrl();
+        setLogServerBaseUrl(def);
+        setLogServerBaseUrlState(def);
+        setLogServerInput(def);
+    };
+
+    const handleSettingsCancel = () => {
+        setIsSettingsOpen(false);
+        setLogServerInput(logServerBaseUrl);
+        setShowMetaInPayloadDraft(showMetaInPayload);
     };
 
     return (
         <>
             <SidebarWrapper>
                 <Column gap={0}>
-                    <Box padding={{ horizontal: 20, top: 20, bottom: 8 }}>
-                        <Row justifyContent="space-between" alignItems="center" gap={8}>
-                            <H3 margin={{ bottom: 0 }}>Live log</H3>
-                            <Row gap={8}>
-                                {events.length > 0 && (
-                                    <Tooltip content="Clear log">
-                                        <IconButton
-                                            size="small"
-                                            priority="secondary"
-                                            intent="critical"
-                                            onClick={async () => {
-                                                await clear();
-                                                seenEventIdsRef.current.clear();
-                                                for (const timeoutId of timeoutsRef.current.values()) {
-                                                    window.clearTimeout(timeoutId);
-                                                }
-                                                timeoutsRef.current.clear();
-                                                setNewEventIds({});
-                                            }}
-                                            icon="prohibit"
-                                        />
-                                    </Tooltip>
-                                )}
-                                <Tooltip content="Settings">
-                                    <IconButton
-                                        icon="gear"
-                                        size="small"
-                                        intent="neutral"
-                                        priority="secondary"
-                                        onClick={() => setIsSettingsOpen(true)}
-                                    />
-                                </Tooltip>
-                            </Row>
-                        </Row>
-                        <Box margin={{ bottom: 8 }}>
-                            <Badge size="small" intent={connected ? 'brand' : 'warning'}>
-                                {connected ? 'Connected' : 'Reconnecting…'}
-                            </Badge>
-                        </Box>
-                        <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
-                            In Suite, set Custom Analytics URL (Settings → Debug) to{' '}
-                            <Text isMonospaced typographyStyle="inherit">
-                                {`${logServerBaseUrl.replace(/\/+$/, '')}/log`}
-                            </Text>
-                        </Text>
-                    </Box>
+                    <LiveLogHeader
+                        connected={connected}
+                        hasEvents={events.length > 0}
+                        logServerBaseUrl={logServerBaseUrl}
+                        onClear={handleClearLog}
+                        onSettingsClick={() => setIsSettingsOpen(true)}
+                    />
 
                     <Box padding={{ horizontal: 16, bottom: 16 }}>
                         <Box margin={{ bottom: 12 }}>
@@ -362,84 +230,16 @@ export const LiveLogSidebar = ({ onEventClick, filterQuery }: LiveLogSidebarProp
                     </Box>
                 </Column>
             </SidebarWrapper>
-            {isSettingsOpen &&
-                createPortal(
-                    <Modal
-                        heading="Live log settings"
-                        onCancel={() => {
-                            setIsSettingsOpen(false);
-                            setLogServerInput(logServerBaseUrl);
-                            setShowMetaInPayloadDraft(showMetaInPayload);
-                        }}
-                        width={600}
-                        bottomContent={
-                            <Modal.Button
-                                onClick={() => {
-                                    const next =
-                                        logServerInput.trim() || getDefaultLogServerBaseUrl();
-                                    setLogServerBaseUrl(next);
-                                    setLogServerBaseUrlState(next);
-                                    setLogServerInput(next);
-                                    setShowMetaInPayload(showMetaInPayloadDraft);
-                                    if (showMetaInPayloadDraft) {
-                                        window.localStorage.setItem(
-                                            SHOW_META_IN_PAYLOAD_STORAGE_KEY,
-                                            '1',
-                                        );
-                                    } else {
-                                        window.localStorage.removeItem(
-                                            SHOW_META_IN_PAYLOAD_STORAGE_KEY,
-                                        );
-                                    }
-                                    setIsSettingsOpen(false);
-                                }}
-                            >
-                                Apply
-                            </Modal.Button>
-                        }
-                    >
-                        <Column gap={12} alignItems="stretch">
-                            <Row gap={8} alignItems="center">
-                                <Input
-                                    size="small"
-                                    value={logServerInput}
-                                    onChange={e => setLogServerInput(e.target.value)}
-                                    placeholder="Log server base URL (e.g. https://analytics-log.example.com)"
-                                    showClearButton
-                                    onClear={() => setLogServerInput('')}
-                                />
-
-                                <Modal.Button
-                                    priority="secondary"
-                                    intent="critical"
-                                    onClick={() => {
-                                        const def = getDefaultLogServerBaseUrl();
-                                        setLogServerBaseUrl(def);
-                                        setLogServerBaseUrlState(def);
-                                        setLogServerInput(def);
-                                    }}
-                                    size="medium"
-                                >
-                                    Reset
-                                </Modal.Button>
-                            </Row>
-                            <Text typographyStyle="body-xs" intent="neutral" priority="secondary">
-                                This controls where analytics-docs connects for live events (SSE)
-                                and where Suite should send events to{' '}
-                                <Text isMonospaced typographyStyle="inherit">
-                                    {`${(logServerInput.trim() || getDefaultLogServerBaseUrl()).replace(/\/+$/, '')}/log`}
-                                </Text>
-                                .
-                            </Text>
-                            <Switch
-                                isChecked={showMetaInPayloadDraft}
-                                onChange={setShowMetaInPayloadDraft}
-                                label="Show metadata in payload table"
-                            />
-                        </Column>
-                    </Modal>,
-                    document.body,
-                )}
+            <LiveLogSettings
+                isOpen={isSettingsOpen}
+                logServerInput={logServerInput}
+                showMetaInPayloadDraft={showMetaInPayloadDraft}
+                onLogServerInputChange={setLogServerInput}
+                onShowMetaInPayloadChange={setShowMetaInPayloadDraft}
+                onCancel={handleSettingsCancel}
+                onApply={handleSettingsApply}
+                onReset={handleSettingsReset}
+            />
         </>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-live-log-sidebar&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-live-log-sidebar&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T13:50:06.368Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-20T13:48:49.892Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->