### PR TITLE
test(e2e-native): simplify deviceOnboardingActions useless calls

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -183,11 +183,10 @@ class DeviceOnboardingActions {
         await this.pressHoldToConfirmButton();
         await this.waitForWalletCreationScreen();
 
-        await TrezorUserEnvLink.swipeEmu('up');
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressNo();
         // at this point, wallet creation + entropy check on device has begun
+        await TrezorUserEnvLink.swipeEmu('up');
+        // backup flow confirmation, so we reject it early, so resetDevice call is resolved
+        await TrezorUserEnvLink.pressNo();
     }
 }
 


### PR DESCRIPTION
## Description

Remove two useless `pressYes` calls.
See the screenshot below: currently it starts backup flow on device, but doesn't finish it, because it rejects it.
We can reject it earlier, Suite doesn't know what's happenning, it just knows when `resetDevice` resolves, so it doesn't matter.

If CI passes then it's OK.

## Screenshots:

[step by step.webm](https://github.com/user-attachments/assets/2caad3f0-2fa5-44fc-bdd8-494d88322d91)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/simplify-device-onboarding-actions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->