### PR TITLE
feat(suite): add legacy labeling migration to suite sync

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -89,6 +89,7 @@
         "@suite/intl": "workspace:*",
         "@suite/locks": "workspace:*",
         "@suite/metadata": "workspace:*",
+        "@suite/metadata-migration": "workspace:*",
         "@suite/modal": "workspace:*",
         "@suite/onboarding-components": "workspace:*",
         "@suite/platform-encryption-electron": "workspace:*",

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -664,6 +664,16 @@ export const NotificationRenderer = ({
                 message: 'TR_BIP_329_LABELS_IMPORTED',
             });
 
+        case 'legacy-labeling-migration-success':
+            return renderNotificationView(render, notification, {
+                variant: 'success',
+                message: 'TR_LABELING_MIGRATION_SUCCESS',
+                values: {
+                    added: notification.added,
+                    skipped: notification.skipped,
+                },
+            });
+
         default:
             return exhaustive(type);
     }

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -8,7 +8,12 @@ import {
     metadataActions,
     metadataLabelingActions,
     selectLabelingDataForAccount,
+    selectLabelingDataForWallet,
 } from '@suite/metadata';
+import {
+    type MetadataMigrationDep,
+    createMetadataMigrationCompositionRoot,
+} from '@suite/metadata-migration';
 import { closeModal, openModal } from '@suite/modal';
 import { createElectronPlatformEncryption } from '@suite/platform-encryption-electron';
 import { createWebauthnPlatformEncryption } from '@suite/platform-encryption-webauthn';
@@ -29,7 +34,7 @@ import { createSuiteSyncDesktopCompositionRoot } from '@suite/suite-sync';
 import { createBip329CompositionRoot } from '@suite-common/bip329';
 import { delegatedIdentityKeyCompositionRoot } from '@suite-common/delegated-identity-key';
 import { toGetter } from '@suite-common/dependency-injection';
