### PR TITLE
Mobile Trade: Update UI of revoke and approve buttons in ExchangeConfirmation

### DIFF
--- a/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/exchangeUtils.test.ts
@@ -95,6 +95,18 @@ describe('getApprovalStatus', () => {
         expect(result).toBe('needs_increase');
     });
 
+    it('should return "needs_revoke" when quote has preapprovedStringAmount !== "0" and status is APPROVAL_REQ and tokenSupportsIncreasingAllowance is false', () => {
+        const quote = {
+            orderId: 'test-order',
+            preapprovedStringAmount: '0.001',
+            isDex: true,
+            send: 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId,
+            status: 'APPROVAL_REQ' as const,
+        };
+        const result = getApprovalStatus(quote);
+        expect(result).toBe('needs_revoke');
+    });
+
     it('should return "needs_approval" when preapprovedStringAmount is "0" and isDex is true', () => {
         const quote = {
             orderId: 'test-order',

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -1,4 +1,6 @@
-import { type CryptoId, type ExchangeTrade, type ExchangeTradeStatus } from 'invity-api';
+import type { CryptoId, ExchangeTrade, ExchangeTradeStatus } from 'invity-api';
+
+import { invariant } from '@suite-common/suite-utils';
 
 import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN } from '../../constants';
 import { type ExchangeInfo } from '../../reducers/exchangeReducer';
@@ -109,7 +111,13 @@ export const tokenSupportsIncreasingAllowance = (contractAddress?: string): bool
     return contractAddress.trim().toLowerCase() !== ethereumUsdtContractAddress.toLowerCase();
 };
 
-export type ApprovalStatus = 'approved' | 'needs_approval' | 'needs_increase' | 'not_needed' | null;
+export type ApprovalStatus =
+    | 'approved'
+    | 'needs_approval'
+    | 'needs_increase'
+    | 'needs_revoke'
+    | 'not_needed'
+    | null;
 
 export const requiresTokenApproval = (quote?: ExchangeTrade): boolean =>
     !!quote && !!quote.isDex && !!quote.send && !isSendingEvmNativeToken(quote.send);
@@ -127,7 +135,13 @@ export const getApprovalStatus = (candidateQuote?: ExchangeTrade): ApprovalStatu
         candidateQuote.preapprovedStringAmount && candidateQuote.preapprovedStringAmount !== '0';
 
     if (isApprovalTxPreApproved && candidateQuote.status === 'APPROVAL_REQ') {
-        return 'needs_increase';
+        // send is defined as requiresTokenApproval checks for it, but we need to assert it for TypeScript
+        invariant(candidateQuote.send, 'candidateQuote.send not defined!');
+        const { contractAddress } = parseCryptoId(candidateQuote.send);
+
+        return tokenSupportsIncreasingAllowance(contractAddress)
+            ? 'needs_increase'
+            : 'needs_revoke';
     }
 
     if (isApprovalTxPreApproved) {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2497,6 +2497,7 @@ export const messages = {
                 continue: 'Continue',
                 swap: 'Swap',
                 approveAndSwap: 'Approve and swap',
+                revoke: 'Revoke approval',
             },
             countryOfResidence: 'Country of residence',
             noCountryOfResidence: 'No country of residence selected',

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -1,7 +1,13 @@
-import { type AnimatedProps, FadeIn, FadeOutDown } from 'react-native-reanimated';
+import {
+    type AnimatedProps,
+    FadeIn,
+    FadeOut,
+    FadeOutDown,
+    LinearTransition,
+} from 'react-native-reanimated';
 
-import { getApprovalStatus } from '@suite-common/trading';
-import { AnimatedBox, Button } from '@suite-native/atoms';
+import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
+import { AnimatedBox, AnimatedVStack, Button } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
@@ -11,7 +17,8 @@ export type ExchangeConfirmationProps = {
     enteringAnimation?: AnimatedProps<any>['entering'];
 };
 
-const CONFIRMATION_TEST_ID = '@trading/exchange/continue-button';
+export const CONFIRMATION_TEST_ID = '@trading/exchange/continue-button';
+export const REVOKE_TEST_ID = '@trading/exchange/revoke-button';
 
 export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmationProps) => {
     const form = useExchangeFormContext();
@@ -20,20 +27,30 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
 
     const quote = form.watch('quote');
     const approvalStatus = getApprovalStatus(quote);
+    const canRevoke = (['approved', 'needs_increase', 'needs_revoke'] as ApprovalStatus[]).includes(
+        approvalStatus,
+    );
 
     return (
-        <AnimatedBox entering={enteringAnimation} exiting={FadeOutDown}>
+        <AnimatedVStack entering={enteringAnimation} exiting={FadeOutDown} spacing="sp16">
             {canProceed && (
-                <AnimatedBox entering={FadeIn}>
+                <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
                     <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
-                        {approvalStatus === 'needs_approval' ? (
-                            <Translation id="moduleTrading.tradingScreen.buttons.approveAndSwap" />
-                        ) : (
-                            <Translation id="moduleTrading.tradingScreen.buttons.swap" />
-                        )}
+                        <Translation id="moduleTrading.tradingScreen.buttons.continue" />
                     </Button>
                 </AnimatedBox>
             )}
-        </AnimatedBox>
+            {canRevoke && (
+                <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                    <Button
+                        onPress={() => {}}
+                        testID={REVOKE_TEST_ID}
+                        colorScheme="tertiaryElevation0"
+                    >
+                        <Translation id="moduleTrading.tradingScreen.buttons.revoke" />
+                    </Button>
+                </AnimatedBox>
+            )}
+        </AnimatedVStack>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -1,4 +1,7 @@
-import { renderWithStoreProvider } from '@suite-native/test-utils';
+import type { CryptoId, ExchangeTrade } from 'invity-api';
+
+import { getTranslation } from '@suite-native/intl';
+import { renderWithStoreProvider, screen } from '@suite-native/test-utils';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
 import { ExchangeConfirmation } from '../ExchangeConfirmation';
@@ -7,13 +10,7 @@ jest.mock('../../../hooks/exchange/useExchangeSelectQuote', () => ({
     useExchangeSelectQuote: jest.fn(),
 }));
 
-const mockQuote = {
-    send: 'BTC',
-    receive: 'ETH',
-    exchange: 'test-provider',
-    isDex: false,
-    preapprovedStringAmount: undefined,
-};
+let mockQuote: ExchangeTrade;
 
 jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
     useExchangeFormContext: () => ({
@@ -30,12 +27,22 @@ describe('ExchangeConfirmation', () => {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
         });
 
+    const queryContinueButton = () =>
+        screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.continue'));
+
+    const queryRevokeButton = () =>
+        screen.queryByText(getTranslation('moduleTrading.tradingScreen.buttons.revoke'));
+
     beforeEach(() => {
-        mockQuote.isDex = false;
-        mockQuote.preapprovedStringAmount = undefined;
+        mockQuote = {
+            send: 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId,
+            receive: 'ethereum' as CryptoId,
+            exchange: 'test-provider',
+            isDex: false,
+        };
     });
 
-    it('should render "Swap" button when canProceed is true and approval not needed', () => {
+    it('should render "Continue" button when canProceed is true', () => {
         mockUseExchangeSelectQuote.mockReturnValue({
             canProceed: true,
             selectQuote: jest.fn(),
@@ -44,58 +51,13 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { getByText } = renderConfirmation();
-        expect(getByText('Swap')).toBeTruthy();
+        renderConfirmation();
+
+        expect(queryContinueButton()).toBeOnTheScreen();
     });
 
-    it('should render "Approve and swap" button when canProceed is true and approval needed', () => {
-        mockQuote.isDex = true;
-
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
-
-        const { getByText } = renderConfirmation();
-        expect(getByText('Approve and swap')).toBeTruthy();
-    });
-
-    it('should render "Swap" button when canProceed is true and approval status is approved', () => {
+    it('should not render "Continue" button when canProceed is false', () => {
         mockQuote.isDex = false;
-
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
-
-        const { getByText } = renderConfirmation();
-        expect(getByText('Swap')).toBeTruthy();
-    });
-
-    it('should render "Swap" button when canProceed is true and approval status is null', () => {
-        mockQuote.isDex = false;
-
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
-
-        const { getByText } = renderConfirmation();
-        expect(getByText('Swap')).toBeTruthy();
-    });
-
-    it('should not render button when canProceed is false', () => {
-        mockQuote.isDex = false;
-
         mockUseExchangeSelectQuote.mockReturnValue({
             canProceed: false,
             selectQuote: jest.fn(),
@@ -104,9 +66,106 @@ describe('ExchangeConfirmation', () => {
             cancelConsent: jest.fn(),
         });
 
-        const { queryByText } = renderConfirmation();
+        renderConfirmation();
 
-        expect(queryByText('Swap')).toBeNull();
-        expect(queryByText('Approve and swap')).toBeNull();
+        expect(queryContinueButton()).not.toBeOnTheScreen();
+    });
+
+    it('should not render "Revoke" button when approval is not needed', () => {
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).not.toBeOnTheScreen();
+    });
+
+    it('should not render "Revoke" button when approval is needed', () => {
+        mockQuote.isDex = true;
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).not.toBeOnTheScreen();
+    });
+
+    it('should render "Revoke" button when approval status is approved', () => {
+        mockQuote.isDex = true;
+        mockQuote.preapprovedStringAmount = '100';
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).toBeOnTheScreen();
+    });
+
+    it('should render "Revoke" button when approval status is needs_increase', () => {
+        mockQuote.isDex = true;
+        mockQuote.preapprovedStringAmount = '100';
+        mockQuote.status = 'APPROVAL_REQ';
+
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).toBeOnTheScreen();
+    });
+
+    it('should not render "Revoke" button when approval status is null', () => {
+        mockQuote.isDex = false;
+
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).not.toBeOnTheScreen();
+    });
+
+    it('should render "Revoke" button when approval status is needs_revoke', () => {
+        mockQuote.isDex = true;
+        mockQuote.preapprovedStringAmount = '100';
+        mockQuote.status = 'APPROVAL_REQ';
+        mockQuote.send = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed: true,
+            selectQuote: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).toBeOnTheScreen();
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -23,7 +23,6 @@ import { type ExchangeFormType } from '@suite-native/trading-types';
 import { useExchangeForm } from '../useExchangeForm';
 import { useExchangeSelectQuote } from '../useExchangeSelectQuote';
 
-const mockTokenSupportsIncreasingAllowance = jest.fn();
 const mockGetApprovalStatus = jest.fn();
 
 jest.mock('@suite-common/trading', () => ({
@@ -37,8 +36,6 @@ jest.mock('@suite-common/trading', () => ({
             unwrap: () => Promise.resolve(undefined),
         }),
     },
-    tokenSupportsIncreasingAllowance: (contractAddress?: string) =>
-        mockTokenSupportsIncreasingAllowance(contractAddress),
     getApprovalStatus: (quote?: any) => mockGetApprovalStatus(quote),
 }));
 
@@ -417,7 +414,6 @@ describe('useExchangeSelectQuote', () => {
 
         it('should navigate to TradingExchangeApproval with shouldIncreaseLimit when approval status is "needs_increase" and token supports increasing allowance', () => {
             mockGetApprovalStatus.mockReturnValue('needs_increase');
-            mockTokenSupportsIncreasingAllowance.mockReturnValue(true);
 
             act(() => {
                 exchangeForm.setValue('quote', exchangeQuotes[1]);
@@ -448,8 +444,7 @@ describe('useExchangeSelectQuote', () => {
         });
 
         it('should navigate to TradingExchangeRevoke when approval status is "needs_increase" and token does not support increasing allowance', () => {
-            mockGetApprovalStatus.mockReturnValue('needs_increase');
-            mockTokenSupportsIncreasingAllowance.mockReturnValue(false);
+            mockGetApprovalStatus.mockReturnValue('needs_revoke');
 
             act(() => {
                 exchangeForm.setValue('quote', exchangeQuotes[1]);

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -6,12 +6,10 @@ import {
     type TradingRootState,
     exchangeThunks,
     getApprovalStatus,
-    parseCryptoId,
     requiresTokenApproval,
     selectTradingExchangeDexQuoteApprovalPrefetchLoadingByQuoteId,
     selectTradingExchangeIsLoading,
     selectTradingMaxSlippagePercentage,
-    tokenSupportsIncreasingAllowance,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import {
@@ -28,6 +26,7 @@ import {
 } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { useNullTimer } from '@trezor/react-utils';
+import { exhaustive } from '@trezor/type-utils';
 
 import { clearExchangeFormQuoteData } from './useExchangeForm';
 import { isFullySelectedReceiveAccount } from '../../utils/general/receiveAccountUtils';
@@ -100,29 +99,30 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                         return navigation.navigate(TradingStackRoutes.TradingExchangePreview, {});
                     }
 
-                    const { contractAddress } = candidateQuote.send
-                        ? parseCryptoId(candidateQuote.send)
-                        : {};
-
-                    const isIncreasingAllowanceSupported =
-                        tokenSupportsIncreasingAllowance(contractAddress);
-
                     dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
 
-                    if (approvalStatus === 'needs_increase' && isIncreasingAllowanceSupported) {
-                        return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
-                            shouldIncreaseLimit: true,
-                        });
-                    }
+                    switch (approvalStatus) {
+                        case 'needs_increase':
+                            return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
+                                shouldIncreaseLimit: true,
+                            });
 
-                    if (approvalStatus === 'needs_increase') {
-                        return navigation.navigate(TradingStackRoutes.TradingExchangeRevoke, {
-                            quote: candidateQuote,
-                            shouldIncreaseLimit: true,
-                        });
-                    }
+                        case 'needs_revoke':
+                            return navigation.navigate(TradingStackRoutes.TradingExchangeRevoke, {
+                                quote: candidateQuote,
+                                shouldIncreaseLimit: true,
+                            });
 
-                    return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {});
+                        case 'needs_approval':
+                        case null:
+                            return navigation.navigate(
+                                TradingStackRoutes.TradingExchangeApproval,
+                                {},
+                            );
+
+                        default:
+                            return exhaustive(approvalStatus);
+                    }
                 },
             }),
         );

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -114,11 +114,14 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                             });
 
                         case 'needs_approval':
-                        case null:
                             return navigation.navigate(
                                 TradingStackRoutes.TradingExchangeApproval,
                                 {},
                             );
+
+                        case null:
+                            // do nothing (should not happen when quote is defined)
+                            return;
 
                         default:
                             return exhaustive(approvalStatus);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Display `Continue` when user can continue with swap or approval flow.
- Display `Revoke approval` when user has already approved any amount.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26140

## Screenshots:
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-03-24 at 16 18 38" src="https://github.com/user-attachments/assets/ca1ca916-5907-4282-9589-05ff235772cf" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26140-mobile-swap-approval-flow-fix-visual-when-increasing-approval&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=26140-mobile-swap-approval-flow-fix-visual-when-increasing-approval&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=26140-mobile-swap-approval-flow-fix-visual-when-increasing-approval&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-25T13:31:15.970Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T13:29:44.276Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->