### PR TITLE
fix: remove forgotten dep-ignore in message-system

### DIFF
--- a/suite-common/message-system/.depcheckrc.json
+++ b/suite-common/message-system/.depcheckrc.json
@@ -1,7 +1,0 @@
-{
-    "ignore-patterns": ["libDev", "lib"],
-    "ignores": [
-        "// Todo: This need so be solved. See: https://github.com/trezor/trezor-suite/issues/21552",
-        "@suite-common/analytics-redux"
-    ]
-}

--- a/suite-common/message-system/package.json
+++ b/suite-common/message-system/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/analytics-redux": "workspace:*",
         "@suite-common/geolocation": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/suite-common/message-system/tsconfig.json
+++ b/suite-common/message-system/tsconfig.json
@@ -10,6 +10,7 @@
         "files"
     ],
     "references": [
+        { "path": "../analytics-redux" },
         { "path": "../geolocation" },
         { "path": "../redux-utils" },
         { "path": "../suite-types" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11484,6 +11484,7 @@ __metadata:
   resolution: "@suite-common/message-system@workspace:suite-common/message-system"
   dependencies:
     "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/analytics-redux": "workspace:*"
     "@suite-common/geolocation": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"


### PR DESCRIPTION
This is probably not needed anymore

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-circular&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-circular&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-circular&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T10:57:35.126Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T10:56:22.204Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->