### PR TITLE
Allocate remaining quota when its smaller than the DEFAULT_INCREMENT

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -9,20 +9,23 @@ import {
     type EnsureOwnerHasAllocatedQuota,
     type EnsureOwnerHasAllocatedQuotaParams,
     type HttpErrType,
+    type NoQuotaLeftToAllocateErrType,
     type ProofOfDelegatedIdentityFailedErrType,
     type WriteModeRequiredForAllocationErrType,
 } from '@suite-common/suite-sync-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
 import {
-    DEFAULT_ACCOUNT_SIZE_QUOTA,
+    DEFAULT_DEVICE_SIZE_QUOTA,
     EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
 } from './constants';
 import { quotaManagerOwnerFetched } from './quotaManagerActions';
-import { selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
+import { selectLeftDeviceQuota, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { checkStorageByOwnerId } from './storage/checkStorage';
 import { transferStorageThunk } from './storage/transferStorageThunk';
+import { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';
 import { prepareMessageBufferEvoluAddSpaceToOwner } from './util/prepareMessageBufferEvoluAddSpaceToOwner';
 
 export const WriteModeRequiredForAllocation = (): WriteModeRequiredForAllocationErrType => ({
@@ -41,14 +44,19 @@ export const ProofOfDelegatedIdentityFailed = (): ProofOfDelegatedIdentityFailed
     type: 'ProofOfDelegatedIdentityFailed',
 });
 
+export const NoQuotaLeftToAllocate = (): NoQuotaLeftToAllocateErrType => ({
+    type: 'NoQuotaLeftToAllocate',
+});
+
 export const ensureOwnerHasAllocatedQuotaThunk =
     ({
         ownerId,
-        walletDescriptor,
+        deviceStaticSessionId,
         delegatedKey,
         isWriteMode,
     }: EnsureOwnerHasAllocatedQuotaParams) =>
     async (dispatch: Dispatch, getState: () => any): ReturnType<EnsureOwnerHasAllocatedQuota> => {
+        const { walletDescriptor, deviceId } = parseDeviceStaticSessionId(deviceStaticSessionId);
         const quotaManagerBaseUrl = selectQuotaManagerBaseUrl(getState());
 
         const hasOwnerStorage = await checkStorageByOwnerId({
@@ -79,6 +87,15 @@ export const ensureOwnerHasAllocatedQuotaThunk =
             return err(WriteModeRequiredForAllocation());
         }
 
+        const leftDeviceQuota = selectLeftDeviceQuota(getState(), deviceId);
+        const sizeToAllocate = getAccountIncrementSizeQuota({
+            unspentStorage: leftDeviceQuota ?? DEFAULT_DEVICE_SIZE_QUOTA,
+        });
+
+        if (sizeToAllocate === 0) {
+            return err(NoQuotaLeftToAllocate());
+        }
+
         const sessionChallenge = await prepareChallengeSession({
             baseUrl: quotaManagerBaseUrl,
         });
@@ -94,7 +111,7 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                 publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                 ownerId,
                 challenge: sessionChallenge.payload.challenge,
-                size: DEFAULT_ACCOUNT_SIZE_QUOTA,
+                size: sizeToAllocate,
             }),
         });
 
@@ -108,11 +125,12 @@ export const ensureOwnerHasAllocatedQuotaThunk =
                     ownerId,
                     publicKey: getPublicIdentityKeyFromDelegatedKey(delegatedKey),
                     proof: proofOfDelegatedIdentity.payload,
-                    size: DEFAULT_ACCOUNT_SIZE_QUOTA,
+                    size: sizeToAllocate,
                     challenge: sessionChallenge.payload.challenge,
                     sessionId: sessionChallenge.payload.sessionId,
                 },
                 walletDescriptor,
+                deviceId,
             }),
         );
 

--- a/suite-common/suite-sync-quota-manager/src/increaseOwnerQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/increaseOwnerQuotaThunk.ts
@@ -12,11 +12,12 @@ import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 
 import { prepareChallengeSession } from './challenge/prepareChallengeSession';
 import {
-    DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+    DEFAULT_DEVICE_SIZE_QUOTA,
     EVOLU_SIGN_ADD_SPACE_TO_OWNER_REQUEST_HEADER,
 } from './constants';
