### PR TITLE
docs: update links after moving to types to connect-common

### DIFF
--- a/docs/packages/connect/events.md
+++ b/docs/packages/connect/events.md
@@ -24,6 +24,6 @@ TrezorConnect.on(DEVICE_EVENT, event => {
 Full list of events is unfortunately beyond the scope of this documentation
 but you may refer to the source code for:
 
-- [device events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/events/device.ts)
-- [transport events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/events/transport.ts)
-- [blockchain events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/events/blockchain.ts)
+- [device events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/events/device.ts)
+- [transport events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/events/transport.ts)
+- [blockchain events](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/events/blockchain.ts)


### PR DESCRIPTION
to be merged after #26141 this couldn't be part of the original PR since CI would not pass because of non existing links