### PR TITLE
fix(suite-native): handle reconnect requested state in home screen

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -693,3 +693,8 @@ export const selectSupportChatDeviceUtmParams = createMemoizedSelector(
         return result;
     },
 );
+
+export const selectIsReconnectRequested = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => !!device?.reconnectRequested,
+);

--- a/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
     selectIsDeviceAuthorized,
     selectIsDeviceInitialized,
     selectIsDeviceUnlocked,
+    selectIsReconnectRequested,
 } from '@suite-common/device';
 import { selectIsDiscoveredDeviceAccountless } from '@suite-common/wallet-core';
 import {
@@ -32,12 +33,14 @@ export const HomeScreen = () => {
     const isBluetoothDeviceOsUnpairingRequired = useSelector(
         selectIsBluetoothDeviceOsUnpairingRequired,
     );
+    const isReconnectRequested = useSelector(selectIsReconnectRequested);
 
     const isEmptyHomeRendererShown =
         (isDiscoveredDeviceAccountless && // There has to be no accounts and discovery not active.
             (isDeviceAuthorized || // Initial state is empty portfolio device, that is authorized.
                 !isDeviceUnlocked)) ||
-        !isDeviceInitialized;
+        !isDeviceInitialized ||
+        isReconnectRequested;
 
     const portfolioContentRef = useRef<PortfolioGraphRef>(null);
     const refreshControl = useHomeRefreshControl({

--- a/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/EmptyHomeRenderer.tsx
@@ -7,6 +7,7 @@ import {
     selectIsDeviceInitialized,
     selectIsDeviceThpLocked,
     selectIsPortfolioTrackerDevice,
+    selectIsReconnectRequested,
 } from '@suite-common/device';
 import { selectHasOnlyEmptyPortfolioTracker } from '@suite-common/wallet-core';
 import { Box } from '@suite-native/atoms';
@@ -28,6 +29,7 @@ export const EmptyHomeRenderer = () => {
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
     const isDeviceThpLocked = useSelector(selectIsDeviceThpLocked);
     const isDeviceSetupSupported = useSelector(selectIsDeviceSetupSupported);
+    const isReconnectRequested = useSelector(selectIsReconnectRequested);
 
     // This state is present only for a fraction of second while redirecting to the Connecting screen is already happening.
     // Because the animation takes some time, this makes sure that the screen content of newly selected device does not flash during the redirect.
@@ -37,12 +39,19 @@ export const EmptyHomeRenderer = () => {
 
     let ScreenContent = EmptyPortfolioTrackerState;
 
-    if (
+    // the reconnect requested flag is set only after the device is wiped. The flag is indicating that the old data state
+    // is still present in the redux state but the physical device is already in the `initialize` state and ready for setup.
+    const wasDeviceWiped = isReconnectRequested;
+
+    const isUninitializedDeviceSetupReady =
+        !isDeviceInitialized &&
+        (isDeviceInBootloader || (isDeviceAuthorized && !isDeviceThpLocked));
+    const shouldShowUninitializedState =
         isDeviceSetupSupported &&
         isDeviceConnected &&
-        !isDeviceInitialized &&
-        (isDeviceInBootloader || (isDeviceAuthorized && !isDeviceThpLocked))
-    ) {
+        (wasDeviceWiped || isUninitializedDeviceSetupReady);
+
+    if (shouldShowUninitializedState) {
         ScreenContent = UninitializedConnectedDeviceState;
     }
     // Crossroads should be displayed if there is no real device connected and portfolio tracker has no accounts

--- a/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/UninitializedConnectedDeviceState.tsx
@@ -38,7 +38,7 @@ export const UninitializedConnectedDeviceState = () => {
 
     const deviceModel = useSelector(selectDeviceModel);
 
-    const handleAddAccount = () => {
+    const navigateToDeviceOnboarding = () => {
         navigation.navigate(RootStackRoutes.DeviceOnboardingStack, {
             screen: DeviceOnboardingStackRoutes.UninitializedDeviceLanding,
             params: {
@@ -62,7 +62,11 @@ export const UninitializedConnectedDeviceState = () => {
                     testID="@homescreen/uninitializedConnectedDeviceText"
                     alignSelf="stretch"
                 />
-                <Button size="large" onPress={handleAddAccount} style={applyStyle(buttonStyle)}>
+                <Button
+                    size="large"
+                    onPress={navigateToDeviceOnboarding}
+                    style={applyStyle(buttonStyle)}
+                >
                     <Translation id="moduleHome.emptyState.uninitializedDevice.button" />
                 </Button>
             </VStack>

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
@@ -131,6 +131,28 @@ describe('EmptyHomeRenderer', () => {
         expectEmptyPortfolioCrossroadsState();
     });
 
+    it('should display UninitializedConnectedDeviceState when reconnect is requested and device is initialized (happens after wipe device flow)', () => {
+        renderEmptyHomeRenderer({
+            device: {
+                selectedDevice: {
+                    connected: true,
+                    reconnectRequested: true,
+                    features: {
+                        initialized: true,
+                        internal_model: DeviceModelInternal.T3B1,
+                        major_version: 2,
+                        minor_version: 6,
+                        patch_version: 3,
+                    },
+                    state: {},
+                },
+                devices: [{ id: 'device_id' }],
+            },
+        });
+
+        expectUninitializedConnectedDeviceState();
+    });
+
     it('should display EmptyConnectedDeviceState when device is connected and authorized', () => {
         renderEmptyHomeRenderer({
             device: {


### PR DESCRIPTION
## Description

After a device wipe, the `reconnectRequested` flag is set on the device while Redux still holds the old (initialized) device state. Without this fix, the home screen would show the wrong empty state — or return `null` — instead of the uninitialized device setup screen.

Changes:
- Use `isReconnectRequested` in `HomeScreen` to include the reconnectedRequested state in `isEmptyHomeRendererShown.`
- Refactor the branching condition in `EmptyHomeRenderer` into named boolean variables (`wasDeviceWiped`, `isUninitializedDeviceSetupReady`, `shouldShowUninitializedState`) for readability
- Add test coverage for both `reconnectRequested` paths (initialized and uninitialized device)

## Notes for QA
Test wiping a device with all supported models, look for any inconsistencies.

## Related Issue

Resolve #26110 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/wipe-device-flow-recover&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/wipe-device-flow-recover&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wipe-device-flow-recover&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-01T08:20:55.858Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-04-01T08:18:45.401Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->