-import { selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
+import { selectLeftDeviceQuota, selectQuotaManagerBaseUrl } from './quotaManagerSelectors';
 import { transferStorageThunk } from './storage/transferStorageThunk';
+import { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';
 import { prepareMessageBufferEvoluAddSpaceToOwner } from './util/prepareMessageBufferEvoluAddSpaceToOwner';
 
 type AllocateMoreOwnerQuotaParams = {
@@ -33,6 +34,15 @@ export const increaseOwnerQuotaThunk =
         }
         const { walletDescriptor } = parseDeviceStaticSessionId(device.state.staticSessionId);
         const quotaManagerBaseUrl = selectQuotaManagerBaseUrl(getState());
+
+        const leftDeviceQuota = selectLeftDeviceQuota(getState(), device.id);
+
+        const sizeToAllocate = getAccountIncrementSizeQuota({
+            unspentStorage: leftDeviceQuota ?? DEFAULT_DEVICE_SIZE_QUOTA,
+        });
+        if (sizeToAllocate === 0) {
+            return;
+        }
 
         const delegatedKey = await extra.services.ensureDelegatedIdentityKey({ device });
         if (!delegatedKey.success) {
@@ -55,7 +65,7 @@ export const increaseOwnerQuotaThunk =
             appendMessageBuffer: prepareMessageBufferEvoluAddSpaceToOwner({
                 ownerId,
                 challenge: sessionChallenge.payload.challenge,
-                size: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                size: sizeToAllocate,
                 publicKey: delegatedPublicKey,
             }),
         });
@@ -66,10 +76,11 @@ export const increaseOwnerQuotaThunk =
 
         dispatch(
             transferStorageThunk({
+                deviceId: device.id,
                 walletDescriptor,
                 params: {
                     ownerId,
-                    size: DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
+                    size: sizeToAllocate,
                     proof: proof.payload,
                     sessionId: sessionChallenge.payload.sessionId,
                     challenge: sessionChallenge.payload.challenge,

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -55,3 +55,5 @@ export {
  * Constants.
  */
 export { DEFAULT_DEVICE_SIZE_QUOTA } from './constants';
+
+export { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -3,6 +3,7 @@ import { mocked } from 'jest-mock';
 import { DELEGATED_IDENTITY_KEY } from '@suite-common/delegated-identity-key-types/mocks';
 import { asSuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
 import { type WalletDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { prepareChallengeSession } from '../challenge/prepareChallengeSession';
@@ -34,6 +35,8 @@ const createGetState = (statePatch?: Partial<SuiteSyncQuotaManagerState>) => () 
 
 const ownerId = asSuiteSyncOwnerId('owner-id');
 const walletDescriptor: WalletDescriptor = asWalletDescriptor('descriptor');
+const deviceId = 'device-123';
+const deviceStaticSessionId = `${walletDescriptor}@${deviceId}` as StaticSessionId;
 
 const prepareChallengeSessionMock = mocked(prepareChallengeSession);
 const checkStorageByOwnerIdMock = mocked(checkStorageByOwnerId);
@@ -54,7 +57,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceStaticSessionId,
             isWriteMode: false,
         })(dispatch, getState);
 
@@ -75,6 +78,33 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         expect(transferStorageThunkMock).not.toHaveBeenCalled();
     });
 
+    it("not attempt to allocate quota when none is remaining and return 'NoQuotaLeftToAllocate' error", async () => {
+        const getState = createGetState({
+            registeredDevices: [
+                {
+                    deviceId,
+                    totalStorageSize: 5000,
+                    unspentStorageSize: 0,
+                    dismissedNoQuotaLeftWarning: false,
+                },
+            ],
+        });
+        const dispatch = jest.fn();
+
+        checkStorageByOwnerIdMock.mockResolvedValue(
+            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
+        );
+        const result = await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey: DELEGATED_IDENTITY_KEY,
+            deviceStaticSessionId,
+            isWriteMode: true,
+        })(dispatch, getState);
+
+        expect(result).toEqual(err({ type: 'NoQuotaLeftToAllocate' }));
+        expect(prepareChallengeSessionMock).not.toHaveBeenCalled();
+    });
+
     it('dispatches quota manager error for non-404 failures', async () => {
         const getState = createGetState();
         const dispatch = jest.fn();
@@ -86,7 +116,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceStaticSessionId,
             isWriteMode: false,
         })(dispatch, getState);
 
@@ -115,7 +145,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
-            walletDescriptor,
+            deviceStaticSessionId,
             isWriteMode: true,
         })(dispatch, getState);
 
@@ -133,7 +163,54 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
                 sessionId: 'session-123',
             },
             walletDescriptor,
+            deviceId,
         });
+        expect(transferThunkInner).toHaveBeenCalled();
+    });
+
+    it('allocates remaining quota when unspent storage is less than default increment', async () => {
+        const remainingQuota = 500;
+        const getState = createGetState({
+            registeredDevices: [
+                {
+                    deviceId,
+                    totalStorageSize: 5000,
+                    unspentStorageSize: remainingQuota,
+                    dismissedNoQuotaLeftWarning: false,
+                },
+            ],
+        });
+        const dispatch: ReturnType<typeof jest.fn> = jest.fn((action: unknown) => {
+            if (typeof action === 'function')
+                return (action as (...args: any[]) => any)(dispatch, getState);
+
+            return action;
+        });
+
+        checkStorageByOwnerIdMock.mockResolvedValue(
+            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
+        );
+        prepareChallengeSessionMock.mockResolvedValue(
+            ok({ sessionId: 'session-456', challenge: 'bb66' }),
+        );
+
+        const transferThunkInner = jest.fn();
+        transferStorageThunkMock.mockReturnValue(transferThunkInner);
+
+        await ensureOwnerHasAllocatedQuotaThunk({
+            ownerId,
+            delegatedKey: DELEGATED_IDENTITY_KEY,
+            deviceStaticSessionId,
+            isWriteMode: true,
+        })(dispatch, getState);
+
+        expect(transferStorageThunkMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    size: remainingQuota,
+                }),
+            }),
+        );
         expect(transferThunkInner).toHaveBeenCalled();
     });
 });

