### PR TITLE
fix(suite-native): do not show setup card for unauthorized devices

### DIFF
--- a/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
+++ b/suite-native/device/src/hooks/useConnectDeviceHandler.tsx
@@ -7,6 +7,7 @@ import { useNavigation } from '@react-navigation/native';
 import { bluetoothActions } from '@suite-common/bluetooth';
 import {
     selectIsAnyPhysicalDeviceConnectedViaUsb,
+    selectIsDeviceAuthorized,
     selectIsDeviceThpLocked,
 } from '@suite-common/device';
 import { acquireDevice } from '@suite-common/wallet-core';
@@ -29,13 +30,14 @@ export const useConnectDeviceHandler = () => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
 
+    const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isDeviceThpLocked = useSelector(selectIsDeviceThpLocked);
     const isAnyPhysicalDeviceConnectedViaUsb = useSelector(
         selectIsAnyPhysicalDeviceConnectedViaUsb,
     );
 
     const onConnectDevicePress = useCallback(() => {
-        if (isDeviceThpLocked) {
+        if (!isDeviceAuthorized || isDeviceThpLocked) {
             dispatch(acquireDevice({}));
         } else if (isAnyPhysicalDeviceConnectedViaUsb || Platform.OS === 'ios') {
             // Make sure auto-connect is enabled in case some device was manually disconnected.
@@ -48,7 +50,13 @@ export const useConnectDeviceHandler = () => {
                 screen: AuthorizeDeviceStackRoutes.ConnectDeviceCrossroads,
             });
         }
-    }, [dispatch, isDeviceThpLocked, isAnyPhysicalDeviceConnectedViaUsb, navigation]);
+    }, [
+        dispatch,
+        isDeviceAuthorized,
+        isDeviceThpLocked,
+        isAnyPhysicalDeviceConnectedViaUsb,
+        navigation,
+    ]);
 
     return { onConnectDevicePress };
 };

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import {
     selectIsDeviceAuthorized,
     selectIsDeviceConnected,
+    selectIsDeviceInBootloader,
     selectIsDeviceInitialized,
     selectIsDeviceThpLocked,
     selectIsPortfolioTrackerDevice,
@@ -17,6 +18,7 @@ import { EmptyPortfolioTrackerState } from './EmptyPortfolioTrackerState';
 import { UninitializedConnectedDeviceState } from './UninitializedConnectedDeviceState';
 
 export const EmptyHomeRenderer = () => {
+    const isDeviceInBootloader = useSelector(selectIsDeviceInBootloader);
     const isDeviceAuthorized = useSelector(selectIsDeviceAuthorized);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
     const hasOnlyEmptyPortfolioTracker = useSelector(selectHasOnlyEmptyPortfolioTracker);
@@ -35,7 +37,12 @@ export const EmptyHomeRenderer = () => {
 
     let ScreenContent = EmptyPortfolioTrackerState;
 
-    if (isDeviceSetupSupported && isDeviceConnected && !isDeviceInitialized && !isDeviceThpLocked) {
+    if (
+        isDeviceSetupSupported &&
+        isDeviceConnected &&
+        !isDeviceInitialized &&
+        (isDeviceInBootloader || (isDeviceAuthorized && !isDeviceThpLocked))
+    ) {
         ScreenContent = UninitializedConnectedDeviceState;
     }
     // Crossroads should be displayed if there is no real device connected and portfolio tracker has no accounts

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
@@ -27,7 +27,52 @@ describe('EmptyHomeRenderer', () => {
         ).toBeTruthy();
     };
 
-    it('should display UninitializedConnectedDeviceState when device is connected but not initialized', () => {
+    it('should display UninitializedConnectedDeviceState when device is connected in bootloader, not initialized', () => {
+        renderEmptyHomeRenderer({
+            device: {
+                selectedDevice: {
+                    connected: true,
+                    mode: 'bootloader',
+                    features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
+                },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectUninitializedConnectedDeviceState();
+    });
+
+    it('should display UninitializedConnectedDeviceState when device is connected, authorized, not initialized', () => {
+        renderEmptyHomeRenderer({
+            device: {
+                selectedDevice: {
+                    connected: true,
+                    state: {},
+                    features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
+                },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectUninitializedConnectedDeviceState();
+    });
+
+    it('should not display EmptyPortfolioCrossroadsState when device is connected, not initialized, but model does not support setup', () => {
+        renderEmptyHomeRenderer({
+            device: {
+                selectedDevice: {
+                    connected: true,
+                    state: undefined,
+                    features: { initialized: false, internal_model: DeviceModelInternal.T1B1 },
+                },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectEmptyPortfolioCrossroadsState();
+    });
+
+    it('should not display EmptyPortfolioCrossroadsState when device is connected, not initialized, but not authorized', () => {
         renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
@@ -38,15 +83,16 @@ describe('EmptyHomeRenderer', () => {
             },
         });
 
-        expectUninitializedConnectedDeviceState();
+        expectEmptyPortfolioCrossroadsState();
     });
 
-    it('should not display UninitializedConnectedDeviceState when device is connected, not initialized, but model does not support setup', () => {
+    it('should not display EmptyPortfolioCrossroadsState when device is connected, not initialized, but thp-locked', () => {
         renderEmptyHomeRenderer({
             device: {
                 selectedDevice: {
                     connected: true,
-                    features: { initialized: false, internal_model: DeviceModelInternal.T1B1 },
+                    status: 'thp-locked',
+                    features: { initialized: false, internal_model: DeviceModelInternal.T3B1 },
                 },
                 devices: [{ id: 'device_id' }],
             },


### PR DESCRIPTION
When a fully set up & soft-locked TS7 is first connected to mobile Suite via USB, device setup card is briefly shown before Suite asks you to unlock the device. If you dismiss the unlock screen, device setup card is still shown and it's possible to enter device onboarding which doesn't make sense.

## Notes for QA

- Both THP and non-THP devices should behave the same.
- Both USB and Bluetooth transports should work as expected.
- Ideally test all possible scenarios:
  - a blank device
  - a device with just FW installed
  - a device with FW installed, seed, and PIN not set
  - a device with FW installed, seed, and PIN set

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/empty-home-unauthorized-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->