### PR TITLE
Earn - Add DeFi Section to Tokens

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -308,6 +308,27 @@ export interface Token {
     totalReceived?: string;
     /** Total amount of tokens sent. */
     totalSent?: string;
+    /** Data containing information about the ERC4626 vault token. */
+    erc4626?: {
+        asset?: {
+            contract: string;
+            name: string;
+            symbol: string;
+            decimals: number;
+        };
+        share?: {
+            contract: string;
+            name: string;
+            symbol: string;
+            decimals: number;
+        };
+        totalAssets?: string;
+        convertToAssets1Share?: string;
+        convertToShares1Asset?: string;
+        previewDeposit1Asset?: string;
+        previewRedeem1Share?: string;
+        error?: string;
+    };
 }
 export interface Address {
     /** Current page index. */
@@ -650,6 +671,8 @@ export interface WsAccountInfoReq {
     secondaryCurrency?: string;
     /** Gap limit for XPUB scanning, if relevant. */
     gap?: number;
+    /** Include ERC4626 vault tokens in the response. */
+    includeErc4626?: boolean;
 }
 export interface WsBackendInfo {
     /** Backend version string. */

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,7 +1,11 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { BaseCurrencyCode } from './baseCurrency';
-import type { TronAccountExtraData, TronChainExtraData } from './blockbook-api';
+import type {
+    Token as BlockbookToken,
+    TronAccountExtraData,
+    TronChainExtraData,
+} from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -322,7 +326,7 @@ export interface TokenInfo {
     accounts?: TokenAccount[];
     policyId?: string;
     fingerprint?: string;
-    erc4626?: any;
+    erc4626?: BlockbookToken['erc4626'];
 }
 
 /**

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -322,6 +322,7 @@ export interface TokenInfo {
     accounts?: TokenAccount[];
     policyId?: string;
     fingerprint?: string;
+    erc4626?: any;
 }
 
 /**

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -58,4 +58,5 @@ export interface AccountInfoParams {
         seq: number;
     };
     tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
+    includeErc4626?: boolean; // blockbook only, include ERC4626 vault tokens
 }

--- a/packages/connect-common/src/types/api/discoverAccounts.ts
+++ b/packages/connect-common/src/types/api/discoverAccounts.ts
@@ -72,7 +72,7 @@ export type AccountTypeKey = DistributivePick<AccountTypeItem, 'symbol' | 'type'
 
 export type AdditionalParams = Pick<
     BlockchainLinkParams<'getAccountInfo'>,
-    'details' | 'pageSize'
+    'details' | 'pageSize' | 'includeErc4626'
 > & {
     identity?: string;
 };

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -99,6 +99,7 @@ export default class DiscoverAccounts extends AbstractMethod<
                 { name: 'identity', type: 'string' },
                 { name: 'details', type: 'string' },
                 { name: 'pageSize', type: 'number' },
+                { name: 'includeErc4626', type: 'boolean' },
             ]);
 
             const { symbol, known: knownAccs, knownOnly, ...rest } = coin;
@@ -322,7 +323,8 @@ export default class DiscoverAccounts extends AbstractMethod<
         request: Request,
         sendCoreMessage: MethodContext['sendCoreMessage'],
     ): Promise<{ nonempty: number; error?: string }> {
-        const { details, identity, pageSize, coinInfo, derivation, offset, skip } = request;
+        const { details, identity, pageSize, includeErc4626, coinInfo, derivation, offset, skip } =
+            request;
         const { path: bip43, ...accountKey } = request.account;
         const backendType = coinInfo.blockchainLink?.type;
         const utxoRequired = isUtxoBased(coinInfo) && details && details !== 'basic';
@@ -351,7 +353,12 @@ export default class DiscoverAccounts extends AbstractMethod<
                 descPromise = this.getDescriptor(coinInfo, bip43, derivation, offset + index + 1);
                 descPromise.catch(() => {});
 
-                const info = await blockchain.getAccountInfo({ descriptor, details, pageSize });
+                const info = await blockchain.getAccountInfo({
+                    descriptor,
+                    details,
+                    pageSize,
+                    includeErc4626,
+                });
 
                 // eslint-disable-next-line no-nested-ternary
                 const utxo = !utxoRequired

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -61,6 +61,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 { name: 'contractFilter', type: 'string' },
                 { name: 'gap', type: 'number' },
                 { name: 'marker', type: 'object' },
+                { name: 'includeErc4626', type: 'boolean' },
                 { name: 'defaultAccountType', type: 'string' },
                 { name: 'derivationType', type: 'number' },
                 { name: 'suppressBackupWarning', type: 'boolean' },
@@ -261,6 +262,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     gap: request.gap,
                     marker: request.marker,
                     tokenAccountsPubKeys: request.tokenAccountsPubKeys,
+                    includeErc4626: request.includeErc4626,
                 });
 
                 if (this.disposed) break;
@@ -437,6 +439,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             contractFilter: request.contractFilter,
             gap: request.gap,
             marker: request.marker,
+            includeErc4626: request.includeErc4626,
         });
 
         let utxo: AccountUtxo[] | undefined;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -37,6 +37,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 details: 'tokenBalances',
                 contractFilter: contractAddress,
                 suppressBackupWarning: true,
+                includeErc4626: acc.networkType === 'ethereum' ? true : undefined,
             });
 
             if (response.success) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountTopPanel/AccountNavigation.tsx
@@ -37,7 +37,12 @@ export const AccountNavigation = () => {
             },
             title: <Translation id="TR_NAV_TOKENS" />,
             isHidden: !hasNetworkFeatures(account, 'tokens'),
-            activeRoutes: ['wallet-tokens', 'wallet-tokens-hidden', 'wallet-tokens-inactive'],
+            activeRoutes: [
+                'wallet-tokens',
+                'wallet-tokens-hidden',
+                'wallet-tokens-inactive',
+                'wallet-tokens-defi',
+            ],
             'data-testid': '@wallet/menu/wallet-tokens',
         },
         {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -69,7 +69,12 @@ export const AccountItemsGroup = ({
         ? BASE_CURRENCY_ZERO
         : getAccountTokensFiatBalance(account, baseCurrencyCode, rates, tokens);
 
-    const tokensRoutes = ['wallet-tokens', 'wallet-tokens-hidden', 'wallet-tokens-inactive'];
+    const tokensRoutes = [
+        'wallet-tokens',
+        'wallet-tokens-hidden',
+        'wallet-tokens-inactive',
+        'wallet-tokens-defi',
+    ];
 
     return (
         <Section $selected={selected} $isSidebarCollapsed={isSidebarCollapsed}>

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 26.5.0
+
+- reset Ethereum account nonces to `-1` in order to force account refresh for DeFi tokens
+
 ## 26.4.0.2
 
 - rename `experimentalFeedback` object store to `featureFeedback`

--- a/packages/suite/src/storage/migrations/versions/26.5.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.5.0.ts
@@ -1,0 +1,15 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+import { updateAll } from '../utils';
+
+export default createMigration<SuiteDBSchema>('26.5.0', async (_, tx) => {
+    await updateAll(tx, 'accounts', account => {
+        if (account.networkType === 'ethereum') {
+            account.misc.nonce = '-1';
+
+            return account;
+        }
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -18,3 +18,4 @@ export { default as m26_3_0_1 } from './26.3.0.1';
 export { default as m26_4_0 } from './26.4.0';
 export { default as m26_4_0_1 } from './26.4.0.1';
 export { default as m26_4_0_2 } from './26.4.0.2';
+export { default as m26_5_0 } from './26.5.0';

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -15,9 +15,10 @@ import {
     getContractAddressForNetworkSymbol,
     getTokenExplorerUrl,
     hasNetworkFeatures,
+    isErc4626,
     isNftToken,
 } from '@suite-common/wallet-utils';
-import { Card, Column, IconButton, Link, Row, Text } from '@trezor/components';
+import { Banner, Card, Column, IconButton, Link, Row, Text } from '@trezor/components';
 import { AssetLogo, CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
@@ -103,6 +104,8 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
 
     const networkTokenContractAddress =
         selectedToken && getContractAddressForNetworkSymbol(account.symbol, selectedToken.contract);
+
+    const isDeFiToken = !!selectedToken && isErc4626(selectedToken);
 
     return (
         <>
@@ -213,6 +216,23 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                         <IconButton icon="caretDown" intent="neutral" priority="secondary" />
                     )}
                 </Row>
+
+                {isDeFiToken && (
+                    <Banner
+                        icon
+                        intent="info"
+                        title={
+                            <Translation
+                                id="TR_DEFI_YIELD_TOKEN_BANNER_TITLE"
+                                values={{
+                                    token: selectedToken?.symbol ?? account.symbol,
+                                }}
+                            />
+                        }
+                        description={<Translation id="TR_DEFI_YIELD_TOKEN_BANNER_DESCRIPTION" />}
+                        margin={{ top: 16 }}
+                    />
+                )}
             </Card>
         </>
     );

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -8,8 +8,10 @@ import { selectIsDebugModeActive } from '@suite/settings';
 import { selectCoinDefinitions, selectNftDefinitions } from '@suite-common/token-definitions';
 import { type NetworkType } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
+import { isErc4626 } from '@suite-common/wallet-utils';
 import { Button, Icon, IconButton, type IconName, Input, Row, SubTabs } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { arrayPartition } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -31,14 +33,27 @@ type SubTabItem = {
 };
 
 const getSubTabConfig = ({ isNft, tokens, goToRoute, networkType }: SubTabConfig) => {
+    const [erc4626Tokens, normalTokens] = arrayPartition(tokens.shownWithBalance, isErc4626);
+
     const baseConfig: SubTabItem[] = [
         {
             id: isNft ? 'wallet-nfts' : 'wallet-tokens',
             iconName: isNft ? 'pictureFrame' : 'coins',
             onClick: goToRoute(isNft ? 'wallet-nfts' : 'wallet-tokens'),
-            count: tokens.shownWithBalance.length,
+            count: normalTokens.length,
             labelId: isNft ? 'TR_NAV_COLLECTIONS' : 'TR_NAV_TOKENS',
         },
+        ...(erc4626Tokens.length
+            ? [
+                  {
+                      id: 'wallet-tokens-defi',
+                      iconName: 'percent',
+                      onClick: goToRoute('wallet-tokens-defi'),
+                      count: erc4626Tokens.length,
+                      labelId: 'TR_DEFI',
+                  } as const,
+              ]
+            : []),
         {
             id: isNft ? 'wallet-nfts-hidden' : 'wallet-tokens-hidden',
             iconName: 'eyeSlash',

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,76 +1,34 @@
-import { type ReactNode, useState } from 'react';
+import { useState } from 'react';
 
-import { events } from '@suite/analytics';
-import { selectIsCopyAddressModalShown, selectIsUnhideTokenModalShown } from '@suite/flags';
-import { Translation } from '@suite/intl';
-import { openModal } from '@suite/modal';
-import { goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
+import { type YieldDto } from '@suite-common/earn-api';
 import {
-    DefinitionType,
     type EnhancedTokenInfo,
-    TokenManagementAction,
+    type TokenManagementAction,
     selectIsSpecificCoinDefinitionKnown,
-    tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
-import {
-    type TradingType,
-    getTradingPrefilledFromAccountData,
-    getUnusedAddressFromAccount,
-    selectTradingInfo,
-    toTokenCryptoId,
-    tradingActions,
-} from '@suite-common/trading';
-import { type Explorer, type Network, getCoingeckoId } from '@suite-common/wallet-config';
-import { selectExplorer, sendFormActions } from '@suite-common/wallet-core';
+import { getUnusedAddressFromAccount } from '@suite-common/trading';
+import { type Network, getCoingeckoId } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import {
-    getContractAddressForNetworkSymbol,
-    getTokenExplorerUrl,
-} from '@suite-common/wallet-utils';
-import {
-    Button,
-    ButtonGroup,
-    Card,
-    Column,
-    Dropdown,
-    IconButton,
-    InfoItem,
-    Link,
-    Row,
-    Table,
-    Text,
-    Tooltip,
-} from '@trezor/components';
+import { Column, Row, Table, Text } from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { SUITE } from 'src/actions/suite/constants';
-import { copyAddressToClipboard, showCopyAddressModal } from 'src/actions/suite/copyAddressActions';
-import { setSendFormPrefill } from 'src/actions/suite/suiteActions';
-import { showAddress } from 'src/actions/wallet/receiveActions';
 import {
-    Address,
     BaseCurrencyValue,
     FormattedCryptoAmount,
     PriceTicker,
     TrendTicker,
 } from 'src/components/suite';
 import { StellarManageTokenModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal';
-import {
-    useDevice,
-    useDispatch,
-    useExternalLink,
-    useLayoutSize,
-    useSelector,
-} from 'src/hooks/suite';
-import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
-import { useAnalytics } from 'src/support/useAnalytics';
-import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
+import { useSelector } from 'src/hooks/suite';
 
 import { BlurUrls } from '../BlurUrls';
+import { TokenRowActions } from './TokenRowActions';
+import type { TokensTableType } from './types';
 
 type TokenRowProps = {
+    type?: TokensTableType;
     account: Account;
     token: EnhancedTokenInfo;
     network: Network;
@@ -78,9 +36,11 @@ type TokenRowProps = {
     hideRates?: boolean;
     isUnverifiedTable?: boolean;
     isCollapsed?: boolean;
+    yieldOpportunities?: YieldDto[];
 };
 
 export const TokenRow = ({
+    type = 'default',
     account,
     token,
     network,
@@ -88,106 +48,19 @@ export const TokenRow = ({
     hideRates,
     isUnverifiedTable,
     isCollapsed,
+    yieldOpportunities,
 }: TokenRowProps) => {
-    const analytics = useAnalytics();
-    const dispatch = useDispatch();
-    const { isBelowTablet } = useLayoutSize();
-    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
     const device = useSelector(selectSelectedDevice);
-    const { isLocked } = useDevice();
-    const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
-    const shouldShowUnhideTokenModal = useSelector(selectIsUnhideTokenModalShown);
     const isTokenKnown = useSelector(state =>
         selectIsSpecificCoinDefinitionKnown(state, account.symbol, token.contract as TokenAddress),
     );
-    const { coins } = useSelector(selectTradingInfo);
-    const isDeviceLocked = isLocked(true);
-    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
+
     const [showDeactivateModal, setShowDeactivateModal] = useState(false);
 
-    const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
-
+    const { address: unusedAddress } = getUnusedAddressFromAccount(account);
     const coingeckoId = getCoingeckoId(account.symbol);
-    const explorerUrl = useExternalLink(getTokenExplorerUrl(explorer, network.networkType, token));
 
     if (!unusedAddress || !device) return null;
-
-    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
-        if (network.networkType) {
-            analytics.report({
-                type: events.accountsActionsEvent.name,
-                payload: { symbol: network.symbol, action: payload.routeName },
-            });
-        }
-        dispatch(goto(payload));
-    };
-
-    const onReceive = () => {
-        if (network.networkType === 'cardano') {
-            goToWithAnalytics({ routeName: 'wallet-receive', preserveParams: true });
-        } else {
-            dispatch(showAddress(path, unusedAddress));
-        }
-    };
-
-    const TokenAddressItem = ({
-        label,
-        address,
-        type,
-    }: {
-        label: ReactNode;
-        address: string;
-        type: 'contract' | 'fingerprint' | 'policyId';
-    }) => (
-        <InfoItem typographyStyle="body-xs" label={label} gap={0}>
-            <Link href={explorerUrl}>
-                <Address
-                    isTruncated
-                    typographyStyle="body-xs"
-                    value={address}
-                    isCopyAllowed
-                    onCopy={() => {
-                        dispatch(
-                            shouldShowCopyAddressModal
-                                ? showCopyAddressModal(address, type)
-                                : copyAddressToClipboard(address),
-                        );
-                    }}
-                />
-            </Link>
-        </InfoItem>
-    );
-
-    const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
-    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
-    const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
-
-    const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
-    const canSwapToken =
-        (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
-    const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
-    const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
-
-    const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
-        dispatch(
-            tradingActions.setTradingFromPrefilledAccount(
-                getTradingPrefilledFromAccountData(account, tokenCryptoId),
-            ),
-        );
-
-        goToWithAnalytics(payload);
-
-        analytics.report({
-            type: events.tradeNavigateEvent.name,
-            payload: {
-                action: 'navigate',
-                type,
-                from: 'account/tokens',
-                networkSymbol: account.symbol,
-                contractAddress: token.contract,
-            },
-        });
-    };
 
     return (
         <>
@@ -205,6 +78,7 @@ export const TokenRow = ({
                         {isTokenKnown ? token.name : <BlurUrls text={token.name} />}
                     </Row>
                 </Table.Cell>
+
                 <Table.Cell>
                     <Column alignItems="flex-start">
                         {!hideRates && (
@@ -226,6 +100,7 @@ export const TokenRow = ({
                         </Text>
                     </Column>
                 </Table.Cell>
+
                 {!hideRates && (
                     <>
                         <Table.Cell align="end">
@@ -235,276 +110,32 @@ export const TokenRow = ({
                                 noEmptyStateTooltip
                             />
                         </Table.Cell>
-                        <Table.Cell>
-                            <TrendTicker
-                                symbol={network.symbol}
-                                contractAddress={token.contract as TokenAddress}
-                                noEmptyStateTooltip
-                            />
-                        </Table.Cell>
+                        {type !== 'defi' && (
+                            <Table.Cell>
+                                <TrendTicker
+                                    symbol={network.symbol}
+                                    contractAddress={token.contract as TokenAddress}
+                                    noEmptyStateTooltip
+                                />
+                            </Table.Cell>
+                        )}
                     </>
                 )}
+
                 <Table.Cell align="end">
-                    <Row gap={8}>
-                        <Dropdown
-                            placement={{ position: 'bottom', alignment: 'start' }}
-                            content={
-                                <Card paddingType="small">
-                                    <Column gap={16}>
-                                        {!token.policyId && (
-                                            <TokenAddressItem
-                                                label={
-                                                    <Translation
-                                                        id={getTokenAddressTranslationId(
-                                                            network.networkType,
-                                                        )}
-                                                    />
-                                                }
-                                                address={token.contract}
-                                                type="contract"
-                                            />
-                                        )}
-                                        {token.fingerprint && (
-                                            <TokenAddressItem
-                                                label={<Translation id="TR_FINGERPRINT_ADDRESS" />}
-                                                address={token.fingerprint}
-                                                type="fingerprint"
-                                            />
-                                        )}
-                                        {token.policyId && (
-                                            <TokenAddressItem
-                                                label={<Translation id="TR_POLICY_ID_ADDRESS" />}
-                                                address={token.policyId}
-                                                type="policyId"
-                                            />
-                                        )}
-                                    </Column>
-                                </Card>
-                            }
-                            items={[
-                                {
-                                    label: <Translation id="TR_BUY" />,
-                                    'data-testid': '@trading/tokens/buy-button',
-                                    icon: 'currencyCircleDollar',
-                                    onClick: () =>
-                                        onTradeButtonClick('buy', {
-                                            routeName: 'wallet-trading-buy',
-                                        }),
-                                    isDisabled: !canBuyToken,
-                                },
-                                {
-                                    label: <Translation id="TR_TRADING_SELL" />,
-                                    'data-testid': '@trading/tokens/sell-button',
-                                    icon: 'currencyCircleDollar',
-                                    onClick: () =>
-                                        onTradeButtonClick('sell', {
-                                            routeName: 'wallet-trading-sell',
-                                        }),
-                                    isDisabled: token.balance === '0' || !canSellToken,
-                                },
-                                {
-                                    label: <Translation id="TR_TRADING_SWAP" />,
-                                    'data-testid': '@trading/tokens/swap-button',
-                                    icon: 'arrowsLeftRight',
-                                    onClick: () =>
-                                        onTradeButtonClick('exchange', {
-                                            routeName: 'wallet-trading-exchange',
-                                        }),
-                                    isHidden: !isBelowTablet,
-                                    isDisabled: !canSwapToken,
-                                },
-                                {
-                                    label: <Translation id="TR_NAV_SEND" />,
-                                    'data-testid': '@trading/tokens/send-button',
-                                    icon: 'arrowUp',
-                                    onClick: () => {
-                                        goToWithAnalytics({
-                                            routeName: 'wallet-send',
-                                            params: {
-                                                symbol: account.symbol,
-                                                accountIndex: account.index,
-                                                accountType: account.accountType,
-                                            },
-                                        });
-                                    },
-                                    isDisabled: token.balance === '0',
-                                    isHidden:
-                                        tokenStatusType === TokenManagementAction.HIDE
-                                            ? !isBelowTablet
-                                            : true,
-                                },
-                                {
-                                    label: <Translation id="TR_NAV_RECEIVE" />,
-                                    'data-testid': '@trading/tokens/receive-button',
-                                    icon: 'arrowDown',
-                                    onClick: onReceive,
-                                    isDisabled: !canReceiveToken,
-                                    isHidden:
-                                        tokenStatusType === TokenManagementAction.HIDE
-                                            ? !isBelowTablet
-                                            : true,
-                                },
-                                {
-                                    label: (
-                                        <Translation
-                                            id={
-                                                tokenStatusType === TokenManagementAction.SHOW
-                                                    ? 'TR_UNHIDE_TOKEN'
-                                                    : 'TR_HIDE_TOKEN'
-                                            }
-                                        />
-                                    ),
-                                    icon: 'eyeSlash',
-                                    onClick: () =>
-                                        dispatch(
-                                            tokenDefinitionsActions.setTokenStatus({
-                                                symbol: network.symbol,
-                                                contractAddress: token.contract,
-                                                status: tokenStatusType,
-                                                type: DefinitionType.COIN,
-                                            }),
-                                        ),
-                                    isHidden:
-                                        tokenStatusType === TokenManagementAction.SHOW &&
-                                        !isBelowTablet,
-                                },
-                                {
-                                    label: <Translation id="TR_VIEW_ALL_TRANSACTION" />,
-                                    'data-testid': '@trading/tokens/transactions-button',
-                                    icon: 'newspaper',
-                                    onClick: () => {
-                                        dispatch({
-                                            type: SUITE.SET_TRANSACTION_HISTORY_PREFILL,
-                                            payload: token.contract,
-                                        });
-                                        goToWithAnalytics({
-                                            routeName: 'wallet-index',
-                                            params: {
-                                                symbol: account.symbol,
-                                                accountIndex: account.index,
-                                                accountType: account.accountType,
-                                            },
-                                        });
-                                    },
-                                },
-                                {
-                                    label: <Translation id="TR_VIEW_IN_EXPLORER" />,
-                                    icon: 'arrowUpRight',
-                                    onClick: () => {
-                                        window.open(explorerUrl, '_blank');
-                                    },
-                                },
-                                {
-                                    label: <Translation id="TR_DEACTIVATE_TOKEN" />,
-                                    icon: 'x',
-                                    onClick: () => setShowDeactivateModal(true),
-                                    // Only show for Stellar tokens
-                                    isHidden: network.networkType !== 'stellar',
-                                },
-                            ]}
-                        />
-                        {!isBelowTablet && (
-                            <Tooltip
-                                content={
-                                    canSwapToken ? (
-                                        <Translation id="TR_TRADING_SWAP" />
-                                    ) : (
-                                        <Translation id="TR_TRADING_SWAP_UNAVAILABLE" />
-                                    )
-                                }
-                            >
-                                <IconButton
-                                    isDisabled={!canSwapToken}
-                                    key="swap"
-                                    intent="neutral"
-                                    priority="secondary"
-                                    icon="arrowsLeftRight"
-                                    onClick={() =>
-                                        onTradeButtonClick('exchange', {
-                                            routeName: 'wallet-trading-exchange',
-                                        })
-                                    }
-                                />
-                            </Tooltip>
-                        )}
-                        {!isBelowTablet &&
-                            (tokenStatusType === TokenManagementAction.SHOW ? (
-                                <Button
-                                    iconLeft="eye"
-                                    onClick={() =>
-                                        isUnverifiedTable && shouldShowUnhideTokenModal
-                                            ? dispatch(
-                                                  openModal({
-                                                      type: 'unhide-token',
-                                                      address: token.contract,
-                                                  }),
-                                              )
-                                            : dispatch(
-                                                  tokenDefinitionsActions.setTokenStatus({
-                                                      symbol: network.symbol,
-                                                      contractAddress: token.contract,
-                                                      status: TokenManagementAction.SHOW,
-                                                      type: DefinitionType.COIN,
-                                                  }),
-                                              )
-                                    }
-                                    intent="neutral"
-                                    priority="secondary"
-                                >
-                                    <Translation id="TR_UNHIDE" />
-                                </Button>
-                            ) : (
-                                <ButtonGroup intent="neutral" priority="secondary">
-                                    <Tooltip content={<Translation id="TR_NAV_SEND" />}>
-                                        <IconButton
-                                            isDisabled={token.balance === '0'}
-                                            key="token-send"
-                                            icon="arrowUp"
-                                            onClick={() => {
-                                                dispatch(
-                                                    setSendFormPrefill({
-                                                        contractAddress: token.contract,
-                                                    }),
-                                                );
-                                                dispatch(
-                                                    sendFormActions.removeDraft({
-                                                        accountKey: account.key,
-                                                    }),
-                                                );
-                                                goToWithAnalytics({
-                                                    routeName: 'wallet-send',
-                                                    params: {
-                                                        symbol: account.symbol,
-                                                        accountIndex: account.index,
-                                                        accountType: account.accountType,
-                                                    },
-                                                });
-                                            }}
-                                        />
-                                    </Tooltip>
-                                    <Tooltip
-                                        content={
-                                            <Translation
-                                                id={
-                                                    isDeviceCompromised
-                                                        ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
-                                                        : 'TR_NAV_RECEIVE'
-                                                }
-                                            />
-                                        }
-                                    >
-                                        <IconButton
-                                            key="token-receive"
-                                            icon="arrowDown"
-                                            isDisabled={!canReceiveToken}
-                                            onClick={onReceive}
-                                        />
-                                    </Tooltip>
-                                </ButtonGroup>
-                            ))}
-                    </Row>
+                    <TokenRowActions
+                        type={type}
+                        token={token}
+                        tokenStatusType={tokenStatusType}
+                        account={account}
+                        network={network}
+                        yieldOpportunities={yieldOpportunities}
+                        isUnverifiedTable={isUnverifiedTable}
+                        setShowDeactivateModal={setShowDeactivateModal}
+                    />
                 </Table.Cell>
             </Table.Row>
+
             {showDeactivateModal && (
                 <StellarManageTokenModal
                     mode="deactivate"

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDto } from '@suite-common/earn-api';
+import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
     type EnhancedTokenInfo,
     type TokenManagementAction,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -1,0 +1,653 @@
+import { type ReactNode } from 'react';
+
+import { events } from '@suite/analytics';
+import { selectIsCopyAddressModalShown, selectIsUnhideTokenModalShown } from '@suite/flags';
+import { Translation } from '@suite/intl';
+import { openModal } from '@suite/modal';
+import { goto } from '@suite/router';
+import { selectSelectedDevice } from '@suite-common/device';
+import { type YieldDto } from '@suite-common/earn-api';
+import {
+    DefinitionType,
+    type EnhancedTokenInfo,
+    TokenManagementAction,
+    tokenDefinitionsActions,
+} from '@suite-common/token-definitions';
+import {
+    type TradingType,
+    getTradingPrefilledFromAccountData,
+    getUnusedAddressFromAccount,
+    selectTradingInfo,
+    toTokenCryptoId,
+    tradingActions,
+} from '@suite-common/trading';
+import { type Explorer, type Network } from '@suite-common/wallet-config';
+import { selectExplorer, sendFormActions } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import {
+    getContractAddressForNetworkSymbol,
+    getTokenExplorerUrl,
+    isErc4626,
+} from '@suite-common/wallet-utils';
+import {
+    Button,
+    ButtonGroup,
+    Card,
+    Column,
+    Dropdown,
+    IconButton,
+    InfoItem,
+    Link,
+    Row,
+    Tooltip,
+} from '@trezor/components';
+
+import { SUITE } from 'src/actions/suite/constants';
+import { copyAddressToClipboard, showCopyAddressModal } from 'src/actions/suite/copyAddressActions';
+import { setSendFormPrefill } from 'src/actions/suite/suiteActions';
+import { showAddress } from 'src/actions/wallet/receiveActions';
+import { getEarnRouteParams } from 'src/components/earn/utils/getEarnRouteParams';
+import { Address } from 'src/components/suite';
+import {
+    useDevice,
+    useDispatch,
+    useExternalLink,
+    useLayoutSize,
+    useSelector,
+} from 'src/hooks/suite';
+import { selectIsDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
+import { useAnalytics } from 'src/support/useAnalytics';
+import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
+
+import type { TokensTableType } from './types';
+
+interface TokenRowYieldActionsProps {
+    token: EnhancedTokenInfo;
+    account: Account;
+    network: Network;
+    yieldOpportunities?: YieldDto[];
+}
+
+const TokenRowYieldActions = ({
+    token,
+    account,
+    network,
+    yieldOpportunities,
+}: TokenRowYieldActionsProps) => {
+    const dispatch = useDispatch();
+    const analytics = useAnalytics();
+
+    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
+
+    const availableVault = yieldOpportunities?.find(
+        vault =>
+            !vault.metadata.underMaintenance &&
+            !vault.metadata.deprecated &&
+            vault.outputToken?.address !== undefined &&
+            getContractAddressForNetworkSymbol(account.symbol, vault.outputToken.address) ===
+                getContractAddressForNetworkSymbol(account.symbol, token.contract),
+    );
+
+    const isSupplyButtonDisabled = !availableVault || !availableVault.status.enter;
+    const isWithdrawButtonDisabled = !availableVault || !availableVault.status.exit;
+
+    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
+        if (network.networkType) {
+            analytics.report({
+                type: events.accountsActionsEvent.name,
+                payload: { symbol: network.symbol, action: payload.routeName },
+            });
+        }
+        dispatch(goto(payload));
+    };
+
+    const navigateToYieldSupply = () => {
+        if (!availableVault) return;
+
+        const yieldId = availableVault.id;
+        const contractAddress = availableVault.token.address;
+
+        dispatch(
+            goto({
+                routeName: 'earn-supply',
+                params: getEarnRouteParams({
+                    account,
+                    yieldId,
+                    contractAddress,
+                }),
+            }),
+        );
+    };
+
+    const navigateToYieldWithdraw = () => {
+        if (!availableVault) return;
+
+        const yieldId = availableVault.id;
+        const contractAddress = availableVault.token.address;
+
+        dispatch(
+            goto({
+                routeName: 'earn-withdraw',
+                params: getEarnRouteParams({
+                    account,
+                    yieldId,
+                    contractAddress,
+                }),
+            }),
+        );
+    };
+
+    const onSendButtonClick = () => {
+        dispatch(
+            setSendFormPrefill({
+                contractAddress: token.contract,
+            }),
+        );
+        dispatch(
+            sendFormActions.removeDraft({
+                accountKey: account.key,
+            }),
+        );
+
+        goToWithAnalytics({
+            routeName: 'wallet-send',
+            params: {
+                symbol: account.symbol,
+                accountIndex: account.index,
+                accountType: account.accountType,
+            },
+        });
+    };
+
+    const onReceiveButtonClick = () => {
+        if (!path) return;
+        dispatch(showAddress(path, unusedAddress));
+    };
+
+    return (
+        <Row gap={8}>
+            <Dropdown
+                placement={{ position: 'bottom', alignment: 'start' }}
+                items={[
+                    {
+                        label: <Translation id="TR_SEND" />,
+                        icon: 'arrowUp',
+                        onClick: onSendButtonClick,
+                    },
+                    {
+                        label: <Translation id="TR_RECEIVE" />,
+                        icon: 'arrowDown',
+                        onClick: onReceiveButtonClick,
+                    },
+                ]}
+            />
+
+            <ButtonGroup intent="neutral" priority="secondary">
+                <Tooltip
+                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
+                    isActive={isSupplyButtonDisabled}
+                >
+                    <IconButton
+                        icon="plus"
+                        isDisabled={isSupplyButtonDisabled}
+                        onClick={navigateToYieldSupply}
+                    />
+                </Tooltip>
+
+                <Tooltip
+                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
+                    isActive={isWithdrawButtonDisabled}
+                >
+                    <IconButton
+                        icon="minus"
+                        isDisabled={isWithdrawButtonDisabled}
+                        onClick={navigateToYieldWithdraw}
+                    />
+                </Tooltip>
+            </ButtonGroup>
+        </Row>
+    );
+};
+
+interface TokenRowBasicActionsProps {
+    type?: TokensTableType;
+    token: EnhancedTokenInfo;
+    tokenStatusType: TokenManagementAction;
+    account: Account;
+    network: Network;
+    isUnverifiedTable?: boolean;
+    setShowDeactivateModal: (value: boolean) => void;
+}
+
+const TokenRowBasicActions = ({
+    token,
+    tokenStatusType,
+    account,
+    network,
+    isUnverifiedTable,
+    setShowDeactivateModal,
+}: TokenRowBasicActionsProps) => {
+    const dispatch = useDispatch();
+    const analytics = useAnalytics();
+    const device = useSelector(selectSelectedDevice);
+    const { isLocked } = useDevice();
+    const { isBelowTablet } = useLayoutSize();
+
+    const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
+    const shouldShowUnhideTokenModal = useSelector(selectIsUnhideTokenModalShown);
+
+    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
+
+    const { coins } = useSelector(selectTradingInfo);
+    const isDeviceLocked = isLocked(true);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
+
+    const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
+
+    const explorerUrl = useExternalLink(getTokenExplorerUrl(explorer, network.networkType, token));
+
+    const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
+    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
+    const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
+
+    const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
+    const canSwapToken =
+        (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
+    const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
+    const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
+
+    if (!unusedAddress || !device) return null;
+
+    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
+        if (network.networkType) {
+            analytics.report({
+                type: events.accountsActionsEvent.name,
+                payload: { symbol: network.symbol, action: payload.routeName },
+            });
+        }
+        dispatch(goto(payload));
+    };
+
+    const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
+        dispatch(
+            tradingActions.setTradingFromPrefilledAccount(
+                getTradingPrefilledFromAccountData(account, tokenCryptoId),
+            ),
+        );
+
+        goToWithAnalytics(payload);
+
+        analytics.report({
+            type: events.tradeNavigateEvent.name,
+            payload: {
+                action: 'navigate',
+                type,
+                from: 'account/tokens',
+                networkSymbol: account.symbol,
+                contractAddress: token.contract,
+            },
+        });
+    };
+
+    const onBuyButtonClick = () => {
+        onTradeButtonClick('buy', {
+            routeName: 'wallet-trading-buy',
+        });
+    };
+
+    const onSellButtonClick = () => {
+        onTradeButtonClick('sell', {
+            routeName: 'wallet-trading-sell',
+        });
+    };
+
+    const onSwapButtonClick = () => {
+        onTradeButtonClick('exchange', {
+            routeName: 'wallet-trading-exchange',
+        });
+    };
+
+    const onSendButtonClick = () => {
+        dispatch(
+            setSendFormPrefill({
+                contractAddress: token.contract,
+            }),
+        );
+        dispatch(
+            sendFormActions.removeDraft({
+                accountKey: account.key,
+            }),
+        );
+
+        goToWithAnalytics({
+            routeName: 'wallet-send',
+            params: {
+                symbol: account.symbol,
+                accountIndex: account.index,
+                accountType: account.accountType,
+            },
+        });
+    };
+
+    const onReceiveButtonClick = () => {
+        if (network.networkType === 'cardano') {
+            goToWithAnalytics({ routeName: 'wallet-receive', preserveParams: true });
+        } else {
+            dispatch(showAddress(path, unusedAddress));
+        }
+    };
+
+    const onShowHideButtonClick = () => {
+        dispatch(
+            tokenDefinitionsActions.setTokenStatus({
+                symbol: network.symbol,
+                contractAddress: token.contract,
+                status: tokenStatusType,
+                type: DefinitionType.COIN,
+            }),
+        );
+    };
+
+    const onViewAllTransactionsButtonClick = () => {
+        dispatch({
+            type: SUITE.SET_TRANSACTION_HISTORY_PREFILL,
+            payload: token.contract,
+        });
+
+        goToWithAnalytics({
+            routeName: 'wallet-index',
+            params: {
+                symbol: account.symbol,
+                accountIndex: account.index,
+                accountType: account.accountType,
+            },
+        });
+    };
+
+    const onViewInExplorerButtonClick = () => {
+        window.open(explorerUrl, '_blank');
+    };
+
+    const onDeactivateTokenButtonClick = () => {
+        setShowDeactivateModal(true);
+    };
+
+    const TokenAddressItem = ({
+        label,
+        address,
+        type,
+    }: {
+        label: ReactNode;
+        address: string;
+        type: 'contract' | 'fingerprint' | 'policyId';
+    }) => (
+        <InfoItem typographyStyle="body-xs" label={label} gap={0}>
+            <Link href={explorerUrl}>
+                <Address
+                    isTruncated
+                    typographyStyle="body-xs"
+                    value={address}
+                    isCopyAllowed
+                    onCopy={() => {
+                        dispatch(
+                            shouldShowCopyAddressModal
+                                ? showCopyAddressModal(address, type)
+                                : copyAddressToClipboard(address),
+                        );
+                    }}
+                />
+            </Link>
+        </InfoItem>
+    );
+
+    return (
+        <Row gap={8}>
+            <Dropdown
+                placement={{ position: 'bottom', alignment: 'start' }}
+                content={
+                    <Card paddingType="small">
+                        <Column gap={16}>
+                            {!token.policyId && (
+                                <TokenAddressItem
+                                    label={
+                                        <Translation
+                                            id={getTokenAddressTranslationId(network.networkType)}
+                                        />
+                                    }
+                                    address={token.contract}
+                                    type="contract"
+                                />
+                            )}
+                            {token.fingerprint && (
+                                <TokenAddressItem
+                                    label={<Translation id="TR_FINGERPRINT_ADDRESS" />}
+                                    address={token.fingerprint}
+                                    type="fingerprint"
+                                />
+                            )}
+                            {token.policyId && (
+                                <TokenAddressItem
+                                    label={<Translation id="TR_POLICY_ID_ADDRESS" />}
+                                    address={token.policyId}
+                                    type="policyId"
+                                />
+                            )}
+                        </Column>
+                    </Card>
+                }
+                items={[
+                    {
+                        label: <Translation id="TR_BUY" />,
+                        'data-testid': '@trading/tokens/buy-button',
+                        icon: 'currencyCircleDollar',
+                        onClick: onBuyButtonClick,
+                        isDisabled: !canBuyToken,
+                    },
+                    {
+                        label: <Translation id="TR_TRADING_SELL" />,
+                        'data-testid': '@trading/tokens/sell-button',
+                        icon: 'currencyCircleDollar',
+                        onClick: onSellButtonClick,
+                        isDisabled: token.balance === '0' || !canSellToken,
+                    },
+                    {
+                        label: <Translation id="TR_TRADING_SWAP" />,
+                        'data-testid': '@trading/tokens/swap-button',
+                        icon: 'arrowsLeftRight',
+                        onClick: onSwapButtonClick,
+                        isHidden: !isBelowTablet,
+                        isDisabled: !canSwapToken,
+                    },
+                    {
+                        label: <Translation id="TR_NAV_SEND" />,
+                        'data-testid': '@trading/tokens/send-button',
+                        icon: 'arrowUp',
+                        onClick: onSendButtonClick,
+                        isDisabled: token.balance === '0',
+                        isHidden:
+                            tokenStatusType === TokenManagementAction.HIDE ? !isBelowTablet : true,
+                    },
+                    {
+                        label: <Translation id="TR_NAV_RECEIVE" />,
+                        'data-testid': '@trading/tokens/receive-button',
+                        icon: 'arrowDown',
+                        onClick: onReceiveButtonClick,
+                        isDisabled: !canReceiveToken,
+                        isHidden:
+                            tokenStatusType === TokenManagementAction.HIDE ? !isBelowTablet : true,
+                    },
+                    {
+                        label: <Translation id="TR_EARN_YIELD_SUPPLY" />,
+                        icon: 'plus',
+                        onClick: () => {},
+                        isDisabled: true,
+                        isHidden: !isErc4626(token),
+                    },
+                    {
+                        label: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
+                        icon: 'minus',
+                        onClick: () => {},
+                        isDisabled: true,
+                        isHidden: !isErc4626(token),
+                    },
+                    {
+                        label: (
+                            <Translation
+                                id={
+                                    tokenStatusType === TokenManagementAction.SHOW
+                                        ? 'TR_UNHIDE_TOKEN'
+                                        : 'TR_HIDE_TOKEN'
+                                }
+                            />
+                        ),
+                        icon: 'eyeSlash',
+                        onClick: onShowHideButtonClick,
+                        isHidden: tokenStatusType === TokenManagementAction.SHOW && !isBelowTablet,
+                    },
+                    {
+                        label: <Translation id="TR_VIEW_ALL_TRANSACTION" />,
+                        'data-testid': '@trading/tokens/transactions-button',
+                        icon: 'newspaper',
+                        onClick: onViewAllTransactionsButtonClick,
+                    },
+                    {
+                        label: <Translation id="TR_VIEW_IN_EXPLORER" />,
+                        icon: 'arrowUpRight',
+                        onClick: onViewInExplorerButtonClick,
+                    },
+                    {
+                        label: <Translation id="TR_DEACTIVATE_TOKEN" />,
+                        icon: 'x',
+                        onClick: onDeactivateTokenButtonClick,
+                        // Only show for Stellar tokens
+                        isHidden: network.networkType !== 'stellar',
+                    },
+                ]}
+            />
+
+            {!isBelowTablet && (
+                <Tooltip
+                    content={
+                        canSwapToken ? (
+                            <Translation id="TR_TRADING_SWAP" />
+                        ) : (
+                            <Translation id="TR_TRADING_SWAP_UNAVAILABLE" />
+                        )
+                    }
+                >
+                    <IconButton
+                        isDisabled={!canSwapToken}
+                        key="swap"
+                        intent="neutral"
+                        priority="secondary"
+                        icon="arrowsLeftRight"
+                        onClick={onSwapButtonClick}
+                    />
+                </Tooltip>
+            )}
+
+            {!isBelowTablet &&
+                (tokenStatusType === TokenManagementAction.SHOW ? (
+                    <Button
+                        iconLeft="eye"
+                        onClick={() =>
+                            isUnverifiedTable && shouldShowUnhideTokenModal
+                                ? dispatch(
+                                      openModal({
+                                          type: 'unhide-token',
+                                          address: token.contract,
+                                      }),
+                                  )
+                                : dispatch(
+                                      tokenDefinitionsActions.setTokenStatus({
+                                          symbol: network.symbol,
+                                          contractAddress: token.contract,
+                                          status: TokenManagementAction.SHOW,
+                                          type: DefinitionType.COIN,
+                                      }),
+                                  )
+                        }
+                        intent="neutral"
+                        priority="secondary"
+                    >
+                        <Translation id="TR_UNHIDE" />
+                    </Button>
+                ) : (
+                    <ButtonGroup intent="neutral" priority="secondary">
+                        <Tooltip content={<Translation id="TR_NAV_SEND" />}>
+                            <IconButton
+                                isDisabled={token.balance === '0'}
+                                key="token-send"
+                                icon="arrowUp"
+                                onClick={onSendButtonClick}
+                            />
+                        </Tooltip>
+
+                        <Tooltip
+                            content={
+                                <Translation
+                                    id={
+                                        isDeviceCompromised
+                                            ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
+                                            : 'TR_NAV_RECEIVE'
+                                    }
+                                />
+                            }
+                        >
+                            <IconButton
+                                key="token-receive"
+                                icon="arrowDown"
+                                isDisabled={!canReceiveToken}
+                                onClick={onReceiveButtonClick}
+                            />
+                        </Tooltip>
+                    </ButtonGroup>
+                ))}
+        </Row>
+    );
+};
+
+interface TokenRowActionsProps {
+    type?: TokensTableType;
+    token: EnhancedTokenInfo;
+    tokenStatusType: TokenManagementAction;
+    account: Account;
+    network: Network;
+    yieldOpportunities?: YieldDto[];
+    isUnverifiedTable?: boolean;
+    setShowDeactivateModal: (value: boolean) => void;
+}
+
+export const TokenRowActions = ({
+    type = 'default',
+    token,
+    tokenStatusType,
+    account,
+    network,
+    yieldOpportunities,
+    isUnverifiedTable,
+    setShowDeactivateModal,
+}: TokenRowActionsProps) => {
+    if (type === 'defi') {
+        return (
+            <TokenRowYieldActions
+                token={token}
+                account={account}
+                network={network}
+                yieldOpportunities={yieldOpportunities}
+            />
+        );
+    }
+
+    return (
+        <TokenRowBasicActions
+            type={type}
+            token={token}
+            tokenStatusType={tokenStatusType}
+            account={account}
+            network={network}
+            isUnverifiedTable={isUnverifiedTable}
+            setShowDeactivateModal={setShowDeactivateModal}
+        />
+    );
+};

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -6,7 +6,7 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDto } from '@suite-common/earn-api';
+import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
     DefinitionType,
     type EnhancedTokenInfo,
@@ -61,23 +61,54 @@ import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import type { TokensTableType } from './types';
 
-interface TokenRowYieldActionsProps {
+interface TokenRowBasicActionsProps {
+    type?: TokensTableType;
     token: EnhancedTokenInfo;
+    tokenStatusType: TokenManagementAction;
     account: Account;
     network: Network;
+    isUnverifiedTable?: boolean;
     yieldOpportunities?: YieldDto[];
+    setShowDeactivateModal: (value: boolean) => void;
 }
 
-const TokenRowYieldActions = ({
+const TokenRowBasicActions = ({
+    type = 'default',
     token,
+    tokenStatusType,
     account,
     network,
+    isUnverifiedTable,
     yieldOpportunities,
-}: TokenRowYieldActionsProps) => {
+    setShowDeactivateModal,
+}: TokenRowBasicActionsProps) => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
+    const device = useSelector(selectSelectedDevice);
+    const { isLocked } = useDevice();
+    const { isBelowTablet } = useLayoutSize();
+
+    const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
+    const shouldShowUnhideTokenModal = useSelector(selectIsUnhideTokenModalShown);
 
     const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
+
+    const { coins } = useSelector(selectTradingInfo);
+    const isDeviceLocked = isLocked(true);
+    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
+
+    const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
+    const explorerUrl = useExternalLink(getTokenExplorerUrl(explorer, network.networkType, token));
+
+    const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
+    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
+    const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
+
+    const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
+    const canSwapToken =
+        (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
+    const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
+    const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
 
     const availableVault = yieldOpportunities?.find(
         vault =>
@@ -90,6 +121,8 @@ const TokenRowYieldActions = ({
 
     const isSupplyButtonDisabled = !availableVault || !availableVault.status.enter;
     const isWithdrawButtonDisabled = !availableVault || !availableVault.status.exit;
+
+    if (!unusedAddress || !device) return null;
 
     const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
         if (network.networkType) {
@@ -135,137 +168,6 @@ const TokenRowYieldActions = ({
                 }),
             }),
         );
-    };
-
-    const onSendButtonClick = () => {
-        dispatch(
-            setSendFormPrefill({
-                contractAddress: token.contract,
-            }),
-        );
-        dispatch(
-            sendFormActions.removeDraft({
-                accountKey: account.key,
-            }),
-        );
-
-        goToWithAnalytics({
-            routeName: 'wallet-send',
-            params: {
-                symbol: account.symbol,
-                accountIndex: account.index,
-                accountType: account.accountType,
-            },
-        });
-    };
-
-    const onReceiveButtonClick = () => {
-        if (!path) return;
-        dispatch(showAddress(path, unusedAddress));
-    };
-
-    return (
-        <Row gap={8}>
-            <Dropdown
-                placement={{ position: 'bottom', alignment: 'start' }}
-                items={[
-                    {
-                        label: <Translation id="TR_SEND" />,
-                        icon: 'arrowUp',
-                        onClick: onSendButtonClick,
-                    },
-                    {
-                        label: <Translation id="TR_RECEIVE" />,
-                        icon: 'arrowDown',
-                        onClick: onReceiveButtonClick,
-                    },
-                ]}
-            />
-
-            <ButtonGroup intent="neutral" priority="secondary">
-                <Tooltip
-                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
-                    isActive={isSupplyButtonDisabled}
-                >
-                    <IconButton
-                        icon="plus"
-                        isDisabled={isSupplyButtonDisabled}
-                        onClick={navigateToYieldSupply}
-                    />
-                </Tooltip>
-
-                <Tooltip
-                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
-                    isActive={isWithdrawButtonDisabled}
-                >
-                    <IconButton
-                        icon="minus"
-                        isDisabled={isWithdrawButtonDisabled}
-                        onClick={navigateToYieldWithdraw}
-                    />
-                </Tooltip>
-            </ButtonGroup>
-        </Row>
-    );
-};
-
-interface TokenRowBasicActionsProps {
-    type?: TokensTableType;
-    token: EnhancedTokenInfo;
-    tokenStatusType: TokenManagementAction;
-    account: Account;
-    network: Network;
-    isUnverifiedTable?: boolean;
-    setShowDeactivateModal: (value: boolean) => void;
-}
-
-const TokenRowBasicActions = ({
-    token,
-    tokenStatusType,
-    account,
-    network,
-    isUnverifiedTable,
-    setShowDeactivateModal,
-}: TokenRowBasicActionsProps) => {
-    const dispatch = useDispatch();
-    const analytics = useAnalytics();
-    const device = useSelector(selectSelectedDevice);
-    const { isLocked } = useDevice();
-    const { isBelowTablet } = useLayoutSize();
-
-    const shouldShowCopyAddressModal = useSelector(selectIsCopyAddressModalShown);
-    const shouldShowUnhideTokenModal = useSelector(selectIsUnhideTokenModalShown);
-
-    const { address: unusedAddress, path } = getUnusedAddressFromAccount(account);
-
-    const { coins } = useSelector(selectTradingInfo);
-    const isDeviceLocked = isLocked(true);
-    const isDeviceCompromised = useSelector(selectIsDeviceCompromised);
-
-    const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
-
-    const explorerUrl = useExternalLink(getTokenExplorerUrl(explorer, network.networkType, token));
-
-    const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
-    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
-    const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
-
-    const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
-    const canSwapToken =
-        (!!tokenTradingOptions && tokenTradingOptions.exchange) || token.balance === '0';
-    const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
-    const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
-
-    if (!unusedAddress || !device) return null;
-
-    const goToWithAnalytics = (...[payload]: Parameters<typeof goto>) => {
-        if (network.networkType) {
-            analytics.report({
-                type: events.accountsActionsEvent.name,
-                payload: { symbol: network.symbol, action: payload.routeName },
-            });
-        }
-        dispatch(goto(payload));
     };
 
     const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
@@ -455,7 +357,7 @@ const TokenRowBasicActions = ({
                         'data-testid': '@trading/tokens/swap-button',
                         icon: 'arrowsLeftRight',
                         onClick: onSwapButtonClick,
-                        isHidden: !isBelowTablet,
+                        isHidden: type === 'defi' ? false : !isBelowTablet,
                         isDisabled: !canSwapToken,
                     },
                     {
@@ -465,7 +367,10 @@ const TokenRowBasicActions = ({
                         onClick: onSendButtonClick,
                         isDisabled: token.balance === '0',
                         isHidden:
-                            tokenStatusType === TokenManagementAction.HIDE ? !isBelowTablet : true,
+                            type !== 'defi' &&
+                            (tokenStatusType === TokenManagementAction.HIDE
+                                ? !isBelowTablet
+                                : true),
                     },
                     {
                         label: <Translation id="TR_NAV_RECEIVE" />,
@@ -474,21 +379,24 @@ const TokenRowBasicActions = ({
                         onClick: onReceiveButtonClick,
                         isDisabled: !canReceiveToken,
                         isHidden:
-                            tokenStatusType === TokenManagementAction.HIDE ? !isBelowTablet : true,
+                            type !== 'defi' &&
+                            (tokenStatusType === TokenManagementAction.HIDE
+                                ? !isBelowTablet
+                                : true),
                     },
                     {
                         label: <Translation id="TR_EARN_YIELD_SUPPLY" />,
                         icon: 'plus',
                         onClick: () => {},
-                        isDisabled: true,
-                        isHidden: !isErc4626(token),
+                        isDisabled: type === 'defi' ? isSupplyButtonDisabled : true,
+                        isHidden: type === 'defi' ? !isBelowTablet : !isErc4626(token),
                     },
                     {
                         label: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
                         icon: 'minus',
                         onClick: () => {},
-                        isDisabled: true,
-                        isHidden: !isErc4626(token),
+                        isDisabled: type === 'defi' ? isWithdrawButtonDisabled : true,
+                        isHidden: type === 'defi' ? !isBelowTablet : !isErc4626(token),
                     },
                     {
                         label: (
@@ -525,7 +433,7 @@ const TokenRowBasicActions = ({
                 ]}
             />
 
-            {!isBelowTablet && (
+            {type !== 'defi' && !isBelowTablet && (
                 <Tooltip
                     content={
                         canSwapToken ? (
@@ -573,35 +481,63 @@ const TokenRowBasicActions = ({
                         <Translation id="TR_UNHIDE" />
                     </Button>
                 ) : (
-                    <ButtonGroup intent="neutral" priority="secondary">
-                        <Tooltip content={<Translation id="TR_NAV_SEND" />}>
-                            <IconButton
-                                isDisabled={token.balance === '0'}
-                                key="token-send"
-                                icon="arrowUp"
-                                onClick={onSendButtonClick}
-                            />
-                        </Tooltip>
+                    <>
+                        {type === 'defi' ? (
+                            <ButtonGroup intent="neutral" priority="secondary">
+                                <Tooltip
+                                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
+                                    isActive={isSupplyButtonDisabled}
+                                >
+                                    <IconButton
+                                        icon="plus"
+                                        isDisabled={isSupplyButtonDisabled}
+                                        onClick={navigateToYieldSupply}
+                                    />
+                                </Tooltip>
 
-                        <Tooltip
-                            content={
-                                <Translation
-                                    id={
-                                        isDeviceCompromised
-                                            ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
-                                            : 'TR_NAV_RECEIVE'
+                                <Tooltip
+                                    content={<Translation id="TR_DEFI_NO_VAULT_TOOLTIP" />}
+                                    isActive={isWithdrawButtonDisabled}
+                                >
+                                    <IconButton
+                                        icon="minus"
+                                        isDisabled={isWithdrawButtonDisabled}
+                                        onClick={navigateToYieldWithdraw}
+                                    />
+                                </Tooltip>
+                            </ButtonGroup>
+                        ) : (
+                            <ButtonGroup intent="neutral" priority="secondary">
+                                <Tooltip content={<Translation id="TR_NAV_SEND" />}>
+                                    <IconButton
+                                        isDisabled={token.balance === '0'}
+                                        key="token-send"
+                                        icon="arrowUp"
+                                        onClick={onSendButtonClick}
+                                    />
+                                </Tooltip>
+
+                                <Tooltip
+                                    content={
+                                        <Translation
+                                            id={
+                                                isDeviceCompromised
+                                                    ? 'TR_RECEIVE_ADDRESS_SECURITY_CHECK_FAILED'
+                                                    : 'TR_NAV_RECEIVE'
+                                            }
+                                        />
                                     }
-                                />
-                            }
-                        >
-                            <IconButton
-                                key="token-receive"
-                                icon="arrowDown"
-                                isDisabled={!canReceiveToken}
-                                onClick={onReceiveButtonClick}
-                            />
-                        </Tooltip>
-                    </ButtonGroup>
+                                >
+                                    <IconButton
+                                        key="token-receive"
+                                        icon="arrowDown"
+                                        isDisabled={!canReceiveToken}
+                                        onClick={onReceiveButtonClick}
+                                    />
+                                </Tooltip>
+                            </ButtonGroup>
+                        )}
+                    </>
                 ))}
         </Row>
     );
@@ -627,27 +563,15 @@ export const TokenRowActions = ({
     yieldOpportunities,
     isUnverifiedTable,
     setShowDeactivateModal,
-}: TokenRowActionsProps) => {
-    if (type === 'defi') {
-        return (
-            <TokenRowYieldActions
-                token={token}
-                account={account}
-                network={network}
-                yieldOpportunities={yieldOpportunities}
-            />
-        );
-    }
-
-    return (
-        <TokenRowBasicActions
-            type={type}
-            token={token}
-            tokenStatusType={tokenStatusType}
-            account={account}
-            network={network}
-            isUnverifiedTable={isUnverifiedTable}
-            setShowDeactivateModal={setShowDeactivateModal}
-        />
-    );
-};
+}: TokenRowActionsProps) => (
+    <TokenRowBasicActions
+        type={type}
+        token={token}
+        tokenStatusType={tokenStatusType}
+        account={account}
+        network={network}
+        isUnverifiedTable={isUnverifiedTable}
+        yieldOpportunities={yieldOpportunities}
+        setShowDeactivateModal={setShowDeactivateModal}
+    />
+);

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { type YieldDto } from '@suite-common/earn-api';
 import {
     type EnhancedTokenInfo,
     type TokenManagementAction,
@@ -14,6 +15,7 @@ import { spacings } from '@trezor/theme';
 import { useDispatch } from 'src/hooks/suite';
 
 import { TokenRow } from './TokenRow';
+import type { TokensTableType } from './types';
 import { DropdownRow } from '../../DropdownRow';
 
 const NoSearchResults = () => (
@@ -29,6 +31,7 @@ export const NoSearchResultsWrapped = () => (
 );
 
 interface TokensTableProps {
+    type?: TokensTableType;
     account: Account;
     tokensWithBalance: EnhancedTokenInfo[];
     tokensWithoutBalance: EnhancedTokenInfo[];
@@ -37,9 +40,11 @@ interface TokensTableProps {
     hideRates?: boolean;
     searchQuery?: string;
     isUnverifiedTable?: boolean;
+    yieldOpportunities?: YieldDto[];
 }
 
 export const TokensTable = ({
+    type = 'default',
     account,
     tokensWithBalance,
     tokensWithoutBalance,
@@ -48,6 +53,7 @@ export const TokensTable = ({
     hideRates,
     searchQuery,
     isUnverifiedTable,
+    yieldOpportunities,
 }: TokensTableProps) => {
     const dispatch = useDispatch();
     const [isZeroBalanceOpen, setIsZeroBalanceOpen] = useState(false);
@@ -82,9 +88,11 @@ export const TokensTable = ({
                                     <Table.Cell align="end">
                                         <Translation id="TR_EXCHANGE_RATE" />
                                     </Table.Cell>
-                                    <Table.Cell colSpan={2}>
-                                        <Translation id="TR_7D_CHANGE" />
-                                    </Table.Cell>
+                                    {type !== 'defi' && (
+                                        <Table.Cell colSpan={2}>
+                                            <Translation id="TR_7D_CHANGE" />
+                                        </Table.Cell>
+                                    )}
                                 </>
                             )}
                         </Table.Row>
@@ -92,6 +100,7 @@ export const TokensTable = ({
                     <Table.Body>
                         {tokensWithBalance.map(token => (
                             <TokenRow
+                                type={type}
                                 key={token.contract}
                                 token={token}
                                 account={account}
@@ -99,6 +108,7 @@ export const TokensTable = ({
                                 tokenStatusType={tokenStatusType}
                                 isUnverifiedTable={isUnverifiedTable}
                                 hideRates={hideRates}
+                                yieldOpportunities={yieldOpportunities}
                             />
                         ))}
                         {tokensWithoutBalance.length !== 0 && (
@@ -117,6 +127,7 @@ export const TokensTable = ({
                                 </Table.Row>
                                 {tokensWithoutBalance.map(token => (
                                     <TokenRow
+                                        type={type}
                                         key={token.contract}
                                         token={token}
                                         account={account}
@@ -125,6 +136,7 @@ export const TokensTable = ({
                                         isUnverifiedTable={isUnverifiedTable}
                                         hideRates={hideRates}
                                         isCollapsed={!isZeroBalanceOpen}
+                                        yieldOpportunities={yieldOpportunities}
                                     />
                                 ))}
                             </>

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokensTable.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { type YieldDto } from '@suite-common/earn-api';
+import { type YieldDto } from '@suite-common/earn-stablecoin-api';
 import {
     type EnhancedTokenInfo,
     type TokenManagementAction,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/types.ts
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/types.ts
@@ -1,0 +1,1 @@
+export type TokensTableType = 'default' | 'defi' | 'hidden';

--- a/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
-import { useAllYieldOpportunities } from '@suite-common/earn-api';
+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
@@ -62,7 +62,7 @@ export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTabl
             <TokensTable
                 type="defi"
                 account={account}
-                tokenStatusType={TokenManagementAction.SHOW}
+                tokenStatusType={TokenManagementAction.HIDE}
                 tokensWithBalance={tokens.shownWithBalance}
                 tokensWithoutBalance={tokens.shownWithoutBalance}
                 network={network}

--- a/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useAllYieldOpportunities } from '@suite-common/earn-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
-import { isErc4626, isTestnet } from '@suite-common/wallet-utils';
+import { isErc4626 } from '@suite-common/wallet-utils';
+import { Banner, Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 import {
@@ -13,27 +15,27 @@ import {
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
 
-import { NoTokens } from '../common/NoTokens';
 import { TokensTable } from '../common/TokensTable/TokensTable';
 
-interface CoinsTableProps {
+interface DefiTokensTableProps {
     selectedAccount: SelectedAccountLoaded;
     searchQuery: string;
 }
 
-export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) => {
-    const fiatRates = useSelector(selectCurrentFiatRates);
-    const baseCurrencyCode = useSelector(selectBaseCurrency);
-
+export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTableProps) => {
     const { account, network } = selectedAccount;
 
+    const fiatRates = useSelector(selectCurrentFiatRates);
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
 
+    const { yieldOpportunities } = useAllYieldOpportunities();
+
     const enhancedTokens = useMemo(() => {
-        const accountTokens = account.tokens?.filter(token => !isErc4626(token));
+        const erc4626Tokens = account.tokens?.filter(isErc4626);
 
         const tokensWithRates = enhanceTokensWithRates(
-            accountTokens,
+            erc4626Tokens,
             baseCurrencyCode,
             account.symbol,
             fiatRates,
@@ -53,31 +55,20 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
         [enhancedTokens, account.symbol, coinDefinitions, searchQuery],
     );
 
-    const hiddenTokensCount =
-        tokens.unverifiedWithBalance.length +
-        tokens.hiddenWithBalance.length +
-        tokens.unverifiedWithoutBalance.length +
-        tokens.hiddenWithoutBalance.length;
+    return (
+        <Column gap={14}>
+            <Banner intent="info" description={<Translation id="TR_DEFI_BANNER_TEXT" />} />
 
-    return tokens.shownWithBalance.length > 0 ||
-        tokens.shownWithoutBalance.length > 0 ||
-        searchQuery ? (
-        <TokensTable
-            account={account}
-            hideRates={isTestnet(account.symbol)}
-            tokenStatusType={TokenManagementAction.HIDE}
-            tokensWithBalance={tokens.shownWithBalance}
-            tokensWithoutBalance={tokens.shownWithoutBalance}
-            network={network}
-            searchQuery={searchQuery}
-        />
-    ) : (
-        <NoTokens
-            title={
-                <Translation
-                    id={hiddenTokensCount > 0 ? 'TR_TOKENS_EMPTY_CHECK_HIDDEN' : 'TR_TOKENS_EMPTY'}
-                />
-            }
-        />
+            <TokensTable
+                type="defi"
+                account={account}
+                tokenStatusType={TokenManagementAction.SHOW}
+                tokensWithBalance={tokens.shownWithBalance}
+                tokensWithoutBalance={tokens.shownWithoutBalance}
+                network={network}
+                searchQuery={searchQuery}
+                yieldOpportunities={yieldOpportunities}
+            />
+        </Column>
     );
 };

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
@@ -76,6 +76,7 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
                         description={<Translation id="TR_TOKEN_UNRECOGNIZED_BY_TREZOR_TOOLTIP" />}
                     />
                     <TokensTable
+                        type="hidden"
                         account={account}
                         hideRates
                         tokenStatusType={TokenManagementAction.SHOW}

--- a/packages/suite/src/views/wallet/tokens/index.tsx
+++ b/packages/suite/src/views/wallet/tokens/index.tsx
@@ -13,6 +13,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { TokensNavigation } from './TokensNavigation';
 import { CoinsTable } from './coins/CoinsTable';
+import { DefiTokensTable } from './defi/DefiTokensTable';
 import { HiddenTokensTable } from './hidden-tokens/HiddenTokensTable';
 import { InactiveTokensTable } from './inactive-tokens/InactiveTokensTable';
 
@@ -85,6 +86,9 @@ export const Tokens = () => {
                         selectedAccount={selectedAccount}
                         searchQuery={searchQuery}
                     />
+                </Route>
+                <Route name="wallet-tokens-defi">
+                    <DefiTokensTable selectedAccount={selectedAccount} searchQuery={searchQuery} />
                 </Route>
             </Column>
 

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -55,6 +55,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
             details: 'tokenBalances',
             contractFilter: t.contract,
             suppressBackupWarning: true,
+            includeErc4626: isEvmNetwork ? true : undefined,
         }),
     );
 
@@ -133,6 +134,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             page: 1, // useful for every network except ripple and stellar
             pageSize,
             suppressBackupWarning: true,
+            includeErc4626: account.networkType === 'ethereum' ? true : undefined,
         });
 
         if (response.success) {

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -113,8 +113,11 @@ export const selectDiscoveryAccountsParam = (
         const { networkType } = networks[symbol];
         const identity = tryGetAccountIdentity({ networkType, deviceState });
 
+        const includeErc4626 = networkType === 'ethereum' ? true : undefined;
+
         // undiscovered network; discover as a whole
-        if (!accounts) return { symbol, identity } as DiscoveryAccountsParam[number];
+        if (!accounts)
+            return { symbol, identity, includeErc4626 } as DiscoveryAccountsParam[number];
 
         const known = getLastAccountsPerAccountType(accounts).map(({ type, lastAccount }) => {
             // last account is a failed one; try to discover it again
@@ -125,7 +128,13 @@ export const selectDiscoveryAccountsParam = (
             else return { type };
         });
 
-        return { symbol, identity, known, knownOnly } as DiscoveryAccountsParam[number];
+        return {
+            symbol,
+            identity,
+            includeErc4626,
+            known,
+            knownOnly,
+        } as DiscoveryAccountsParam[number];
     });
 
 export const selectShowRediscoverButton = (

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -481,6 +481,7 @@ export const fetchTransactionsPageThunk = createThunk(
             // if back on first page, the marker is reset
             ...(marker && !isFirstPage ? { marker } : {}),
             suppressBackupWarning: true,
+            includeErc4626: account.networkType === 'ethereum' ? true : undefined,
         });
 
         // Account might have changed during async getAccountInfo call, so we fetch current state

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -111,3 +111,5 @@ const PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS: ReadonlySet<TokenStandard> = new Set
 
 export const shouldUppercaseTokenSymbol = (token: TokenInfo) =>
     token.standard ? !PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS.has(token.standard) : true;
+
+export const isErc4626 = (token: TokenInfo) => 'erc4626' in token;

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -7,7 +7,12 @@ import {
     selectFilterKnownTokens,
     selectNetworkTokenDefinitions,
 } from '@suite-common/token-definitions';
-import { type AccountType, type Bip43Path, type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountType,
+    type Bip43Path,
+    type NetworkSymbol,
+    getNetworkType,
+} from '@suite-common/wallet-config';
 import {
     accountsActions,
     selectAccountsByNetworkAndDeviceState,
@@ -101,6 +106,7 @@ export const getAccountInfoThunk = createThunk<
                     descriptor: taprootXpubWithApostrophes ?? xpubAddress,
                     details: 'txs',
                     suppressBackupWarning: true,
+                    includeErc4626: getNetworkType(symbol) === 'ethereum' ? true : undefined,
                 }),
                 dispatch(
                     updateFiatRatesThunk({

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1758,6 +1758,19 @@ export const messages = defineMessages({
         defaultMessage: 'Hidden',
         id: 'TR_HIDDEN',
     },
+    TR_DEFI: {
+        defaultMessage: 'DeFi',
+        id: 'TR_DEFI',
+    },
+    TR_DEFI_BANNER_TEXT: {
+        id: 'TR_DEFI_BANNER_TEXT',
+        defaultMessage:
+            'These tokens represent your DeFi positions. Sending or swapping them will transfer ownership of those positions.',
+    },
+    TR_DEFI_NO_VAULT_TOOLTIP: {
+        id: 'TR_DEFI_NO_VAULT_TOOLTIP',
+        defaultMessage: 'No vault found',
+    },
     TR_CONFIRM: {
         defaultMessage: 'Confirm',
         id: 'TR_CONFIRM',
@@ -2929,6 +2942,10 @@ export const messages = defineMessages({
         description:
             'User is instructed to enter words from seed (backup) into the form in browser',
         id: 'TR_RANDOM_SEED_WORDS_DISCLAIMER',
+    },
+    TR_SEND: {
+        defaultMessage: 'Send',
+        id: 'TR_SEND',
     },
     TR_RECEIVE: {
         defaultMessage: 'Receive',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1767,6 +1767,15 @@ export const messages = defineMessages({
         defaultMessage:
             'These tokens represent your DeFi positions. Sending or swapping them will transfer ownership of those positions.',
     },
+    TR_DEFI_YIELD_TOKEN_BANNER_TITLE: {
+        id: 'TR_DEFI_YIELD_TOKEN_BANNER_TITLE',
+        defaultMessage: '{token} represents your position in a vault.',
+    },
+    TR_DEFI_YIELD_TOKEN_BANNER_DESCRIPTION: {
+        id: 'TR_DEFI_YIELD_TOKEN_BANNER_DESCRIPTION',
+        defaultMessage:
+            'If you transfer this token elsewhere, you will move your entire position and stop future rewards.',
+    },
     TR_DEFI_NO_VAULT_TOOLTIP: {
         id: 'TR_DEFI_NO_VAULT_TOOLTIP',
         defaultMessage: 'No vault found',

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -311,6 +311,13 @@ export const routes = [
         isNestedRoute: true,
     },
     {
+        name: 'wallet-tokens-defi',
+        pattern: '/accounts/tokens/defi',
+        app: 'wallet',
+        params: walletParams,
+        isNestedRoute: true,
+    },
+    {
         name: 'wallet-nfts',
         pattern: '/accounts/nfts',
         app: 'wallet',

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -16,6 +16,7 @@ const ACCOUNT_TABS = [
     'wallet-nfts-hidden',
     'wallet-tokens-hidden',
     'wallet-tokens-inactive',
+    'wallet-tokens-defi',
     'wallet-staking',
 ];
 


### PR DESCRIPTION
## Description

- add new `DeFi` section to account tokens with supply/withdraw buttons.
- add DeFi token banner to send form

## Related Issue

Resolve #25636 
Resolve #25637 

## Screenshots

<img width="100%" alt="Screenshot 2026-04-20 at 16 45 12" src="https://github.com/user-attachments/assets/78443b25-4523-48dc-baa8-eb1de97731ed" />

<img width="100%" alt="Screenshot 2026-04-22 at 11 02 45" src="https://github.com/user-attachments/assets/b40f1469-7858-4ce9-b042-4a4f20405b1f" />

<img width="100%" alt="Screenshot 2026-04-22 at 11 06 04" src="https://github.com/user-attachments/assets/9629d072-099c-4387-82c4-a4d8998c7760" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/defi&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/defi&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/defi&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T10:05:40.585Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-22T12:06:42.230Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/defi/web/](https://dev.suite.sldev.cz/suite-web/feat/defi/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->