### PR TITLE
fix(analytics-docs): Fix changelog version sorting

### DIFF
--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -17,10 +17,124 @@ import {
 import type { EventDoc } from '../types';
 import type { VersionWithEvents } from '../utils/filterUtils';
 
-const isAdded = (event: EventDoc, version: string) => event.changelog?.addedInVersion === version;
+type ChangeInfo = {
+    isEventAdded: boolean;
+    isEventUpdated: boolean;
+    addedAttributes: string[];
+    updatedAttributes: string[];
+};
 
-const getEventChangeProps = (event: EventDoc, version: string) =>
-    isAdded(event, version)
+const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
+    const info: ChangeInfo = {
+        isEventAdded: false,
+        isEventUpdated: false,
+        addedAttributes: [],
+        updatedAttributes: [],
+    };
+
+    // Check if this version is when the event was first added
+    const eventAddedVersion = event.changelog?.addedInVersion;
+    const isEventAddedInThisVersion = eventAddedVersion === version;
+
+    // Check event changelog entries for this version
+    const eventChanges = event.changelog?.entries?.filter(e => e.version === version);
+    if (eventChanges && eventChanges.length > 0) {
+        // Only show "Event added" if this is the version where event was first added
+        // AND there are no attribute-only changes in this version
+        const hasEventLevelChanges = eventChanges.some(
+            c =>
+                c.notes.toLowerCase().includes('added') || !c.notes.toLowerCase().includes('added'),
+        );
+
+        if (isEventAddedInThisVersion && hasEventLevelChanges) {
+            info.isEventAdded = true;
+        } else if (!isEventAddedInThisVersion && hasEventLevelChanges) {
+            info.isEventUpdated = true;
+        }
+    }
+
+    // Check attributes
+    for (const [attrName, attrDoc] of Object.entries(event.attributes)) {
+        const attrChanges = attrDoc.changelog?.entries?.filter(e => e.version === version);
+        if (attrChanges && attrChanges.length > 0) {
+            const isAdded = attrChanges.some(c => c.notes.toLowerCase().includes('added'));
+
+            // If attribute was added in the same version as event was first added,
+            // don't show it separately (it's part of the initial event)
+            if (isAdded && isEventAddedInThisVersion) {
+                continue;
+            }
+
+            // If attribute has "added on [platform]" notes but event also has same notes in this version,
+            // treat it as "updated" if the event was already added on another platform
+            const attrNotes = attrChanges.map(c => c.notes.toLowerCase()).join(' ');
+            const eventNotes = eventChanges?.map(c => c.notes.toLowerCase()).join(' ') ?? '';
+            const hasMatchingPlatformNote =
+                (attrNotes.includes('added on desktop') &&
+                    eventNotes.includes('added on desktop')) ||
+                (attrNotes.includes('added on mobile') && eventNotes.includes('added on mobile'));
+
+            if (hasMatchingPlatformNote && !isEventAddedInThisVersion) {
+                // Event exists on another platform, so attributes are being "updated" (added to new platform)
+                info.updatedAttributes.push(attrName);
+                continue;
+            }
+
+            if (hasMatchingPlatformNote && isEventAddedInThisVersion) {
+                // Both event and attributes are being added for the first time
+                continue;
+            }
+
+            if (isAdded) {
+                info.addedAttributes.push(attrName);
+            } else {
+                info.updatedAttributes.push(attrName);
+            }
+        }
+    }
+
+    // If we only have attribute changes and no event-level changes, mark as event updated
+    if (
+        !info.isEventAdded &&
+        !info.isEventUpdated &&
+        (info.addedAttributes.length > 0 || info.updatedAttributes.length > 0)
+    ) {
+        info.isEventUpdated = true;
+    }
+
+    return info;
+};
+
+const getTooltipContent = (changeInfo: ChangeInfo) => {
+    const parts: string[] = [];
+
+    if (changeInfo.isEventAdded) {
+        parts.push(`Event added`);
+    }
+
+    if (changeInfo.isEventUpdated) {
+        parts.push(`Event updated`);
+    }
+
+    if (changeInfo.addedAttributes.length > 0) {
+        parts.push(`Attribute${changeInfo.addedAttributes.length > 1 ? 's' : ''} added:`);
+        changeInfo.addedAttributes.forEach(attr => {
+            parts.push(`  - ${attr}`);
+        });
+    }
+
+    if (changeInfo.updatedAttributes.length > 0) {
+        parts.push(`Attribute${changeInfo.updatedAttributes.length > 1 ? 's' : ''} updated:`);
+        changeInfo.updatedAttributes.forEach(attr => {
+            parts.push(`  - ${attr}`);
+        });
+    }
+
+    return parts.map(p => <div key={p}>{p}</div>);
+};
+
+const getEventChangeProps = (changeInfo: ChangeInfo) =>
+    changeInfo.isEventAdded
         ? { name: 'plus' as const, intent: 'brand' as const }
         : { name: 'arrowsClockwiseFilled' as const, intent: 'warning' as const };
 