-import type { DeviceReducerState } from '@suite-common/device';
+import { type DeviceReducerState } from '@suite-common/device';
 import { FW_HASH_CHECK_DEFAULT_TIMEOUTS } from '@suite-common/firmware-authenticity';
 import {
     type CommonServices,
@@ -37,7 +42,11 @@ import {
     type ExtraDependenciesStatic,
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
-import { selectAllLabelsForAccount, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import {
+    selectAllLabelsForAccount,
+    selectIsSuiteSyncEnabled,
+    selectSuiteSyncWalletLabel,
+} from '@suite-common/suite-sync';
 import {
     type TokenDefinitionsState,
     buildTokenDefinitionsFromStorage,
@@ -51,6 +60,7 @@ import {
     type SendState,
     type TransactionsState,
     type WalletSettingsState,
+    selectAccountsByDeviceState,
 } from '@suite-common/wallet-core';
 import { createAccountKey } from '@suite-common/wallet-types';
 import { buildHistoricRatesFromStorage } from '@suite-common/wallet-utils';
@@ -87,7 +97,10 @@ export type StoreAPIDep = {
 
 export type SuiteAppDeps = StoreAPIDep & HistoryDep;
 
-export type SuiteServices = CommonServices & DesktopAnalyticsDep & SuiteRouterHistoryDep;
+export type SuiteServices = CommonServices &
+    DesktopAnalyticsDep &
+    MetadataMigrationDep &
+    SuiteRouterHistoryDep;
 
 export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
     const platformEncryption = isDesktop()
@@ -120,9 +133,22 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         updateOutputLabel: suiteSync.labeling.updateOutputLabel,
     });
 
+    const { migrateLegacyLabelsToSuiteSync } = createMetadataMigrationCompositionRoot({
+        getAccountsByDeviceState: toGetter(deps.getState, selectAccountsByDeviceState),
+        getLegacyWalletLabels: toGetter(deps.getState, selectLabelingDataForWallet),
+        getLegacyAccountLabels: toGetter(deps.getState, selectLabelingDataForAccount),
+        getCurrentWalletLabel: toGetter(deps.getState, selectSuiteSyncWalletLabel),
+        getCurrentAccountLabels: toGetter(deps.getState, selectAllLabelsForAccount),
+        updateWalletLabel: suiteSync.labeling.updateWalletLabel,
+        updateAccountLabel: suiteSync.labeling.updateAccountLabel,
+        updateAddressLabel: suiteSync.labeling.updateAddressLabel,
+        updateOutputLabel: suiteSync.labeling.updateOutputLabel,
+    });
+
     return {
         suiteSync,
         bip329,
+        migrateLegacyLabelsToSuiteSync,
         ensureDelegatedIdentityKey,
         platformEncryption,
         analytics,
@@ -130,7 +156,7 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
             history: deps.history,
         }),
         reportSecurityCheck,
-        saveAs: (data, fileName) => saveAs(data, fileName),
+        saveAs: (data: Blob, fileName: string) => saveAs(data, fileName),
         connectInitSettings,
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({

--- a/packages/suite/src/support/tests/extraDependenciesDesktop.mock.ts
+++ b/packages/suite/src/support/tests/extraDependenciesDesktop.mock.ts
@@ -1,5 +1,6 @@
 import { type ExtraDependenciesStatic } from '@suite-common/redux-utils';
 import { analyticsMock, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { ok } from '@trezor/type-utils';
 
 import { type SuiteServices } from '../extraDependencies';
 
@@ -19,5 +20,6 @@ export const extraDependenciesDesktopMock: ExtraDependenciesSuiteMock = {
             navigate: (to, state) => console.warn(`Mock navigating to ${to} with state`, state),
             listen: (_: {}) => () => {},
         },
+        migrateLegacyLabelsToSuiteSync: () => Promise.resolve(ok({ changed: 0, skipped: 0 })),
     },
 };

--- a/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/SettingsDebug.tsx
@@ -2,12 +2,16 @@ import { selectFlags } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SuiteSyncSettings } from '@suite/suite-sync';
 import { Context } from '@suite-common/message-system';
+import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
+import { type EnsureWalletSuiteSyncOnErrors } from '@suite-common/suite-sync-types';
+import { type StaticSessionId } from '@trezor/connect';
 import { isDesktop } from '@trezor/env-utils';
 import { SettingsSection } from '@trezor/product-components';
 
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
+import { suiteSyncErrorHandler } from 'src/components/suite/labeling/suiteSyncErrorHandler';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 import { AnalyticsLogging } from './AnalyticsLogging';
@@ -42,9 +46,24 @@ import { TriggerToast } from './TriggerToast';
 import { WipeData } from './WipeData';
 
 export const SettingsDebug = () => {
+    const dispatch = useDispatch();
     const { isBelowLaptop } = useLayoutSize();
     const flags = useSelector(selectFlags);
     const { suiteSync } = useSuiteServices();
+
+    const handleWipeSuiteSyncLabelsError = ({
+        error,
+        deviceStaticSessionId,
+    }: {
+        error: EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError;
+        deviceStaticSessionId: StaticSessionId;
+    }) => {
+        suiteSyncErrorHandler({
+            error,
+            dispatch,
+            deviceStaticSessionId,
+        });
+    };
 
     return (
         <SettingsLayout>
@@ -123,7 +142,7 @@ export const SettingsDebug = () => {
             <SettingsSection isBelowLaptop={isBelowLaptop} title="Firmware channel">
                 <FirmwareUpdateEnvironmentSelect />
             </SettingsSection>
-            <SuiteSyncSettings suiteSync={suiteSync} />
+            <SuiteSyncSettings onError={handleWipeSuiteSyncLabelsError} suiteSync={suiteSync} />
             <QuotaManagerSettings />
             <PlatformEncrypton />
         </SettingsLayout>

--- a/packages/suite/src/views/settings/SettingsGeneral/LegacyLabelingMigration.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/LegacyLabelingMigration.tsx
@@ -1,0 +1,23 @@
+import { LegacyLabelingMigration as MetadataMigrationLegacyLabelingMigration } from '@suite/metadata-migration';
+
+import { suiteSyncErrorHandler } from 'src/components/suite/labeling/suiteSyncErrorHandler';
+import { useDispatch } from 'src/hooks/suite';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+
+export const LegacyLabelingMigration = () => {
+    const dispatch = useDispatch();
+    const { migrateLegacyLabelsToSuiteSync } = useSuiteServices();
+
+    return (
+        <MetadataMigrationLegacyLabelingMigration
+            migrateLegacyLabelsToSuiteSync={migrateLegacyLabelsToSuiteSync}
+            onSuiteSyncError={({ error, deviceStaticSessionId }) =>
+                suiteSyncErrorHandler({
+                    error,
+                    dispatch,
+                    deviceStaticSessionId,
+                })
+            }
+        />
+    );
+};

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -35,6 +35,7 @@ import { DustPhishing } from './DustPhishing';
 import { EarlyAccess } from './EarlyAccess';
 import { Experimental } from './Experimental';
 import { Language } from './Language';
+import { LegacyLabelingMigration } from './LegacyLabelingMigration';
 import { McpServer } from './McpServer';
 import { MevProtection } from './MevProtection';
 import { NetworkReserve } from './NetworkReserve';
@@ -112,6 +113,7 @@ export const SettingsGeneral = () => {
                     ) : (
                         <ConnectLabelingProvider />
                     ))}
+                <LegacyLabelingMigration />
             </SettingsSection>
 
             <SettingsSection

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -172,6 +172,9 @@
         { "path": "../../suite/intl" },
         { "path": "../../suite/locks" },
         { "path": "../../suite/metadata" },
+        {
+            "path": "../../suite/metadata-migration"
+        },
         { "path": "../../suite/modal" },
         {
             "path": "../../suite/onboarding-components"

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -197,6 +197,9 @@ export interface AccountLabels {
     addressLabels: Record<string, MetadataItem>;
 }
 
+/**
+ * @deprecated Legacy Labeling
+ */
 export interface WalletLabels {
     walletLabel?: string;
 }

--- a/suite-common/suite-sync-types/src/SuiteSync.ts
+++ b/suite-common/suite-sync-types/src/SuiteSync.ts
@@ -1,3 +1,4 @@
+import { type DangerouslyWipeAllLabelsFromWalletDep } from './data/dangerouslyWipeAllLabelsFromWallet';
 import { type UpdateAccountLabelDep } from './data/updateAccountLabel';
 import { type UpdateAddressLabelDep } from './data/updateAddressLabel';
 import { type UpdateOutputLabelDep } from './data/updateOutputLabel';
@@ -12,6 +13,7 @@ export type SuiteSync = ChangeRelayUrlDep &
     TurnOnSuiteSyncDep &
     TurnOffSuiteSyncDep &
     EnsureWalletSuiteSyncOnDep &
+    DangerouslyWipeAllLabelsFromWalletDep &
     TurnOffSuiteSyncForWalletDep & {
         labeling: UpdateWalletLabelDep &
             UpdateAccountLabelDep &

--- a/suite-common/suite-sync-types/src/data/dangerouslyWipeAllLabelsFromWallet.ts
+++ b/suite-common/suite-sync-types/src/data/dangerouslyWipeAllLabelsFromWallet.ts
@@ -1,0 +1,26 @@
+import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
+import { type WalletDescriptor } from '@suite-common/wallet-types';
+import { type Result } from '@trezor/type-utils';
+
+import { type EnsureWalletSuiteSyncOnErrors } from '../storage/ensureWalletSuiteSyncOn';
+
+/**
+ * @deprecated Intended only for debug & testing
+ */
+export type DangerouslyWipeAllLabelsFromWalletParams = {
+    walletDescriptor: WalletDescriptor;
+};
+
+/**
+ * @deprecated Intended only for debug & testing
+ */
+export type DangerouslyWipeAllLabelsFromWallet = (
+    params: DangerouslyWipeAllLabelsFromWalletParams,
+) => Promise<Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>>;
+
+/**
+ * @deprecated Intended only for debug & testing
+ */
+export type DangerouslyWipeAllLabelsFromWalletDep = {
+    dangerouslyWipeAllLabelsFromWallet: DangerouslyWipeAllLabelsFromWallet;
+};

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -31,6 +31,11 @@ export type {
     SubscriptionStorageParams,
 } from './storage/subscriptionStorage';
 export type {
+    DangerouslyWipeAllLabelsFromWallet,
+    DangerouslyWipeAllLabelsFromWalletDep,
+    DangerouslyWipeAllLabelsFromWalletParams,
+} from './data/dangerouslyWipeAllLabelsFromWallet';
+export type {
     TurnOffSuiteSyncForWallet,
     TurnOffSuiteSyncForWalletDep,
 } from './storage/turnOffSuiteSyncForWallet';

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -11,6 +11,7 @@ import {
     type CreateSuiteSyncOwnerDep,
 } from '@suite-common/suite-sync-storage';
 import { type SuiteSync } from '@suite-common/suite-sync-types';
+import { selectAccounts } from '@suite-common/wallet-core';
 import { type Analytics } from '@trezor/analytics-uploader';
 
 import { createEnsureSuiteSyncKeys } from './createEnsureSuiteSyncKeys';
@@ -20,10 +21,12 @@ import { selectSuiteSyncAccountLabel } from './data/account/selectSuiteSyncAccou
 import { selectSuiteSyncAddressLabel } from './data/address/suiteSyncAddressSelectors';
 import { createEnsureSubscribedStorage } from './data/createEnsureSubscribedStorage';
 import { createSuiteSyncListener } from './data/createSuiteSyncListener';
+import { createDangerouslyWipeAllLabelsFromWallet } from './data/labeling/createDangerouslyWipeAllLabelsFromWallet';
 import { createUpdateAccountLabel } from './data/labeling/createUpdateAccountLabel';
 import { createUpdateAddressLabel } from './data/labeling/createUpdateAddressLabel';
 import { createUpdateOutputLabel } from './data/labeling/createUpdateOutputLabel';
 import { createUpdateWalletLabel } from './data/labeling/createUpdateWalletLabel';
+import { selectAllLabelsForAccount } from './data/labeling/selectAllLabelsForAccount';
 import { selectSuiteSyncOutputLabel } from './data/output/suiteSyncOutputSelectors';
 import { selectSuiteSyncWalletLabel } from './data/wallet/suiteSyncWalletSelectors';
 import { type GetDeviceForStaticSessionId } from './getDeviceForStaticSessionId';
@@ -144,6 +147,7 @@ export const createSuiteSyncCompositionRoot = (
 
     const getIsSuiteSyncEnabled = toGetter(deps.getState, selectIsSuiteSyncEnabled);
     const getAllDeviceSessionIds = toGetter(deps.getState, selectAllDeviceStaticIds);
+    const getAccounts = toGetter(deps.getState, selectAccounts);
 
     const labelingDeps = {
         ensureWalletSuiteSyncOn,
@@ -153,6 +157,11 @@ export const createSuiteSyncCompositionRoot = (
         getAddressLabel: toGetter(deps.getState, selectSuiteSyncAddressLabel),
         getOutputLabel: toGetter(deps.getState, selectSuiteSyncOutputLabel),
     };
+
+    const updateWalletLabel = createUpdateWalletLabel(labelingDeps);
+    const updateAccountLabel = createUpdateAccountLabel(labelingDeps);
+    const updateOutputLabel = createUpdateOutputLabel(labelingDeps);
+    const updateAddressLabel = createUpdateAddressLabel(labelingDeps);
 
     return {
         changeRelayUrl: createChangeRelayUrl({
@@ -174,11 +183,20 @@ export const createSuiteSyncCompositionRoot = (
             ensureWalletSuiteSyncOn,
             getDeviceForStaticSessionId,
         }),
+        dangerouslyWipeAllLabelsFromWallet: createDangerouslyWipeAllLabelsFromWallet({
+            getWalletLabel: labelingDeps.getWalletLabel,
+            getAccounts,
+            getAllLabelsForAccount: toGetter(deps.getState, selectAllLabelsForAccount),
+            updateWalletLabel,
+            updateAccountLabel,
+            updateOutputLabel,
+            updateAddressLabel,
+        }),
         labeling: {
-            updateWalletLabel: createUpdateWalletLabel(labelingDeps),
-            updateAccountLabel: createUpdateAccountLabel(labelingDeps),
-            updateOutputLabel: createUpdateOutputLabel(labelingDeps),
-            updateAddressLabel: createUpdateAddressLabel(labelingDeps),
+            updateWalletLabel,
+            updateAccountLabel,
+            updateOutputLabel,
+            updateAddressLabel,
         },
     };
 };

--- a/suite-common/suite-sync/src/data/labeling/createDangerouslyWipeAllLabelsFromWallet.ts
+++ b/suite-common/suite-sync/src/data/labeling/createDangerouslyWipeAllLabelsFromWallet.ts
@@ -1,0 +1,124 @@
+import {
+    type DangerouslyWipeAllLabelsFromWallet,
+    type UpdateAccountLabelDep,
+    type UpdateAddressLabelDep,
+    type UpdateOutputLabelDep,
+    type UpdateWalletLabelDep,
+} from '@suite-common/suite-sync-types';
+import { type Account, type WalletDescriptor } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { ok } from '@trezor/type-utils';
+
+import {
+    type AllLabelsForAccount,
+    type SelectAllLabelsForAccountParams,
+} from './selectAllLabelsForAccount';
+
+type GetWalletLabelDep = {
+    getWalletLabel: (walletDescriptor: WalletDescriptor) => string | null;
+};
+
+type GetAccountsDep = {
+    getAccounts: () => Account[];
+};
+
+type GetAllLabelsForAccountDep = {
+    getAllLabelsForAccount: (params: SelectAllLabelsForAccountParams) => AllLabelsForAccount;
+};
+
+export type DangerouslyWipeAllLabelsFromWalletDeps = GetWalletLabelDep &
+    GetAccountsDep &
+    GetAllLabelsForAccountDep &
+    UpdateWalletLabelDep &
+    UpdateAccountLabelDep &
+    UpdateAddressLabelDep &
+    UpdateOutputLabelDep;
+
+export const createDangerouslyWipeAllLabelsFromWallet =
+    (deps: DangerouslyWipeAllLabelsFromWalletDeps): DangerouslyWipeAllLabelsFromWallet =>
+    async ({ walletDescriptor }) => {
+        const walletAccounts = deps
+            .getAccounts()
+            .filter(
+                account =>
+                    parseDeviceStaticSessionId(account.deviceState).walletDescriptor ===
+                    walletDescriptor,
+            );
+
+        const deviceStaticSessionId = walletAccounts[0]?.deviceState;
+        if (deviceStaticSessionId === undefined) {
+            return ok();
+        }
+
+        const walletLabel = deps.getWalletLabel(walletDescriptor);
+
+        if (walletLabel !== null) {
+            const walletResult = await deps.updateWalletLabel({
+                deviceStaticSessionId,
+                label: null,
+            });
+
+            if (!walletResult.success) {
+                return walletResult;
+            }
+        }
+
+        for (const account of walletAccounts) {
+            const labels = deps.getAllLabelsForAccount({
+                walletDescriptor,
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
+            });
+
+            if (labels.accountLabel !== null) {
+                const accountResult = await deps.updateAccountLabel({
+                    deviceStaticSessionId: account.deviceState,
+                    accountKey: account.key,
+                    label: null,
+                });
+
+                if (!accountResult.success) {
+                    return accountResult;
+                }
+            }
+
+            for (const addressLabel of labels.addressLabels) {
+                if (addressLabel.label === null) {
+                    continue;
+                }
+
+                const addressResult = await deps.updateAddressLabel({
+                    deviceStaticSessionId: account.deviceState,
+                    address: addressLabel.address,
+                    label: null,
+                    accountDescriptor: account.descriptor,
+                    networkSymbol: account.symbol,
+                });
+
+                if (!addressResult.success) {
+                    return addressResult;
+                }
+            }
+
+            for (const outputLabel of labels.outputLabels) {
+                if (outputLabel.label === null) {
+                    continue;
+                }
+
+                const outputResult = await deps.updateOutputLabel({
+                    deviceStaticSessionId: account.deviceState,
+                    txId: outputLabel.txId,
+                    txTargetId: outputLabel.txTargetId,
+                    label: null,
+                    accountDescriptor: account.descriptor,
+                    networkSymbol: account.symbol,
+                });
+
+                if (!outputResult.success) {
+                    return outputResult;
+                }
+            }
+        }
+
+        return ok();
+    };

--- a/suite-common/suite-sync/src/data/labeling/tests/createDangerouslyWipeAllLabelsFromWallet.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createDangerouslyWipeAllLabelsFromWallet.test.ts
@@ -1,0 +1,173 @@
+import { createMockDeps, mock } from '@suite-common/dependency-injection';
+import {
+    type SuiteSyncUpdateError,
+    createSuiteSyncAddressId,
+    createSuiteSyncOutputId,
+} from '@suite-common/suite-sync-storage';
+import {
+    type UpdateAccountLabelDep,
+    type UpdateAddressLabelDep,
+    type UpdateOutputLabelDep,
+    type UpdateWalletLabelDep,
+} from '@suite-common/suite-sync-types';
+import { asAccountDescriptor, asWalletDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { err, ok } from '@trezor/type-utils';
+
+import {
+    type DangerouslyWipeAllLabelsFromWalletDeps,
+    createDangerouslyWipeAllLabelsFromWallet,
+} from '../createDangerouslyWipeAllLabelsFromWallet';
+
+const walletDescriptor = asWalletDescriptor('wallet-1');
+const deviceStaticSessionId = 'wallet-1@device:0';
+
+const account = mockWalletAccount({
+    symbol: 'btc',
+    deviceState: deviceStaticSessionId,
+    descriptor: asAccountDescriptor('account-1'),
+});
+
+const createDeps = ({
+    updateWalletLabel,
+    updateAccountLabel,
+    updateAddressLabel,
+    updateOutputLabel,
+}: UpdateWalletLabelDep &
+    UpdateAccountLabelDep &
+    UpdateAddressLabelDep &
+    UpdateOutputLabelDep): DangerouslyWipeAllLabelsFromWalletDeps => {
+    const otherWalletAccount = mockWalletAccount({
+        symbol: 'btc',
+        deviceState: 'wallet-2@device:0',
+        descriptor: asAccountDescriptor('account-2'),
+    });
+
+    return createMockDeps<DangerouslyWipeAllLabelsFromWalletDeps>({
+        getWalletLabel: currentWalletDescriptor =>
+            currentWalletDescriptor === walletDescriptor ? 'Wallet label' : null,
+        getAccounts: () => [account, otherWalletAccount],
+        getAllLabelsForAccount: ({ accountDescriptor }) => ({
+            accountLabel: accountDescriptor === account.descriptor ? 'Account label' : null,
+            addressLabels:
+                accountDescriptor === account.descriptor
+                    ? [
+                          {
+                              id: createSuiteSyncAddressId('bc1address', 'btc'),
+                              address: 'bc1address',
+                              label: 'Address label',
+                              accountDescriptor: account.descriptor,
+                              networkSymbol: 'btc',
+                          },
+                          {
+                              id: createSuiteSyncAddressId('bc1empty', 'btc'),
+                              address: 'bc1empty',
+                              label: null,
+                              accountDescriptor: account.descriptor,
+                              networkSymbol: 'btc',
+                          },
+                      ]
+                    : [],
+            outputLabels:
+                accountDescriptor === account.descriptor
+                    ? [
+                          {
+                              id: createSuiteSyncOutputId('tx-id', '0'),
+                              txId: 'tx-id',
+                              txTargetId: '0',
+                              label: 'Output label',
+                              accountDescriptor: account.descriptor,
+                              networkSymbol: 'btc',
+                          },
+                          {
+                              id: createSuiteSyncOutputId('tx-id-2', '1'),
+                              txId: 'tx-id-2',
+                              txTargetId: '1',
+                              label: null,
+                              accountDescriptor: account.descriptor,
+                              networkSymbol: 'btc',
+                          },
+                      ]
+                    : [],
+        }),
+        updateWalletLabel,
+        updateAccountLabel,
+        updateAddressLabel,
+        updateOutputLabel,
+    });
+};
+
+describe(createDangerouslyWipeAllLabelsFromWallet.name, () => {
+    it('wipes wallet, account, address, and output labels for one wallet only', async () => {
+        const updateWalletLabel = mock(() => Promise.resolve(ok(undefined)));
+        const updateAccountLabel = mock(() => Promise.resolve(ok(undefined)));
+        const updateAddressLabel = mock(() => Promise.resolve(ok(undefined)));
+        const updateOutputLabel = mock(() => Promise.resolve(ok(undefined)));
+
+        const deps = createDeps({
+            updateWalletLabel,
+            updateAccountLabel,
+            updateAddressLabel,
+            updateOutputLabel,
+        });
+        const dangerouslyWipeAllLabelsFromWallet = createDangerouslyWipeAllLabelsFromWallet(deps);
+
+        const result = await dangerouslyWipeAllLabelsFromWallet({ walletDescriptor });
+
+        expect(result).toEqual(ok(undefined));
+        expect(updateWalletLabel).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            label: null,
+        });
+        expect(updateAccountLabel).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            accountKey: account.key,
+            label: null,
+        });
+        expect(updateAddressLabel).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            address: 'bc1address',
+            label: null,
+            accountDescriptor: account.descriptor,
+            networkSymbol: 'btc',
+        });
+        expect(updateOutputLabel).toHaveBeenCalledWith({
+            deviceStaticSessionId,
+            txId: 'tx-id',
+            txTargetId: '0',
+            label: null,
+            accountDescriptor: account.descriptor,
+            networkSymbol: 'btc',
+        });
+        expect(updateAccountLabel).toHaveBeenCalledTimes(1);
+        expect(updateAddressLabel).toHaveBeenCalledTimes(1);
+        expect(updateOutputLabel).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops on first update error and propagates it', async () => {
+        const updateError: SuiteSyncUpdateError = {
+            type: 'SuiteSyncUpdateError',
+            caused: new Error('update failed'),
+        };
+        const updateWalletLabel = mock(() => Promise.resolve(ok(undefined)));
+        const updateAccountLabel = mock(() => Promise.resolve(err(updateError)));
+        const updateAddressLabel = mock(() => Promise.resolve(ok(undefined)));
+        const updateOutputLabel = mock(() => Promise.resolve(ok(undefined)));
+
+        const deps = createDeps({
+            updateWalletLabel,
+            updateAccountLabel,
+            updateAddressLabel,
+            updateOutputLabel,
+        });
+
+        const dangerouslyWipeAllLabelsFromWallet = createDangerouslyWipeAllLabelsFromWallet(deps);
+
+        const result = await dangerouslyWipeAllLabelsFromWallet({ walletDescriptor });
+
+        expect(result).toEqual(err(updateError));
+        expect(updateAccountLabel).toHaveBeenCalledTimes(1);
+        expect(updateAddressLabel).not.toHaveBeenCalled();
+        expect(updateOutputLabel).not.toHaveBeenCalled();
+    });
+});

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -67,7 +67,11 @@ export {
     selectSuiteSyncOutputLabel,
     selectSuiteSyncOutputLabels,
 } from './data/output/suiteSyncOutputSelectors';
-export { selectAllLabelsForAccount } from './data/labeling/selectAllLabelsForAccount';
+export {
+    selectAllLabelsForAccount,
+    type AllLabelsForAccount,
+    type SelectAllLabelsForAccountParams,
+} from './data/labeling/selectAllLabelsForAccount';
 export {
     fromSuiteSyncToSearchAccountLabels,
     fromSuiteSyncToSearchOutputLabels,

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -32,6 +32,7 @@ const suiteSyncMock: SuiteSync = {
     turnOffSuiteSyncForWallet: () => Promise.resolve(),
     turnOnSuiteSync: () => Promise.resolve(ok()),
     turnOffSuiteSync: () => Promise.resolve(),
+    dangerouslyWipeAllLabelsFromWallet: () => Promise.resolve(ok()),
     labeling: {
         updateAccountLabel: () => Promise.resolve(ok()),
         updateAddressLabel: () => Promise.resolve(ok()),

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -135,6 +135,11 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
               | 'suite-sync-keys-error'
               | 'bip-329-labels-imported';
       }
+    | {
+          type: 'legacy-labeling-migration-success';
+          added: number;
+          skipped: number;
+      }
     | SentTransactionNotification
     | ApproveTransactionNotification
     | RevokeTransactionNotification

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6476,6 +6476,32 @@ export const messages = defineMessages({
             'Keep your wallet, account, and transaction labels consistent on all your devices.',
         id: 'TR_LEGACY_LABELING_TURN_ON_SUITE_SYNC_BANNER_DESCRIPTION',
     },
+    TR_LABELING_MIGRATION_TITLE: {
+        defaultMessage: 'Migrate legacy labels to Suite Sync',
+        id: 'TR_LABELING_MIGRATION_TITLE',
+    },
+    TR_LABELING_MIGRATION_DESCRIPTION: {
+        defaultMessage:
+            'Select a legacy labeling provider and import labels from selected wallet. Existing Suite Sync labels will stay unchanged.',
+        id: 'TR_LABELING_MIGRATION_DESCRIPTION',
+    },
+    TR_LABELING_MIGRATION_MODAL_HEADING: {
+        defaultMessage: 'Migrate legacy labels',
+        id: 'TR_LABELING_MIGRATION_MODAL_HEADING',
+    },
+    TR_LABELING_MIGRATION_MODAL_DESCRIPTION: {
+        defaultMessage:
+            'Choose where your legacy labels are stored. Only missing labels will be copied to Suite Sync.',
+        id: 'TR_LABELING_MIGRATION_MODAL_DESCRIPTION',
+    },
+    TR_LABELING_MIGRATION_FAILED: {
+        defaultMessage: 'Migration failed. Try again.',
+        id: 'TR_LABELING_MIGRATION_FAILED',
+    },
+    TR_LABELING_MIGRATION_SUCCESS: {
+        defaultMessage: '{added} labels migrated successfully, {skipped} skipped',
+        id: 'TR_LABELING_MIGRATION_SUCCESS',
+    },
     TR_TO_MAKE_YOUR_LABELS_PERSISTENT: {
         defaultMessage:
             'To make your labels consistent and available on different devices, connect to a cloud storage provider.',
@@ -8751,6 +8777,10 @@ export const messages = defineMessages({
     TR_LOADING_ACCOUNTS_DESCRIPTION: {
         id: 'TR_LOADING_ACCOUNTS_DESCRIPTION',
         defaultMessage: 'You can change your selected assets once your accounts are loaded.',
+    },
+    TR_MIGRATE: {
+        defaultMessage: 'Migrate',
+        id: 'TR_MIGRATE',
     },
     TR_LOADING_FACT_TITLE: {
         id: 'TR_LOADING_FACT_TITLE',

--- a/suite/metadata-migration/jest.config.js
+++ b/suite/metadata-migration/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite/metadata-migration/package.json
+++ b/suite/metadata-migration/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@suite/suite-sync",
+    "name": "@suite/metadata-migration",
     "version": "1.0.0",
     "private": true,
     "license": "See LICENSE.md in repo root",
@@ -8,31 +8,32 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
+        "test:unit": "yarn g:jest",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@evolu/common": "8.0.0-next.3",
-        "@evolu/web": "3.0.0-next.0",
-        "@hookform/resolvers": "^5.2.2",
-        "@reduxjs/toolkit": "2.11.2",
-        "@suite-common/delegated-identity-key-types": "workspace:*",
+        "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
-        "@suite-common/platform-encryption": "workspace:*",
+        "@suite-common/metadata-types": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
-        "@suite-common/suite-sync-evolu": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
-        "@suite/analytics": "workspace:*",
         "@suite/intl": "workspace:*",
+        "@suite/metadata": "workspace:*",
+        "@suite/router": "workspace:*",
         "@trezor/components": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/product-components": "workspace:*",
-        "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "react": "19.2.4",
-        "react-hook-form": "^7.71.2",
-        "react-redux": "9.2.0"
+        "react-redux": "9.2.0",
+        "redux-thunk": "^3.1.0"
     }
 }

--- a/suite/metadata-migration/src/LegacyLabelingMigration.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigration.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { Translation } from '@suite/intl';
+import { Anchor, SettingsAnchor } from '@suite/router';
+import { selectSelectedDevice } from '@suite-common/device';
+import { selectIsSuiteSyncDebugEnabled, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { Tooltip } from '@trezor/components';
+import { type StaticSessionId } from '@trezor/connect';
+import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { LegacyLabelingMigrationModal } from './LegacyLabelingMigrationModal';
+import type { MigrationError } from './legacyLabelsMigration';
+import type { MigrateLegacyLabelsToSuiteSync } from './migrateLegacyLabelsToSuiteSync';
+import { isMigratableDevice } from './migrationUtils';
+
+export type LegacyLabelingMigrationProps = {
+    migrateLegacyLabelsToSuiteSync: MigrateLegacyLabelsToSuiteSync;
+    onSuiteSyncError: (params: {
+        error: MigrationError['cause'];
+        deviceStaticSessionId: StaticSessionId;
+    }) => void;
+};
+
+export const LegacyLabelingMigration = ({
+    migrateLegacyLabelsToSuiteSync,
+    onSuiteSyncError,
+}: LegacyLabelingMigrationProps) => {
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
+
+    const isMigratable = isMigratableDevice(selectedDevice);
+
+    // Todo: remove the `isSuiteSyncDebugEnabled` check after we are confident to offer migration
+    if (!isSuiteSyncEnabled || !isSuiteSyncDebugEnabled) {
+        return null;
+    }
+
+    return (
+        <>
+            {isModalVisible && (
+                <LegacyLabelingMigrationModal
+                    onCancel={() => setIsModalVisible(false)}
+                    onFinish={() => setIsModalVisible(false)}
+                    migrateLegacyLabelsToSuiteSync={migrateLegacyLabelsToSuiteSync}
+                    onSuiteSyncError={onSuiteSyncError}
+                />
+            )}
+
+            <Anchor anchorId={SettingsAnchor.LabelingMigration}>
+                {({ anchorId, anchorRef, shouldHighlight }) => (
+                    <SectionItem
+                        data-testid={anchorId}
+                        ref={anchorRef}
+                        shouldHighlight={shouldHighlight}
+                    >
+                        <TextColumn
+                            title={<Translation id="TR_LABELING_MIGRATION_TITLE" />}
+                            description={<Translation id="TR_LABELING_MIGRATION_DESCRIPTION" />}
+                        />
+                        <ActionColumn>
+                            <Tooltip
+                                content={
+                                    isMigratable ? undefined : (
+                                        <Translation id="TR_DEVICE_NOT_CONNECTED" />
+                                    )
+                                }
+                            >
+                                <ActionButton
+                                    intent="brand"
+                                    onClick={() => setIsModalVisible(true)}
+                                    isDisabled={!isMigratable}
+                                    data-testid="@settings/metadata/migrate-button"
+                                >
+                                    <Translation id="TR_MIGRATE" />
+                                </ActionButton>
+                            </Tooltip>
+                        </ActionColumn>
+                    </SectionItem>
+                )}
+            </Anchor>
+        </>
+    );
+};

--- a/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigrationModal.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import type { ThunkDispatch } from 'redux-thunk';
+
+import { Translation } from '@suite/intl';
+import {
+    MetadataProviderSelectionModal,
+    type MetadataRootState,
+    connectProvider,
+    metadataLabelingActions,
+    selectSelectedProviderForLabels,
+} from '@suite/metadata';
+import { selectSelectedDevice } from '@suite-common/device';
+import { type MetadataProviderType } from '@suite-common/metadata-types';
+import { type AnyAction, type ExtraDependencies } from '@suite-common/redux-utils';
+import { notificationsActions } from '@suite-common/toast-notifications';
+import { type StaticSessionId } from '@trezor/connect';
+
+import type { MigrationError } from './legacyLabelsMigration';
+import type { MigrateLegacyLabelsToSuiteSync } from './migrateLegacyLabelsToSuiteSync';
+import { isMigratableDevice } from './migrationUtils';
+
+type LegacyLabelingMigrationModalProps = {
+    onCancel: () => void;
+    onFinish: () => void;
+    migrateLegacyLabelsToSuiteSync: MigrateLegacyLabelsToSuiteSync;
+    onSuiteSyncError: (params: {
+        error: MigrationError['cause'];
+        deviceStaticSessionId: StaticSessionId;
+    }) => void;
+};
+
+type MetadataDispatch = ThunkDispatch<MetadataRootState, ExtraDependencies, AnyAction>;
+
+export const LegacyLabelingMigrationModal = ({
+    onCancel,
+    onFinish,
+    migrateLegacyLabelsToSuiteSync,
+    onSuiteSyncError,
+}: LegacyLabelingMigrationModalProps) => {
+    const dispatch = useDispatch<MetadataDispatch>();
+    const selectedProvider = useSelector(selectSelectedProviderForLabels);
+    const selectedDevice = useSelector(selectSelectedDevice);
+    const [providerLoading, setProviderLoading] = useState<MetadataProviderType | null>(null);
+    const [error, setError] = useState('');
+
+    const isMigratable = isMigratableDevice(selectedDevice);
+
+    const handleMigrate = async (providerType: MetadataProviderType) => {
+        if (!isMigratableDevice(selectedDevice)) {
+            setError('Connect device to continue.');
+
+            return;
+        }
+
+        setError('');
+        setProviderLoading(providerType);
+
+        const isProviderAlreadyConnected = selectedProvider?.type === providerType;
+
+        if (!isProviderAlreadyConnected) {
+            const providerConnected = await dispatch(connectProvider({ type: providerType }));
+
+            if (providerConnected === 'window closed') {
+                setProviderLoading(null);
+
+                return;
+            }
+
+            if (typeof providerConnected === 'string') {
+                setError(providerConnected);
+                setProviderLoading(null);
+
+                return;
+            }
+
+            if (!providerConnected) {
+                setError('Migration failed. Try again.');
+                setProviderLoading(null);
+
+                return;
+            }
+        }
+
+        const initialized = await dispatch(
+            metadataLabelingActions.init(true, selectedDevice.state.staticSessionId),
+        );
+
+        if (!initialized) {
+            setError('Migration failed. Try again.');
+            setProviderLoading(null);
+
+            return;
+        }
+
+        const result = await migrateLegacyLabelsToSuiteSync(selectedDevice);
+
+        if (result.success) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'legacy-labeling-migration-success',
+                    added: result.payload.changed,
+                    skipped: result.payload.skipped,
+                }),
+            );
+        } else {
+            onSuiteSyncError({
+                error: result.error.cause,
+                deviceStaticSessionId: result.error.deviceStaticSessionId,
+            });
+
+            setError('Migration failed. Try again.');
+        }
+
+        setProviderLoading(null);
+
+        if (result.success) {
+            onFinish();
+        }
+    };
+
+    return (
+        <MetadataProviderSelectionModal
+            onCancel={onCancel}
+            onSelect={handleMigrate}
+            loadingProvider={providerLoading ?? ''}
+            isDisabled={!isMigratable}
+            error={error || (!isMigratable ? 'Connect device to continue.' : '')}
+            heading={<Translation id="TR_LABELING_MIGRATION_MODAL_HEADING" />}
+            description={<Translation id="TR_LABELING_MIGRATION_MODAL_DESCRIPTION" />}
+            testId="@modal/legacy-labeling-migration"
+        />
+    );
+};

--- a/suite/metadata-migration/src/__tests__/migrateLegacyLabelsToSuiteSync.test.ts
+++ b/suite/metadata-migration/src/__tests__/migrateLegacyLabelsToSuiteSync.test.ts
@@ -1,0 +1,285 @@
+import { createMockDeps } from '@suite-common/dependency-injection';
+import { isTrezorDeviceWithState } from '@suite-common/device';
+import type { AllLabelsForAccount } from '@suite-common/suite-sync';
+import {
+    createSuiteSyncAddressId,
+    createSuiteSyncOutputId,
+    createSuiteSyncUpdateError,
+} from '@suite-common/suite-sync-storage';
+import type { SuiteSyncAddress, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import type { TrezorDeviceWithState } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import type { StaticSessionId } from '@trezor/connect';
+import { err, ok } from '@trezor/type-utils';
+
+import {
+    type MigrateAccountLabelsDeps,
+    createMigrateAccountLabels,
+} from '../entities/createMigrateAccountLabels';
+import {
+    type MigrateAddressLabelsDeps,
+    createMigrateAddressLabels,
+} from '../entities/createMigrateAddressLabels';
+import {
+    type MigrateOutputLabelsDeps,
+    createMigrateOutputLabels,
+} from '../entities/createMigrateOutputLabels';
+import {
+    type MigrateWalletLabelsDeps,
+    createMigrateWalletLabels,
+} from '../entities/createMigrateWalletLabels';
+import {
+    type GetCurrentAccountLabels,
+    type GetLegacyAccountLabels,
+} from '../legacyLabelsMigration';
+import {
+    type MigrateLegacyLabelsToSuiteSyncDeps,
+    createMigrateLegacyLabelsToSuiteSync,
+} from '../migrateLegacyLabelsToSuiteSync';
+
+const createDevice = (staticSessionId: StaticSessionId): TrezorDeviceWithState => {
+    const device = mockSuiteDevice({
+        connected: true,
+        available: true,
+        id: 'device-id',
+        state: { staticSessionId },
+    });
+
+    if (!isTrezorDeviceWithState(device)) {
+        throw new Error('Expected device with static session id');
+    }
+
+    return device;
+};
+
+const createAccount = (params: {
+    descriptor: string;
+    symbol: NetworkSymbol;
+    deviceState: StaticSessionId;
+}) =>
+    mockWalletAccount({
+        deviceState: params.deviceState,
+        descriptor: asAccountDescriptor(params.descriptor),
+        symbol: params.symbol,
+    });
+
+const getLegacyAccountLabels: GetLegacyAccountLabels = () => ({
+    accountLabel: undefined,
+    addressLabels: {},
+    outputLabels: {},
+});
+
+const createCurrentAccountLabels = (
+    overrides: Partial<AllLabelsForAccount> = {},
+): AllLabelsForAccount => ({
+    accountLabel: null,
+    addressLabels: [],
+    outputLabels: [],
+    ...overrides,
+});
+
+const getCurrentAccountLabels: GetCurrentAccountLabels = () => createCurrentAccountLabels();
+
+const createSuiteSyncAddressLabel = (
+    address: string,
+    label: string,
+    accountDescriptor = asAccountDescriptor('descriptor-1'),
+    networkSymbol: NetworkSymbol = 'btc',
+): SuiteSyncAddress => ({
+    id: createSuiteSyncAddressId(address, networkSymbol),
+    address,
+    label,
+    accountDescriptor,
+    networkSymbol,
+});
+
+const createSuiteSyncOutputLabel = (
+    txId: string,
+    txTargetId: string,
+    label: string,
+    accountDescriptor = asAccountDescriptor('descriptor-1'),
+    networkSymbol: NetworkSymbol = 'btc',
+): SuiteSyncOutput => {
+    const targetId = asTxTargetId(txTargetId);
+
+    return {
+        id: createSuiteSyncOutputId(txId, targetId),
+        txId,
+        txTargetId: targetId,
+        label,
+        accountDescriptor,
+        networkSymbol,
+    };
+};
+
+const createMigrate = (
+    overrides: {
+        selectedDevice?: TrezorDeviceWithState;
+    } & Partial<
+        MigrateLegacyLabelsToSuiteSyncDeps &
+            MigrateWalletLabelsDeps &
+            MigrateAccountLabelsDeps &
+            MigrateAddressLabelsDeps &
+            MigrateOutputLabelsDeps
+    > = {},
+) => {
+    const { selectedDevice = createDevice('device@wallet:1'), ...depsOverrides } = overrides;
+    const deps = createMockDeps({
+        getAccountsByDeviceState: () => [],
+        getLegacyWalletLabels: () => ({ walletLabel: 'Legacy wallet' }),
+        getLegacyAccountLabels,
+        getCurrentWalletLabel: () => null,
+        getCurrentAccountLabels,
+        updateWalletLabel: () => Promise.resolve(ok()),
+        updateAccountLabel: () => Promise.resolve(ok()),
+        updateAddressLabel: () => Promise.resolve(ok()),
+        updateOutputLabel: () => Promise.resolve(ok()),
+        ...depsOverrides,
+    });
+
+    const migrateLegacyLabelsToSuiteSync = createMigrateLegacyLabelsToSuiteSync({
+        getAccountsByDeviceState: deps.getAccountsByDeviceState,
+        getLegacyAccountLabels: deps.getLegacyAccountLabels,
+        getCurrentAccountLabels: deps.getCurrentAccountLabels,
+
+        migrateWalletLabels: createMigrateWalletLabels({
+            getLegacyWalletLabels: deps.getLegacyWalletLabels,
+            getCurrentWalletLabel: deps.getCurrentWalletLabel,
+            updateWalletLabel: deps.updateWalletLabel,
+        }),
+        migrateAccountLabels: createMigrateAccountLabels({
+            updateAccountLabel: deps.updateAccountLabel,
+        }),
+        migrateAddressLabels: createMigrateAddressLabels({
+            updateAddressLabel: deps.updateAddressLabel,
+        }),
+        migrateOutputLabels: createMigrateOutputLabels({
+            updateOutputLabel: deps.updateOutputLabel,
+        }),
+    });
+
+    return () => migrateLegacyLabelsToSuiteSync(selectedDevice);
+};
+
+describe(createMigrateLegacyLabelsToSuiteSync.name, () => {
+    it('migrates missing wallet, account, address, and output labels', async () => {
+        const updateWalletLabel = jest.fn(() => Promise.resolve(ok()));
+        const updateAccountLabel = jest.fn(() => Promise.resolve(ok()));
+        const updateAddressLabel = jest.fn(() => Promise.resolve(ok()));
+        const updateOutputLabel = jest.fn(() => Promise.resolve(ok()));
+
+        const migrateLegacyLabelsToSuiteSync = createMigrate({
+            getAccountsByDeviceState: () => [
+                createAccount({
+                    descriptor: 'descriptor-1',
+                    symbol: 'btc',
+                    deviceState: 'device@wallet:1',
+                }),
+            ],
+            getLegacyWalletLabels: () => ({ walletLabel: 'Legacy wallet' }),
+            getLegacyAccountLabels: () => ({
+                accountLabel: 'Legacy account',
+                addressLabels: { address1: 'Legacy address' },
+                outputLabels: { tx1: { '0': 'Legacy output' } },
+            }),
+            updateWalletLabel,
+            updateAccountLabel,
+            updateAddressLabel,
+            updateOutputLabel,
+        });
+
+        const result = await migrateLegacyLabelsToSuiteSync();
+
+        expect(result).toEqual(ok({ changed: 4, skipped: 0 }));
+
+        expect(updateWalletLabel).toHaveBeenCalledTimes(1);
+        expect(updateAccountLabel).toHaveBeenCalledTimes(1);
+        expect(updateAddressLabel).toHaveBeenCalledTimes(1);
+        expect(updateOutputLabel).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips labels already present in SuiteSync', async () => {
+        const migrateLegacyLabelsToSuiteSync = createMigrate({
+            getAccountsByDeviceState: () => [
+                createAccount({
+                    descriptor: 'descriptor-1',
+                    symbol: 'btc',
+                    deviceState: 'device@wallet:1',
+                }),
+            ],
+            getLegacyWalletLabels: () => ({ walletLabel: 'Legacy wallet' }),
+            getLegacyAccountLabels: () => ({
+                accountLabel: 'Legacy account',
+                addressLabels: { address1: 'Legacy address' },
+                outputLabels: { tx1: { '0': 'Legacy output' } },
+            }),
+            getCurrentWalletLabel: () => 'SuiteSync wallet',
+            getCurrentAccountLabels: () =>
+                createCurrentAccountLabels({
+                    accountLabel: 'SuiteSync account',
+                    addressLabels: [createSuiteSyncAddressLabel('address1', 'SuiteSync address')],
+                    outputLabels: [createSuiteSyncOutputLabel('tx1', '0', 'SuiteSync output')],
+                }),
+        });
+
+        const result = await migrateLegacyLabelsToSuiteSync();
+
+        expect(result).toEqual(ok({ changed: 0, skipped: 4 }));
+    });
+
+    it('migrates only the selected device', async () => {
+        const getAccountsByDeviceState = jest.fn(() => []);
+
+        const migrateLegacyLabelsToSuiteSync = createMigrate({
+            selectedDevice: createDevice('device@wallet:2'),
+            getAccountsByDeviceState,
+        });
+
+        await migrateLegacyLabelsToSuiteSync();
+
+        expect(getAccountsByDeviceState).toHaveBeenCalledWith('device@wallet:2');
+    });
+
+    it('is idempotent across repeated runs', async () => {
+        let hasWalletLabel = false;
+
+        const updateWalletLabel = jest.fn(() => {
+            hasWalletLabel = true;
+
+            return Promise.resolve(ok());
+        });
+
+        const migrateLegacyLabelsToSuiteSync = createMigrate({
+            getCurrentWalletLabel: () => (hasWalletLabel ? 'Legacy wallet' : null),
+            updateWalletLabel,
+        });
+
+        const firstRun = await migrateLegacyLabelsToSuiteSync();
+        const secondRun = await migrateLegacyLabelsToSuiteSync();
+
+        expect(firstRun).toEqual(ok({ changed: 1, skipped: 0 }));
+        expect(secondRun).toEqual(ok({ changed: 0, skipped: 1 }));
+
+        expect(updateWalletLabel).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns typed failure when a SuiteSync update fails', async () => {
+        const migrateLegacyLabelsToSuiteSync = createMigrate({
+            updateWalletLabel: () =>
+                Promise.resolve(err(createSuiteSyncUpdateError({ reason: 'boom' }))),
+        });
+
+        await expect(migrateLegacyLabelsToSuiteSync()).resolves.toEqual({
+            success: false,
+            error: {
+                type: 'update-failed',
+                entity: 'wallet',
+                deviceStaticSessionId: 'device@wallet:1',
+                cause: createSuiteSyncUpdateError({ reason: 'boom' }),
+            },
+        });
+    });
+});

--- a/suite/metadata-migration/src/createMetadataMigrationCompositionRoot.ts
+++ b/suite/metadata-migration/src/createMetadataMigrationCompositionRoot.ts
@@ -1,0 +1,70 @@
+import {
+    type UpdateAccountLabelDep,
+    type UpdateAddressLabelDep,
+    type UpdateOutputLabelDep,
+    type UpdateWalletLabelDep,
+} from '@suite-common/suite-sync-types';
+
+import { createMigrateAccountLabels } from './entities/createMigrateAccountLabels';
+import { createMigrateAddressLabels } from './entities/createMigrateAddressLabels';
+import { createMigrateOutputLabels } from './entities/createMigrateOutputLabels';
+import { createMigrateWalletLabels } from './entities/createMigrateWalletLabels';
+import type {
+    GetAccountsByDeviceState,
+    GetCurrentAccountLabels,
+    GetCurrentWalletLabel,
+    GetLegacyAccountLabels,
+    GetLegacyWalletLabels,
+} from './legacyLabelsMigration';
+import {
+    type MigrateLegacyLabelsToSuiteSync,
+    createMigrateLegacyLabelsToSuiteSync,
+} from './migrateLegacyLabelsToSuiteSync';
+
+export type MetadataMigrationDep = {
+    migrateLegacyLabelsToSuiteSync: MigrateLegacyLabelsToSuiteSync;
+};
+
+type CreateMetadataMigrationCompositionRootDeps = {
+    getAccountsByDeviceState: GetAccountsByDeviceState;
+    getLegacyWalletLabels: GetLegacyWalletLabels;
+    getLegacyAccountLabels: GetLegacyAccountLabels;
+    getCurrentWalletLabel: GetCurrentWalletLabel;
+    getCurrentAccountLabels: GetCurrentAccountLabels;
+} & UpdateWalletLabelDep &
+    UpdateAccountLabelDep &
+    UpdateAddressLabelDep &
+    UpdateOutputLabelDep;
+
+export const createMetadataMigrationCompositionRoot = (
+    deps: CreateMetadataMigrationCompositionRootDeps,
+): MetadataMigrationDep => {
+    const migrateWalletLabels = createMigrateWalletLabels({
+        getLegacyWalletLabels: deps.getLegacyWalletLabels,
+        getCurrentWalletLabel: deps.getCurrentWalletLabel,
+        updateWalletLabel: deps.updateWalletLabel,
+    });
+    const migrateAccountLabels = createMigrateAccountLabels({
+        updateAccountLabel: deps.updateAccountLabel,
+    });
+    const migrateAddressLabels = createMigrateAddressLabels({
+        updateAddressLabel: deps.updateAddressLabel,
+    });
+    const migrateOutputLabels = createMigrateOutputLabels({
+        updateOutputLabel: deps.updateOutputLabel,
+    });
+
+    const migrateLegacyLabelsToSuiteSync = createMigrateLegacyLabelsToSuiteSync({
+        getAccountsByDeviceState: deps.getAccountsByDeviceState,
+        getLegacyAccountLabels: deps.getLegacyAccountLabels,
+        getCurrentAccountLabels: deps.getCurrentAccountLabels,
+        migrateWalletLabels,
+        migrateAccountLabels,
+        migrateAddressLabels,
+        migrateOutputLabels,
+    });
+
+    return {
+        migrateLegacyLabelsToSuiteSync,
+    };
+};

--- a/suite/metadata-migration/src/entities/createMigrateAccountLabels.ts
+++ b/suite/metadata-migration/src/entities/createMigrateAccountLabels.ts
@@ -1,0 +1,56 @@
+import type { AccountLabels } from '@suite-common/metadata-types';
+import type { AllLabelsForAccount } from '@suite-common/suite-sync';
+import { type UpdateAccountLabelDep } from '@suite-common/suite-sync-types';
+import type { Account } from '@suite-common/wallet-types';
+import { err, ok } from '@trezor/type-utils';
+import type { Result } from '@trezor/type-utils';
+
+import type { MigrationCounts, MigrationError } from '../legacyLabelsMigration';
+import { normalizeLabel } from '../migrationUtils';
+
+export type MigrateAccountLabelsDeps = UpdateAccountLabelDep;
+
+export type MigrateAccountLabelsParams = {
+    account: Account;
+    legacyAccountLabels: AccountLabels;
+    currentAccountLabels: AllLabelsForAccount;
+};
+
+export type MigrateAccountLabels = (
+    params: MigrateAccountLabelsParams,
+) => Promise<Result<MigrationCounts, MigrationError>>;
+
+export type MigrateAccountLabelsDep = {
+    migrateAccountLabels: MigrateAccountLabels;
+};
+
+export const createMigrateAccountLabels =
+    (deps: MigrateAccountLabelsDeps): MigrateAccountLabels =>
+    async ({ account, legacyAccountLabels, currentAccountLabels }) => {
+        const legacyAccountLabel = normalizeLabel(legacyAccountLabels.accountLabel);
+
+        if (legacyAccountLabel === null) {
+            return ok({ changed: 0, skipped: 0 });
+        }
+
+        if (currentAccountLabels.accountLabel !== null) {
+            return ok({ changed: 0, skipped: 1 });
+        }
+
+        const updateAccountLabelResult = await deps.updateAccountLabel({
+            deviceStaticSessionId: account.deviceState,
+            accountKey: account.key,
+            label: legacyAccountLabel,
+        });
+
+        if (!updateAccountLabelResult.success) {
+            return err({
+                type: 'update-failed' as const,
+                entity: 'account' as const,
+                deviceStaticSessionId: account.deviceState,
+                cause: updateAccountLabelResult.error,
+            });
+        }
+
+        return ok({ changed: 1, skipped: 0 });
+    };

--- a/suite/metadata-migration/src/entities/createMigrateAddressLabels.ts
+++ b/suite/metadata-migration/src/entities/createMigrateAddressLabels.ts
@@ -1,0 +1,74 @@
+import type { AccountLabels } from '@suite-common/metadata-types';
+import type { AllLabelsForAccount } from '@suite-common/suite-sync';
+import { type UpdateAddressLabelDep } from '@suite-common/suite-sync-types';
+import type { Account } from '@suite-common/wallet-types';
+import { err, ok } from '@trezor/type-utils';
+import type { Result } from '@trezor/type-utils';
+import { typedObjectEntries } from '@trezor/utils';
+
+import type { MigrationCounts, MigrationError } from '../legacyLabelsMigration';
+import { normalizeLabel } from '../migrationUtils';
+
+export type MigrateAddressLabelsDeps = UpdateAddressLabelDep;
+
+export type MigrateAddressLabelsParams = {
+    account: Account;
+    legacyAccountLabels: AccountLabels;
+    currentAccountLabels: AllLabelsForAccount;
+};
+
+export type MigrateAddressLabels = (
+    params: MigrateAddressLabelsParams,
+) => Promise<Result<MigrationCounts, MigrationError>>;
+
+export type MigrateAddressLabelsDep = {
+    migrateAddressLabels: MigrateAddressLabels;
+};
+
+export const createMigrateAddressLabels =
+    (deps: MigrateAddressLabelsDeps): MigrateAddressLabels =>
+    async ({ account, legacyAccountLabels, currentAccountLabels }) => {
+        let changed = 0;
+        let skipped = 0;
+
+        for (const [address, addressLabel] of typedObjectEntries(
+            legacyAccountLabels.addressLabels,
+        )) {
+            const normalizedAddressLabel = normalizeLabel(addressLabel);
+
+            if (normalizedAddressLabel === null) {
+                continue;
+            }
+
+            const currentAddressLabel = currentAccountLabels.addressLabels.find(
+                item => item.address === address,
+            );
+
+            if (currentAddressLabel !== undefined && currentAddressLabel.label !== null) {
+                skipped += 1;
+
+                continue;
+            }
+
+            const updateAddressLabelResult = await deps.updateAddressLabel({
+                deviceStaticSessionId: account.deviceState,
+                address,
+                label: normalizedAddressLabel,
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
+            });
+
+            if (!updateAddressLabelResult.success) {
+                return err({
+                    type: 'update-failed' as const,
+                    entity: 'address' as const,
+                    deviceStaticSessionId: account.deviceState,
+                    cause: updateAddressLabelResult.error,
+                });
+            }
+
+            changed += 1;
+        }
+
+        return ok({ changed, skipped });
+    };

--- a/suite/metadata-migration/src/entities/createMigrateOutputLabels.ts
+++ b/suite/metadata-migration/src/entities/createMigrateOutputLabels.ts
@@ -1,0 +1,76 @@
+import type { AccountLabels } from '@suite-common/metadata-types';
+import type { AllLabelsForAccount } from '@suite-common/suite-sync';
+import { type UpdateOutputLabelDep } from '@suite-common/suite-sync-types';
+import type { Account } from '@suite-common/wallet-types';
+import { asTxTargetId } from '@suite-common/wallet-types';
+import { err, ok } from '@trezor/type-utils';
+import type { Result } from '@trezor/type-utils';
+import { typedObjectEntries } from '@trezor/utils';
+
+import type { MigrationCounts, MigrationError } from '../legacyLabelsMigration';
+import { normalizeLabel } from '../migrationUtils';
+
+export type MigrateOutputLabelsDeps = UpdateOutputLabelDep;
+
+export type MigrateOutputLabelsParams = {
+    account: Account;
+    legacyAccountLabels: AccountLabels;
+    currentAccountLabels: AllLabelsForAccount;
+};
+
+export type MigrateOutputLabels = (
+    params: MigrateOutputLabelsParams,
+) => Promise<Result<MigrationCounts, MigrationError>>;
+
+export type MigrateOutputLabelsDep = {
+    migrateOutputLabels: MigrateOutputLabels;
+};
+
+export const createMigrateOutputLabels =
+    (deps: MigrateOutputLabelsDeps): MigrateOutputLabels =>
+    async ({ account, legacyAccountLabels, currentAccountLabels }) => {
+        let changed = 0;
+        let skipped = 0;
+
+        for (const [txId, outputLabels] of typedObjectEntries(legacyAccountLabels.outputLabels)) {
+            for (const [txTargetId, outputLabel] of typedObjectEntries(outputLabels)) {
+                const normalizedOutputLabel = normalizeLabel(outputLabel);
+
+                if (normalizedOutputLabel === null) {
+                    continue;
+                }
+
+                const currentOutputLabel = currentAccountLabels.outputLabels.find(
+                    item => item.txId === txId && String(item.txTargetId) === String(txTargetId),
+                );
+
+                if (currentOutputLabel !== undefined && currentOutputLabel.label !== null) {
+                    skipped += 1;
+
+                    continue;
+                }
+
+                const updateOutputLabelResult = await deps.updateOutputLabel({
+                    deviceStaticSessionId: account.deviceState,
+                    txId,
+                    txTargetId: asTxTargetId(String(txTargetId)),
+                    label: normalizedOutputLabel,
+                    accountDescriptor: account.descriptor,
+                    networkSymbol: account.symbol,
+                });
+
+                if (!updateOutputLabelResult.success) {
+                    return err({
+                        type: 'update-failed' as const,
+                        entity: 'output' as const,
+                        deviceStaticSessionId: account.deviceState,
+                        cause: updateOutputLabelResult.error,
+                    });
+                }
+
+                changed += 1;
+            }
+        }
+
+        return ok({ changed, skipped });
+    };

--- a/suite/metadata-migration/src/entities/createMigrateWalletLabels.ts
+++ b/suite/metadata-migration/src/entities/createMigrateWalletLabels.ts
@@ -1,0 +1,65 @@
+import { type UpdateWalletLabelDep } from '@suite-common/suite-sync-types';
+import type { WalletDescriptor } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
+import { err, ok } from '@trezor/type-utils';
+import type { Result } from '@trezor/type-utils';
+
+import type {
+    GetCurrentWalletLabel,
+    GetLegacyWalletLabels,
+    MigrationCounts,
+    MigrationError,
+} from '../legacyLabelsMigration';
+import { normalizeLabel } from '../migrationUtils';
+
+export type MigrateWalletLabelsDeps = {
+    getLegacyWalletLabels: GetLegacyWalletLabels;
+    getCurrentWalletLabel: GetCurrentWalletLabel;
+} & UpdateWalletLabelDep;
+
+export type MigrateWalletLabelsParams = {
+    deviceStaticSessionId: StaticSessionId;
+    walletDescriptor: WalletDescriptor;
+};
+
+export type MigrateWalletLabels = (
+    params: MigrateWalletLabelsParams,
+) => Promise<Result<MigrationCounts, MigrationError>>;
+
+export type MigrateWalletLabelsDep = {
+    migrateWalletLabels: MigrateWalletLabels;
+};
+
+export const createMigrateWalletLabels =
+    (deps: MigrateWalletLabelsDeps): MigrateWalletLabels =>
+    async ({ deviceStaticSessionId, walletDescriptor }) => {
+        const legacyWalletLabel = normalizeLabel(
+            deps.getLegacyWalletLabels(deviceStaticSessionId).walletLabel,
+        );
+
+        if (legacyWalletLabel === null) {
+            return ok({ changed: 0, skipped: 0 });
+        }
+
+        const currentWalletLabel = deps.getCurrentWalletLabel(walletDescriptor);
+
+        if (currentWalletLabel !== null) {
+            return ok({ changed: 0, skipped: 1 });
+        }
+
+        const updateWalletLabelResult = await deps.updateWalletLabel({
+            deviceStaticSessionId,
+            label: legacyWalletLabel,
+        });
+
+        if (!updateWalletLabelResult.success) {
+            return err({
+                type: 'update-failed' as const,
+                entity: 'wallet' as const,
+                deviceStaticSessionId,
+                cause: updateWalletLabelResult.error,
+            });
+        }
+
+        return ok({ changed: 1, skipped: 0 });
+    };

--- a/suite/metadata-migration/src/index.ts
+++ b/suite/metadata-migration/src/index.ts
@@ -1,0 +1,8 @@
+export {
+    createMetadataMigrationCompositionRoot,
+    type MetadataMigrationDep,
+} from './createMetadataMigrationCompositionRoot';
+export {
+    LegacyLabelingMigration,
+    type LegacyLabelingMigrationProps,
+} from './LegacyLabelingMigration';

--- a/suite/metadata-migration/src/legacyLabelsMigration.ts
+++ b/suite/metadata-migration/src/legacyLabelsMigration.ts
@@ -1,0 +1,29 @@
+import { type AccountLabels, type WalletLabels } from '@suite-common/metadata-types';
+import type {
+    AllLabelsForAccount,
+    SelectAllLabelsForAccountParams,
+} from '@suite-common/suite-sync';
+import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
+import { type EnsureWalletSuiteSyncOnErrors } from '@suite-common/suite-sync-types';
+import type { Account, AccountKey, WalletDescriptor } from '@suite-common/wallet-types';
+import { type StaticSessionId } from '@trezor/connect';
+
+export type MigrationCounts = {
+    changed: number;
+    skipped: number;
+};
+
+export type MigrationError = {
+    type: 'update-failed';
+    entity: 'wallet' | 'account' | 'address' | 'output';
+    deviceStaticSessionId: StaticSessionId;
+    cause: EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError;
+};
+
+export type GetAccountsByDeviceState = (deviceState: StaticSessionId) => Account[];
+export type GetLegacyWalletLabels = (deviceState: StaticSessionId) => WalletLabels;
+export type GetLegacyAccountLabels = (accountKey: AccountKey) => AccountLabels;
+export type GetCurrentWalletLabel = (walletDescriptor: WalletDescriptor) => string | null;
+export type GetCurrentAccountLabels = (
+    params: SelectAllLabelsForAccountParams,
+) => AllLabelsForAccount;

--- a/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.ts
+++ b/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.ts
@@ -1,0 +1,117 @@
+import type { TrezorDeviceWithState } from '@suite-common/suite-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { err, ok } from '@trezor/type-utils';
+import type { Result } from '@trezor/type-utils';
+
+import type { MigrateAccountLabelsDep } from './entities/createMigrateAccountLabels';
+import type { MigrateAddressLabelsDep } from './entities/createMigrateAddressLabels';
+import type { MigrateOutputLabelsDep } from './entities/createMigrateOutputLabels';
+import type {
+    MigrateWalletLabelsDep,
+    MigrateWalletLabelsParams,
+} from './entities/createMigrateWalletLabels';
+import type {
+    GetAccountsByDeviceState,
+    GetCurrentAccountLabels,
+    GetLegacyAccountLabels,
+    MigrationCounts,
+    MigrationError,
+} from './legacyLabelsMigration';
+import { createAccountLabelsParams } from './migrationUtils';
+
+export type MigrateLegacyLabelsToSuiteSync = (
+    selectedDevice: TrezorDeviceWithState,
+) => Promise<Result<MigrationCounts, MigrationError>>;
+
+export type MigrateLegacyLabelsToSuiteSyncDeps = {
+    getAccountsByDeviceState: GetAccountsByDeviceState;
+    getLegacyAccountLabels: GetLegacyAccountLabels;
+    getCurrentAccountLabels: GetCurrentAccountLabels;
+} & MigrateWalletLabelsDep &
+    MigrateAccountLabelsDep &
+    MigrateAddressLabelsDep &
+    MigrateOutputLabelsDep;
+
+export const createMigrateLegacyLabelsToSuiteSync =
+    (deps: MigrateLegacyLabelsToSuiteSyncDeps): MigrateLegacyLabelsToSuiteSync =>
+    async selectedDevice => {
+        let changed = 0;
+        let skipped = 0;
+
+        const deviceStaticSessionId = selectedDevice.state.staticSessionId;
+        const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
+        const walletLabelsParams: MigrateWalletLabelsParams = {
+            deviceStaticSessionId,
+            walletDescriptor,
+        };
+        const walletLabelsResult = await deps.migrateWalletLabels(walletLabelsParams);
+
+        if (!walletLabelsResult.success) {
+            return err({
+                ...walletLabelsResult.error,
+                deviceStaticSessionId,
+            });
+        }
+
+        changed += walletLabelsResult.payload.changed;
+        skipped += walletLabelsResult.payload.skipped;
+
+        const accounts = deps.getAccountsByDeviceState(deviceStaticSessionId);
+
+        for (const account of accounts) {
+            const legacyAccountLabels = deps.getLegacyAccountLabels(account.key);
+            const currentAccountLabels = deps.getCurrentAccountLabels(
+                createAccountLabelsParams(account),
+            );
+
+            const accountLabelsResult = await deps.migrateAccountLabels({
+                account,
+                legacyAccountLabels,
+                currentAccountLabels,
+            });
+
+            if (!accountLabelsResult.success) {
+                return err({
+                    ...accountLabelsResult.error,
+                    deviceStaticSessionId,
+                });
+            }
+
+            changed += accountLabelsResult.payload.changed;
+            skipped += accountLabelsResult.payload.skipped;
+
+            const addressLabelsResult = await deps.migrateAddressLabels({
+                account,
+                legacyAccountLabels,
+                currentAccountLabels,
+            });
+
+            if (!addressLabelsResult.success) {
+                return err({
+                    ...addressLabelsResult.error,
+                    deviceStaticSessionId,
+                });
+            }
+
+            changed += addressLabelsResult.payload.changed;
+            skipped += addressLabelsResult.payload.skipped;
+
+            const outputLabelsResult = await deps.migrateOutputLabels({
+                account,
+                legacyAccountLabels,
+                currentAccountLabels,
+            });
+
+            if (!outputLabelsResult.success) {
+                return err({
+                    ...outputLabelsResult.error,
+                    deviceStaticSessionId,
+                });
+            }
+
+            changed += outputLabelsResult.payload.changed;
+            skipped += outputLabelsResult.payload.skipped;
+        }
+
+        return ok({ changed, skipped });
+    };

--- a/suite/metadata-migration/src/migrationUtils.ts
+++ b/suite/metadata-migration/src/migrationUtils.ts
@@ -1,0 +1,28 @@
+import { isTrezorDeviceWithState } from '@suite-common/device';
+import type { SelectAllLabelsForAccountParams } from '@suite-common/suite-sync';
+import type { TrezorDevice, TrezorDeviceWithState } from '@suite-common/suite-types';
+import type { Account } from '@suite-common/wallet-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+
+export const normalizeLabel = (label: string | undefined) => {
+    const trimmedLabel = label?.trim();
+
+    return trimmedLabel
+        ? trimmedLabel.slice(0, 1000) // Trim it to work with Evolu NonEmptyString1000
+        : null;
+};
+
+export const createAccountLabelsParams = (account: Account): SelectAllLabelsForAccountParams => {
+    const { walletDescriptor } = parseDeviceStaticSessionId(account.deviceState);
+
+    return {
+        walletDescriptor,
+        accountDescriptor: account.descriptor,
+        networkSymbol: account.symbol,
+    };
+};
+
+export const isMigratableDevice = (
+    device: TrezorDevice | undefined,
+): device is TrezorDeviceWithState =>
+    isTrezorDeviceWithState(device) && device.connected && device.available;

--- a/suite/metadata-migration/tsconfig.json
+++ b/suite/metadata-migration/tsconfig.json
@@ -1,20 +1,19 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": { "outDir": "./libDev" },
-    "include": [".", "**/*.json"],
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
-            "path": "../../suite-common/delegated-identity-key-types"
+            "path": "../../suite-common/dependency-injection"
         },
         { "path": "../../suite-common/device" },
         {
-            "path": "../../suite-common/platform-encryption"
+            "path": "../../suite-common/metadata-types"
+        },
+        {
+            "path": "../../suite-common/redux-utils"
         },
         {
             "path": "../../suite-common/suite-sync"
-        },
-        {
-            "path": "../../suite-common/suite-sync-evolu"
         },
         {
             "path": "../../suite-common/suite-sync-storage"
@@ -26,16 +25,26 @@
             "path": "../../suite-common/suite-types"
         },
         {
+            "path": "../../suite-common/toast-notifications"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
             "path": "../../suite-common/wallet-utils"
         },
-        { "path": "../analytics" },
         { "path": "../intl" },
+        { "path": "../metadata" },
+        { "path": "../router" },
         { "path": "../../packages/components" },
         { "path": "../../packages/connect" },
         {
             "path": "../../packages/product-components"
         },
-        { "path": "../../packages/theme" },
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite/metadata/src/MetadataProviderModal.tsx
+++ b/suite/metadata/src/MetadataProviderModal.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Translation } from '@suite/intl';
 import { type MetadataProviderType } from '@suite-common/metadata-types';
-import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
-import { Banner, Column, H3, Modal, Paragraph } from '@trezor/components';
 import type { Deferred } from '@trezor/utils';
 
+import { MetadataProviderSelectionModal } from './MetadataProviderSelectionModal';
 import { connectProvider } from './metadataProviderThunks';
 
 type MetadataProviderModalProps = {
@@ -15,7 +13,7 @@ type MetadataProviderModalProps = {
 };
 
 export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderModalProps) => {
-    const [isLoading, setIsLoading] = useState('');
+    const [isLoading, setIsLoading] = useState<MetadataProviderType | ''>('');
     // error from authorization popup
     const [error, setError] = useState('');
 
@@ -48,62 +46,11 @@ export const MetadataProviderModal = ({ onCancel, decision }: MetadataProviderMo
     };
 
     return (
-        <Modal
+        <MetadataProviderSelectionModal
             onCancel={onModalCancel}
-            data-testid="@modal/metadata-provider"
-            width={600}
-            iconName="tag"
-            bottomContent={
-                <>
-                    <Modal.Button
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={() => connect('dropbox')}
-                        isLoading={isLoading === 'dropbox'}
-                        isDisabled={!!isLoading}
-                        data-testid="@modal/metadata-provider/dropbox-button"
-                        iconLeft="dropboxLogoFilled"
-                    >
-                        <Translation id="TR_DROPBOX" />
-                    </Modal.Button>
-
-                    <Modal.Button
-                        intent="neutral"
-                        priority="secondary"
-                        onClick={() => connect('google')}
-                        isLoading={isLoading === 'google'}
-                        isDisabled={!!isLoading}
-                        data-testid="@modal/metadata-provider/google-button"
-                        iconLeft="googleDriveLogoFilled"
-                    >
-                        <Translation id="TR_GOOGLE_DRIVE" />
-                    </Modal.Button>
-
-                    {/* desktop only */}
-                    {isFeatureFlagEnabled('FILE_SYSTEM_SYNC') && (
-                        <Modal.Button
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={() => connect('fileSystem')}
-                            isLoading={isLoading === 'fileSystem'}
-                            isDisabled={!!isLoading}
-                            data-testid="@modal/metadata-provider/file-system-button"
-                        >
-                            <Translation id="TR_LOCAL_FILE_SYSTEM" />
-                        </Modal.Button>
-                    )}
-                </>
-            }
-        >
-            <Column gap={4}>
-                <H3>
-                    <Translation id="METADATA_MODAL_HEADING" />
-                </H3>
-                <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
-                    <Translation id="METADATA_MODAL_DESCRIPTION" />
-                </Paragraph>
-                {error && <Banner intent="critical" icon description={error} />}
-            </Column>
-        </Modal>
+            onSelect={connect}
+            loadingProvider={isLoading}
+            error={error}
+        />
     );
 };

--- a/suite/metadata/src/MetadataProviderSelectionModal.tsx
+++ b/suite/metadata/src/MetadataProviderSelectionModal.tsx
@@ -1,0 +1,84 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { type MetadataProviderType } from '@suite-common/metadata-types';
+import { isFeatureFlagEnabled } from '@suite-common/suite-utils';
+import { Banner, Column, H3, Modal, Paragraph } from '@trezor/components';
+
+type MetadataProviderSelectionModalProps = {
+    onCancel: () => void;
+    onSelect: (providerType: MetadataProviderType) => void;
+    loadingProvider?: MetadataProviderType | '';
+    isDisabled?: boolean;
+    error?: ReactNode | '';
+    heading?: ReactNode;
+    description?: ReactNode;
+    testId?: string;
+};
+
+export const MetadataProviderSelectionModal = ({
+    onCancel,
+    onSelect,
+    loadingProvider = '',
+    isDisabled = false,
+    error = '',
+    heading,
+    description,
+    testId = '@modal/metadata-provider',
+}: MetadataProviderSelectionModalProps) => (
+    <Modal
+        onCancel={onCancel}
+        data-testid={testId}
+        width={600}
+        iconName="tag"
+        bottomContent={
+            <>
+                <Modal.Button
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={() => onSelect('dropbox')}
+                    isLoading={loadingProvider === 'dropbox'}
+                    isDisabled={isDisabled || !!loadingProvider}
+                    data-testid={`${testId}/dropbox-button`}
+                    iconLeft="dropboxLogoFilled"
+                >
+                    <Translation id="TR_DROPBOX" />
+                </Modal.Button>
+
+                <Modal.Button
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={() => onSelect('google')}
+                    isLoading={loadingProvider === 'google'}
+                    isDisabled={isDisabled || !!loadingProvider}
+                    data-testid={`${testId}/google-button`}
+                    iconLeft="googleDriveLogoFilled"
+                >
+                    <Translation id="TR_GOOGLE_DRIVE" />
+                </Modal.Button>
+
+                {/* desktop only */}
+                {isFeatureFlagEnabled('FILE_SYSTEM_SYNC') && (
+                    <Modal.Button
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={() => onSelect('fileSystem')}
+                        isLoading={loadingProvider === 'fileSystem'}
+                        isDisabled={isDisabled || !!loadingProvider}
+                        data-testid={`${testId}/file-system-button`}
+                    >
+                        <Translation id="TR_LOCAL_FILE_SYSTEM" />
+                    </Modal.Button>
+                )}
+            </>
+        }
+    >
+        <Column gap={4}>
+            <H3>{heading ?? <Translation id="METADATA_MODAL_HEADING" />}</H3>
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
+                {description ?? <Translation id="METADATA_MODAL_DESCRIPTION" />}
+            </Paragraph>
+            {error && <Banner intent="critical" icon description={error} />}
+        </Column>
+    </Modal>
+);

--- a/suite/metadata/src/index.ts
+++ b/suite/metadata/src/index.ts
@@ -8,6 +8,7 @@ export * as metadataLabelingConstants from './metadataLabelingConstants';
 export * as METADATA from './metadataConstants';
 export { moveLabelsForRbfOldMetadataThunk } from './moveLabelsForRbfOldMetadataThunk';
 export { MetadataProviderModal } from './MetadataProviderModal';
+export { MetadataProviderSelectionModal } from './MetadataProviderSelectionModal';
 export { metadataMiddleware } from './metadataMiddleware';
 export * from './fromLegacyMetadataToSearchLabels';
 export * from './selectIsLegacyLabelingVisible';

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -20,6 +20,7 @@ export const SettingsAnchor = {
     LabelingServers: '@general-settings/labeling-servers',
     LabelingDisconnect: '@general-settings/labeling-disconnect',
     LabelingConnect: '@general-settings/labeling-connect',
+    LabelingMigration: '@general-settings/labeling-migration',
     Tor: '@general-settings/tor',
     TorExternal: '@general-settings/tor-external',
     TorOnionLinks: '@general-settings/tor-onion-links',

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -16,16 +16,19 @@ import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/
 import { type BreakpointFlags } from '@trezor/theme';
 import { spacings } from '@trezor/theme';
 
+import { WipeSuiteSyncLabels, type WipeSuiteSyncLabelsOnError } from './WipeSuiteSyncLabels';
+
 const selectIsBelowLaptop = (state: { window: BreakpointFlags }) => state.window.isBelowLaptop;
 
 const LOCAL_SUITE_SYNC_RELAY_URL = 'http://127.0.0.1:4000/evolu/';
 
 type SuiteSyncSettingsProps = {
+    onError: WipeSuiteSyncLabelsOnError;
     suiteSync: SuiteSync;
 };
 
-export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
-    const [isLoading, setIsLoading] = useState(false);
+export const SuiteSyncSettings = ({ onError, suiteSync }: SuiteSyncSettingsProps) => {
+    const [isRelayUrlLoading, setIsRelayUrlLoading] = useState(false);
 
     const dispatch = useDispatch();
     const isBelowLaptop = useSelector(selectIsBelowLaptop);
@@ -41,7 +44,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
     };
 
     const onRelayUrlSave = async (url = relayUrl) => {
-        setIsLoading(true);
+        setIsRelayUrlLoading(true);
 
         setRelayUrl(url);
 
@@ -49,7 +52,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
 
         // Fake it, to make some UI interaction for the user
         setTimeout(() => {
-            setIsLoading(false);
+            setIsRelayUrlLoading(false);
         }, 300);
     };
 
@@ -68,13 +71,13 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                     <Column gap={spacings.xxs}>
                         <Input
                             data-testid="@settings/debug/suite-sync/relay-url-input"
-                            isDisabled={isLoading}
+                            isDisabled={isRelayUrlLoading}
                             value={relayUrl}
                             onChange={e => setRelayUrl(e.target.value)}
                             rightContent={
                                 <Button
                                     data-testid="@settings/debug/suite-sync/save-button"
-                                    isLoading={isLoading}
+                                    isLoading={isRelayUrlLoading}
                                     onClick={() => onRelayUrlSave()}
                                     size="small"
                                 >
@@ -88,7 +91,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                         <ButtonGroup size="small" priority="secondary">
                             <Button
                                 intent="critical"
-                                isDisabled={isLoading}
+                                isDisabled={isRelayUrlLoading}
                                 onClick={() =>
                                     onRelayUrlPresetClick(DEFAULT_SUITE_SYNC_RELAY_URL_PROD)
                                 }
@@ -97,7 +100,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                             </Button>
                             <Button
                                 intent="brand"
-                                isDisabled={isLoading}
+                                isDisabled={isRelayUrlLoading}
                                 onClick={() =>
                                     onRelayUrlPresetClick(DEFAULT_SUITE_SYNC_RELAY_URL_DEV)
                                 }
@@ -106,7 +109,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                             </Button>
                             <Button
                                 intent="info"
-                                isDisabled={isLoading}
+                                isDisabled={isRelayUrlLoading}
                                 onClick={() => onRelayUrlPresetClick(LOCAL_SUITE_SYNC_RELAY_URL)}
                             >
                                 Local
@@ -115,6 +118,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                     </Column>
                 </ActionColumn>
             </SectionItem>
+            <WipeSuiteSyncLabels onError={onError} suiteSync={suiteSync} />
             <SectionItem>
                 <TextColumn title="Suite Sync (Evolu) Debug" />
                 <ActionColumn>

--- a/suite/suite-sync/src/WipeSuiteSyncLabels.tsx
+++ b/suite/suite-sync/src/WipeSuiteSyncLabels.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectSelectedDevice } from '@suite-common/device';
+import { type SuiteSyncUpdateError } from '@suite-common/suite-sync-storage';
+import { type EnsureWalletSuiteSyncOnErrors, type SuiteSync } from '@suite-common/suite-sync-types';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { Button } from '@trezor/components';
+import { type StaticSessionId } from '@trezor/connect';
+import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+import { type TimerId, exhaustive } from '@trezor/type-utils';
+
+const WIPE_CONFIRM_DELAY_MS = 3_000;
+
+type WipeSuiteSyncLabelsError = EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError;
+
+export type WipeSuiteSyncLabelsOnError = (params: {
+    deviceStaticSessionId: StaticSessionId;
+    error: WipeSuiteSyncLabelsError;
+}) => void;
+
+type WipeSuiteSyncLabelsProps = {
+    onError: WipeSuiteSyncLabelsOnError;
+    suiteSync: SuiteSync;
+};
+
+type WipeSuiteSyncLabelsStep = 'wipingLoading' | 'areYouSure' | 'confirmDeletion' | 'start';
+
+/**
+ * @deprecated Intended only for debug & testing
+ */
+export const WipeSuiteSyncLabels = ({ onError, suiteSync }: WipeSuiteSyncLabelsProps) => {
+    const [step, setStep] = useState<WipeSuiteSyncLabelsStep>('start');
+    const [wipeConfirmationCountdown, setWipeConfirmationCountdown] = useState(0);
+
+    const wipeConfirmationTimeoutRef = useRef<TimerId | null>(null);
+    const wipeConfirmationIntervalRef = useRef<TimerId | null>(null);
+
+    const selectedDevice = useSelector(selectSelectedDevice);
+
+    const selectedDeviceStaticSessionId = selectedDevice?.state?.staticSessionId;
+
+    const getButtonLabel = (currentStep: WipeSuiteSyncLabelsStep) => {
+        switch (currentStep) {
+            case 'wipingLoading':
+                return 'Wiping labels...';
+            case 'areYouSure':
+                return `Are you sure? (${wipeConfirmationCountdown}s)`;
+            case 'confirmDeletion':
+                return 'Confirm deletion, CAN NOT BE UNDONE ❗';
+            case 'start':
+                return 'Wipe labels';
+            default:
+                return exhaustive(currentStep);
+        }
+    };
+
+    useEffect(
+        () => () => {
+            if (wipeConfirmationTimeoutRef.current !== null) {
+                clearTimeout(wipeConfirmationTimeoutRef.current);
+            }
+
+            if (wipeConfirmationIntervalRef.current !== null) {
+                clearInterval(wipeConfirmationIntervalRef.current);
+            }
+        },
+        [],
+    );
+
+    const isDisabled =
+        step === 'wipingLoading' ||
+        step === 'areYouSure' ||
+        selectedDeviceStaticSessionId === undefined;
+
+    const handleWipeButtonClick = async () => {
+        switch (step) {
+            case 'start':
+                setStep('areYouSure');
+                setWipeConfirmationCountdown(Math.ceil(WIPE_CONFIRM_DELAY_MS / 1_000));
+
+                if (wipeConfirmationTimeoutRef.current !== null) {
+                    clearTimeout(wipeConfirmationTimeoutRef.current);
+                }
+
+                if (wipeConfirmationIntervalRef.current !== null) {
+                    clearInterval(wipeConfirmationIntervalRef.current);
+                }
+
+                wipeConfirmationIntervalRef.current = setInterval(() => {
+                    setWipeConfirmationCountdown(countdown => Math.max(countdown - 1, 0));
+                }, 1_000);
+
+                wipeConfirmationTimeoutRef.current = setTimeout(() => {
+                    setStep('confirmDeletion');
+                    setWipeConfirmationCountdown(0);
+
+                    if (wipeConfirmationIntervalRef.current !== null) {
+                        clearInterval(wipeConfirmationIntervalRef.current);
+                        wipeConfirmationIntervalRef.current = null;
+                    }
+                }, WIPE_CONFIRM_DELAY_MS);
+
+                return;
+            case 'areYouSure':
+            case 'wipingLoading':
+                return;
+
+            case 'confirmDeletion':
+                setStep('wipingLoading');
+
+                if (selectedDeviceStaticSessionId !== undefined) {
+                    const { walletDescriptor } = parseDeviceStaticSessionId(
+                        selectedDeviceStaticSessionId,
+                    );
+                    const result = await suiteSync.dangerouslyWipeAllLabelsFromWallet({
+                        walletDescriptor,
+                    });
+
+                    if (!result.success) {
+                        onError({
+                            error: result.error,
+                            deviceStaticSessionId: selectedDeviceStaticSessionId,
+                        });
+                    }
+                }
+
+                setStep('start');
+                setWipeConfirmationCountdown(0);
+
+                if (wipeConfirmationIntervalRef.current !== null) {
+                    clearInterval(wipeConfirmationIntervalRef.current);
+                    wipeConfirmationIntervalRef.current = null;
+                }
+
+                return;
+            default:
+                exhaustive(step);
+        }
+    };
+
+    return (
+        <SectionItem>
+            <TextColumn
+                title="Wipe Suite Sync labels"
+                description="Sets all current Suite Sync wallet, account, address, and output labels for the selected wallet to null."
+            />
+            <ActionColumn>
+                <Button
+                    data-testid="@settings/debug/suite-sync/wipe-labels-button"
+                    intent="critical"
+                    isLoading={step === 'wipingLoading'}
+                    isDisabled={isDisabled}
+                    size="small"
+                    onClick={handleWipeButtonClick}
+                >
+                    {getButtonLabel(step)}
+                </Button>
+            </ActionColumn>
+        </SectionItem>
+    );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14809,6 +14809,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/metadata-migration@workspace:*, @suite/metadata-migration@workspace:suite/metadata-migration":
+  version: 0.0.0-use.local
+  resolution: "@suite/metadata-migration@workspace:suite/metadata-migration"
+  dependencies:
+    "@suite-common/dependency-injection": "workspace:*"
+    "@suite-common/device": "workspace:*"
+    "@suite-common/metadata-types": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-sync": "workspace:*"
+    "@suite-common/suite-sync-storage": "workspace:*"
+    "@suite-common/suite-sync-types": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
+    "@suite-common/wallet-utils": "workspace:*"
+    "@suite/intl": "workspace:*"
+    "@suite/metadata": "workspace:*"
+    "@suite/router": "workspace:*"
+    "@trezor/components": "workspace:*"
+    "@trezor/connect": "workspace:*"
+    "@trezor/product-components": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
+    react: "npm:19.2.4"
+    react-redux: "npm:9.2.0"
+    redux-thunk: "npm:^3.1.0"
+  languageName: unknown
+  linkType: soft
+
 "@suite/metadata@workspace:*, @suite/metadata@workspace:suite/metadata":
   version: 0.0.0-use.local
   resolution: "@suite/metadata@workspace:suite/metadata"
@@ -14994,6 +15024,7 @@ __metadata:
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-sync-evolu": "workspace:*"
+    "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
@@ -15003,6 +15034,7 @@ __metadata:
     "@trezor/connect": "workspace:*"
     "@trezor/product-components": "workspace:*"
     "@trezor/theme": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     react-redux: "npm:9.2.0"
@@ -16425,6 +16457,7 @@ __metadata:
     "@suite/intl": "workspace:*"
     "@suite/locks": "workspace:*"
     "@suite/metadata": "workspace:*"
+    "@suite/metadata-migration": "workspace:*"
     "@suite/modal": "workspace:*"
     "@suite/onboarding-components": "workspace:*"
     "@suite/platform-encryption-electron": "workspace:*"


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/19604


<img width="941" height="351" alt="image" src="https://github.com/user-attachments/assets/21440ac0-f8e2-4942-aeff-96c1dc935d4a" />

<img width="932" height="530" alt="image" src="https://github.com/user-attachments/assets/506f4636-98b7-4fe3-98e7-be8195d5a423" />

<img width="597" height="146" alt="image" src="https://github.com/user-attachments/assets/ae48152c-4fe0-4c36-b436-76abe7d5a944" />
<img width="597" height="146" alt="image" src="https://github.com/user-attachments/assets/c6778889-bd87-4a46-a5bc-a5eadf076192" />

----------------------------

This may help with testing:
<img width="847" height="132" alt="image" src="https://github.com/user-attachments/assets/8fc642ec-919b-4e22-ba02-af3834f40f19" />
<img width="847" height="132" alt="image" src="https://github.com/user-attachments/assets/f0be27a2-07e9-4746-8814-164e0635865e" />
<img width="847" height="132" alt="image" src="https://github.com/user-attachments/assets/a3a96bce-9001-492d-b16e-21a132fc5a76" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=labeling-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=labeling-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=labeling-migration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T10:31:16.392Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T10:45:13.891Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/labeling-migration/web/](https://dev.suite.sldev.cz/suite-web/labeling-migration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->