### PR TITLE
Chore: update socks proxy agent

### DIFF
--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -34,7 +34,8 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
-        "@trezor/utxo-lib": "workspace:*"
+        "@trezor/utxo-lib": "workspace:*",
+        "socks-proxy-agent": "8.0.5"
     },
     "devDependencies": {
         "@trezor/type-utils": "workspace:*"

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,4 +1,4 @@
-import type tls from 'tls';
+import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { BaseCurrencyCode } from './baseCurrency';
 import type { TronAccountExtraData, TronChainExtraData } from './blockbook-api';
@@ -136,30 +136,11 @@ export interface ContractInfo {
 
 /* Common types used in both params and responses */
 
-type AgentOptions = {
-    timeout?: number | undefined;
-};
-
-interface BaseSocksProxyAgentOptions {
-    host?: string | null;
-    port?: string | number | null;
-    username?: string | null;
-    tls?: tls.ConnectionOptions | null;
-    ipaddress?: string;
-    type: 4 | 5;
-    userId?: string;
-    password?: string;
-}
-
-// todo: connect10 here we are using the old `SocksProxyAgentOptions` from older version of socks-proxy-agent
-// but we keep the old API so we do not introduce breaking changes.
-interface SocksProxyAgentOptions extends AgentOptions, BaseSocksProxyAgentOptions {}
-
 export interface BlockchainSettings {
     name: string;
     worker: string | (() => any);
     server: string[];
-    proxy?: string | SocksProxyAgentOptions;
+    proxy?: { uri: string | URL; opts?: SocksProxyAgentOptions };
     debug?: boolean;
     timeout?: number;
     pingTimeout?: number;

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -95,7 +95,7 @@
         "@trezor/websocket-client": "workspace:*",
         "@types/web": "^0.0.197",
         "crypto-browserify": "3.12.0",
-        "socks-proxy-agent": "8.0.5",
+        "socks-proxy-agent": "9.0.0",
         "stream-browserify": "^3.0.0",
         "viem": "^2.46.3",
         "xrpl": "4.6.0"

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -95,7 +95,7 @@
         "@trezor/websocket-client": "workspace:*",
         "@types/web": "^0.0.197",
         "crypto-browserify": "3.12.0",
-        "socks-proxy-agent": "9.0.0",
+        "socks-proxy-agent": "8.0.5",
         "stream-browserify": "^3.0.0",
         "viem": "^2.46.3",
         "xrpl": "4.6.0"

--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -148,11 +148,7 @@ export abstract class BaseWorker<API> {
             this.settings = data.settings;
             const { proxy } = data.settings;
             if (proxy) {
-                const agentUri =
-                    typeof proxy === 'string' ? proxy : `socks://${proxy.host}:${proxy.port}`;
-                const socketOptions =
-                    typeof proxy === 'object' ? { timeout: proxy?.timeout } : undefined;
-                this.proxyAgent = new SocksProxyAgent(agentUri, socketOptions);
+                this.proxyAgent = new SocksProxyAgent(proxy.uri, proxy.opts);
             } else {
                 this.proxyAgent = undefined;
             }

--- a/packages/connect-common/src/types/api/__tests__/misc.ts
+++ b/packages/connect-common/src/types/api/__tests__/misc.ts
@@ -31,22 +31,24 @@ export const cipherKeyValue = async (api: TrezorConnect) => {
 
 export const updateConnectSettings = async (api: TrezorConnect) => {
     // proxy settings
-    const proxy = await api.updateConnectSettings({ proxy: 'socks://localhost:9050' });
+    const proxy = await api.updateConnectSettings({ proxy: { uri: 'socks://localhost:9050' } });
     if (proxy.success) {
         proxy.payload.message.toLowerCase();
     } else {
         proxy.error.message.toLowerCase();
     }
+
+    const type = 5;
+    const host = 'localhost';
+    const port = 9050;
+    const username = 'johndoe';
     api.updateConnectSettings({
         proxy: {
-            type: 5,
-            host: 'localhost',
-            port: 9050,
-            username: 'johndoe',
-            timeout: 100000,
+            uri: `socks${type}://${username}@${host}:${port}`,
+            opts: { timeout: 100000 },
         },
     });
-    api.updateConnectSettings({ proxy: 'socks://localhost:9050' });
+    api.updateConnectSettings({ proxy: { uri: 'socks://localhost:9050' } });
     api.updateConnectSettings({ proxy: undefined });
 
     // transports settings
@@ -57,7 +59,10 @@ export const updateConnectSettings = async (api: TrezorConnect) => {
     api.updateConnectSettings({ transports: ['InvalidTransport'] });
 
     // both proxy and transports together
-    api.updateConnectSettings({ proxy: 'socks://localhost:9050', transports: ['BridgeTransport'] });
+    api.updateConnectSettings({
+        proxy: { uri: 'socks://localhost:9050' },
+        transports: ['BridgeTransport'],
+    });
 
     // empty object is valid (no-op)
     api.updateConnectSettings({});

--- a/packages/suite-desktop-core/src/modules/tor.ts
+++ b/packages/suite-desktop-core/src/modules/tor.ts
@@ -76,9 +76,9 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
 
         return shouldEnableTor
             ? {
-                  proxy: `socks://${host}:${useExternalTor ? externalPort : port}`,
+                  uri: `socks://${host}:${useExternalTor ? externalPort : port}`,
               }
-            : { proxy: '' };
+            : { uri: '' };
     };
     const handleTorProcessStatus = (status: TorProcessStatus, shouldEnableTor: boolean) => {
         const { useExternalTor } = store.getTorSettings();
@@ -266,11 +266,11 @@ const load = async ({ mainWindowProxy, store, mainThreadEmitter }: Dependencies)
             const proxySettings = getProxySettings(shouldEnableTor);
 
             // Proxy is also set in packages/suite-desktop-core/src/modules/trezor-connect.ts
-            await TrezorConnect.updateConnectSettings(proxySettings);
+            await TrezorConnect.updateConnectSettings({ proxy: proxySettings });
 
             logger.info(
                 'tor',
-                `${shouldEnableTor ? 'Enabled' : 'Disabled'} proxy ${proxySettings.proxy}`,
+                `${shouldEnableTor ? 'Enabled' : 'Disabled'} proxy ${proxySettings.uri}`,
             );
         } catch (error) {
             // When `setupTor` fails to initialize we do not want to dissable it

--- a/packages/suite-desktop-core/src/modules/trezor-connect.ts
+++ b/packages/suite-desktop-core/src/modules/trezor-connect.ts
@@ -70,9 +70,9 @@ export const initBackground: ModuleInitBackground = ({ mainThreadEmitter, store 
 
     const setProxy = () => {
         const { running, host, port, externalPort, useExternalTor } = store.getTorSettings();
-        const payload = running
-            ? { proxy: `socks://${host}:${useExternalTor ? externalPort : port}` }
-            : { proxy: '' };
+        const proxyUri = running ? `socks://${host}:${useExternalTor ? externalPort : port}` : '';
+        const payload = { proxy: { uri: proxyUri } };
+
         logger.info(SERVICE_NAME, `${running ? 'Enable' : 'Disable'} proxy ${payload.proxy}`);
 
         return TrezorConnect.updateConnectSettings(payload);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14983,6 +14983,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
+    socks-proxy-agent: "npm:^9.0.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -18917,6 +18918,13 @@ __metadata:
   dependencies:
     debug: "npm:4"
   checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:8.0.0":
+  version: 8.0.0
+  resolution: "agent-base@npm:8.0.0"
+  checksum: 10/a660ae60d389c4ce0f5a178efd5e6ebeefeddf0f6defbb105c638056ec0ebd3828d00d029cf5b26e3ce52d09c393735bf9c187ed1000a0be2c6cf5d95ac15bff
   languageName: node
   linkType: hard
 
@@ -41685,6 +41693,17 @@ __metadata:
     debug: "npm:^4.3.4"
     socks: "npm:^2.8.3"
   checksum: 10/ee99e1dacab0985b52cbe5a75640be6e604135e9489ebdc3048635d186012fbaecc20fbbe04b177dee434c319ba20f09b3e7dfefb7d932466c0d707744eac05c
+  languageName: node
+  linkType: hard
+
+"socks-proxy-agent@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "socks-proxy-agent@npm:9.0.0"
+  dependencies:
+    agent-base: "npm:8.0.0"
+    debug: "npm:^4.3.4"
+    socks: "npm:^2.8.3"
+  checksum: 10/ed4a661de91b04186ef6901c7a97ee70017535348708afdd1dcd30dd1f17ff97037dc37d9cd9eab21554e979b9aa39e0d847d6f759749452362070439944639f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14983,7 +14983,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    socks-proxy-agent: "npm:^9.0.0"
+    socks-proxy-agent: "npm:8.0.5"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -18918,13 +18918,6 @@ __metadata:
   dependencies:
     debug: "npm:4"
   checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
-  languageName: node
-  linkType: hard
-
-"agent-base@npm:8.0.0":
-  version: 8.0.0
-  resolution: "agent-base@npm:8.0.0"
-  checksum: 10/a660ae60d389c4ce0f5a178efd5e6ebeefeddf0f6defbb105c638056ec0ebd3828d00d029cf5b26e3ce52d09c393735bf9c187ed1000a0be2c6cf5d95ac15bff
   languageName: node
   linkType: hard
 
@@ -41693,17 +41686,6 @@ __metadata:
     debug: "npm:^4.3.4"
     socks: "npm:^2.8.3"
   checksum: 10/ee99e1dacab0985b52cbe5a75640be6e604135e9489ebdc3048635d186012fbaecc20fbbe04b177dee434c319ba20f09b3e7dfefb7d932466c0d707744eac05c
-  languageName: node
-  linkType: hard
-
-"socks-proxy-agent@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "socks-proxy-agent@npm:9.0.0"
-  dependencies:
-    agent-base: "npm:8.0.0"
-    debug: "npm:^4.3.4"
-    socks: "npm:^2.8.3"
-  checksum: 10/ed4a661de91b04186ef6901c7a97ee70017535348708afdd1dcd30dd1f17ff97037dc37d9cd9eab21554e979b9aa39e0d847d6f759749452362070439944639f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing what we store for Proxy so we satisfy the API and keep things simple.

I tried to update to latest version 9.0.0 but they are providing ESM only and it generates some issues in our libraries. We could fix those issues with some "hacks" but I would wait since it seams they are recently considering dual ESM and CJS https://github.com/TooTallNate/proxy-agents/issues/405



## Notes for QA

Nothing to test.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23787

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-socks-proxy-agent&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-socks-proxy-agent&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/update-socks-proxy-agent&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T17:19:38.022Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T17:17:55.854Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->