### PR TITLE
chore(common): update storage ASK return code

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureDeviceHasQuotaThunk.ts
@@ -34,8 +34,14 @@ export const ensureDeviceHasQuotaThunk =
             publicKey: delegatedKeyPublic,
         });
 
+        if (!hasPublicKeyStorage.success) {
+            dispatch(quotaManagerFetchError({ error: hasPublicKeyStorage.error.message }));
+
+            return;
+        }
+
         // already registered, don't need to register again
-        if (hasPublicKeyStorage.success) {
+        if (hasPublicKeyStorage.payload.status === 'Allocated') {
             dispatch(
                 quotaManagerDeviceFetched({
                     deviceId: device.id,
@@ -43,18 +49,6 @@ export const ensureDeviceHasQuotaThunk =
                     unspentStorageSize: hasPublicKeyStorage.payload.unspentSpace,
                 }),
             );
-
-            return;
-        }
-
-        // 404 is expected when device is not registered yet, other errors should be shown to the user
-        // as quota manager unavailability
-        const isHttp404 =
-            hasPublicKeyStorage.error.type === 'HttpError' &&
-            hasPublicKeyStorage.error.code === 404;
-
-        if (!isHttp404) {
-            dispatch(quotaManagerFetchError({ error: hasPublicKeyStorage.error.message }));
 
             return;
         }

--- a/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
+++ b/suite-common/suite-sync-quota-manager/src/ensureOwnerHasAllocatedQuotaThunk.ts
@@ -64,22 +64,20 @@ export const ensureOwnerHasAllocatedQuotaThunk =
             ownerId,
         });
 
-        if (hasOwnerStorage.success) {
+        if (!hasOwnerStorage.success) {
+            return err(HttpError());
+        }
+
+        // Storage exists for this owner
+        if (hasOwnerStorage.payload.status === 'Allocated') {
             dispatch(
                 quotaManagerOwnerFetched({
                     walletDescriptor,
-                    totalSpace: hasOwnerStorage.payload.totalSpace ?? 0,
+                    totalSpace: hasOwnerStorage.payload.totalSpace,
                 }),
             );
 
             return ok();
-        }
-
-        const isHttp404 =
-            hasOwnerStorage.error.type === 'HttpError' && hasOwnerStorage.error.code === 404;
-
-        if (!isHttp404) {
-            return err(HttpError());
         }
 
         if (isWriteMode === false) {

--- a/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
+++ b/suite-common/suite-sync-quota-manager/src/storage/checkStorage.ts
@@ -2,13 +2,23 @@ import { err, ok } from '@trezor/type-utils';
 
 import { quotaManagerFetch } from '../quotaManagerFetch';
 
-type AskForStorageResponse = {
+type NoQuotaResponse = {
+    status: 'NoQuota';
+};
+
+type QuotaOwnerResponse = {
+    status: 'Allocated';
     totalSpace: number;
 };
 
-type AskForStoragePublicKeyResponse = AskForStorageResponse & {
+type QuotaPublicKeyResponse = {
+    status: 'Allocated';
+    totalSpace: number;
     unspentSpace: number;
 };
+
+export type AskForStorageResponse = NoQuotaResponse | QuotaOwnerResponse;
+export type AskForStoragePublicKeyResponse = NoQuotaResponse | QuotaPublicKeyResponse;
 
 export type CheckStorageByPublicKeyParams = {
     baseUrl: string | null;

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureDeviceHasQuotaThunk.test.ts
@@ -70,7 +70,9 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
         const getState = createGetState();
         const dispatch = jest.fn();
 
-        checkStorageByPublicKeyMock.mockResolvedValue(ok({ totalSpace: 5000, unspentSpace: 1200 }));
+        checkStorageByPublicKeyMock.mockResolvedValue(
+            ok({ status: 'Allocated', totalSpace: 5000, unspentSpace: 1200 }),
+        );
 
         await ensureDeviceHasQuotaThunk({ delegatedKey: DELEGATED_IDENTITY_KEY, device })(
             dispatch,
@@ -128,9 +130,7 @@ describe(ensureDeviceHasQuotaThunk.name, () => {
             return action;
         });
 
-        checkStorageByPublicKeyMock.mockResolvedValue(
-            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
-        );
+        checkStorageByPublicKeyMock.mockResolvedValue(ok({ status: 'NoQuota' }));
         prepareChallengeSessionMock.mockResolvedValue(
             ok({ sessionId: 'session-123', challenge: 'aa55' }),
         );

--- a/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/tests/ensureOwnerHasAllocatedQuotaThunk.test.ts
@@ -52,7 +52,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         const getState = createGetState();
         const dispatch = jest.fn();
 
-        checkStorageByOwnerIdMock.mockResolvedValue(ok({ totalSpace: 2048 }));
+        checkStorageByOwnerIdMock.mockResolvedValue(ok({ status: 'Allocated', totalSpace: 2048 }));
 
         await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
@@ -91,9 +91,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
         });
         const dispatch = jest.fn();
 
-        checkStorageByOwnerIdMock.mockResolvedValue(
-            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
-        );
+        checkStorageByOwnerIdMock.mockResolvedValue(ok({ status: 'NoQuota' }));
         const result = await ensureOwnerHasAllocatedQuotaThunk({
             ownerId,
             delegatedKey: DELEGATED_IDENTITY_KEY,
@@ -132,9 +130,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
             return action;
         });
 
-        checkStorageByOwnerIdMock.mockResolvedValue(
-            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
-        );
+        checkStorageByOwnerIdMock.mockResolvedValue(ok({ status: 'NoQuota' }));
         prepareChallengeSessionMock.mockResolvedValue(
             ok({ sessionId: 'session-123', challenge: 'aa55' }),
         );
@@ -187,9 +183,7 @@ describe(ensureOwnerHasAllocatedQuotaThunk.name, () => {
             return action;
         });
 
-        checkStorageByOwnerIdMock.mockResolvedValue(
-            err({ type: 'HttpError', code: 404, message: 'Not Found' }),
-        );
+        checkStorageByOwnerIdMock.mockResolvedValue(ok({ status: 'NoQuota' }));
         prepareChallengeSessionMock.mockResolvedValue(
             ok({ sessionId: 'session-456', challenge: 'bb66' }),
         );


### PR DESCRIPTION
Related to this PR https://github.com/trezor/trezor-suite-sync/pull/115

**Changes**:
- updated return type from QM (storage/ask now does not return 404 HTTP code when there is no allowance) for all consumers

## Notes for QA

- registration and quota allocation should work the same

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/qm/update-response-code&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/qm/update-response-code&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/qm/update-response-code&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T11:28:35.938Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-02T15:14:21.157Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->