### PR TITLE
refactor(e2e-suite): rework test data for suite-sync

### DIFF
--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -18,6 +18,8 @@
         "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch",
         "@suite-common/suite-sync-evolu": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@types/better-sqlite3": "^7.6.13"
     }
 }

--- a/suite-common/e2e-evolu-client/src/createEvoluRowIds.ts
+++ b/suite-common/e2e-evolu-client/src/createEvoluRowIds.ts
@@ -1,0 +1,47 @@
+import { createIdFromString, getOrThrow } from '@evolu/common';
+
+import {
+    AccountEvoluId,
+    AddressEvoluId,
+    OutputEvoluId,
+    WalletLabelId,
+    createEvoluAppOwnerFromTrezorData,
+} from '@suite-common/suite-sync-evolu';
+import {
+    createSuiteSyncAccountId,
+    createSuiteSyncAddressId,
+    createSuiteSyncOutputId,
+} from '@suite-common/suite-sync-storage';
+import type { SuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import type { AccountDescriptor, TxTargetId, WalletDescriptor } from '@suite-common/wallet-types';
+
+export const createOwnerIdFromSecret = (ownerSecret: SuiteSyncOwnerSecretHex): string => {
+    const result = createEvoluAppOwnerFromTrezorData({ data: ownerSecret });
+    if (!result.ok) {
+        throw new Error(`Failed to compute ownerId: ${JSON.stringify(result.error)}`);
+    }
+
+    return result.value.id;
+};
+
+export const createWalletRowId = (walletDescriptor: WalletDescriptor) =>
+    getOrThrow(WalletLabelId.from(createIdFromString(walletDescriptor)));
+
+export const createAccountRowId = (
+    accountDescriptor: AccountDescriptor,
+    networkSymbol: NetworkSymbol,
+) =>
+    getOrThrow(
+        AccountEvoluId.from(
+            createIdFromString(createSuiteSyncAccountId(accountDescriptor, networkSymbol)),
+        ),
+    );
+
+export const createAddressRowId = (address: string, networkSymbol: NetworkSymbol) =>
+    getOrThrow(
+        AddressEvoluId.from(createIdFromString(createSuiteSyncAddressId(address, networkSymbol))),
+    );
+
+export const createOutputRowId = (txId: string, txTargetId: TxTargetId) =>
+    getOrThrow(OutputEvoluId.from(createIdFromString(createSuiteSyncOutputId(txId, txTargetId))));

--- a/suite-common/e2e-evolu-client/src/index.ts
+++ b/suite-common/e2e-evolu-client/src/index.ts
@@ -7,3 +7,10 @@ export {
     seedQuotaManagerData,
 } from './baseEvoluClient';
 export type { EvoluClientInitParams } from './baseEvoluClient';
+export {
+    createOwnerIdFromSecret,
+    createWalletRowId,
+    createAccountRowId,
+    createAddressRowId,
+    createOutputRowId,
+} from './createEvoluRowIds';

--- a/suite-common/e2e-evolu-client/tsconfig.json
+++ b/suite-common/e2e-evolu-client/tsconfig.json
@@ -3,6 +3,8 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-sync-evolu" },
-        { "path": "../suite-sync-storage" }
+        { "path": "../suite-sync-storage" },
+        { "path": "../wallet-config" },
+        { "path": "../wallet-types" }
     ]
 }

--- a/suite-common/suite-sync-evolu/src/index.ts
+++ b/suite-common/suite-sync-evolu/src/index.ts
@@ -8,3 +8,7 @@ export { createEvoluInstanceFactory } from './createEvoluInstance';
 export { evoluCreateSuiteSyncOwner } from './evoluCreateSuiteSyncOwner';
 export { createEvoluAppOwnerFromTrezorData } from './createEvoluAppOwnerFromTrezorData';
 export { Schema } from './schema';
+export { AccountEvoluId } from './data/accountTable';
+export { AddressEvoluId } from './data/addressTable';
+export { OutputEvoluId } from './data/outputTable';
+export { WalletLabelId } from './data/walletTable';

--- a/suite/e2e/fixtures/metadata/default-metadata-ids.ts
+++ b/suite/e2e/fixtures/metadata/default-metadata-ids.ts
@@ -1,13 +1,12 @@
-import { OwnerId } from '@evolu/common';
-
+import { createOwnerIdFromSecret } from '@suite-common/e2e-evolu-client';
 import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
 import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
 
 // Ids for default mnemonic_12: 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
