### PR TITLE
refactor(connect): use TrezorConnectManagement in call types

### DIFF
--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -2,7 +2,7 @@ import type { SerializedError } from '@trezor/connect-common/src/constants/error
 import { serializeError } from '@trezor/connect-common/src/constants/errors';
 
 import type { CORE_CALL } from './core-call';
-import type { TrezorConnect } from '../types/api';
+import type { TrezorConnect, TrezorConnectManagement } from '../types/api';
 import type { IDevice } from '../types/idevice';
 import type { CommonParams, DeviceIdentity } from '../types/params';
 
@@ -42,19 +42,12 @@ type CallApi = {
         ? never
         : UnwrappedMethod<TrezorConnect[K], { method: K }>;
 };
-type TopLevelMethods =
-    | 'cancel'
-    | 'dispose'
-    | 'off'
-    | 'on'
-    | 'removeAllListeners'
-    | 'updateConnectSettings'
-    | 'uiResponse';
+type TrezorConnectManagementMethods = keyof TrezorConnectManagement;
 
 // necessary part of CallMethod which shouldn't be exposed to the consumers
 type SupportParams = { useEventListener?: boolean };
 
-export type CallMethodKeys = Exclude<keyof CallApi, TopLevelMethods>;
+export type CallMethodKeys = Exclude<keyof CallApi, TrezorConnectManagementMethods>;
 export type CallMethodUnion = CallApi[CallMethodKeys];
 export type CallMethodPayload = Parameters<CallMethodUnion>[0] & SupportParams;
 export type CallMethodParams<M extends CallMethodKeys> = Parameters<CallApi[M]>[0];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow-up from https://github.com/trezor/trezor-suite/pull/25314

Now we have type `TrezorConnectManagement` that can be used to avoid repetition of the `TopLevelMethods`.

## Notes for QA

Nothing to test just code refactor.

## Related Issue

Related to https://github.com/trezor/trezor-suite/pull/25314

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/refacto-top-level-methods&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/refacto-top-level-methods&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T09:00:10.090Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->