### PR TITLE
fix(suite): use quote amount for compose on confirm/retry

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 import { isTranslationKey, useTranslation } from '@suite/intl';
@@ -35,6 +35,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     values,
     methods,
     setShowReserveBanner,
+    quoteAmount,
 }: TradingUseComposeTransactionProps<T>): TradingUseComposeTransactionReturnProps => {
     const dispatch = useDispatch();
     const accounts = useSelector(selectAccounts);
@@ -61,6 +62,25 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
     const [shouldUpdateMaxAmount, setShouldUpdateMaxAmount] = useState(true);
 
+    const patchedGetValues = useCallback(
+        (...args: Parameters<typeof getValues>) => {
+            if (args.length > 0) return getValues(...args);
+
+            const formValues = getValues();
+
+            if (!quoteAmount) return formValues;
+
+            return {
+                ...formValues,
+                setMaxOutputId: undefined,
+                outputs: formValues.outputs?.map((output, index) =>
+                    index === 0 ? { ...output, amount: quoteAmount } : output,
+                ),
+            };
+        },
+        [getValues, quoteAmount],
+    ) as typeof getValues;
+
     // sub-hook, Composing transaction
     const {
         isLoading: isComposing,
@@ -70,6 +90,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         setComposedLevels,
     } = useCompose({
         ...methods,
+        getValues: patchedGetValues as unknown as UseFormReturn<T>['getValues'],
         state,
     });
 
@@ -132,10 +153,19 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         type,
     ]);
 
