### PR TITLE
fix(suite-native): disable shadow on Android for animated card layouts

### DIFF
--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 
 import { Icon, type IconName } from '@suite-native/icons';
@@ -72,10 +72,11 @@ export const CompactCardWithIconLayout = ({
     subtitle,
     alertBoxProps,
     onPress,
+    noShadow,
+    testID,
     isDisabled = false,
     variant = 'normal',
     borderColor = 'borderElevation1',
-    testID,
     ...cardProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
@@ -91,6 +92,8 @@ export const CompactCardWithIconLayout = ({
                     noPadding
                     borderColor={borderColor ?? undefined}
                     style={animatedStyle}
+                    // Android shadow does not work well with the Reanimated opacity animation.
+                    noShadow={Platform.OS === 'android' ? true : noShadow}
                     {...cardProps}
                 >
                     <HStack

--- a/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { GestureDetector } from 'react-native-gesture-handler';
 
 import { Icon, type IconName } from '@suite-native/icons';
@@ -35,7 +35,13 @@ export const PressableCardWithIconLayout = ({
     return (
         <GestureDetector gesture={tapGesture}>
             <View collapsable={false}>
-                <AnimatedCard borderColor="borderElevation1" noPadding style={animatedStyle}>
+                <AnimatedCard
+                    borderColor="borderElevation1"
+                    noPadding
+                    style={animatedStyle}
+                    // Android shadow does not work well with the Reanimated opacity animation.
+                    noShadow={Platform.OS === 'android'}
+                >
                     <HStack margin="sp16" spacing="sp12">
                         <Box marginVertical="sp2">
                             <Icon name={icon} size="mediumLarge" />


### PR DESCRIPTION
## Description

Added `noShadow={Platform.OS === 'android'}` to `AnimatedCard` in `CompactCardWithIconLayout` and `PressableCardWithIconLayout` — Android shadow rendering doesn't work well with Reanimated opacity animations.

## Notes for QA

Test app settings card press animations on Android and iOS.

## Screenshots:

### BEFORE

https://github.com/user-attachments/assets/a0b0cdaf-e358-4541-b874-8548e132cf81



### AFTER

https://github.com/user-attachments/assets/d4a82bc9-6a32-4011-9557-cfe0d5bb37d9


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/settings-card-android-animation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->