### PR TITLE
feature(suite-native): add fee selection for approval flow

### DIFF
--- a/suite-native/module-trading/src/__tests__/thunks.test.ts
+++ b/suite-native/module-trading/src/__tests__/thunks.test.ts
@@ -5,15 +5,11 @@ import {
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
-import {
-    type Account,
-    type AccountKey,
-    type TokenAddress,
-    type TokenInfoBranded,
-} from '@suite-common/wallet-types';
+import { type Account, type TokenAddress, type TokenInfoBranded } from '@suite-common/wallet-types';
+import { getFormDraftKey } from '@suite-common/wallet-utils';
 import { type PreloadedState, type TestStore, initStore } from '@suite-native/test-utils';
 import { selectAccountTokenInfo } from '@suite-native/tokens';
-import { exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
+import { eth1NormalAccount, exchangeQuotes, getWalletState } from '@suite-native/trading-fixtures';
 
 import { clearTradingStateThunk, composeEvmApprovalFeeLevelsThunk } from '../thunks';
 
@@ -157,7 +153,7 @@ describe('thunks', () => {
 
         beforeEach(() => {
             const walletState = getWalletState({ tradeType: 'exchange' });
-            walletState.trading.exchange.tradingAccountKey = 'eth-account-1' as AccountKey;
+            walletState.trading.exchange.tradingAccountKey = eth1NormalAccount.key;
 
             const preloadedState: PreloadedState = {
                 wallet: walletState,
@@ -179,9 +175,7 @@ describe('thunks', () => {
 
             const ethAccount = store
                 .getState()
-                .wallet.accounts.find(
-                    (account: Account) => account.key === ('eth-account-1' as AccountKey),
-                );
+                .wallet.accounts.find((account: Account) => account.key === eth1NormalAccount.key);
 
             const result = await store.dispatch(
                 composeEvmApprovalFeeLevelsThunk({
@@ -198,9 +192,7 @@ describe('thunks', () => {
         it('should compose allowance fee levels for a DEX quote', async () => {
             const ethAccount = store
                 .getState()
-                .wallet.accounts.find(
-                    (account: Account) => account.key === ('eth-account-1' as AccountKey),
-                );
+                .wallet.accounts.find((account: Account) => account.key === eth1NormalAccount.key);
 
             const result = await store.dispatch(
                 composeEvmApprovalFeeLevelsThunk({
@@ -211,6 +203,97 @@ describe('thunks', () => {
             );
 
             expect(result.type).toContain('fulfilled');
+        });
+
+        it('should merge composed approval fees into existing exchange form draft without dropping fields', async () => {
+            const formDraftKey = getFormDraftKey('trading-exchange', '');
+            const walletState = getWalletState({ tradeType: 'exchange' });
+            walletState.trading.exchange.tradingAccountKey = eth1NormalAccount.key;
+
+            const preloadedState: PreloadedState = {
+                wallet: {
+                    ...walletState,
+                    formDrafts: {
+                        [formDraftKey]: {
+                            swapOnlyField: 'keep-around',
+                            outputs: [
+                                {
+                                    type: 'payment' as const,
+                                    address: '0xabc',
+                                    amount: '1',
+                                    fiat: '',
+                                    currency: { label: '', value: '' },
+                                    label: '',
+                                    token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
+                                },
+                            ],
+                        },
+                    },
+                },
+                device: {
+                    selectedDevice: {
+                        state: { staticSessionId: 'device1@test:123' },
+                        features: { major_version: 2, minor_version: 6, patch_version: 0 },
+                    },
+                },
+            };
+            const localStore = initStore(preloadedState).store;
+            const ethAccount = localStore
+                .getState()
+                .wallet.accounts.find((account: Account) => account.key === eth1NormalAccount.key);
+
+            const result = await localStore.dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote: dexQuoteWithApprovalData,
+                    account: ethAccount!,
+                    feeInfo,
+                }),
+            );
+
+            expect(result.type).toContain('fulfilled');
+
+            const draft = localStore.getState().wallet.formDrafts[formDraftKey];
+            expect(draft.swapOnlyField).toBe('keep-around');
+            expect(draft.selectedFee).toBe('normal');
+            expect(draft.feePerUnit).toBe('20');
+            expect(draft.feeLimit).toBe('52000');
+            expect(draft.outputs[0].address).toBe('0xabc');
+        });
+
+        it('should add default payment output with token when exchange form draft has no outputs', async () => {
+            const formDraftKey = getFormDraftKey('trading-exchange', '');
+            const walletState = getWalletState({ tradeType: 'exchange' });
+            walletState.trading.exchange.tradingAccountKey = eth1NormalAccount.key;
+
+            const preloadedState: PreloadedState = {
+                wallet: {
+                    ...walletState,
+                    formDrafts: {},
+                },
+                device: {
+                    selectedDevice: {
+                        state: { staticSessionId: 'device1@test:123' },
+                        features: { major_version: 2, minor_version: 6, patch_version: 0 },
+                    },
+                },
+            };
+            const localStore = initStore(preloadedState).store;
+            const ethAccount = localStore
+                .getState()
+                .wallet.accounts.find((account: Account) => account.key === eth1NormalAccount.key);
+
+            const result = await localStore.dispatch(
+                composeEvmApprovalFeeLevelsThunk({
+                    quote: dexQuoteWithApprovalData,
+                    account: ethAccount!,
+                    feeInfo,
+                }),
+            );
+
+            expect(result.type).toContain('fulfilled');
+
+            const draft = localStore.getState().wallet.formDrafts[formDraftKey];
+            expect(draft.outputs[0].token).toBe('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
         });
     });
 });

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.tsx
@@ -1,8 +1,15 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useNavigation } from '@react-navigation/native';
+
 import { Card, InlineAlertBox } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
+import {
+    type StackNavigationProps,
+    type TradingStackParamList,
+    TradingStackRoutes,
+} from '@suite-native/navigation';
 import { NetworkAndAccountCard } from '@suite-native/trading-atoms';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
@@ -16,14 +23,27 @@ type ExchangeApprovalDetailsProps = {
     exchange: string | undefined;
 };
 
-const noop = () => {};
-
 export const ExchangeApprovalDetails = ({
     fee,
     isLoading,
     exchange,
 }: ExchangeApprovalDetailsProps) => {
     const account = useSelector(selectExchangeSelectedSendAccount);
+
+    const navigation =
+        useNavigation<
+            StackNavigationProps<TradingStackParamList, TradingStackRoutes.TradingExchangeApproval>
+        >();
+
+    const navigateToFees = () => {
+        if (fee === undefined || !account?.key) {
+            return;
+        }
+        navigation.navigate(TradingStackRoutes.TradingFees, {
+            accountKey: account.key,
+            tradingType: 'exchange',
+        });
+    };
 
     useEffect(() => {
         if (!account) {
@@ -56,7 +76,7 @@ export const ExchangeApprovalDetails = ({
                 <FeePicker
                     fee={fee ?? '0'}
                     symbol={account.symbol}
-                    onPress={noop}
+                    onPress={navigateToFees}
                     isLoading={isLoading}
                     noBorder
                 />

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
@@ -1,5 +1,6 @@
 import { tradingActions } from '@suite-common/trading';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { getFormDraftKey } from '@suite-common/wallet-utils';
 import {
     type PreloadedState,
     type TestStore,
@@ -21,6 +22,21 @@ jest.mock('../../../../thunks', () => ({
 describe('useEvmApprovalFees', () => {
     let store: TestStore;
     let preloadedState: PreloadedState;
+
+    const exchangeFormDraftKey = getFormDraftKey('trading-exchange', '');
+
+    const ethFeeInfoPreload = {
+        eth: {
+            status: 'loaded' as const,
+            data: {
+                blockHeight: 1000,
+                blockTime: 15,
+                minFee: 1,
+                maxFee: 100,
+                levels: [{ label: 'normal' as const, feePerUnit: '20', blocks: 1 }],
+            },
+        },
+    };
 
     const dexQuoteWithApprovalData = {
         ...exchangeQuotes[3],
@@ -120,6 +136,91 @@ describe('useEvmApprovalFees', () => {
         expect(result.current).toEqual(
             expect.objectContaining({
                 composeFees: expect.any(Function),
+            }),
+        );
+    });
+
+    it('should pass selected fee level from exchange form draft to compose thunk', async () => {
+        preloadedState!.wallet!.fees = ethFeeInfoPreload;
+        preloadedState!.wallet!.formDrafts = {
+            [exchangeFormDraftKey]: { selectedFee: 'high' },
+        };
+        store = initStore(preloadedState).store;
+
+        renderUseEvmApprovalFees();
+
+        await waitFor(() => {
+            expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();
+        });
+
+        expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                selectedFeeLevel: 'high',
+            }),
+        );
+    });
+
+    it('should pass custom fee fields from exchange form draft when fee level is custom', async () => {
+        preloadedState!.wallet!.fees = ethFeeInfoPreload;
+        preloadedState!.wallet!.formDrafts = {
+            [exchangeFormDraftKey]: {
+                selectedFee: 'custom',
+                feeLimit: '21000',
+                feePerUnit: '25',
+                maxFeePerGas: '100',
+                maxPriorityFeePerGas: '2',
+            },
+        };
+        store = initStore(preloadedState).store;
+
+        renderUseEvmApprovalFees();
+
+        await waitFor(() => {
+            expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();
+        });
+
+        expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                selectedFeeLevel: 'custom',
+                customFee: {
+                    feeLimit: '21000',
+                    feePerUnit: '25',
+                    maxFeePerGas: '100',
+                    maxPriorityFeePerGas: '2',
+                },
+            }),
+        );
+    });
+
+    it('should default to normal fee level when exchange form draft has no selected fee', async () => {
+        preloadedState!.wallet!.fees = ethFeeInfoPreload;
+        preloadedState!.wallet!.formDrafts = {
+            [exchangeFormDraftKey]: {
+                outputs: [
+                    {
+                        type: 'payment' as const,
+                        address: '',
+                        amount: '0',
+                        fiat: '',
+                        currency: { label: '', value: '' },
+                        label: '',
+                        token: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
+                    },
+                ],
+            },
+        };
+        store = initStore(preloadedState).store;
+
+        renderUseEvmApprovalFees();
+
+        await waitFor(() => {
+            expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalled();
+        });
+
+        expect(mockComposeEvmApprovalFeeLevelsThunk).toHaveBeenCalledWith(
+            expect.objectContaining({
+                selectedFeeLevel: 'normal',
+                customFee: undefined,
             }),
         );
     });

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { type DexApprovalType } from 'invity-api';
@@ -10,11 +10,17 @@ import {
 import {
     type AccountsRootState,
     type FeesRootState,
+    type FormDraftRootState,
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
+    selectDeepCopyOfFormDraft,
 } from '@suite-common/wallet-core';
+import { type FeeLevelLabel } from '@suite-common/wallet-types';
 import { useTranslate } from '@suite-native/intl';
-import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+import {
+    getFormDraftKeyByTradeType,
+    selectExchangeSelectedSendAccount,
+} from '@suite-native/trading-state';
 
 import { composeEvmApprovalFeeLevelsThunk } from '../../../thunks';
 
@@ -38,6 +44,30 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
     );
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
 
+    const formDraftKey = getFormDraftKeyByTradeType('exchange');
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        selectDeepCopyOfFormDraft(state, formDraftKey),
+    );
+    const selectedFeeLevel = (formDraft?.selectedFee as FeeLevelLabel) ?? 'normal';
+
+    const feeLimit = formDraft?.feeLimit as string | undefined;
+    const feePerUnit = formDraft?.feePerUnit as string | undefined;
+    const maxFeePerGas = formDraft?.maxFeePerGas as string | undefined;
+    const maxPriorityFeePerGas = formDraft?.maxPriorityFeePerGas as string | undefined;
+
+    const customFee = useMemo(() => {
+        if (selectedFeeLevel !== 'custom' || !feeLimit || !feePerUnit) {
+            return undefined;
+        }
+
+        return {
+            feeLimit,
+            feePerUnit,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+        };
+    }, [selectedFeeLevel, feeLimit, feePerUnit, maxFeePerGas, maxPriorityFeePerGas]);
+
     const approvalType =
         approvalTypeOverride ?? ((quote?.approvalType ?? 'INFINITE') as DexApprovalType);
     const fee = composedTransactionInfo?.composed?.fee;
@@ -56,6 +86,8 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
                     quote,
                     account,
                     feeInfo,
+                    selectedFeeLevel,
+                    customFee,
                     approvalTypeOverride,
                 }),
             ).unwrap();
@@ -65,17 +97,26 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
         } finally {
             setIsComposing(false);
         }
-    }, [dispatch, quote, account, feeInfo, approvalTypeOverride, translate]);
+    }, [
+        dispatch,
+        quote,
+        account,
+        feeInfo,
+        selectedFeeLevel,
+        customFee,
+        approvalTypeOverride,
+        translate,
+    ]);
 
     // Keep a ref to the latest composeFees so the effect always calls the
     // current version without needing it as a dependency.
     const composeFeesRef = useRef(composeFees);
     composeFeesRef.current = composeFees;
 
-    // Recompose only when the approval type or dex transaction data changes.
+    // Recompose when the approval type, dex transaction data, fee level, or custom gas fields change.
     useEffect(() => {
         composeFeesRef.current();
-    }, [approvalType, quote?.dexTx?.data]);
+    }, [approvalType, quote?.dexTx?.data, selectedFeeLevel, customFee]);
 
     return {
         fee,

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useEvmApprovalFees.ts
@@ -10,17 +10,13 @@ import {
 import {
     type AccountsRootState,
     type FeesRootState,
-    type FormDraftRootState,
     selectAccountByKey,
     selectConvertedNetworkFeeInfo,
-    selectDeepCopyOfFormDraft,
+    useFormDraft,
 } from '@suite-common/wallet-core';
-import { type FeeLevelLabel } from '@suite-common/wallet-types';
+import { type FormState } from '@suite-common/wallet-types';
 import { useTranslate } from '@suite-native/intl';
-import {
-    getFormDraftKeyByTradeType,
-    selectExchangeSelectedSendAccount,
-} from '@suite-native/trading-state';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
 
 import { composeEvmApprovalFeeLevelsThunk } from '../../../thunks';
 
@@ -44,16 +40,10 @@ export const useEvmApprovalFees = ({ approvalTypeOverride }: UseEvmApprovalFeesP
     );
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
 
-    const formDraftKey = getFormDraftKeyByTradeType('exchange');
-    const formDraft = useSelector((state: FormDraftRootState) =>
-        selectDeepCopyOfFormDraft(state, formDraftKey),
-    );
-    const selectedFeeLevel = (formDraft?.selectedFee as FeeLevelLabel) ?? 'normal';
+    const { draft } = useFormDraft<FormState>('trading-exchange', '');
+    const selectedFeeLevel = draft?.selectedFee ?? 'normal';
 
-    const feeLimit = formDraft?.feeLimit as string | undefined;
-    const feePerUnit = formDraft?.feePerUnit as string | undefined;
-    const maxFeePerGas = formDraft?.maxFeePerGas as string | undefined;
-    const maxPriorityFeePerGas = formDraft?.maxPriorityFeePerGas as string | undefined;
+    const { feeLimit, feePerUnit, maxFeePerGas, maxPriorityFeePerGas } = draft ?? {};
 
     const customFee = useMemo(() => {
         if (selectedFeeLevel !== 'custom' || !feeLimit || !feePerUnit) {

--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -360,11 +360,30 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                     );
 
                     const formDraftKey = getFormDraftKeyByTradeType('exchange');
+                    const existingDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey) ?? {};
+                    // Preserve swap form fields (especially outputs[0].token). A full replace would drop
+                    // outputs; composeSendFormTransactionFeeLevelsThunk then cannot resolve the ERC-20
+                    // contract for approval fee composition and custom gas shows insufficient balance.
+                    const outputs =
+                        existingDraft.outputs?.[0]?.token != null
+                            ? existingDraft.outputs
+                            : [
+                                  {
+                                      type: 'payment' as const,
+                                      address: '',
+                                      amount: '0',
+                                      fiat: '',
+                                      currency: { label: '', value: '' },
+                                      label: '',
+                                      token: contractAddress as TokenAddress,
+                                  },
+                              ];
 
                     dispatch(
                         formDraftActions.storeDraft({
                             key: formDraftKey,
                             formDraft: {
+                                ...existingDraft,
                                 selectedFee: selectedFeeLevel,
                                 feePerUnit: composed.feePerByte,
                                 feeLimit: composed.feeLimit ?? '',
@@ -372,6 +391,7 @@ export const composeEvmApprovalFeeLevelsThunk = createThunk(
                                 maxPriorityFeePerGas: composed.maxPriorityFeePerGas ?? '',
                                 estimatedFeeLimit: composed.estimatedFeeLimit,
                                 transactionData: data,
+                                outputs,
                             },
                         }),
                     );


### PR DESCRIPTION
Select fee for contract approval in swap.


## Notes for QA
User can select fee for approval

## Related Issue

Resolve #25740



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25740-mobile-swap-approval-flow-add-fee-selection&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->