### PR TITLE
refactor(node-utils): extract parseRequestUrl utility wrapping url.parse

### DIFF
--- a/packages/node-utils/src/http.ts
+++ b/packages/node-utils/src/http.ts
@@ -1,12 +1,12 @@
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import * as http from 'http';
 import type * as net from 'net';
-import * as url from 'url';
 
 import type { RequiredKey } from '@trezor/type-utils';
 import { type Log, TypedEmitter, arrayPartition } from '@trezor/utils';
 
 import { findProcessFromIncomingPort } from './findProcessFromIncomingPort';
+import { formatRequestUrl, parseRequestUrl } from './parseRequestUrl';
 
 type Request = RequiredKey<http.IncomingMessage, 'url'>;
 const isRequest = (request: http.IncomingMessage): request is Request => request.url !== undefined;
@@ -408,7 +408,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
             this.logger.info(`Request ${request.method} ${request.url} aborted`);
         });
 
-        const { protocol, hostname, pathname, query } = url.parse(request.url, true);
+        const { protocol, hostname, pathname, query } = parseRequestUrl(request.url);
 
         if (query) {
             for (const key in query) {
@@ -433,7 +433,7 @@ export class HttpServer<T extends EventMap> extends TypedEmitter<T & BaseEvents>
                 }
             }
         }
