### PR TITLE
fix(suite): fix btc csv import test

### DIFF
--- a/suite/e2e/fixtures/btcTest.csv
+++ b/suite/e2e/fixtures/btcTest.csv
@@ -1,3 +1,3 @@
 address,amount,currency,label
 bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz,0.31337,BTC,meow
-bc1quqgq44wq0zjh6d920zs42nsy4n4ev5vt8nxke4,0.1,USD
+bc1quqgq44wq0zjh6d920zs42nsy4n4ev5vt8nxke4,0.5,USD, meow2

--- a/suite/e2e/tests/wallet/import-btc-csv.test.ts
+++ b/suite/e2e/tests/wallet/import-btc-csv.test.ts
@@ -9,10 +9,11 @@ import { MetadataProvider } from '../../support/mocks/metadataMock';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
 test.describe('Import a BTC csv file', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
-    test.beforeEach(async ({ metadataMock, onboardingPage, settingsPage }) => {
+    test.beforeEach(async ({ metadataMock, onboardingPage, settingsPage, metadataPage }) => {
         await metadataMock.start(MetadataProvider.DROPBOX);
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
+        await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
     });
 
     test(
@@ -46,8 +47,11 @@ test.describe('Import a BTC csv file', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
                 convertedData[0]?.amount ?? '',
             );
             await expect(page.getByTestId('outputs.0.fiat')).toBeVisible();
-            // TODO: Uncomment this when https://github.com/trezor/trezor-suite/issues/19146 is fixed
-            //await expect(page.getByTestId('outputs.0.fiat')).toHaveValue(/^\d+(\.\d+)?$/);
+            await expect(page.getByTestId('outputs.0.fiat')).toHaveValue(/^[\d,]+(\.\d+)?$/);
+            await expect(page.getByTestId('@metadata/outputLabel/0/hover-container')).toBeVisible();
+            await expect(page.getByTestId('@metadata/outputLabel/0/hover-container')).toHaveText(
+                convertedData[0]?.label ?? '',
+            );
 
             await expect(page.getByTestId('outputs.1.address')).toBeVisible();
             await expect(page.getByTestId('outputs.1.address')).toHaveValue(
@@ -58,6 +62,10 @@ test.describe('Import a BTC csv file', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, 
             await expect(page.getByTestId('outputs.1.fiat')).toBeVisible();
             await expect(page.getByTestId('outputs.1.fiat')).toHaveValue(
                 convertedData[1]?.amount ?? '',
+            );
+            await expect(page.getByTestId('@metadata/outputLabel/1/hover-container')).toBeVisible();
+            await expect(page.getByTestId('@metadata/outputLabel/1/hover-container')).toHaveText(
+                convertedData[1]?.label ?? '',
             );
         },
     );


### PR DESCRIPTION
Fixes a test for importing a csv because it wasn't asserting labels included in the csv. I also included label for the second input and fixed checking of the fiat input value to assert for all positive number values.

Although, it needs to wait for this fix first https://github.com/trezor/trezor-suite/pull/26328

## Description

- Added assertions for CSV labels on both outputs in the BTC CSV import test
- Fixed fiat value assertion to match any positive number (regex) rather than a fixed value
- Added `settingsPage.changeNetworks` to enable BTC network in `beforeEach` (merged from develop)

## Notes for QA



## Related Issue

Resolve 

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-btc-import-test/web/](https://dev.suite.sldev.cz/suite-web/test/fix-btc-import-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-btc-import-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-btc-import-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Remembered wallet loading > Load remembered wallet and open receive forms without connected device | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-12T16:16:46.470Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-12T16:15:23.940Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->