### PR TITLE
test(connect): update cancel.test to latest FW T1B1 1.14.1

### DIFF
--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -221,6 +221,10 @@ describe('TrezorConnect.cancel', () => {
         const recoveryDeviceCall = TrezorConnect.recoveryDevice({
             passphrase_protection: false,
             pin_protection: false,
+            // Since Version 1.14.1 — 18th March 2026 - if `word_count` is less than 24 words it requires Matrix input,
+            // So we have to provide `word_count: 24,` so this tests stays as it is.
+            // https://github.com/trezor/trezor-firmware/blob/main/legacy/firmware/recovery.c#L481
+            word_count: 24,
         });
 
         await wordPromise;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Since Version 1.14.1 — 18th March 2026 - if `word_count` is less than 24 words it requires Matrix input, So we have to provide `word_count: 24,` so this tests stays as it is.
 https://github.com/trezor/trezor-firmware/blob/main/legacy/firmware/recovery.c#L481

## Notes for QA
Nothing to test.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-test-device-cancel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-test-device-cancel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T11:31:14.853Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->