### PR TITLE
fix(suite): ensure descriptor.apiType with migration

### DIFF
--- a/packages/suite/src/storage/migrations/versions/26.4.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.1.ts
@@ -1,0 +1,23 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+export default createMigration<SuiteDBSchema>('26.4.0.1', async (_, tx) => {
+    await updateAll(tx, 'devices', device => {
+        // Ensure apiType is set for remembered devices from old versions of Suite.
+        // Bluetooth didn't exist before, so defaulting to 'usb' is safe.
+        if (!device.descriptor) {
+            device.descriptor = { apiType: 'usb' };
+
+            return device;
+        }
+
+        if (!device.descriptor.apiType) {
+            device.descriptor.apiType = 'usb';
+
+            return device;
+        }
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.4.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.4.0.1.test.ts
@@ -1,0 +1,95 @@
+import '@suite-common/test-utils/src/globalOverrides';
+import { type IDBPDatabase, deleteDB, openDB } from 'idb';
+
+import { type SuiteDBSchema } from '../../../definitions';
+import migration from '../26.4.0.1';
+
+const DB_NAME = 'suite-idb-test-26.4.0.1';
+const INITIAL_VERSION = 1;
+
+const runMigration = () =>
+    openDB(DB_NAME, INITIAL_VERSION + 1, {
+        upgrade(db: IDBPDatabase<SuiteDBSchema>, _oldVersion, _newVersion, tx) {
+            migration.migrate(db, tx);
+        },
+    });
+
+describe('migration 26.4.0.1', () => {
+    beforeEach(async () => {
+        await deleteDB(DB_NAME);
+    });
+
+    test('adds descriptor with apiType "usb" when descriptor is missing', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('devices');
+            },
+        });
+        await db.put('devices', { id: 'device-1' }, 'device-1');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const device = await migratedDb.get('devices', 'device-1');
+        expect(device).toBeDefined();
+        expect(device?.descriptor).toEqual({ apiType: 'usb' });
+
+        migratedDb.close();
+    });
+
+    test('adds apiType "usb" when descriptor exists but apiType is missing', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('devices');
+            },
+        });
+        await db.put('devices', { id: 'device-1', descriptor: { id: 'some-id' } }, 'device-1');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const device = await migratedDb.get('devices', 'device-1');
+        expect(device).toBeDefined();
+        expect(device?.descriptor).toEqual({ id: 'some-id', apiType: 'usb' });
+
+        migratedDb.close();
+    });
+
+    test('does not modify device when descriptor.apiType is already set', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('devices');
+            },
+        });
+        const originalDevice = {
+            id: 'device-1',
+            descriptor: { apiType: 'bluetooth', id: 'bt-id' },
+        };
+        await db.put('devices', originalDevice, 'device-1');
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        const device = await migratedDb.get('devices', 'device-1');
+        expect(device).toBeDefined();
+        expect(device?.descriptor).toEqual({ apiType: 'bluetooth', id: 'bt-id' });
+
+        migratedDb.close();
+    });
+
+    test('handles empty devices store without error', async () => {
+        const db = await openDB(DB_NAME, INITIAL_VERSION, {
+            upgrade(db) {
+                db.createObjectStore('devices');
+            },
+        });
+        db.close();
+
+        const migratedDb = await runMigration();
+
+        // Just verify the migration completed without throwing
+        expect(migratedDb.objectStoreNames.contains('devices')).toBe(true);
+
+        migratedDb.close();
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -16,3 +16,4 @@ export { default as m26_2_0 } from './26.2.0';
 export { default as m26_3_0 } from './26.3.0';
 export { default as m26_3_0_1 } from './26.3.0.1';
 export { default as m26_4_0 } from './26.4.0';
+export { default as m26_4_0_1 } from './26.4.0.1';


### PR DESCRIPTION
## Description

Ensure that `device.descriptor.apiType` is set for remembered devices from old versions of Suite

## Notes for QA

See issue

## Related Issue

Resolve #26080

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26080-ensure-descriptor-apitype&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26080-ensure-descriptor-apitype&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T09:44:40.503Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T09:43:02.361Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->