-export const ownerId = OwnerId.orThrow('0Fco3XDgKR59zX5VBvyyGQ');
 export const ownerSecret = asSuiteSyncOwnerSecretHex(
     'd5cafbfc837fcdba7fd54025ce352fac369db9383d41d73dbd4f3353b63bc4644585f41195021419707ccdf76bbdf0b1cb0e11f07ff19a41b5f22602dfee3b63',
 );
+export const ownerId = createOwnerIdFromSecret(ownerSecret);
 export const walletDescriptor = asWalletDescriptor('mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer');
 export const accountDescriptor = asAccountDescriptor(
     'zpub6qSSRL9wLd6LNee7qjDEuULWccP5Vbm5nuX4geBu8zMCQBWsF5Jo5UswLVxFzcbCMr2yQPG27ZhDs1cUGKVH1RmqkG1PFHkEXyHG7EV3ogY',

--- a/suite/e2e/fixtures/metadata/suite-sync-data.ts
+++ b/suite/e2e/fixtures/metadata/suite-sync-data.ts
@@ -1,33 +1,98 @@
-import { accountDescriptor, ownerSecret, walletDescriptor } from './default-metadata-ids';
+import {
+    createAccountRowId,
+    createAddressRowId,
+    createOutputRowId,
+    createWalletRowId,
+} from '@suite-common/e2e-evolu-client';
+import { asTxTargetId } from '@suite-common/wallet-types';
+
+import { accountDescriptor, ownerId, ownerSecret, walletDescriptor } from './default-metadata-ids';
+
+const networkSymbol = 'btc' as const;
+const BTC_ADDRESS = 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa';
+const BTC_TX_ID = 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393';
+const BTC_TX_TARGET_ID = '0';
 
 export const walletSeed = {
-    id: 'ya1CCDTCVPyRa6egTac7yg',
+    id: createWalletRowId(walletDescriptor),
     walletDescriptor,
     label: 'Evolu synced wallet',
 };
 
 export const accountSeed = {
-    id: 'RSZ0aKqUcO_e0WoQO32x4w',
+    id: createAccountRowId(accountDescriptor, networkSymbol),
     accountDescriptor,
-    networkSymbol: 'btc',
+    networkSymbol,
     label: 'Evolu synced BTC account',
 };
 
 export const addressSeed = {
-    id: 'DmBRN-GwcRyC-cuTPczSXg',
+    id: createAddressRowId(BTC_ADDRESS, networkSymbol),
     label: 'Evolu synced BTC address',
-    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+    address: BTC_ADDRESS,
     accountDescriptor,
-    networkSymbol: 'btc',
+    networkSymbol,
 };
 
 export const outputSeed = {
-    id: 'TR7Axj6suVoVTBJO5saruA',
+    id: createOutputRowId(BTC_TX_ID, asTxTargetId(BTC_TX_TARGET_ID)),
     accountDescriptor,
     label: 'Evolu synced output',
-    networkSymbol: 'btc',
-    outputIndex: '0',
-    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
+    networkSymbol,
+    outputIndex: BTC_TX_TARGET_ID,
+    txId: BTC_TX_ID,
 };
+
+export const buildExpectedWallet = <T extends string | null>({ label }: { label: T }) => ({
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    walletDescriptor,
+    label,
+});
+
+export const buildExpectedAccount = <T extends string | null>({ label }: { label: T }) => ({
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    accountDescriptor,
+    networkSymbol,
+    label,
+});
+
+export const buildExpectedAddress = <T extends string | null>({
+    address,
+    label,
+}: {
+    address: string;
+    label: T;
+}) => ({
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    accountDescriptor,
+    networkSymbol,
+    address,
+    label,
+});
+
+export const buildExpectedOutput = <T extends string | null>({
+    txId,
+    outputIndex,
+    label,
+}: {
+    txId: string;
+    outputIndex: string;
+    label: T;
+}) => ({
+    updatedAt: null,
+    isDeleted: null,
+    ownerId,
+    accountDescriptor,
+    networkSymbol,
+    txId,
+    outputIndex,
+    label,
+});
 
 export { ownerSecret };

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -1,50 +1,26 @@
 import {
-    accountDescriptor,
-    ownerId,
+    buildExpectedAccount,
+    buildExpectedAddress,
+    buildExpectedOutput,
+    buildExpectedWallet,
     ownerSecret,
-    walletDescriptor,
-} from '../../../fixtures/metadata/default-metadata-ids';
+} from '../../../fixtures/metadata/suite-sync-data';
 import { AccountLabelId } from '../../../support/enums/accountLabelId';
 import { expect, test } from '../../../support/fixtures';
 
 const defaultWalletIndex = 0;
