### PR TITLE
chore(suite): remove device from extraDependencies

### DIFF
--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -18,7 +18,10 @@ import {
     isStakeTypeTx,
 } from '@suite-common/wallet-utils';
 import { Row } from '@trezor/components';
-import { TransactionNotification } from '@trezor/product-components';
+import {
+    TransactionNotification,
+    type TransactionNotificationType,
+} from '@trezor/product-components';
 
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { AccountLabeling } from 'src/components/suite/labeling';
@@ -27,16 +30,7 @@ import type { NotificationViewProps } from 'src/components/suite/notifications/N
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type TransactionRendererProps = NotificationViewProps &
-    NotificationRendererProps<
-        | 'tx-sent'
-        | 'tx-received'
-        | 'tx-confirmed'
-        | 'tx-staked'
-        | 'tx-unstaked'
-        | 'tx-claimed'
-        | 'tx-approved'
-        | 'tx-revoked'
-    >;
+    NotificationRendererProps<TransactionNotificationType>;
 
 export const TransactionRenderer = ({ render: View, ...props }: TransactionRendererProps) => {
     const { symbol, descriptor, txid, device } = props.notification;

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -154,7 +154,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
         selectDebugSettings,
         // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
         selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
-        selectDevice: (state: AppState) => state.device.selectedDevice,
         selectLanguage,
         selectMetadata: (state: AppState) => state.metadata,
         selectAddressDisplayType,

--- a/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
+++ b/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
@@ -1,4 +1,4 @@
-import { deviceActions } from '@suite-common/device';
+import { deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { Feature, selectIsFeatureDisabled } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
 import { type StoredAuthenticateDeviceResult } from '@suite-common/suite-types';
@@ -22,9 +22,9 @@ export const checkDeviceAuthenticityThunk = createThunk<
     `${ACTION_PREFIX}/checkDeviceAuthenticity`,
     async (
         { allowDebugKeys, skipSuccessToast },
-        { dispatch, getState, extra, fulfillWithValue, rejectWithValue },
+        { dispatch, getState, fulfillWithValue, rejectWithValue },
     ) => {
-        const device = extra.selectors.selectDevice(getState());
+        const device = selectSelectedDevice(getState());
         if (!device) {
             throw new Error('device is not connected');
         }

--- a/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
+++ b/suite-common/device-authenticity/tests/deviceAuthenticityThunks.test.ts
@@ -11,12 +11,11 @@ import { checkDeviceAuthenticityThunk } from '../src/checkDeviceAuthenticityThun
 
 const initStore = (device?: TrezorDevice) =>
     configureMockStore({
-        extra: {
-            selectors: {
-                selectDevice: () => device,
-            },
-        },
         preloadedState: {
+            device: {
+                selectedDevice: device,
+                devices: device ? [device] : [],
+            },
             messageSystem: messageSystemInitialState,
         },
     });

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -10,11 +10,7 @@ import { type MetadataAddPayload } from '@suite-common/metadata-types';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption'; // also only types
 import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
-import {
-    type ReportSecurityCheckDep,
-    type TrezorDevice,
-    type UserContextPayload,
-} from '@suite-common/suite-types';
+import { type ReportSecurityCheckDep, type UserContextPayload } from '@suite-common/suite-types';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
@@ -69,8 +65,6 @@ export type ExtraDependenciesStatic = {
         // but this is exactly what I need to get DebugModeOptions type instead of any
         selectDebugSettings: SuiteCompatibleSelector<any>;
         selectDesktopBinDir: SuiteCompatibleSelector<string | undefined>;
-        // a wallet-core selector that could be reused directly, but this one is used very often and would create circular deps
-        selectDevice: SuiteCompatibleSelector<TrezorDevice | undefined>;
         selectLanguage: SuiteCompatibleSelector<string>;
         selectIsWindowVisible: SuiteCompatibleSelector<boolean>;
         selectMetadata: SuiteCompatibleSelector<any>;

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -15,7 +15,6 @@ import {
 } from '@suite-common/redux-utils';
 import type { SuiteSync } from '@suite-common/suite-sync-types';
 import { type ReportSecurityCheckParams, asDelegatedIdentityKey } from '@suite-common/suite-types';
-import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import {
     AddressDisplayOptions,
     type SelectedAccountLoaded,
@@ -101,9 +100,6 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         }),
         selectDesktopBinDir: notImplementedSelector('selectDesktopBinDir', '/bin'),
         selectMetadata: notImplementedSelector('selectMetadata', {}),
-        selectDevice: notImplementedSelector('selectDevice', {
-            ...mockSuiteDevice(),
-        }),
         selectLanguage: notImplementedSelector('selectLanguage', 'en'),
         selectAddressDisplayType: notImplementedSelector(
             'selectAddressDisplayType',

--- a/suite-common/toast-notifications/src/notificationsActions.ts
+++ b/suite-common/toast-notifications/src/notificationsActions.ts
@@ -1,10 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { createActionWithExtraDeps } from '@suite-common/redux-utils';
-import { type TrezorDevice } from '@suite-common/suite-types';
 
 import { selectVisibleNotificationsByType } from './notificationsSelectors';
 import {
+    type AddNotificationAction,
     type NotificationEntry,
     type NotificationEventPayload,
     type NotificationId,
@@ -32,41 +32,41 @@ const remove = createAction(
 );
 
 // Shared function to transform payload to NotificationEntry
-export const toastPayloadTransform = (payload: ToastPayload, device?: TrezorDevice) =>
-    ({
-        context: 'toast' as const,
-        id: new Date().getTime(),
-        seen: true,
-        device,
-        ...payload,
-    }) satisfies NotificationEntry;
+const toastPayloadTransform = (payload: ToastPayload): NotificationEntry => ({
+    context: 'toast' as const,
+    id: new Date().getTime(),
+    seen: true,
+    ...payload,
+});
 
-export const addToast = createActionWithExtraDeps(
+export const addToast = createAction(
     `${ACTION_PREFIX}/addToast`,
-    (payload: ToastPayload, { getState, extra }): NotificationEntry =>
-        toastPayloadTransform(payload, extra.selectors.selectDevice(getState())),
+    (payload: ToastPayload): AddNotificationAction => ({
+        payload: toastPayloadTransform(payload),
+    }),
 );
 
 // Adds a Toast if there is not one of same type visible.
 export const addToastOnce = createActionWithExtraDeps(
     `${ACTION_PREFIX}/addToastOnce`,
-    (payload: ToastPayload, { getState, extra }): NotificationEntry | undefined => {
+    (payload: ToastPayload, { getState }): NotificationEntry | undefined => {
         const notifications = selectVisibleNotificationsByType(getState(), payload.type);
         if (notifications.length > 0) {
             return;
         }
 
-        return toastPayloadTransform(payload, extra.selectors.selectDevice(getState()));
+        return toastPayloadTransform(payload);
     },
 );
 
-export const addEvent = createActionWithExtraDeps(
+export const addEvent = createAction(
     `${ACTION_PREFIX}/addEvent`,
-    (payload: NotificationEventPayload, { getState, extra }): NotificationEntry => ({
-        context: 'event',
-        id: new Date().getTime(),
-        device: extra.selectors.selectDevice(getState()),
-        ...payload,
+    (payload: NotificationEventPayload): AddNotificationAction => ({
+        payload: {
+            context: 'event',
+            id: new Date().getTime(),
+            ...payload,
+        },
     }),
 );
 

--- a/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
+++ b/suite-common/toast-notifications/src/tests/notificationsReducer.test.ts
@@ -14,11 +14,6 @@ interface InitStoreArgs {
 
 const initStore = ({ preloadedState }: InitStoreArgs = {}) => {
     const store = configureMockStore({
-        extra: {
-            selectors: {
-                selectDevice: () => undefined,
-            },
-        },
         reducer: { notifications: notificationsReducer },
         preloadedState,
     });

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -218,6 +218,10 @@ export type NotificationEntry<TranslationKey extends string = UnknownTranslation
     | ToastNotification<TranslationKey>
     | EventNotification;
 
+export type AddNotificationAction<TranslationKey extends string = UnknownTranslationKey> = {
+    payload: NotificationEntry<TranslationKey>;
+};
+
 export type NotificationsState<TranslationKey extends string = UnknownTranslationKey> =
     NotificationEntry<TranslationKey>[];
 

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -3,7 +3,6 @@ import { Platform } from 'react-native';
 import * as Device from 'expo-device';
 
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
-import { selectSelectedDevice } from '@suite-common/device';
 import { createNativePlatformEncryption } from '@suite-common/platform-encryption-native';
 import {
     type ExtraDependenciesStatic,
@@ -104,7 +103,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
     selectors: {
         selectLanguage: selectSupportedLanguageLocale,
         selectTokenDefinitionsEnabledNetworks,
-        selectDevice: selectSelectedDevice,
         selectDebugSettings: () => ({
             transports,
         }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `selectSelectedDevice` from `extraDependencies`. 


## Notes for QA
Nothing to test, app should behave the same.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/suite/selected-device-in-extra-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/suite/selected-device-in-extra-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/suite/selected-device-in-extra-deps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T14:31:45.294Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T14:29:59.160Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->