### PR TITLE
feat(suite): create new wallet on t3w1

### DIFF
--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -1,0 +1,62 @@
+import { TestCategory, TestPriority } from '@trezor/e2e-utils';
+
+import { expect, test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
+    test.use({ setupEmulator: false });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.disableNecessaryFirmwareChecks();
+    });
+
+    test(
+        'Success (Shamir backup)',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verify that a user can successfully create a wallet during the onboarding process.',
+                category: TestCategory.Onboarding,
+                priority: TestPriority.Critical,
+            }),
+        },
+        async ({ page, device, onboardingPage, devicePrompt, analyticsSection, dashboardPage }) => {
+            await onboardingPage.optionallyDismissFwHashCheckError();
+            await analyticsSection.continueButton.click();
+
+            await devicePrompt.allowConnectToTrezor();
+            await onboardingPage.enterTHPPairingCode();
+            await analyticsSection.continueButton.click();
+
+            await onboardingPage.firmware.continueThroughFirmware();
+            await page.waitForTimeout(500);
+            await onboardingPage.tutorial.skip();
+
+            // Create wallet with Shamir backup
+            await onboardingPage.createWalletButton.click();
+            await onboardingPage.selectSeedType('shamir-advanced');
+
+            // Create backup with Shamir shares and threshold
+            const shares = 3;
+            const threshold = 2;
+
+            await onboardingPage.backup.passThroughShamirBackup(shares, threshold, {
+                deviceConfirmations: 3,
+            });
+
+            // Set PIN
+            await onboardingPage.pin.setPinButton.click();
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+            // method is used as a workaround to setup PIN with value 12
+            await device.selectNumberOfWords(12);
+            await device.selectNumberOfWords(12);
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await device.pressYes();
+
+            await test.step('Finish wallet creation', async () => {
+                await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
+                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+            });
+        },
+    );
+});


### PR DESCRIPTION
## Description
This PR adds new test to create new wallet with Shamir Backup on T3W1

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-e2e-t3w1-create-wallet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-e2e-t3w1-create-wallet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T08:38:08.144Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T08:41:39.969Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->