### PR TITLE
fix(trading): prevent cross-network address contamination in swap form

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -140,7 +140,6 @@ export const useTradingBuyForm = ({
     const tradingReceiveAddress = useTradingReceiveAddress({
         type: 'buy',
         cryptoId: values.cryptoSelect?.id,
-        isPreviousRouteFromTradeSection,
         nonSuiteAccount: !selectedQuote?.tags?.includes('noExternalAddress'),
         pageType,
     });

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -180,7 +180,6 @@ export const useTradingExchangeForm = ({
     const tradingReceiveAddress = useTradingReceiveAddress({
         type: 'exchange',
         cryptoId: receiveCryptoSelect?.id,
-        isPreviousRouteFromTradeSection,
         nonSuiteAccount: !selectedQuote?.tags?.includes('noExternalAddress'),
         pageType,
     });

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { type CryptoId } from 'invity-api';
@@ -19,6 +19,7 @@ import {
 } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
 import { filterReceiveAccounts } from '@suite-common/wallet-utils';
+import addressValidator from '@trezor/address-validator';
 
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -49,7 +50,6 @@ const getTranslationIds = (
 interface UseTradingReceiveAddressProps {
     cryptoId?: CryptoId;
     nonSuiteAccount: boolean;
-    isPreviousRouteFromTradeSection: boolean;
     pageType: TradingPageType;
     type: TradingType;
 }
@@ -58,7 +58,6 @@ export const useTradingReceiveAddress = ({
     type,
     cryptoId,
     nonSuiteAccount,
-    isPreviousRouteFromTradeSection,
     pageType,
 }: UseTradingReceiveAddressProps) => {
     const dispatch = useDispatch();
@@ -90,13 +89,6 @@ export const useTradingReceiveAddress = ({
     const [selectedAccount, setSelectedAccount] = useState<Account | null | undefined>(undefined);
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState<boolean | undefined>(undefined);
-    const initialSymbolRef = useRef<typeof symbol>(undefined);
-
-    useEffect(() => {
-        if (initialSymbolRef.current === undefined && symbol !== undefined) {
-            initialSymbolRef.current = symbol;
-        }
-    }, [symbol]);
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,
@@ -147,10 +139,14 @@ export const useTradingReceiveAddress = ({
     useEffect(() => {
         setSelectedAccount(undefined);
         setHasSelectionInitialized(false);
-    }, [symbol]);
+        methods.setValue('address', '', { shouldValidate: false });
+        methods.setValue('extraField', '', { shouldValidate: false });
+    }, [symbol, methods]);
 
     useEffect(() => {
-        if (!sendAccountKey) return;
+        if (!sendAccountKey || hasSelectionInitialized) {
+            return; // Don't override user selection
+        }
 
         const sendAccount =
             type === 'exchange'
@@ -168,14 +164,21 @@ export const useTradingReceiveAddress = ({
         if (!matchingAccount) return;
 
         selectSuiteAccount(matchingAccount);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [sendAccountKey, symbol]);
+    }, [
+        sendAccountKey,
+        symbol,
+        accounts,
+        suiteReceiveAccounts,
+        hasSelectionInitialized,
+        type,
+        selectSuiteAccount,
+    ]);
 
     useEffect(() => {
         if (!symbol) return;
         if (hasSelectionInitialized) return;
 
-        if (isPreviousRouteFromTradeSection && persistedReceiveAccountKey) {
+        if (persistedReceiveAccountKey) {
             const matchingAccount = suiteReceiveAccounts?.find(
                 account => account.key === persistedReceiveAccountKey,
             );
@@ -187,15 +190,17 @@ export const useTradingReceiveAddress = ({
             }
         }
 
-        if (
-            isPreviousRouteFromTradeSection &&
-            persistedReceiveAddress &&
-            canUseNonSuiteAccount &&
-            symbol === initialSymbolRef.current
-        ) {
-            selectNonSuiteAddress(persistedReceiveAddress);
+        if (persistedReceiveAddress && canUseNonSuiteAccount && symbol) {
+            const isValidForCurrentSymbol = addressValidator.validate(
+                persistedReceiveAddress,
+                symbol,
+            );
 
-            return;
+            if (isValidForCurrentSymbol) {
+                selectNonSuiteAddress(persistedReceiveAddress);
+
+                return;
+            }
         }
 
         const preferredReceiveAccountKey =
@@ -247,7 +252,6 @@ export const useTradingReceiveAddress = ({
         suiteReceiveAccounts,
         persistedReceiveAccountKey,
         persistedReceiveAddress,
-        isPreviousRouteFromTradeSection,
         walletSelectedAccount.account?.key,
         selectSuiteAccount,
         selectNonSuiteAddress,


### PR DESCRIPTION
Resolves #23875

## Description
Fixes the issue where the swap form uses wrong destination address after reconnecting device. When preparing a swap/trade in Suite desktop (e.g., WBTC→ETH), after pre-filling the form and disconnecting then reconnecting the device, the form incorrectly inputs another address (such as BTC address) into the Ethereum 'To' field.

## Notes for QA
- Open the desktop app and go to Swap (trade)
- Pre-fill a trade form (e.g., WBTC→ETH with a recipient address)
- Disconnect the hardware device
- Reconnect the device
- Verify: The destination address should be preserved correctly and match the selected asset
- Cross-asset address autofill should never occur

## Related Issue
Resolves #23875

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-swap-form-destination-address&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-swap-form-destination-address&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T07:26:54.075Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-24T09:41:05.153Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->