### PR TITLE
fix: PageHeader incorrectly shows scrolled state when opening switch …

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -1,14 +1,9 @@
 import { Translation } from '@suite/intl';
-import {
-    resolveEffectiveBackgroundRouteName,
-    selectIsAccountTabPage,
-    selectRoute,
-} from '@suite/router';
+import { selectEffectiveRouteName, selectIsAccountTabPageWithLocation } from '@suite/router';
 import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 
-import { useSelector } from 'src/hooks/suite';
+import { useCurrentHistoryLocation, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 import { AccountName } from './AccountName/AccountName';
 import { AccountSubpageName } from './AccountName/AccountSubpageName';
@@ -16,14 +11,13 @@ import { BasicName } from './BasicName';
 import { SettingsName } from './SettingsName';
 
 export const PageName = () => {
-    const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useSuiteServices();
-    const currentRoute = resolveEffectiveBackgroundRouteName(
-        route,
-        suiteRouterHistory.getLocation(),
-    );
+    const location = useCurrentHistoryLocation();
+
     const selectedAccount = useSelector(selectSelectedAccount);
-    const isAccountTabPage = useSelector(selectIsAccountTabPage);
+    const effectiveRouteName = useSelector(state => selectEffectiveRouteName(state, location));
+    const isAccountTabPage = useSelector(state =>
+        selectIsAccountTabPageWithLocation(state, location),
+    );
     const { params } = useSelector(state => state.wallet.selectedAccount);
 
     const fallbackAccount = useSelector(state =>
@@ -38,11 +32,11 @@ export const PageName = () => {
     // TODO: does not work properly with foreground apps, e.g. FW update,
     // as the `route` does not indicate the current page
     // (however location.pathname does)
-    if (currentRoute?.includes('settings')) {
+    if (effectiveRouteName?.includes('settings')) {
         return <SettingsName />;
     }
 
-    if (currentRoute?.includes('earn')) {
+    if (effectiveRouteName?.includes('earn')) {
         return (
             <BasicName>
                 <Translation id="TR_EARN" />

--- a/packages/suite/src/hooks/suite/index.ts
+++ b/packages/suite/src/hooks/suite/index.ts
@@ -18,6 +18,7 @@ export { useDebugLanguageShortcut } from './useDebugLanguageShortcut';
 export { useDisplayMode } from './useDisplayMode';
 export { useDefaultAccountLabel } from './useDefaultAccountLabel';
 export { useFirmwareInstallationProgressCheck } from './useFirmwareInstallationProgressCheck';
+export { useCurrentHistoryLocation } from './useCurrentHistoryLocation';
 
 // replaced in suite-native
 export { useLocales } from 'src/hooks/suite/useLocales';

--- a/packages/suite/src/hooks/suite/useCurrentHistoryLocation.ts
+++ b/packages/suite/src/hooks/suite/useCurrentHistoryLocation.ts
@@ -1,0 +1,24 @@
+import { useSyncExternalStore } from 'react';
+
+import type { RouterPath } from 'src/utils/suite/router';
+
+import { useSuiteServices } from '../../support/SuiteServicesProvider';
+
+/**
+ * Hook that returns the current browser location and subscribes to location changes.
+ * This makes the location reactive - the component will re-render when the URL changes.
+ *
+ * Uses useSyncExternalStore to properly synchronize with the router history.
+ */
+export const useCurrentHistoryLocation = (): RouterPath => {
+    const { suiteRouterHistory } = useSuiteServices();
+
+    return useSyncExternalStore(
+        // Subscribe function - returns cleanup function
+        callback => suiteRouterHistory.listen(() => callback()),
+        // Get snapshot function - returns current state
+        () => suiteRouterHistory.getLocation(),
+        // Get server snapshot (for SSR) - same as client
+        () => suiteRouterHistory.getLocation(),
+    );
+};

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -5,7 +5,13 @@ import { type ModalRootState, selectHasActiveModal } from '@suite/modal';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 
 import { type AnchorType } from './anchors';
-import { type RouterPath, type RouterPathOptional } from './router';
+import {
+    type HashString,
+    type PathString,
+    type RouterPath,
+    type RouterPathOptional,
+    resolveEffectiveBackgroundRouteName,
+} from './router';
 import { type RouterAppWithParams, type SettingsBackRoute } from './routes';
 
 const ACCOUNT_TABS = [
@@ -115,3 +121,35 @@ export type RouterAction =
           payload: AnchorType | undefined;
       }
     | ReturnType<typeof routerAppChanged>;
+
+/**
+ * Selector that determines if the effective background route is an account tab page.
+ * Use this when foreground apps (like switch-device modal) are open and the Redux route
+ * doesn't reflect the actual background page.
+ *
+ * @param location - The current browser location from suiteRouterHistory.getLocation()
+ */
+export const selectIsAccountTabPageWithLocation = (
+    state: RouterRootState,
+    location: { pathname: PathString; hash?: HashString },
+) => {
+    const route = selectRoute(state);
+    const effectiveRouteName = resolveEffectiveBackgroundRouteName(route, location);
+
+    return effectiveRouteName !== undefined && ACCOUNT_TABS.includes(effectiveRouteName);
+};
+
+/**
+ * Selector that returns the effective route name, accounting for foreground apps.
+ * When a foreground app is open, returns the background route name from the browser URL.
+ *
+ * @param location - The current browser location from suiteRouterHistory.getLocation()
+ */
+export const selectEffectiveRouteName = (
+    state: RouterRootState,
+    location: { pathname: PathString; hash?: HashString },
+) => {
+    const route = selectRoute(state);
+
+    return resolveEffectiveBackgroundRouteName(route, location);
+};


### PR DESCRIPTION
…device modal

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-page-header-switch-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-page-header-switch-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T11:10:10.753Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T11:07:20.972Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->