### PR TITLE
fix(redux): tighten dispatch and action typings

### DIFF
--- a/packages/analytics-uploader/src/analytics.ts
+++ b/packages/analytics-uploader/src/analytics.ts
@@ -18,7 +18,7 @@ export interface Analytics<T extends AnalyticsEvent> {
 }
 
 export class QueuedAnalytics<T extends AnalyticsEvent> implements Analytics<T> {
-    private enabled?: boolean;
+    private enabled: boolean | undefined;
 
     private useQueue = false;
     private queue = new Array<T>();

--- a/packages/analytics-uploader/src/utils.ts
+++ b/packages/analytics-uploader/src/utils.ts
@@ -78,7 +78,7 @@ interface ReportEventProps {
     url: string;
     options: RequestInit;
     retry: boolean;
-    loggerEnabled?: boolean;
+    loggerEnabled?: boolean | undefined;
 }
 
 export const reportEvent = async ({

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -72,12 +72,12 @@ export type WalletSettingsAction =
     | SetHideBalanceAction
     | SetBitcoinAmountUnitsAction;
 
-export const setDiscreetMode = (toggled: boolean): WalletSettingsAction => ({
+export const setDiscreetMode = (toggled: boolean): SetHideBalanceAction => ({
     type: WALLET_SETTINGS.SET_HIDE_BALANCE,
     toggled,
 });
 
-export const setBitcoinAmountUnits = (units: PROTO.AmountUnit): WalletSettingsAction => ({
+export const setBitcoinAmountUnits = (units: PROTO.AmountUnit): SetBitcoinAmountUnitsAction => ({
     type: WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS,
     payload: units,
 });


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/26013

Just type-fixies.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-types-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-types-3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-types-3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T09:29:49.043Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T09:28:23.425Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->