### PR TITLE
refactor(suite-common): extract bip329 label package

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -24,6 +24,7 @@
         "@suite-common/analytics": "workspace:*",
         "@suite-common/analytics-redux": "workspace:*",
         "@suite-common/assets": "workspace:*",
+        "@suite-common/bip329": "workspace:*",
         "@suite-common/bluetooth": "workspace:*",
         "@suite-common/connect-init": "workspace:*",
         "@suite-common/connect-popup": "workspace:*",

--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -1,6 +1,6 @@
 import { METADATA, selectLabelingDataForAccount, slip15ToBip329 } from '@suite/metadata';
+import { type Bip329Label } from '@suite-common/bip329';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type Bip329Label } from '@suite-common/metadata-types';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     selectAllLabelsForAccount,

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -19,6 +19,7 @@
             "path": "../../suite-common/analytics-redux"
         },
         { "path": "../../suite-common/assets" },
+        { "path": "../../suite-common/bip329" },
         {
             "path": "../../suite-common/bluetooth"
         },

--- a/suite-common/bip329/package.json
+++ b/suite-common/bip329/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@suite-common/bip329",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    }
+}

--- a/suite-common/bip329/src/bip329.ts
+++ b/suite-common/bip329/src/bip329.ts
@@ -1,0 +1,6 @@
+export type Bip329Label = {
+    type: 'tx' | 'addr' | 'wallet' | 'xpub' | 'pubkey' | 'input' | 'output';
+    ref?: string; // The identifier for the object being labeled (e.g., txid, address, txid:vout)
+    label: string; // The label text
+    spendable?: boolean;
+};

--- a/suite-common/bip329/src/index.ts
+++ b/suite-common/bip329/src/index.ts
@@ -1,0 +1,1 @@
+export type { Bip329Label } from './bip329';

--- a/suite-common/bip329/tsconfig.json
+++ b/suite-common/bip329/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "libDev",
+        "exactOptionalPropertyTypes": true
+    },
+    "references": []
+}

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -294,10 +294,3 @@ export type PasswordManagerState = {
     extVersion?: string;
     tags: Record<number, PasswordTag>;
 };
-
-export type Bip329Label = {
-    type: 'tx' | 'addr' | 'wallet' | 'xpub' | 'pubkey' | 'input' | 'output';
-    ref?: string; // The identifier for the object being labeled (e.g., txid, address, txid:vout)
-    label: string; // The label text
-    spendable?: boolean;
-};

--- a/suite-common/suite-sync/package.json
+++ b/suite-common/suite-sync/package.json
@@ -13,11 +13,11 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/bip329": "workspace:*",
         "@suite-common/delegated-identity-key": "workspace:*",
         "@suite-common/delegated-identity-key-types": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
-        "@suite-common/metadata-types": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync-quota-manager": "workspace:*",

--- a/suite-common/suite-sync/src/data/labeling/suiteSyncToBip329.ts
+++ b/suite-common/suite-sync/src/data/labeling/suiteSyncToBip329.ts
@@ -1,4 +1,4 @@
-import { type Bip329Label } from '@suite-common/metadata-types';
+import { type Bip329Label } from '@suite-common/bip329';
 import { type SuiteSyncAddress, type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 
 type SuiteSyncToBip329Params = {

--- a/suite-common/suite-sync/tsconfig.json
+++ b/suite-common/suite-sync/tsconfig.json
@@ -5,13 +5,13 @@
         "exactOptionalPropertyTypes": true
     },
     "references": [
+        { "path": "../bip329" },
         { "path": "../delegated-identity-key" },
         {
             "path": "../delegated-identity-key-types"
         },
         { "path": "../dependency-injection" },
         { "path": "../device" },
-        { "path": "../metadata-types" },
         { "path": "../platform-encryption" },
         { "path": "../redux-utils" },
         { "path": "../suite-sync-quota-manager" },

--- a/suite/metadata/package.json
+++ b/suite/metadata/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/bip329": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",

--- a/suite/metadata/src/slip15ToBip329.ts
+++ b/suite/metadata/src/slip15ToBip329.ts
@@ -1,4 +1,5 @@
-import { type AccountLabels, type Bip329Label } from '@suite-common/metadata-types';
+import { type Bip329Label } from '@suite-common/bip329';
+import { type AccountLabels } from '@suite-common/metadata-types';
 
 // Transforms a custom SLIP-15 like wallet label object into an array of BIP-329 label objects.
 export const slip15ToBip329 = (inputData: AccountLabels, allSpendable = true): Bip329Label[] => {

--- a/suite/metadata/tsconfig.json
+++ b/suite/metadata/tsconfig.json
@@ -11,6 +11,7 @@
     },
     "include": [".", "**/*.json"],
     "references": [
+        { "path": "../../suite-common/bip329" },
         { "path": "../../suite-common/device" },
         {
             "path": "../../suite-common/metadata-types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11216,6 +11216,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/bip329@workspace:*, @suite-common/bip329@workspace:suite-common/bip329":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/bip329@workspace:suite-common/bip329"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/bluetooth@workspace:*, @suite-common/bluetooth@workspace:suite-common/bluetooth":
   version: 0.0.0-use.local
   resolution: "@suite-common/bluetooth@workspace:suite-common/bluetooth"
@@ -11814,11 +11820,11 @@ __metadata:
   resolution: "@suite-common/suite-sync@workspace:suite-common/suite-sync"
   dependencies:
     "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/bip329": "workspace:*"
     "@suite-common/delegated-identity-key": "workspace:*"
     "@suite-common/delegated-identity-key-types": "workspace:*"
     "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
-    "@suite-common/metadata-types": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-sync-quota-manager": "workspace:*"
@@ -15046,6 +15052,7 @@ __metadata:
   resolution: "@suite/metadata@workspace:suite/metadata"
   dependencies:
     "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/bip329": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
@@ -16519,6 +16526,7 @@ __metadata:
     "@suite-common/analytics": "workspace:*"
     "@suite-common/analytics-redux": "workspace:*"
     "@suite-common/assets": "workspace:*"
+    "@suite-common/bip329": "workspace:*"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/connect-init": "workspace:*"
     "@suite-common/connect-popup": "workspace:*"


### PR DESCRIPTION
Code improvement only. 

The `metadata-types` will be removed with the rest of the legacy labeling one day, but this needs to live.

I haven't find good package for it, so I created domain package for it. Is it overkill? Yes. But where to put it? I do not want to create a doom `types` or `utils` package that will bloat and create mess & potential circulars.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bip329import&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bip329import&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bip329import&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-24T15:12:54.114Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-24T15:12:20.049Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->