### PR TITLE
chore(suite-desktop): separate getProcessIcon for future reuse

### DIFF
--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -1,4 +1,4 @@
-import { ipcMain, nativeImage } from 'electron';
+import { ipcMain } from 'electron';
 import { WebSocketServer } from 'ws';
 
 import {
@@ -10,14 +10,14 @@ import {
     type PopupHandshake,
 } from '@trezor/connect';
 import { parseManifest, parseVersion } from '@trezor/connect/src/data/connectSettings';
-import { isLinux, isMacOs, isWindows } from '@trezor/env-utils';
+import { isLinux } from '@trezor/env-utils';
 import { type ProcessInfo, findProcessFromIncomingPort } from '@trezor/node-utils';
 import { type ConnectPopupResponse } from '@trezor/suite-desktop-api/src/messages';
 import { type Deferred, createDeferred, resolveAfter } from '@trezor/utils';
 
 import { type createHttpReceiver } from './http-receiver';
+import { getProcessIcon } from './process-icon';
 import { type Dependencies } from '../modules';
-import { app } from '../typed-electron';
 
 const LOG_PREFIX = 'connect-ws';
 
@@ -58,32 +58,6 @@ const validateIncomingMessage = (message: any): message is IncomingMessage => {
     }
 
     return false;
-};
-
-export const getProcessIcon = async (path: string) => {
-    try {
-        const iconDim = { width: 48, height: 48 };
-        if (isWindows()) {
-            const icon = await app.getFileIcon(path, {
-                size: 'normal',
-            });
-
-            if (icon.isEmpty()) {
-                return undefined;
-            }
-
-            return icon.resize(iconDim).toDataURL();
-        } else if (isMacOs()) {
-            const icon = await nativeImage.createThumbnailFromPath(path, iconDim);
-            if (icon.isEmpty()) {
-                return undefined;
-            }
-
-            return icon.toDataURL();
-        }
-    } catch (error) {
-        logger.warn(LOG_PREFIX, 'Failed to get icon of process - ' + error);
-    }
 };
 
 export const exposeConnectWs = ({

--- a/packages/suite-desktop-core/src/libs/process-icon.ts
+++ b/packages/suite-desktop-core/src/libs/process-icon.ts
@@ -1,0 +1,33 @@
+import { nativeImage } from 'electron';
+
+import { isMacOs, isWindows } from '@trezor/env-utils';
+
+import { app } from '../typed-electron';
+
+const LOG_PREFIX = 'process-icon';
+
+export const getProcessIcon = async (path: string) => {
+    try {
+        const iconDim = { width: 48, height: 48 };
+        if (isWindows()) {
+            const icon = await app.getFileIcon(path, {
+                size: 'normal',
+            });
+
+            if (icon.isEmpty()) {
+                return undefined;
+            }
+
+            return icon.resize(iconDim).toDataURL();
+        } else if (isMacOs()) {
+            const icon = await nativeImage.createThumbnailFromPath(path, iconDim);
+            if (icon.isEmpty()) {
+                return undefined;
+            }
+
+            return icon.toDataURL();
+        }
+    } catch (error) {
+        global.logger.warn(LOG_PREFIX, 'Failed to get icon of process - ' + error);
+    }
+};


### PR DESCRIPTION
cherry-picked from #25825, which is too big for my little brain to comprehend.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor-get-process-icon&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor-get-process-icon&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor-get-process-icon&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T09:26:53.257Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T09:28:47.509Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->