### PR TITLE
Extend http server

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -272,7 +272,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
         return [baseSegments, paramsSegments];
     }
 
-    private registerRoute(pathname: string, method: 'POST' | 'GET', handler: AnyRequestHandler[]) {
+    private registerRoute(pathname: string, method: Route['method'], handler: AnyRequestHandler[]) {
         const [baseSegments, paramsSegments] = this.splitSegments(pathname);
         const basePathname = baseSegments.join('/');
         this.routes.push({
@@ -295,7 +295,9 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
         this.registerRoute(pathname, 'GET', handler);
     }
 
-    // PUT, DELETE etc are not used anywhere in our codebase, so no need to implement them now
+    public delete(pathname: string, handler: AnyRequestHandler[]) {
+        this.registerRoute(pathname, 'DELETE', handler);
+    }
 
     /**
      * Register common handlers that are run for all requests before route handlers
@@ -671,6 +673,65 @@ export const parseBodyJSON: RequestHandler<unknown, JSON> = (request, response, 
             response.end(JSON.stringify({ error: `Invalid json body: ${error.message}` }));
         });
 };
+
+/**
+ * Factory that creates a body parser middleware with a maximum body size limit.
+ * Returns 413 if the body exceeds the limit.
+ */
+export const parseBodyJSONWithLimit =
+    (maxBytes: number): RequestHandler<unknown, JSON> =>
+    (request, response, next) => {
+        const hasData =
+            (request.headers['content-length'] &&
+                Number.parseInt(request.headers['content-length']) > 0) ||
+            request.headers['transfer-encoding'] === 'chunked';
+
+        if (!hasData) {
+            next(
+                Object.assign(request, { body: {} }) as unknown as RequestWithParams<JSON>,
+                response,
+            );
+
+            return;
+        }
+
+        const chunks: Buffer[] = [];
+        let size = 0;
+        let rejected = false;
+
+        request
+            .on('data', (chunk: Buffer) => {
+                if (rejected) return;
+                size += chunk.length;
+                if (size > maxBytes) {
+                    rejected = true;
+                    request.resume();
+                    response.statusCode = 413;
+                    response.end(JSON.stringify({ error: 'Payload too large' }));
+
+                    return;
+                }
+                chunks.push(chunk);
+            })
+            .on('end', () => {
+                if (rejected) return;
+                try {
+                    const text = Buffer.concat(chunks).toString();
+                    const body = text ? JSON.parse(text) : {};
+                    next(
+                        Object.assign(request, { body }) as unknown as RequestWithParams<JSON>,
+                        response,
+                    );
+                } catch (error) {
+                    response.statusCode = 400;
+                    response.end(
+                        JSON.stringify({
+                            error: `Invalid json body: ${error instanceof Error ? error.message : String(error)}`,
+                        }),
+                    );
+                }
+            });
+    };
 
 /**
  * set request.body as string

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -4,6 +4,7 @@ export {
     HttpServer,
     allowReferers,
     parseBodyJSON,
+    parseBodyJSONWithLimit,
     parseBodyText,
     type RequestHandler,
     type ParamsValidatorHandler,

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -9,6 +9,7 @@ import {
     type RequestHandler,
     allowReferers,
     parseBodyJSON,
+    parseBodyJSONWithLimit,
     parseBodyText,
 } from '../http';
 
@@ -802,6 +803,122 @@ describe('HttpServer', () => {
             expect(res3.status).toEqual(200);
             await expect(res3.text()).resolves.toEqual('root');
             expect(rootHandler).toHaveBeenCalled();
+        });
+    });
+
+    describe('DELETE route', () => {
+        test('DELETE route matches DELETE requests', async () => {
+            const handler = jest.fn((_request, response) => {
+                response.end('deleted');
+            });
+
+            server.delete('/resource', [handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/resource`, {
+                method: 'DELETE',
+            });
+
+            expect(res.status).toEqual(200);
+            await expect(res.text()).resolves.toEqual('deleted');
+            expect(handler).toHaveBeenCalled();
+        });
+
+        test('DELETE route does not match GET, POST, or PUT', async () => {
+            const handler = jest.fn((_request, response) => {
+                response.end('deleted');
+            });
+
+            server.delete('/resource', [handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            for (const method of ['GET', 'POST', 'PUT']) {
+                const res = await fetch(`http://${address}:${port}/resource`, { method });
+                expect(res.status).toEqual(404);
+            }
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('parseBodyJSONWithLimit', () => {
+        test('rejects body larger than limit with 413', async () => {
+            const handler = jest.fn((_request, response) => {
+                response.end('ok');
+            });
+
+            server.post('/upload', [parseBodyJSONWithLimit(100), handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/upload`, {
+                method: 'POST',
+                body: JSON.stringify({ data: 'x'.repeat(200) }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            expect(res.status).toEqual(413);
+            const body = await res.json();
+            expect(body.error).toContain('Payload too large');
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        test('rejects invalid JSON with 400', async () => {
+            const handler = jest.fn((_request, response) => {
+                response.end('ok');
+            });
+
+            server.post('/upload', [parseBodyJSONWithLimit(1024), handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/upload`, {
+                method: 'POST',
+                body: '{invalid json!!!',
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            expect(res.status).toEqual(400);
+            const body = await res.json();
+            expect(body.error).toContain('Invalid json body');
+            expect(handler).not.toHaveBeenCalled();
+        });
+
+        test('parses valid JSON within limit', async () => {
+            const handler = jest.fn((request, response) => {
+                response.end(JSON.stringify(request.body));
+            });
+
+            server.post('/upload', [parseBodyJSONWithLimit(1024), handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/upload`, {
+                method: 'POST',
+                body: JSON.stringify({ foo: 'bar' }),
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            expect(res.status).toEqual(200);
+            expect(await res.json()).toEqual({ foo: 'bar' });
+        });
+
+        test('treats empty body as empty object', async () => {
+            const handler = jest.fn((request, response) => {
+                response.end(JSON.stringify(request.body));
+            });
+
+            server.post('/upload', [parseBodyJSONWithLimit(1024), handler]);
+            await server.start();
+            const { address, port } = server.getServerAddress();
+
+            const res = await fetch(`http://${address}:${port}/upload`, {
+                method: 'POST',
+            });
+
+            expect(res.status).toEqual(200);
+            expect(await res.json()).toEqual({});
         });
     });
 });


### PR DESCRIPTION
some little additions to node-utils/http so that it can be reused in  #25825

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=extend-http-server&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=extend-http-server&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=extend-http-server&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T12:31:53.234Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T12:30:38.017Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->