### PR TITLE
fix(trading): prevent sell input resets on percentage clicks

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -15,6 +15,7 @@ import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { selectAccounts, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { AddressDisplayOptions } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useCompose } from 'src/hooks/wallet/form/useCompose';
@@ -59,7 +60,6 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
     const outputAddress = values?.outputs?.[0].address;
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
-    const [shouldUpdateMaxAmount, setShouldUpdateMaxAmount] = useState(true);
 
     // sub-hook, Composing transaction
     const {
@@ -150,16 +150,20 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         }
 
         if (composed.type === 'final' || composed.type === 'nonfinal') {
-            if (typeof setMaxOutputId === 'number' && composed.max && shouldUpdateMaxAmount) {
-                setShouldUpdateMaxAmount(false);
-                setShowReserveBanner(true);
-                setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
-                    shouldValidate: true,
-                    shouldDirty: true,
-                });
+            const currentOutputAmount = values.outputs?.[0]?.amount;
+
+            if (typeof setMaxOutputId === 'number' && composed.max) {
+                const currentBN = new BigNumber(currentOutputAmount || '0');
+                const composedMaxBN = new BigNumber(composed.max);
+
+                if (!currentBN.isEqualTo(composedMaxBN)) {
+                    setShowReserveBanner(true);
+                    setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
+                        shouldValidate: true,
+                        shouldDirty: true,
+                    });
+                }
                 clearErrors(TRADING_FORM_OUTPUT_AMOUNT);
-            } else {
-                setShouldUpdateMaxAmount(true);
             }
 
             dispatch(

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -266,16 +266,19 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
                 : maxAmount;
 
             setValue(TRADING_FORM_OUTPUT_AMOUNT, cryptoInputValue, { shouldDirty: true });
-        } else {
-            setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
         }
 
         setValue(TRADING_FORM_OUTPUT_MAX, 0, { shouldDirty: true });
-        setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
 
         setFractionButton(1);
+
+        if (type === 'exchange') {
+            dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
+        }
+
         composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
+        setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
     };
 
     // reset preselectedQuote when opening swap form

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -203,9 +203,7 @@ export const useTradingExchangeForm = ({
     const isAmountEmpty = output?.amount === '';
     const noProviders = Object.keys(exchangeInfo?.providerInfos ?? {}).length === 0;
     const isInitialDataLoading = !exchangeInfo?.providerInfos;
-    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
-    const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
+
     const { getAssetDecimals } = useTradingAssetDecimals();
     const decimals = useMemo(
         () =>
@@ -243,6 +241,10 @@ export const useTradingExchangeForm = ({
         methods,
         setShowReserveBanner,
     });
+
+    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
+    const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -178,9 +178,7 @@ export const useTradingSellForm = ({
     const isAmountEmpty = output?.amount === '';
     const noProviders = Object.keys(sellInfo?.providerInfos ?? {}).length === 0;
     const isInitialDataLoading = !sellInfo?.providerInfos;
-    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
-    const isFormInvalid = !(formIsValid && hasValues);
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
+
     const quotesByPaymentMethod = getTradingQuotesByPaymentMethod<TradingSellType>(
         quotes,
         values?.paymentMethod?.value ?? '',
@@ -214,6 +212,11 @@ export const useTradingSellForm = ({
         methods,
         setShowReserveBanner,
     });
+
+    const isFormLoading =
+        isInitialDataLoading || formState.isSubmitting || isLoading || isComposing;
+    const isFormInvalid = !(formIsValid && hasValues);
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
         account,

--- a/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/__tests__/tradingReducerExtended.test.ts
@@ -114,6 +114,40 @@ describe('Testing trading reducer', () => {
         );
     });
 
+    it('sellThunks.handleRequestThunk.pending should clear payment methods and set isLoading to true', () => {
+        const store = configureMockStore({
+            extra: {},
+            reducer: combineReducers({
+                wallet: combineReducers({
+                    trading: tradingReducer,
+                }),
+            }),
+            preloadedState: {
+                wallet: {
+                    trading: {
+                        ...initialState,
+                        info: { paymentMethods: [{ value: 'creditCard', label: 'Credit Card' }] },
+                        sell: {
+                            ...sellInitialState,
+                            isLoading: false,
+                        },
+                    },
+                },
+            },
+        });
+
+        store.dispatch({ type: sellThunks.handleRequestThunk.pending.type });
+
+        expect(store.getState().wallet.trading.sell).toEqual(
+            expect.objectContaining({
+                isLoading: true,
+            }),
+        );
+        expect(store.getState().wallet.trading.info).toEqual(
+            expect.objectContaining({ paymentMethods: [] }),
+        );
+    });
+
     describe('action delegation', () => {
         let store: ReturnType<
             typeof configureMockStore<{ wallet: { trading: typeof initialState } }>

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -57,6 +57,7 @@ const tradingSlice = createSliceWithExtraDeps({
             })
             .addCase(sellThunks.handleRequestThunk.pending, state => {
                 state.sell.isLoading = true;
+                state.info.paymentMethods = [];
             })
             .addCase(sellThunks.handleRequestThunk.fulfilled, state => {
                 state.sell.isLoading = false;


### PR DESCRIPTION
## Description

Fixes flaky sell percentage behavior where crypto amount could reset when switching repeatedly between MAX and other percentage buttons.

The change stabilizes amount synchronization during compose and prevents stale quote state from influencing follow-up compose runs.

## Notes for QA
MAX button should not reset amount field and form is not stuck without a quotes

## Related Issue

Resolve #26163

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-sell-input-reset-26163&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-30T09:29:36.992Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T11:59:37.134Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->