### PR TITLE
refactor(trading): Add missing individual selectors and shared quote selectors

### DIFF
--- a/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/__tests__/tradingSelectors.test.ts
@@ -23,20 +23,28 @@ import { type TradingRootState, initialState } from '../../reducers/tradingCommo
 import type { TradingPaymentMethodListProps, TradingType } from '../../types';
 import {
     type TradingRootStateWithDeviceAndAccounts,
+    bestBuyQuotePerPaymentMethodProjection,
+    bestSellQuotePerPaymentMethodProjection,
     selectDeviceHasTradingTrades,
     selectDeviceTradingTradesOrderedByDate,
+    selectGroupedTradingExchangeQuotes,
     selectTrading,
     selectTradingAccountAccordingActiveSection,
     selectTradingAccountKeyByTradeType,
     selectTradingActiveSection,
     selectTradingBuy,
+    selectTradingBuyAmountLimits,
+    selectTradingBuyBestQuote,
     selectTradingBuyInfo,
+    selectTradingBuyIsFromRedirect,
     selectTradingBuyIsLoading,
     selectTradingBuyLastErrorMessage,
     selectTradingBuyLoadingTimestampAndStatus,
+    selectTradingBuyPreselectedQuote,
     selectTradingBuyProviders,
     selectTradingBuyQuoteByOrderId,
     selectTradingBuyQuotes,
+    selectTradingBuyQuotesByPaymentMethod,
     selectTradingBuyQuotesRequest,
     selectTradingBuySelectedQuote,
     selectTradingBuySupportedCryptoIds,
@@ -45,11 +53,15 @@ import {
     selectTradingComposedTransactionInfo,
     selectTradingExchange,
     selectTradingExchangeActiveQuote,
+    selectTradingExchangeAmountLimits,
     selectTradingExchangeBuyCryptoIds,
+    selectTradingExchangeCexQuotes,
     selectTradingExchangeDexQuoteApprovalPrefetchLoading,
     selectTradingExchangeDexQuoteApprovalPrefetchLoadingByQuoteId,
+    selectTradingExchangeDexQuotes,
     selectTradingExchangeFormStep,
     selectTradingExchangeInfo,
+    selectTradingExchangeIsFromRedirect,
     selectTradingExchangeIsLoading,
     selectTradingExchangeLastErrorMessage,
     selectTradingExchangeLoadingTimestampAndStatus,
@@ -68,12 +80,17 @@ import {
     selectTradingProviderByNameAndTradeType,
     selectTradingProviderMetadata,
     selectTradingSellAccountKey,
+    selectTradingSellAmountLimits,
+    selectTradingSellBestQuote,
     selectTradingSellFormStep,
     selectTradingSellInfo,
+    selectTradingSellIsFromRedirect,
     selectTradingSellLastErrorMessage,
     selectTradingSellLoadingTimestampAndStatus,
+    selectTradingSellPreselectedQuote,
     selectTradingSellProviders,
     selectTradingSellQuotes,
+    selectTradingSellQuotesByPaymentMethod,
     selectTradingSellQuotesRequest,
     selectTradingSellSelectedQuote,
     selectTradingSellSellCryptoIds,
@@ -583,10 +600,22 @@ describe('tradingSelectors', () => {
         expect(selectTradingBuyQuotesRequest(state)).toBe(state.wallet.trading.buy.quotesRequest);
     });
 
+    it('selectTradingBuyIsFromRedirect should return correct data', () => {
+        state.wallet.trading.buy.isFromRedirect = true;
+
+        expect(selectTradingBuyIsFromRedirect(state)).toBe(true);
+    });
+
     it('selectTradingExchangeQuotesRequest should return correct data', () => {
         expect(selectTradingExchangeQuotesRequest(state)).toBe(
             state.wallet.trading.exchange.quotesRequest,
         );
+    });
+
+    it('selectTradingExchangeIsFromRedirect should return correct data', () => {
+        state.wallet.trading.exchange.isFromRedirect = true;
+
+        expect(selectTradingExchangeIsFromRedirect(state)).toBe(true);
     });
 
     it('selectTradingExchangeQuotes should return correct data', () => {
@@ -617,8 +646,22 @@ describe('tradingSelectors', () => {
         expect(selectTradingSellQuotesRequest(state)).toBe(state.wallet.trading.sell.quotesRequest);
     });
 
+    it('selectTradingSellIsFromRedirect should return correct data', () => {
+        state.wallet.trading.sell.isFromRedirect = true;
+
+        expect(selectTradingSellIsFromRedirect(state)).toBe(true);
+    });
+
     it('selectTradingBuySelectedQuote should return correct data', () => {
         expect(selectTradingBuySelectedQuote(state)).toBe(state.wallet.trading.buy.selectedQuote);
+    });
+
+    it('selectTradingBuyPreselectedQuote should return correct data', () => {
+        state.wallet.trading.buy.preselectedQuote = state.wallet.trading.buy.quotes[0];
+
+        expect(selectTradingBuyPreselectedQuote(state)).toBe(
+            state.wallet.trading.buy.preselectedQuote,
+        );
     });
 
     it('selectTradingExchangeSelectedQuote should return correct data', () => {
@@ -656,6 +699,14 @@ describe('tradingSelectors', () => {
 
     it('selectTradingSellSelectedQuote should return correct data', () => {
         expect(selectTradingSellSelectedQuote(state)).toBe(state.wallet.trading.sell.selectedQuote);
+    });
+
+    it('selectTradingSellPreselectedQuote should return correct data', () => {
+        state.wallet.trading.sell.preselectedQuote = state.wallet.trading.sell.quotes[0];
+
+        expect(selectTradingSellPreselectedQuote(state)).toBe(
+            state.wallet.trading.sell.preselectedQuote,
+        );
     });
 
     it('selectTradingPaymentMethods should return correct data', () => {
@@ -959,9 +1010,78 @@ describe('tradingSelectors', () => {
         });
     });
 
+    it('selectTradingBuyAmountLimits should return correct data', () => {
+        state.wallet.trading.buy.amountLimits = {
+            currency: 'BTC',
+            minFiat: '20',
+            maxFiat: '2000',
+        };
+
+        expect(selectTradingBuyAmountLimits(state)).toEqual(state.wallet.trading.buy.amountLimits);
+    });
+
     describe(selectTradingBuyQuotes.name, () => {
         it('should return quotes', () => {
             expect(selectTradingBuyQuotes(state)).toBe(state.wallet.trading.buy.quotes);
+        });
+    });
+
+    describe(selectTradingBuyQuotesByPaymentMethod.name, () => {
+        it('should filter quotes by payment method and ignore quote errors', () => {
+            state.wallet.trading.buy.quotes = [
+                {
+                    ...state.wallet.trading.buy.quotes[0],
+                    orderId: 'orderId-buy-fixed-1',
+                    paymentMethod: 'eps',
+                },
+                {
+                    ...state.wallet.trading.buy.quotes[1],
+                    orderId: 'orderId-buy-fixed-2',
+                    paymentMethod: 'eps',
+                    error: 'Quote unavailable',
+                },
+                {
+                    ...state.wallet.trading.buy.quotes[2],
+                    orderId: 'orderId-buy-fixed-3',
+                    paymentMethod: 'creditCard',
+                },
+            ];
+
+            expect(selectTradingBuyQuotesByPaymentMethod(state, 'eps')).toEqual({
+                fixed: [state.wallet.trading.buy.quotes[0]],
+            });
+        });
+
+        it('should be stable', () => {
+            expect(selectTradingBuyQuotesByPaymentMethod(state, 'eps')).toBe(
+                selectTradingBuyQuotesByPaymentMethod(state, 'eps'),
+            );
+        });
+    });
+
+    describe(selectTradingBuyBestQuote.name, () => {
+        it('should return the best rated buy quote', () => {
+            expect(selectTradingBuyBestQuote(state)?.orderId).toBe('orderId3');
+        });
+
+        it('should return undefined when there are no valid quotes', () => {
+            state.wallet.trading.buy.quotes = [];
+
+            expect(selectTradingBuyBestQuote(state)).toBeUndefined();
+        });
+    });
+
+    describe('bestBuyQuotePerPaymentMethodProjection', () => {
+        it('should return the first valid quote for each payment method sorted by rate', () => {
+            const quotes = state.wallet.trading.buy.quotes.map(quote => ({
+                ...quote,
+                paymentMethodName: quote.paymentMethod,
+            }));
+
+            expect(bestBuyQuotePerPaymentMethodProjection(quotes)).toEqual([
+                expect.objectContaining({ orderId: 'orderId3' }),
+                expect.objectContaining({ orderId: 'orderId1' }),
+            ]);
         });
     });
 
@@ -991,6 +1111,128 @@ describe('tradingSelectors', () => {
             state.wallet.trading.exchange.isLoading = true;
 
             expect(selectTradingExchangeIsLoading(state)).toBe(true);
+        });
+    });
+
+    it('selectTradingExchangeAmountLimits should return correct data', () => {
+        state.wallet.trading.exchange.amountLimits = {
+            currency: 'BTC',
+            minCrypto: '0.001',
+            maxCrypto: '10',
+        };
+
+        expect(selectTradingExchangeAmountLimits(state)).toEqual(
+            state.wallet.trading.exchange.amountLimits,
+        );
+    });
+
+    describe(selectGroupedTradingExchangeQuotes.name, () => {
+        beforeEach(() => {
+            state.wallet.trading.exchange.exchangeInfo = {
+                providerInfos: {
+                    'fixed-provider': { isFixedRate: true },
+                    'float-provider': { isFixedRate: false },
+                },
+                buyCryptoIds: ['bitcoin'] as CryptoId[],
+                sellCryptoIds: ['ethereum'] as CryptoId[],
+            } as unknown as ExchangeInfo;
+            state.wallet.trading.exchange.quotes = [
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'fixed-quote',
+                    exchange: 'fixed-provider',
+                    isDex: false,
+                },
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'float-quote',
+                    exchange: 'float-provider',
+                    isDex: false,
+                },
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'dex-quote',
+                    exchange: 'dex-provider',
+                    isDex: true,
+                },
+            ];
+        });
+
+        it('should group exchange quotes into fixed, float, and dex buckets', () => {
+            expect(selectGroupedTradingExchangeQuotes(state)).toEqual({
+                fixed: [expect.objectContaining({ quoteId: 'fixed-quote' })],
+                float: [expect.objectContaining({ quoteId: 'float-quote' })],
+                dex: [expect.objectContaining({ quoteId: 'dex-quote' })],
+            });
+        });
+
+        it('should be stable', () => {
+            expect(selectGroupedTradingExchangeQuotes(state)).toBe(
+                selectGroupedTradingExchangeQuotes(state),
+            );
+        });
+    });
+
+    describe(selectTradingExchangeDexQuotes.name, () => {
+        it('should return dex exchange quotes only', () => {
+            state.wallet.trading.exchange.exchangeInfo = {
+                providerInfos: {},
+                buyCryptoIds: ['bitcoin'] as CryptoId[],
+                sellCryptoIds: ['ethereum'] as CryptoId[],
+            } as unknown as ExchangeInfo;
+            state.wallet.trading.exchange.quotes = [
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'cex-quote',
+                    isDex: false,
+                },
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'dex-quote',
+                    isDex: true,
+                },
+            ];
+
+            expect(selectTradingExchangeDexQuotes(state)).toEqual([
+                expect.objectContaining({ quoteId: 'dex-quote' }),
+            ]);
+        });
+    });
+
+    describe(selectTradingExchangeCexQuotes.name, () => {
+        it('should return non-dex exchange quotes only', () => {
+            state.wallet.trading.exchange.exchangeInfo = {
+                providerInfos: {
+                    'fixed-provider': { isFixedRate: true },
+                    'float-provider': { isFixedRate: false },
+                },
+                buyCryptoIds: ['bitcoin'] as CryptoId[],
+                sellCryptoIds: ['ethereum'] as CryptoId[],
+            } as unknown as ExchangeInfo;
+            state.wallet.trading.exchange.quotes = [
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'fixed-quote',
+                    exchange: 'fixed-provider',
+                    isDex: false,
+                },
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'float-quote',
+                    exchange: 'float-provider',
+                    isDex: false,
+                },
+                {
+                    ...invityAPIFixtures.exchangeTrade,
+                    quoteId: 'dex-quote',
+                    isDex: true,
+                },
+            ];
+
+            expect(selectTradingExchangeCexQuotes(state)).toEqual([
+                expect.objectContaining({ quoteId: 'fixed-quote' }),
+                expect.objectContaining({ quoteId: 'float-quote' }),
+            ]);
         });
     });
 