-const expectedWallet = {
-    updatedAt: null,
-    isDeleted: null,
-    ownerId,
-    walletDescriptor,
-    label: 'Evolu write wallet',
-};
 
-const expectedAccount = {
-    updatedAt: null,
-    isDeleted: null,
-    ownerId,
-    accountDescriptor,
-    networkSymbol: 'btc',
-    label: 'Evolu write BTC account',
-};
-
-const expectedAddress = {
-    updatedAt: null,
-    isDeleted: null,
-    ownerId,
-    accountDescriptor,
-    label: 'Evolu write BTC address',
+const expectedWallet = buildExpectedWallet({ label: 'Evolu write wallet' });
+const expectedAccount = buildExpectedAccount({ label: 'Evolu write BTC account' });
+const expectedAddress = buildExpectedAddress({
     address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
-    networkSymbol: 'btc',
-};
-
-const expectedOutput = {
-    isDeleted: null,
-    updatedAt: null,
-    ownerId,
-    accountDescriptor,
-    label: 'Evolu write output',
-    networkSymbol: 'btc',
-    outputIndex: '0',
+    label: 'Evolu write BTC address',
+});
+const expectedOutput = buildExpectedOutput({
     txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
-};
+    outputIndex: '0',
+    label: 'Evolu write output',
+});
 
 test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -1,41 +1,33 @@
-import { OwnerId } from '@evolu/common';
-
+import { createOwnerIdFromSecret } from '@suite-common/e2e-evolu-client';
 import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
 import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
 
-import {
-    ownerId as defaultWalletOwnerId,
-    ownerSecret as defaultWalletOwnerSecret,
-    walletDescriptor,
-} from '../../../fixtures/metadata/default-metadata-ids';
+import { ownerSecret as defaultWalletOwnerSecret } from '../../../fixtures/metadata/default-metadata-ids';
+import { buildExpectedWallet } from '../../../fixtures/metadata/suite-sync-data';
 import { AccountLabelId } from '../../../support/enums/accountLabelId';
 import { expect, test } from '../../../support/fixtures';
 
+const walletOneOwnerSecret = asSuiteSyncOwnerSecretHex(
+    'a42c516df49ec13ef4df8d2edfd33a893ddb3c5bb5423fb55e5f33a1852e2bc2d2fc70db8b35db609c730763f81c2d2bb491abf4f07505b0449386d54285b267',
+);
 const walletOne = {
     index: 1,
     passphrase: 'First passphrase',
-    ownerId: OwnerId.orThrow('nv3sJB3YFuddnYPsMy03BA'),
-    ownerSecret: asSuiteSyncOwnerSecretHex(
-        'a42c516df49ec13ef4df8d2edfd33a893ddb3c5bb5423fb55e5f33a1852e2bc2d2fc70db8b35db609c730763f81c2d2bb491abf4f07505b0449386d54285b267',
-    ),
+    ownerSecret: walletOneOwnerSecret,
+    ownerId: createOwnerIdFromSecret(walletOneOwnerSecret),
 };
 
+const walletTwoOwnerSecret = asSuiteSyncOwnerSecretHex(
+    '2b1643b805e3dec4ec2c3f57e707bce641f197ddd468070ffd4225393c4cb1a8e3935be81dd63f1e6d55145a73415d330328ba9c6eaa65fa56be8234fe512690',
+);
 const walletTwo = {
     index: 2,
     passphrase: 'Second passphrase',
-    ownerId: OwnerId.orThrow('Mvz4DxvvznAgmppCU67NPw'),
-    ownerSecret: asSuiteSyncOwnerSecretHex(
-        '2b1643b805e3dec4ec2c3f57e707bce641f197ddd468070ffd4225393c4cb1a8e3935be81dd63f1e6d55145a73415d330328ba9c6eaa65fa56be8234fe512690',
-    ),
+    ownerSecret: walletTwoOwnerSecret,
+    ownerId: createOwnerIdFromSecret(walletTwoOwnerSecret),
 };
 
