### PR TITLE
chore(suite): added N4W1 feature flag

### DIFF
--- a/packages/suite/src/reducers/suite/suiteReducer.ts
+++ b/packages/suite/src/reducers/suite/suiteReducer.ts
@@ -26,6 +26,7 @@ export interface DebugModeOptions {
     transports: Extract<NonNullable<ConnectSettings['transports']>[number], string>[];
     isUnlockedBootloaderAllowed: boolean;
     showConnectLogs: boolean;
+    isN4w1BackupEnabled: boolean;
 }
 
 export interface AutodetectSettings {
@@ -135,6 +136,7 @@ const initialState: SuiteState = {
             transports: [],
             isUnlockedBootloaderAllowed: false,
             showConnectLogs: false,
+            isN4w1BackupEnabled: false,
         },
         autodetect: {
             language: true,

--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -35,6 +35,8 @@ export const selectTorOnionLinks = (state: SuiteRootState) => state.suite.settin
 // TODO: use this selector in all places where we need to check if debug mode is active
 export const selectIsDebugModeActive = (state: SuiteRootState) =>
     state.suite.settings.debug.showDebugMenu;
+export const selectIsN4w1BackupEnabled = (state: SuiteRootState) =>
+    state.suite.settings.debug.isN4w1BackupEnabled;
 export const selectLanguage = (state: SuiteRootState) => state.suite.settings.language;
 export const selectAutodetectLanguage = (state: SuiteRootState) =>
     state.suite.settings.autodetect.language;

--- a/packages/suite/src/views/settings/SettingsDebug/N4w1Backup.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/N4w1Backup.tsx
@@ -1,0 +1,26 @@
+import { Switch } from '@trezor/components';
+
+import { setDebugMode } from 'src/actions/suite/suiteActions';
+import { ActionColumn, SectionItem, TextColumn } from 'src/components/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { selectIsN4w1BackupEnabled } from '../../../selectors/suite/suiteSelectors';
+
+export const N4w1Backup = () => {
+    const isN4w1BackupEnabled = useSelector(selectIsN4w1BackupEnabled);
+    const dispatch = useDispatch();
+
+    const toggle = () => dispatch(setDebugMode({ isN4w1BackupEnabled: !isN4w1BackupEnabled }));
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="N4W1 Backup"
+                description="Enable Trezor device N4W1 backup features."
+            />
+            <ActionColumn>
+                <Switch isChecked={isN4w1BackupEnabled} onChange={toggle} />
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -22,6 +22,7 @@ import { GithubIssue } from './GithubIssue';
 import { MessageSystemConfigSourceSelect } from './MessageSystem/MessageSystemConfigSourceSelect';
 import { MessageSystemDebug } from './MessageSystem/MessageSystemDebug';
 import { Metadata } from './Metadata';
+import { N4w1Backup } from './N4w1Backup';
 import { OAuthApi } from './OAuthApi';
 import { PlatformEncrypton } from './PlatformEncrypton';
 import { PreField } from './PreField';
@@ -69,6 +70,7 @@ export const SettingsDebug = () => {
                 <Devkit />
                 <CheckFirmwareAuthenticity />
                 <ClearDevicePersistentData />
+                <N4w1Backup />
             </SettingsSection>
             <SettingsSection title="Testing">
                 <ThrowTestingError />

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -14,5 +14,7 @@ export type LaunchArguments = {
     isTradingResidenceCheckEnabled?: boolean;
     isTradingDebugEnabled?: boolean;
     isEarnEnabled?: boolean;
+    isN4w1BackupEnabled?: boolean;
     isStablecoinYieldEnabled?: boolean;
+    isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/__tests__/featureFlagsSlice.test.ts
@@ -25,6 +25,7 @@ describe('featureFlagsSlice', () => {
                 isTradingResidenceCheckEnabled: true,
                 isTradingSellEnabled: false,
                 isTradingDebugEnabled: false,
+                isN4w1BackupEnabled: false,
                 isEarnEnabled: false,
                 isStablecoinYieldEnabled: false,
             });
@@ -47,6 +48,7 @@ describe('featureFlagsSlice', () => {
                 areTradingExchangeDexesEnabled: false,
                 isTradingResidenceCheckEnabled: false,
                 isTradingDebugEnabled: false,
+                isN4w1BackupEnabled: false,
                 isEarnEnabled: false,
                 isStablecoinYieldEnabled: false,
             });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -15,6 +15,7 @@ export const FeatureFlag = {
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsEarnEnabled: 'isEarnEnabled',
     IsStablecoinYieldEnabled: 'isStablecoinYieldEnabled',
+    IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -48,6 +49,7 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsEarnEnabled]: process.env.EXPO_PUBLIC_FF_IS_EARN_ENABLED === 'true',
     [FeatureFlag.IsStablecoinYieldEnabled]:
         process.env.EXPO_PUBLIC_FF_IS_STABLECOIN_YIELD_DEBUG_ENABLED === 'true',
+    [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -62,6 +64,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsEarnEnabled,
     FeatureFlag.IsStablecoinYieldEnabled,
+    FeatureFlag.IsN4w1BackupEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -19,6 +19,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsEarnEnabled]: 'Earn',
     [FeatureFlagEnum.IsStablecoinYieldEnabled]: 'Stablecoin Yield',
+    [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {


### PR DESCRIPTION
**Description**                                          
                                                                                                                                                                                                                          
  Added a new feature flag`isN4w1BackupEnabled` to control N4W1 backup functionality in Trezor Suite. This flag allows developers to enable/disable N4W1 backup features through the debug menu.                           
                                                                                                                                                                                                                          
  **Changes included**:                                                                                                                                                                                                       
                                                                                                                                                                                                                        
  - Added isN4w1BackupEnabled state to suite reducer and initial state
  - Created new debug menu componen `N4w1Backup.tsx` with a toggle switch
  - Added selector `selectIsN4w1BackupEnabled` for accessing the flag state
  - Integrated the new flag into SettingsDebug menu
  - Added feature flag constant and initialization in native module
  - Updated FeatureFlagsCard to display the new flag

  **Notes for QA**

  To test this feature:

  1. Navigate to Settings → Debug
  2. Look for the "N4W1 Backup" toggle in the Settings section
  3. Toggle the switch to enable/disable N4W1 backup features
  4. Verify the toggle state persists after navigation
  5. Check that the native feature flag is properly initialized via environment variable EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED

  Areas affected:
  - Debug menu settings
  - Feature flag state management (both web and native)
  - N4W1 backup feature components (when integration is added)

  What doesn't need testing:
  - Actual N4W1 backup functionality (not yet integrated, I'm )

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/n4w1-feature-flag&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/n4w1-feature-flag&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/n4w1-feature-flag&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Labeling migration > Migration from Dropbox | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T00:33:09.030Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Suite Sync - Remove Labels > Remove labels syncs null to relay | 🤖 auto |
| Suite Sync - Passphrase wallets > Labels on multiple wallets | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T00:31:26.369Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->