### PR TITLE
tron account activation, sending to contract address warning, resources info in tx modal

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,7 +1,7 @@
 import type tls from 'tls';
 
 import type { BaseCurrencyCode } from './baseCurrency';
-import type { TronAccountExtraData } from './blockbook-api';
+import type { TronAccountExtraData, TronChainExtraData } from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -282,6 +282,7 @@ export interface Transaction {
             isRemoval: boolean;
         };
     };
+    tronSpecific?: TronChainExtraData;
 }
 
 /* Account */

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -167,6 +167,21 @@ type TransformAddresses = {
 export const isTxFailed = (tx: BlockbookTransaction) =>
     !(!tx.blockHeight || tx.blockHeight < 0) && tx.ethereumSpecific?.status === 0;
 
+const getTransactionFee = (tx: BlockbookTransaction): string => {
+    if (tx.chainExtraData?.payloadType === 'tron') {
+        return tx.chainExtraData.payload?.totalFee || tx.fees;
+    }
+    if (tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed) {
+        return new BigNumber(
+            tx.ethereumSpecific.maxFeePerGas ?? tx.ethereumSpecific.gasPrice ?? '0',
+        )
+            .times(tx.ethereumSpecific.gasLimit)
+            .toString();
+    }
+
+    return tx.fees;
+};
+
 export const transformTransaction = (
     tx: BlockbookTransaction,
     addressesOrDescriptor?: TransformAddresses | string,
@@ -268,14 +283,7 @@ export const transformTransaction = (
             ? true
             : undefined;
 
-    const fee =
-        tx.ethereumSpecific && !tx.ethereumSpecific.gasUsed
-            ? new BigNumber(
-                  tx.ethereumSpecific?.maxFeePerGas ?? tx.ethereumSpecific?.gasPrice ?? '0',
-              )
-                  .times(tx.ethereumSpecific.gasLimit)
-                  .toString()
-            : tx.fees;
+    const fee = getTransactionFee(tx);
 
     // some instances of bb don't send vsize yet
     const feeRate = tx.vsize
@@ -307,6 +315,8 @@ export const transformTransaction = (
             ...tx.ethereumSpecific,
             gasPrice: tx.ethereumSpecific.gasPrice ?? '0', // even if it shouldn't, `null` sometimes came from Erigon
         },
+        tronSpecific:
+            tx.chainExtraData?.payloadType === 'tron' ? tx.chainExtraData.payload : undefined,
         details: {
             vin: inputs.map(enhanceVinVout(myAddresses)),
             vout: outputs.map(enhanceVinVout(myAddresses)),

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -382,6 +382,7 @@ export const transformAccountInfo = (payload: BlockbookAccountInfo): AccountInfo
     if (payload.chainExtraData?.payloadType === 'tron') {
         misc = {
             tronResources: payload.chainExtraData.payload,
+            contractInfo: payload.contractInfo,
         };
     } else if (isEVM) {
         misc = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -286,6 +286,18 @@ export const BasicTxDetails = ({
                         {tx.txid}
                     </Link>
                 </Item>
+
+                {tx.tronSpecific?.energyUsage && (
+                    <Item label={<Translation id="TR_TRON_ENERGY" />} iconName="gasPump">
+                        {tx.tronSpecific.energyUsage}
+                    </Item>
+                )}
+
+                {tx.tronSpecific?.bandwidthUsage && (
+                    <Item label={<Translation id="TR_TRON_BANDWIDTH" />} iconName="gasPump">
+                        {tx.tronSpecific.bandwidthUsage}
+                    </Item>
+                )}
             </Grid>
         </Card>
     );

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -325,7 +325,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <FormattedCryptoAmount
                                     value={fee}
                                     symbol={tx.symbol}
-                                    signValue="negative"
+                                    signValue={new BigNumber(fee).isZero() ? undefined : 'negative'}
                                 />
                             </Text>
                         </Table.Cell>

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -94,7 +94,9 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
 
     const [isExternalAddressCheckWarningDismissed, setIsExternalAddressCheckWarningDismissed] =
         useState(false);
-    const isExternalAddressCheckEnabled = ['eth', 'tsep', 'thod', 'sol', 'dsol'].includes(symbol);
+    const isExternalAddressCheckEnabled = ['eth', 'tsep', 'thod', 'sol', 'dsol', 'trx'].includes(
+        symbol,
+    );
 
     useEffect(() => {
         setIsExternalAddressCheckWarningDismissed(false);
@@ -189,7 +191,7 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                     learnMoreUrl: addressDeprecatedUrl ? ALL_URLS[addressDeprecatedUrl] : undefined,
                 };
             case 'evmChecks':
-                if (!checkAddressCheckSum(address)) {
+                if (networkType === 'ethereum' && !checkAddressCheckSum(address)) {
                     return {
                         buttonProps: {
                             onClick: () => {
@@ -318,45 +320,42 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
                 }
             },
             evmChecks: async (address: string) => {
-                // TODO: tron?
-                if (networkType === 'ethereum') {
-                    if (!isOnline) {
-                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
+                if (networkType !== 'ethereum' && networkType !== 'tron') return;
+
+                if (!isOnline) {
+                    return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
+                }
+
+                const result = await TrezorConnect.getAccountInfo({
+                    descriptor: address,
+                    coin: symbol,
+                });
+
+                if (!result.success) {
+                    return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
+                }
+
+                const { payload } = result;
+
+                // 1. Validate address checksum.
+                // Eth addresses are valid without checksum but Trezor displays them as checksummed.
+                if (networkType === 'ethereum' && !checkAddressCheckSum(address)) {
+                    const checksumAndUsageValidationResult = checkIsAddressNotUsedNotChecksummed(
+                        address,
+                        payload.history,
+                        inputName,
+                        setValue,
+                        setHasAddressChecksummed,
+                    );
+                    if (checksumAndUsageValidationResult) {
+                        return translationString('TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED');
                     }
-                    const params = {
-                        descriptor: address,
-                        coin: symbol,
-                    };
-                    const result = await TrezorConnect.getAccountInfo(params);
+                }
 
-                    if (!result.success) {
-                        return translationString('TR_ADDRESS_CANT_VERIFY_HISTORY');
-                    }
-
-                    const { payload } = result;
-
-                    // 1. Validate address checksum.
-                    // Eth addresses are valid without checksum but Trezor displays them as checksummed.
-                    if (!checkAddressCheckSum(address)) {
-                        const checksumAndUsageValidationResult =
-                            checkIsAddressNotUsedNotChecksummed(
-                                address,
-                                payload.history,
-                                inputName,
-                                setValue,
-                                setHasAddressChecksummed,
-                            );
-                        if (checksumAndUsageValidationResult) {
-                            return translationString('TR_ETH_ADDRESS_NOT_USED_NOT_CHECKSUMMED');
-                        }
-                    }
-
-                    // 2. Check if address is a contract address (right now only for Eth, Hoodi and Sepolia)
-                    if (!isExternalAddressCheckWarningDismissed && isExternalAddressCheckEnabled) {
-                        const isContract = payload.misc?.contractInfo;
-                        if (isContract) {
-                            return translationString('TR_EVM_ADDRESS_IS_CONTRACT');
-                        }
+                if (!isExternalAddressCheckWarningDismissed && isExternalAddressCheckEnabled) {
+                    const isContract = payload.misc?.contractInfo;
+                    if (isContract) {
+                        return translationString('TR_EVM_ADDRESS_IS_CONTRACT');
                     }
                 }
             },

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -7,6 +7,7 @@ import {
     getNetworkDisplaySymbol,
 } from '@suite-common/wallet-config';
 import {
+    type Account,
     type ExternalOutput,
     type PrecomposedLevels,
     type PrecomposedTransaction,
@@ -126,12 +127,18 @@ const calculateTrc20Transfer = (
     return payloadData;
 };
 
+const TRON_ACCOUNT_ACTIVATION_FEE_SUN = 1_000_000;
+
 const calculateTrxTransfer = (
     availableBalance: string,
     output: ExternalOutput,
     feeLevel: EstimateFeeLevel,
+    isNewAccount: boolean,
 ): PrecomposedTransaction => {
-    const totalFeeInSun = feeLevel.feePerTx || '0';
+    const baseFeeInSun = feeLevel.feePerTx || '0';
+    const totalFeeInSun = isNewAccount
+        ? new BigNumber(baseFeeInSun).plus(TRON_ACCOUNT_ACTIVATION_FEE_SUN).toString()
+        : baseFeeInSun;
     const isSendMax = output.type === 'send-max' || output.type === 'send-max-noaddress';
 
     let amount: string;
@@ -175,16 +182,28 @@ const calculateTrxTransfer = (
     return payloadData;
 };
 
+const isNewTronAccount = async (address: string, account: Account): Promise<boolean> => {
+    if (!address) return false;
+    const result = await TrezorConnect.getAccountInfo({
+        coin: account.symbol,
+        identity: getAccountIdentity(account),
+        descriptor: address,
+    });
+
+    return result.success && (result.payload.empty ?? false);
+};
+
 const calculate = (
     availableBalance: string,
     output: ExternalOutput,
     feeLevel: EstimateFeeLevel,
     networkSymbol: NetworkSymbol,
     token?: TokenInfo,
+    isNewAccount?: boolean,
 ): PrecomposedTransaction =>
     token
         ? calculateTrc20Transfer(availableBalance, output, feeLevel, token, networkSymbol)
-        : calculateTrxTransfer(availableBalance, output, feeLevel);
+        : calculateTrxTransfer(availableBalance, output, feeLevel, isNewAccount ?? false);
 
 export const composeTronTransactionFeeLevelsThunk = createThunk<
     PrecomposedLevels,
@@ -262,7 +281,17 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
             };
         }
 
-        const tx = calculate(account.availableBalance, output, feeLevel, account.symbol, tokenInfo);
+        const isNewAccount =
+            !tokenInfo && (await isNewTronAccount(formState.outputs[0].address, account));
+
+        const tx = calculate(
+            account.availableBalance,
+            output,
+            feeLevel,
+            account.symbol,
+            tokenInfo,
+            isNewAccount,
+        );
 
         if (tx.type !== 'error' && tx.max !== undefined) {
             tx.max = subunitsToUnits({

--- a/suite-common/wallet-utils/src/tronUtils.ts
+++ b/suite-common/wallet-utils/src/tronUtils.ts
@@ -31,13 +31,12 @@ export const calculateTronFeeBreakdown = (
     const coveredBandwidth = new BigNumber(isBandwidthCovered ? bandwidthBytes : 0);
     const coveredEnergy = new BigNumber(Math.min(availableEnergy, energyConsumed));
 
-    const bandwidthBurnSun = isBandwidthCovered
-        ? 0
-        : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE;
-    const energyBurnSun = new BigNumber(energyConsumed - coveredEnergy.toNumber()).multipliedBy(
-        tx.feePerByte ?? '0',
-    );
-    const totalBurnSun = energyBurnSun.plus(bandwidthBurnSun);
+    const isTokenTransfer = 'token' in tx && tx.token !== undefined;
+    const totalBurnSun = isTokenTransfer
+        ? new BigNumber(energyConsumed - coveredEnergy.toNumber())
+              .multipliedBy(tx.feePerByte ?? '0')
+              .plus(isBandwidthCovered ? 0 : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE)
+        : new BigNumber(tx.fee);
     const trxBurned = new BigNumber(
         subunitsToUnits({ value: asAmountSubunit(totalBurnSun), symbol }),
     );


### PR DESCRIPTION
## Description

This PR implements:
- Warning message when sending tokens to a contract address
- 1 TRX account activation fee when sending TRX to new account
- Energy/bandwidth + correct fee info in transaction detail modal

## Notes for QA

## Related Issue

Resolve #24659 
Resolve #24660 
Resolve #24649

## Screenshots:

### Sending to contract address warning
<img width="1073" height="822" alt="image" src="https://github.com/user-attachments/assets/5d04fcf0-0ff9-42af-b392-16c7b5195b19" />

### Transaction detail resources spent info
<img width="790" height="506" alt="Screenshot 2026-04-01 at 15 09 05" src="https://github.com/user-attachments/assets/e92f2494-4613-4619-bb94-80ea308257ae" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-send-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->