@@ -1163,6 +1405,76 @@ describe('tradingSelectors', () => {
 
         it('should be stable', () => {
             expect(selectValidTradingSellQuotes(state)).toBe(selectValidTradingSellQuotes(state));
+        });
+    });
+
+    it('selectTradingSellAmountLimits should return correct data', () => {
+        state.wallet.trading.sell.amountLimits = {
+            currency: 'ETH',
+            minFiat: '20',
+            maxFiat: '2000',
+        };
+
+        expect(selectTradingSellAmountLimits(state)).toEqual(
+            state.wallet.trading.sell.amountLimits,
+        );
+    });
+
+    describe(selectTradingSellQuotesByPaymentMethod.name, () => {
+        it('should filter quotes by payment method and ignore quote errors', () => {
+            state.wallet.trading.sell.quotes = [
+                {
+                    ...state.wallet.trading.sell.quotes[0],
+                    orderId: 'orderId-sell-fixed-1',
+                    paymentMethod: 'creditCard',
+                },
+                {
+                    ...state.wallet.trading.sell.quotes[1],
+                    orderId: 'orderId-sell-fixed-2',
+                    paymentMethod: 'creditCard',
+                    error: 'Quote unavailable',
+                },
+                {
+                    ...state.wallet.trading.sell.quotes[0],
+                    orderId: 'orderId-sell-fixed-3',
+                    paymentMethod: 'bankTransfer',
+                },
+            ];
+
+            expect(selectTradingSellQuotesByPaymentMethod(state, 'creditCard')).toEqual({
+                fixed: [state.wallet.trading.sell.quotes[0]],
+            });
+        });
+
+        it('should be stable', () => {
+            expect(selectTradingSellQuotesByPaymentMethod(state, 'creditCard')).toBe(
+                selectTradingSellQuotesByPaymentMethod(state, 'creditCard'),
+            );
+        });
+    });
+
+    describe(selectTradingSellBestQuote.name, () => {
+        it('should return the best rated sell quote', () => {
+            expect(selectTradingSellBestQuote(state)?.orderId).toBe(
+                '05a031d0-2c7a-4e7f-9001-67cec1253fae',
+            );
+        });
+
+        it('should return undefined when there are no valid quotes', () => {
+            state.wallet.trading.sell.quotes = [];
+
+            expect(selectTradingSellBestQuote(state)).toBeUndefined();
+        });
+    });
+
+    describe('bestSellQuotePerPaymentMethodProjection', () => {
+        it('should return the first valid quote for each payment method sorted by rate', () => {
+            expect(
+                bestSellQuotePerPaymentMethodProjection(state.wallet.trading.sell.quotes),
+            ).toEqual([
+                expect.objectContaining({ paymentMethod: 'bankTransfer' }),
+                expect.objectContaining({ paymentMethod: 'creditCard' }),
+            ]);
         });
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -1,4 +1,13 @@
-import { type Coins, type CryptoId, type FiatCurrencyCode, type Platforms } from 'invity-api';
+import {
+    type BuyCryptoPaymentMethod,
+    type BuyTrade,
+    type Coins,
+    type CryptoId,
+    type FiatCurrencyCode,
+    type Platforms,
+    type SellCryptoPaymentMethod,
+    type SellFiatTrade,
+} from 'invity-api';
 
 import { type DeviceRootState, selectDeviceUnavailableCapabilities } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
@@ -12,16 +21,27 @@ import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-t
 import addressValidator from '@trezor/address-validator';
 import { exhaustive } from '@trezor/type-utils';
 
+import { groupTradingExchangeQuotesProjection } from './utils/groupTradingExchangeQuotesProjection';
+import { bestQuotePerPaymentMethodProjection } from './utils/quotePerPaymentMethodProjection';
 import { type BuyInfo, type TradingBuyState } from '../reducers/buyReducer';
 import { type ExchangeInfo, type TradingExchangeState } from '../reducers/exchangeReducer';
 import { type SellInfo, type TradingSellState } from '../reducers/sellReducer';
 import type { TradingRootState, TradingState } from '../reducers/tradingCommonReducer';
 import {
+    type TradingBuyPaymentMethodProps,
     type TradingFiatCurrenciesProps,
+    type TradingSellPaymentMethodProps,
     type TradingTransaction,
     type TradingType,
 } from '../types';
-import { cryptoIdToNetwork, isBuyTrade, isExchangeProvider, testnetToProdCryptoId } from '../utils';
+import {
+    cryptoIdToNetwork,
+    getBestRatedQuote,
+    getTradingQuotesByPaymentMethod,
+    isBuyTrade,
+    isExchangeProvider,
+    testnetToProdCryptoId,
+} from '../utils';
 import {
     getTradingCoinInfoByCryptoId,
     getTradingCoinSymbolByCryptoId,
@@ -86,6 +106,18 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange' | 'sell
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
 const createMemoizedSelectorWithDeviceAndAccounts =
     createWeakMapSelector.withTypes<TradingRootStateWithDeviceAndAccounts>();
+
+export const bestBuyQuotePerPaymentMethodProjection = (quotes: BuyTrade[]) =>
+    bestQuotePerPaymentMethodProjection<BuyCryptoPaymentMethod, BuyTrade>(
+        quotes,
+        (aRate, bRate) => aRate - bRate,
+    );
+
+export const bestSellQuotePerPaymentMethodProjection = (quotes: SellFiatTrade[]) =>
+    bestQuotePerPaymentMethodProjection<SellCryptoPaymentMethod, SellFiatTrade>(
+        quotes,
+        (aRate, bRate) => bRate - aRate,
+    );
 
 export const selectTradingLoadingAndTimestamp = createMemoizedSelector(
     [
@@ -281,8 +313,14 @@ export const selectTradingProviderKycPolicy = (
 export const selectTradingBuyQuotesRequest = (state: TradingRootState) =>
     state.wallet.trading.buy.quotesRequest;
 
+export const selectTradingBuyIsFromRedirect = (state: TradingRootState) =>
+    state.wallet.trading.buy.isFromRedirect;
+
 export const selectTradingExchangeQuotesRequest = (state: TradingRootState) =>
     state.wallet.trading.exchange.quotesRequest;
+
+export const selectTradingExchangeIsFromRedirect = (state: TradingRootState) =>
+    state.wallet.trading.exchange.isFromRedirect;
 
 export const selectTradingExchangeQuotes = (state: TradingRootState) =>
     state.wallet.trading.exchange.quotes;
@@ -290,8 +328,14 @@ export const selectTradingExchangeQuotes = (state: TradingRootState) =>
 export const selectTradingSellQuotesRequest = (state: TradingRootState) =>
     state.wallet.trading.sell.quotesRequest;
 
+export const selectTradingSellIsFromRedirect = (state: TradingRootState) =>
+    state.wallet.trading.sell.isFromRedirect;
+
 export const selectTradingBuySelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.buy.selectedQuote;
+
+export const selectTradingBuyPreselectedQuote = (state: TradingRootState) =>
+    state.wallet.trading.buy.preselectedQuote;
 
 export const selectTradingExchangeSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.exchange.selectedQuote;
@@ -304,6 +348,9 @@ export const selectTradingExchangeActiveQuote = (state: TradingRootState) =>
 
 export const selectTradingSellSelectedQuote = (state: TradingRootState) =>
     state.wallet.trading.sell.selectedQuote;
+
+export const selectTradingSellPreselectedQuote = (state: TradingRootState) =>
+    state.wallet.trading.sell.preselectedQuote;
 
 export const selectTradingPaymentMethods = (state: TradingRootState) =>
     state.wallet.trading.info.paymentMethods;
@@ -501,7 +548,21 @@ export const selectTradingSellSellCryptoIds = createMemoizedSelector(
 export const selectTradingBuyIsLoading = (state: TradingRootState) =>
     state.wallet.trading.buy.isLoading;
 
+export const selectTradingBuyAmountLimits = (state: TradingRootState) =>
+    state.wallet.trading.buy.amountLimits;
+
 export const selectTradingBuyQuotes = (state: TradingRootState) => state.wallet.trading.buy.quotes;
+
+export const selectTradingBuyQuotesByPaymentMethod = createMemoizedSelector(
+    [
+        selectTradingBuyQuotes,
+        (_: TradingRootState, paymentMethod: TradingBuyPaymentMethodProps | undefined) =>
+            paymentMethod,
+    ],
+    (quotes, paymentMethod) => ({
+        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'buy'>(quotes, paymentMethod) : [],
+    }),
+);
 
 export const selectTradingBuyQuoteByOrderId = (
     state: TradingRootState,
@@ -510,6 +571,24 @@ export const selectTradingBuyQuoteByOrderId = (
 
 export const selectTradingExchangeIsLoading = (state: TradingRootState) =>
     state.wallet.trading.exchange.isLoading;
+
+export const selectTradingExchangeAmountLimits = (state: TradingRootState) =>
+    state.wallet.trading.exchange.amountLimits;
+
+export const selectGroupedTradingExchangeQuotes = createMemoizedSelector(
+    [selectTradingExchangeQuotes, selectTradingExchangeProviders],
+    groupTradingExchangeQuotesProjection,
+);
+
+export const selectTradingExchangeDexQuotes = createMemoizedSelector(
+    [selectGroupedTradingExchangeQuotes],
+    groupedQuotes => groupedQuotes.dex,
+);
+
+export const selectTradingExchangeCexQuotes = createMemoizedSelector(
+    [selectGroupedTradingExchangeQuotes],
+    groupedQuotes => returnStableArrayIfEmpty([...groupedQuotes.fixed, ...groupedQuotes.float]),
+);
 
 export const selectTradingExchangeDexQuoteApprovalPrefetchLoading = (state: TradingRootState) =>
     !!state.wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId;
@@ -526,8 +605,22 @@ export const selectTradingExchangeDexQuoteApprovalPrefetchLoadingQuoteId = (
 export const selectTradingSellIsLoading = (state: TradingRootState) =>
     state.wallet.trading.sell.isLoading;
 
+export const selectTradingSellAmountLimits = (state: TradingRootState) =>
+    state.wallet.trading.sell.amountLimits;
+
 export const selectTradingSellQuotes = (state: TradingRootState) =>
     state.wallet.trading.sell.quotes;
+
+export const selectTradingSellQuotesByPaymentMethod = createMemoizedSelector(
+    [
+        selectTradingSellQuotes,
+        (_: TradingRootState, paymentMethod: TradingSellPaymentMethodProps | undefined) =>
+            paymentMethod,
+    ],
+    (quotes, paymentMethod) => ({
+        fixed: paymentMethod ? getTradingQuotesByPaymentMethod<'sell'>(quotes, paymentMethod) : [],
+    }),
+);
 
 export const selectTradingExchangeFormStep = (state: TradingRootState) =>
     state.wallet.trading.exchange.formStep;
@@ -575,6 +668,11 @@ export const selectValidTradingBuyQuotes = createMemoizedSelector(
     },
 );
 
+export const selectTradingBuyBestQuote = createMemoizedSelector(
+    [selectValidTradingBuyQuotes],
+    quotes => getBestRatedQuote(quotes, 'buy'),
+);
+
 export const selectValidTradingSellQuotes = createMemoizedSelector(
     [selectTradingSellQuotes],
     quotes => {
@@ -582,6 +680,11 @@ export const selectValidTradingSellQuotes = createMemoizedSelector(
 
         return quotes.filter(item => item.rate && item.rate !== 0);
     },
+);
+
+export const selectTradingSellBestQuote = createMemoizedSelector(
+    [selectValidTradingSellQuotes],
+    quotes => getBestRatedQuote(quotes, 'sell'),
 );
 
 export const selectTradingBuyAccountKey = (state: TradingRootState) =>

--- a/suite-common/trading/src/selectors/utils/__tests__/groupTradingExchangeQuotesProjection.test.ts
+++ b/suite-common/trading/src/selectors/utils/__tests__/groupTradingExchangeQuotesProjection.test.ts
@@ -1,0 +1,43 @@
+import { type ExchangeTrade } from 'invity-api';
+
+import { groupTradingExchangeQuotesProjection } from '../groupTradingExchangeQuotesProjection';
+
+describe(groupTradingExchangeQuotesProjection.name, () => {
+    it('groups quotes into dex, fixed and float groups', () => {
+        const quotes = [
+            {
+                exchange: '1inch',
+                quoteId: 'dex-quote',
+                isDex: true,
+            } as ExchangeTrade,
+            {
+                exchange: 'changellyfr',
+                quoteId: 'fixed-quote',
+            } as ExchangeTrade,
+            {
+                exchange: 'changelly',
+                quoteId: 'float-quote',
+            } as ExchangeTrade,
+            {
+                exchange: 'changenow',
+                quoteId: 'float-quote-2',
+            } as ExchangeTrade,
+            {
+                exchange: 'unknown-provider',
+                quoteId: 'fallback-float-quote',
+            } as ExchangeTrade,
+        ];
+
+        const providers = {
+            changellyfr: { isFixedRate: true },
+            changelly: { isFixedRate: false },
+            changenow: { isFixedRate: false },
+        };
+
+        const groupedQuotes = groupTradingExchangeQuotesProjection(quotes, providers);
+
+        expect(groupedQuotes.dex).toEqual([quotes[0]]);
+        expect(groupedQuotes.fixed).toEqual([quotes[1]]);
+        expect(groupedQuotes.float).toEqual([quotes[2], quotes[3], quotes[4]]);
+    });
+});

--- a/suite-common/trading/src/selectors/utils/__tests__/quotePerPaymentMethodProjection.test.ts
+++ b/suite-common/trading/src/selectors/utils/__tests__/quotePerPaymentMethodProjection.test.ts
@@ -1,0 +1,78 @@
+import { bestQuotePerPaymentMethodProjection } from '../quotePerPaymentMethodProjection';
+
+type PaymentMethod = 'bankTransfer' | 'creditCard' | 'applePay';
+
+type TestQuote = {
+    orderId: string;
+    paymentMethod?: PaymentMethod;
+    paymentMethodName?: string;
+    rate?: number;
+};
+
+describe(bestQuotePerPaymentMethodProjection.name, () => {
+    it('returns first valid quote for each payment method and sorts by rate', () => {
+        const quotes: TestQuote[] = [
+            {
+                orderId: 'cexdirect-bank-1',
+                paymentMethod: 'bankTransfer',
+                paymentMethodName: 'Bank Transfer',
+                rate: 20000,
+            },
+            {
+                orderId: 'moonpay-bank-2',
+                paymentMethod: 'bankTransfer',
+                paymentMethodName: 'Bank Transfer',
+                rate: 19500,
+            },
+            {
+                orderId: 'mercuryo-applepay',
+                paymentMethod: 'applePay',
+                paymentMethodName: 'Apple Pay',
+                rate: 19800,
+            },
+            {
+                orderId: 'simplex-card',
+                paymentMethod: 'creditCard',
+                paymentMethodName: 'Credit Card',
+                rate: 19900,
+            },
+        ];
+
+        const result = bestQuotePerPaymentMethodProjection(quotes, (aRate, bRate) => bRate - aRate);
+
+        expect(result.map(({ orderId }) => orderId)).toEqual([
+            'cexdirect-bank-1',
+            'simplex-card',
+            'mercuryo-applepay',
+        ]);
+    });
+
+    it('ignores quotes with missing payment method or payment method name', () => {
+        const quotes: TestQuote[] = [
+            {
+                orderId: 'mercuryo-missing-name',
+                paymentMethod: 'creditCard',
+                rate: 21000,
+            },
+            {
+                orderId: 'simplex-missing-method',
+                paymentMethodName: 'Credit Card',
+                rate: 20500,
+            },
+            {
+                orderId: 'cexdirect-valid',
+                paymentMethod: 'creditCard',
+                paymentMethodName: 'Credit Card',
+                rate: 20000,
+            },
+        ];
+
+        const result = bestQuotePerPaymentMethodProjection(quotes, (aRate, bRate) => bRate - aRate);
+
+        expect(result).toEqual([
+            expect.objectContaining({
+                orderId: 'cexdirect-valid',
+            }),
+        ]);
+    });
+});

--- a/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.ts
+++ b/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.ts
@@ -1,0 +1,41 @@
+import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
+
+export type GroupedTradingExchangeQuotes = {
+    fixed: ExchangeTrade[];
+    float: ExchangeTrade[];
+    dex: ExchangeTrade[];
+};
+
+type ExchangeProvidersMap = Record<string, Pick<ExchangeProviderInfo, 'isFixedRate'> | undefined>;
+
+export const groupTradingExchangeQuotesProjection = (
+    quotes: ExchangeTrade[],
+    providers: ExchangeProvidersMap | undefined,
+): GroupedTradingExchangeQuotes =>
+    quotes.reduce<GroupedTradingExchangeQuotes>(
+        (groups, quote) => {
+            const { exchange = '', isDex } = quote;
+            const { isFixedRate } = providers?.[exchange] || {};
+
+            if (isDex) {
+                groups.dex.push(quote);
+
+                return groups;
+            }
+
+            if (isFixedRate) {
+                groups.fixed.push(quote);
+
+                return groups;
+            }
+
+            groups.float.push(quote);
+
+            return groups;
+        },
+        {
+            fixed: [],
+            float: [],
+            dex: [],
+        },
+    );

--- a/suite-common/trading/src/selectors/utils/quotePerPaymentMethodProjection.ts
+++ b/suite-common/trading/src/selectors/utils/quotePerPaymentMethodProjection.ts
@@ -1,0 +1,28 @@
+type QuoteWithPaymentMethod<TPaymentMethod extends string> = {
+    paymentMethod?: TPaymentMethod;
+    paymentMethodName?: string;
+    rate?: number;
+};
+
+export const bestQuotePerPaymentMethodProjection = <
+    TPaymentMethod extends string,
+    TQuote extends QuoteWithPaymentMethod<TPaymentMethod>,
+>(
+    quotes: TQuote[],
+    sortRates: (aRate: number, bRate: number) => number,
+) => {
+    const bestQuoteByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
+        const { paymentMethod, paymentMethodName } = quote;
+        const isValidPaymentMethod = paymentMethod && paymentMethodName;
+
+        if (isValidPaymentMethod && !quotesByPaymentMethodMap.has(paymentMethod)) {
+            quotesByPaymentMethodMap.set(paymentMethod, quote);
+        }
+
+        return quotesByPaymentMethodMap;
+    }, new Map<TPaymentMethod, TQuote>());
+
+    return [...bestQuoteByPaymentMethodMap.values()].sort(({ rate: aRate }, { rate: bRate }) =>
+        sortRates(aRate ?? 0, bRate ?? 0),
+    );
+};

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -109,7 +109,9 @@ export type TradingParsedCryptoIdProps = {
 };
 
 export type TradingFiatCurrenciesProps = Map<FiatCurrencyCode, string>;
-export type TradingPaymentMethodProps = BuyCryptoPaymentMethod | '';
+export type TradingBuyPaymentMethodProps = BuyCryptoPaymentMethod | '';
+export type TradingSellPaymentMethodProps = SellCryptoPaymentMethod | '';
+export type TradingPaymentMethodProps = TradingPaymentMethodType | '';
 export type TradingPaymentMethodListProps = {
     value: TradingPaymentMethodProps;
     label: string;

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -1,12 +1,13 @@
 import { Platform } from 'react-native';
 
-import type { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
+import type { BuyTrade } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingCountryCode,
     type TradingPaymentMethodProps,
+    bestBuyQuotePerPaymentMethodProjection,
     getCurrencyLabel,
     getTradingQuotesByPaymentMethod,
     nonSanctionedRegional,
@@ -137,29 +138,7 @@ export const selectValidTradingBuyQuotesNative = createMemoizedSelector(
 
 export const selectBuyBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
     [selectValidTradingBuyQuotesNative],
-    quotes => {
-        const bestQuoteByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
-            const { paymentMethod, paymentMethodName } = quote;
-            const isValidPaymentMethod = paymentMethod && paymentMethodName;
-
-            // we only want one quote per payment method (and the 1st is considered the best)
-            if (isValidPaymentMethod && !quotesByPaymentMethodMap.has(paymentMethod)) {
-                quotesByPaymentMethodMap.set(paymentMethod, quote);
-            }
-
-            return quotesByPaymentMethodMap;
-        }, new Map<BuyCryptoPaymentMethod, BuyTrade>());
-
-        return [...bestQuoteByPaymentMethodMap.values()].sort(
-            ({ rate: aRate }, { rate: bRate }) => {
-                // note that quotes without a valid rate should be filtered out by selectValidTradingBuyQuotesNative -> selectValidTradingBuyQuotes
-                invariant(aRate, 'rate in object "a" is required for sorting');
-                invariant(bRate, 'rate in object "b" is required for sorting');
-
-                return aRate - bRate;
-            },
-        );
-    },
+    bestBuyQuotePerPaymentMethodProjection,
 );
 
 export const selectBuyQuotesByPaymentMethodNative = createMemoizedSelector(

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.ts
@@ -1,8 +1,8 @@
 import type { ExchangeTrade } from 'invity-api';
 
 import {
+    selectGroupedTradingExchangeQuotes,
     selectTradingExchangeBuyCryptoIds,
-    selectTradingExchangeProviders,
 } from '@suite-common/trading';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -91,37 +91,26 @@ export const selectExchangeQuotes = (state: TradingRootState) =>
 
 export const selectGroupedExchangeQuotes = createTradingWithFeatureFlagsMemoizedSelector(
     [
-        selectExchangeQuotes,
-        selectTradingExchangeProviders as unknown as (
+        selectGroupedTradingExchangeQuotes as unknown as (
             state: TradingRootState,
-        ) => ReturnType<typeof selectTradingExchangeProviders>,
+        ) => ReturnType<typeof selectGroupedTradingExchangeQuotes>,
         (state: TradingWithFeatureFlagsRootState) =>
             selectIsFeatureFlagEnabled(state, FeatureFlag.AreTradingExchangeDexesEnabled),
     ],
-    (quotes, providers = {}, areTradingExchangeDexesEnabled) => {
-        const groups = {
-            fixed: [] as ExchangeTrade[],
-            float: [] as ExchangeTrade[],
+    (groupedQuotes, areTradingExchangeDexesEnabled) => {
+        if (!groupedQuotes) {
+            return { fixed: [], float: [], dex: [] as ExchangeTrade[] };
+        }
+
+        if (areTradingExchangeDexesEnabled) {
+            return groupedQuotes;
+        }
+
+        return {
+            fixed: groupedQuotes.fixed,
+            float: groupedQuotes.float,
             dex: [] as ExchangeTrade[],
         };
-
-        quotes.forEach(quote => {
-            const { exchange = '', isDex } = quote;
-            const { isFixedRate } = providers[exchange] || {};
-
-            if (isDex) {
-                if (!areTradingExchangeDexesEnabled) {
-                    return;
-                }
-                groups.dex.push(quote);
-            } else if (isFixedRate) {
-                groups.fixed.push(quote);
-            } else {
-                groups.float.push(quote);
-            }
-        });
-
-        return groups;
     },
 );
 

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -1,10 +1,10 @@
-import type { FiatCurrencyCode, SellCryptoPaymentMethod, SellFiatTrade } from 'invity-api';
+import type { FiatCurrencyCode } from 'invity-api';
 
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
-import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingCountryCode,
     type TradingPaymentMethodProps,
+    bestSellQuotePerPaymentMethodProjection,
     getCurrencyLabel,
     getTradingQuotesByPaymentMethod,
     nonSanctionedRegional,
@@ -76,29 +76,7 @@ export const selectSellSelectedSendAccount = createMemoizedSelectorWithAccounts(
 
 export const selectSellBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
     [selectValidTradingSellQuotes],
-    quotes => {
-        const bestQuoteByPaymentMethodMap = quotes.reduce((quotesByPaymentMethodMap, quote) => {
-            const { paymentMethod, paymentMethodName } = quote;
-            const isValidPaymentMethod = paymentMethod && paymentMethodName;
-
-            // we only want one quote per payment method (and the 1st is considered the best)
-            if (isValidPaymentMethod && !quotesByPaymentMethodMap.has(paymentMethod)) {
-                quotesByPaymentMethodMap.set(paymentMethod, quote);
-            }
-
-            return quotesByPaymentMethodMap;
-        }, new Map<SellCryptoPaymentMethod, SellFiatTrade>());
-
-        return [...bestQuoteByPaymentMethodMap.values()].sort(
-            ({ rate: aRate }, { rate: bRate }) => {
-                // note that quotes without a valid rate should be filtered out by selectValidTradingSellQuotes
-                invariant(aRate, 'rate in object "a" is required for sorting');
-                invariant(bRate, 'rate in object "b" is required for sorting');
-
-                return bRate - aRate;
-            },
-        );
-    },
+    bestSellQuotePerPaymentMethodProjection,
 );
 
 export const selectSellQuotesByPaymentMethod = createMemoizedSelector(


### PR DESCRIPTION
## Description

- Add individual trading state selectors for `isFromRedirect`, `preselectedQuote`, and `amountLimits` for buy, exchange, and sell trading types
- Add shared quote selectors grouped by payment method (`selectTradingBuyQuotesByPaymentMethod`, `selectTradingExchangeQuotesByPaymentMethod`, `selectTradingSellQuotesByPaymentMethod`)
- Add exchange quote selectors for grouping DEX and CEX quotes (`selectGroupedTradingExchangeQuotes`, `selectTradingExchangeDexQuotes`, `selectTradingExchangeCexQuotes`)
- Add utility functions for quote projection and grouping with comprehensive test coverage

## Notes for QA

Just DEV thing. No need QA.

## Related Issue

Resolve #26281

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/trading-shared-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/trading-shared-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/trading-shared-selectors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T05:59:26.564Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-31T05:58:11.226Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->