### PR TITLE
fix(ci): duplicate artifact names in connect test upload logs

### DIFF
--- a/.github/workflows/template-connect-test-params.yml
+++ b/.github/workflows/template-connect-test-params.yml
@@ -34,7 +34,7 @@ on:
         description: "Disable Cache transactions (when `true` tests don't use cache for transactions)"
         type: "string"
         required: false
-        default: false
+        default: "false"
       transport:
         description: "Transport to use (example: bridge, node-bridge)"
         type: "string"
@@ -42,6 +42,10 @@ on:
         default: "node-bridge"
       testEnv:
         description: "Environment to test (example: node, web)"
+        type: "string"
+        required: true
+      testGroup:
+        description: "Test group name used for artifact naming (example: PR-check, all-fws)"
         type: "string"
         required: true
 
@@ -84,4 +88,4 @@ jobs:
         uses: ./.github/actions/upload-test-logs
         with:
           target: ${{ inputs.testEnv }}
-          test-group: ${{ inputs.testDescription }}
+          test-group: ${{ inputs.testGroup }}-${{ inputs.testDescription }}

--- a/.github/workflows/test-connect.yml
+++ b/.github/workflows/test-connect.yml
@@ -88,6 +88,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: PR-check
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
@@ -106,6 +107,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: PR-check-web
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyWebMatrix) }}
@@ -124,6 +126,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: PR-nightly-t3w1
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.nightlyT3W1Matrix) }}
@@ -143,6 +146,7 @@ jobs:
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
       testRandomizedOrder: true
+      testGroup: randomized-order
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.dailyMatrix) }}
@@ -161,6 +165,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: all-fws
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.allFwsMatrix) }}
@@ -179,6 +184,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: all-models-api
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.otherDevicesMatrix) }}
@@ -197,6 +203,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: all-transports
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.allTransportsMatrix) }}
@@ -215,6 +222,7 @@ jobs:
       transport: ${{ matrix.transport }}
       testEnv: ${{ matrix.env }}
       testFirmwareModel: ${{ matrix.model }}
+      testGroup: model-one-api
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.modelOneMatrix) }}


### PR DESCRIPTION
## Description

Newly added upload logs step fails during nightly due to duplicate artifact names

Problem: https://github.com/trezor/trezor-suite/actions/runs/23571473318
After fix: https://github.com/trezor/trezor-suite/actions/runs/23590690947

## Notes for QA

Nothing to test

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-upload-logs-duplicate-artifact-name&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-upload-logs-duplicate-artifact-name&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T11:02:52.754Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T11:01:10.338Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->