### PR TITLE
chore(suite): set default QM when empty string is present

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import {
+    DEFAULT_QUOTA_MANAGER_URL,
     enforceQuotaManagerUpdated,
     eraseFetchedData,
     selectEnforceQuotaManager,
@@ -9,7 +10,7 @@ import {
     selectRegisteredDevices,
     updateQuotaManagerBaseUrl,
 } from '@suite-common/suite-sync-quota-manager';
-import { Button, Checkbox, Column, Input } from '@trezor/components';
+import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
@@ -28,9 +29,14 @@ export const QuotaManagerSettings = () => {
 
     const onQuotaManagerBaseUrlSave = () => {
         setIsUpdateUrlLoading(true);
+
+        const normalizedUrl =
+            quotaManagerUrl.trim() === '' ? DEFAULT_QUOTA_MANAGER_URL : quotaManagerUrl;
+
+        setQuotaManagerUrl(normalizedUrl);
         dispatch(
             updateQuotaManagerBaseUrl({
-                baseUrl: quotaManagerUrl,
+                baseUrl: normalizedUrl,
             }),
         );
 
@@ -71,6 +77,9 @@ export const QuotaManagerSettings = () => {
                                 </Button>
                             }
                         />
+                        <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                            Default is: <Code>{DEFAULT_QUOTA_MANAGER_URL}</Code>
+                        </Text>
                     </Column>
                 </ActionColumn>
             </SectionItem>

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -57,6 +57,6 @@ export {
 /**
  * Constants.
  */
-export { DEFAULT_DEVICE_SIZE_QUOTA } from './constants';
+export { DEFAULT_DEVICE_SIZE_QUOTA, DEFAULT_QUOTA_MANAGER_URL } from './constants';
 
 export { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';


### PR DESCRIPTION
When user set a custom QM URL in debug settings and reverted it back to the empty string - it saved empty string and not reverted to the default URL. 

## Notes for QA

- set some QM url in the debug settings
- clear the input and save it
- now it should fallback to the default url



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/qm/default-url&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/qm/default-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/qm/default-url&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T14:53:54.446Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-02T14:52:52.994Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->