### PR TITLE
fix(suite-native): fix text overflow in contact support checkbox label

### DIFF
--- a/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
+++ b/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
@@ -37,7 +37,7 @@ export const ContactSupportAlertAppendix = forwardRef<ContactSupportAlertAppendi
                     onChange={setIsChecked}
                     testID="@contact-support-alert/share-info-switch"
                 />
-                <Text variant="body-md-strong">
+                <Text variant="body-md-strong" style={{ flex: 1 }}>
                     <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.toggleLabel" />
                 </Text>
             </HStack>


### PR DESCRIPTION
## Description

Added `flex: 1` to the checkbox label `Text` in the Contact Support alert so it wraps instead of overflowing.

## Notes for QA

Open Settings → Support → Contact support. Check that the checkbox label wraps correctly in the Czech locale.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26246

## Screenshots:
![Screenshot_2026-03-27-10-33-09-62_f0e0ef16e89dc3099c9d2ea44a0bcfa0](https://github.com/user-attachments/assets/5ea045d0-593e-4d93-a8e5-1ea34ac9afe9)


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/contact-support-text-overflow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->