### PR TITLE
fix: timerId typing issue

### DIFF
--- a/packages/blockchain-link/src/workers/solana/utils/getThrottledTransport.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/getThrottledTransport.ts
@@ -1,5 +1,7 @@
 import { type ClusterUrl, type RpcTransportFromClusterUrl } from '@solana/kit';
 
+import { type TimerId } from '@trezor/type-utils';
+
 const DEFAULT_MAX_RPS = 4; // Default maximum requests per second
 const DEFAULT_INTERVAL = 1000; // Default interval in milliseconds (1 second)
 
@@ -37,7 +39,7 @@ export const getThrottledTransport = <TClusterUrl extends ClusterUrl>(
      * When the first request is made, schedule a reset of the request budget for 1 second from now,
      * and store the timer of that scheduled reset here.
      */
-    let pendingQueueRunTimerId: NodeJS.Timeout | undefined;
+    let pendingQueueRunTimerId: TimerId | undefined;
     /**
      * Keep a queue of requests and resolve/reject functions.
      */


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/issues/26013

Node-only type for Timer. 

See explanation in the: `packages/type-utils/src/timeout.ts`

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-time-id&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-time-id&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T11:07:52.481Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T11:06:24.557Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->