### PR TITLE
Fix hot reload

### DIFF
--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -35,7 +35,7 @@ const messageSystemMockFile = path.join(
 const config: webpack.Configuration = {
     // Electron 39 runs on Chromium 142 https://www.electronjs.org/blog/electron-39-0
     target: 'browserslist:Chrome >= 142',
-    entry: [path.join(baseDirUI, 'src', 'index.tsx')],
+    entry: { main: [path.join(baseDirUI, 'src', 'index.tsx')] },
     output: {
         // This builds JS directly `dist/` (instead `dist/js/`)
         // without this, Evolu worker import won't (for unknow reason) work

--- a/packages/suite-build/configs/dev.webpack.config.ts
+++ b/packages/suite-build/configs/dev.webpack.config.ts
@@ -16,7 +16,7 @@ const config: webpack.Configuration = {
     mode: 'development',
     watch: true,
     devtool: 'eval-source-map',
-    entry: ['webpack-plugin-serve/client'],
+    entry: { main: ['webpack-plugin-serve/client'] },
     output: {
         // This builds JS directly `dist/` (instead `dist/js/`)
         // without this, Evolu worker import won't (for unknow reason) work

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -15,8 +15,8 @@ export const baseDir = getPathForProject('web');
 const config: webpack.Configuration = {
     target: 'browserslist',
     entry: {
-        main: path.join(baseDir, 'src', 'index.ts'),
-        ['sessions-background-sharedworker']: {
+        main: [path.join(baseDir, 'src', 'index.ts')],
+        'sessions-background-sharedworker': {
             filename: 'workers/[name].js',
             import: path.resolve(
                 __dirname,


### PR DESCRIPTION
## Description

It seems that since #23829 hot reload wasn't working for `yarn suite:dev`.

The reason is that `entry` in `web.webpack.config.ts` changed format from an array to an object, therefore merging it with array from `dev.webpack.config.ts` (containing `'webpack-plugin-serve/client'` vital for hot reloading) effectively replaced it instead. I've changed it to an object as well (also in `desktop.webpack.config.ts`) so merging the configs works again in both cases.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hot-reload&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hot-reload&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-23T16:21:29.642Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T16:20:02.056Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->