### PR TITLE
refactor(suite-common): extend forget device thunks with isOsUnpairingFinished

### DIFF
--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -62,4 +62,5 @@ export type ForgetBluetoothDeviceThunkParams = {
     // This thunk must rely on `bluetoothId` directly. When this thunk is called,
     // the device may already be disconnected, and therefore, it cannot be selected from the state.
     bluetoothId: BluetoothDeviceId;
+    isOsUnpairingFinished?: boolean;
 };

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -61,7 +61,10 @@ export type ExtraDependenciesStatic = {
         addAccountMetadata: SuiteCompatibleThunk<
             Exclude<MetadataAddPayload, { type: 'walletLabel' }>
         >;
-        forgetBluetoothDevice: SuiteCompatibleThunk<{ bluetoothId: BluetoothDeviceId }>;
+        forgetBluetoothDevice: SuiteCompatibleThunk<{
+            bluetoothId: BluetoothDeviceId;
+            isOsUnpairingFinished?: boolean;
+        }>;
     };
     selectors: {
         // TODO when tokens are implemented 1:1 in both apps, delete from extras

--- a/suite-common/wallet-core/src/device/__tests__/deviceThunks.test.ts
+++ b/suite-common/wallet-core/src/device/__tests__/deviceThunks.test.ts
@@ -9,7 +9,7 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { prepareThpReducer } from '@suite-common/thp';
 
 import { forgetPersistentDataPreloadedStateFixture } from '../__fixtures__/forgetPersistentDataPreloadedState';
-import { forgetSingleDevicePersistentDataThunk } from '../deviceThunks';
+import { forgetDevicePersistentDataThunk } from '../deviceThunks';
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const bluetoothReducer = prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(
@@ -27,10 +27,10 @@ const initStore = () =>
         preloadedState: forgetPersistentDataPreloadedStateFixture,
     });
 
-describe(forgetSingleDevicePersistentDataThunk.name, () => {
+describe(forgetDevicePersistentDataThunk.name, () => {
     it('forgets a single device data with Bluetooth and THP', async () => {
         const store = initStore();
-        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-1' }));
+        await store.dispatch(forgetDevicePersistentDataThunk({ deviceId: 'device-id-1' }));
         const state = store.getState();
 
         // device-id-1 persistent data is removed, others remain
@@ -46,7 +46,7 @@ describe(forgetSingleDevicePersistentDataThunk.name, () => {
 
     it('forgets a single device data with THP, but no Bluetooth data', async () => {
         const store = initStore();
-        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-2' }));
+        await store.dispatch(forgetDevicePersistentDataThunk({ deviceId: 'device-id-2' }));
         const state = store.getState();
 
         expect(state.device.persistentDeviceData.map(d => d.device_id)).toEqual([
@@ -59,7 +59,7 @@ describe(forgetSingleDevicePersistentDataThunk.name, () => {
 
     it('forgets a single device data with pointer to non-existent data', async () => {
         const store = initStore();
-        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-3' }));
+        await store.dispatch(forgetDevicePersistentDataThunk({ deviceId: 'device-id-3' }));
         const state = store.getState();
 
         expect(state.device.persistentDeviceData.map(d => d.device_id)).toEqual([
@@ -72,7 +72,7 @@ describe(forgetSingleDevicePersistentDataThunk.name, () => {
 
     it('does nothing for a non-existent device', async () => {
         const store = initStore();
-        await store.dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: 'device-id-4' }));
+        await store.dispatch(forgetDevicePersistentDataThunk({ deviceId: 'device-id-4' }));
         const state = store.getState();
         expect(state).toEqual(forgetPersistentDataPreloadedStateFixture);
     });

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -384,8 +384,9 @@ export const toggleAutoEjectThunk = createThunk(
         ),
 );
 
-type ForgetAllDeviceDataThunkParams = {
+type ForgetDevicePersistentDataThunkParams = {
     deviceId: TrezorDevice['id'];
+    isOsUnpairingFinished?: boolean;
 };
 
 /**
@@ -393,9 +394,12 @@ type ForgetAllDeviceDataThunkParams = {
  * This includes wallets, `persistentDeviceData`, Bluetooth, THP.
  * But not wallets, see `forgetDevice` (ejecting wallets & forgetting the rest are separate features).
  */
-export const forgetSingleDevicePersistentDataThunk = createThunk(
+export const forgetDevicePersistentDataThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetSingleDevicePersistentDataThunk`,
-    async ({ deviceId }: ForgetAllDeviceDataThunkParams, { dispatch, extra, getState }) => {
+    async (
+        { deviceId, isOsUnpairingFinished }: ForgetDevicePersistentDataThunkParams,
+        { dispatch, extra, getState },
+    ) => {
         if (!deviceId) return;
 
         const device = selectDeviceById(getState(), deviceId);
@@ -410,7 +414,9 @@ export const forgetSingleDevicePersistentDataThunk = createThunk(
         if (bluetoothId !== undefined) {
             dispatch(bluetoothActions.removeKnownDeviceAction({ id: bluetoothId }));
             // try to remove OS-level Bluetooth bonds, if supported by the platform
-            await dispatch(extra.thunks.forgetBluetoothDevice({ bluetoothId }));
+            await dispatch(
+                extra.thunks.forgetBluetoothDevice({ bluetoothId, isOsUnpairingFinished }),
+            );
         }
         const credentials = matchingDevice?.thp?.credentials;
         if (credentials !== undefined) {
@@ -419,16 +425,25 @@ export const forgetSingleDevicePersistentDataThunk = createThunk(
     },
 );
 
+export type ForgetDeviceThunkParams = {
+    isOsUnpairingFinished?: boolean;
+};
+
 export const forgetDeviceThunk = createThunk(
     `${DEVICE_MODULE_PREFIX}/forgetDevice`,
-    async (_, { dispatch, getState }) => {
+    async (
+        { isOsUnpairingFinished }: ForgetDeviceThunkParams | undefined = {},
+        { dispatch, getState },
+    ) => {
         const device = selectSelectedDevice(getState());
         if (!device) return;
 
         const devices = selectDevices(getState());
         const deviceInstances = getDeviceInstances(device, devices);
 
-        await dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: device.id }));
+        await dispatch(
+            forgetDevicePersistentDataThunk({ deviceId: device.id, isOsUnpairingFinished }),
+        );
 
         deviceInstances.forEach(instance => {
             dispatch(deviceActions.forgetDevice({ device: instance }));
@@ -468,7 +483,7 @@ const handlePostWipeCleanupThunk = createThunk(
         if (initialDevice.id !== undefined) {
             // Wiping a device changes bluetoothId and THP static key, so wipe BT known device & THP credentials
             // (and persistent device data as well, because device.id changed).
-            await dispatch(forgetSingleDevicePersistentDataThunk({ deviceId: initialDevice.id }));
+            await dispatch(forgetDevicePersistentDataThunk({ deviceId: initialDevice.id }));
         }
 
         dispatch(extra.actions.openModal({ type: 'wipe-device-success' }));


### PR DESCRIPTION
Pass the info about finished OS unpairing down the forget device thunks. To be used in `forgetBluetoothDevice` thunk implementations.

## Related Issue

Required for #25127

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/common/forget-device-thunk-params&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/common/forget-device-thunk-params&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/common/forget-device-thunk-params&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-20T18:57:37.285Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-20T18:56:04.939Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->