### PR TITLE
feat(suite): add option to add networks to empty wallet dashboard

### DIFF
--- a/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/EmptyWallet.tsx
@@ -1,17 +1,14 @@
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
-import { selectIsDeviceUsingPassphrase } from '@suite-common/device';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 import { Button, Column, H3, IconCircle, Paragraph, Row } from '@trezor/components';
 import { CoinLogo } from '@trezor/product-components';
-import { spacings } from '@trezor/theme';
 
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const EmptyWallet = () => {
     const { supportedMainnets } = useNetworkSupport();
-    const isPassphraseType = useSelector(selectIsDeviceUsingPassphrase);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const dispatch = useDispatch();
 
@@ -20,24 +17,23 @@ export const EmptyWallet = () => {
     );
 
     return (
-        <Column gap={spacings.xxs} data-testid="@dashboard/wallet-ready" alignItems="center">
+        <Column gap={4} data-testid="@dashboard/wallet-ready" alignItems="center">
             <IconCircle name="check" size={96} intent="brand" />
-            <H3 margin={{ top: spacings.md }}>
+            <H3 margin={16}>
                 <Translation id="TR_YOUR_WALLET_IS_READY_WHAT" />
             </H3>
-            {isPassphraseType && !areAllNetworksEnabled && (
-                <Row gap={spacings.xs} flexWrap="wrap">
+            {!areAllNetworksEnabled && (
+                <Row gap={8} flexWrap="wrap">
                     <Paragraph intent="neutral" priority="secondary" typographyStyle="body-sm">
                         <Translation id="TR_CHECKED_BALANCES_ON" />:
                     </Paragraph>
-                    <Row gap={spacings.xxs} flexWrap="wrap">
+                    <Row gap={4} flexWrap="wrap">
                         {enabledNetworks.map(network => (
                             <CoinLogo key={network} symbol={network} size={16} />
                         ))}
                     </Row>
                     <Button
-                        intent="neutral"
-                        priority="secondary"
+                        intent="brand"
                         iconLeft="plus"
                         size="small"
                         onClick={() => {


### PR DESCRIPTION
## Notes for QA
Added option to add more networks to dashboard in case of an empty wallet


## Screenshots:
<img width="1198" height="497" alt="image" src="https://github.com/user-attachments/assets/b49d7f90-4c24-40f6-a160-a581e19f5236" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/empty-wallet-updates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/empty-wallet-updates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T10:20:22.815Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T10:19:09.778Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->