### PR TITLE
chore(ci): optimize Nx caching for lint

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -52,7 +52,7 @@
         },
         "lint:js": {
             "inputs": [
-                "default",
+                "{projectRoot}/**/*",
                 "{workspaceRoot}/eslint.config.mjs",
                 "{workspaceRoot}/packages/eslint/**/*"
             ],


### PR DESCRIPTION
## Description

Small optimization that just occurred to me: for `lint:js`, the cache input should be only the project, not `sharedGlobals`.

Seems to me there is nothing in root package.json that affects it – well, there is the eslint version in that package.json, but it is also in `packages/eslint/**` and that's enough :slightly_smiling_face: 
This will save some time – no invalidation of whole repo because _anything_ has changed in root `package.json`

I also wanted to do it for `lint:styles` and `depcheck`, but :no_entry_sign:  those need to invalidate if the npm packages `stylelint, depcheck` change.

### Notes

[Uhh, I also realised, this is not correct at all](https://github.com/trezor/trezor-suite/issues/14358#issuecomment-4169708992) :see_no_evil:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/nx-lint-caching&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/nx-lint-caching&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-04-01T10:59:20.257Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-01T11:01:28.125Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->