### PR TITLE
fix(suite): enable labeling for fresh receive address

### DIFF
--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
-import { Translation } from '@suite/intl';
+import { Translation, useTranslation } from '@suite/intl';
+import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
+import { selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectIsAccountUtxoBased } from '@suite-common/wallet-core';
 import { getFirstFreshAddress } from '@suite-common/wallet-utils';
@@ -18,7 +20,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 import { showAddress } from 'src/actions/wallet/receiveActions';
-import { Address, ReadMoreLink } from 'src/components/suite';
+import { Address, Labeling, ReadMoreLink } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 import { type AppState } from 'src/types/suite';
@@ -86,7 +88,12 @@ export const FreshAddress = ({
     const isAccountUtxoBased = useSelector((state: AccountsRootState) =>
         selectIsAccountUtxoBased(state, account?.key ?? null),
     );
+    const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
+    const suiteSyncAddressLabels = useSelector(state =>
+        account ? selectSuiteSyncAddressLabels(state, account.deviceState) : [],
+    );
     const { isReceiveDisabled, receiveDisabledTooltipContent } = useReceiveDisabled();
+    const { translationString } = useTranslation();
     const dispatch = useDispatch();
 
     const firstFreshAddress = useMemo(() => {
@@ -132,6 +139,10 @@ export const FreshAddress = ({
         minWidth: 220,
         size: 'large',
     };
+    const firstFreshAddressLabel = firstFreshAddress?.address
+        ? (suiteSyncAddressLabels.find(it => it.address === firstFreshAddress.address)?.label ??
+          addressLabels[firstFreshAddress.address])
+        : undefined;
 
     return (
         <Card>
@@ -148,7 +159,25 @@ export const FreshAddress = ({
                 >
                     <Text typographyStyle="headline-md">
                         {firstFreshAddress?.address ? (
-                            <Address value={firstFreshAddress.address} isTruncated />
+                            <Labeling
+                                payload={{
+                                    type: 'addressLabel',
+                                    entityKey: account.key,
+                                    defaultValue: firstFreshAddress.address,
+                                    networkSymbol: account.symbol,
+                                    accountDescriptor: account.descriptor,
+                                    value: firstFreshAddressLabel,
+                                }}
+                                deviceStaticSessionId={account.deviceState}
+                                displayValue={
+                                    <Address value={firstFreshAddress.address} isTruncated />
+                                }
+                                placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
+                                minHeight={28}
+                                maxWidth={300}
+                            >
+                                {firstFreshAddressLabel}
+                            </Labeling>
                         ) : (
                             <Translation id="RECEIVE_ADDRESS_UNAVAILABLE" />
                         )}

--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -174,7 +174,6 @@ export const FreshAddress = ({
                                 }
                                 placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
                                 minHeight={28}
-                                maxWidth={300}
                             >
                                 {firstFreshAddressLabel}
                             </Labeling>


### PR DESCRIPTION
- enable inline labeling for the fresh receive address in Receive
- keep the fresh address formatting consistent with the used-address list, including chunking by 4 characters


https://github.com/user-attachments/assets/24cd895b-394d-491c-bcca-404fe2e80284


Resolve https://github.com/trezor/trezor-suite/issues/26172

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/label-new-receive-address&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/label-new-receive-address&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-25T19:00:07.928Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-25T18:58:46.668Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->