### PR TITLE
test(blockchain-link): change usdc to USDC integration stellar tests

### DIFF
--- a/packages/blockchain-link/tests/integration/stellar.test.ts
+++ b/packages/blockchain-link/tests/integration/stellar.test.ts
@@ -90,7 +90,7 @@ describe('Stellar', () => {
                     decimals: 7,
                     name: 'USDC',
                     standard: 'STELLAR-CLASSIC',
-                    symbol: 'usdc',
+                    symbol: 'USDC',
                 },
             ],
         });
@@ -171,7 +171,7 @@ describe('Stellar', () => {
                     decimals: 7,
                     name: 'USDC',
                     standard: 'STELLAR-CLASSIC',
-                    symbol: 'usdc',
+                    symbol: 'USDC',
                 },
             ],
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We are now getting `USDC` as token symbol instead of `usdt` from the stellar API so it broke tests.


## Notes for QA

Noting to test.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-lik-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-lik-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T10:08:31.717Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-02T10:07:06.217Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->