### PR TITLE
feat(suite-native): migrate react-freeze to React Activity API

### DIFF
--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -62,7 +62,6 @@ openpgp
 prettier
 react-native-ble-plx
 react-native-mmkv
-react-freeze
 react-native-nitro-modules
 set.prototype.difference
 set.prototype.intersection

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -137,7 +137,6 @@
         "metro-config": "^0.83.0",
         "minimist": "^1.2.8",
         "react": "19.2.4",
-        "react-freeze": "^1.0.4",
         "react-intl": "^8.1.3",
         "react-native": "0.83.2",
         "react-native-ble-plx": "3.5.1",

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef } from 'react';
-import { Freeze } from 'react-freeze';
+import { Activity, useEffect, useRef } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -80,9 +79,9 @@ const AppComponent = () => {
             {__DEV__ && <InitRosenitePlugin />}
             <BannersRenderer />
             <BottomSheetModalProvider>
-                <Freeze freeze={isBiometricsOverlayVisible}>
+                <Activity mode={isBiometricsOverlayVisible ? 'hidden' : 'visible'}>
                     <RootStackNavigator />
-                </Freeze>
+                </Activity>
             </BottomSheetModalProvider>
             <ModalsRenderer />
             {/* NOTE: Rendered as last item so that it covers the whole app screen */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11795,7 +11795,6 @@ __metadata:
     metro-config: "npm:^0.83.0"
     minimist: "npm:^1.2.8"
     react: "npm:19.2.4"
-    react-freeze: "npm:^1.0.4"
     react-intl: "npm:^8.1.3"
     react-native: "npm:0.83.2"
     react-native-ble-plx: "npm:3.5.1"
@@ -38673,7 +38672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-freeze@npm:^1.0.0, react-freeze@npm:^1.0.4":
+"react-freeze@npm:^1.0.0":
   version: 1.0.4
   resolution: "react-freeze@npm:1.0.4"
   peerDependencies:


### PR DESCRIPTION
## Description

Replaces `react-freeze` with React's native [`<Activity>`](https://react.dev/reference/react/Activity) API, introduced in React 19.2. `<Activity mode="hidden">` uses React's scheduler to deprioritize background work and automatically pauses `useEffect` hooks — a proper built-in replacement for the third-party `react-freeze` hack.

Removes `react-freeze` dependency.

## Notes for QA

Test that the biometrics overlay correctly freezes the app content on both iOS and Android. Try to replicate this issue and make sure that it is not happening again: https://github.com/trezor/trezor-suite/issues/22756

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26294

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/native/remove-react-freeze&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/native/remove-react-freeze&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-react-freeze&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-30T14:52:48.055Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-30T14:51:09.311Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->