### PR TITLE
fix(suite-native): fix swap entering animation

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { LinearTransition } from 'react-native-reanimated';
+import { FadeIn, FadeInDown, LinearTransition } from 'react-native-reanimated';
 
 import { AnimatedBox, Card, VStack } from '@suite-native/atoms';
 import { AmountEditingDoneButton } from '@suite-native/trading-atoms';
@@ -13,6 +13,7 @@ import { ExchangeSendCard } from './send/ExchangeSendCard';
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { useExchangeQuotes } from '../../hooks/exchange/useExchangeQuotes';
 import { useFocusedValueWatch } from '../../hooks/general/useFocusedValueWatch';
+import { useMountedRecentlyFlag } from '../../hooks/general/useMountedRecentlyFlag';
 
 type ExchangeFormProps = {
     shouldAnimateEntering?: boolean;
@@ -26,26 +27,45 @@ type ExchangeFormMemoizedProps = {
 const EXCHANGE_FORM_TEST_ID = '@trading/exchange/form';
 const AMOUNT_EDITING_DONE_BUTTON_TEST_ID = '@trading/exchange/amount-editing-done-button';
 
-const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoizedProps) => (
-    <AnimatedBox layout={LinearTransition}>
-        <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
-            <ExchangeAlert />
-            <ExchangeSendCard isAmountInputActive={isAmountInputActive} />
-            <ExchangeReceiveCard />
-            {isAmountInputActive ? (
-                <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
-            ) : (
-                <>
-                    <Card noPadding>
-                        <ExchangeReceiveAccountPicker />
-                        <ExchangeRateAndProviderPicker />
-                    </Card>
-                    <ExchangeConfirmation enteringAnimation={LinearTransition} />
-                </>
-            )}
-        </VStack>
-    </AnimatedBox>
-));
+const getEnteringAnimation = (isFormMountedRecently?: boolean, shouldAnimateEntering?: boolean) => {
+    if (!isFormMountedRecently) {
+        return FadeInDown;
+    }
+
+    return shouldAnimateEntering ? FadeIn : undefined;
+};
+
+const ExchangeFormMemoized = memo(
+    ({ isAmountInputActive, shouldAnimateEntering }: ExchangeFormMemoizedProps) => {
+        const isFormMountedRecently = useMountedRecentlyFlag();
+
+        const enteringAnimation = getEnteringAnimation(
+            isFormMountedRecently,
+            shouldAnimateEntering,
+        );
+
+        return (
+            <AnimatedBox layout={LinearTransition}>
+                <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
+                    <ExchangeAlert />
+                    <ExchangeSendCard isAmountInputActive={isAmountInputActive} />
+                    <ExchangeReceiveCard />
+                    {isAmountInputActive ? (
+                        <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
+                    ) : (
+                        <>
+                            <Card noPadding>
+                                <ExchangeReceiveAccountPicker />
+                                <ExchangeRateAndProviderPicker />
+                            </Card>
+                            <ExchangeConfirmation enteringAnimation={enteringAnimation} />
+                        </>
+                    )}
+                </VStack>
+            </AnimatedBox>
+        );
+    },
+);
 
 export const ExchangeForm = ({ shouldAnimateEntering }: ExchangeFormProps) => {
     const exchangeForm = useExchangeFormContext();


### PR DESCRIPTION
When you tap `Swap` console log shows warning about invalid layout metrics:

```
 WARN  [Reanimated] Initial values for animation are missing for property height
 WARN  [Reanimated] Initial values for animation are missing for property width
 WARN  [Reanimated] Initial values for animation are missing for property originY
 WARN  [Reanimated] Initial values for animation are missing for property originX
 WARN  -[UIView(ComponentViewProtocol) updateLayoutMetrics:oldLayoutMetrics:]: Received invalid layout metrics ({{nan, nan}, {nan, nan}}) for a view (<RCTViewComponentView: 0x1696d55a0; frame = (0 288; 370 0); tag = 9564; layer = <CALayer: 0x600000ed8d50>>).
 WARN  -[UIView(ComponentViewProtocol) updateLayoutMetrics:oldLayoutMetrics:]: Received invalid layout metrics ({{nan, nan}, {nan, nan}}) for a view (<RCTViewComponentView: 0x1696d55a0; frame = (0 288; 370 0); tag = 9564; layer = <CALayer: 0x600000ed8d50>>).
 WARN  -[UIView(ComponentViewProtocol) updateLayoutMetrics:oldLayoutMetrics:]: Received invalid layout metrics ({{nan, nan}, {nan, nan}}) for a view (<RCTViewComponentView: 0x1696d55a0; frame = (0 288; 370 0); tag = 9564; layer = <CALayer: 0x600000ed8d50>>).
 WARN  -[UIView(ComponentViewProtocol) updateLayoutMetrics:oldLayoutMetrics:]: Received invalid layout metrics ({{nan, nan}, {nan, nan}}) for a view (<RCTViewComponentView: 0x1696d55a0; frame = (0 288; 370 0); tag = 9564; layer = <CALayer: 0x600000ed8d50>>).
```

This PR fixes the problem by not animating on first appearance

## Notes for QA
not for QA


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/swap-entering-animation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->