-const expectedDefaultWalletLabel = {
-    updatedAt: null,
-    isDeleted: null,
-    ownerId: defaultWalletOwnerId,
-    walletDescriptor,
-    label: 'Evolu Default wallet',
-};
+const expectedDefaultWalletLabel = buildExpectedWallet({ label: 'Evolu Default wallet' });
 
 const expectedWalletOneLabel = {
     updatedAt: null,

--- a/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts
@@ -1,7 +1,10 @@
-import { ownerId } from '../../../fixtures/metadata/default-metadata-ids';
 import {
     accountSeed,
     addressSeed,
+    buildExpectedAccount,
+    buildExpectedAddress,
+    buildExpectedOutput,
+    buildExpectedWallet,
     outputSeed,
     ownerSecret,
     walletSeed,
@@ -10,6 +13,15 @@ import { AccountLabelId } from '../../../support/enums/accountLabelId';
 import { expect, test } from '../../../support/fixtures';
 
 const defaultWalletIndex = 0;
+
+const expectedAccount = buildExpectedAccount({ label: null });
+const expectedWallet = buildExpectedWallet({ label: null });
+const expectedAddress = buildExpectedAddress({ address: addressSeed.address, label: null });
+const expectedOutput = buildExpectedOutput({
+    txId: outputSeed.txId,
+    outputIndex: outputSeed.outputIndex,
+    label: null,
+});
 
 test.describe('Suite Sync - Remove Labels', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ wipeEvoluRelay: true });
@@ -82,74 +94,10 @@ test.describe('Suite Sync - Remove Labels', { tag: ['@T3W1', '@T3T1'] }, () => {
         await test.step('Verify labels are removed in relay (label is null)', async () => {
             evoluClient.init({ ownerSecret });
 
-            await evoluClient.expectInTable(
-                'account',
-                [
-                    {
-                        updatedAt: null,
-                        isDeleted: null,
-                        ownerId,
-                        accountDescriptor: accountSeed.accountDescriptor,
-                        networkSymbol: accountSeed.networkSymbol,
-                        label: null,
-                    },
-                ],
-                { softExpect: true },
-            );
-
-            await evoluClient.expectInTable(
-                'wallet',
-                [
-                    {
-                        isDeleted: null,
-                        label: 'Evolu synced wallet',
-                        ownerId: '0Fco3XDgKR59zX5VBvyyGQ',
-                        updatedAt: null,
-                        walletDescriptor: 'mkqRFzxmkCGX9jxgpqqFHcxRUmLJcLDBer',
-                    },
-                    {
-                        updatedAt: null,
-                        isDeleted: null,
-                        ownerId,
-                        walletDescriptor: walletSeed.walletDescriptor,
-                        label: null,
-                    },
-                ],
-                { softExpect: true },
-            );
-
-            await evoluClient.expectInTable(
-                'address',
-                [
-                    {
-                        updatedAt: null,
-                        isDeleted: null,
-                        ownerId,
-                        accountDescriptor: addressSeed.accountDescriptor,
-                        networkSymbol: addressSeed.networkSymbol,
-                        address: addressSeed.address,
-                        label: null,
-                    },
-                ],
-                { softExpect: true },
-            );
-
-            await evoluClient.expectInTable(
-                'output',
-                [
-                    {
-                        updatedAt: null,
-                        isDeleted: null,
-                        ownerId,
-                        accountDescriptor: outputSeed.accountDescriptor,
-                        networkSymbol: outputSeed.networkSymbol,
-                        txId: outputSeed.txId,
-                        outputIndex: outputSeed.outputIndex,
-                        label: null,
-                    },
-                ],
-                { softExpect: true },
-            );
+            await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
+            await evoluClient.expectInTable('wallet', [expectedWallet], { softExpect: true });
+            await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
+            await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11308,6 +11308,8 @@ __metadata:
     "@evolu/common": "patch:@evolu/common@npm%3A7.3.0#~/.yarn/patches/@evolu-common-npm-7.3.0-dc4f142770.patch"
     "@suite-common/suite-sync-evolu": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@types/better-sqlite3": "npm:^7.6.13"
     better-sqlite3: "npm:^12.1.1"
     ws: "npm:^8.18.0"


### PR DESCRIPTION
Test data was all over the place. Multiple definitions and duplicity. Moreover one specific data was used with wrong ID and test was asserting incorrect results.
more over it promotes readability on test level.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-refactor-suite-sync-test-data&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-refactor-suite-sync-test-data&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-refactor-suite-sync-test-data&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T09:08:42.688Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T09:07:28.633Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->