### PR TITLE
Fix/dropbox web

### DIFF
--- a/packages/suite-data/files/oauth/oauthReceiver.js
+++ b/packages/suite-data/files/oauth/oauthReceiver.js
@@ -5,15 +5,20 @@
  *   - Dropbox authorization code flow - search
  */
 
+const OAUTH_BROADCAST_CHANNEL_NAME = 'trezor-oauth';
+
+const payload = {
+    key: 'trezor-oauth',
+    hash: window.location.hash,
+    search: window.location.search,
+};
+
+const channel = new BroadcastChannel(OAUTH_BROADCAST_CHANNEL_NAME);
+channel.postMessage(payload);
+channel.close();
+
 if (window.opener) {
-    window.opener.postMessage(
-        {
-            key: 'trezor-oauth',
-            hash: window.location.hash,
-            search: window.location.search,
-        },
-        window.location.origin,
-    );
+    window.opener.postMessage(payload, window.location.origin);
 }
 
 window.close();

--- a/packages/suite-data/files/oauth/oauthReceiver.js
+++ b/packages/suite-data/files/oauth/oauthReceiver.js
@@ -5,20 +5,14 @@
  *   - Dropbox authorization code flow - search
  */
 
-const OAUTH_BROADCAST_CHANNEL_NAME = 'trezor-oauth';
+const OAUTH_CHANNEL_NAME = 'trezor-oauth';
 
-const payload = {
-    key: 'trezor-oauth',
+const channel = new BroadcastChannel(OAUTH_CHANNEL_NAME);
+channel.postMessage({
+    key: OAUTH_CHANNEL_NAME,
     hash: window.location.hash,
     search: window.location.search,
-};
-
-const channel = new BroadcastChannel(OAUTH_BROADCAST_CHANNEL_NAME);
-channel.postMessage(payload);
+});
 channel.close();
-
-if (window.opener) {
-    window.opener.postMessage(payload, window.location.origin);
-}
 
 window.close();

--- a/suite/e2e/support/mocks/metadataMock.ts
+++ b/suite/e2e/support/mocks/metadataMock.ts
@@ -21,12 +21,15 @@ const stubOpen = `
         console.log('Intercepted window.open call:', url.toString());
         const urlObj = typeof url === 'string' ? new URL(url) : url;
         const state = urlObj.searchParams?.get('state') || new Array(128).fill('Y').join('');
-        window.postMessage(
-            { 
-              search: '?' + new URLSearchParams({ state, code: 'chicken-cho-cha', }).toString(),
-              key: 'trezor-oauth' 
-            },
-        );
+        const channel = new BroadcastChannel('trezor-oauth');
+        channel.postMessage({
+            key: 'trezor-oauth',
+            search: '?' + new URLSearchParams({ state, code: 'chicken-cho-cha' }).toString(),
+            hash: '',
+        });
+        channel.close();
+
+        return { closed: false, close: () => {} };
     };
 `;
 

