### PR TITLE
refactor(trading): use selector-based exchange quote filtering

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeQuotesFilter.ts
@@ -1,7 +1,5 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import type { UseFormSetValue } from 'react-hook-form';
-
-import { type ExchangeTrade } from 'invity-api';
 
 import {
     TRADING_EXCHANGE_FORM,
@@ -9,25 +7,23 @@ import {
     TRADING_EXCHANGE_FORM_DEX,
     type TradingExchangeFormProps,
     type TradingExchangeFormType,
+    selectTradingExchangeCexQuotes,
+    selectTradingExchangeDexQuotes,
 } from '@suite-common/trading';
-import { arrayPartition } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
 
 interface TradingExchangeQuotesFilterProps {
-    quotes: ExchangeTrade[];
     exchangeType: TradingExchangeFormType;
-    exchangeInfo: any;
     setValue: UseFormSetValue<TradingExchangeFormProps>;
 }
 
 export const useTradingExchangeQuotesFilter = ({
     exchangeType,
-    quotes,
     setValue,
 }: TradingExchangeQuotesFilterProps) => {
-    const [dexQuotes, cexQuotes] = useMemo(
-        () => arrayPartition(quotes, quote => quote?.isDex ?? false),
-        [quotes],
-    );
+    const dexQuotes = useSelector(selectTradingExchangeDexQuotes);
+    const cexQuotes = useSelector(selectTradingExchangeCexQuotes);
 
     // handle edge case when there are no longer quotes of selected exchange type
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -29,8 +29,15 @@ import {
     invityAPI,
     isSendingEvmNativeToken,
     selectTradingComposedTransactionInfo,
-    selectTradingExchange,
+    selectTradingExchangeAmountLimits,
     selectTradingExchangeInfo,
+    selectTradingExchangeIsFromRedirect,
+    selectTradingExchangeIsLoading,
+    selectTradingExchangePreselectedQuote,
+    selectTradingExchangeQuotes,
+    selectTradingExchangeQuotesRequest,
+    selectTradingExchangeSelectedQuote,
+    selectTradingExchangeTransactionId,
     selectTradingIsSlip24Allowed,
     selectTradingTrades,
     selectTradingVerifiedAddress,
@@ -82,16 +89,14 @@ export const useTradingExchangeForm = ({
     const isFormPage = pageType === 'form';
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const {
-        quotesRequest,
-        isFromRedirect,
-        quotes,
-        transactionId,
-        selectedQuote,
-        preselectedQuote,
-        amountLimits,
-        isLoading,
-    } = useSelector(selectTradingExchange);
+    const quotesRequest = useSelector(selectTradingExchangeQuotesRequest);
+    const isFromRedirect = useSelector(selectTradingExchangeIsFromRedirect);
+    const quotes = useSelector(selectTradingExchangeQuotes);
+    const transactionId = useSelector(selectTradingExchangeTransactionId);
+    const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);
+    const preselectedQuote = useSelector(selectTradingExchangePreselectedQuote);
+    const amountLimits = useSelector(selectTradingExchangeAmountLimits);
+    const isLoading = useSelector(selectTradingExchangeIsLoading);
     const verifiedAddress = useSelector(selectTradingVerifiedAddress);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
@@ -220,8 +225,6 @@ export const useTradingExchangeForm = ({
 
     const { cexQuotes, dexQuotes } = useTradingExchangeQuotesFilter({
         exchangeType,
-        quotes,
-        exchangeInfo,
         setValue,
     });
 

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -586,8 +586,8 @@ export const selectTradingExchangeDexQuotes = createMemoizedSelector(
 );
 
 export const selectTradingExchangeCexQuotes = createMemoizedSelector(
-    [selectGroupedTradingExchangeQuotes],
-    groupedQuotes => returnStableArrayIfEmpty([...groupedQuotes.fixed, ...groupedQuotes.float]),
+    [selectTradingExchangeQuotes],
+    quotes => returnStableArrayIfEmpty(quotes.filter(quote => !quote.isDex)),
 );
 
 export const selectTradingExchangeDexQuoteApprovalPrefetchLoading = (state: TradingRootState) =>


### PR DESCRIPTION
## Description

- Replace in-hook quote partitioning in useTradingExchangeQuotesFilter with selector-based DEX/CEX quote sources.
- Remove redundant quotes and exchangeInfo hook parameters and keep exchange-type fallback behavior driven by store selectors.
- Refactor useTradingExchangeForm to read exchange state via dedicated granular selectors instead of one aggregated selectTradingExchange selector.

## Notes for QA

- In Suite desktop, open Trading > Exchange, enter a valid pair and verify quotes load in both CEX and DEX contexts as before.
- Toggle exchange type and verify if one side has no quotes, the form auto-switches to the available type and does not stay stuck on an empty type.
- Change input amount repeatedly to refresh quotes and verify selected and preselected quote handling remains stable.

## Related Issue

Resolve #26284

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26284/exchange-selctors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26284/exchange-selctors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/26284/exchange-selctors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-03-31T14:18:24.065Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-03-31T14:16:46.681Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->