+    const prevQuoteAmountRef = useRef(quoteAmount);
+
+    useEffect(() => {
+        if (quoteAmount !== prevQuoteAmountRef.current) {
+            composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
+        }
+        prevQuoteAmountRef.current = quoteAmount;
+    }, [quoteAmount, composeRequest]);
+
     useEffect(() => {
         if (!composedLevels) return;
 
-        const values = getValues();
+        const values = patchedGetValues();
         const { setMaxOutputId } = values;
         const selectedFeeLevel = selectedFee || 'normal';
         const composed = composedLevels[selectedFeeLevel];
@@ -150,7 +180,12 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         }
 
         if (composed.type === 'final' || composed.type === 'nonfinal') {
-            if (typeof setMaxOutputId === 'number' && composed.max && shouldUpdateMaxAmount) {
+            if (
+                !quoteAmount &&
+                typeof setMaxOutputId === 'number' &&
+                composed.max &&
+                shouldUpdateMaxAmount
+            ) {
                 setShouldUpdateMaxAmount(false);
                 setShowReserveBanner(true);
                 setValue(TRADING_FORM_OUTPUT_AMOUNT, composed.max, {
@@ -158,7 +193,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
                     shouldDirty: true,
                 });
                 clearErrors(TRADING_FORM_OUTPUT_AMOUNT);
-            } else {
+            } else if (!quoteAmount) {
                 setShouldUpdateMaxAmount(true);
             }
 
@@ -178,7 +213,8 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         selectedFee,
         clearErrors,
         dispatch,
-        getValues,
+        patchedGetValues,
+        quoteAmount,
         setError,
         setValue,
         translationString,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -45,6 +45,7 @@ import {
     useFormDraft,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
@@ -225,6 +226,22 @@ export const useTradingExchangeForm = ({
         setValue,
     });
 
+    const quoteAmount = useMemo(() => {
+        if (pageType !== 'confirm' && pageType !== 'retry') return undefined;
+        if (selectedQuote?.isDex) return undefined;
+        if (!selectedQuote?.sendStringAmount) return undefined;
+
+        return shouldSendInSats
+            ? convertAmountUnitsToSubunits(selectedQuote.sendStringAmount, decimals)
+            : selectedQuote.sendStringAmount;
+    }, [
+        pageType,
+        selectedQuote?.isDex,
+        selectedQuote?.sendStringAmount,
+        shouldSendInSats,
+        decimals,
+    ]);
+
     const {
         composedLevels,
         feeInfo,
@@ -239,6 +256,7 @@ export const useTradingExchangeForm = ({
         values,
         methods,
         setShowReserveBanner,
+        quoteAmount,
     });
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
@@ -432,13 +450,16 @@ export const useTradingExchangeForm = ({
                 }),
             ).unwrap();
 
+        const isQuoteActiveConfirm =
+            (pageType === 'confirm' || pageType === 'retry') && !!quoteAmount;
+
         try {
             await dispatch(
                 exchangeThunks.sendTransactionThunk({
                     account,
                     trade: trade?.data,
                     returnUrl,
-                    setMaxOutputId: values.setMaxOutputId,
+                    setMaxOutputId: isQuoteActiveConfirm ? undefined : values.setMaxOutputId,
                     decimals,
                     shouldSendInSats,
                     // TODO: slip24 - exclude from debug mode

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -36,6 +36,7 @@ import {
 import { networks } from '@suite-common/wallet-config';
 import { selectBaseCurrency, useFormDraft } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { isChanged } from '@trezor/utils';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
@@ -193,6 +194,15 @@ export const useTradingSellForm = ({
         dispatch(tradingSellActions.setAmountLimits(limits));
     };
 
+    const quoteAmount = useMemo(() => {
+        if (pageType !== 'confirm' && pageType !== 'retry') return undefined;
+        if (!selectedQuote?.cryptoStringAmount) return undefined;
+
+        return shouldSendInSats
+            ? convertAmountUnitsToSubunits(selectedQuote.cryptoStringAmount, decimals)
+            : selectedQuote.cryptoStringAmount;
+    }, [pageType, selectedQuote?.cryptoStringAmount, shouldSendInSats, decimals]);
+
     const {
         isComposing,
         composedLevels,
@@ -207,6 +217,7 @@ export const useTradingSellForm = ({
         values: values as TradingSellFormProps,
         methods,
         setShowReserveBanner,
+        quoteAmount,
     });
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
@@ -430,6 +441,9 @@ export const useTradingSellForm = ({
                 }),
             ).unwrap();
 
+        const isQuoteActiveConfirm =
+            (pageType === 'confirm' || pageType === 'retry') && !!quoteAmount;
+
         try {
             await dispatch(
                 sellThunks.sendTransactionThunk({
@@ -437,7 +451,10 @@ export const useTradingSellForm = ({
                     trade: trade?.data,
                     shouldSendInSats,
                     decimals,
-                    formValues: values as TradingSellFormProps,
+                    formValues: {
+                        ...(values as TradingSellFormProps),
+                        ...(isQuoteActiveConfirm ? { setMaxOutputId: undefined } : {}),
+                    },
                     // TODO: slip24 - exclude from debug mode
                     isSlip24Active,
                     nextStep,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -367,6 +367,7 @@ export interface TradingUseComposeTransactionProps<T extends TradingSellExchange
     methods: UseFormReturn<T>;
     values: T;
     setShowReserveBanner: (showReserveBanner: boolean) => void;
+    quoteAmount?: string;
 }
 
 export interface TradingUseComposeTransactionStateProps {


### PR DESCRIPTION
- Add `quoteAmount` parameter to `useTradingComposeTransaction` hook to use quoted amounts instead of user input on confirm/retry pages
- Implement `patchedGetValues` callback that overrides output amount with `quoteAmount` when available
- Add effect to trigger recompose when `quoteAmount` changes
- Skip max amount updates and setMaxOutputId when quote amount is active
- Calculate `quoteAmount` in both exchange and sell forms, converting to subunits when needed
- Update transaction send logic to exclude `setMaxOutputId` when quote is active on confirm/retry pages

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=claude/vigorous-benz&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=claude/vigorous-benz&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Analytics Events > Analytics captures important events when started enabled by default | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-27T22:18:28.401Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-27T22:16:35.967Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->