### PR TITLE
26221 Mobile trade: introduce receiving less in fiat value 

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingFiatDeviationWarning.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatDeviationWarning.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { selectLanguage } from '@suite/settings';
 import { useExchangeFiatDeviation } from '@suite-common/trading';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
@@ -14,6 +16,7 @@ type TradingFiatDeviationWarningProps = {
 export const TradingFiatDeviationWarning = ({
     selectedQuote,
 }: TradingFiatDeviationWarningProps) => {
+    const language = useSelector(selectLanguage);
     const fiatCurrency = useSelector(selectBaseCurrency);
     const exchangeDeviation = useExchangeFiatDeviation({
         sendCryptoId: selectedQuote.send,
@@ -23,19 +26,25 @@ export const TradingFiatDeviationWarning = ({
         fiatCurrency,
     });
 
+    const percentFormatter = useMemo(
+        () =>
+            new Intl.NumberFormat(language, {
+                style: 'percent',
+                maximumFractionDigits: 0,
+            }),
+        [language],
+    );
+
     if (!exchangeDeviation?.exceedsThreshold) return null;
+
+    const percentage = percentFormatter.format(exchangeDeviation.deviation);
 
     return (
         <Banner
             intent={exchangeDeviation.exceedsHighThreshold ? 'critical' : 'warning'}
             data-testid="@trading/fiat-deviation-warning"
             description={
-                <Translation
-                    id="TR_TRADING_FIAT_DEVIATION_WARNING"
-                    values={{
-                        percentage: exchangeDeviation.deviation,
-                    }}
-                />
+                <Translation id="TR_TRADING_FIAT_DEVIATION_WARNING" values={{ percentage }} />
             }
         />
     );

--- a/suite-common/trading/src/hooks/__tests__/useExchangeFiatDeviation.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useExchangeFiatDeviation.test.ts
@@ -49,7 +49,7 @@ describe('useExchangeFiatDeviation', () => {
         const { result } = renderUseExchangeFiatDeviation();
 
         expect(result.current).toEqual({
-            deviation: 2,
+            deviation: 0.02,
             exceedsThreshold: false,
             exceedsHighThreshold: false,
         });
@@ -63,7 +63,7 @@ describe('useExchangeFiatDeviation', () => {
         const { result } = renderUseExchangeFiatDeviation();
 
         expect(result.current).toEqual({
-            deviation: 10,
+            deviation: 0.1,
             exceedsThreshold: true,
             exceedsHighThreshold: false,
         });
@@ -77,7 +77,7 @@ describe('useExchangeFiatDeviation', () => {
         const { result } = renderUseExchangeFiatDeviation();
 
         expect(result.current).toEqual({
-            deviation: 20,
+            deviation: 0.2,
             exceedsThreshold: true,
             exceedsHighThreshold: true,
         });

--- a/suite-common/trading/src/hooks/useExchangeFiatDeviation.ts
+++ b/suite-common/trading/src/hooks/useExchangeFiatDeviation.ts
@@ -4,8 +4,8 @@ import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { useTradingFiatValues } from './useTradingFiatValues';
 
-const FIAT_DEVIATION_THRESHOLD_PERCENT = 10;
-const FIAT_DEVIATION_HIGH_THRESHOLD_PERCENT = 20;
+const FIAT_DEVIATION_THRESHOLD_RATIO = 0.1;
+const FIAT_DEVIATION_HIGH_THRESHOLD_RATIO = 0.2;
 
 type ExchangeFiatDeviationProps = {
     sendCryptoId?: CryptoId;
@@ -54,11 +54,11 @@ export const useExchangeFiatDeviation = ({
         return null;
     }
 
-    const deviationPercent = ((sendFiatValue - receiveFiatValue) / sendFiatValue) * 100;
+    const deviation = (sendFiatValue - receiveFiatValue) / sendFiatValue;
 
     return {
-        deviation: deviationPercent,
-        exceedsThreshold: deviationPercent >= FIAT_DEVIATION_THRESHOLD_PERCENT,
-        exceedsHighThreshold: deviationPercent >= FIAT_DEVIATION_HIGH_THRESHOLD_PERCENT,
+        deviation,
+        exceedsThreshold: deviation >= FIAT_DEVIATION_THRESHOLD_RATIO,
+        exceedsHighThreshold: deviation >= FIAT_DEVIATION_HIGH_THRESHOLD_RATIO,
     };
 };

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2645,6 +2645,7 @@ export const messages = {
                 bullet2: 'No gas fees - the smart contract handles everything for you',
                 bullet3: 'Your swap might be partially filled based on the market conditions',
             },
+            fiatDeviationWarning: 'Receiving {percent} less in estimated value.',
         },
         tradingSellPreviewScreen: {
             title: 'Sell',

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
@@ -36,7 +36,7 @@ export const ExchangeFiatDeviationWarning = ({ quote }: ExchangeFiatDeviationWar
         return null;
     }
 
-    const percent = percentFormatter.format(exchangeDeviation.deviation / 100);
+    const percent = percentFormatter.format(exchangeDeviation.deviation);
 
     return (
         <InlineAlertBox

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import type { ExchangeTrade } from 'invity-api';
+
+import { useExchangeFiatDeviation } from '@suite-common/trading';
+import { selectBaseCurrency } from '@suite-common/wallet-core';
+import { InlineAlertBox } from '@suite-native/atoms';
+import { Translation, selectLocale } from '@suite-native/intl';
+
+export type ExchangeFiatDeviationWarningProps = {
+    quote?: ExchangeTrade;
+};
+
+export const ExchangeFiatDeviationWarning = ({ quote }: ExchangeFiatDeviationWarningProps) => {
+    const fiatCurrency = useSelector(selectBaseCurrency);
+    const locale = useSelector(selectLocale);
+    const exchangeDeviation = useExchangeFiatDeviation({
+        fiatCurrency,
+        receiveAmount: quote?.receiveStringAmount,
+        receiveCryptoId: quote?.receive,
+        sendAmount: quote?.sendStringAmount,
+        sendCryptoId: quote?.send,
+    });
+
+    const percentFormatter = useMemo(
+        () =>
+            new Intl.NumberFormat(locale, {
+                style: 'percent',
+                maximumFractionDigits: 0,
+            }),
+        [locale],
+    );
+
+    if (!quote || !exchangeDeviation || !exchangeDeviation.exceedsThreshold) {
+        return null;
+    }
+
+    const percent = percentFormatter.format(exchangeDeviation.deviation / 100);
+
+    return (
+        <InlineAlertBox
+            title={
+                <Translation
+                    id="moduleTrading.tradingExchangePreviewScreen.fiatDeviationWarning"
+                    values={{ percent }}
+                />
+            }
+            iconName={exchangeDeviation.exceedsHighThreshold ? 'warningCircle' : 'warning'}
+            variant={exchangeDeviation.exceedsHighThreshold ? 'critical' : 'warning'}
+        />
+    );
+};

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -7,6 +7,7 @@ import { InlineAlertBox, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { ExchangeFeePickerCard } from './ExchangeFeePickerCard';
+import { ExchangeFiatDeviationWarning } from './ExchangeFiatDeviationWarning';
 import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
 import { ExchangeFusionPlusInfo } from './ExchangeFusionPlusInfo';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
@@ -41,6 +42,7 @@ export const ExchangePreviewView = memo(
                 )}
                 <ExchangeFromAccountTradePreviewCard quote={quote} />
                 <ExchangeToAccountTradePreviewCard quote={quote} />
+                <ExchangeFiatDeviationWarning quote={quote} />
                 <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
                 {isFusionPlus && <ExchangeFusionPlusInfo />}
             </VStack>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
@@ -1,0 +1,103 @@
+import type { ExchangeTrade } from 'invity-api';
+
+import { getTranslation } from '@suite-native/intl';
+import { renderWithStoreProvider } from '@suite-native/test-utils';
+import { exchangeQuotes } from '@suite-native/trading-fixtures';
+
+import { ExchangeFiatDeviationWarning } from '../ExchangeFiatDeviationWarning';
+
+const mockExchangeFiatDeviation = jest.fn();
+
+jest.mock('@suite-common/trading', () => ({
+    ...jest.requireActual('@suite-common/trading'),
+    useExchangeFiatDeviation: (...args: unknown[]) => mockExchangeFiatDeviation(...args),
+}));
+
+describe('ExchangeFiatDeviationWarning', () => {
+    const renderExchangeFiatDeviationWarning = (quote?: ExchangeTrade) =>
+        renderWithStoreProvider(<ExchangeFiatDeviationWarning quote={quote} />, {
+            preloadedState: {
+                wallet: { settings: { localCurrency: 'usd' } },
+            },
+        });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockExchangeFiatDeviation.mockReturnValue({
+            deviation: 15,
+            exceedsThreshold: true,
+            exceedsHighThreshold: false,
+        });
+    });
+
+    it('should render nothing when no quote is provided', () => {
+        const { toJSON } = renderExchangeFiatDeviationWarning();
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when rate does not deviate', () => {
+        mockExchangeFiatDeviation.mockReturnValue({
+            deviation: 1,
+            exceedsThreshold: false,
+            exceedsHighThreshold: false,
+        });
+
+        const { toJSON } = renderExchangeFiatDeviationWarning(exchangeQuotes[0]);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should render nothing when useExchangeFiatDeviation returns null', () => {
+        mockExchangeFiatDeviation.mockReturnValue(null);
+
+        const { toJSON } = renderExchangeFiatDeviationWarning(exchangeQuotes[0]);
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('should call useExchangeFiatDeviation with proper params', () => {
+        const quote = exchangeQuotes[0];
+
+        renderExchangeFiatDeviationWarning(quote);
+
+        expect(mockExchangeFiatDeviation).toHaveBeenCalledWith({
+            sendCryptoId: quote.send,
+            sendAmount: quote.sendStringAmount,
+            receiveCryptoId: quote.receive,
+            receiveAmount: quote.receiveStringAmount,
+            fiatCurrency: 'usd',
+        });
+    });
+
+    it('should call display warning when threshold is exceeded', () => {
+        const { getByText } = renderExchangeFiatDeviationWarning(exchangeQuotes[0]);
+
+        expect(
+            getByText(
+                getTranslation('moduleTrading.tradingExchangePreviewScreen.fiatDeviationWarning', {
+                    percent: '15%',
+                }),
+            ),
+        ).toBeOnTheScreen();
+    });
+
+    it('should call display error when high threshold is exceeded', () => {
+        mockExchangeFiatDeviation.mockReturnValue({
+            deviation: 25,
+            exceedsThreshold: true,
+            exceedsHighThreshold: true,
+        });
+
+        const { getByText } = renderExchangeFiatDeviationWarning(exchangeQuotes[0]);
+
+        expect(
+            getByText(
+                getTranslation('moduleTrading.tradingExchangePreviewScreen.fiatDeviationWarning', {
+                    percent: '25%',
+                }),
+            ),
+        ).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
@@ -25,7 +25,7 @@ describe('ExchangeFiatDeviationWarning', () => {
         jest.clearAllMocks();
 
         mockExchangeFiatDeviation.mockReturnValue({
-            deviation: 15,
+            deviation: 0.15,
             exceedsThreshold: true,
             exceedsHighThreshold: false,
         });
@@ -39,7 +39,7 @@ describe('ExchangeFiatDeviationWarning', () => {
 
     it('should render nothing when rate does not deviate', () => {
         mockExchangeFiatDeviation.mockReturnValue({
-            deviation: 1,
+            deviation: 0.01,
             exceedsThreshold: false,
             exceedsHighThreshold: false,
         });
@@ -85,7 +85,7 @@ describe('ExchangeFiatDeviationWarning', () => {
 
     it('should call display error when high threshold is exceeded', () => {
         mockExchangeFiatDeviation.mockReturnValue({
-            deviation: 25,
+            deviation: 0.25,
             exceedsThreshold: true,
             exceedsHighThreshold: true,
         });

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1003,7 +1003,7 @@ export const messages = defineMessages({
         id: 'TR_TRADING_YOU_GET',
     },
     TR_TRADING_FIAT_DEVIATION_WARNING: {
-        defaultMessage: 'Receiving over {percentage}% less in estimated fiat value',
+        defaultMessage: 'Receiving over {percentage} less in estimated fiat value.',
         id: 'TR_TRADING_FIAT_DEVIATION_WARNING',
     },
     TR_TRADING_COUNTRY: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Display deviation warning when amounts differ fr more than 10%.
- Display deviation error when amounts differ fr more than 20%.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26221


## Screenshots:

<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-03-26 at 18 05 32" src="https://github.com/user-attachments/assets/62b55771-2184-41af-8bb3-dcef7308f53f" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=26221-trading-introduce-receiving-less-in-fiat-value-mobile&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26221-trading-introduce-receiving-less-in-fiat-value-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=26221-trading-introduce-receiving-less-in-fiat-value-mobile&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T10:13:00.584Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T17:37:21.362Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->