### PR TITLE
fix(suite-native): navigate to PIN protection screen in PIN e2e test

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceSettingsActions.ts
@@ -39,7 +39,7 @@ class DeviceSettingsActions {
         const redirectToPinScreenButton = element(
             by.id('@device-pin-protection/redirectToPinScreen'),
         );
-        await waitForVisible(redirectToPinScreenButton);
+        await scrollUntilVisible(redirectToPinScreenButton);
         await redirectToPinScreenButton.tap();
     }
 
@@ -49,11 +49,8 @@ class DeviceSettingsActions {
     }
 
     async tapEnablePinProtectionButton() {
-        await waitForVisible(by.id('@screen/PinProtection'));
-
         const enablePinProtectionButton = element(by.id('@device-pin-protection/enable-button'));
         await waitForVisible(enablePinProtectionButton);
-
         await enablePinProtectionButton.tap();
     }
 

--- a/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
+++ b/suite-native/app/e2e/tests/deviceSettingsT3T1.test.ts
@@ -26,6 +26,8 @@ describe('Device settings T3T1 [@androidOnly @smoke @T3T1]', () => {
     // Firmware 2.9.4 brought instability in firmware/emu interaction, this will be discussed with firmware team
     // We would have to put wait(500) in each step interacting with emulator
     test('Enable, change & disable PIN', async () => {
+        await onDeviceSettings.redirectToPinProtectionScreen();
+
         await onDeviceSettings.tapEnablePinProtectionButton();
         await TrezorUserEnvLink.pressNo();
         await onAlertSheet.tapPrimaryButton();


### PR DESCRIPTION
When FW update is available, the PIN protection card is not visible/tappable.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/e2e-device-settings-t3t1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->