### PR TITLE
chore(e2e): add skill for agentic test creation

### DIFF
--- a/suite/e2e/AGENTS.md
+++ b/suite/e2e/AGENTS.md
@@ -12,3 +12,4 @@ Apart from [top-level AGENTS.md](../../AGENTS.md), the following skills are mand
 - [Await & Retry Strategy](skills/retries.md) – Playwright auto-waiting, custom polling, Redux waits, flakiness prevention
 - [Test Tagging](skills/tagging.md) – Device models, platforms, execution scope, project filtering
 - [Test Data Organization](skills/test-data.md) – Fixtures structure, API responses, device metadata, best practices
+- [Agentic Test Creation](skills/agentic-test-creation.md) – Mandatory discovery-first workflow for writing new tests from user stories

--- a/suite/e2e/skills/agentic-test-creation.md
+++ b/suite/e2e/skills/agentic-test-creation.md
@@ -1,0 +1,73 @@
+# Agentic E2E Test Creation Workflow
+
+> **When to use**: When writing a new Playwright e2e test from a user story, feature description, or bug report.
+> **Prerequisites**: Read all other skills in this directory before proceeding — this file only covers the workflow order and what to discover first. The rules for each area live in their dedicated skill.
+
+---
+
+## Step 1 — Find the right test folder
+
+```
+onboarding flow?        → tests/onboarding/
+wallet / accounts?      → tests/wallet/
+settings?               → tests/settings/
+trading / buy / sell?   → tests/trading/
+passphrase?             → tests/passphrase/
+staking?                → tests/staking/
+metadata / labels?      → tests/metadata/
+general suite flow?     → tests/suite/
+browser-only scenario?  → tests/browser/
+none of the above?      → tests/<feature-name>/
+```
+
+Check for an **existing file** in that folder first — the test may belong there.
+
+---
+
+## Step 2 — Discover before writing
+
+Do not write a single line of test code before completing all three of these:
+
+**Page objects** — Read `support/pageObjects/` and map every user action in the story to an existing page object method or locator. Rules for when to extend vs create are in [page-objects.md](page-objects.md).
+
+**Fixtures and mocks** — Check `support/fixtures.ts` and `support/mocks/` for what already exists. Rules for fixture scope and mock lifecycle are in [fixtures.md](fixtures.md).
+
+**Tags** — Determine device models, platform constraint, and execution scope before writing the test signature. Rules are in [tagging.md](tagging.md).
+
+---
+
+## Step 3 — Test file structure
+
+```typescript
+import { expect, test } from '../../support/fixtures';
+
+test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+test.describe('<feature> - <scenario>', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+    });
+
+    test('<what the user can do>', async ({ dashboardPage, walletPage }) => {
+        // Arrange → Act → Assert
+    });
+});
+```
+
+- Import `test` and `expect` from `../../support/fixtures`, never from `@playwright/test` directly.
+- Test names describe user capability (`'User can send BTC'`), not implementation (`'send BTC test'`).
+- One user story per `test()` block.
+
+---
+
+## Pre-submit checklist
+
+- [ ] Existing page objects and fixtures were checked before creating new ones
+- [ ] Test is in the correct folder under `tests/`
+- [ ] Imports from `../../support/fixtures`, not `@playwright/test`
+- [ ] Tags cover device models, platform, and execution scope → [tagging.md](tagging.md)
+- [ ] Assertions use web-first assertions and translation keys → [assertions.md](assertions.md)
+- [ ] No hardcoded `waitForTimeout` calls → [retries.md](retries.md)
+- [ ] Locators are in page objects, not scattered in tests → [locators.md](locators.md)
+- [ ] New page objects registered in `fixtures.ts` → [page-objects.md](page-objects.md)
+- [ ] New mocks have `start()`/`stop()` lifecycle and fixture registration → [fixtures.md](fixtures.md)


### PR DESCRIPTION
## Summary

Adds `suite/e2e/skills/agentic-test-creation.md `— a workflow skill **for AI agents writing new Playwright e2e** tests. The skill enforces a discovery-first approach: find the right test folder, map user actions to existing page objects and fixtures, and determine tags — all before writing any code.

The file deliberately contains no duplicated rules. Everything covered by existing skills (tagging, assertions, retries, locators, page objects, fixtures) is only referenced via links. The skill is registered in `AGENTS.md` as mandatory reading alongside the other e2e skills.

## Why

Without this, an agent writing a new test has no guidance on workflow order — it tends to write everything from scratch, miss existing page objects, place tests in wrong folders, or skip tags. This skill provides the missing entry point that ties all other skills together into an actionable sequence.