### PR TITLE
fix(suite-native): fix Skia canvas not updating colors on theme change

### DIFF
--- a/suite-native/icons/src/CryptoIconWithPercentage.tsx
+++ b/suite-native/icons/src/CryptoIconWithPercentage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@shopify/react-native-skia';
 
 import { type CryptoIconName, cryptoIcons } from '@suite-common/icons';
+import { useActiveColorScheme } from '@suite-native/theme';
 import { useNativeStyles } from '@trezor/styles-native';
 import { paletteV1 } from '@trezor/theme';
 
@@ -36,6 +37,7 @@ export const CryptoIconWithPercentage = ({
 }: CryptoIconProps) => {
     const iconSvg = useSVG(cryptoIcons[iconName]);
     const { utils } = useNativeStyles();
+    const colorScheme = useActiveColorScheme();
     // @ts-expect-error: coinsColors uses "NetworkSymbol" type. However, here we use deprecated "CryptoIconName".
     // Not worth fixing it as this package will be removed soon.
     const percentageColor = utils.coinsColors[iconName] ?? utils.colors.textSubdued;
@@ -71,7 +73,10 @@ export const CryptoIconWithPercentage = ({
 
     return (
         <Pressable onPress={handleIconPress}>
-            <Canvas style={{ height: CANVAS_SIZE, width: CANVAS_SIZE }}>
+            {/* key forces the canvas to remount on theme change so Skia picks up the new colors.
+                Without this, the canvas in sometime won't repaint the colors when the
+                animation has already completed and no shared values are actively changing.*/}
+            <Canvas key={colorScheme} style={{ height: CANVAS_SIZE, width: CANVAS_SIZE }}>
                 {/* show pizza instead of BTC icon on pizza day. */}
                 {isPizzaDay && isBitcoin && isPizzaIconSelected ? (
                     <PizzaIcon


### PR DESCRIPTION
## Description

Skia canvas in Reanimated mode doesn't reliably repaint React props when the animation is dormant. Fix by passing `colorScheme` as `key` to force a canvas remount on theme switch.

## Notes for QA

Switch color theme while the asset list is visible — all `CryptoIconWithPercentage` ring colors should update consistently across all items. Test primarily on iOS, where the UI was glitching.

## Screenshots:

### BEFORE

https://github.com/user-attachments/assets/b9e18af2-60ba-4976-b4a6-d1bea46f0b4a



### AFTER

https://github.com/user-attachments/assets/8f23018c-aeed-4905-847d-3524884c4347


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/asset-item-colors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/asset-item-colors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/asset-item-colors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T12:29:53.420Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-02T12:28:12.794Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->