--- a/suite-common/suite-sync-quota-manager/src/util/getAccountIncrementSizeQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/util/getAccountIncrementSizeQuota.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA } from '../constants';
+
+type GetAccountIncrementSizeQuotaParams = {
+    unspentStorage: number;
+};
+
+export const getAccountIncrementSizeQuota = ({
+    unspentStorage,
+}: GetAccountIncrementSizeQuotaParams) => {
+    if (unspentStorage < DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA) {
+        return unspentStorage;
+    }
+
+    return DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA;
+};

--- a/suite-common/suite-sync-quota-manager/src/util/tests/getAccountIncrementSizeQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/util/tests/getAccountIncrementSizeQuota.test.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA, DEFAULT_DEVICE_SIZE_QUOTA } from '../../constants';
+import { getAccountIncrementSizeQuota } from '../getAccountIncrementSizeQuota';
+
+describe(getAccountIncrementSizeQuota.name, () => {
+    it('return default account size quota if unspent storage is bigger than default', () => {
+        const result = getAccountIncrementSizeQuota({ unspentStorage: DEFAULT_DEVICE_SIZE_QUOTA });
+
+        expect(result).toBe(DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA);
+    });
+
+    it("return remaining unspent storage if it's smaller than default account size quota", () => {
+        const unspentStorage = 500;
+        const result = getAccountIncrementSizeQuota({ unspentStorage });
+
+        expect(result).toBe(unspentStorage);
+    });
+
+    it('return 0 when unspentStorage size is 0', () => {
+        const unspentStorage = 0;
+        const result = getAccountIncrementSizeQuota({ unspentStorage });
+
+        expect(result).toBe(0);
+    });
+});

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -89,4 +89,5 @@ export type {
     ChallengeFailedErrType,
     HttpErrType,
     ProofOfDelegatedIdentityFailedErrType,
+    NoQuotaLeftToAllocateErrType,
 } from './quotaManager/ensureOwnerHasAllocatedQuotaThunk';

--- a/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-types/src/quotaManager/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -1,6 +1,6 @@
 import { type SuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
 import { type DelegatedIdentityKey } from '@suite-common/suite-types';
-import { type WalletDescriptor } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
 import { type Result } from '@trezor/type-utils';
 
 import { type WriteModeRequiredForAllocationErrType } from './quotaManagerTypes';
@@ -11,9 +11,11 @@ export type ChallengeFailedErrType = { type: 'ChallengeFailed' };
 
 export type ProofOfDelegatedIdentityFailedErrType = { type: 'ProofOfDelegatedIdentityFailed' };
 
+export type NoQuotaLeftToAllocateErrType = { type: 'NoQuotaLeftToAllocate' };
+
 export type EnsureOwnerHasAllocatedQuotaParams = {
     ownerId: SuiteSyncOwnerId;
-    walletDescriptor: WalletDescriptor;
+    deviceStaticSessionId: StaticSessionId;
     delegatedKey: DelegatedIdentityKey;
     isWriteMode: boolean;
 };
@@ -27,5 +29,6 @@ export type EnsureOwnerHasAllocatedQuota = (
         | HttpErrType
         | ChallengeFailedErrType
         | ProofOfDelegatedIdentityFailedErrType
+        | NoQuotaLeftToAllocateErrType
     >
 >;

--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -72,7 +72,7 @@ export const createEnsureQuota =
 
         const allocatedQuota = await deps.dispatch(
             ensureOwnerHasAllocatedQuotaThunk({
-                walletDescriptor,
+                deviceStaticSessionId,
                 ownerId: owner.ownerId,
                 delegatedKey,
                 isWriteMode,


### PR DESCRIPTION
Due to the rounding, users could have a "dead remaining" quota left. So, I have added a util to allocate even the remaining quota.

**Changes**:
- added `getAccountIncrementSizeQuota` util and tests
- implemented the util above in `ensureOwnerHasAllocatedQuotaThunk` and `increaseOwnerQuotaThunk`
- passing `deviceSessionId` to `ensureOwnerHasAllocatedQuotaThunk`


## Notes for QA
- user should be able to allocate quota until the device's unspent storage size is 0

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/ss/account-increment-size-quota&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/ss/account-increment-size-quota&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/ss/account-increment-size-quota&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T00:28:40.042Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Sync labels from server | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-23T22:51:01.917Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->