### PR TITLE
fix(suite-native): add vite aliases for @formatjs polyfill imports in storybook

### DIFF
--- a/suite-native/storybook/.depcheckrc.json
+++ b/suite-native/storybook/.depcheckrc.json
@@ -5,6 +5,9 @@
         "@react-native-community/datetimepicker",
         "@react-native-community/slider",
         "@storybook/addon-ondevice-controls",
-        "babel-plugin-react-native-web"
+        "babel-plugin-react-native-web",
+        "@formatjs/intl-getcanonicallocales",
+        "@formatjs/intl-locale",
+        "@formatjs/intl-listformat"
     ]
 }

--- a/suite-native/storybook/.storybook/main.ts
+++ b/suite-native/storybook/.storybook/main.ts
@@ -39,6 +39,14 @@ const main: StorybookConfig = {
                     ),
                     '@trezor/address-validator':
                         require.resolve('./mocks/address-validator.mock.ts'),
+                    // @formatjs packages export ./polyfill.js but imports use ./polyfill (no extension)
+                    // Vite enforces strict exports resolution so we alias to the full paths
+                    '@formatjs/intl-getcanonicallocales/polyfill':
+                        require.resolve('@formatjs/intl-getcanonicallocales/polyfill.js'),
+                    '@formatjs/intl-locale/polyfill':
+                        require.resolve('@formatjs/intl-locale/polyfill.js'),
+                    '@formatjs/intl-listformat/polyfill':
+                        require.resolve('@formatjs/intl-listformat/polyfill.js'),
                 },
             },
             optimizeDeps: {


### PR DESCRIPTION
## Description

`@formatjs` packages export `./polyfill.js` but are imported without the `.js` extension. Vite enforces strict exports resolution and fails with `Missing "./polyfill" specifier`. Added Vite aliases in `.storybook/main.ts` to map the extensionless specifiers to the actual file paths.

## Notes for QA
it works ✅ https://github.com/trezor/trezor-suite/actions/runs/23430803701/job/68156418768
<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/storybook-web-formatjs-polyfill-aliases&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->