### PR TITLE
Mobile Swap: Approval Flow - Set swap amount as default limit for approval

### DIFF
--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -28,10 +28,29 @@ describe('LimitPicker', () => {
         store = initStore(preloadedState).store;
     });
 
-    it('should render Unlimited when no limit is specified', () => {
+    it('should render limit by default', () => {
         const { getByTestId } = renderLimitPicker();
 
         const picker = getByTestId('ExchangeApproval/LimitPicker');
+
+        expect(within(picker).getByText('100 USDC')).toBeOnTheScreen();
+        expect(
+            within(picker).getByText(
+                getTranslation('moduleTrading.exchangeApprovalLimitSheet.limitedCard.info'),
+            ),
+        ).toBeOnTheScreen();
+        expect(selectTradingExchangeSelectedQuote(store.getState())).toEqual(
+            expect.objectContaining({ approvalType: 'MINIMAL' }),
+        );
+    });
+
+    it('should render Unlimited when selected by user', async () => {
+        const { getByTestId } = renderLimitPicker();
+
+        const picker = getByTestId('ExchangeApproval/LimitPicker');
+        const sheet = getByTestId('ExchangeApproval/LimitSheet');
+
+        await userEvent.press(within(sheet).getByText('Unlimited'));
 
         expect(within(picker).getByText('Unlimited')).toBeOnTheScreen();
         expect(

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useApprovalTypeControls.test.ts
@@ -34,18 +34,18 @@ describe('useApprovalTypeControls', () => {
         store.dispatch(tradingExchangeActions.savePreselectedQuote(exchangeQuotes[0]));
     });
 
-    it('should use INFINITE as default', () => {
+    it('should use MINIMAL as default', () => {
         const { result } = renderUseApprovalTypeControls();
 
         expect(result.current).toEqual({
-            approvalType: 'INFINITE',
+            approvalType: 'MINIMAL',
             isSheetVisible: false,
             showSheet: expect.any(Function),
             hideSheet: expect.any(Function),
             handleApprovalTypeChange: expect.any(Function),
         });
         expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
-            expect.objectContaining({ approvalType: 'INFINITE' }),
+            expect.objectContaining({ approvalType: 'MINIMAL' }),
         );
     });
 
@@ -53,16 +53,16 @@ describe('useApprovalTypeControls', () => {
         const { result } = renderUseApprovalTypeControls();
 
         act(() => {
-            result.current.handleApprovalTypeChange('MINIMAL');
+            result.current.handleApprovalTypeChange('INFINITE');
         });
 
         expect(result.current).toEqual(
             expect.objectContaining({
-                approvalType: 'MINIMAL',
+                approvalType: 'INFINITE',
             }),
         );
         expect(selectTradingExchangeActiveQuote(store.getState())).toEqual(
-            expect.objectContaining({ approvalType: 'MINIMAL' }),
+            expect.objectContaining({ approvalType: 'INFINITE' }),
         );
     });
 
@@ -71,7 +71,7 @@ describe('useApprovalTypeControls', () => {
         const { result } = renderUseApprovalTypeControls();
 
         expect(result.current).toEqual({
-            approvalType: 'INFINITE',
+            approvalType: 'MINIMAL',
             isSheetVisible: false,
             showSheet: expect.any(Function),
             hideSheet: expect.any(Function),
@@ -80,12 +80,12 @@ describe('useApprovalTypeControls', () => {
         expect(selectTradingExchangeActiveQuote(store.getState())).toBeUndefined();
 
         act(() => {
-            result.current.handleApprovalTypeChange('MINIMAL');
+            result.current.handleApprovalTypeChange('INFINITE');
         });
 
         expect(result.current).toEqual(
             expect.objectContaining({
-                approvalType: 'INFINITE',
+                approvalType: 'MINIMAL',
             }),
         );
         expect(selectTradingExchangeActiveQuote(store.getState())).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/useApprovalTypeControls.ts
@@ -15,7 +15,7 @@ export const useApprovalTypeControls = (quote: ExchangeTrade | undefined) => {
             dispatch(
                 tradingExchangeActions.saveSelectedQuote({
                     ...quote,
-                    approvalType: 'INFINITE',
+                    approvalType: 'MINIMAL',
                 }),
             );
         }
@@ -37,7 +37,7 @@ export const useApprovalTypeControls = (quote: ExchangeTrade | undefined) => {
     );
 
     return {
-        approvalType: quote?.approvalType ?? 'INFINITE',
+        approvalType: quote?.approvalType ?? 'MINIMAL',
         isSheetVisible,
         showSheet,
         hideSheet,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes default approval type from INFINITE to MINIMAL in useApprovalTypeControls.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25699

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=25699-set-swap-amount-as-default-limit-for-approval&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->