### PR TITLE
Tron added to receive test and added address verification

### DIFF
--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -250,7 +250,7 @@ export class SettingsPage {
     @step()
     async toggleTestnetNetworks() {
         await this.navigateTo('application');
-        await this.page.getByTestId('@settings/experimental-features/toggle-switch').click();
+        await this.experimentalFeaturesSwitch.click();
         await this.page
             .getByTestId('@settings/experimental-features/testnet-networks-checkbox')
             .click();

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -17,13 +17,26 @@ test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
         await page.getByTestId('@settings/experimental-features/tron-view-only-checkbox').click();
     });
 
-    const testCases: Array<{ coin: NetworkSymbol; category: TestCategory }> = [
-        { coin: 'btc', category: TestCategory.BTC },
-        { coin: 'eth', category: TestCategory.ETH },
-        { coin: 'sol', category: TestCategory.Solana },
-        { coin: 'trx', category: TestCategory.Coins },
-    ];
-    testCases.forEach(({ coin, category }) => {
+    const testCases: Array<{ coin: NetworkSymbol; category: TestCategory; addressFormat: RegExp }> =
+        [
+            {
+                coin: 'btc',
+                category: TestCategory.BTC,
+                addressFormat: /^(bc1[a-z0-9]{39,59}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})$/,
+            },
+            { coin: 'eth', category: TestCategory.ETH, addressFormat: /^0x[a-fA-F0-9]{40}$/ },
+            {
+                coin: 'sol',
+                category: TestCategory.Solana,
+                addressFormat: /^[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+            },
+            {
+                coin: 'trx',
+                category: TestCategory.Coins,
+                addressFormat: /^T[1-9A-HJ-NP-Za-km-z]{33}$/,
+            },
+        ];
+    testCases.forEach(({ coin, category, addressFormat }) => {
         test(
             `Receive a ${coin.toUpperCase()} transaction`,
             {
@@ -49,7 +62,8 @@ test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
                 await walletPage.copyAddressButton.click();
                 await expect(walletPage.copyToCliboardToast).toBeVisible();
                 const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-                expect(clipboardText).toEqual(address);
+                expect.soft(clipboardText).toEqual(address);
+                expect.soft(address).toMatch(addressFormat);
             },
         );
     });

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -10,14 +10,18 @@ test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
             permissions: ['clipboard-read', 'clipboard-write'],
         },
     });
-    test.beforeEach(async ({ onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, page }) => {
         await onboardingPage.completeOnboarding();
+        await settingsPage.navigateTo('application');
+        await settingsPage.experimentalFeaturesSwitch.click();
+        await page.getByTestId('@settings/experimental-features/tron-view-only-checkbox').click();
     });
 
     const testCases: Array<{ coin: NetworkSymbol; category: TestCategory }> = [
         { coin: 'btc', category: TestCategory.BTC },
         { coin: 'eth', category: TestCategory.ETH },
         { coin: 'sol', category: TestCategory.Solana },
+        { coin: 'trx', category: TestCategory.Coins },
     ];
     testCases.forEach(({ coin, category }) => {
         test(


### PR DESCRIPTION
## Description

This PR extends the receive tests by adding support for TRON and introduces address validation for additional networks.


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-tron&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-tron&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T11:35:03.200Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-06T13:31:42.152Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->