### PR TITLE
refactor(trading): use individual selectors in sell form

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -25,7 +25,15 @@ import {
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
     selectTradingPaymentMethods,
-    selectTradingSell,
+    selectTradingSellAmountLimits,
+    selectTradingSellInfo,
+    selectTradingSellIsFromRedirect,
+    selectTradingSellIsLoading,
+    selectTradingSellPreselectedQuote,
+    selectTradingSellQuotes,
+    selectTradingSellQuotesRequest,
+    selectTradingSellSelectedQuote,
+    selectTradingSellTransactionId,
     selectTradingTrades,
     sellThunks,
     sellUtils,
@@ -68,17 +76,15 @@ export const useTradingSellForm = ({
     const isOffersPage = pageType === 'offers';
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const {
-        isLoading,
-        quotesRequest,
-        isFromRedirect,
-        quotes,
-        transactionId,
-        preselectedQuote,
-        selectedQuote,
-        sellInfo,
-        amountLimits,
-    } = useSelector(selectTradingSell);
+    const isLoading = useSelector(selectTradingSellIsLoading);
+    const quotesRequest = useSelector(selectTradingSellQuotesRequest);
+    const isFromRedirect = useSelector(selectTradingSellIsFromRedirect);
+    const quotes = useSelector(selectTradingSellQuotes);
+    const transactionId = useSelector(selectTradingSellTransactionId);
+    const preselectedQuote = useSelector(selectTradingSellPreselectedQuote);
+    const selectedQuote = useSelector(selectTradingSellSelectedQuote);
+    const sellInfo = useSelector(selectTradingSellInfo);
+    const amountLimits = useSelector(selectTradingSellAmountLimits);
     const paymentMethods = useSelector(selectTradingPaymentMethods);
 
     const isPreviousRouteFromTradeSection = useTradingPreviousRoute(type);


### PR DESCRIPTION
## Description

- Replace the aggregated sell state selector in the sell form with dedicated field selectors.
- Keep the form logic scoped to the sell fields it actually consumes.
- Reduce unnecessary coupling to the full sell slice in the desktop trading form.

## Notes for QA

Just dev thing

## Related Issue

Resolve #26283

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26283/sell-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26283/sell-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T10:11:20.693Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-31T10:09:09.207Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->