@@ -72,26 +186,28 @@ export const VersionsSidebar = ({ versionsWithEvents, onEventClick }: VersionsSi
                             .sort((a: EventDoc, b: EventDoc) =>
                                 (a.name ?? '').localeCompare(b.name ?? ''),
                             )
-                            .map(event => (
-                                <CardList.Item
-                                    paddingType="small"
-                                    onClick={() => {
-                                        onEventClick?.(event.name);
-                                    }}
-                                    key={event.name}
-                                >
-                                    <Text typographyStyle="body-xs">{event.name}</Text>
+                            .map(event => {
+                                const changeInfo = getChangeInfo(event, version);
 
-                                    <Tooltip
-                                        content={isAdded(event, version) ? 'Added' : 'Updated'}
+                                return (
+                                    <CardList.Item
+                                        paddingType="small"
+                                        onClick={() => {
+                                            onEventClick?.(event.name);
+                                        }}
+                                        key={event.name}
                                     >
-                                        <Icon
-                                            {...(getEventChangeProps(event, version) as IconProps)}
-                                            size={12}
-                                        />
-                                    </Tooltip>
-                                </CardList.Item>
-                            ))}
+                                        <Text typographyStyle="body-xs">{event.name}</Text>
+
+                                        <Tooltip content={getTooltipContent(changeInfo)}>
+                                            <Icon
+                                                {...(getEventChangeProps(changeInfo) as IconProps)}
+                                                size={12}
+                                            />
+                                        </Tooltip>
+                                    </CardList.Item>
+                                );
+                            })}
                     </CardList>
                 </Box>
             ))}