--- a/suite/metadata/src/oauth.ts
+++ b/suite/metadata/src/oauth.ts
@@ -126,7 +126,6 @@ const handleResponse = (
 
 // keep handler function instance in top level scope
 let desktopHandlerInstance: (message: OAuthResponseMessage) => void;
-let webHandlerInstance: (e: MessageEvent<OAuthResponseMessage>) => void;
 
 const getDesktopHandlerInstance = (
     dfd: Deferred<OAuthCredentials>,
@@ -150,60 +149,54 @@ const getDesktopHandlerInstance = (
     return desktopHandlerInstance;
 };
 
-const getWebHandlerInstance = (
-    dfd: Deferred<OAuthCredentials>,
-    originalParams: URLSearchParams,
-) => {
-    if (webHandlerInstance) {
-        window.removeEventListener('message', webHandlerInstance);
-    }
-    webHandlerInstance = (e: MessageEvent<OAuthResponseMessage>) => {
-        if (window.location.origin !== e.origin) return;
-        if (!oauthResult.safeParse(e.data).success) return;
-
-        handleResponse(
-            e.data,
-            originalParams,
-            credentials => {
-                dfd.resolve(credentials);
-            },
-            error => {
-                dfd.reject(error);
-            },
-        );
-    };
-
-    return webHandlerInstance;
-};
-
-const getWebBroadcastChannelHandlerInstance = (
+const createWebBroadcastChannel = (
     dfd: Deferred<OAuthCredentials>,
     originalParams: URLSearchParams,
 ) => {
     const channel = new BroadcastChannel(OAUTH_BROADCAST_CHANNEL_NAME);
-    const messageHandler = (e: MessageEvent) => {
+
+    channel.addEventListener('message', (e: MessageEvent) => {
         try {
             const parsedMessage = oauthResponseMessage.parse(e.data);
             handleResponse(
                 parsedMessage,
                 originalParams,
-                credentials => {
-                    channel.close();
-                    dfd.resolve(credentials);
-                },
-                error => {
-                    channel.close();
-                    dfd.reject(error);
-                },
+                credentials => dfd.resolve(credentials),
+                error => dfd.reject(error),
             );
         } catch (error) {
             console.error(error);
         }
-    };
-
-    channel.addEventListener('message', messageHandler);
+    });
 
     return channel;
+};
+
+/**
+ * Watch popup window and call onClose when it is closed by the user or after a timeout.
+ * Returns a cleanup function to clear the timers.
+ */
+const watchPopup = (popup: Window, onClose: () => void) => {
+    const timers = { pollIntervalId: 0, timeoutId: 0 };
+
+    const clear = () => {
+        window.clearInterval(timers.pollIntervalId);
+        window.clearTimeout(timers.timeoutId);
+    };
+
+    timers.pollIntervalId = window.setInterval(() => {
+        if (popup.closed) {
+            clear();
+            onClose();
+        }
+    }, POPUP_POLL_INTERVAL_MS);
+
+    timers.timeoutId = window.setTimeout(() => {
+        clear();
+        onClose();
+    }, POPUP_TIMEOUT_MS);
+
+    return clear;
 };
 
 /**
@@ -219,8 +212,7 @@ export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
         desktopApi.once('oauth/response', getDesktopHandlerInstance(dfd, url.searchParams));
         window.open(url, METADATA_PROVIDER.AUTH_WINDOW_TITLE, METADATA_PROVIDER.AUTH_WINDOW_PROPS);
     } else {
-        const messageHandler = getWebHandlerInstance(dfd, url.searchParams);
-        const broadcastChannel = getWebBroadcastChannelHandlerInstance(dfd, url.searchParams);
+        const channel = createWebBroadcastChannel(dfd, url.searchParams);
 
         const popup = window.open(
             url,
@@ -228,42 +220,21 @@ export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
             METADATA_PROVIDER.AUTH_WINDOW_PROPS,
         );
 
-        window.addEventListener('message', messageHandler);
-
         if (!popup) {
-            window.removeEventListener('message', messageHandler);
-            broadcastChannel.close();
+            channel.close();
             dfd.reject(new Error('window closed'));
 
             return dfd.promise;
         }
 
-        let pollIntervalId = 0;
-        let timeoutId = 0;
-
-        const cleanup = () => {
-            window.removeEventListener('message', messageHandler);
-            broadcastChannel.close();
-            window.clearInterval(pollIntervalId);
-            window.clearTimeout(timeoutId);
-        };
-
-        // Poll for popup being closed by the user (e.g. manually closing the window).
-        pollIntervalId = window.setInterval(() => {
-            if (popup.closed) {
-                cleanup();
-                dfd.reject(new Error('window closed'));
-            }
-        }, POPUP_POLL_INTERVAL_MS);
-
-        // Safety timeout to avoid hanging indefinitely.
-        timeoutId = window.setTimeout(() => {
-            cleanup();
+        const clearTimers = watchPopup(popup, () => {
+            channel.close();
             dfd.reject(new Error('window closed'));
-        }, POPUP_TIMEOUT_MS);
+        });
 
         void dfd.promise.finally(() => {
-            cleanup();
+            channel.close();
+            clearTimers();
 
             if (!popup.closed) {
                 popup.close();

--- a/suite/metadata/src/oauth.ts
+++ b/suite/metadata/src/oauth.ts
@@ -30,35 +30,9 @@ export const getOauthReceiverUrl = () => {
     return desktopApi.getHttpReceiverAddress('/oauth');
 };
 
-let interval: number;
-
-/**
- * Use this function to workaround impossibility to detect beforeunload event
- * for windows loaded on another domains
- * @param uri
- * @param name
- * @param options
- * @param closeCallback
- */
-const openWindowOnAnotherDomain = (
-    url: URL,
-    name: string,
-    options: string,
-    closeCallback: () => void,
-) => {
-    const win = window.open(url, name, options);
-    clearInterval(interval);
-    interval = window.setInterval(() => {
-        // todo: for some reason, when used in electron, win has closed=true right from the start and thus closeCallback
-        // is invoked immediately. temporary workaround is not to use openWindowOnAnotherDomain in electron
-        if (!win) {
-            window.clearInterval(interval);
-            closeCallback();
-        }
-    }, 1000);
-
-    return win;
-};
+const POPUP_POLL_INTERVAL_MS = 500;
+const POPUP_TIMEOUT_MS = 60 * 1000;
+const OAUTH_BROADCAST_CHANNEL_NAME = 'trezor-oauth';
 
 const oauthResponseMessage = z
     .object({
@@ -131,7 +105,10 @@ const handleResponse = (
             return onError(new Error('Invalid response from data provider'));
         }
 
-        handleResponseError(error, error_description);
+        const responseError = handleResponseError(error, error_description);
+        if (responseError) {
+            return onError(responseError);
+        }
 
         onSuccess({ code, access_token });
     } catch (error) {
@@ -199,6 +176,36 @@ const getWebHandlerInstance = (
     return webHandlerInstance;
 };
 
+const getWebBroadcastChannelHandlerInstance = (
+    dfd: Deferred<OAuthCredentials>,
+    originalParams: URLSearchParams,
+) => {
+    const channel = new BroadcastChannel(OAUTH_BROADCAST_CHANNEL_NAME);
+    const messageHandler = (e: MessageEvent) => {
+        try {
+            const parsedMessage = oauthResponseMessage.parse(e.data);
+            handleResponse(
+                parsedMessage,
+                originalParams,
+                credentials => {
+                    channel.close();
+                    dfd.resolve(credentials);
+                },
+                error => {
+                    channel.close();
+                    dfd.reject(error);
+                },
+            );
+        } catch (error) {
+            console.error(error);
+        }
+    };
+
+    channel.addEventListener('message', messageHandler);
+
+    return channel;
+};
+
 /**
  * Handle extraction of authorization code from Oauth2 protocol
  */
@@ -213,21 +220,55 @@ export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
         window.open(url, METADATA_PROVIDER.AUTH_WINDOW_TITLE, METADATA_PROVIDER.AUTH_WINDOW_PROPS);
     } else {
         const messageHandler = getWebHandlerInstance(dfd, url.searchParams);
+        const broadcastChannel = getWebBroadcastChannelHandlerInstance(dfd, url.searchParams);
 
-        window.addEventListener('message', messageHandler);
-        openWindowOnAnotherDomain(
+        const popup = window.open(
             url,
             METADATA_PROVIDER.AUTH_WINDOW_TITLE,
             METADATA_PROVIDER.AUTH_WINDOW_PROPS,
-            () => {
-                // note that this rejection happens even on successful authorization.
-                // 'window closed' error message may be used to differentiate between errors
-                setTimeout(() => {
-                    window.removeEventListener('message', messageHandler);
-                    dfd.reject(new Error('window closed'));
-                }, 5000);
-            },
         );
+
+        window.addEventListener('message', messageHandler);
+
+        if (!popup) {
+            window.removeEventListener('message', messageHandler);
+            broadcastChannel.close();
+            dfd.reject(new Error('window closed'));
+
+            return dfd.promise;
+        }
+
+        let pollIntervalId = 0;
+        let timeoutId = 0;
+
+        const cleanup = () => {
+            window.removeEventListener('message', messageHandler);
+            broadcastChannel.close();
+            window.clearInterval(pollIntervalId);
+            window.clearTimeout(timeoutId);
+        };
+
+        // Poll for popup being closed by the user (e.g. manually closing the window).
+        pollIntervalId = window.setInterval(() => {
+            if (popup.closed) {
+                cleanup();
+                dfd.reject(new Error('window closed'));
+            }
+        }, POPUP_POLL_INTERVAL_MS);
+
+        // Safety timeout to avoid hanging indefinitely.
+        timeoutId = window.setTimeout(() => {
+            cleanup();
+            dfd.reject(new Error('window closed'));
+        }, POPUP_TIMEOUT_MS);
+
+        void dfd.promise.finally(() => {
+            cleanup();
+
+            if (!popup.closed) {
+                popup.close();
+            }
+        });
     }
 
     return dfd.promise;

--- a/suite/metadata/src/oauth.ts
+++ b/suite/metadata/src/oauth.ts
@@ -30,7 +30,6 @@ export const getOauthReceiverUrl = () => {
     return desktopApi.getHttpReceiverAddress('/oauth');
 };
 
-const POPUP_POLL_INTERVAL_MS = 500;
 const POPUP_TIMEOUT_MS = 60 * 1000;
 const OAUTH_BROADCAST_CHANNEL_NAME = 'trezor-oauth';
 
@@ -173,33 +172,6 @@ const createWebBroadcastChannel = (
 };
 
 /**
- * Watch popup window and call onClose when it is closed by the user or after a timeout.
- * Returns a cleanup function to clear the timers.
- */
-const watchPopup = (popup: Window, onClose: () => void) => {
-    const timers = { pollIntervalId: 0, timeoutId: 0 };
-
-    const clear = () => {
-        window.clearInterval(timers.pollIntervalId);
-        window.clearTimeout(timers.timeoutId);
-    };
-
-    timers.pollIntervalId = window.setInterval(() => {
-        if (popup.closed) {
-            clear();
-            onClose();
-        }
-    }, POPUP_POLL_INTERVAL_MS);
-
-    timers.timeoutId = window.setTimeout(() => {
-        clear();
-        onClose();
-    }, POPUP_TIMEOUT_MS);
-
-    return clear;
-};
-
-/**
  * Handle extraction of authorization code from Oauth2 protocol
  */
 export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
@@ -227,17 +199,21 @@ export const extractCredentialsFromAuthorizationFlow = (url: URL) => {
             return dfd.promise;
         }
 
-        const clearTimers = watchPopup(popup, () => {
+        // Safety timeout — COOP prevents detecting popup closure via popup.closed,
+        // so we rely on BroadcastChannel as the primary signal and timeout as fallback.
+        const timeoutId = window.setTimeout(() => {
             channel.close();
             dfd.reject(new Error('window closed'));
-        });
+        }, POPUP_TIMEOUT_MS);
 
         void dfd.promise.finally(() => {
+            window.clearTimeout(timeoutId);
             channel.close();
-            clearTimers();
 
-            if (!popup.closed) {
+            try {
                 popup.close();
+            } catch {
+                // COOP may block access to the popup.
             }
         });
     }

--- a/suite/metadata/src/providers/DropboxProvider.ts
+++ b/suite/metadata/src/providers/DropboxProvider.ts
@@ -70,7 +70,6 @@ export class DropboxProvider extends AbstractMetadataProvider {
         try {
             // dropbox supports authorization code flow for both web and desktop
             const { code } = await extractCredentialsFromAuthorizationFlow(new URL(url.toString()));
-
             if (!code)
                 return this.error('AUTH_ERROR', 'Failed to extract code from authorization flow');
 


### PR DESCRIPTION
## Summary
  - Dropbox and Google Drive OAuth on web was broken — after authorizing in the popup, the modal stayed loading
  - Root cause: `window.opener` is `null` on the OAuth receiver page after the cross-origin redirect chain (due to COOP headers), so `window.opener.postMessage()` never fires
  - Additionally, COOP makes `popup.closed` return `true` immediately for cross-origin popups, preventing reliable popup-closed detection
  - Replaced popup-to-parent communication with `BroadcastChannel` — same-origin, in-memory, no dependency on `window.opener`
  - Fixed a bug where `handleResponseError()` returned an `Error` but the return value was silently ignored
  - Removed broken `openWindowOnAnotherDomain` helper (was checking `!win` instead of `win.closed`)

  ## How it works now
  1. Main app opens OAuth popup and listens on `BroadcastChannel('trezor-oauth')`
  2. Popup completes OAuth, lands on `oauth_receiver.html`
  3. Receiver sends payload via `BroadcastChannel`, then closes itself
  4. Main app receives the code, validates state, exchanges for token, done
  5. If no response arrives within 20s, the flow times out and rejects

  ## Known limitations
  - COOP prevents detecting popup closure via `popup.closed`, so if the user manually closes the popup mid-flow, the modal with providers is hanging, but it can just be closed and the flow restarted. Better UX could be implemented here, but it's out of scope for this PR and up for discussion whether it's necessary.
  
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/24901

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/dropbox-web&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/dropbox-web&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T12:46:00.786Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T09:42:18.466Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->