### PR TITLE
fix(suite-native): trade - filter accounts without trade id

### DIFF
--- a/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/__tests__/commonSelectors.test.ts
@@ -876,6 +876,48 @@ describe('commonSelectors', () => {
             expect(result[0].sectionData.symbol).toBe('btc');
         });
 
+        it('should filter out accounts whose network has no tradeCryptoId', () => {
+            const testDeviceState = 'test-device';
+            const regtestAccount = {
+                ...getBtcAccount(),
+                key: 'regtest-account-1' as AccountKey,
+                symbol: 'regtest' as Account['symbol'],
+                accountLabel: 'Regtest Account #1',
+                balance: '1000000',
+                formattedBalance: '0.01',
+                networkType: 'bitcoin' as Account['networkType'],
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const btcAccount = {
+                ...getBtcAccount(),
+                visible: true,
+                deviceState: testDeviceState,
+            };
+            const cleanState = getInitializedTradingState('exchange');
+
+            const stateWithDevice = {
+                wallet: {
+                    trading: cleanState,
+                    accounts: [regtestAccount, btcAccount],
+                    settings: { localCurrency: 'usd', enabledNetworks: ['regtest', 'btc'] },
+                    transactions: { transactions: {} },
+                },
+                device: { selectedDevice: { state: { staticSessionId: testDeviceState } } },
+                tokenDefinitions: {},
+                fiat: { rates: {}, current: 'usd' },
+                featureFlags: featureFlagsInitialState,
+            } as any;
+
+            const result = selectAccountsWithTokensToSellSectionListByTradingType(
+                stateWithDevice,
+                'exchange',
+            );
+
+            expect(result.length).toBe(1);
+            expect(result[0].sectionData.symbol).toBe('btc');
+        });
+
         it('should include Cardano accounts when IsCardanoSendEnabled feature flag is enabled', () => {
             const testDeviceState = 'test-device';
             const cardanoAccount = {

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -231,7 +231,9 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             // TODO: Remove this filter when Cardano send is implemented (#15068)
             // Currently filtering out Cardano accounts and tokens from trading until Cardano send is supported
             const filteredAccounts = accounts.filter(account => {
-                if (!getNetwork(account.symbol).tradeCryptoId) return false;
+                if (!getNetwork(account.symbol).tradeCryptoId) {
+                    return false;
+                }
                 const networkType = getNetworkType(account.symbol);
 
                 return networkType !== 'cardano' || isCardanoSendEnabled;

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -231,6 +231,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             // TODO: Remove this filter when Cardano send is implemented (#15068)
             // Currently filtering out Cardano accounts and tokens from trading until Cardano send is supported
             const filteredAccounts = accounts.filter(account => {
+                if (!getNetwork(account.symbol).tradeCryptoId) return false;
                 const networkType = getNetworkType(account.symbol);
 
                 return networkType !== 'cardano' || isCardanoSendEnabled;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent the app from crashing if the user opens the trade flow with an enabled coin without a trade ID. https://satoshilabs.slack.com/archives/C07CNUB6HGC/p1774517854821789

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/undefined-trade-id&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->