--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -55,29 +55,14 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
     for (const [attrName, attrDoc] of Object.entries(event.attributes)) {
         const attrChanges = attrDoc.changelog?.entries?.filter(e => e.version === version);
         if (attrChanges && attrChanges.length > 0) {
-            const isAdded = attrChanges.some(c => c.notes.toLowerCase().includes('added'));
+            const attrAddedVersion = attrDoc.changelog?.addedInVersion;
+            const isAttrAddedInThisVersion = attrAddedVersion === version;
 
-            if (isAdded && isEventAddedInThisVersion) {
+            if (isAttrAddedInThisVersion && isEventAddedInThisVersion) {
                 continue;
             }
 
-            const attrNotes = attrChanges.map(c => c.notes.toLowerCase()).join(' ');
-            const eventNotes = eventChanges?.map(c => c.notes.toLowerCase()).join(' ') ?? '';
-            const hasMatchingPlatformNote =
-                (attrNotes.includes('added on desktop') &&
-                    eventNotes.includes('added on desktop')) ||
-                (attrNotes.includes('added on mobile') && eventNotes.includes('added on mobile'));
-
-            if (hasMatchingPlatformNote && !isEventAddedInThisVersion) {
-                info.updatedAttributes.push(attrName);
-                continue;
-            }
-
-            if (hasMatchingPlatformNote && isEventAddedInThisVersion) {
-                continue;
-            }
-
-            if (isAdded) {
+            if (isAttrAddedInThisVersion) {
                 info.addedAttributes.push(attrName);
             } else {
                 info.updatedAttributes.push(attrName);

--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -35,15 +35,11 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
         updatedAttributes: [],
     };
 
-    // Check if this version is when the event was first added
     const eventAddedVersion = event.changelog?.addedInVersion;
     const isEventAddedInThisVersion = eventAddedVersion === version;
 
-    // Check event changelog entries for this version
     const eventChanges = event.changelog?.entries?.filter(e => e.version === version);
     if (eventChanges && eventChanges.length > 0) {
-        // Only show "Event added" if this is the version where event was first added
-        // AND there are no attribute-only changes in this version
         const hasEventLevelChanges = eventChanges.some(
             c =>
                 c.notes.toLowerCase().includes('added') || !c.notes.toLowerCase().includes('added'),
@@ -56,20 +52,15 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
         }
     }
 
-    // Check attributes
     for (const [attrName, attrDoc] of Object.entries(event.attributes)) {
         const attrChanges = attrDoc.changelog?.entries?.filter(e => e.version === version);
         if (attrChanges && attrChanges.length > 0) {
             const isAdded = attrChanges.some(c => c.notes.toLowerCase().includes('added'));
 
-            // If attribute was added in the same version as event was first added,
-            // don't show it separately (it's part of the initial event)
             if (isAdded && isEventAddedInThisVersion) {
                 continue;
             }
 
-            // If attribute has "added on [platform]" notes but event also has same notes in this version,
-            // treat it as "updated" if the event was already added on another platform
             const attrNotes = attrChanges.map(c => c.notes.toLowerCase()).join(' ');
             const eventNotes = eventChanges?.map(c => c.notes.toLowerCase()).join(' ') ?? '';
             const hasMatchingPlatformNote =
@@ -78,13 +69,11 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
                 (attrNotes.includes('added on mobile') && eventNotes.includes('added on mobile'));
 
             if (hasMatchingPlatformNote && !isEventAddedInThisVersion) {
-                // Event exists on another platform, so attributes are being "updated" (added to new platform)
                 info.updatedAttributes.push(attrName);
                 continue;
             }
 
             if (hasMatchingPlatformNote && isEventAddedInThisVersion) {
-                // Both event and attributes are being added for the first time
                 continue;
             }
 
@@ -96,7 +85,6 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
         }
     }
 
-    // If we only have attribute changes and no event-level changes, mark as event updated
     if (
         !info.isEventAdded &&
         !info.isEventUpdated &&

--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -108,8 +108,8 @@ const getTooltipContent = (changeInfo: ChangeInfo) => {
         );
         changeInfo.addedAttributes.forEach(attr => {
             elements.push(
-                <Paragraph key={`added-${attr}`} typographyStyle="body-xs">
-                    &nbsp;&nbsp;- {attr}
+                <Paragraph key={`added-${attr}`} typographyStyle="body-xs" margin={{ left: 8 }}>
+                    - {attr}
                 </Paragraph>,
             );
         });
@@ -123,8 +123,8 @@ const getTooltipContent = (changeInfo: ChangeInfo) => {
         );
         changeInfo.updatedAttributes.forEach(attr => {
             elements.push(
-                <Paragraph key={`updated-${attr}`} typographyStyle="body-xs">
-                    &nbsp;&nbsp;- <Text isMonospaced>{attr}</Text>
+                <Paragraph key={`updated-${attr}`} typographyStyle="body-xs" margin={{ left: 8 }}>
+                    - <Text isMonospaced>{attr}</Text>
                 </Paragraph>,
             );
         });

--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import styled from 'styled-components';
 
 import {
@@ -8,6 +10,7 @@ import {
     H3,
     Icon,
     type IconProps,
+    Paragraph,
     type SuiteThemeColors,
     Text,
     Tooltip,
@@ -106,31 +109,55 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
 };
 
 const getTooltipContent = (changeInfo: ChangeInfo) => {
-    const parts: string[] = [];
+    const elements: JSX.Element[] = [];
 
     if (changeInfo.isEventAdded) {
-        parts.push(`Event added`);
+        elements.push(
+            <Paragraph key="event-added" typographyStyle="body-sm-strong">
+                Event added.
+            </Paragraph>,
+        );
     }
 
     if (changeInfo.isEventUpdated) {
-        parts.push(`Event updated`);
+        elements.push(
+            <Paragraph key="event-updated" typographyStyle="body-sm-strong">
+                Event updated.
+            </Paragraph>,
+        );
     }
 
     if (changeInfo.addedAttributes.length > 0) {
-        parts.push(`Attribute${changeInfo.addedAttributes.length > 1 ? 's' : ''} added:`);
+        elements.push(
+            <Paragraph key="attrs-added-title" typographyStyle="body-sm-strong">
+                Attribute{changeInfo.addedAttributes.length > 1 ? 's' : ''} added:
+            </Paragraph>,
+        );
         changeInfo.addedAttributes.forEach(attr => {
-            parts.push(`  - ${attr}`);
+            elements.push(
+                <Paragraph key={`added-${attr}`} typographyStyle="body-xs">
+                    &nbsp;&nbsp;- {attr}
+                </Paragraph>,
+            );
         });
     }
 
     if (changeInfo.updatedAttributes.length > 0) {
-        parts.push(`Attribute${changeInfo.updatedAttributes.length > 1 ? 's' : ''} updated:`);
+        elements.push(
+            <Paragraph key="attrs-updated-title" typographyStyle="body-sm-strong">
+                Attribute{changeInfo.updatedAttributes.length > 1 ? 's' : ''} updated:
+            </Paragraph>,
+        );
         changeInfo.updatedAttributes.forEach(attr => {
-            parts.push(`  - ${attr}`);
+            elements.push(
+                <Paragraph key={`updated-${attr}`} typographyStyle="body-xs">
+                    &nbsp;&nbsp;- <Text isMonospaced>{attr}</Text>
+                </Paragraph>,
+            );
         });
     }
 
-    return parts.map(p => <div key={p}>{p}</div>);
+    return <Column gap={4}>{elements}</Column>;
 };
 
 const getEventChangeProps = (changeInfo: ChangeInfo) =>

--- a/packages/analytics-docs/src/components/VersionsSidebar.tsx
+++ b/packages/analytics-docs/src/components/VersionsSidebar.tsx
@@ -40,14 +40,9 @@ const getChangeInfo = (event: EventDoc, version: string): ChangeInfo => {
 
     const eventChanges = event.changelog?.entries?.filter(e => e.version === version);
     if (eventChanges && eventChanges.length > 0) {
-        const hasEventLevelChanges = eventChanges.some(
-            c =>
-                c.notes.toLowerCase().includes('added') || !c.notes.toLowerCase().includes('added'),
-        );
-
-        if (isEventAddedInThisVersion && hasEventLevelChanges) {
+        if (isEventAddedInThisVersion) {
             info.isEventAdded = true;
-        } else if (!isEventAddedInThisVersion && hasEventLevelChanges) {
+        } else {
             info.isEventUpdated = true;
         }
     }

--- a/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
+++ b/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
@@ -96,20 +96,19 @@ describe('getEventId', () => {
 });
 
 describe('getVersionsWithEvents', () => {
-    it('uses only event.changelog.entries as the source of truth', () => {
+    it('includes both event and attribute changelog versions', () => {
         const eventA = {
             name: 'accounts/active-staking',
             descriptionTrigger: 'trigger',
             changelog: {
                 entries: [
                     { version: '1.0.0', notes: 'event note' },
-                    { version: '1.1.0', notes: 'attribute merged note' },
+                    { version: '1.1.0', notes: 'event note 2' },
                 ],
             },
             attributes: {
                 someAttribute: {
                     changelog: {
-                        // This version should be ignored because it's not present in event.changelog.entries.
                         entries: [{ version: '2.0.0', notes: 'attribute-only note' }],
                     },
                 },
@@ -119,9 +118,10 @@ describe('getVersionsWithEvents', () => {
 
         const versionsWithEvents = getVersionsWithEvents([eventA]);
 
-        expect(versionsWithEvents.map(v => v.version)).toEqual(['1.1.0', '1.0.0']);
+        expect(versionsWithEvents.map(v => v.version)).toEqual(['2.0.0', '1.1.0', '1.0.0']);
         expect(versionsWithEvents[0].events).toEqual([eventA]);
         expect(versionsWithEvents[1].events).toEqual([eventA]);
+        expect(versionsWithEvents[2].events).toEqual([eventA]);
     });
 
     it('deduplicates events for the same version', () => {

--- a/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
+++ b/packages/analytics-docs/src/utils/__tests__/filterUtils.test.ts
@@ -1,4 +1,11 @@
-import { fuzzyMatch, fuzzyMatchExportName, getEventId, toEventExportName } from '../filterUtils';
+import type { EventDoc } from '../../types';
+import {
+    fuzzyMatch,
+    fuzzyMatchExportName,
+    getEventId,
+    getVersionsWithEvents,
+    toEventExportName,
+} from '../filterUtils';
 
 describe('fuzzyMatch (event name)', () => {
     it('empty query matches everything', () => {
@@ -85,5 +92,56 @@ describe('toEventExportName', () => {
 describe('getEventId', () => {
     it('produces safe DOM id from event name', () => {
         expect(getEventId('accounts/active-staking')).toBe('event-accounts-active-staking');
+    });
+});
+
+describe('getVersionsWithEvents', () => {
+    it('uses only event.changelog.entries as the source of truth', () => {
+        const eventA = {
+            name: 'accounts/active-staking',
+            descriptionTrigger: 'trigger',
+            changelog: {
+                entries: [
+                    { version: '1.0.0', notes: 'event note' },
+                    { version: '1.1.0', notes: 'attribute merged note' },
+                ],
+            },
+            attributes: {
+                someAttribute: {
+                    changelog: {
+                        // This version should be ignored because it's not present in event.changelog.entries.
+                        entries: [{ version: '2.0.0', notes: 'attribute-only note' }],
+                    },
+                },
+            },
+            platform: 'desktop',
+        } as EventDoc;
+
+        const versionsWithEvents = getVersionsWithEvents([eventA]);
+
+        expect(versionsWithEvents.map(v => v.version)).toEqual(['1.1.0', '1.0.0']);
+        expect(versionsWithEvents[0].events).toEqual([eventA]);
+        expect(versionsWithEvents[1].events).toEqual([eventA]);
+    });
+
+    it('deduplicates events for the same version', () => {
+        const eventA = {
+            name: 'accounts/active-staking',
+            descriptionTrigger: 'trigger',
+            changelog: {
+                entries: [
+                    { version: '1.0.0', notes: 'first note' },
+                    { version: '1.0.0', notes: 'second note' },
+                ],
+            },
+            attributes: {},
+            platform: 'desktop',
+        } as EventDoc;
+
+        const versionsWithEvents = getVersionsWithEvents([eventA]);
+
+        expect(versionsWithEvents).toHaveLength(1);
+        expect(versionsWithEvents[0].version).toBe('1.0.0');
+        expect(versionsWithEvents[0].events).toEqual([eventA]);
     });
 });

--- a/packages/analytics-docs/src/utils/__tests__/normalizeChangelog.test.ts
+++ b/packages/analytics-docs/src/utils/__tests__/normalizeChangelog.test.ts
@@ -1,0 +1,26 @@
+import { normalizeChangelog } from '../normalizeChangelog';
+
+describe('normalizeChangelog', () => {
+    it('ignores "?" for added/updated versions and places it at the end', () => {
+        const result = normalizeChangelog([
+            { version: '?', notes: 'unknown entry' },
+            { version: '26.1.0', notes: 'added' },
+            { version: '26.2.0', notes: 'updated' },
+        ]);
+
+        expect(result.addedInVersion).toBe('26.1.0');
+        expect(result.lastUpdatedInVersion).toBe('26.2.0');
+        expect(result.entries.map(e => e.version)).toEqual(['26.1.0', '26.2.0', '?']);
+    });
+
+    it('falls back to "?" when there are no numeric versions', () => {
+        const result = normalizeChangelog([
+            { version: '?', notes: 'unknown entry 1' },
+            { version: '?', notes: 'unknown entry 2' },
+        ]);
+
+        expect(result.addedInVersion).toBe('?');
+        expect(result.lastUpdatedInVersion).toBeUndefined();
+        expect(result.entries.map(e => e.version)).toEqual(['?', '?']);
+    });
+});

--- a/packages/analytics-docs/src/utils/__tests__/normalizeEvents.test.ts
+++ b/packages/analytics-docs/src/utils/__tests__/normalizeEvents.test.ts
@@ -1,0 +1,51 @@
+import { normalizeEvents } from '../normalizeEvents';
+
+describe('normalizeEvents', () => {
+    it('keeps event.changelog.entries event-scoped (attributes do not leak into entries)', () => {
+        const input = [
+            {
+                name: 'accounts/active-staking',
+                descriptionTrigger: 'trigger',
+                description: 'desc',
+                changelog: [{ version: '1.0.0', notes: 'event note' }],
+                attributes: {
+                    someAttribute: {
+                        description: 'attr desc',
+                        changelog: [{ version: '2.0.0', notes: 'attribute note' }],
+                    },
+                },
+                platform: 'desktop',
+            },
+        ] as any;
+
+        const eventDoc = normalizeEvents(input)[input[0].name];
+
+        expect(eventDoc.changelog.entries.map(e => e.version)).toEqual(['1.0.0']);
+        expect(eventDoc.changelog.addedInVersion).toBe('1.0.0');
+        expect(eventDoc.changelog.lastUpdatedInVersion).toBe('2.0.0');
+    });
+
+    it('does not affect addedInVersion with attribute unknown versions ("?")', () => {
+        const input = [
+            {
+                name: 'accounts/active-staking',
+                descriptionTrigger: 'trigger',
+                description: 'desc',
+                changelog: [{ version: '1.0.0', notes: 'event note' }],
+                attributes: {
+                    someAttribute: {
+                        description: 'attr desc',
+                        changelog: [{ version: '?', notes: 'unknown attribute note' }],
+                    },
+                },
+                platform: 'desktop',
+            },
+        ] as any;
+
+        const eventDoc = normalizeEvents(input)[input[0].name];
+
+        expect(eventDoc.changelog.entries.map(e => e.version)).toEqual(['1.0.0']);
+        expect(eventDoc.changelog.addedInVersion).toBe('1.0.0');
+        expect(eventDoc.changelog.lastUpdatedInVersion).toBeUndefined();
+    });
+});

--- a/packages/analytics-docs/src/utils/filterUtils.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.ts
@@ -122,8 +122,6 @@ export type VersionWithEvents = {
 /**
  * Returns versions (desc) with events that were changed in that version.
  *
- * Note: `attribute.changelog.entries` are merged into `event.changelog.entries` by `normalizeEvents()`,
- * so `event.changelog.entries` is the single source of truth here.
  */
 export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] => {
     const versionToEvents = new Map<string, EventDoc[]>();
@@ -138,6 +136,17 @@ export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] =
             const list = versionToEvents.get(v) ?? [];
             list.push(event);
             versionToEvents.set(v, list);
+        }
+
+        for (const attribute of Object.values(event.attributes)) {
+            for (const entry of attribute.changelog?.entries ?? []) {
+                const v = entry.version;
+                if (!v || seenVersions.has(v)) continue;
+                seenVersions.add(v);
+                const list = versionToEvents.get(v) ?? [];
+                list.push(event);
+                versionToEvents.set(v, list);
+            }
         }
     }
 

--- a/packages/analytics-docs/src/utils/filterUtils.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.ts
@@ -125,6 +125,8 @@ export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] =
 
     for (const event of events) {
         const seenVersions = new Set<string>();
+
+        // Add event changelog entries
         for (const entry of event.changelog?.entries ?? []) {
             const v = entry.version;
             if (!v || seenVersions.has(v)) continue;
@@ -132,6 +134,18 @@ export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] =
             const list = versionToEvents.get(v) ?? [];
             list.push(event);
             versionToEvents.set(v, list);
+        }
+
+        // Add attribute changelog entries
+        for (const attribute of Object.values(event.attributes)) {
+            for (const entry of attribute.changelog?.entries ?? []) {
+                const v = entry.version;
+                if (!v || seenVersions.has(v)) continue;
+                seenVersions.add(v);
+                const list = versionToEvents.get(v) ?? [];
+                list.push(event);
+                versionToEvents.set(v, list);
+            }
         }
     }
 

--- a/packages/analytics-docs/src/utils/filterUtils.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.ts
@@ -119,14 +119,18 @@ export type VersionWithEvents = {
     events: EventDoc[];
 };
 
-/** Returns versions (desc) with events that were changed in that version (every changelog entry). */
+/**
+ * Returns versions (desc) with events that were changed in that version.
+ *
+ * Note: `attribute.changelog.entries` are merged into `event.changelog.entries` by `normalizeEvents()`,
+ * so `event.changelog.entries` is the single source of truth here.
+ */
 export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] => {
     const versionToEvents = new Map<string, EventDoc[]>();
 
     for (const event of events) {
         const seenVersions = new Set<string>();
 
-        // Add event changelog entries
         for (const entry of event.changelog?.entries ?? []) {
             const v = entry.version;
             if (!v || seenVersions.has(v)) continue;
@@ -134,18 +138,6 @@ export const getVersionsWithEvents = (events: EventDoc[]): VersionWithEvents[] =
             const list = versionToEvents.get(v) ?? [];
             list.push(event);
             versionToEvents.set(v, list);
-        }
-
-        // Add attribute changelog entries
-        for (const attribute of Object.values(event.attributes)) {
-            for (const entry of attribute.changelog?.entries ?? []) {
-                const v = entry.version;
-                if (!v || seenVersions.has(v)) continue;
-                seenVersions.add(v);
-                const list = versionToEvents.get(v) ?? [];
-                list.push(event);
-                versionToEvents.set(v, list);
-            }
         }
     }
 

--- a/packages/analytics-docs/src/utils/normalizeChangelog.ts
+++ b/packages/analytics-docs/src/utils/normalizeChangelog.ts
@@ -31,7 +31,6 @@ export const normalizeChangelog = (
 ): NormalizedChangelog => {
     if (!changelog?.length) return { entries: [] };
 
-    // Remove duplicate versions, keeping all entries
     const uniqueVersions = new Map<string, { version: AppVersion; notes: string }[]>();
     for (const entry of changelog) {
         const existing = uniqueVersions.get(entry.version) || [];
@@ -39,14 +38,12 @@ export const normalizeChangelog = (
         uniqueVersions.set(entry.version, existing);
     }
 
-    // Sort versions chronologically
     const sortedVersions = Array.from(uniqueVersions.keys()).sort(compareVersions);
 
-    // Flatten entries back, maintaining chronological order
     const sortedEntries = sortedVersions.flatMap(version => uniqueVersions.get(version) || []);
 
-    const first = sortedVersions[0];
-    const last = sortedVersions[sortedVersions.length - 1];
+    const first = sortedVersions[0] as AppVersion;
+    const last = sortedVersions[sortedVersions.length - 1] as AppVersion;
 
     return {
         entries: sortedEntries,

--- a/packages/analytics-docs/src/utils/normalizeChangelog.ts
+++ b/packages/analytics-docs/src/utils/normalizeChangelog.ts
@@ -9,6 +9,8 @@ export type NormalizedChangelog = {
     lastUpdatedInVersion?: AppVersion;
 };
 
+const UNKNOWN_VERSION: AppVersion = '?';
+
 const parseVersion = (v: string): [number, number, number] => {
     const [a = 0, b = 0, c = 0] = v.split('.').map(n => Number(n) || 0);
 
@@ -16,6 +18,10 @@ const parseVersion = (v: string): [number, number, number] => {
 };
 
 const compareVersions = (va: string, vb: string): number => {
+    if (va === UNKNOWN_VERSION && vb === UNKNOWN_VERSION) return 0;
+    if (va === UNKNOWN_VERSION) return 1; // Put unknown versions at the end.
+    if (vb === UNKNOWN_VERSION) return -1; // Put unknown versions at the end.
+
     const [a1, b1, c1] = parseVersion(va);
     const [a2, b2, c2] = parseVersion(vb);
 
@@ -38,16 +44,29 @@ export const normalizeChangelog = (
         uniqueVersions.set(entry.version, existing);
     }
 
-    const sortedVersions = Array.from(uniqueVersions.keys()).sort(compareVersions);
+    const allVersions = Array.from(uniqueVersions.keys()) as AppVersion[];
+    const numericVersions = allVersions.filter(
+        (v): v is Exclude<AppVersion, '?'> => v !== UNKNOWN_VERSION,
+    );
+    const unknownVersions = allVersions.filter(v => v === UNKNOWN_VERSION);
+
+    const sortedNumericVersions = numericVersions.sort(compareVersions);
+    const sortedVersions = [...sortedNumericVersions, ...unknownVersions];
 
     const sortedEntries = sortedVersions.flatMap(version => uniqueVersions.get(version) || []);
 
-    const first = sortedVersions[0] as AppVersion;
-    const last = sortedVersions[sortedVersions.length - 1] as AppVersion;
+    const firstNumeric = sortedNumericVersions[0] as AppVersion | undefined;
+    const lastNumeric = sortedNumericVersions[sortedNumericVersions.length - 1] as
+        | AppVersion
+        | undefined;
+    const onlyUnknown = !firstNumeric && unknownVersions.length > 0 ? UNKNOWN_VERSION : undefined;
+
+    const first = firstNumeric ?? onlyUnknown;
+    const last = lastNumeric ?? onlyUnknown;
 
     return {
         entries: sortedEntries,
         addedInVersion: first,
-        lastUpdatedInVersion: last !== first ? last : undefined,
+        lastUpdatedInVersion: last && first && last !== first ? last : undefined,
     };
 };

--- a/packages/analytics-docs/src/utils/normalizeChangelog.ts
+++ b/packages/analytics-docs/src/utils/normalizeChangelog.ts
@@ -9,15 +9,47 @@ export type NormalizedChangelog = {
     lastUpdatedInVersion?: AppVersion;
 };
 
+const parseVersion = (v: string): [number, number, number] => {
+    const [a = 0, b = 0, c = 0] = v.split('.').map(n => Number(n) || 0);
+
+    return [a, b, c];
+};
+
+const compareVersions = (va: string, vb: string): number => {
+    const [a1, b1, c1] = parseVersion(va);
+    const [a2, b2, c2] = parseVersion(vb);
+
+    if (a1 !== a2) return a1 - a2;
+    if (b1 !== b2) return b1 - b2;
+    if (c1 !== c2) return c1 - c2;
+
+    return 0;
+};
+
 export const normalizeChangelog = (
     changelog?: Array<{ version: AppVersion; notes: string }>,
 ): NormalizedChangelog => {
     if (!changelog?.length) return { entries: [] };
-    const first = changelog[0].version;
-    const last = changelog[changelog.length - 1].version;
+
+    // Remove duplicate versions, keeping all entries
+    const uniqueVersions = new Map<string, { version: AppVersion; notes: string }[]>();
+    for (const entry of changelog) {
+        const existing = uniqueVersions.get(entry.version) || [];
+        existing.push(entry);
+        uniqueVersions.set(entry.version, existing);
+    }
+
+    // Sort versions chronologically
+    const sortedVersions = Array.from(uniqueVersions.keys()).sort(compareVersions);
+
+    // Flatten entries back, maintaining chronological order
+    const sortedEntries = sortedVersions.flatMap(version => uniqueVersions.get(version) || []);
+
+    const first = sortedVersions[0];
+    const last = sortedVersions[sortedVersions.length - 1];
 
     return {
-        entries: changelog,
+        entries: sortedEntries,
         addedInVersion: first,
         lastUpdatedInVersion: last !== first ? last : undefined,
     };

--- a/packages/analytics-docs/src/utils/normalizeEvents.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.ts
@@ -27,6 +27,14 @@ const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
         ),
     );
 
+    // Collect all changelog entries from attributes
+    const attributeChangelogs = Object.values(attributes).flatMap(
+        attr => attr.changelog.entries || [],
+    );
+
+    // Merge event changelog with attribute changelogs
+    const allChangelogEntries = [...(event.changelog ?? []), ...attributeChangelogs];
+
     return [
         event.name,
         {
@@ -34,7 +42,7 @@ const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
             description: event.description,
             descriptionTrigger: event.descriptionTrigger,
             possibleImprovements: event.possibleImprovements,
-            changelog: normalizeChangelog(event.changelog),
+            changelog: normalizeChangelog(allChangelogEntries),
             attributes,
             platform: event.platform ?? '',
         },

--- a/packages/analytics-docs/src/utils/normalizeEvents.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.ts
@@ -27,11 +27,16 @@ const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
         ),
     );
 
-    const attributeChangelogs = Object.values(attributes).flatMap(
+    const eventChangelogEntries = event.changelog ?? [];
+    const attributeChangelogEntries = Object.values(attributes).flatMap(
         attr => attr.changelog.entries || [],
     );
 
-    const allChangelogEntries = [...(event.changelog ?? []), ...attributeChangelogs];
+    const eventChangelog = normalizeChangelog(eventChangelogEntries);
+    const combinedChangelog = normalizeChangelog([
+        ...eventChangelogEntries,
+        ...attributeChangelogEntries,
+    ]);
 
     return [
         event.name,
@@ -40,7 +45,11 @@ const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
             description: event.description,
             descriptionTrigger: event.descriptionTrigger,
             possibleImprovements: event.possibleImprovements,
-            changelog: normalizeChangelog(allChangelogEntries),
+            changelog: {
+                entries: eventChangelog.entries,
+                addedInVersion: eventChangelog.addedInVersion,
+                lastUpdatedInVersion: combinedChangelog.lastUpdatedInVersion,
+            },
             attributes,
             platform: event.platform ?? '',
         },

--- a/packages/analytics-docs/src/utils/normalizeEvents.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.ts
@@ -27,12 +27,10 @@ const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {
         ),
     );
 
-    // Collect all changelog entries from attributes
     const attributeChangelogs = Object.values(attributes).flatMap(
         attr => attr.changelog.entries || [],
     );
 
-    // Merge event changelog with attribute changelogs
     const allChangelogEntries = [...(event.changelog ?? []), ...attributeChangelogs];
 
     return [

--- a/suite/analytics/src/events/transactionCreatedEvent.ts
+++ b/suite/analytics/src/events/transactionCreatedEvent.ts
@@ -78,10 +78,10 @@ export const transactionCreatedEvent: EventDef<Attributes, EventType.Transaction
             changelog: [{ version: '1.9.0', notes: 'added' }],
         },
         isCoinControlEnabled: {
-            changelog: [{ version: '2023.2.1', notes: 'added' }],
+            changelog: [{ version: '23.2.1', notes: 'added' }],
         },
         hasCoinControlBeenOpened: {
-            changelog: [{ version: '2023.2.1', notes: 'added' }],
+            changelog: [{ version: '23.2.1', notes: 'added' }],
         },
         txType: {
             description: '`stake` or `trade` whether the user is staking or trading',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- attributes were not properly sorted in sidebar and docs if you show them according to added or last updated version
- I also added tooltip description in sidebar that describes changes. See screenshot below

## Notes for QA

see description
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="1168" height="917" alt="image" src="https://github.com/user-attachments/assets/58b566ed-ced1-4fc0-99d5-d9b549092993" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=analytics-docs-fix-changelog-sidebar&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=analytics-docs-fix-changelog-sidebar&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T17:36:56.425Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-20T17:35:19.512Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->