### PR TITLE
fix(suite-native): replace Object.assign on animated components with direct assignment

### DIFF
--- a/suite-native/atoms/src/AnimatedBox.tsx
+++ b/suite-native/atoms/src/AnimatedBox.tsx
@@ -2,6 +2,4 @@ import Animated from 'react-native-reanimated';
 
 import { Box } from './Box';
 
-export const AnimatedBox = Object.assign(Animated.createAnimatedComponent(Box), {
-    displayName: 'AnimatedBox',
-});
+export const AnimatedBox = Animated.createAnimatedComponent(Box);

--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -167,6 +167,4 @@ export const Card = React.forwardRef<View, CardProps>(
 );
 
 Card.displayName = 'Card';
-export const AnimatedCard = Object.assign(Animated.createAnimatedComponent(Card), {
-    displayName: 'AnimatedCard',
-});
+export const AnimatedCard = Animated.createAnimatedComponent(Card);

--- a/suite-native/atoms/src/Stack.tsx
+++ b/suite-native/atoms/src/Stack.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from 'react';
 import { type View } from 'react-native';
-import Animated, { type AnimatedProps } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type NativeSpacing } from '@trezor/theme';
@@ -54,10 +54,10 @@ export const Stack = React.forwardRef<View, StackProps>(
 export const VStack = Stack;
 export const HStack = (props: StackProps) => <Stack {...props} orientation="horizontal" />;
 
-const AnimatedStack = Object.assign(Animated.createAnimatedComponent(Stack), {
-    displayName: 'AnimatedStack',
-});
-export const AnimatedVStack = AnimatedStack;
-export const AnimatedHStack = (props: AnimatedProps<StackProps>) => (
-    <AnimatedStack {...props} orientation="horizontal" />
-);
+Stack.displayName = 'Stack';
+VStack.displayName = 'VStack';
+HStack.displayName = 'HStack';
+
+export const AnimatedStack = Animated.createAnimatedComponent(Stack);
+export const AnimatedVStack = Animated.createAnimatedComponent(VStack);
+export const AnimatedHStack = Animated.createAnimatedComponent(HStack);

--- a/suite-native/atoms/src/Text.tsx
+++ b/suite-native/atoms/src/Text.tsx
@@ -105,6 +105,4 @@ export const Text = React.forwardRef<RNText, TextProps>(
 
 Text.displayName = 'Text';
 
-export const AnimatedText = Object.assign(Animated.createAnimatedComponent(Text), {
-    displayName: 'AnimatedText',
-});
+export const AnimatedText = Animated.createAnimatedComponent(Text);


### PR DESCRIPTION
## Description

`Object.assign` on the result of `Animated.createAnimatedComponent` breaks Reanimated's internal component identification, causing `opacity` animations to malfunction. Reanimated also sets `displayName` automatically as `AnimatedComponent(${Component.displayName || Component.name})`, making the override unnecessary.

## Notes for QA

Navigate to the wallet backup tutorial's last step (see the issue). Verify that instruction cards animate correctly on both Android and iOS.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26071

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/animated-component-object-assign&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->