### PR TITLE
chore(suite): update links of FW downgrade articles

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -184,19 +184,19 @@ export const HELP_CENTER_TOR_URL: Url = withPlatformUtm(
     'https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/tor-in-trezor-suite',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T1B1_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-model-one',
+    'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-model-one',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T2T1_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-model-t',
+    'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-model-t',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T3B1_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-trezor-safe-3',
+    'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-3',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T3T1_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-trezor-safe-5',
+    'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-5',
 );
 export const HELP_CENTER_FW_DOWNGRADE_T3W1_URL: Url = withPlatformUtm(
-    'https://trezor.io/support/troubleshooting/device-issues/downgrade-firmware-trezor-safe-7',
+    'https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-7',
 );
 export const HELP_CENTER_RECOVERY_ISSUES_URL: Url = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/trezor-suite-issues/trezor-recovery-issues',


### PR DESCRIPTION
## Description

Updating KB links to follow the new structure of links:

- https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-model-one
- https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-model-t
- https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-3
- https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-5
- https://trezor.io/support/troubleshooting/device-issues/install-custom-firmware-on-trezor-safe-7

## Notes for QA

Click `Learn more` in the Install custom firmware section (referring to the screenshot below).

<img width="1912" height="426" alt="Image" src="https://github.com/user-attachments/assets/21e48656-8cfc-47f3-a7ea-da7af4d4e058" />

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26308

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/update-fw-links&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/update-fw-links&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T07:51:31.942Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-31T07:50:23.247Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->