### PR TITLE
chore(e2e): comment out Bitcoin input tests until issue #26163 is res…

### DIFF
--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -1,11 +1,11 @@
-import { localizeNumber } from '@suite-common/wallet-utils';
+// import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { expect, test } from '../../support/fixtures';
 import { fulfillWithResult } from '../../support/mocks/solanaStakingMock';
 
 const solanaBalanceAddress = '41baq3croaLZEj8dPWZnXn8e6xdAtvtWu2h941vm3Ngw';
-const customFeeRate = 1;
-let bitcoinBalance: string | null;
+// const customFeeRate = 1;
+// let bitcoinBalance: string | null;
 let solanaBalance: string | null;
 
 test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
@@ -34,8 +34,8 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
 
     test('Sell form % inputs and limits', async ({ page, walletPage, tradingPage }) => {
         await test.step('Find out btc and sol balances', async () => {
-            await walletPage.openAccount({ symbol: 'btc' });
-            bitcoinBalance = await walletPage.topPanelBalance.textContent();
+            // await walletPage.openAccount({ symbol: 'btc' });
+            // bitcoinBalance = await walletPage.topPanelBalance.textContent();
             await walletPage.openAccount({ symbol: 'sol' });
             solanaBalance = await walletPage.topPanelBalance.textContent();
             await walletPage.openTrading();
@@ -64,43 +64,44 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
             await expect.soft(tradingPage.inputs.bottomText).toBeHidden();
         });
 
-        await test.step('Try all % inputs for Bitcoin', async () => {
-            await tradingPage.inputs.selectFiatCurrency('eur');
-            for (const percentage of [10, 25, 50]) {
-                await test.step(`${percentage}% of BTC balance`, async () => {
-                    await tradingPage.inputs.fractionButtons
-                        .getByRole('button', { name: percentage + '%' })
-                        .click();
-                    await tradingPage.inputs.expectInputToBe({
-                        percentage,
-                        balance: bitcoinBalance,
-                        symbol: 'btc',
-                    });
-                });
-            }
-            await tradingPage.fees.switchToCustom();
-            await tradingPage.fees.customInput.fill(customFeeRate.toString());
+        // does not fork until https://github.com/trezor/trezor-suite/issues/26163 is resolved
+        // await test.step('Try all % inputs for Bitcoin', async () => {
+        //     await tradingPage.inputs.selectFiatCurrency('eur');
+        //     for (const percentage of [10, 25, 50]) {
+        //         await test.step(`${percentage}% of BTC balance`, async () => {
+        //             await tradingPage.inputs.fractionButtons
+        //                 .getByRole('button', { name: percentage + '%' })
+        //                 .click();
+        //             await tradingPage.inputs.expectInputToBe({
+        //                 percentage,
+        //                 balance: bitcoinBalance,
+        //                 symbol: 'btc',
+        //             });
+        //         });
+        //     }
+        //     await tradingPage.fees.switchToCustom();
+        //     await tradingPage.fees.customInput.fill(customFeeRate.toString());
 
-            await test.step('Max of BTC balance', async () => {
-                await tradingPage.inputs.fractionButtons
-                    .getByRole('button', { name: 'Max' })
-                    .click();
-                await expect
-                    .soft(async () => {
-                        const resultingFee = await tradingPage.fees.maxFee.textContent();
-                        if (!resultingFee) {
-                            throw new Error('Custom Fee amount is undefined or null');
-                        }
-                        const maxValue = (
-                            parseFloat(bitcoinBalance!) - parseFloat(resultingFee)
-                        ).toString();
-                        await expect(tradingPage.inputs.cryptoAmount).toHaveValue(
-                            localizeNumber(maxValue, 'en-US', 0, 8),
-                        );
-                    })
-                    .toPass({ timeout: 15_000 });
-            });
-        });
+        //     await test.step('Max of BTC balance', async () => {
+        //         await tradingPage.inputs.fractionButtons
+        //             .getByRole('button', { name: 'Max' })
+        //             .click();
+        //         await expect
+        //             .soft(async () => {
+        //                 const resultingFee = await tradingPage.fees.maxFee.textContent();
+        //                 if (!resultingFee) {
+        //                     throw new Error('Custom Fee amount is undefined or null');
+        //                 }
+        //                 const maxValue = (
+        //                     parseFloat(bitcoinBalance!) - parseFloat(resultingFee)
+        //                 ).toString();
+        //                 await expect(tradingPage.inputs.cryptoAmount).toHaveValue(
+        //                     localizeNumber(maxValue, 'en-US', 0, 8),
+        //                 );
+        //             })
+        //             .toPass({ timeout: 15_000 });
+        //     });
+        // });
 
         await test.step('Try all % inputs on Solana', async () => {
             await walletPage.openAccount({ symbol: 'sol', atIndex: 0 });

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -64,7 +64,7 @@ test.describe('Trading - Sell inputs', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
             await expect.soft(tradingPage.inputs.bottomText).toBeHidden();
         });
 
-        // does not fork until https://github.com/trezor/trezor-suite/issues/26163 is resolved
+        // BUG https://github.com/trezor/trezor-suite/issues/26163
         // await test.step('Try all % inputs for Bitcoin', async () => {
         //     await tradingPage.inputs.selectFiatCurrency('eur');
         //     for (const percentage of [10, 25, 50]) {


### PR DESCRIPTION
Temporarily comment out Bitcoin-specific sell input tests (% inputs and max balance) in sell-inputs.test.ts due to a known issue tracked in #26163
Solana sell input tests remain active and unaffected
Related unused variables (localizeNumber, customFeeRate, bitcoinBalance) are also commented out

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=stabilize-sell-input-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=stabilize-sell-input-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T12:31:04.405Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T12:29:27.410Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->