### PR TITLE
Tron resources in account dashboard

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -1,5 +1,34 @@
 /* Do not change, this code is generated from Golang structs */
 
+export interface TronVoteExtra {
+    address?: string;
+    count?: string;
+}
+export interface TronChainExtraData {
+    contractType?: string;
+    operation?: string;
+    resource?: string;
+    stakeAmount?: string;
+    unstakeAmount?: string;
+    delegateAmount?: string;
+    delegateTo?: string;
+    assetIssueID?: string;
+    totalFee?: string;
+    feeLimit?: string;
+    energyUsage?: string;
+    energyUsageTotal?: string;
+    energyFee?: string;
+    bandwidthUsage?: string;
+    bandwidthFee?: string;
+    result?: string;
+    votes?: TronVoteExtra[];
+}
+export interface TronAccountExtraData {
+    availableBandwidth: number;
+    totalBandwidth: number;
+    availableEnergy: number;
+    totalEnergy: number;
+}
 export interface APIError {
     /** Human-readable error message describing the issue. */
     Text: string;
@@ -189,6 +218,10 @@ export interface Tx {
     rbf?: boolean;
     /** Blockchain-specific extended data. */
     coinSpecificData?: any;
+    /** Additional normalized chain-specific transaction data. Use payloadType as discriminator for payload. */
+    chainExtraData?:
+        | { payloadType: 'tron'; payload?: TronChainExtraData }
+        | { payloadType: string; payload?: any };
     /** List of token transfers that occurred in this transaction. */
     tokenTransfers?: TokenTransfer[];
     /** Ethereum-like blockchain specific data (if applicable). */
@@ -333,6 +366,10 @@ export interface Address {
     addressAliases?: { [key: string]: AddressAlias };
     /** List of staking pool data if address interacts with staking. */
     stakingPools?: StakingPool[];
+    /** Additional normalized chain-specific account/address data. Use payloadType as discriminator for payload. */
+    chainExtraData?:
+        | { payloadType: 'tron'; payload?: TronAccountExtraData }
+        | { payloadType: string; payload?: any };
 }
 export interface Utxo {
     /** Transaction ID in which this UTXO was created. */

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,6 +1,7 @@
 import type tls from 'tls';
 
 import type { BaseCurrencyCode } from './baseCurrency';
+import type { TronAccountExtraData } from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -395,6 +396,7 @@ export interface AccountInfo {
         solStakingAccounts?: SolanaStakingAccount[]; // Solana staking accounts (Everstake)
         solExternalStakingAccounts?: SolanaStakingAccount[]; // Solana staking accounts (non-Everstake)
         solEpoch?: number; // Solana current epoch
+        tronResources?: TronAccountExtraData;
     };
     page?: {
         // blockbook and blockfrost

--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -5,6 +5,7 @@ export type { Response } from './responses';
 export * from './baseCurrency';
 
 export type { Transaction as BlockbookTransaction } from './blockbook';
+export type { TronAccountExtraData } from './blockbook-api';
 export type {
     AssetBalance,
     BlockfrostAccountInfo,

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -379,7 +379,11 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     // However, the nonce is specific to Ethereum, so we can determine the network type based on its availability.
     const isEVM = typeof payload.nonce === 'string';
     let misc: AccountInfo['misc'];
-    if (isEVM) {
+    if (payload.chainExtraData?.payloadType === 'tron') {
+        misc = {
+            tronResources: payload.chainExtraData.payload,
+        };
+    } else if (isEVM) {
         misc = {
             nonce: payload.nonce,
             contractInfo: payload.contractInfo,

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -17,6 +17,7 @@ import { WalletTransactionList } from './TransactionList/WalletTransactionList';
 import { AccountEmpty } from './components/AccountEmpty';
 import { NoTransactions } from './components/NoTransactions';
 import { TransactionSummary } from './components/TransactionSummary';
+import { TronResources } from './components/TronResources';
 import { CardanoNewProviderCard } from '../staking/components/AdaStakingDashboard/CardanoNewProviderCard';
 
 interface LayoutProps {
@@ -72,6 +73,7 @@ export const Transactions = () => {
         return (
             <Layout selectedAccount={selectedAccount}>
                 <CardanoNewProviderCard account={account} />
+                <TronResources account={account} />
                 <TransactionSummary account={account} />
                 <TradeBox account={account} />
                 <SolanaLimitedHistoryBanner account={account} />

--- a/packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx
@@ -1,0 +1,24 @@
+import { type ReactNode } from 'react';
+
+import { Column, ProgressBar, Row, Text, Tooltip } from '@trezor/components';
+
+export type ResourceProps = {
+    label: ReactNode;
+    tooltip: ReactNode;
+    available: number;
+    total: number;
+};
+
+export const Resource = ({ label, tooltip, available, total }: ResourceProps) => (
+    <Column gap={8} minWidth={200} maxWidth={400} flex="1">
+        <Row justifyContent="space-between" alignItems="center">
+            <Tooltip hasIcon content={tooltip}>
+                <Text>{label}</Text>
+            </Tooltip>
+            <Text>
+                {available} / {total}
+            </Text>
+        </Row>
+        <ProgressBar value={available} max={total} />
+    </Column>
+);

--- a/packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx
@@ -1,0 +1,38 @@
+import { Translation } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { Card, Row } from '@trezor/components';
+
+import { Resource } from './Resource';
+
+type TronResourcesProps = {
+    account: Account;
+};
+
+export const TronResources = ({ account }: TronResourcesProps) => {
+    if (account.networkType !== 'tron') return null;
+
+    const { tronResources } = account.misc;
+
+    if (!tronResources) return null;
+
+    const { availableBandwidth, totalBandwidth, availableEnergy, totalEnergy } = tronResources;
+
+    return (
+        <Card>
+            <Row gap={48} flexWrap="wrap">
+                <Resource
+                    label={<Translation id="TR_TRON_BANDWIDTH" />}
+                    tooltip={<Translation id="TR_TRON_BANDWIDTH_TOOLTIP" />}
+                    available={availableBandwidth}
+                    total={totalBandwidth}
+                />
+                <Resource
+                    label={<Translation id="TR_TRON_ENERGY" />}
+                    tooltip={<Translation id="TR_TRON_ENERGY_TOOLTIP" />}
+                    available={availableEnergy}
+                    total={totalEnergy}
+                />
+            </Row>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/components/TronResources/index.ts
+++ b/packages/suite/src/views/wallet/transactions/components/TronResources/index.ts
@@ -1,0 +1,1 @@
+export { TronResources } from './TronResources';

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -10,6 +10,7 @@ import type {
     ContractInfo,
     SolanaStakingAccount,
     StakingPool,
+    TronAccountExtraData,
 } from '@trezor/blockchain-link-types';
 import type { AccountInfo, PROTO, StaticSessionId, TokenInfo } from '@trezor/connect';
 import { type Branded } from '@trezor/type-utils';
@@ -83,6 +84,7 @@ type AccountNetworkSpecific =
           networkType: 'tron';
           misc: {
               contractInfo?: ContractInfo;
+              tronResources?: TronAccountExtraData;
           };
           marker: undefined;
           stellarCursor: undefined;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5192,6 +5192,24 @@ export const messages = defineMessages({
         id: 'TR_EXPERIMENTAL_SUITE_SYNC_TITLE',
         defaultMessage: 'Suite Sync',
     },
+    TR_TRON_BANDWIDTH: {
+        id: 'TR_TRON_BANDWIDTH',
+        defaultMessage: 'Bandwidth',
+    },
+    TR_TRON_ENERGY: {
+        id: 'TR_TRON_ENERGY',
+        defaultMessage: 'Energy',
+    },
+    TR_TRON_BANDWIDTH_TOOLTIP: {
+        id: 'TR_TRON_BANDWIDTH_TOOLTIP',
+        defaultMessage:
+            'Used for basic transactions like sending TRX. If you run out, TRX is burned as a network fee. Refills within 24 hours.',
+    },
+    TR_TRON_ENERGY_TOOLTIP: {
+        id: 'TR_TRON_ENERGY_TOOLTIP',
+        defaultMessage:
+            'Used for smart contract actions like sending tokens. If you run out, TRX is burned as a network fee. Refills within 24 hours.',
+    },
     TR_EXPERIMENTAL_TRON_VIEW_ONLY: {
         id: 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
         defaultMessage: 'Tron View-Only (Beta)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements bandwidth and energy info in Tron account dashboard

## Notes for QA

Tron resources should be visible for non empty accounts

## Related Issue

Resolve #24650

## Screenshots:

<img width="1061" height="901" alt="image" src="https://github.com/user-attachments/assets/c7c570cc-c889-406c-85e9-3145d36962d8" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-resources&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-resources&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-resources&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T15:08:51.418Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-24T15:07:54.800Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->