### PR TITLE
chore(e2e-native): commentary on deviceOnboardingActions

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -183,11 +183,11 @@ class DeviceOnboardingActions {
         await this.pressHoldToConfirmButton();
         await this.waitForWalletCreationScreen();
 
-        await TrezorUserEnvLink.swipeEmu('up');
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressYes();
-        await TrezorUserEnvLink.pressNo();
-        // at this point, wallet creation + entropy check on device has begun
+        await TrezorUserEnvLink.swipeEmu('up'); // begins wallet creation + entropy check on device
+        // wallet creation is finished, but because resetDevice is called with skip_backup: false, the resetDevice call is still pending
+        await TrezorUserEnvLink.pressYes(); // start backup flow
+        await TrezorUserEnvLink.pressYes(); // press Continue
+        await TrezorUserEnvLink.pressNo(); // reject backup flow early, so pending resetDevice settles
     }
 }
 


### PR DESCRIPTION
## Description

Fix and add more commentary about what the steps mean.
Screencast below.

## Screenshots:

[step by step.webm](https://github.com/user-attachments/assets/2caad3f0-2fa5-44fc-bdd8-494d88322d91)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/device-onboarding-actions-commentary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->