### PR TITLE
Mobile: eth staking – unstake

### DIFF
--- a/suite-native/accounts/src/components/AccountDetailsCard.tsx
+++ b/suite-native/accounts/src/components/AccountDetailsCard.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { G } from '@mobily/ts-belt';
@@ -15,16 +16,27 @@ type AccountDetailsCardProps = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
     isStakeVariant?: boolean;
+    titleLabel?: ReactNode;
 };
 
-const stakeCardStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
-}));
+const stakeCardStyle = prepareNativeStyle<{ isStakeVariant: boolean }>(
+    (utils, { isStakeVariant }) => ({
+        extend: {
+            condition: isStakeVariant,
+            style: {
+                backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
+                borderColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
+                borderWidth: utils.borders.widths.small,
+            },
+        },
+    }),
+);
 
 export const AccountDetailsCard = ({
     accountKey,
     tokenContract,
     isStakeVariant = false,
+    titleLabel,
 }: AccountDetailsCardProps) => {
     const { translate } = useTranslate();
     const { applyStyle } = useNativeStyles();
@@ -44,8 +56,7 @@ export const AccountDetailsCard = ({
             <Card
                 noPadding={!tokenContract}
                 noShadow={isStakeVariant}
-                borderColor={isStakeVariant ? 'backgroundTertiaryDefaultOnElevation0' : undefined}
-                style={isStakeVariant ? applyStyle(stakeCardStyle) : undefined}
+                style={applyStyle(stakeCardStyle, { isStakeVariant })}
             >
                 {tokenContract ? (
                     <TokenReceiveCard contract={tokenContract} accountKey={accountKey} />
@@ -54,6 +65,7 @@ export const AccountDetailsCard = ({
                         account={account}
                         isNativeCoinOnly
                         isCryptoBalancePrimary={isStakeVariant}
+                        titleLabel={titleLabel}
                     />
                 )}
             </Card>

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -35,6 +35,7 @@ export type AccountListItemProps = {
     isLast?: boolean;
     showDivider?: boolean;
     isCryptoBalancePrimary?: boolean;
+    titleLabel?: React.ReactNode;
 };
 
 const CRYPTO_PRIMARY_BALANCE_TEXT_PROPS = [
@@ -66,6 +67,7 @@ export const AccountsListItem = ({
     isLast = false,
     showDivider = false,
     isCryptoBalancePrimary = false,
+    titleLabel,
 }: AccountListItemProps) => {
     const formattedAccountType = useSelector((state: AccountsRootState) =>
         selectFormattedAccountType(state, account.key),
@@ -134,6 +136,20 @@ export const AccountsListItem = ({
         />
     );
 
+    const getTitle = () => {
+        if (titleLabel) {
+            return titleLabel;
+        }
+
+        if (shouldShowAccountLabel) {
+            return <AccountLabel account={account} />;
+        }
+
+        return <NetworkDisplaySymbolNameFormatter value={account.symbol} />;
+    };
+
+    const title = getTitle();
+
     return (
         <AccountsListItemBase
             hasBackground={hasBackground}
@@ -143,13 +159,7 @@ export const AccountsListItem = ({
             onPress={handleOnPress}
             disabled={disabled}
             icon={icon}
-            title={
-                shouldShowAccountLabel ? (
-                    <AccountLabel account={account} />
-                ) : (
-                    <NetworkDisplaySymbolNameFormatter value={account.symbol} />
-                )
-            }
+            title={title}
             badges={
                 <>
                     {formattedAccountType && (

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -34,6 +34,8 @@ import {
     StakingDetailScreen,
     StakingInsufficientBalanceScreen,
     StakingManagementScreen,
+    UnstakeFlowScreen,
+    UnstakeTransactionDataReviewScreen,
 } from '@suite-native/module-earn';
 import { ExperimentalFeedbackModalScreen } from '@suite-native/module-home';
 import { OnboardingStackNavigator } from '@suite-native/module-onboarding';
@@ -117,6 +119,11 @@ export const RootStackNavigator = () => {
                 component={StakingInsufficientBalanceScreen}
             />
             <RootStack.Screen
+                options={{ title: RootStackRoutes.UnstakeFlow }}
+                name={RootStackRoutes.UnstakeFlow}
+                component={UnstakeFlowScreen}
+            />
+            <RootStack.Screen
                 options={{ title: RootStackRoutes.HowStakeWorksScreen }}
                 name={RootStackRoutes.HowStakeWorksScreen}
                 component={HowStakeWorksScreen}
@@ -135,6 +142,11 @@ export const RootStackNavigator = () => {
                 options={{ title: RootStackRoutes.EarnTransactionDataReview }}
                 name={RootStackRoutes.EarnTransactionDataReview}
                 component={EarnTransactionDataReviewScreen}
+            />
+            <RootStack.Screen
+                options={{ title: RootStackRoutes.UnstakeTransactionDataReview }}
+                name={RootStackRoutes.UnstakeTransactionDataReview}
+                component={UnstakeTransactionDataReviewScreen}
             />
             <RootStack.Screen
                 name={RootStackRoutes.DevUtilsStack}

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2451,6 +2451,7 @@ export const messages = {
             totalRewardsLabel: 'Total rewards',
             nextRewardLabel: 'Next reward in {value, plural, one {# day} other {# days}}',
             unstakeButton: 'Unstake',
+            stakeButton: 'Stake',
             stakeMoreButton: 'Stake more',
             stakingHistory: 'Staking history',
             pendingActions: 'Pending actions',
@@ -2514,17 +2515,46 @@ export const messages = {
                 primaryButton: 'Go to home',
             },
         },
+        unstakeTransactionDataReviewScreen: {
+            title: 'Review with Trezor',
+            successMessage: "You're all set.",
+            viewTransactionButton: 'Unstake now',
+            pushTransactionFailedAlert: {
+                title: 'Transaction failed',
+                description: 'Failed to submit your unstake transaction. Please try again.',
+                primaryButton: 'Go to home',
+            },
+            pendingTransactionConflictAlert: {
+                title: 'Pending transaction detected',
+                description:
+                    'An unstake transaction is already pending for this account. Please wait for it to be confirmed before unstaking again.',
+                primaryButton: 'Go to home',
+            },
+        },
+        earnUnstakeOutputItem: {
+            title: 'Unstake',
+            description: 'Unstake {displaySymbol} from stake account?',
+        },
         earnStakeOutputItem: {
             title: 'Stake',
-            description: 'Stake {symbol} on Everstake?',
+            description: 'Stake {displaySymbol} on Everstake?',
         },
         earnSummaryOutputItem: {
             title: 'Total including fee',
         },
         earnFormScreen: {
             title: '{assetName} staking',
+            unstakeTitle: 'Unstake {displaySymbol}',
+            availableBalance: 'Available balance',
+            unstakingTimeline: 'Unstaking timeline',
+            unstakingPeriodInfo:
+                'The unstaking period is currently {days, plural, one {~# day} other {~# days}}',
+            networkFeeWarning:
+                'Network fees may exceed this amount. Your balance may decrease. Enter higher amount.',
+            reviewAndSign: 'Review & Sign',
             amountLabel: 'Amount',
             stakeMaxButton: 'Stake max',
+            unstakeMaxButton: 'Unstake max',
             withdrawalFeesBanner:
                 "We've left {amount} {displaySymbol} in your account so you can pay for withdrawal fees.",
             estimatedRewardsLabel: 'Estimated yearly rewards',
@@ -2534,6 +2564,13 @@ export const messages = {
                 amountBelowMinimum: 'Amount must be at least {amount} {symbol}.',
                 insufficientBalance: "You don't have enough balance to stake this amount.",
                 feeBufferReserve: 'Not enough funds left after we reserve for withdrawal fees.',
+                tooManyDecimals: 'Too many decimals.',
+            },
+        },
+        unstakeFormScreen: {
+            validation: {
+                amountIsZero: 'Amount must be greater than 0.',
+                insufficientBalance: "You don't have enough staked balance to unstake this amount.",
                 tooManyDecimals: 'Too many decimals.',
             },
         },
@@ -2563,6 +2600,7 @@ export const messages = {
                 copyLabel: 'Tap to copy',
             },
             adaInfo: 'Your ADA stays fully accessible while earning rewards.',
+            unstakeButton: 'Unstake',
         },
         howStakeWorksScreen: {
             title: 'How {displaySymbol} staking works?',

--- a/suite-native/module-earn/src/components/EarnAmountInputs.tsx
+++ b/suite-native/module-earn/src/components/EarnAmountInputs.tsx
@@ -8,16 +8,23 @@ import { Translation } from '@suite-native/intl';
 import { EarnAmountErrorMessage } from './EarnAmountErrorMessage';
 import { EarnCryptoAmountInput } from './EarnCryptoAmountInput';
 import { EarnFiatAmountInput } from './EarnFiatAmountInput';
-import { EarnMaxButton } from './EarnMaxButton';
+import { EarnMaxButton, type EarnMaxButtonVariant } from './EarnMaxButton';
 import { EarnWithdrawalFeesBanner } from './EarnWithdrawalFeesBanner';
 
 type EarnAmountInputsProps = {
     accountKey: AccountKey;
     symbol: NetworkSymbol;
+    maxButtonVariant?: EarnMaxButtonVariant;
+    isWithdrawalFeesBannerVisible?: boolean;
 };
 
-export const EarnAmountInputs = ({ accountKey, symbol }: EarnAmountInputsProps) => {
-    const [isStakeMax, setIsStakeMax] = useState(false);
+export const EarnAmountInputs = ({
+    accountKey,
+    symbol,
+    maxButtonVariant,
+    isWithdrawalFeesBannerVisible = true,
+}: EarnAmountInputsProps) => {
+    const [isMaxSelected, setIsMaxSelected] = useState(false);
 
     return (
         <VStack spacing="sp12">
@@ -31,8 +38,9 @@ export const EarnAmountInputs = ({ accountKey, symbol }: EarnAmountInputsProps) 
                         <EarnMaxButton
                             accountKey={accountKey}
                             symbol={symbol}
-                            isChecked={isStakeMax}
-                            onChange={setIsStakeMax}
+                            isChecked={isMaxSelected}
+                            onChange={setIsMaxSelected}
+                            variant={maxButtonVariant}
                         />
                     </>
                 )}
@@ -40,7 +48,7 @@ export const EarnAmountInputs = ({ accountKey, symbol }: EarnAmountInputsProps) 
                     <EarnCryptoAmountInput
                         symbol={symbol}
                         inputRef={inputRef}
-                        isDisabled={isStakeMax || isDisabled}
+                        isDisabled={isMaxSelected || isDisabled}
                         onPress={onPress}
                     />
                 )}
@@ -48,7 +56,7 @@ export const EarnAmountInputs = ({ accountKey, symbol }: EarnAmountInputsProps) 
                     <EarnFiatAmountInput
                         symbol={symbol}
                         inputRef={inputRef}
-                        isDisabled={isStakeMax || isDisabled}
+                        isDisabled={isMaxSelected || isDisabled}
                         onPress={onPress}
                     />
                 )}
@@ -56,7 +64,9 @@ export const EarnAmountInputs = ({ accountKey, symbol }: EarnAmountInputsProps) 
                     <EarnAmountErrorMessage isFiatDisplayed={isFiatDisplayed} />
                 )}
             />
-            <EarnWithdrawalFeesBanner accountKey={accountKey} symbol={symbol} />
+            {isWithdrawalFeesBannerVisible && (
+                <EarnWithdrawalFeesBanner accountKey={accountKey} symbol={symbol} />
+            )}
         </VStack>
     );
 };

--- a/suite-native/module-earn/src/components/EarnMaxButton.tsx
+++ b/suite-native/module-earn/src/components/EarnMaxButton.tsx
@@ -7,7 +7,7 @@ import {
     selectBaseCurrency,
     selectIsBaseCurrencyInSats,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type StakeType } from '@suite-common/wallet-types';
 import {
     formatNetworkAmount,
     getDecimalsForBaseCurrency,
@@ -17,22 +17,38 @@ import { HStack, Switch, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+import {
+    type NativeStakingRootState,
+    selectStakedBalanceByAccountKey,
+} from '@suite-native/staking';
 import { BigNumber } from '@trezor/utils';
 
 import { type EarnFormValues } from '../earnFormSchema';
+
+export type EarnMaxButtonVariant = Extract<StakeType, 'stake' | 'unstake'>;
 
 type EarnMaxButtonProps = {
     accountKey: AccountKey;
     symbol: NetworkSymbol;
     isChecked: boolean;
     onChange: (value: boolean) => void;
+    variant?: EarnMaxButtonVariant;
 };
 
-export const EarnMaxButton = ({ accountKey, symbol, isChecked, onChange }: EarnMaxButtonProps) => {
+export const EarnMaxButton = ({
+    accountKey,
+    symbol,
+    isChecked,
+    onChange,
+    variant = 'stake',
+}: EarnMaxButtonProps) => {
     const { setValue } = useFormContext<EarnFormValues>();
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
+    );
+    const stakedBalance = useSelector((state: NativeStakingRootState) =>
+        selectStakedBalanceByAccountKey(state, accountKey),
     );
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
@@ -43,13 +59,22 @@ export const EarnMaxButton = ({ accountKey, symbol, isChecked, onChange }: EarnM
         isInSats: isBaseCurrencyInSats,
     });
 
-    const setMaxStakeAmount = () => {
-        if (!account) return;
+    const getMaxAmount = (): string => {
+        if (variant === 'unstake') {
+            return stakedBalance ?? '0';
+        }
 
         const limits = getStakingLimitsByNetworkSymbol(symbol);
-        const availableAmount = formatNetworkAmount(account.availableBalance, symbol);
+        const availableAmount = formatNetworkAmount(account!.availableBalance, symbol);
         const buffer = limits?.MIN_BALANCE_FOR_FEE_BUFFER ?? 0;
-        const maxAmount = BigNumber.max(new BigNumber(availableAmount).minus(buffer), 0).toFixed();
+
+        return BigNumber.max(new BigNumber(availableAmount).minus(buffer), 0).toFixed();
+    };
+
+    const setMaxAmount = () => {
+        if (!account) return;
+
+        const maxAmount = getMaxAmount();
 
         setValue('amount', maxAmount, { shouldValidate: true });
 
@@ -69,13 +94,17 @@ export const EarnMaxButton = ({ accountKey, symbol, isChecked, onChange }: EarnM
             return;
         }
 
-        setMaxStakeAmount();
+        setMaxAmount();
     };
 
     return (
         <HStack alignItems="center" spacing="sp8">
             <Text variant="body-sm">
-                <Translation id="earn.earnFormScreen.stakeMaxButton" />
+                {variant === 'unstake' ? (
+                    <Translation id="earn.earnFormScreen.unstakeMaxButton" />
+                ) : (
+                    <Translation id="earn.earnFormScreen.stakeMaxButton" />
+                )}
             </Text>
             <Switch isChecked={isChecked} onChange={handleChange} />
         </HStack>

--- a/suite-native/module-earn/src/components/EarnOutputFields.tsx
+++ b/suite-native/module-earn/src/components/EarnOutputFields.tsx
@@ -6,9 +6,12 @@ import { Card } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { EarnAmountInputs } from './EarnAmountInputs';
+import { type EarnMaxButtonVariant } from './EarnMaxButton';
 
 type EarnOutputFieldsProps = {
     accountKey: AccountKey;
+    maxButtonVariant?: EarnMaxButtonVariant;
+    isWithdrawalFeesBannerVisible?: boolean;
 };
 
 const cardStyle = prepareNativeStyle(utils => ({
@@ -16,7 +19,11 @@ const cardStyle = prepareNativeStyle(utils => ({
     borderWidth: utils.borders.widths.small,
 }));
 
-export const EarnOutputFields = ({ accountKey }: EarnOutputFieldsProps) => {
+export const EarnOutputFields = ({
+    accountKey,
+    maxButtonVariant,
+    isWithdrawalFeesBannerVisible,
+}: EarnOutputFieldsProps) => {
     const { applyStyle } = useNativeStyles();
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -26,7 +33,12 @@ export const EarnOutputFields = ({ accountKey }: EarnOutputFieldsProps) => {
 
     return (
         <Card style={applyStyle(cardStyle)}>
-            <EarnAmountInputs accountKey={accountKey} symbol={symbol} />
+            <EarnAmountInputs
+                accountKey={accountKey}
+                symbol={symbol}
+                maxButtonVariant={maxButtonVariant}
+                isWithdrawalFeesBannerVisible={isWithdrawalFeesBannerVisible}
+            />
         </Card>
     );
 };

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -18,6 +18,7 @@ import {
     useSelector,
 } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { BigNumber } from '@trezor/utils';
 
 import { ApyValue } from './ApyValue';
 import { CRYPTO_BALANCE_DECIMALS } from '../constants';
@@ -47,14 +48,19 @@ export const StakingManagementStakedCard = ({
     const { applyStyle } = useNativeStyles();
     const navigation = useNavigation<NavigationProp>();
 
-    const handleStakeMore = () => {
+    const handleStake = () => {
         navigation.navigate(RootStackRoutes.HowStakeWorksScreen, {
             accountKey,
             symbol: networkSymbol,
         });
     };
 
+    const handleUnstake = () => {
+        navigation.navigate(RootStackRoutes.UnstakeFlow, { accountKey });
+    };
+
     const stakedBalance = useSelector(state => selectStakedBalanceByAccountKey(state, accountKey));
+    const hasStakedBalance = new BigNumber(stakedBalance ?? '0').gt(0);
     const rewardsBalance = useSelector(state =>
         selectRewardsBalanceByAccountKey(state, accountKey),
     );
@@ -116,12 +122,19 @@ export const StakingManagementStakedCard = ({
                 )}
             </HStack>
             <HStack style={applyStyle(buttonsRowStyle)}>
-                {/* TODO: wire up unstake action */}
-                <Button flex={1} colorScheme="primaryElevation0">
-                    <Translation id="earn.stakingManagementScreen.unstakeButton" />
-                </Button>
-                <Button flex={1} colorScheme="primaryElevation0" onPress={handleStakeMore}>
-                    <Translation id="earn.stakingManagementScreen.stakeMoreButton" />
+                {hasStakedBalance && (
+                    <Button flex={1} colorScheme="primaryElevation0" onPress={handleUnstake}>
+                        <Translation id="earn.stakingManagementScreen.unstakeButton" />
+                    </Button>
+                )}
+                <Button flex={1} colorScheme="primaryElevation0" onPress={handleStake}>
+                    <Translation
+                        id={
+                            hasStakedBalance
+                                ? 'earn.stakingManagementScreen.stakeMoreButton'
+                                : 'earn.stakingManagementScreen.stakeButton'
+                        }
+                    />
                 </Button>
             </HStack>
         </Card>

--- a/suite-native/module-earn/src/components/UnstakeFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/UnstakeFlowScreenHeader.tsx
@@ -1,0 +1,35 @@
+import { useSelector } from 'react-redux';
+
+import { type RouteProp, useRoute } from '@react-navigation/native';
+
+import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import {
+    type RootStackParamList,
+    type RootStackRoutes,
+    ScreenHeader,
+} from '@suite-native/navigation';
+
+export const UnstakeFlowScreenHeader = () => {
+    const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.UnstakeFlow>>();
+    const { accountKey } = route.params;
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    if (!account) return null;
+
+    const displaySymbol = getNetworkDisplaySymbolName(account.symbol);
+
+    return (
+        <ScreenHeader
+            customContent={
+                <Text variant="body-md-strong">
+                    <Translation id="earn.earnFormScreen.unstakeTitle" values={{ displaySymbol }} />
+                </Text>
+            }
+        />
+    );
+};

--- a/suite-native/module-earn/src/components/UnstakeOutputItem.tsx
+++ b/suite-native/module-earn/src/components/UnstakeOutputItem.tsx
@@ -6,29 +6,25 @@ import { Text } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { ReviewOutputCard } from '@suite-native/transaction-management';
 
-type EarnStakeOutputItemProps = {
+type UnstakeOutputItemProps = {
     symbol: NetworkSymbol;
     outputState: ReviewOutputState;
     onLayout: (event: LayoutChangeEvent) => void;
 };
 
-export const EarnStakeOutputItem = ({
-    symbol,
-    outputState,
-    onLayout,
-}: EarnStakeOutputItemProps) => {
+export const UnstakeOutputItem = ({ symbol, outputState, onLayout }: UnstakeOutputItemProps) => {
     const { translate } = useTranslate();
     const displaySymbol = getNetworkDisplaySymbol(symbol);
 
     return (
         <View onLayout={onLayout}>
             <ReviewOutputCard
-                title={translate('earn.earnStakeOutputItem.title')}
+                title={translate('earn.earnUnstakeOutputItem.title')}
                 outputState={outputState}
             >
                 <Text variant="body-sm" color="textSubdued">
                     <Translation
-                        id="earn.earnStakeOutputItem.description"
+                        id="earn.earnUnstakeOutputItem.description"
                         values={{ displaySymbol }}
                     />
                 </Text>

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+import { useSelector } from 'react-redux';
+
+import { type RouteProp, useRoute } from '@react-navigation/native';
+
+import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import { Button, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
+import { ethToWei } from '@suite-native/staking';
+import {
+    LIST_VERTICAL_SPACING,
+    SlidingFooterOverlay,
+    type TransactionReviewOutputsState,
+    selectIsTransactionReviewInProgress,
+    selectReviewSummaryOutput,
+    useActiveStepOffset,
+} from '@suite-native/transaction-management';
+
+import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
+import { UnstakeOutputItem } from './UnstakeOutputItem';
+import { useHandleOnUnstakeTransactionReview } from '../hooks/useHandleOnUnstakeTransactionReview';
+
+const NUMBER_OF_STEPS = 2;
+
+type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.UnstakeTransactionDataReview>;
+
+type UnstakeTransactionDataReviewStepListProps = {
+    onTransactionSubmitted: (txid: string) => void;
+};
+
+export const UnstakeTransactionDataReviewStepList = ({
+    onTransactionSubmitted,
+}: UnstakeTransactionDataReviewStepListProps) => {
+    const route = useRoute<RouteProps>();
+    const { accountKey, amount } = route.params;
+
+    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
+        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
+    );
+
+    const summaryOutput = useSelector((state: TransactionReviewOutputsState) =>
+        selectReviewSummaryOutput(state, 'unstake', accountKey),
+    );
+
+    const accountSymbol = useSelector((state: AccountsRootState) =>
+        selectAccountNetworkSymbol(state, accountKey),
+    );
+
+    const [stepIndex, setStepIndex] = useState(0);
+
+    const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(stepIndex);
+    const handleOnUnstakeTransactionReview = useHandleOnUnstakeTransactionReview({
+        accountKey,
+        amount,
+        onTransactionSubmitted,
+    });
+
+    const areAllStepsDone = stepIndex === NUMBER_OF_STEPS - 1 || isTransactionReviewInProgress;
+
+    const handleNextStep = () => {
+        setStepIndex(prevStepIndex => prevStepIndex + 1);
+
+        if (stepIndex === NUMBER_OF_STEPS - 2) {
+            handleOnUnstakeTransactionReview();
+        }
+    };
+
+    const amountInWei = ethToWei(amount);
+
+    return (
+        <View>
+            <VStack spacing={LIST_VERTICAL_SPACING}>
+                {!!accountSymbol && (
+                    <>
+                        <UnstakeOutputItem
+                            symbol={accountSymbol}
+                            outputState={stepIndex > 0 ? 'success' : 'active'}
+                            onLayout={event => handleReadListItemHeight(event, 0)}
+                        />
+                        <EarnSummaryOutputItem
+                            accountKey={accountKey}
+                            amount={amountInWei}
+                            fee={summaryOutput?.fee ?? '0'}
+                            outputState={summaryOutput?.state}
+                            onLayout={event => handleReadListItemHeight(event, 1)}
+                        />
+                    </>
+                )}
+            </VStack>
+            {!areAllStepsDone && (
+                <SlidingFooterOverlay activeStepOffset={activeStepBottomOffset}>
+                    <Button onPress={handleNextStep} testID="@earn/unstake-review-continue">
+                        <Translation id="generic.buttons.next" />
+                    </Button>
+                </SlidingFooterOverlay>
+            )}
+        </View>
+    );
+};

--- a/suite-native/module-earn/src/components/UnstakingTimelineCard.tsx
+++ b/suite-native/module-earn/src/components/UnstakingTimelineCard.tsx
@@ -1,0 +1,90 @@
+import { useSelector } from 'react-redux';
+
+import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import {
+    BottomSheetModal,
+    Card,
+    HStack,
+    InlineAlertBox,
+    PressableOpacity,
+    Text,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import {
+    type NativeStakingRootState,
+    selectUnstakingPeriodInDaysBySymbol,
+} from '@suite-native/staking';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { HowStakeWorksUnstakingTimeline } from './HowStakeWorksUnstakingTimeline';
+
+type UnstakingTimelineCardProps = {
+    accountKey: AccountKey;
+};
+
+const cardPressableStyle = prepareNativeStyle(() => ({
+    width: '100%',
+}));
+
+const unstakingTimelineCardPaddingStyle = prepareNativeStyle(utils => ({
+    padding: utils.spacings.sp4,
+}));
+
+export const UnstakingTimelineCard = ({ accountKey }: UnstakingTimelineCardProps) => {
+    const { applyStyle } = useNativeStyles();
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+
+    const symbol = useAccountsSelector(state => selectAccountNetworkSymbol(state, accountKey));
+
+    const unstakingPeriodInDays = useSelector((state: NativeStakingRootState) =>
+        selectUnstakingPeriodInDaysBySymbol(state, symbol ?? undefined),
+    );
+
+    if (!symbol) return null;
+
+    return (
+        <>
+            <PressableOpacity style={applyStyle(cardPressableStyle)} onPress={openModal}>
+                <Card
+                    borderColor="borderElevation1"
+                    noShadow
+                    style={applyStyle(unstakingTimelineCardPaddingStyle)}
+                >
+                    <HStack alignItems="center" justifyContent="space-between" padding="sp16">
+                        <Text variant="body-md-strong">
+                            <Translation id="earn.earnFormScreen.unstakingTimeline" />
+                        </Text>
+                        <Icon name="caretDown" color="textDefault" />
+                    </HStack>
+
+                    {unstakingPeriodInDays !== undefined && (
+                        <InlineAlertBox
+                            variant="info"
+                            title={
+                                <Translation
+                                    id="earn.earnFormScreen.unstakingPeriodInfo"
+                                    values={{ days: unstakingPeriodInDays }}
+                                />
+                            }
+                        />
+                    )}
+                </Card>
+            </PressableOpacity>
+
+            <BottomSheetModal
+                ref={bottomSheetRef}
+                title={<Translation id="earn.earnFormScreen.unstakingTimeline" />}
+                isCloseDisplayed
+                onClose={closeModal}
+            >
+                <HowStakeWorksUnstakingTimeline
+                    symbol={symbol}
+                    unstakingPeriodInDays={unstakingPeriodInDays}
+                />
+            </BottomSheetModal>
+        </>
+    );
+};

--- a/suite-native/module-earn/src/constants.ts
+++ b/suite-native/module-earn/src/constants.ts
@@ -1,1 +1,2 @@
 export const CRYPTO_BALANCE_DECIMALS = 5;
+export const NETWORK_FEE_WARNING_MULTIPLIER = 4;

--- a/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
@@ -1,0 +1,119 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+import { isFulfilled, isRejected } from '@reduxjs/toolkit';
+
+import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { getFormDraftKey } from '@suite-common/wallet-utils';
+import {
+    type RootStackParamList,
+    type RootStackRoutes,
+    type StackNavigationProps,
+    useOverrideBackNavigation,
+} from '@suite-native/navigation';
+import { signEthUnstakeTransactionNativeThunk } from '@suite-native/staking';
+import {
+    type TransactionReviewOutputsState,
+    selectIsTransactionReviewInProgress,
+    useShowReviewCancellationAlert,
+} from '@suite-native/transaction-management';
+
+import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
+import { useShowPushTransactionFailedDuringUnstakeReviewAlert } from './useShowPushTransactionFailedDuringUnstakeReviewAlert';
+
+type NavigationProps = StackNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.UnstakeTransactionDataReview
+>;
+
+type HandleOnUnstakeTransactionReviewProps = {
+    accountKey: AccountKey;
+    amount: string;
+    onTransactionSubmitted: (txid: string) => void;
+};
+
+const USER_CANCELLED_ERROR_CODES = [
+    'Failure_PinCancelled',
+    'Method_Cancel',
+    'Failure_ActionCancelled',
+] as const;
+
+export const useHandleOnUnstakeTransactionReview = ({
+    accountKey,
+    amount,
+    onTransactionSubmitted,
+}: HandleOnUnstakeTransactionReviewProps) => {
+    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
+        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
+    );
+
+    const dispatch = useDispatch();
+    const navigation = useNavigation<NavigationProps>();
+    const showReviewCancellationAlert = useShowReviewCancellationAlert();
+    const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
+    const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
+        useShowPushTransactionFailedDuringUnstakeReviewAlert();
+
+    const onNavigateBack = useCallback(async () => {
+        if (isTransactionReviewInProgress) {
+            const { wasReviewCanceled } = await showReviewCancellationAlert();
+            if (!wasReviewCanceled) return;
+        }
+        dispatch(sendFormActions.discardTransaction());
+        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('unstake', '') }));
+        navigation.goBack();
+    }, [isTransactionReviewInProgress, showReviewCancellationAlert, dispatch, navigation]);
+
+    useOverrideBackNavigation({ onNavigateBack });
+
+    const handleOnUnstakeTransactionReview = useCallback(async () => {
+        const response = await dispatch(
+            signEthUnstakeTransactionNativeThunk({ accountKey, amount }),
+        );
+
+        if (isFulfilled(response)) {
+            onTransactionSubmitted(response.payload.txid);
+
+            return;
+        }
+
+        if (!isRejected(response)) {
+            return;
+        }
+
+        if (response.payload?.error === 'push-transaction-pending-conflict') {
+            showPendingTransactionConflictAlert();
+
+            return;
+        }
+
+        if (response.payload?.error === 'push-transaction-failed') {
+            showPushTransactionFailedAlert();
+
+            return;
+        }
+
+        const errorCode = response.payload?.errorCode;
+
+        if (USER_CANCELLED_ERROR_CODES.some(code => code === errorCode)) {
+            navigation.pop();
+
+            return;
+        }
+
+        showDeviceDisconnectedAlert();
+    }, [
+        accountKey,
+        amount,
+        dispatch,
+        navigation,
+        onTransactionSubmitted,
+        showDeviceDisconnectedAlert,
+        showPendingTransactionConflictAlert,
+        showPushTransactionFailedAlert,
+    ]);
+
+    return handleOnUnstakeTransactionReview;
+};

--- a/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringUnstakeReviewAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useShowPushTransactionFailedDuringUnstakeReviewAlert.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { useAlert } from '@suite-native/alerts';
+import { Translation } from '@suite-native/intl';
+import {
+    type AppTabsParamList,
+    AppTabsRoutes,
+    HomeStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackToStackCompositeNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackToStackCompositeNavigationProps<
+    AppTabsParamList,
+    AppTabsRoutes.HomeStack,
+    RootStackParamList
+>;
+
+export const useShowPushTransactionFailedDuringUnstakeReviewAlert = () => {
+    const { showAlert } = useAlert();
+    const navigation = useNavigation<NavigationProps>();
+
+    const handleGoHome = useCallback(() => {
+        navigation.popTo(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.HomeStack,
+            params: { screen: HomeStackRoutes.Home },
+        });
+    }, [navigation]);
+
+    const showPushTransactionFailedAlert = useCallback(
+        () =>
+            showAlert({
+                title: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.title" />
+                ),
+                description: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.description" />
+                ),
+                primaryButtonTitle: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pushTransactionFailedAlert.primaryButton" />
+                ),
+                primaryButtonVariant: 'redBold',
+                onPressPrimaryButton: handleGoHome,
+            }),
+        [handleGoHome, showAlert],
+    );
+
+    const showPendingTransactionConflictAlert = useCallback(
+        () =>
+            showAlert({
+                title: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.title" />
+                ),
+                description: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.description" />
+                ),
+                primaryButtonTitle: (
+                    <Translation id="earn.unstakeTransactionDataReviewScreen.pendingTransactionConflictAlert.primaryButton" />
+                ),
+                primaryButtonVariant: 'redBold',
+                onPressPrimaryButton: handleGoHome,
+            }),
+        [handleGoHome, showAlert],
+    );
+
+    return { showPushTransactionFailedAlert, showPendingTransactionConflictAlert };
+};

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -1,0 +1,56 @@
+import { useSelector } from 'react-redux';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
+import { useForm, useWatch } from '@suite-native/forms';
+import { useTranslate } from '@suite-native/intl';
+import {
+    type NativeStakingRootState,
+    selectStakedBalanceByAccountKey,
+} from '@suite-native/staking';
+import { BigNumber } from '@trezor/utils';
+
+import { NETWORK_FEE_WARNING_MULTIPLIER } from '../constants';
+import { type EarnFormValues } from '../earnFormSchema';
+import { unstakeFormValidationSchema } from '../unstakeFormSchema';
+
+export const useUnstakeForm = (accountKey: AccountKey) => {
+    const { translate } = useTranslate();
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const stakedBalance = useSelector((state: NativeStakingRootState) =>
+        selectStakedBalanceByAccountKey(state, accountKey),
+    );
+
+    const network = account ? getNetwork(account.symbol) : null;
+
+    const form = useForm<EarnFormValues>({
+        validation: unstakeFormValidationSchema,
+        mode: 'onTouched',
+        context: {
+            stakedBalance,
+            decimals: network?.decimals,
+            translate,
+        },
+        defaultValues: { amount: '', fiat: '' },
+    });
+
+    const amountValue = useWatch({ control: form.control, name: 'amount' });
+
+    if (!account) return null;
+
+    const limits = getStakingLimitsByNetworkSymbol(account.symbol);
+    const networkFeeWarningThreshold = limits?.MIN_BALANCE_FOR_FEE_BUFFER.times(
+        NETWORK_FEE_WARNING_MULTIPLIER,
+    );
+    const showNetworkFeeWarning =
+        !!networkFeeWarningThreshold &&
+        !!amountValue &&
+        new BigNumber(amountValue).gt(0) &&
+        new BigNumber(amountValue).lt(networkFeeWarningThreshold);
+
+    return { form, amountValue, showNetworkFeeWarning };
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -5,5 +5,7 @@ export { EarnConsentsScreen } from './screens/EarnConsentsScreen';
 export { EarnFormScreen } from './screens/EarnFormScreen';
 export { HowStakeWorksScreen } from './screens/HowStakeWorksScreen';
 export { StakingDetailScreen } from './screens/StakingDetailScreen';
+export { UnstakeFlowScreen } from './screens/UnstakeFlowScreen';
+export { UnstakeTransactionDataReviewScreen } from './screens/UnstakeTransactionDataReviewScreen';
 export { FiveBinariesHomeBanner } from './components/FiveBinariesHomeBanner';
 export { EarnStackNavigator } from './navigation/EarnStackNavigator';

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -1,0 +1,84 @@
+import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+
+import { AccountDetailsCard } from '@suite-native/accounts';
+import { Box, Button, InlineAlertBox, ScreenFooterGradient } from '@suite-native/atoms';
+import { Form } from '@suite-native/forms';
+import { Translation } from '@suite-native/intl';
+import {
+    type RootStackParamList,
+    RootStackRoutes,
+    Screen,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+
+import { EarnOutputFields } from '../components/EarnOutputFields';
+import { UnstakeFlowScreenHeader } from '../components/UnstakeFlowScreenHeader';
+import { UnstakingTimelineCard } from '../components/UnstakingTimelineCard';
+import { useUnstakeForm } from '../hooks/useUnstakeForm';
+
+export const UnstakeFlowScreen = () => {
+    const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.UnstakeFlow>>();
+    const { accountKey } = route.params;
+    const navigation =
+        useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes.UnstakeFlow>>();
+
+    const unstakeForm = useUnstakeForm(accountKey);
+
+    if (!unstakeForm) return null;
+
+    const { form, amountValue, showNetworkFeeWarning } = unstakeForm;
+    const {
+        formState: { isValid },
+    } = form;
+
+    const handleReviewAndSign = form.handleSubmit(() => {
+        navigation.navigate(RootStackRoutes.UnstakeTransactionDataReview, {
+            accountKey,
+            amount: amountValue,
+        });
+    });
+
+    return (
+        <Screen
+            header={<UnstakeFlowScreenHeader />}
+            footer={
+                <>
+                    <ScreenFooterGradient />
+                    <Box paddingHorizontal="sp16" paddingBottom="sp16">
+                        <Button isDisabled={!isValid} onPress={handleReviewAndSign}>
+                            <Translation id="earn.earnFormScreen.reviewAndSign" />
+                        </Button>
+                    </Box>
+                </>
+            }
+        >
+            <AccountDetailsCard
+                accountKey={accountKey}
+                isStakeVariant
+                titleLabel={<Translation id="earn.earnFormScreen.availableBalance" />}
+            />
+
+            <Box marginTop="sp16">
+                <UnstakingTimelineCard accountKey={accountKey} />
+            </Box>
+
+            <Box marginTop="sp16">
+                <Form form={form}>
+                    <EarnOutputFields
+                        accountKey={accountKey}
+                        maxButtonVariant="unstake"
+                        isWithdrawalFeesBannerVisible={false}
+                    />
+                </Form>
+            </Box>
+            {showNetworkFeeWarning && (
+                <Box marginTop="sp16">
+                    <InlineAlertBox
+                        variant="warning"
+                        title={<Translation id="earn.earnFormScreen.networkFeeWarning" />}
+                    />
+                </Box>
+            )}
+        </Screen>
+    );
+};

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { CommonActions, useFocusEffect } from '@react-navigation/native';
+
+import {
+    type AccountsRootState,
+    type TransactionsRootState,
+    selectAccountByKey,
+    selectTransactionByAccountKeyAndTxid,
+} from '@suite-common/wallet-core';
+import { Button, Card, LottieAnimation, Text, VStack } from '@suite-native/atoms';
+import {
+    ConfirmOnTrezorWrapper,
+    useConfirmOnTrezorController,
+} from '@suite-native/confirm-on-trezor';
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    ScreenHeader,
+    type StackProps,
+    TransactionDetailStackRoutes,
+} from '@suite-native/navigation';
+import {
+    type TransactionReviewOutputsState,
+    selectIsReceiveAddressOutputConfirmed,
+    selectIsTransactionAlreadySigned,
+    selectIsTransactionReviewInProgress,
+    sendArrowsLottie,
+} from '@suite-native/transaction-management';
+
+import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
+
+const navigateToUnstakedTransactionAction = ({
+    accountKey,
+    txid,
+}: {
+    accountKey: string;
+    txid: string;
+}) =>
+    CommonActions.reset({
+        index: 1,
+        routes: [
+            {
+                name: RootStackRoutes.AppTabs,
+                params: { screen: AppTabsRoutes.HomeStack },
+            },
+            {
+                name: RootStackRoutes.TransactionDetailStack,
+                params: {
+                    screen: TransactionDetailStackRoutes.TransactionDetail,
+                    params: {
+                        accountKey,
+                        txid,
+                        closeActionType: 'close',
+                    },
+                },
+            },
+        ],
+    });
+
+export const UnstakeTransactionDataReviewScreen = ({
+    route,
+    navigation,
+}: StackProps<RootStackParamList, RootStackRoutes.UnstakeTransactionDataReview>) => {
+    const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
+        useConfirmOnTrezorController();
+    const { accountKey } = route.params;
+    const [txid, setTxid] = useState<string>('');
+
+    const isAddressConfirmed = useSelector((state: TransactionReviewOutputsState) =>
+        selectIsReceiveAddressOutputConfirmed(state, 'unstake', accountKey),
+    );
+
+    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
+        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
+    );
+
+    const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    const isTransactionProcessedByBackend = !!useSelector((state: TransactionsRootState) =>
+        selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
+    );
+
+    const showSignSuccessMessage = isTransactionAlreadySigned && !!account;
+
+    useFocusEffect(
+        useCallback(() => {
+            if (isAddressConfirmed) {
+                navigation.navigate(RootStackRoutes.StakingDetail, { accountKey });
+            }
+        }, [accountKey, isAddressConfirmed, navigation]),
+    );
+
+    useEffect(() => {
+        if (isTransactionReviewInProgress) {
+            revealConfirmOnTrezorSheet();
+        }
+    }, [isTransactionReviewInProgress, revealConfirmOnTrezorSheet]);
+
+    useEffect(() => {
+        if (showSignSuccessMessage) {
+            closeSheet();
+        }
+    }, [closeSheet, showSignSuccessMessage]);
+
+    const handleClose = useCallback(() => {
+        navigation.dispatch(
+            CommonActions.reset({
+                index: 0,
+                routes: [
+                    { name: RootStackRoutes.AppTabs, params: { screen: AppTabsRoutes.EarnStack } },
+                ],
+            }),
+        );
+    }, [navigation]);
+
+    const handleViewTransaction = useCallback(() => {
+        navigation.dispatch(navigateToUnstakedTransactionAction({ accountKey, txid }));
+    }, [accountKey, navigation, txid]);
+
+    return (
+        <ConfirmOnTrezorWrapper
+            isManualControlEnabled
+            controlRef={confirmOnTrezorRef}
+            closeActionType="close"
+            defaultHeader={
+                <ScreenHeader
+                    customContent={
+                        <Text variant="body-md-strong">
+                            <Translation id="earn.unstakeTransactionDataReviewScreen.title" />
+                        </Text>
+                    }
+                    closeActionType="close"
+                    closeAction={handleClose}
+                />
+            }
+        >
+            <VStack flex={1} justifyContent="space-between">
+                <VStack justifyContent="center" spacing="sp24">
+                    <UnstakeTransactionDataReviewStepList onTransactionSubmitted={setTxid} />
+                </VStack>
+                {txid && (
+                    <Card>
+                        <VStack
+                            paddingTop="sp8"
+                            paddingHorizontal="sp24"
+                            paddingBottom="sp24"
+                            alignItems="center"
+                            spacing="sp24"
+                        >
+                            <LottieAnimation source={sendArrowsLottie} size="small" />
+                            <Text variant="body-md-strong" textAlign="center">
+                                <Translation id="earn.unstakeTransactionDataReviewScreen.successMessage" />
+                            </Text>
+                        </VStack>
+                        <Button
+                            isLoading={!isTransactionProcessedByBackend}
+                            onPress={handleViewTransaction}
+                        >
+                            <Translation id="earn.unstakeTransactionDataReviewScreen.viewTransactionButton" />
+                        </Button>
+                    </Card>
+                )}
+            </VStack>
+        </ConfirmOnTrezorWrapper>
+    );
+};

--- a/suite-native/module-earn/src/unstakeFormSchema.ts
+++ b/suite-native/module-earn/src/unstakeFormSchema.ts
@@ -1,0 +1,55 @@
+import { yup } from '@suite-common/validators';
+import { isDecimalsValid } from '@suite-common/wallet-utils';
+import { type Translate } from '@suite-native/intl';
+import { BigNumber } from '@trezor/utils';
+
+export type UnstakeFormContext = {
+    stakedBalance?: string;
+    decimals?: number;
+    translate: Translate;
+};
+
+export const unstakeFormValidationSchema = yup.object({
+    amount: yup
+        .string()
+        .required('Amount is required.')
+        .matches(/^\d*\.?\d+$/, 'Invalid decimal value.')
+        .test('is-zero', 'Amount must be greater than 0.', function (value) {
+            if (!value) return true;
+
+            const { translate } = this.options.context as UnstakeFormContext;
+
+            if (new BigNumber(value).isZero()) {
+                return this.createError({
+                    message: translate('earn.unstakeFormScreen.validation.amountIsZero'),
+                });
+            }
+
+            return true;
+        })
+        .test('is-higher-than-staked', "You don't have enough staked balance.", function (value) {
+            const { stakedBalance, translate } = this.options.context as UnstakeFormContext;
+
+            if (!value || !stakedBalance) return true;
+
+            if (new BigNumber(value).gt(stakedBalance)) {
+                return this.createError({
+                    message: translate('earn.unstakeFormScreen.validation.insufficientBalance'),
+                });
+            }
+
+            return true;
+        })
+        .test('too-many-decimals', 'Too many decimals.', function (value) {
+            const { decimals = 8, translate } = this.options.context as UnstakeFormContext;
+
+            if (!isDecimalsValid(value, decimals)) {
+                return this.createError({
+                    message: translate('earn.unstakeFormScreen.validation.tooManyDecimals'),
+                });
+            }
+
+            return true;
+        }),
+    fiat: yup.string(),
+});

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -404,6 +404,11 @@ export type RootStackParamList = {
         accountKey: AccountKey;
         amount: string;
     };
+    [RootStackRoutes.UnstakeFlow]: { accountKey: AccountKey };
+    [RootStackRoutes.UnstakeTransactionDataReview]: {
+        accountKey: AccountKey;
+        amount: string;
+    };
     [RootStackRoutes.DeviceSettingsStack]: NavigatorScreenParams<DeviceSettingsStackParamList>;
     [RootStackRoutes.AddCoinAccountStack]: NavigatorScreenParams<AddCoinAccountStackParamList>;
     [RootStackRoutes.ReceiveStack]: NavigatorScreenParams<ReceiveStackParamList>;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -34,6 +34,8 @@ export enum RootStackRoutes {
     PassphraseStack = 'PassphraseStack',
     StellarManageTokenStack = 'StellarManageTokenStack',
     ExperimentalFeedbackModal = 'ExperimentalFeedbackModal',
+    UnstakeFlow = 'UnstakeFlow',
+    UnstakeTransactionDataReview = 'UnstakeTransactionDataReview',
 }
 
 export enum AppTabsRoutes {

--- a/suite-native/staking/package.json
+++ b/suite-native/staking/package.json
@@ -27,7 +27,8 @@
         "@trezor/connect": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "react-redux": "9.2.0"
+        "react-redux": "9.2.0",
+        "web3-utils": "^4.3.3"
     },
     "devDependencies": {
         "@suite-common/suite-types": "workspace:*"

--- a/suite-native/staking/src/index.ts
+++ b/suite-native/staking/src/index.ts
@@ -6,6 +6,7 @@
 export * from './utils';
 export * from './selectors';
 export { signEthStakeTransactionNativeThunk } from './stakeEthFormNativeThunks';
+export { signEthUnstakeTransactionNativeThunk } from './unstakeEthFormNativeThunk';
 export type * from './types';
 export * from './hooks/useSelector';
 

--- a/suite-native/staking/src/unstakeEthFormNativeThunk.ts
+++ b/suite-native/staking/src/unstakeEthFormNativeThunk.ts
@@ -3,6 +3,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { getEthNetworkAddresses } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
     type FeesRootState,
     type SignTransactionError,
     type SignTransactionTimeoutError,
@@ -15,26 +16,22 @@ import {
     updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
-import {
-    getAccountIdentity,
-    getEthereumEstimateFeeParams,
-    getFormDraftKey,
-} from '@suite-common/wallet-utils';
+import { getAccountIdentity, getFormDraftKey } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 import TrezorConnect from '@trezor/connect';
 
+import { type StakePushTransactionError, selectPreferredFeeLevel } from './stakeFormNativeUtils';
 import {
-    STAKE_CALLDATA,
-    type StakePushTransactionError,
-    buildEthStakeTx,
-    buildStakeFormState,
-    buildStakePrecomposedTx,
-    selectPreferredFeeLevel,
-} from './stakeFormNativeUtils';
+    buildEthUnstakeTx,
+    buildUnstakeCalldata,
+    buildUnstakeFormState,
+    buildUnstakePrecomposedTx,
+} from './unstakeFormNativeUtils';
+import { ethToWei } from './utils';
 
-const STAKE_NATIVE_MODULE_PREFIX = '@suite-native/staking';
+const STAKE_NATIVE_MODULE_PREFIX = '@suite-native/unstaking';
 
-export const signEthStakeTransactionNativeThunk = createThunk<
+export const signEthUnstakeTransactionNativeThunk = createThunk<
     { txid: string },
     { accountKey: AccountKey; amount: string },
     {
@@ -45,14 +42,15 @@ export const signEthStakeTransactionNativeThunk = createThunk<
             | undefined;
     }
 >(
-    `${STAKE_NATIVE_MODULE_PREFIX}/signEthStakeTransactionNativeThunk`,
+    `${STAKE_NATIVE_MODULE_PREFIX}/signEthUnstakeTransactionNativeThunk`,
     async ({ accountKey, amount }, { dispatch, rejectWithValue, getState }) => {
         try {
-            const account = selectAccountByKey(getState(), accountKey);
+            const state = getState() as AccountsRootState & FeesRootState & DeviceRootState;
+            const account = selectAccountByKey(state, accountKey);
 
             if (!account || account.networkType !== 'ethereum') {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Ethereum account not found for key ${accountKey}`,
+                    `signEthUnstakeTransactionNativeThunk: Ethereum account not found for key ${accountKey}`,
                 );
 
                 return rejectWithValue({
@@ -65,7 +63,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             if (!network.chainId) {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Chain ID not found for network ${account.symbol}`,
+                    `signEthUnstakeTransactionNativeThunk: Chain ID not found for network ${account.symbol}`,
                 );
 
                 return rejectWithValue({
@@ -84,7 +82,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             if (!feeLevel) {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Fee info not available for ${account.symbol}`,
+                    `signEthUnstakeTransactionNativeThunk: Fee info not available for ${account.symbol}`,
                 );
 
                 return rejectWithValue({
@@ -96,6 +94,9 @@ export const signEthStakeTransactionNativeThunk = createThunk<
             const identity = getAccountIdentity(account);
             const { addressContractPool } = getEthNetworkAddresses(account.symbol);
 
+            const amountInWei = ethToWei(amount);
+            const calldata = buildUnstakeCalldata(amountInWei);
+
             const estimatedFee = await TrezorConnect.blockchainEstimateFee({
                 coin: account.symbol,
                 identity,
@@ -103,19 +104,16 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                     blocks: [2],
                     specific: {
                         from: account.descriptor,
-                        ...getEthereumEstimateFeeParams(
-                            addressContractPool,
-                            amount,
-                            undefined,
-                            STAKE_CALLDATA,
-                        ),
+                        to: addressContractPool,
+                        value: '0x0',
+                        data: calldata,
                     },
                 },
             });
 
             if (!estimatedFee.success) {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Gas limit estimation failed: ${estimatedFee.error.message}`,
+                    `signEthUnstakeTransactionNativeThunk: Gas limit estimation failed: ${estimatedFee.error.message}`,
                 );
 
                 return rejectWithValue({
@@ -128,7 +126,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             if (!rawGasLimit) {
                 console.error(
-                    'signEthStakeTransactionNativeThunk: Gas limit estimation returned empty value.',
+                    'signEthUnstakeTransactionNativeThunk: Gas limit estimation returned empty value.',
                 );
 
                 return rejectWithValue({
@@ -137,8 +135,8 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                 });
             }
 
-            const stakeFormState = buildStakeFormState(feeLevel, rawGasLimit);
-            const precomposedTx = buildStakePrecomposedTx(
+            const unstakeFormState = buildUnstakeFormState(feeLevel, rawGasLimit, calldata);
+            const precomposedTx = buildUnstakePrecomposedTx(
                 feeLevel,
                 rawGasLimit,
                 addressContractPool,
@@ -147,15 +145,15 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             dispatch(
                 sendFormActions.storePrecomposedTransaction({
-                    formState: stakeFormState,
+                    formState: unstakeFormState,
                     precomposedTransaction: precomposedTx,
                     accountKey,
                 }),
             );
             dispatch(
                 formDraftActions.storeDraft({
-                    key: getFormDraftKey('stake', ''),
-                    formDraft: stakeFormState,
+                    key: getFormDraftKey('unstake', ''),
+                    formDraft: unstakeFormState,
                 }),
             );
 
@@ -168,7 +166,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                     }),
                 ).unwrap();
 
-                const tx = buildEthStakeTx({
+                const tx = buildEthUnstakeTx({
                     contractAddress: addressContractPool,
                     amount,
                     chainId: network.chainId!,
@@ -193,12 +191,12 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             if (!deviceAccessResponse.success) {
                 console.error(
-                    'signEthStakeTransactionNativeThunk: Prioritized device access or stake preparation failed.',
+                    'signEthUnstakeTransactionNativeThunk: Prioritized device access or unstake preparation failed.',
                 );
 
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
-                    message: 'Prioritized device access or stake preparation failed.',
+                    message: 'Prioritized device access or unstake preparation failed.',
                 });
             }
 
@@ -206,7 +204,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             if (!signResponse.success) {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
+                    `signEthUnstakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
                 );
 
                 return rejectWithValue({
@@ -239,7 +237,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                 );
 
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Push transaction failed: ${pushResponse.error.message}`,
+                    `signEthUnstakeTransactionNativeThunk: Push transaction failed: ${pushResponse.error.message}`,
                 );
 
                 return rejectWithValue({
@@ -255,7 +253,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
             dispatch(
                 addFakePendingEvmTxThunk({
                     precomposedTransaction: precomposedTx,
-                    precomposedForm: stakeFormState,
+                    precomposedForm: unstakeFormState,
                     txid,
                     account,
                 }),
@@ -263,7 +261,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             return { txid };
         } catch (error) {
-            console.error(`signEthStakeTransactionNativeThunk: Unexpected error: ${error}`);
+            console.error(`signEthUnstakeTransactionNativeThunk: Unexpected error: ${error}`);
 
             return rejectWithValue(undefined);
         }

--- a/suite-native/staking/src/unstakeFormNativeUtils.ts
+++ b/suite-native/staking/src/unstakeFormNativeUtils.ts
@@ -1,0 +1,131 @@
+import { transformTx } from '@suite-common/staking';
+import {
+    STAKE_GAS_LIMIT_RESERVE,
+    UNSTAKE_INTERCHANGES,
+    WALLET_SDK_SOURCE,
+} from '@suite-common/wallet-constants';
+import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import {
+    type EthereumTransaction,
+    type EthereumTransactionEIP1559,
+    type FeeLevel,
+} from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
+
+import { ethToWei } from './utils';
+
+/**
+ * ABI-encodes unstake(uint256 amountWei, uint16 interchanges, uint64 source).
+ * The web version uses @everstake/wallet-sdk-ethereum which is not React Native compatible.
+ */
+export const buildUnstakeCalldata = (amountWei: string): string => {
+    const UNSTAKE_SELECTOR = '76ec871c';
+    const pad32 = (hex: string) => hex.replace('0x', '').padStart(64, '0');
+
+    return [
+        `0x${UNSTAKE_SELECTOR}`,
+        pad32(BigInt(amountWei).toString(16)),
+        pad32(BigInt(UNSTAKE_INTERCHANGES).toString(16)),
+        pad32(BigInt(WALLET_SDK_SOURCE).toString(16)),
+    ].join('');
+};
+
+export const buildUnstakeFormState = (
+    feeLevel: FeeLevel,
+    rawGasLimit: string,
+    calldata: string,
+): StakeFormState => ({
+    outputs: [],
+    feePerUnit: feeLevel.feePerUnit,
+    feeLimit: rawGasLimit,
+    transactionData: calldata,
+    stakeType: 'unstake',
+    options: [],
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+    ...(feeLevel.maxFeePerGas
+        ? {
+              maxFeePerGas: feeLevel.maxFeePerGas,
+              maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas ?? '0',
+              baseFeePerGas: feeLevel.baseFeePerGas ?? undefined,
+          }
+        : {}),
+});
+
+export const buildUnstakePrecomposedTx = (
+    feeLevel: FeeLevel,
+    rawGasLimit: string,
+    contractAddress: string,
+    amount: string,
+): PrecomposedTransactionFinal => {
+    const amountInWei = ethToWei(amount);
+    const gasLimitWithReserve = new BigNumber(rawGasLimit).plus(STAKE_GAS_LIMIT_RESERVE);
+    const gasPriceGwei = feeLevel.maxFeePerGas ?? feeLevel.feePerUnit;
+    const fee = new BigNumber(gasPriceGwei)
+        .times(gasLimitWithReserve)
+        .times(new BigNumber(10).pow(9))
+        .toFixed(0);
+
+    return {
+        type: 'final',
+        inputs: [],
+        outputs: [
+            {
+                address: contractAddress,
+                script_type: 'PAYTOADDRESS',
+                amount: amountInWei,
+            },
+        ],
+        outputsPermutation: [0],
+        fee,
+        feePerByte: feeLevel.feePerUnit,
+        feeLimit: rawGasLimit,
+        bytes: 0,
+        totalSpent: fee, // No ETH value is sent for unstake; total spent = fee only
+        ...(feeLevel.maxFeePerGas
+            ? {
+                  maxFeePerGas: feeLevel.maxFeePerGas,
+                  maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas ?? '0',
+              }
+            : {}),
+    };
+};
+
+export const buildEthUnstakeTx = ({
+    contractAddress,
+    amount,
+    chainId,
+    nonce,
+    rawGasLimit,
+    feeLevel,
+}: {
+    contractAddress: string;
+    amount: string;
+    chainId: number;
+    nonce: number | string;
+    rawGasLimit: string;
+    feeLevel: FeeLevel;
+}): EthereumTransaction | EthereumTransactionEIP1559 => {
+    const adjustedGasLimit = new BigNumber(rawGasLimit)
+        .plus(STAKE_GAS_LIMIT_RESERVE)
+        .integerValue(BigNumber.ROUND_DOWN)
+        .toNumber();
+    const amountInWei = ethToWei(amount);
+    const data = buildUnstakeCalldata(amountInWei);
+    const tx = {
+        to: contractAddress,
+        value: '0', // No ETH value for unstake
+        gasLimit: adjustedGasLimit,
+        data,
+    };
+
+    return transformTx(
+        tx,
+        String(nonce),
+        chainId,
+        feeLevel.maxFeePerGas ? undefined : feeLevel.feePerUnit,
+        feeLevel.maxFeePerGas,
+        feeLevel.maxPriorityFeePerGas,
+    );
+};

--- a/suite-native/staking/src/utils.ts
+++ b/suite-native/staking/src/utils.ts
@@ -1,3 +1,5 @@
+import { toWei } from 'web3-utils';
+
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { isArrayMember } from '@trezor/utils';
 
@@ -15,3 +17,5 @@ export const doesCoinSupportStaking = (symbol: NetworkSymbol): symbol is Network
     isArrayMember(symbol, stakingCoins);
 
 export const AUTO_STAKED_SYMBOLS: NetworkSymbol[] = ['ada'] as const;
+
+export const ethToWei = (amount: string): string => toWei(amount, 'ether');

--- a/yarn.lock
+++ b/yarn.lock
@@ -13776,6 +13776,7 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     react-redux: "npm:9.2.0"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Created the ETH unstaking flow for mobile. And update the logic of action buttons in the dashboard (hide the "unstake" button when the user does not have enough balance for unstake, and update the text of the "stake" button)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25673

## Screenshots:
<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-03-31 at 08 23 57" src="https://github.com/user-attachments/assets/8e9fa092-696e-4dcd-907e-a90c10c7e167" />
<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-03-31 at 08 23 38" src="https://github.com/user-attachments/assets/45bdf3ed-fb5c-45cf-bae6-65cf269cbf4d" />
<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-03-31 at 07 43 15" src="https://github.com/user-attachments/assets/ca73ce9d-997b-4263-9fc9-4c6a045f99b2" />
<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2026-03-31 at 07 43 53" src="https://github.com/user-attachments/assets/a822edb4-d071-48b9-bf99-6629f16ebe71" />
