### PR TITLE
feat(trading): add visual warning for non-production trading API

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
@@ -1,10 +1,13 @@
 import { type ReactNode } from 'react';
 
+import { selectInvityServerEnvironment } from '@suite/settings';
+import { TradingEnvironmentWarning } from '@suite/trading';
 import { Context } from '@suite-common/message-system';
 import { Box, Card, Column } from '@trezor/components';
 import { breakpoints, spacings } from '@trezor/theme';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingFeaturedOffers } from 'src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffers';
@@ -19,10 +22,12 @@ interface TradingFormLayoutProps {
 
 export const TradingFormLayout = ({ children }: TradingFormLayoutProps) => {
     const { tradingDeviceDisconnected } = useTradingDeviceDisconnected();
+    const invityServerEnvironment = useSelector(selectInvityServerEnvironment);
 
     return (
         <Column gap={spacings.md} data-testid="@trading/form">
             {tradingDeviceDisconnected && <ConnectDeviceGenericPromo />}
+            <TradingEnvironmentWarning tradingEnvironment={invityServerEnvironment} />
 
             {/* If clicking on disabled input, the click propagates to the form and submits it (some form values are then pushed to URL search params) */}
             <form onSubmit={e => e.preventDefault()}>

--- a/suite/trading/src/ui/TradingEnvironmentWarning.tsx
+++ b/suite/trading/src/ui/TradingEnvironmentWarning.tsx
@@ -1,0 +1,16 @@
+import { type InvityServerEnvironment } from '@suite-common/trading';
+import { Banner } from '@trezor/components';
+
+interface TradingEnvironmentWarningProps {
+    tradingEnvironment: InvityServerEnvironment | undefined;
+}
+
+export const TradingEnvironmentWarning = ({
+    tradingEnvironment,
+}: TradingEnvironmentWarningProps) => {
+    if (!tradingEnvironment || tradingEnvironment === 'production') {
+        return null;
+    }
+
+    return <Banner intent="warning" description={`Trading environment: ${tradingEnvironment}`} />;
+};

--- a/suite/trading/src/ui/index.ts
+++ b/suite/trading/src/ui/index.ts
@@ -1,3 +1,4 @@
+export { TradingEnvironmentWarning } from './TradingEnvironmentWarning';
 export { PaymentMethodIcon } from './payment-methods/PaymentMethodIcon';
 export { PaymentMethodPlainType } from './payment-methods/PaymentMethodPlainType';
 export { PaymentMethodType } from './payment-methods/PaymentMethodType';


### PR DESCRIPTION
## Description

Adds a warning banner in desktop trading form when a non-production Invity server environment is selected.

The banner is rendered in desktop trading form layout and uses shared UI component from suite/trading, but behavior is desktop-only in this PR.

## Notes for QA

1. Enable debug mode and set Trading API server to staging / dev / localhost in Settings > Debug.
2. Open Wallet > Trading form (buy/exchange/sell views) and verify warning banner is visible with the selected environment value.
3. Switch Trading API server back to production and verify the warning banner is not shown.
4. Regression check: trading form still loads normally (offers panel, form inputs, and legal message unchanged) and no extra banner appears outside trading form.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/25597

## Screenshots:

![Uploading image.png…]()

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-25597&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T08:17:50.303Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->