### PR TITLE
feat(trading): add fiat deviation warning to exchange confirm

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingFiatDeviationWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatDeviationWarning.tsx
@@ -1,0 +1,42 @@
+import { useSelector } from 'react-redux';
+
+import { type ExchangeTrade } from 'invity-api';
+
+import { Translation } from '@suite/intl';
+import { useExchangeFiatDeviation } from '@suite-common/trading';
+import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { Banner } from '@trezor/components';
+
+type TradingFiatDeviationWarningProps = {
+    selectedQuote: ExchangeTrade;
+};
+
+export const TradingFiatDeviationWarning = ({
+    selectedQuote,
+}: TradingFiatDeviationWarningProps) => {
+    const fiatCurrency = useSelector(selectBaseCurrency);
+    const exchangeDeviation = useExchangeFiatDeviation({
+        sendCryptoId: selectedQuote.send,
+        sendAmount: selectedQuote.sendStringAmount,
+        receiveCryptoId: selectedQuote.receive,
+        receiveAmount: selectedQuote.receiveStringAmount,
+        fiatCurrency,
+    });
+
+    if (!exchangeDeviation?.exceedsThreshold) return null;
+
+    return (
+        <Banner
+            intent={exchangeDeviation.exceedsHighThreshold ? 'critical' : 'warning'}
+            data-testid="@trading/fiat-deviation-warning"
+            description={
+                <Translation
+                    id="TR_TRADING_FIAT_DEVIATION_WARNING"
+                    values={{
+                        percentage: exchangeDeviation.deviation,
+                    }}
+                />
+            }
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -20,6 +20,7 @@ import { type TradingOfferExchangeProps } from 'src/types/trading/tradingForm';
 import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 
 import { TradingOfferExchangeDetails } from './TradingOfferExchangeDetails';
+import { TradingFiatDeviationWarning } from '../../TradingFiatDeviationWarning';
 import { TradingInfoItem } from '../TradingInfo/TradingInfoItem';
 
 export const TradingOfferExchange = ({
@@ -98,7 +99,7 @@ export const TradingOfferExchange = ({
                 receiveAddress={selectedQuote.receiveAddress}
                 isReceive
             />
-
+            <TradingFiatDeviationWarning selectedQuote={selectedQuote} />
             <TradingOfferExchangeDetails
                 exchangeQuote={selectedQuote}
                 providers={providers as TradingExchangeProvidersInfoProps}

--- a/suite-common/trading/src/hooks/__tests__/useExchangeFiatDeviation.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useExchangeFiatDeviation.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react';
+import { type CryptoId } from 'invity-api';
+
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { useExchangeFiatDeviation } from '../useExchangeFiatDeviation';
+import { type TradingFiatRatesReturn, useTradingFiatValues } from '../useTradingFiatValues';
+
+jest.mock('../useTradingFiatValues', () => ({
+    useTradingFiatValues: jest.fn(),
+}));
+
+const mockedUseTradingFiatValues = jest.mocked(useTradingFiatValues);
+
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+
+const defaultProps = {
+    sendCryptoId: BITCOIN_CRYPTO_ID,
+    sendAmount: '1',
+    receiveCryptoId: ETHEREUM_CRYPTO_ID,
+    receiveAmount: '10',
+    fiatCurrency: 'usd' as BaseCurrencyCode,
+};
+
+const createTradingFiatValuesResult = (fiatValue: string | null): TradingFiatRatesReturn => ({
+    fiatValue,
+    fiatRate: undefined,
+    accountBalance: '1',
+    formattedBalance: '1',
+    symbol: 'btc',
+    networkDecimals: 8,
+    tokenAddress: undefined,
+    fiatRatesUpdater: () => Promise.resolve(null),
+});
+
+const renderUseExchangeFiatDeviation = (props: Partial<typeof defaultProps> = {}) =>
+    renderHook(() => useExchangeFiatDeviation({ ...defaultProps, ...props }));
+
+describe('useExchangeFiatDeviation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+    it('returns deviation and no threshold flags when below threshold', () => {
+        mockedUseTradingFiatValues
+            .mockReturnValueOnce(createTradingFiatValuesResult('1000'))
+            .mockReturnValueOnce(createTradingFiatValuesResult('980'));
+
+        const { result } = renderUseExchangeFiatDeviation();
+
+        expect(result.current).toEqual({
+            deviation: 2,
+            exceedsThreshold: false,
+            exceedsHighThreshold: false,
+        });
+    });
+
+    it('sets deviation at 10%', () => {
+        mockedUseTradingFiatValues
+            .mockReturnValueOnce(createTradingFiatValuesResult('1000'))
+            .mockReturnValueOnce(createTradingFiatValuesResult('900'));
+
+        const { result } = renderUseExchangeFiatDeviation();
+
+        expect(result.current).toEqual({
+            deviation: 10,
+            exceedsThreshold: true,
+            exceedsHighThreshold: false,
+        });
+    });
+
+    it('sets deviation at 20%', () => {
+        mockedUseTradingFiatValues
+            .mockReturnValueOnce(createTradingFiatValuesResult('1000'))
+            .mockReturnValueOnce(createTradingFiatValuesResult('800'));
+
+        const { result } = renderUseExchangeFiatDeviation();
+
+        expect(result.current).toEqual({
+            deviation: 20,
+            exceedsThreshold: true,
+            exceedsHighThreshold: true,
+        });
+    });
+
+    it('returns null when fiat values are missing', () => {
+        mockedUseTradingFiatValues.mockReturnValue(null);
+
+        const { result } = renderUseExchangeFiatDeviation();
+
+        expect(result.current).toBeNull();
+    });
+});

--- a/suite-common/trading/src/hooks/useExchangeFiatDeviation.ts
+++ b/suite-common/trading/src/hooks/useExchangeFiatDeviation.ts
@@ -1,0 +1,64 @@
+import { type CryptoId } from 'invity-api';
+
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+
+import { useTradingFiatValues } from './useTradingFiatValues';
+
+const FIAT_DEVIATION_THRESHOLD_PERCENT = 10;
+const FIAT_DEVIATION_HIGH_THRESHOLD_PERCENT = 20;
+
+type ExchangeFiatDeviationProps = {
+    sendCryptoId?: CryptoId;
+    sendAmount?: string;
+    receiveCryptoId?: CryptoId;
+    receiveAmount?: string;
+    fiatCurrency?: BaseCurrencyCode;
+};
+
+export type FiatDeviationResult = {
+    deviation: number;
+    exceedsThreshold: boolean;
+    exceedsHighThreshold: boolean;
+};
+
+const parseFiatValue = (value: string | undefined | null): number | null => {
+    if (!value) return null;
+    const n = Number(value);
+
+    return Number.isFinite(n) && n > 0 ? n : null;
+};
+
+export const useExchangeFiatDeviation = ({
+    sendCryptoId,
+    sendAmount,
+    receiveCryptoId,
+    receiveAmount,
+    fiatCurrency,
+}: ExchangeFiatDeviationProps): FiatDeviationResult | null => {
+    const sendFiat = useTradingFiatValues({
+        cryptoId: sendCryptoId,
+        fiatCurrency,
+        amount: sendAmount,
+    });
+
+    const receiveFiat = useTradingFiatValues({
+        cryptoId: receiveCryptoId,
+        fiatCurrency,
+        amount: receiveAmount,
+    });
+
+    const sendFiatValue = parseFiatValue(sendFiat?.fiatValue);
+    const receiveFiatValue = parseFiatValue(receiveFiat?.fiatValue);
+
+    if (sendFiatValue === null || receiveFiatValue === null) {
+        return null;
+    }
+
+    const deviationPercent = ((sendFiatValue - receiveFiatValue) / sendFiatValue) * 100;
+
+    return {
+        deviation: deviationPercent,
+        exceedsThreshold: deviationPercent >= FIAT_DEVIATION_THRESHOLD_PERCENT,
+        exceedsHighThreshold: deviationPercent >= FIAT_DEVIATION_HIGH_THRESHOLD_PERCENT,
+    };
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -9,6 +9,7 @@ export * from './hooks/useCountryFilteredData';
 export * from './hooks/useCountrySubdivisionFilteredData';
 export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
+export * from './hooks/useExchangeFiatDeviation';
 export * from './hooks/useApprovalStep';
 export * from './invityAPI';
 export * from './reducers/buyReducer';

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1002,6 +1002,10 @@ export const messages = defineMessages({
         defaultMessage: 'You get',
         id: 'TR_TRADING_YOU_GET',
     },
+    TR_TRADING_FIAT_DEVIATION_WARNING: {
+        defaultMessage: 'Receiving over {percentage}% less in estimated fiat value',
+        id: 'TR_TRADING_FIAT_DEVIATION_WARNING',
+    },
     TR_TRADING_COUNTRY: {
         defaultMessage: 'Country of residence',
         id: 'TR_TRADING_COUNTRY',


### PR DESCRIPTION
## Description

- Add `useExchangeFiatDeviation` in `suite-common/trading` and export it from the package index.
- Compute fiat deviation between send and receive values using `useTradingFiatValues` and return threshold flags for `>=10%` and `>=20%`.
- Add `TradingFiatDeviationWarning` and render it in exchange confirm (`TradingOfferExchange`) when deviation is at least 10%.
- Show a warning banner for `>=10%` deviation and a critical banner for `>=20%`, with a new i18n message including the percentage.
- Add unit tests for the hook covering below-threshold, 10%, 20%, and missing-fiat-value cases.

## Notes for QA

- In exchange confirm, verify the warning banner appears when receive estimated fiat value is at least 10% lower than send value.
- Verify severity changes to critical at 20% deviation and stays warning between 10% and 19.99%.
- Verify no banner is shown when deviation is below 10% or fiat values are unavailable.

## Related Issue

Resolve #22690

## Screenshots:

N/A
