### PR TITLE
chore(suite): remove isTrezorDeviceWithState duplicity

### DIFF
--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -1,5 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
+import { isTrezorDeviceWithState } from '@suite-common/device';
 import {
     WriteModeRequiredForAllocation,
     ensureDeviceHasQuotaThunk,
@@ -8,7 +9,7 @@ import {
 import { type SuiteSyncOwner } from '@suite-common/suite-sync-storage';
 import { type WriteModeRequiredForAllocationErrType } from '@suite-common/suite-sync-types';
 import { type DelegatedIdentityKey } from '@suite-common/suite-types';
-import { isTrezorDeviceWithState, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
+import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 import { type Result, err, ok } from '@trezor/type-utils';
 import { isNotNull, isNotNullOrUndefined } from '@trezor/utils';

--- a/suite-common/wallet-utils/src/deviceUtils.ts
+++ b/suite-common/wallet-utils/src/deviceUtils.ts
@@ -1,7 +1,6 @@
-import { type TrezorDevice, type TrezorDeviceWithState } from '@suite-common/suite-types';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { asWalletDescriptor } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
-import { isNotNullOrUndefined, isNotUndefined } from '@trezor/utils';
 
 export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionId) => {
     const [walletDescriptor, deviceId] = deviceStaticSessionId.split('@');
@@ -15,10 +14,3 @@ export const parseDeviceStaticSessionId = (deviceStaticSessionId: StaticSessionI
 // local copy of import { isApprovalFlowSupported } from '@suite-common/device'; > reviewTransactionUtils
 export const isApprovalFlowSupported = (device: TrezorDevice | undefined) =>
     !device?.unavailableCapabilities?.['evmApproval'];
-
-export const isTrezorDeviceWithState = (
-    device: TrezorDevice | undefined,
-): device is TrezorDeviceWithState =>
-    isNotUndefined(device) &&
-    isNotNullOrUndefined(device.state) &&
-    isNotUndefined(device.state.staticSessionId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove duplicity of same util, probably created by incorrect rebase conflict resolution. 

## Notes for QA
Nothing to test.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-device-util-duplication&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-device-util-duplication&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/remove-device-util-duplication&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T10:27:07.487Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T09:48:27.808Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->