### PR TITLE
fix(suite): reorder receive and send header actions

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceiveButtons.tsx
@@ -22,19 +22,6 @@ export const GlobalSendReceiveButtons = ({
     return (
         <ButtonGroup intent={intent} priority={priority}>
             <HeaderActionButton
-                key="wallet-send"
-                icon="arrowUp"
-                onClick={() => {
-                    setActiveModal('send');
-
-                    analytics.report({ type: events.dashboardSendModalEvent.name });
-                }}
-                data-testid="@wallet/menu/wallet-global-send"
-            >
-                <Translation id="TR_NAV_SEND" />
-            </HeaderActionButton>
-
-            <HeaderActionButton
                 key="wallet-receive"
                 icon="arrowDown"
                 onClick={() => {
@@ -45,6 +32,19 @@ export const GlobalSendReceiveButtons = ({
                 data-testid="@wallet/menu/wallet-global-receive"
             >
                 <Translation id="TR_NAV_RECEIVE" />
+            </HeaderActionButton>
+
+            <HeaderActionButton
+                key="wallet-send"
+                icon="arrowUp"
+                onClick={() => {
+                    setActiveModal('send');
+
+                    analytics.report({ type: events.dashboardSendModalEvent.name });
+                }}
+                data-testid="@wallet/menu/wallet-global-send"
+            >
+                <Translation id="TR_NAV_SEND" />
             </HeaderActionButton>
         </ButtonGroup>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderActions.tsx
@@ -41,6 +41,20 @@ export const HeaderActions = () => {
                     intent={isDeviceConnected ? 'brand' : 'neutral'}
                     priority={isDeviceConnected ? 'primary' : 'secondary'}
                 >
+                    <HeaderActionButton
+                        key="wallet-receive"
+                        icon="arrowDown"
+                        onClick={() => {
+                            goToWithAnalytics({
+                                routeName: 'wallet-receive',
+                                preserveParams: true,
+                            });
+                        }}
+                        data-testid="@wallet/menu/wallet-receive"
+                    >
+                        <Translation id="TR_NAV_RECEIVE" />
+                    </HeaderActionButton>
+
                     {isSendVisible ? (
                         <HeaderActionButton
                             key="wallet-send"
@@ -56,20 +70,6 @@ export const HeaderActions = () => {
                             <Translation id="TR_NAV_SEND" />
                         </HeaderActionButton>
                     ) : null}
-
-                    <HeaderActionButton
-                        key="wallet-receive"
-                        icon="arrowDown"
-                        onClick={() => {
-                            goToWithAnalytics({
-                                routeName: 'wallet-receive',
-                                preserveParams: true,
-                            });
-                        }}
-                        data-testid="@wallet/menu/wallet-receive"
-                    >
-                        <Translation id="TR_NAV_RECEIVE" />
-                    </HeaderActionButton>
                 </ButtonGroup>
             </AppNavigationTooltip>
         </Row>


### PR DESCRIPTION
## Description

Reorders the `Receive` and `Send` action buttons in the top-right header so that `Receive` is shown first and `Send` second. This corresponds with mobile and with common sense that user receive first and send second...

The change is applied in both places where these header actions are rendered:
- account detail header
- dashboard header

| Mobile reference: | Desktop |
| --- | --- |
| <img width="750" height="1334" alt="img_9383" src="https://github.com/user-attachments/assets/feb471cd-ccb6-4bf7-85af-b2eab0f9fc01" /> | Before:  <img width="424" height="58" alt="Screenshot 2026-03-25 at 19 41 19" src="https://github.com/user-attachments/assets/85ba5cae-5f19-402b-bde3-9870d3995769" /> After: <img width="411" height="62" alt="Screenshot 2026-03-25 at 19 41 02" src="https://github.com/user-attachments/assets/eda40bc6-0006-478d-8234-324932a7ebcb" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/receive-send-buttons-reorder&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/receive-send-buttons-reorder&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T10:25:47.664Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T08:54:19.966Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->