### PR TITLE
fix(connect): add d.mts and export it properly

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Pack packages
         run: yarn tsx ./scripts/ci/pack-packages.ts
 
+      - name: Check exports
+        # Fow now only testing @trezor/connect-web
+        run: npx --yes @arethetypeswrong/cli --pack ./tmp/packed-packages/trezor-connect-web.tgz 
+
       - name: Test local install
         run: ./packages/connect/e2e/test-connect-local.sh
 

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -26,12 +26,23 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/impl/*": "./lib/impl/*.js",
-            "./libESM/impl/*": "./libESM/impl/*"
+            "./lib/impl/*": {
+                "types": "./lib/impl/*.d.ts",
+                "default": "./lib/impl/*.js"
+            },
+            "./libESM/impl/*": {
+                "types": "./libESM/impl/*.d.mts",
+                "default": "./libESM/impl/*.mjs"
+            }
         }
     },
     "files": [

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -38,9 +38,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
             "./lib/constants/*": "./lib/constants/*.js",
             "./lib/data/*": "./lib/data/*.js",

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -53,4 +53,7 @@ if [ "$2" == "esm" ]; then
     # rename all esm js files to mjs
     find "$1" -name "*.js" -type f -exec sh -c 'mv "$0" "${0%.js}.mjs"' {} \;
     find "$1" -name "*.js.map" -type f -exec sh -c 'mv "$0" "${0%.js.map}.mjs.map"' {} \;
+    # rename declaration files to .d.mts so TypeScript treats them as ESM, matching the .mjs runtime files
+    find "$1" -name "*.d.ts.map" -type f -exec sh -c 'mv "$0" "${0%.d.ts.map}.d.mts.map"' {} \;
+    find "$1" -name "*.d.ts" -type f -exec sh -c 'mv "$0" "${0%.d.ts}.d.mts"' {} \;
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing some issues in exporting types for connect-web.

1. "types": "./lib/index.d.ts" has to be first before `"require"`, `"import"` or `"default"`.
2. Type files for ESM has to be in the format `d.mts`.
3. We need to export the types for the rest of exports not only for `"."`

Added test that checks we are following good export practices https://github.com/trezor/trezor-suite/pull/26206/changes/8510e37672fb2e52f8b66d7060469726d594abb5

I am looking into other packages, that will most likely come with improvements in follow-ups.

## Notes for QA

Nothing to test.

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23779

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/improve-connect-web-export-types-esm&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/improve-connect-web-export-types-esm&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/improve-connect-web-export-types-esm&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T14:24:56.295Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T15:30:09.376Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->