### PR TITLE
fix(suite): handle THP pairing in all onboarding steps

### DIFF
--- a/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
+++ b/packages/suite/src/views/onboarding/UnexpectedState/index.tsx
@@ -1,7 +1,9 @@
 import { type JSX } from 'react';
 
 import { selectSelectedDevice } from '@suite-common/device';
+import { selectThpStep } from '@suite-common/thp';
 
+import { ThpPairingStep } from 'src/components/onboarding/ThpPairingStep/ThpPairingStep';
 import { useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectPrerequisite } from 'src/selectors/suite/suiteSelectors';
 
@@ -19,6 +21,7 @@ type UnexpectedStateProps = {
 export const UnexpectedState = ({ children }: UnexpectedStateProps) => {
     const device = useSelector(selectSelectedDevice);
     const prerequisite = useSelector(selectPrerequisite);
+    const thpStep = useSelector(selectThpStep);
 
     const { prevDeviceId, activeStep, activeStepId, showPinMatrix } = useOnboarding();
 
@@ -38,6 +41,11 @@ export const UnexpectedState = ({ children }: UnexpectedStateProps) => {
 
     // otherwise handle common prerequisite which are determined and passed as prop from Preloader component
     if (prerequisite && activeStep?.prerequisites?.includes(prerequisite)) {
+        // ThpPairingStep renders default view. we want to show it only if thpStep is set
+        if (thpStep && prerequisite === 'device-thp-locked') {
+            return <ThpPairingStep />;
+        }
+
         return <DeviceDisconnectedStep />;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ThpPairing view was not handled in onboarding steps other than `FirmwareStep` where its expected


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25465

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-onboarding-thp-pairing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-onboarding-thp-pairing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T12:13:55.141Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-31T12:12:10.102Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->