-        request.url = url.format({ protocol, hostname, pathname, query });
+        request.url = formatRequestUrl({ protocol, hostname, pathname, query });
 
         if (!pathname) {
             const msg = `url ${request.url} could not be parsed`;

--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -15,3 +15,4 @@ export { checkFileExists } from './checkFileExists';
 export { checkSocks5Proxy } from './checkSocks5Proxy';
 export { validateJsonSchema } from './validateJsonSchema';
 export { findProcessFromIncomingPort, type ProcessInfo } from './findProcessFromIncomingPort';
+export { parseRequestUrl, formatRequestUrl, type ParsedRequestUrl } from './parseRequestUrl';

--- a/packages/node-utils/src/parseRequestUrl.ts
+++ b/packages/node-utils/src/parseRequestUrl.ts
@@ -1,0 +1,34 @@
+import type { ParsedUrlQuery } from 'querystring';
+import * as url from 'url';
+
+export interface ParsedRequestUrl {
+    protocol: string | null;
+    hostname: string | null;
+    pathname: string | null;
+    query: ParsedUrlQuery;
+    search: string | null;
+    hash: string | null;
+}
+
+/**
+ * Parse a request URL (typically a relative path like `/foo?a=1`) into its components.
+ * Returns the same shape as `url.parse(requestUrl, true)` for the fields that are
+ * consumed by HttpServer and http-receiver handlers.
+ */
+export const parseRequestUrl = (requestUrl: string): ParsedRequestUrl => {
+    const { protocol, hostname, pathname, query, search, hash } = url.parse(requestUrl, true);
+
+    return { protocol, hostname, pathname, query, search, hash };
+};
+
+/**
+ * Format a parsed request URL back into a URL string.
+ * Counterpart to `parseRequestUrl` — replaces `url.format({ protocol, hostname, pathname, query })`.
+ */
+export const formatRequestUrl = ({
+    protocol,
+    hostname,
+    pathname,
+    query,
+}: Pick<ParsedRequestUrl, 'protocol' | 'hostname' | 'pathname' | 'query'>): string =>
+    url.format({ protocol, hostname, pathname, query });

--- a/packages/node-utils/src/tests/http.test.ts
+++ b/packages/node-utils/src/tests/http.test.ts
@@ -1,5 +1,3 @@
-import url from 'url';
-
 import { type Log } from '@trezor/utils';
 
 import { getFreePort } from '../getFreePort';
@@ -12,6 +10,7 @@ import {
     parseBodyJSONWithLimit,
     parseBodyText,
 } from '../http';
+import { parseRequestUrl } from '../parseRequestUrl';
 
 type Events = {
     foo: (arg: string) => void;
@@ -361,7 +360,7 @@ describe('HttpServer', () => {
 
     test('query string as array', async () => {
         const handler = jest.fn((request, response) => {
-            const { search } = url.parse(request.url, true);
+            const { search } = parseRequestUrl(request.url);
             response.end(search);
         });
         server.post('/foo', [parseBodyText, handler]);
@@ -378,7 +377,7 @@ describe('HttpServer', () => {
 
     test('should get query string as url when using encoded parameters', async () => {
         const handler = jest.fn((request, response) => {
-            const { search } = url.parse(request.url, true);
+            const { search } = parseRequestUrl(request.url);
             response.end(search);
         });
         server.post('/foo', [parseBodyText, handler]);
@@ -398,7 +397,7 @@ describe('HttpServer', () => {
 
     test('should not get query string as url when using invalid encoded parameters', async () => {
         const handler = jest.fn((request, response) => {
-            const { search } = url.parse(request.url, true);
+            const { search } = parseRequestUrl(request.url);
             response.end(search);
         });
         server.post('/foo', [parseBodyText, handler]);
@@ -415,7 +414,7 @@ describe('HttpServer', () => {
 
     test('query string sanitization', async () => {
         const handler = jest.fn((request, response) => {
-            const { search } = url.parse(request.url, true);
+            const { search } = parseRequestUrl(request.url);
             response.end(search);
         });
         server.post('/foo', [parseBodyText, handler]);

--- a/packages/node-utils/src/tests/parseRequestUrl.test.ts
+++ b/packages/node-utils/src/tests/parseRequestUrl.test.ts
@@ -1,0 +1,219 @@
+import type { ParsedUrlQuery } from 'querystring';
+
+import { formatRequestUrl, parseRequestUrl } from '../parseRequestUrl';
+
+type ParseFixture = {
+    description: string;
+    input: string;
+    expected: {
+        protocol: string | null;
+        hostname: string | null;
+        pathname: string | null;
+        query: ParsedUrlQuery;
+        search: string | null;
+        hash: string | null;
+    };
+};
+
+const parseFixtures: ParseFixture[] = [
+    {
+        description: 'simple path',
+        input: '/foo',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: {},
+            search: null,
+            hash: null,
+        },
+    },
+    {
+        description: 'root path',
+        input: '/',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/',
+            query: {},
+            search: null,
+            hash: null,
+        },
+    },
+    {
+        description: 'single query param',
+        input: '/foo?a=1',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { a: '1' },
+            search: '?a=1',
+            hash: null,
+        },
+    },
+    {
+        description: 'multiple query params',
+        input: '/foo?a=1&b=2',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { a: '1', b: '2' },
+            search: '?a=1&b=2',
+            hash: null,
+        },
+    },
+    {
+        description: 'array query params',
+        input: '/foo?a=1&a=2',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { a: ['1', '2'] },
+            search: '?a=1&a=2',
+            hash: null,
+        },
+    },
+    {
+        description: 'encoded query param',
+        input: '/foo?c=%2Fredirect%2Fdetail',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { c: '/redirect/detail' },
+            search: '?c=%2Fredirect%2Fdetail',
+            hash: null,
+        },
+    },
+    {
+        description: 'hash fragment',
+        input: '/foo#bar',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: {},
+            search: null,
+            hash: '#bar',
+        },
+    },
+    {
+        description: 'query and hash',
+        input: '/foo?a=1#bar',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { a: '1' },
+            search: '?a=1',
+            hash: '#bar',
+        },
+    },
+    {
+        description: 'oauth-like redirect',
+        input: '/oauth?code=abc&state=xyz',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/oauth',
+            query: { code: 'abc', state: 'xyz' },
+            search: '?code=abc&state=xyz',
+            hash: null,
+        },
+    },
+    {
+        description: 'buy-redirect with p param',
+        input: '/buy-redirect?p=somevalue',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/buy-redirect',
+            query: { p: 'somevalue' },
+            search: '?p=somevalue',
+            hash: null,
+        },
+    },
+    {
+        description: 'query with javascript: xss attempt',
+        input: '/foo?ok=meow&notok=javascript:alert(1)',
+        expected: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { ok: 'meow', notok: 'javascript:alert(1)' },
+            search: '?ok=meow&notok=javascript:alert(1)',
+            hash: null,
+        },
+    },
+];
+
+type FormatFixture = {
+    description: string;
+    input: {
+        protocol: string | null;
+        hostname: string | null;
+        pathname: string | null;
+        query: ParsedUrlQuery;
+    };
+    expected: string;
+};
+
+const formatFixtures: FormatFixture[] = [
+    {
+        description: 'simple path without query',
+        input: { protocol: null, hostname: null, pathname: '/foo', query: {} },
+        expected: '/foo',
+    },
+    {
+        description: 'path with single query param',
+        input: { protocol: null, hostname: null, pathname: '/foo', query: { a: '1' } },
+        expected: '/foo?a=1',
+    },
+    {
+        description: 'path with multiple query params',
+        input: { protocol: null, hostname: null, pathname: '/foo', query: { a: '1', b: '2' } },
+        expected: '/foo?a=1&b=2',
+    },
+    {
+        description: 'path with array query params',
+        input: { protocol: null, hostname: null, pathname: '/foo', query: { a: ['1', '2'] } },
+        expected: '/foo?a=1&a=2',
+    },
+    {
+        description: 'path with encoded characters',
+        input: {
+            protocol: null,
+            hostname: null,
+            pathname: '/foo',
+            query: { c: '/redirect/detail' },
+        },
+        expected: '/foo?c=%2Fredirect%2Fdetail',
+    },
+    {
+        description: 'root path',
+        input: { protocol: null, hostname: null, pathname: '/', query: {} },
+        expected: '/',
+    },
+];
+
+describe('parseRequestUrl', () => {
+    it.each(parseFixtures)('$description: $input', ({ input, expected }) => {
+        expect(parseRequestUrl(input)).toEqual(expected);
+    });
+});
+
+describe('formatRequestUrl', () => {
+    it.each(formatFixtures)('$description', ({ input, expected }) => {
+        expect(formatRequestUrl(input)).toEqual(expected);
+    });
+
+    it('round-trips: formatRequestUrl(parseRequestUrl(url)) preserves the url', () => {
+        const urls = ['/foo?a=1', '/foo?a=1&b=2', '/foo?a=1&a=2', '/'];
+        for (const u of urls) {
+            expect(formatRequestUrl(parseRequestUrl(u))).toEqual(u);
+        }
+    });
+});

--- a/packages/suite-desktop-core/src/libs/http-receiver.ts
+++ b/packages/suite-desktop-core/src/libs/http-receiver.ts
@@ -1,7 +1,5 @@
-import * as url from 'url';
-
 import { trezorLogo } from '@suite-common/suite-constants';
-import { HttpServer, allowReferers } from '@trezor/node-utils';
+import { HttpServer, allowReferers, parseRequestUrl } from '@trezor/node-utils';
 import { type RendererChannels } from '@trezor/suite-desktop-api';
 import { xssFilters } from '@trezor/utils';
 
@@ -81,7 +79,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
     httpReceiver.get('/oauth', [
         allowReferers(['', '127.0.0.1', 'www.dropbox.com']), // No referer is sent by Google, Dropbox sends referer when using Safari
         (request, response) => {
-            const { search, hash } = url.parse(request.url, true);
+            const { search, hash } = parseRequestUrl(request.url);
 
             // send data back to main window
             httpReceiver.emit('oauth/response', {
@@ -98,7 +96,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
     httpReceiver.get('/buy-redirect', [
         allowReferers(['', 'localhost:3000', '*.invity.io', 'invity.io']),
         (request, response) => {
-            const { query } = url.parse(request.url, true);
+            const { query } = parseRequestUrl(request.url);
             if (query && query.p) {
                 httpReceiver.emit('buy/redirect', query.p.toString());
             }
@@ -150,7 +148,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
     httpReceiver.get('/sell-redirect', [
         allowReferers(['']), // No referer
         (request, response) => {
-            const { query } = url.parse(request.url, true);
+            const { query } = parseRequestUrl(request.url);
             if (query && query.p) {
                 httpReceiver.emit('sell/redirect', query.p.toString());
             }
@@ -164,7 +162,7 @@ export const createHttpReceiver = (options?: { port?: number }) => {
     httpReceiver.get('/exchange-redirect', [
         allowReferers(['']), // No referer
         (request, response) => {
-            const { query } = url.parse(request.url, true);
+            const { query } = parseRequestUrl(request.url);
             if (query && query.p) {
                 httpReceiver.emit('exchange/redirect', query.p.toString());
             }


### PR DESCRIPTION
cherry-picked from #26238

First, create tests for the API we are going to replace.

## Description

Adds `parseRequestUrl` and `formatRequestUrl` utilities in `@trezor/node-utils` wrapping `url.parse`/`url.format`, along with unit tests covering the full API surface.

Test file improvements (based on review feedback):
- Use `import type { ParsedUrlQuery } from 'querystring'` consistent with `parseRequestUrl.ts`
- Extract inline fixture object types to named types (`ParseFixture`, `FormatFixture`) for readability
- Use `ParsedUrlQuery` for `query` fields instead of the inline `Record<string, string | string[]>`

## Notes for QA

No runtime behaviour changes — all changes are confined to types and test structure in `parseRequestUrl.test.ts`.

## Related Issue

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=url-parse-utility&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=url-parse-utility&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T21:03:03.999Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T21:01:17.782Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->