### PR TITLE
fix(ci): fix param

### DIFF
--- a/.github/workflows/bot-needs-qa.yml
+++ b/.github/workflows/bot-needs-qa.yml
@@ -62,7 +62,7 @@ jobs:
           CONTENT_ID="${{ steps.context.outputs.content_id }}"
 
           RESPONSE=$(gh api graphql -f query='
-            query($content_id: ID!, $project_id: ID!) {
+            query($content_id: ID!) {
               node(id: $content_id) {
                 ... on Issue {
                   projectItems(first: 10) {
@@ -76,8 +76,7 @@ jobs:
                 }
               }
             }' \
-            -f content_id="$CONTENT_ID" \
-            -f project_id="${{ env.PROJECT_ID }}")
+            -f content_id="$CONTENT_ID")
 
           ITEM_ID=$(echo "$RESPONSE" | jq -r \
             ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\") | .id")
@@ -127,6 +126,6 @@ jobs:
             }' -f project=${{ env.PROJECT_ID }} \
                -f item=$ITEM_ID \
                -f field=${{ env.STATUS_FIELD_ID }} \
-               -f value=${{ steps.target-status.outputs.option_id }} \
+               -f value=${{ steps.target-status.outputs.option_id }}
 
           echo "✅ Status set to '${{ steps.target-status.outputs.status_name }}' for ${{ steps.context.outputs.event_type }}"


### PR DESCRIPTION
follow up of https://github.com/trezor/trezor-suite/pull/26088

- fixes project_id and trailign slash

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ci/qa-bot&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ci/qa-bot&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-26T20:54:27.880Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-26T20:52:38.113Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->