### PR TITLE
Add TradingDeviceConnectionGuard to Exchange Approval and Revoke screens

### DIFF
--- a/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeApprovalScreen.tsx
@@ -21,6 +21,7 @@ import {
 
 import { ApprovalButton } from '../components/exchange/Approval/ApprovalButton';
 import { ExchangeApprovalDetails } from '../components/exchange/Approval/ExchangeApprovalDetails';
+import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
 import { useApprovalFlow } from '../hooks/exchange/Approval/useApprovalFlow';
 import { useEvmApprovalFees } from '../hooks/exchange/Approval/useEvmApprovalFees';
 
@@ -83,51 +84,53 @@ export const TradingExchangeApprovalScreen = ({
     }
 
     return (
-        <Screen
-            header={
-                <DynamicScreenHeader
-                    title={
-                        <Translation
-                            id="moduleTrading.tradingExchangeApprovalScreen.approveTitle"
-                            values={{ symbol: coinSymbol }}
-                        />
-                    }
-                    subtitle={
-                        <Translation
-                            id="moduleTrading.tradingExchangeApprovalScreen.approveSubtitle"
-                            values={{ symbol: coinSymbol }}
-                        />
-                    }
-                    closeActionType="back"
-                />
-            }
-            footer={<ApprovalButton isReady={isApprovalReady} isDisabled={!!error} />}
-        >
-            <VStack spacing="sp12">
-                {!!shouldIncreaseLimit && (
-                    <InlineAlertBox
-                        variant="info"
+        <TradingDeviceConnectionGuard>
+            <Screen
+                header={
+                    <DynamicScreenHeader
                         title={
-                            <Translation id="moduleTrading.tradingExchangeApprovalScreen.lowLimitInfoAlert" />
+                            <Translation
+                                id="moduleTrading.tradingExchangeApprovalScreen.approveTitle"
+                                values={{ symbol: coinSymbol }}
+                            />
                         }
-                    />
-                )}
-
-                {!!isRevoked && (
-                    <InlineAlertBox
-                        variant="success"
-                        title={
-                            <Translation id="moduleTrading.tradingExchangeApprovalScreen.revokeSuccessAlert" />
+                        subtitle={
+                            <Translation
+                                id="moduleTrading.tradingExchangeApprovalScreen.approveSubtitle"
+                                values={{ symbol: coinSymbol }}
+                            />
                         }
+                        closeActionType="back"
                     />
-                )}
+                }
+                footer={<ApprovalButton isReady={isApprovalReady} isDisabled={!!error} />}
+            >
+                <VStack spacing="sp12">
+                    {!!shouldIncreaseLimit && (
+                        <InlineAlertBox
+                            variant="info"
+                            title={
+                                <Translation id="moduleTrading.tradingExchangeApprovalScreen.lowLimitInfoAlert" />
+                            }
+                        />
+                    )}
 
-                <ExchangeApprovalDetails
-                    fee={fee}
-                    isLoading={isLoading}
-                    exchange={quote.exchange}
-                />
-            </VStack>
-        </Screen>
+                    {!!isRevoked && (
+                        <InlineAlertBox
+                            variant="success"
+                            title={
+                                <Translation id="moduleTrading.tradingExchangeApprovalScreen.revokeSuccessAlert" />
+                            }
+                        />
+                    )}
+
+                    <ExchangeApprovalDetails
+                        fee={fee}
+                        isLoading={isLoading}
+                        exchange={quote.exchange}
+                    />
+                </VStack>
+            </Screen>
+        </TradingDeviceConnectionGuard>
     );
 };

--- a/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangeRevokeScreen.tsx
@@ -28,6 +28,7 @@ import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 import { BigNumber } from '@trezor/utils';
 
 import { TradingCoinAmountFormatter } from '../components/general/TradingCoinAmountFormatter';
+import { TradingDeviceConnectionGuard } from '../components/general/TradingDeviceConnectionGuard';
 
 type TradingExchangeRevokeScreenProps = StackToStackCompositeScreenProps<
     TradingStackParamList,
@@ -76,145 +77,149 @@ export const TradingExchangeRevokeScreen = ({
     const fee = '4.76'; // TODO
 
     return (
-        <Screen
-            header={
-                <DynamicScreenHeader
-                    title={
-                        <Translation
-                            id="moduleTrading.tradingExchangeRevokeScreen.title"
-                            values={{ symbol: coinSymbol }}
-                        />
-                    }
-                    subtitle={
-                        <Translation
-                            id="moduleTrading.tradingExchangeRevokeScreen.subtitle"
-                            values={{ symbol: coinSymbol }}
-                        />
-                    }
-                    closeActionType="back"
-                />
-            }
-        >
-            <VStack spacing="sp16">
-                {!!shouldIncreaseLimit && (
-                    <Animated.View>
-                        <InlineAlertBox
-                            title={
-                                <Translation id="moduleTrading.tradingExchangeRevokeScreen.infoAlert" />
-                            }
-                            variant="warning"
-                        />
-                    </Animated.View>
-                )}
-                <Card noPadding>
-                    <TradeInfoHeader
-                        title={<Translation id="moduleTrading.tradingExchangeRevokeScreen.from" />}
-                        rightContent={
-                            !!network?.symbol && (
-                                <HStack alignItems="center">
-                                    <NetworkIcon symbol={network.symbol} size="extraLarge" />
-                                    <Text variant="body-sm">{network.name}</Text>
-                                </HStack>
-                            )
-                        }
-                    />
-                    <TradeInfoRow>
-                        <VStack spacing="sp4">
-                            <Text variant="body-sm">
-                                <Translation id="moduleTrading.exchangeTradePreviewCard.account" />
-                            </Text>
-                            <Text variant="body-sm" color="textSubdued">
-                                {account?.accountLabel}
-                            </Text>
-                        </VStack>
-                    </TradeInfoRow>
-                </Card>
-
-                <Card noPadding>
-                    <TradeInfoHeader
+        <TradingDeviceConnectionGuard>
+            <Screen
+                header={
+                    <DynamicScreenHeader
                         title={
-                            <Translation id="moduleTrading.tradingExchangeRevokeScreen.details" />
+                            <Translation
+                                id="moduleTrading.tradingExchangeRevokeScreen.title"
+                                values={{ symbol: coinSymbol }}
+                            />
                         }
+                        subtitle={
+                            <Translation
+                                id="moduleTrading.tradingExchangeRevokeScreen.subtitle"
+                                values={{ symbol: coinSymbol }}
+                            />
+                        }
+                        closeActionType="back"
                     />
-                    <TradeInfoRow>
-                        <Text variant="body-sm">
-                            <Translation id="moduleTrading.tradingScreen.provider" />
-                        </Text>
-                        <HStack alignItems="center">
-                            {!!providerInfo?.logo && (
-                                <ProviderLogo logo={providerInfo.logo} size="body-sm" />
-                            )}
-                            <Text variant="body-sm" color="textSubdued">
-                                {providerInfo?.companyName}
+                }
+            >
+                <VStack spacing="sp16">
+                    {!!shouldIncreaseLimit && (
+                        <Animated.View>
+                            <InlineAlertBox
+                                title={
+                                    <Translation id="moduleTrading.tradingExchangeRevokeScreen.infoAlert" />
+                                }
+                                variant="warning"
+                            />
+                        </Animated.View>
+                    )}
+                    <Card noPadding>
+                        <TradeInfoHeader
+                            title={
+                                <Translation id="moduleTrading.tradingExchangeRevokeScreen.from" />
+                            }
+                            rightContent={
+                                !!network?.symbol && (
+                                    <HStack alignItems="center">
+                                        <NetworkIcon symbol={network.symbol} size="extraLarge" />
+                                        <Text variant="body-sm">{network.name}</Text>
+                                    </HStack>
+                                )
+                            }
+                        />
+                        <TradeInfoRow>
+                            <VStack spacing="sp4">
+                                <Text variant="body-sm">
+                                    <Translation id="moduleTrading.exchangeTradePreviewCard.account" />
+                                </Text>
+                                <Text variant="body-sm" color="textSubdued">
+                                    {account?.accountLabel}
+                                </Text>
+                            </VStack>
+                        </TradeInfoRow>
+                    </Card>
+
+                    <Card noPadding>
+                        <TradeInfoHeader
+                            title={
+                                <Translation id="moduleTrading.tradingExchangeRevokeScreen.details" />
+                            }
+                        />
+                        <TradeInfoRow>
+                            <Text variant="body-sm">
+                                <Translation id="moduleTrading.tradingScreen.provider" />
                             </Text>
-                        </HStack>
-                    </TradeInfoRow>
-                    <TradeInfoRow>
-                        <Text variant="body-sm">
-                            <Translation id="moduleTrading.tradingExchangeRevokeScreen.currentLimit" />
-                        </Text>
-                        <HStack alignItems="center">
-                            {!!network?.symbol && (
-                                <CryptoIcon
-                                    symbol={network.symbol}
-                                    contractAddress={contractAddress}
-                                    size="extraSmall"
-                                />
-                            )}
-                            <Text variant="body-sm" color="textSubdued">
+                            <HStack alignItems="center">
+                                {!!providerInfo?.logo && (
+                                    <ProviderLogo logo={providerInfo.logo} size="body-sm" />
+                                )}
+                                <Text variant="body-sm" color="textSubdued">
+                                    {providerInfo?.companyName}
+                                </Text>
+                            </HStack>
+                        </TradeInfoRow>
+                        <TradeInfoRow>
+                            <Text variant="body-sm">
+                                <Translation id="moduleTrading.tradingExchangeRevokeScreen.currentLimit" />
+                            </Text>
+                            <HStack alignItems="center">
+                                {!!network?.symbol && (
+                                    <CryptoIcon
+                                        symbol={network.symbol}
+                                        contractAddress={contractAddress}
+                                        size="extraSmall"
+                                    />
+                                )}
+                                <Text variant="body-sm" color="textSubdued">
+                                    <TradingCoinAmountFormatter
+                                        amount={quote.preapprovedStringAmount}
+                                        cryptoId={quote.send}
+                                        variant="body-sm"
+                                        color="textSubdued"
+                                    />
+                                </Text>
+                            </HStack>
+                        </TradeInfoRow>
+                        <TradeInfoRow>
+                            <Text variant="body-sm">
+                                <Translation id="moduleTrading.tradingExchangeRevokeScreen.newLimit" />
+                            </Text>
+                            <HStack alignItems="center">
+                                {!!network?.symbol && (
+                                    <CryptoIcon
+                                        symbol={network.symbol}
+                                        contractAddress={contractAddress}
+                                        size="extraSmall"
+                                    />
+                                )}
                                 <TradingCoinAmountFormatter
-                                    amount={quote.preapprovedStringAmount}
+                                    amount="0"
                                     cryptoId={quote.send}
                                     variant="body-sm"
                                     color="textSubdued"
                                 />
+                            </HStack>
+                        </TradeInfoRow>
+                        <TradeInfoRow>
+                            <Text variant="body-sm">
+                                <Translation id="transactions.detail.feeLabel" />
                             </Text>
-                        </HStack>
-                    </TradeInfoRow>
-                    <TradeInfoRow>
-                        <Text variant="body-sm">
-                            <Translation id="moduleTrading.tradingExchangeRevokeScreen.newLimit" />
-                        </Text>
-                        <HStack alignItems="center">
-                            {!!network?.symbol && (
-                                <CryptoIcon
-                                    symbol={network.symbol}
-                                    contractAddress={contractAddress}
-                                    size="extraSmall"
+                            <HStack alignItems="center" spacing="sp8">
+                                <Text variant="body-sm" color="textSubdued">
+                                    ≈
+                                </Text>
+                                <BaseCurrencyAmountFormatter
+                                    value={asBaseCurrencyAmount(new BigNumber(fee))}
+                                    variant="body-sm"
+                                    color="textSubdued"
                                 />
-                            )}
-                            <TradingCoinAmountFormatter
-                                amount="0"
-                                cryptoId={quote.send}
-                                variant="body-sm"
-                                color="textSubdued"
-                            />
-                        </HStack>
-                    </TradeInfoRow>
-                    <TradeInfoRow>
-                        <Text variant="body-sm">
-                            <Translation id="transactions.detail.feeLabel" />
-                        </Text>
-                        <HStack alignItems="center" spacing="sp8">
-                            <Text variant="body-sm" color="textSubdued">
-                                ≈
-                            </Text>
-                            <BaseCurrencyAmountFormatter
-                                value={asBaseCurrencyAmount(new BigNumber(fee))}
-                                variant="body-sm"
-                                color="textSubdued"
-                            />
-                            <Icon name="caretDown" size="medium" />
-                        </HStack>
-                    </TradeInfoRow>
-                </Card>
-            </VStack>
+                                <Icon name="caretDown" size="medium" />
+                            </HStack>
+                        </TradeInfoRow>
+                    </Card>
+                </VStack>
 
-            <Box paddingTop="sp20">
-                <Button onPress={handleContinue}>
-                    <Translation id="generic.buttons.continue" />
-                </Button>
-            </Box>
-        </Screen>
+                <Box paddingTop="sp20">
+                    <Button onPress={handleContinue}>
+                        <Translation id="generic.buttons.continue" />
+                    </Button>
+                </Box>
+            </Screen>
+        </TradingDeviceConnectionGuard>
     );
 };

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -41,6 +41,9 @@ jest.mock('@react-navigation/native', () => ({
         ({
             params: undefined,
         }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingHistory>,
+    useNavigation: () => ({
+        setOptions: jest.fn(),
+    }),
 }));
 
 jest.mock('@suite-native/trading-atoms', () => ({
@@ -50,6 +53,12 @@ jest.mock('@suite-native/trading-atoms', () => ({
         showSheet: mockShowSheet,
         hideSheet: mockHideSheet,
     }),
+}));
+
+let mockIsDeviceConnected = true;
+jest.mock('@suite-common/device', () => ({
+    ...jest.requireActual('@suite-common/device'),
+    selectIsDeviceConnected: () => mockIsDeviceConnected,
 }));
 
 const testQuote = exchangeQuotes[0];
@@ -73,6 +82,8 @@ describe('TradingExchangeApprovalScreen', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+
+        mockIsDeviceConnected = true;
 
         const preloadedState = {
             wallet: getWalletState({
@@ -146,5 +157,15 @@ describe('TradingExchangeApprovalScreen', () => {
 
         const selectedQuote = selectTradingExchangeSelectedQuote(store.getState());
         expect(selectedQuote).toBeUndefined();
+    });
+
+    it('should display device guard when device is not connected', () => {
+        mockIsDeviceConnected = false;
+
+        const { getByText } = renderScreen();
+
+        expect(
+            getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
@@ -1,5 +1,6 @@
 import { type RouteProp } from '@react-navigation/native';
 
+import { getTranslation } from '@suite-native/intl';
 import { type TradingStackParamList, type TradingStackRoutes } from '@suite-native/navigation';
 import { renderWithStoreProvider } from '@suite-native/test-utils';
 import {
@@ -16,6 +17,15 @@ jest.mock('@react-navigation/native', () => ({
         ({
             params: undefined,
         }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingHistory>,
+    useNavigation: () => ({
+        setOptions: jest.fn(),
+    }),
+}));
+
+let mockIsDeviceConnected = true;
+jest.mock('@suite-common/device', () => ({
+    ...jest.requireActual('@suite-common/device'),
+    selectIsDeviceConnected: () => mockIsDeviceConnected,
 }));
 
 const testQuote = exchangeQuotes[0];
@@ -57,6 +67,12 @@ describe('TradingExchangeRevokeScreen', () => {
 
         return result;
     };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockIsDeviceConnected = true;
+    });
 
     afterEach(() => {
         if (unmount) {
@@ -108,6 +124,16 @@ describe('TradingExchangeRevokeScreen', () => {
             getByText(
                 'This stops the provider from using your USDC. You’ll need to approve again to swap.',
             ),
+        ).toBeOnTheScreen();
+    });
+
+    it('should display device guard when device is not connected', () => {
+        mockIsDeviceConnected = false;
+
+        const { getByText } = renderScreen();
+
+        expect(
+            getByText(getTranslation('moduleConnectDevice.connectAndUnlockScreen.title')),
         ).toBeOnTheScreen();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Title says it all.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26159

## Screenshots:

https://github.com/user-attachments/assets/e8150d60-304a-4639-8ca9-93db4d49fbd3


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26159-mobile-swap-approval-flow-put-approval-and-revoke-previews-behind-device-guard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->