### PR TITLE
chore(suite): remove outdated connect-src security config

### DIFF
--- a/packages/suite-desktop-core/src/modules/csp.ts
+++ b/packages/suite-desktop-core/src/modules/csp.ts
@@ -17,8 +17,6 @@ const createCspRules = ({ nonce }: CreateCspRulesParams) => [
     "default-src 'self'",
     "script-src 'self'",
     `style-src 'self' 'nonce-${nonce}'`,
-    // Allow all API calls (Can't be restricted bc of custom backends)
-    'connect-src data: *',
     // Allow images from trezor.io
     "img-src 'self' blob: data: https://*.trezor.io",
 ];

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -52,7 +52,6 @@ const PRODUCTION_SECURITY_HEADERS = {
         'style-src': ['self', 'unsafe-inline'],
         'style-src-elem': ['self', 'unsafe-inline'],
         'img-src': ['self', 'blob:', 'data:', 'https://*.trezor.io'],
-        'connect-src': ['data:', '*'],
         'upgrade-insecure-requests': true,
         'script-src': ['self', 'unsafe-eval'],
         'report-uri': SENTRY_REPORT_URL,

--- a/packages/suite-web/types/securityHeaders.ts
+++ b/packages/suite-web/types/securityHeaders.ts
@@ -5,7 +5,6 @@ export type ContentSecurityPolicyRules = {
     'style-src': string[];
     'style-src-elem': string[];
     'img-src': string[];
-    'connect-src': string[];
     'upgrade-insecure-requests': true;
     'report-uri': string;
     'report-to': string;


### PR DESCRIPTION
## Description

Since #17242 there is no `connect-src` API exposed from Connect to Suite Web or Desktop.
The security policy exceptions for `connect-src` are useless since then _(maybe even before that, does not matter)_

## Notes for QA

Check that Connect network functionality is not affected – no bugs because of inaccessible resources.
- e.g. discovery, fees, custom backends, all works

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-connect-src-security-configs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-connect-src-security-configs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T09:07:28.857Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-24T09:06:07.905Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->