### PR TITLE
chore(transport): remove unused export

### DIFF
--- a/packages/connect/src/events/ui-response.ts
+++ b/packages/connect/src/events/ui-response.ts
@@ -1,8 +1,7 @@
 import type { ThpPairingMethod } from '@trezor/protocol';
 
-import { UI_EVENT } from './ui-request';
+import type { UI_EVENT } from './ui-request';
 import type { LocalFirmwares } from '../types/settings';
-import type { MessageFactoryFn } from '../types/utils';
 
 /*
  * messages from UI sent by popup or using .uiResponse method
@@ -90,13 +89,3 @@ export type UiResponseEvent =
     | UiResponseFirmwares;
 
 export type UiResponseMessage = UiResponseEvent & { event: typeof UI_EVENT };
-
-export const createUiResponse: MessageFactoryFn<typeof UI_EVENT, UiResponseEvent> = (
-    type,
-    payload,
-) =>
-    ({
-        event: UI_EVENT,
-        type,
-        payload,
-    }) as any;

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -7,10 +7,6 @@ export { AbstractTransport as Transport, isTransportInstance } from './transport
 export { AbstractApiTransport } from './transports/abstractApi';
 export { UsbApi } from './api/usb';
 
-// messages are exported but there is no real need to use them elsewhere
-// transports have reference to this already
-export { Messages } from '@trezor/protobuf';
-
 // browser + node
 export { BridgeTransport } from './transports/bridge';
 


### PR DESCRIPTION
cherry-picking occasional standalone refactorings from #26141

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-unused-stuff&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-unused-stuff&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-unused-stuff&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T12:49:19.313Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-02T12:47:42.149Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->