### PR TITLE
feat(e2e): Live swap spl token test

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -42,6 +42,7 @@ export const TradingInfoItem = ({
 
     const showAccountLabel = !!account;
     const isExternalExchange = type === 'exchange' && !account && !!receiveAddress;
+    const testIdPrefix = `@trading/detail/${isReceive ? 'receive' : 'send'}`;
 
     const {
         id,
@@ -62,13 +63,19 @@ export const TradingInfoItem = ({
     if (!amount || !currency) return null;
 
     return (
-        <Column width="100%" gap={8}>
+        <Column width="100%" gap={8} data-testid={`${testIdPrefix}-info`}>
             <Row justifyContent="space-between">
                 <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
                     <Translation id={label} />
                 </Text>
                 {(showAccountLabel || isExternalExchange) && (
-                    <Text intent="neutral" priority="secondary" typographyStyle="body-sm" as="div">
+                    <Text
+                        intent="neutral"
+                        priority="secondary"
+                        typographyStyle="body-sm"
+                        as="div"
+                        data-testid={`${testIdPrefix}-account`}
+                    >
                         <Row>
                             {accountLabelPrefix}&nbsp;
                             {isExternalExchange && (
@@ -115,12 +122,15 @@ export const TradingInfoItem = ({
                                 />
                             )}
                             <Column alignItems="start">
-                                <Text>{displayName}</Text>
+                                <Text data-testid={`${testIdPrefix}-asset-name`}>
+                                    {displayName}
+                                </Text>
                                 {showNetwork && (
                                     <Text
                                         intent="neutral"
                                         priority="secondary"
                                         typographyStyle="body-sm"
+                                        data-testid={`${testIdPrefix}-network-name`}
                                     >
                                         {networkName}
                                     </Text>

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -11,6 +11,7 @@ import { FeeSection } from './feeSection';
 import { TradingFormInputs } from './formInputs';
 import { TradingQuotesSection } from './quotesSection';
 import { TradingReceiveAccount } from './receiveAccount';
+import { TransactionDetailSidebar } from './transactionDetailSidebar';
 import { invityEndpoint } from '../../../fixtures/invity';
 import { step } from '../../common';
 import { expect } from '../../testExtends/customMatchers';
@@ -23,6 +24,7 @@ export class TradingPage {
     readonly quotes: TradingQuotesSection;
     readonly confirmation: TradingConfirmationModal;
     readonly inputs: TradingFormInputs;
+    readonly transactionDetailSidebar: TransactionDetailSidebar;
 
     // Navigation and action buttons
     readonly section: Locator;
@@ -46,6 +48,12 @@ export class TradingPage {
     // Transactions
     readonly transactionDetailStatus: Locator;
 
+    // Swap toast notifications
+    readonly swapToastSendAccount: Locator;
+    readonly swapToastReceiveAccount: Locator;
+    readonly swapToastSendAmount: Locator;
+    readonly swapToastReceiveAmount: Locator;
+
     constructor(
         private page: Page,
         devicePrompt: DevicePrompt,
@@ -56,6 +64,7 @@ export class TradingPage {
         this.quotes = new TradingQuotesSection(page);
         this.confirmation = new TradingConfirmationModal(page, devicePrompt);
         this.inputs = new TradingFormInputs(page);
+        this.transactionDetailSidebar = new TransactionDetailSidebar(page);
 
         this.section = this.page.getByTestId('@trading');
         this.buyButton = this.page.getByTestId('@trading/menu/wallet-trading-buy');
@@ -75,6 +84,12 @@ export class TradingPage {
 
         // Transactions
         this.transactionDetailStatus = this.page.getByTestId('@trading/transaction/detail/status');
+
+        // Swap toast notifications
+        this.swapToastSendAccount = this.page.getByTestId('@toast/tx-exchange/send-account');
+        this.swapToastReceiveAccount = this.page.getByTestId('@toast/tx-exchange/receive-account');
+        this.swapToastSendAmount = this.page.getByTestId('@toast/tx-exchange/send-amount');
+        this.swapToastReceiveAmount = this.page.getByTestId('@toast/tx-exchange/receive-amount');
     }
 
     /**

--- a/suite/e2e/support/pageObjects/trading/transactionDetailSidebar.ts
+++ b/suite/e2e/support/pageObjects/trading/transactionDetailSidebar.ts
@@ -1,0 +1,29 @@
+import { Locator, Page } from '@playwright/test';
+
+export class TransactionDetailSidebar {
+    readonly container: Locator;
+    readonly sendSection: Locator;
+    readonly sendAccount: Locator;
+    readonly sendAssetName: Locator;
+    readonly sendNetworkName: Locator;
+    readonly receiveSection: Locator;
+    readonly receiveAccount: Locator;
+    readonly receiveAssetName: Locator;
+    readonly receiveNetworkName: Locator;
+    readonly cryptoAmounts: Locator;
+
+    constructor(page: Page) {
+        this.container = page.getByTestId('@trading/transaction/detail/sidebar');
+        this.sendSection = this.container.getByTestId('@trading/detail/send-info');
+        this.sendAccount = this.container.getByTestId('@trading/detail/send-account');
+        this.sendAssetName = this.container.getByTestId('@trading/detail/send-asset-name');
+        this.sendNetworkName = this.container.getByTestId('@trading/detail/send-network-name');
+        this.receiveSection = this.container.getByTestId('@trading/detail/receive-info');
+        this.receiveAccount = this.container.getByTestId('@trading/detail/receive-account');
+        this.receiveAssetName = this.container.getByTestId('@trading/detail/receive-asset-name');
+        this.receiveNetworkName = this.container.getByTestId(
+            '@trading/detail/receive-network-name',
+        );
+        this.cryptoAmounts = this.container.getByTestId('@trading/form/info/crypto-amount');
+    }
+}

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -5,6 +5,8 @@ import { diff } from 'jest-diff';
 import { isEqualWith } from 'lodash';
 
 import { type TranslationKey, messages } from '@suite/intl';
+import { type Account } from '@suite-common/wallet-types';
+import { isAddressValid } from '@suite-common/wallet-utils';
 import { Model } from '@trezor/trezor-user-env-link';
 
 import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
@@ -319,6 +321,18 @@ export const expect = baseExpect.extend({
         return {
             pass: true,
             message: () => 'errors are handled in expects above',
+        };
+    },
+
+    async toHaveValidAddress(locator: Locator, symbol: Account['symbol']) {
+        await baseExpect(locator).toBeVisible();
+        const text = await locator.textContent();
+        const stripped = text?.replace(/\s/g, '') ?? '';
+
+        return {
+            pass: isAddressValid(stripped, symbol),
+            message: () =>
+                `expected locator text to be a valid '${symbol}' address, but got '${text}' (stripped: '${stripped}')`,
         };
     },
 

--- a/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
@@ -62,9 +62,7 @@ test.describe(
             await test.step('Initiate send', async () => {
                 await tradingPage.confirmation.initiateSendConfirmation();
                 await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
-                await expect(devicePrompt.outputValueOf('address')).toHaveText(
-                    /^[1-9A-HJ-NP-Za-km-z\s]{53,54}$/,
-                ); // base58 with spaces/newlines
+                await expect(devicePrompt.outputValueOf('address')).toHaveValidAddress('sol');
 
                 await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                     formattedSendAmount,
@@ -75,18 +73,10 @@ test.describe(
             await test.step('Send crypto to provider', async () => {
                 await devicePrompt.sendButton.click();
 
-                await expect(page.getByTestId('@toast/tx-exchange/send-account')).toContainText(
-                    accountLabel,
-                );
-                await expect(page.getByTestId('@toast/tx-exchange/receive-account')).toContainText(
-                    'Base #1',
-                );
-                await expect(page.getByTestId('@toast/tx-exchange/send-amount')).toContainText(
-                    sendAmount,
-                );
-                await expect(page.getByTestId('@toast/tx-exchange/receive-amount')).toContainText(
-                    receiveAmount,
-                );
+                await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
+                await expect(tradingPage.swapToastReceiveAccount).toContainText('Base #1');
+                await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+                await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
 
                 await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                     'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',

--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -1,0 +1,173 @@
+import { getCryptoId } from '@suite-common/trading';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { expect, test } from '../../support/fixtures';
+
+const tenMinutes = 10 * 60 * 1000;
+const sendAmount = '7.77';
+const sendTokenSymbol = 'USDT';
+const sendAssetName = 'Tether';
+const receiveAssetName = 'Solana';
+const receiveCoinSymbol = 'SOL';
+const formattedSendAmount = `${localizeNumber(sendAmount)} ${sendTokenSymbol}`;
+const accountLabel = 'Solana #2';
+
+// limiting number of runs due to fees onchain and nonce issues during teardown - by using specific model and FW tags
+test.describe(
+    'Trading - Swap SPL token to coin via CEX',
+    { tag: ['@nightlyOnly', '@specificFirmware', '@T3W1', '@webOnly'] },
+    () => {
+        test.setTimeout(tenMinutes);
+        test.use({
+            deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
+        });
+        test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage }) => {
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE_LIVE!);
+
+            await walletPage.openSwapTrading({ symbol: 'sol', atIndex: 1 });
+        });
+
+        test('Swap USDT to SOL via CEX', async ({ tradingPage, page, devicePrompt }) => {
+            await test.step('Fill in a Swap form', async () => {
+                await tradingPage.fillSwapForm({
+                    amount: sendAmount,
+                    sellAsset: {
+                        networkSymbol: 'sol',
+                        tokenSymbol: sendTokenSymbol,
+                    },
+                    buyAsset: {
+                        searchFilter: receiveAssetName,
+                        assetCryptoId: getCryptoId('sol'),
+                    },
+                    selectReceiveAddress: async () => {
+                        await tradingPage.receiveAccount.selectSuiteReceiveAccount(1, 'sol');
+                    },
+                });
+            });
+
+            let receiveAmount: string;
+            await test.step('Confirm the Swap trade', async () => {
+                await expect(tradingPage.quotes.bestOfferAmount).toContainText(receiveCoinSymbol);
+                const [amount] = (await tradingPage.quotes.bestOfferAmount.innerText()).split(' ');
+                receiveAmount = localizeNumber(amount);
+                await tradingPage.waitForSolanaFeesAndClickSwapBestOffer();
+            });
+
+            await test.step('Initiate send', async () => {
+                await tradingPage.confirmation.initiateSendConfirmation({
+                    confirmAlsoToken: true,
+                });
+                await expect(devicePrompt.headerParagraph).toContainText(accountLabel);
+                await expect(devicePrompt.outputValueOf('address')).toHaveValidAddress('sol');
+                await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
+                    formattedSendAmount,
+                );
+                await expect(devicePrompt.cryptoAmountOf('fee')).toHaveTextGreaterThan(0);
+            });
+
+            await test.step('Send crypto to provider', async () => {
+                await devicePrompt.sendButton.click();
+
+                await expect(tradingPage.swapToastSendAccount).toContainText(accountLabel);
+                await expect(tradingPage.swapToastReceiveAccount).toContainText(accountLabel);
+                await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+                await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
+
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
+                    { timeout: tenMinutes },
+                );
+            });
+
+            await test.step('Verify swap detail sidebar', async () => {
+                // "You pay" section
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.sendAccount)
+                    .toContainText(accountLabel);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.sendAssetName)
+                    .toHaveText(sendAssetName);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.sendNetworkName)
+                    .toHaveText(receiveAssetName);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.cryptoAmounts.first())
+                    .toContainText(sendAmount);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.cryptoAmounts.first())
+                    .toContainText(sendTokenSymbol);
+
+                // "You get" section
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.receiveAccount)
+                    .toContainText(accountLabel);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.receiveAssetName)
+                    .toHaveText(receiveAssetName);
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.cryptoAmounts.last())
+                    .toContainText(receiveCoinSymbol);
+
+                // Provider
+                await expect.soft(tradingPage.confirmation.provider).toBeVisible();
+
+                // Rate type (can be floating or fixed depending on provider)
+                await expect.soft(tradingPage.confirmation.exchangeType).toBeVisible();
+            });
+
+            await test.step('Return to account swap form', async () => {
+                await tradingPage.backToAccountButton('Swap').click();
+                await expect(
+                    page.getByTestId('@trading/menu/wallet-trading-transactions'),
+                ).toBeVisible();
+            });
+        });
+
+        test.afterEach(async ({ tradingPage, devicePrompt, walletPage }) => {
+            await walletPage.openAccount({ symbol: 'sol', atIndex: 1 });
+            const balanceText = await walletPage.topPanelBalance.innerText();
+            const solBalance = parseFloat(balanceText);
+            if (solBalance < 0.1) {
+                return;
+            }
+
+            const swapBackAmount = (solBalance - 0.05).toFixed(6);
+
+            await walletPage.openSwapTrading({ symbol: 'sol', atIndex: 1 });
+            await test.step('Fill in a Swap form', async () => {
+                await tradingPage.fillSwapForm({
+                    amount: swapBackAmount,
+                    sellAsset: {
+                        searchFilter: 'Solana #2',
+                        networkSymbol: 'sol',
+                    },
+                    buyAsset: {
+                        searchFilter: sendTokenSymbol,
+                        networkFilter: 'sol',
+                        networkSymbol: 'sol',
+                        tokenSymbol: sendTokenSymbol,
+                    },
+                    selectReceiveAddress: async () => {
+                        await tradingPage.receiveAccount.selectSuiteReceiveAccount(1, 'sol');
+                    },
+                });
+            });
+
+            await test.step('Confirm the Swap trade', async () => {
+                await expect(tradingPage.quotes.bestOfferAmount).toContainText(sendTokenSymbol);
+                await tradingPage.waitForSolanaFeesAndClickSwapBestOffer();
+            });
+
+            await test.step('Initiate send', async () => {
+                await tradingPage.confirmation.initiateSendConfirmation();
+            });
+
+            await test.step('Send crypto to provider', async () => {
+                await devicePrompt.sendButton.click();
+            });
+        });
+    },
+);

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -81,18 +81,10 @@ test.describe('Trading - Swap coin to token', { tag: ['@webOnly', '@T3W1', '@T3T
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange/send-account')).toContainText(
-                'Solana #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-account')).toContainText(
-                'Ethereum #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/send-amount')).toContainText(
-                sendAmount,
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-amount')).toContainText(
-                receiveAmount,
-            );
+            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Ethereum #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/suite/e2e/tests/trading/swap-coins.test.ts
+++ b/suite/e2e/tests/trading/swap-coins.test.ts
@@ -146,18 +146,10 @@ test.describe('Trading - Swap coins', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, (
         await test.step('Send crypto to provider', async () => {
             await page.clock.install();
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange/send-account')).toContainText(
-                'Solana #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-account')).toContainText(
-                'Bitcoin #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/send-amount')).toContainText(
-                sendAmount,
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-amount')).toContainText(
-                receiveAmount,
-            );
+            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
         });
 
         for (const { transactionStatus, displayedText, translationValues } of transactionStates) {

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -40,7 +40,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
         },
     );
 
-    test('Swap Solana Tether token to Bitcoin', async ({ tradingPage, page, devicePrompt }) => {
+    test('Swap Solana Tether token to Bitcoin', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
@@ -77,18 +77,10 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange/send-account')).toContainText(
-                'Solana #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-account')).toContainText(
-                'Bitcoin #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/send-amount')).toContainText(
-                sendAmount,
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-amount')).toContainText(
-                receiveAmount,
-            );
+            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Bitcoin #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );

--- a/suite/e2e/tests/trading/swap-tokens.test.ts
+++ b/suite/e2e/tests/trading/swap-tokens.test.ts
@@ -41,7 +41,7 @@ test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
         },
     );
 
-    test('Swap Solana tokens', async ({ tradingPage, page, devicePrompt }) => {
+    test('Swap Solana tokens', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
@@ -80,18 +80,10 @@ test.describe('Trading - Swap tokens', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
         // Thanks to our mocked responses, the crypto is actually not send.
         await test.step('Send crypto to provider', async () => {
             await devicePrompt.sendButton.click();
-            await expect(page.getByTestId('@toast/tx-exchange/send-account')).toContainText(
-                'Solana #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-account')).toContainText(
-                'Solana #1',
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/send-amount')).toContainText(
-                sendAmount,
-            );
-            await expect(page.getByTestId('@toast/tx-exchange/receive-amount')).toContainText(
-                receiveAmount,
-            );
+            await expect(tradingPage.swapToastSendAccount).toContainText('Solana #1');
+            await expect(tradingPage.swapToastReceiveAccount).toContainText('Solana #1');
+            await expect(tradingPage.swapToastSendAmount).toContainText(sendAmount);
+            await expect(tradingPage.swapToastReceiveAmount).toContainText(receiveAmount);
             await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
                 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
             );


### PR DESCRIPTION
- Add live E2E test for swapping SPL token (USDT) to SOL via CEX, including teardown that swaps back to preserve balance
- Add data-testid attributes to TradingInfoItem for swap detail sidebar assertions
- Add toHaveValidAddress custom matcher for address validation in device prompts
- Extend TradingPage page object with sidebar detail and toast notification locators
- Refactor existing swap tests to use shared TradingPage locators instead of inline getByTestId calls
- Fix typo in test directory name (tradeing-live -> trading-live)

Manual nightly run: https://app.currents.dev/run/f3bdb5b91bd4b75d


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=live-swap-SPL&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=live-swap-SPL&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T10:28:25.689Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T12:20:56.966Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->