### PR TITLE
fix(suite-native): display network reserve banner only if relevant

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2557,6 +2557,7 @@ export const messages = {
             max: 'Maximum is {max}',
             noQuotes: 'No offers available for your request. Change amount or currency.',
             insufficientBalance: 'Insufficient balance',
+            networkReserve: 'Not enough {displaySymbol} after network fees',
         },
         tradingExchangePreviewScreen: {
             title: 'Swap',

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -1,12 +1,19 @@
 import { useFieldArray } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
-import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    selectAccountFormattedBalance,
+    selectAccountNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Card, Text, VStack } from '@suite-native/atoms';
 import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
-import { NetworkReserveBanner } from '@suite-native/transaction-management';
+import {
+    NetworkReserveBanner,
+    useIsNetworkReserveBannerVisible,
+} from '@suite-native/transaction-management';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { RecipientInputs } from './RecipientInputs';
@@ -16,6 +23,7 @@ import { CorrectNetworkMessageCard } from './CorrectNetworkMessageCard';
 type SendOutputFieldsProps = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
+    maxAmount?: string;
 };
 
 const cardStyle = prepareNativeStyle(utils => ({
@@ -23,13 +31,30 @@ const cardStyle = prepareNativeStyle(utils => ({
     borderWidth: utils.borders.widths.small,
 }));
 
-export const SendOutputFields = ({ accountKey, tokenContract }: SendOutputFieldsProps) => {
+export const SendOutputFields = ({
+    accountKey,
+    tokenContract,
+    maxAmount,
+}: SendOutputFieldsProps) => {
     const { applyStyle } = useNativeStyles();
-    const { control } = useFormContext<SendOutputsFormValues>();
+    const { control, watch } = useFormContext<SendOutputsFormValues>();
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
+    const formattedBalance = useSelector((state: AccountsRootState) =>
+        selectAccountFormattedBalance(state, accountKey),
+    );
     const outputsFieldArray = useFieldArray({ control, name: 'outputs' });
+
+    const amount = watch('outputs.0.amount');
+
+    const shouldShowBanner = useIsNetworkReserveBannerVisible({
+        symbol,
+        contractAddress: tokenContract,
+        amount,
+        balance: formattedBalance,
+        maxAmount,
+    });
 
     return (
         <VStack spacing="sp16">
@@ -46,7 +71,7 @@ export const SendOutputFields = ({ accountKey, tokenContract }: SendOutputFields
                     TODO: add output (outputs.append({...})) button
                     issue: https://github.com/trezor/trezor-suite/issues/12944
                     */}
-                    {symbol && (
+                    {symbol && shouldShowBanner && (
                         <NetworkReserveBanner symbol={symbol} contractAddress={tokenContract} />
                     )}
                 </VStack>

--- a/suite-native/module-send/src/hooks/useSendForm.ts
+++ b/suite-native/module-send/src/hooks/useSendForm.ts
@@ -339,5 +339,6 @@ export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress
         form,
         network,
         amount,
+        feeLevelsMaxAmount,
     };
 };

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -29,7 +29,7 @@ export const SendOutputsScreen = ({
         return null;
     }
 
-    const { form, handleSubmitSendForm, amount, network } = sendForm;
+    const { form, handleSubmitSendForm, amount, network, feeLevelsMaxAmount } = sendForm;
     const {
         formState: { isValid, isSubmitting },
     } = form;
@@ -68,7 +68,11 @@ export const SendOutputsScreen = ({
 
                 <Box marginTop="sp32">
                     <Form form={form}>
-                        <SendOutputFields accountKey={accountKey} tokenContract={tokenContract} />
+                        <SendOutputFields
+                            accountKey={accountKey}
+                            tokenContract={tokenContract}
+                            maxAmount={feeLevelsMaxAmount?.normal}
+                        />
                         {network?.networkType === 'bitcoin' && (
                             <Box flexDirection="row" justifyContent="center" marginTop="sp24">
                                 <SwitchCoinControlButton amount={amount} accountKey={accountKey} />

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendCard.tsx
@@ -1,8 +1,14 @@
+import { useSelector } from 'react-redux';
+
 import { cryptoIdToSymbol } from '@suite-common/trading';
+import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { AnimatedCard, HStack, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { CardTitle, useAnimatedBorderStyle } from '@suite-native/trading-atoms';
-import { NetworkReserveBanner } from '@suite-native/transaction-management';
+import {
+    NetworkReserveBanner,
+    useIsNetworkReserveBannerVisible,
+} from '@suite-native/transaction-management';
 
 import { ExchangeSendAccountCryptoBalance } from './ExchangeSendAccountCryptoBalance';
 import { ExchangeSendAmountBadge } from './ExchangeSendAmountBadge';
@@ -19,7 +25,20 @@ export const ExchangeSendCard = ({ isAmountInputActive }: ExchangeSendCardProps)
     const { watch } = useExchangeFormContext();
 
     const asset = watch('sendAsset');
+    const sendCryptoAmount = watch('sendCryptoAmount');
+    const sendAccount = watch('sendAccount');
     const symbol = asset ? cryptoIdToSymbol(asset.cryptoId) : undefined;
+
+    const formattedBalance = useSelector((state: AccountsRootState) =>
+        selectAccountFormattedBalance(state, sendAccount?.key),
+    );
+
+    const shouldShowBanner = useIsNetworkReserveBannerVisible({
+        symbol,
+        contractAddress: asset?.contractAddress,
+        amount: sendCryptoAmount,
+        balance: formattedBalance,
+    });
 
     return (
         <AnimatedCard style={animatedStyle} noPadding>
@@ -40,7 +59,7 @@ export const ExchangeSendCard = ({ isAmountInputActive }: ExchangeSendCardProps)
                     <TradeableAssetNetworkInfo asset={asset} />
                     <ExchangeSendAccountCryptoBalance />
                 </HStack>
-                {symbol && (
+                {symbol && shouldShowBanner && (
                     <NetworkReserveBanner
                         symbol={symbol}
                         contractAddress={asset?.contractAddress}

--- a/suite-native/module-trading/src/components/sell/SellCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.tsx
@@ -1,11 +1,16 @@
 import { Platform } from 'react-native';
 import { FadeIn, LinearTransition } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
 import { cryptoIdToSymbol } from '@suite-common/trading';
+import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { AnimatedBox, AnimatedCard, Box, HStack, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { CardTitle, useAnimatedBorderStyle } from '@suite-native/trading-atoms';
-import { NetworkReserveBanner } from '@suite-native/transaction-management';
+import {
+    NetworkReserveBanner,
+    useIsNetworkReserveBannerVisible,
+} from '@suite-native/transaction-management';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles';
 
 import { SellFormFieldErrorBadge } from './SellFormFieldErrorBadge';
@@ -40,7 +45,20 @@ export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCar
     const { watch } = useSellFormContext();
 
     const asset = watch('sendAsset');
+    const cryptoStringAmount = watch('cryptoStringAmount');
+    const sendAccount = watch('sendAccount');
     const symbol = asset ? cryptoIdToSymbol(asset.cryptoId) : undefined;
+
+    const formattedBalance = useSelector((state: AccountsRootState) =>
+        selectAccountFormattedBalance(state, sendAccount?.key),
+    );
+
+    const shouldShowBanner = useIsNetworkReserveBannerVisible({
+        symbol,
+        contractAddress: asset?.contractAddress,
+        amount: cryptoStringAmount,
+        balance: formattedBalance,
+    });
 
     // on android fade animation looks ugly on view with shadows, better to skip it
     const enteringAnimation = shouldAnimateEntering && Platform.OS === 'ios' ? FadeIn : undefined;
@@ -71,7 +89,7 @@ export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCar
                         <TradeableAssetNetworkInfo asset={asset} />
                         <SellSendAccountCryptoBalance />
                     </HStack>
-                    {symbol && (
+                    {symbol && shouldShowBanner && (
                         <NetworkReserveBanner
                             symbol={symbol}
                             contractAddress={asset?.contractAddress}

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -141,6 +141,15 @@ export const sendCryptoAmountValidationSchema = yup
             return true;
         }
 
+        if (networkReserve && convertedValue <= parseFloat(balance)) {
+            return testContext.createError({
+                type: 'network-reserve',
+                message: translate('moduleTrading.validators.networkReserve', {
+                    displaySymbol: sendSymbol.toUpperCase(),
+                }),
+            });
+        }
+
         return testContext.createError({
             type: 'insufficient-balance',
             message: translate('moduleTrading.validators.insufficientBalance'),

--- a/suite-native/transaction-management/src/hooks/__tests__/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useIsNetworkReserveBannerVisible.test.ts
@@ -1,0 +1,100 @@
+import { type TestStore, initStore, renderHookWithStoreProvider } from '@suite-native/test-utils';
+
+import { useIsNetworkReserveBannerVisible } from '../useIsNetworkReserveBannerVisible';
+
+// SOL nativeTokenReserve: "0.003"; base: "0.0002"
+describe('useIsNetworkReserveBannerVisible', () => {
+    let store: TestStore;
+
+    beforeEach(() => {
+        store = initStore().store;
+    });
+
+    const renderHook = (params: Parameters<typeof useIsNetworkReserveBannerVisible>[0]) =>
+        renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), { store });
+
+    it('returns false for null symbol, null amount, null balance, or no-reserve network', () => {
+        expect(renderHook({ symbol: undefined, amount: '1', balance: '2' }).result.current).toBe(
+            false,
+        );
+        expect(renderHook({ symbol: 'sol', amount: null, balance: '1' }).result.current).toBe(
+            false,
+        );
+        expect(renderHook({ symbol: 'sol', amount: '1', balance: null }).result.current).toBe(
+            false,
+        );
+        expect(renderHook({ symbol: 'btc', amount: '0.5', balance: '1' }).result.current).toBe(
+            false,
+        );
+    });
+
+    it('returns false for tokens (contractAddress set)', () => {
+        expect(
+            renderHook({
+                symbol: 'sol',
+                contractAddress: 'some-token-contract',
+                amount: '0.998',
+                balance: '1.0',
+            }).result.current,
+        ).toBe(false);
+    });
+
+    it('shows banner when remainder is at or below static network reserve (no maxAmount)', () => {
+        // remainder = 1.0 - 0.997 = 0.003 = SOL reserve
+        expect(renderHook({ symbol: 'sol', amount: '0.997', balance: '1.0' }).result.current).toBe(
+            true,
+        );
+        // remainder = 1.0 - 0.998 = 0.002 < 0.003
+        expect(renderHook({ symbol: 'sol', amount: '0.998', balance: '1.0' }).result.current).toBe(
+            true,
+        );
+    });
+
+    it('hides banner when amount is below reserve zone', () => {
+        expect(renderHook({ symbol: 'sol', amount: '0.5', balance: '1.0' }).result.current).toBe(
+            false,
+        );
+    });
+
+    it('hides banner when amount exceeds balance', () => {
+        expect(renderHook({ symbol: 'sol', amount: '1.1', balance: '1.0' }).result.current).toBe(
+            false,
+        );
+    });
+
+    it('hides banner for zero amount', () => {
+        expect(renderHook({ symbol: 'sol', amount: '0', balance: '1.0' }).result.current).toBe(
+            false,
+        );
+    });
+
+    it('shows banner when amount equals composed maxAmount (send / fee path)', () => {
+        // feeWithReserve = balance - maxAmount = 0.01; remainder = 0.01
+        expect(
+            renderHook({
+                symbol: 'sol',
+                amount: '0.99',
+                balance: '1.0',
+                maxAmount: '0.99',
+            }).result.current,
+        ).toBe(true);
+    });
+
+    it('hides banner when below composed maxAmount threshold', () => {
+        expect(
+            renderHook({
+                symbol: 'sol',
+                amount: '0.5',
+                balance: '1.0',
+                maxAmount: '0.99',
+            }).result.current,
+        ).toBe(false);
+    });
+
+    it('shows banner on base network at reserve boundary', () => {
+        // remainder = 0.1 - 0.0999 = 0.0001 <= base reserve 0.0002
+        expect(
+            renderHook({ symbol: 'base', amount: '0.0999', balance: '0.1' }).result.current,
+        ).toBe(true);
+    });
+});

--- a/suite-native/transaction-management/src/hooks/index.ts
+++ b/suite-native/transaction-management/src/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useOutputsReviewBackInterceptor';
 export * from './useWaitForButtonRequest';
 export * from './fees';
 export * from './usePrecomposedTransactionError';
+export * from './useIsNetworkReserveBannerVisible';

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.ts
@@ -1,0 +1,47 @@
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
+import { getNetworkReserve } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+type UseIsNetworkReserveBannerVisibleParams = {
+    symbol?: NetworkSymbol | null;
+    contractAddress?: string | null;
+    amount?: string | null;
+    balance?: string | null;
+    maxAmount?: string | null;
+};
+
+export const useIsNetworkReserveBannerVisible = ({
+    symbol,
+    contractAddress,
+    amount,
+    balance,
+    maxAmount,
+}: UseIsNetworkReserveBannerVisibleParams): boolean => {
+    const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
+
+    if (!symbol) return false;
+
+    const networkReserve = getNetworkReserve({
+        symbol,
+        contractAddress,
+        isEnabled: isNetworkReserveEnabled,
+    });
+
+    if (!networkReserve || !amount || !balance) return false;
+
+    // Same logic as sendOutputsFormSchema: feeWithReserve = balance - maxAmount.
+    // For Trading (no maxAmount), feeWithReserve = networkReserve.
+    const feeWithReserve = maxAmount
+        ? new BigNumber(balance).minus(maxAmount).toString()
+        : networkReserve;
+
+    const amountBN = new BigNumber(amount);
+    // Banner shows when amount reaches the reserve zone (>= balance - feeWithReserve)
+    // but does not exceed the total balance.
+    const threshold = new BigNumber(balance).minus(feeWithReserve);
+
+    return amountBN.gte(threshold) && amountBN.gt(0) && amountBN.lte(balance);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23704

## Screenshots:

https://github.com/user-attachments/assets/1edf1919-4017-4d77-890a-860cd579b2f5


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/reserve-banner-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->