### PR TITLE
chore: toGetter now supports selector with params

### DIFF
--- a/suite-common/delegated-identity-key/package.json
+++ b/suite-common/delegated-identity-key/package.json
@@ -14,6 +14,7 @@
         "@noble/curves": "^2.0.1",
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/delegated-identity-key-types": "workspace:*",
+        "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
+++ b/suite-common/delegated-identity-key/src/delegatedIdentityKeyCompositionRoot.ts
@@ -1,5 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
+import { toGetter } from '@suite-common/dependency-injection';
 import { selectDeviceDelegatedIdentityKey } from '@suite-common/device';
 import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 
@@ -24,8 +25,10 @@ export const delegatedIdentityKeyCompositionRoot = (
         loadDelegatedIdentityKeyFromState: createLoadDelegatedIdentityKeyFromState({
             dispatch: deps.dispatch,
             platformEncryption: deps.platformEncryption,
-            getDeviceDelegatedIdentityKey: deviceId =>
-                selectDeviceDelegatedIdentityKey(deps.getState(), deviceId),
+            getDeviceDelegatedIdentityKey: toGetter(
+                deps.getState,
+                selectDeviceDelegatedIdentityKey,
+            ),
         }),
         retrieveDelegatedIdentityKeyFromDevice: createRetrieveDelegatedIdentityKeyFromDevice({
             trezorConnect: deps.trezorConnect,

--- a/suite-common/delegated-identity-key/tsconfig.json
+++ b/suite-common/delegated-identity-key/tsconfig.json
@@ -8,6 +8,7 @@
         {
             "path": "../delegated-identity-key-types"
         },
+        { "path": "../dependency-injection" },
         { "path": "../device" },
         { "path": "../platform-encryption" },
         { "path": "../suite-types" },

--- a/suite-common/dependency-injection/src/__tests__/toGetter.test.ts
+++ b/suite-common/dependency-injection/src/__tests__/toGetter.test.ts
@@ -1,0 +1,46 @@
+import { toGetter } from '../toGetter';
+
+type TestState = {
+    relayUrl: string;
+    selectedWalletDescriptor: string;
+};
+
+const state: TestState = {
+    relayUrl: 'wss://relay.example.com',
+    selectedWalletDescriptor: 'wallet-1',
+};
+
+const getState = () => state;
+
+describe(toGetter.name, () => {
+    it('creates a getter for selectors without extra params', () => {
+        const getRelayUrl = toGetter(getState, currentState => currentState.relayUrl);
+
+        expect(getRelayUrl()).toBe('wss://relay.example.com');
+    });
+
+    it('creates a getter for selectors with one extra param', () => {
+        type GetIsSelectedWallet = (walletDescriptor: string) => boolean;
+
+        const isSelectedWallet: GetIsSelectedWallet = toGetter(
+            getState,
+            (currentState: TestState, walletDescriptor: string) =>
+                currentState.selectedWalletDescriptor === walletDescriptor,
+        );
+
+        expect(isSelectedWallet('wallet-1')).toBe(true);
+        expect(isSelectedWallet('wallet-2')).toBe(false);
+    });
+
+    it('forwards multiple selector params', () => {
+        type GetRelayLabel = (walletDescriptor: string, suffix: number) => string;
+
+        const getRelayLabel: GetRelayLabel = toGetter(
+            getState,
+            (currentState: TestState, label: string, suffix: number) =>
+                `${label}:${currentState.relayUrl}:${suffix}`,
+        );
+
+        expect(getRelayLabel('relay', 2)).toBe('relay:wss://relay.example.com:2');
+    });
+});

--- a/suite-common/dependency-injection/src/createMockDeps.ts
+++ b/suite-common/dependency-injection/src/createMockDeps.ts
@@ -1,7 +1,7 @@
 import { type NullablePropsRecursive } from '@trezor/type-utils';
 
 import { mockNotExpected } from './mock';
-import { type RecursiveDeps, type ServiceFunction } from '../service';
+import { type RecursiveDeps, type ServiceFunction } from './service';
 
 export type MockDeps<T extends RecursiveDeps> = {
     [K in keyof T]: T[K] extends ServiceFunction<any, any>

--- a/suite-common/dependency-injection/src/index.ts
+++ b/suite-common/dependency-injection/src/index.ts
@@ -1,5 +1,3 @@
 export { toGetter } from './toGetter';
-
-// Test
-export { mockNotExpected, mock } from './test/mock';
-export { createMockDeps } from './test/createMockDeps';
+export { mockNotExpected, mock } from './mock';
+export { createMockDeps } from './createMockDeps';

--- a/suite-common/dependency-injection/src/mock.ts
+++ b/suite-common/dependency-injection/src/mock.ts
@@ -1,4 +1,4 @@
-import { type ServiceFunction } from '../service';
+import { type ServiceFunction } from '../src/service';
 
 export const mock = <T extends ServiceFunction<any, any>>(fn: T) =>
     jest.fn<ReturnType<T>, Parameters<T>>().mockImplementation(fn);

--- a/suite-common/dependency-injection/src/toGetter.ts
+++ b/suite-common/dependency-injection/src/toGetter.ts
@@ -4,10 +4,19 @@
  * Simply wrap any Redux selector with this + provide getState callback,
  * and you get a service, ready to be used in Dependency Injection.
  */
-export const toGetter =
-    <TReturn, TParams extends any[], TState = any>(
-        getState: () => TState,
-        selector: (state: TState, ...params: TParams) => TReturn,
-    ) =>
-    (...params: TParams): TReturn =>
-        selector(getState(), ...params);
+export function toGetter<TState, TReturn>(
+    getState: () => TState,
+    selector: (state: TState) => TReturn,
+): () => TReturn;
+
+export function toGetter<TState, TParams extends unknown[], TReturn>(
+    getState: () => TState,
+    selector: (state: TState, ...params: TParams) => TReturn,
+): (...params: TParams) => TReturn;
+
+export function toGetter<TState, TParams extends unknown[], TReturn>(
+    getState: () => TState,
+    selector: (state: TState, ...params: TParams) => TReturn,
+) {
+    return (...params: TParams): TReturn => selector(getState(), ...params);
+}

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -19,14 +19,7 @@ import {
     type SuiteSyncAppReloaderDep,
     type SuiteSyncErrorHandler,
 } from '@suite-common/suite-sync-types';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import {
-    type AccountDescriptor,
-    type TxTargetId,
-    type WalletDescriptor,
-} from '@suite-common/wallet-types';
 import { type Analytics } from '@trezor/analytics-uploader';
-import { type StaticSessionId } from '@trezor/connect';
 
 import { createRefreshSuiteSync } from './createRefreshSuiteSyncKeys';
 import { createSuiteSyncErrorHandler } from './createSuiteSyncErrorHandler';
@@ -128,8 +121,7 @@ export const createSuiteSyncCompositionRoot = (
     const ensureQuota = createEnsureQuota({
         dispatch: deps.dispatch,
         getDeviceForStaticSessionId,
-        hasAllowance: ({ walletDescriptor, deviceId }) =>
-            selectHasDeviceAllowance(deps.getState(), deviceId ?? null, walletDescriptor),
+        hasAllowance: toGetter(deps.getState, selectHasDeviceAllowance),
         getIsDefaultRelayUrlSet: () =>
             isUsingTrezorServer(selectSuiteSyncRelayUrl(deps.getState())),
         getEnforceQuotaManager: toGetter(deps.getState, selectEnforceQuotaManager),
@@ -183,26 +175,10 @@ export const createSuiteSyncCompositionRoot = (
     const labelingDeps = {
         ensureWalletSuiteSyncOn,
         analytics: deps.analytics,
-        getWalletLabel: (walletDescriptor: WalletDescriptor) =>
-            selectSuiteSyncWalletLabel(deps.getState(), walletDescriptor),
-        getAccountLabel: (
-            walletDescriptor: WalletDescriptor | null,
-            accountDescriptor: AccountDescriptor,
-            networkSymbol: NetworkSymbol,
-        ) =>
-            selectSuiteSyncAccountLabel(
-                deps.getState(),
-                walletDescriptor,
-                accountDescriptor,
-                networkSymbol,
-            ),
-        getAddressLabel: (deviceStaticSessionId: StaticSessionId, address: string) =>
-            selectSuiteSyncAddressLabel(deps.getState(), deviceStaticSessionId, address),
-        getOutputLabel: (
-            txId: string,
-            txTargetId: TxTargetId,
-            deviceStaticSessionId: StaticSessionId,
-        ) => selectSuiteSyncOutputLabel(deps.getState(), txId, txTargetId, deviceStaticSessionId),
+        getWalletLabel: toGetter(deps.getState, selectSuiteSyncWalletLabel),
+        getAccountLabel: toGetter(deps.getState, selectSuiteSyncAccountLabel),
+        getAddressLabel: toGetter(deps.getState, selectSuiteSyncAddressLabel),
+        getOutputLabel: toGetter(deps.getState, selectSuiteSyncOutputLabel),
     };
 
     return {

--- a/suite-common/suite-sync/src/getDeviceHasAllowance.ts
+++ b/suite-common/suite-sync/src/getDeviceHasAllowance.ts
@@ -1,9 +1,6 @@
 import type { WalletDescriptor } from '@suite-common/wallet-types';
 
-export type GetDeviceHasAllowance = ({
-    walletDescriptor,
-    deviceId,
-}: {
-    walletDescriptor: WalletDescriptor;
-    deviceId: string;
-}) => boolean;
+export type GetDeviceHasAllowance = (
+    deviceId: string,
+    walletDescriptor: WalletDescriptor,
+) => boolean;

--- a/suite-common/suite-sync/src/storage/createEnsureQuota.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureQuota.ts
@@ -55,10 +55,7 @@ export const createEnsureQuota =
         const isQuotaManagerEnabled =
             deps.getIsDefaultRelayUrlSet() || deps.getEnforceQuotaManager();
 
-        if (
-            deps.hasAllowance({ walletDescriptor, deviceId: device.id }) ||
-            !isQuotaManagerEnabled
-        ) {
+        if (deps.hasAllowance(device.id, walletDescriptor) || !isQuotaManagerEnabled) {
             return ok();
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10667,6 +10667,7 @@ __metadata:
     "@noble/curves": "npm:^2.0.1"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/delegated-identity-key-types": "workspace:*"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/suite-types": "workspace:*"


### PR DESCRIPTION
Just code improvement nothing to test.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=toGetterWithParams&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=toGetterWithParams&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=toGetterWithParams&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-01T20:56:44.360Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-04-01T20:55:11.899Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->