### PR TITLE
harden electron security config and add missing ipc validation

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -74,6 +74,9 @@ const createMainWindow = ({ winBounds, cspNonce, store }: CreateMainWindowParams
               }
             : {}),
         webPreferences: {
+            nodeIntegration: false,
+            contextIsolation: true,
+            sandbox: true,
             webSecurity: !isDevEnv,
             allowRunningInsecureContent: isDevEnv,
             preload: path.join(__dirname, 'preload.js'),

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -9,6 +9,7 @@ import {
 import { unlinkSync } from 'fs';
 
 import { isDevEnv, isFeatureFlagEnabled } from '@suite-common/suite-utils';
+import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { type HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
@@ -238,7 +239,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         );
     });
 
-    ipcMain.on('update/check', (_, { isManual }) => {
+    ipcMain.on('update/check', (ipcEvent, { isManual }) => {
+        validateIpcMessage({ ipcEvent });
         if (isManual === true) {
             isManualCheck = true;
         }
@@ -247,16 +249,21 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         autoUpdater.checkForUpdates();
     });
 
-    ipcMain.on('update/download', startDownload);
+    ipcMain.on('update/download', ipcEvent => {
+        validateIpcMessage({ ipcEvent });
+        startDownload();
+    });
 
-    ipcMain.on('update/set-auto-install-on-app-quit', () => {
+    ipcMain.on('update/set-auto-install-on-app-quit', ipcEvent => {
+        validateIpcMessage({ ipcEvent });
         // If the update is triggered manually by the button in the app, we want to force update,
         // because it may have been disabled by the user switch the automatic update off. But because the user deliberately
         // clicked the "Update on quit" button, we want to install it.
         autoUpdater.autoInstallOnAppQuit = true;
     });
 
-    ipcMain.on('update/install', () => {
+    ipcMain.on('update/install', ipcEvent => {
+        validateIpcMessage({ ipcEvent });
         logger.info(SERVICE_NAME, 'Restart and update request');
 
         setImmediate(() => {
@@ -271,7 +278,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         });
     });
 
-    ipcMain.on('update/cancel', () => {
+    ipcMain.on('update/cancel', ipcEvent => {
+        validateIpcMessage({ ipcEvent });
         logger.info(
             SERVICE_NAME,
             `Cancel update request (in progress: ${b2t(!!updateCancellationToken)})`,
@@ -281,7 +289,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         }
     });
 
-    ipcMain.on('update/allow-prerelease', (_, value = true) => {
+    ipcMain.on('update/allow-prerelease', (ipcEvent, value = true) => {
+        validateIpcMessage({ ipcEvent });
         logger.info(SERVICE_NAME, `${value ? 'allow' : 'disable'} prerelease!`);
         mainWindowProxy.getInstance()?.webContents.send('update/allow-prerelease', value);
         const settings = store.getUpdateSettings();
@@ -293,7 +302,8 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         logger.info(SERVICE_NAME, `New feed url: ${feedURL}`);
     });
 
-    ipcMain.on('update/set-automatic-update-enabled', (_, value = true) => {
+    ipcMain.on('update/set-automatic-update-enabled', (ipcEvent, value = true) => {
+        validateIpcMessage({ ipcEvent });
         logger.info(SERVICE_NAME, `set-automatic-update-enabled: ${value ? 'true' : 'false'}`);
 
         mainWindowProxy

--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -17,7 +17,9 @@ const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     "default-src 'self'",
     "script-src 'self'",
     `style-src 'self' 'nonce-${nonce}'`,
-    // Allow all API calls (Can't be restricted bc of custom backends)
+    // connect-src is permissive because custom backends need arbitrary domains.
+    // The request-filter module provides additional domain-level allowlisting.
+    // Note that connect-src is a CSP policy that has nothing to do with the former TrezorConnect parameter of the same name
     'connect-src data: *',
     // Allow images from trezor.io
     "img-src 'self' blob: data: https://*.trezor.io",

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -52,6 +52,8 @@ const PRODUCTION_SECURITY_HEADERS = {
         'style-src': ['self', 'unsafe-inline'],
         'style-src-elem': ['self', 'unsafe-inline'],
         'img-src': ['self', 'blob:', 'data:', 'https://*.trezor.io'],
+        // connect-src is permissive because custom backends need arbitrary domains.
+        // Note that connect-src is a CSP policy that has nothing to do with the former TrezorConnect parameter of the same name
         'connect-src': ['data:', '*'],
         'upgrade-insecure-requests': true,
         'script-src': ['self', 'unsafe-eval'],


### PR DESCRIPTION
## Description

Recreate #25930 from @YashejShah

I agree overall with the `validateIpc` change. Although desktop-updater accepts no payload from renderer process except for `value: boolean` in one particular case, so a malicious senderFrame could not inject anything but that, it still can trigger actions that user might not want. Or this might change in future.
So it's a good call. I tested it and it works ✔️ 

As for the BrowserWindow defaults, I doubt that Electron would silently change these defaults without a Breaking change alert, Electron is very conservative about API changes, nevertheless I agree with this, explicit is better than implicit when it comes to security 👍 

## Notes for QA

Can be done as part of routine release checks :slightly_smiling_face: 

- Build desktop app with old suite version in `packages/suite/package.json`
- Test desktop update on all platforms 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/electron-security-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/electron-security-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T08:56:17.217Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-24T09:51:42.412Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->