### PR TITLE
fix(suite): bypass gas limit for simulation in connect popup

### DIFF
--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -17,6 +17,7 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts
+++ b/suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { U_INT_32 } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type TxSimulationAction, type TxSimulationMethod } from '@suite-common/wallet-types';
 
@@ -28,13 +29,24 @@ export function useTxSimulationPopupCall() {
         const { method, payload, fromAddress, source } = txSimulationPopupCall;
 
         switch (method) {
-            case 'ethereumSignTransaction':
+            case 'ethereumSignTransaction': {
+                const typedPayload =
+                    payload as TxSimulationMethod<'ethereumSignTransaction'>['payload'];
+
                 return {
                     method,
-                    payload: payload as TxSimulationMethod<'ethereumSignTransaction'>['payload'],
+                    payload: {
+                        ...typedPayload,
+                        transaction: {
+                            ...typedPayload.transaction,
+                            // Ensure a high gas limit to prevent out of gas errors during simulation
+                            gasLimit: `0x${U_INT_32.toString(16)}`,
+                        },
+                    },
                     fromAddress,
                     sourceOrigin: source.origin,
                 };
+            }
 
             case 'ethereumSignTypedData':
                 return {

--- a/suite-common/connect-popup/tsconfig.json
+++ b/suite-common/connect-popup/tsconfig.json
@@ -7,6 +7,7 @@
         { "path": "../redux-utils" },
         { "path": "../toast-notifications" },
         { "path": "../wallet-config" },
+        { "path": "../wallet-constants" },
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11281,6 +11281,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
## Description

Bypass EVM gas limit when running simulations in Connect Popup flow. 
Previously we were using Suite's default value of 250 000, which was too low for certain contracts such as Morpho, causing simulations to fail.  

## Notes for QA

Test Morpho deposit / withdraw via WalletConnect

## Related Issue

Resolve #26191

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/gas-limit-simulation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/gas-limit-simulation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/gas-limit-simulation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-25T11:09:22.916Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T11:07:44.593Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->