### PR TITLE
Firmware validation

### DIFF
--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -23,7 +23,6 @@ export const ERROR_CODES = {
     Method_Interrupted: 'Popup closed', // interruption: popup closed
     Method_UnknownCoin: 'Coin not found', // coin definition not found
     Method_AddressNotMatch: 'Addresses do not match', // thrown by all getAddress methods with custom UI validation
-    Method_Discovery_BundleException: '', // thrown by getAccountInfo method
     Method_Override: 'override', // inner "error", it's more like a interruption
     Method_NoResponse: 'Call resolved without response', // thrown by npm index(es), call to Core resolved without response, should not happen
     Method_Unsupported: 'Unsupported method', // 3rd party called a method unknown by current version

--- a/packages/connect-common/src/types/coinInfo.ts
+++ b/packages/connect-common/src/types/coinInfo.ts
@@ -30,15 +30,10 @@ export const CoinObj = Type.Object({
 });
 
 export type CoinSupport = Static<typeof CoinSupport>;
-export const CoinSupport = Type.Composite([
-    Type.Object({
-        connect: Type.Boolean(),
-    }),
-    Type.Record(
-        Type.KeyOfEnum(DeviceModelInternal),
-        Type.Union([Type.String(), Type.Literal(false)]),
-    ),
-]);
+export const CoinSupport = Type.Record(
+    Type.KeyOfEnum(DeviceModelInternal),
+    Type.Union([Type.String(), Type.Literal(false)]),
+);
 
 export type BlockchainLink = Static<typeof BlockchainLink>;
 export const BlockchainLink = Type.Object({

--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -7,13 +7,30 @@ import type {
 } from '@trezor/device-utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
+export type FirmwareBoundary = `${number}.${number}.${number}` | '0';
+
 export type FirmwareRange = Record<
     DeviceModelInternal,
-    {
-        min: string;
-        max: string;
-    }
+    { min: FirmwareBoundary; max: FirmwareBoundary }
 >;
+
+type AtLeastOne<T> = {
+    [K in keyof T]: Pick<T, K> & Partial<Omit<T, K>>;
+}[keyof T];
+
+type RuleSelector = AtLeastOne<{
+    coin: string[];
+    coinType: string;
+    methods: string[];
+    capabilities: string[];
+}>;
+
+type RuleDeclaration = AtLeastOne<{
+    min: Partial<Record<DeviceModelInternal, FirmwareBoundary>>;
+    max: Partial<Record<DeviceModelInternal, FirmwareBoundary>>;
+}>;
+
+export type FirmwareRule = RuleSelector & RuleDeclaration & { comment?: string[] };
 
 export type BinaryInfo = {
     binary: ArrayBuffer;

--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -11,7 +11,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class AuthenticateDevice extends AbstractMethod<
     'authenticateDevice',
@@ -33,7 +32,6 @@ export default class AuthenticateDevice extends AbstractMethod<
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.skipFinalReload = false;
         this.useDeviceState = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/api/authorizeCoinjoin.ts
+++ b/packages/connect/src/api/authorizeCoinjoin.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getScriptType, validatePath } from '../utils/pathUtils';
 
@@ -33,7 +32,7 @@ export default class AuthorizeCoinjoin extends AbstractMethod<
 
         super(message, params);
 
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.requiredFirmwareCoins = [coinInfo];
         this.preauthorized = payload.preauthorized;
     }
 

--- a/packages/connect/src/api/cancelCoinjoinAuthorization.ts
+++ b/packages/connect/src/api/cancelCoinjoinAuthorization.ts
@@ -3,7 +3,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class CancelCoinjoinAuthorization extends AbstractMethod<'cancelCoinjoinAuthorization'> {
     constructor(message: MethodMessage<'cancelCoinjoinAuthorization'>) {
@@ -14,7 +13,6 @@ export default class CancelCoinjoinAuthorization extends AbstractMethod<'cancelC
         super(message, undefined);
         this.preauthorized =
             typeof payload.preauthorized === 'boolean' ? payload.preauthorized : true;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -19,7 +19,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 import {
     addressParametersFromProto,
     addressParametersToProto,
@@ -66,11 +66,7 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetNativeScriptHash.ts
@@ -9,7 +9,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 const validateScript = (script: CardanoNativeScript) => {
     if (script.keyPath) {
@@ -62,11 +61,7 @@ export default class CardanoGetNativeScriptHash extends AbstractMethod<
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -18,7 +18,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 interface Params {
     proto: PROTO.CardanoGetPublicKey;
     suppressBackupWarning?: boolean;
@@ -54,11 +54,7 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
             batch => batch.suppressBackupWarning || !batch.proto.show_display,
         );
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignMessage.ts
@@ -15,7 +15,6 @@ import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { hasHexPrefix, isHexString } from '../../../utils/formatUtils';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { addressParametersToProto } from '../cardanoAddressParameters';
 import type { Path } from '../cardanoInputs';
 import { hexStringByteLength } from '../cardanoUtils';
@@ -61,11 +60,7 @@ export default class CardanoSignMessage extends AbstractMethod<
 
         super(message, params);
 
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
+++ b/packages/connect/src/api/cardano/api/cardanoSignTransaction.ts
@@ -19,7 +19,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import {
     modifyAuxiliaryDataForBackwardsCompatibility,
     transformAuxiliaryData,
@@ -225,11 +224,7 @@ export default class CardanoSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Cardano'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/cipherKeyValue.ts
+++ b/packages/connect/src/api/cipherKeyValue.ts
@@ -11,7 +11,7 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { bundlify, getFirmwareRange } from './common/paramsValidator';
+import { bundlify } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';
 
 export default class CipherKeyValue extends AbstractMethod<
@@ -40,7 +40,6 @@ export default class CipherKeyValue extends AbstractMethod<
 
         super(message, params);
         this.hasBundle = hasBundle;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['read', 'write'];

--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -1,6 +1,5 @@
-import type { FirmwareRange } from '@trezor/connect-common';
-import type { DeviceModelInternal } from '@trezor/device-utils';
-import { typedObjectKeys } from '@trezor/utils';
+import type { CoinInfo, FirmwareRange } from '@trezor/connect-common';
+import { typedObjectEntries, typedObjectKeys } from '@trezor/utils';
 
 export const validateParams = [
     {
@@ -172,7 +171,7 @@ export const validateParams = [
     },
 ];
 
-const DEFAULT_RANGE: FirmwareRange = {
+const DEFAULT_RANGE = {
     UNKNOWN: { min: '1.0.0', max: '0' },
     T1B1: { min: '1.0.0', max: '0' },
     T2T1: { min: '2.0.0', max: '0' },
@@ -180,13 +179,9 @@ const DEFAULT_RANGE: FirmwareRange = {
     T3B1: { min: '2.0.0', max: '0' },
     T3T1: { min: '2.0.0', max: '0' },
     T3W1: { min: '2.0.0', max: '0' },
-};
+} satisfies FirmwareRange;
 
-const DEFAULT_COIN_INFO: {
-    support: Record<DeviceModelInternal, string>;
-    shortcut: string;
-    type: string;
-} = {
+const DEFAULT_COIN_INFO = {
     support: {
         UNKNOWN: '1.0.0',
         T1B1: '1.6.2',
@@ -198,7 +193,7 @@ const DEFAULT_COIN_INFO: {
     },
     shortcut: 'btc',
     type: 'bitcoin',
-};
+} as const satisfies Partial<CoinInfo>;
 
 const EMPTY_CONFIG = {
     supportedFirmware: [],
@@ -215,7 +210,7 @@ export const getFirmwareRange = [
         description: 'range from coinInfo',
         config: EMPTY_CONFIG,
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
-        result: typedObjectKeys(DEFAULT_RANGE).reduce((acc, model: DeviceModelInternal) => {
+        result: typedObjectKeys(DEFAULT_RANGE).reduce((acc, model) => {
             acc[model] = {
                 min: DEFAULT_COIN_INFO.support[model],
                 max: '0',
@@ -249,9 +244,7 @@ export const getFirmwareRange = [
             },
             DEFAULT_RANGE,
         ],
-        result: (
-            Object.entries(DEFAULT_COIN_INFO.support) as [DeviceModelInternal, string][]
-        ).reduce((acc, [model, min]) => {
+        result: typedObjectEntries(DEFAULT_COIN_INFO.support).reduce((acc, [model, min]) => {
             acc[model] = { min: model === 'T1B1' ? '0' : min, max: '0' };
 
             return acc;
@@ -277,9 +270,7 @@ export const getFirmwareRange = [
             },
             DEFAULT_RANGE,
         ],
-        result: (
-            Object.entries(DEFAULT_COIN_INFO.support) as [DeviceModelInternal, string][]
-        ).reduce((acc, [model, min]) => {
+        result: typedObjectEntries(DEFAULT_COIN_INFO.support).reduce((acc, [model, min]) => {
             acc[model] = { min: model === 'T1B1' ? min : '0', max: '0' };
 
             return acc;

--- a/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
+++ b/packages/connect/src/api/common/__fixtures__/paramsValidator.ts
@@ -347,7 +347,7 @@ export const getFirmwareRange = [
         description: 'range from config.json (by methods)',
         config: {
             supportedFirmware: [
-                // this one is ignored, no data
+                // this one is always used (but is made impossible by types)
                 { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored, different excludedMethod
                 { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
@@ -363,21 +363,21 @@ export const getFirmwareRange = [
                     methods: ['showAddress'],
                     min: { T1B1: '1.11.0', T2T1: '2.5.0' },
                 },
-                { methods: ['signTransaction'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+                { methods: ['signTransaction'], min: { T1B1: '1.10.0', T2T1: '2.6.0' } },
             ],
         },
         params: ['signTransaction', DEFAULT_COIN_INFO, DEFAULT_RANGE],
         result: {
             ...DEFAULT_RANGE,
-            T1B1: { min: '1.10.0', max: '0' },
-            T2T1: { min: '2.4.0', max: '0' },
+            T1B1: { min: '1.11.0', max: '0' },
+            T2T1: { min: '2.6.0', max: '0' },
         },
     },
     {
         description: 'range from config.json (by capabilities)',
         config: {
             supportedFirmware: [
-                // this one is ignored, no data
+                // this one is always used (but is made impossible by types)
                 { min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
                 // this one is ignored, different excludedMethod
                 { coin: ['btc'], methods: ['showAddress'], min: { T1B1: '1.11.0', T2T1: '2.5.0' } },
@@ -393,14 +393,14 @@ export const getFirmwareRange = [
                     methods: ['showAddress'],
                     min: { T1B1: '1.11.0', T2T1: '2.5.0' },
                 },
-                { capabilities: ['decreaseOutput'], min: { T1B1: '1.10.0', T2T1: '2.4.0' } },
+                { capabilities: ['decreaseOutput'], min: { T1B1: '1.10.0', T2T1: '2.6.0' } },
             ],
         },
         params: ['decreaseOutput', DEFAULT_COIN_INFO, DEFAULT_RANGE],
         result: {
             ...DEFAULT_RANGE,
-            T1B1: { min: '1.10.0', max: '0' },
-            T2T1: { min: '2.4.0', max: '0' },
+            T1B1: { min: '1.11.0', max: '0' },
+            T2T1: { min: '2.6.0', max: '0' },
         },
     },
     {
@@ -454,7 +454,25 @@ export const getFirmwareRange = [
                 T2T1: { min: '1.0.0', max: '2.10.0' },
             },
         ],
-        result: { T1B1: { min: '1.6.2', max: '1.10.0' }, T2T1: { min: '2.1.0', max: '2.10.0' } },
+        result: { T1B1: { min: '1.6.2', max: '1.0.1' }, T2T1: { min: '2.1.0', max: '2.0.1' } },
+    },
+    {
+        description: 'range from config.json (handle zeros in both min and max)',
+        config: {
+            supportedFirmware: [
+                {
+                    methods: ['signTransaction'],
+                    min: { T1B1: '1.6.0', T2T1: '0' },
+                    max: { T1B1: '1.10.0', T2T1: '2.8.0' },
+                },
+            ],
+        },
+        params: [
+            'signTransaction',
+            null,
+            { T1B1: { min: '0', max: '0' }, T2T1: { min: '2.6.0', max: '0' } },
+        ],
+        result: { T1B1: { min: '0', max: '1.10.0' }, T2T1: { min: '0', max: '2.8.0' } },
     },
     // real config.json data
     {

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -28,8 +28,10 @@ describe('helpers/paramsValidator', () => {
             it(f.description, () => {
                 if (f.config) jest.replaceProperty(data, 'config', f.config as any);
 
-                // @ts-expect-error
-                expect(getFirmwareRange(...f.params)).toEqual(f.result);
+                expect(
+                    // @ts-expect-error
+                    getFirmwareRange([f.params[0]], f.params[1] ? [f.params[1]] : [], f.params[2]),
+                ).toEqual(f.result);
             });
         });
     });

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -1,5 +1,6 @@
+import * as data from '../../../data/config';
 import * as fixtures from '../__fixtures__/paramsValidator';
-import { validateParams } from '../paramsValidator';
+import { getFirmwareRange, validateParams } from '../paramsValidator';
 
 describe('helpers/paramsValidator', () => {
     describe('validateParams', () => {
@@ -20,33 +21,16 @@ describe('helpers/paramsValidator', () => {
 
     describe('getFirmwareRange', () => {
         afterEach(() => {
-            jest.clearAllMocks();
+            jest.restoreAllMocks();
         });
+
         fixtures.getFirmwareRange.forEach(f => {
-            it(
-                f.description,
-                () =>
-                    new Promise<void>(done => {
-                        jest.resetModules();
+            it(f.description, () => {
+                if (f.config) jest.replaceProperty(data, 'config', f.config as any);
 
-                        const mock = f.config;
-                        jest.mock('../../../data/config', () => {
-                            const actualConfig = jest.requireActual('../../../data/config').config;
-
-                            return {
-                                __esModule: true,
-                                config: mock || actualConfig,
-                            };
-                        });
-
-                        import('../paramsValidator').then(({ getFirmwareRange }) => {
-                            // added new capability
-                            // @ts-expect-error
-                            expect(getFirmwareRange(...f.params)).toEqual(f.result);
-                            done();
-                        });
-                    }),
-            );
+                // @ts-expect-error
+                expect(getFirmwareRange(...f.params)).toEqual(f.result);
+            });
         });
     });
 });

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,7 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
-import type { CoinInfo, FirmwareBoundary, FirmwareRange } from '@trezor/connect-common';
+import type {
+    CoinInfo,
+    FirmwareBoundary,
+    FirmwareRange,
+    FirmwareRule,
+} from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import { typedObjectKeys, versionUtils } from '@trezor/utils';
+import { typedObjectTransformValues, versionUtils } from '@trezor/utils';
 
 import { config } from '../../data/config';
 import { fromHardened } from '../../utils/pathUtils';
@@ -108,94 +113,84 @@ export const validateCoinPath = (path: number[], coinInfo?: CoinInfo) => {
     }
 };
 
+export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
+    UNKNOWN: { min: '1.0.0', max: '0' },
+    T1B1: { min: '1.0.0', max: '0' },
+    T2T1: { min: '2.0.0', max: '0' },
+    T2B1: { min: '2.6.1', max: '0' },
+    T3B1: { min: '2.8.1', max: '0' },
+    T3T1: { min: '2.7.1', max: '0' },
+    T3W1: { min: '2.7.1', max: '0' },
+};
+
+const intersectMin = (a: FirmwareBoundary, b: FirmwareBoundary) =>
+    a === '0' || (b !== '0' && versionUtils.isNewer(a, b)) ? a : b;
+
+const intersectMax = (a: FirmwareBoundary, b: FirmwareBoundary) =>
+    a === '0' || (b !== '0' && versionUtils.isNewer(a, b)) ? b : a;
+
+const intersectRange = (a: FirmwareRange, b: FirmwareRange) =>
+    typedObjectTransformValues(a, (value, model) => ({
+        min: intersectMin(value.min, b[model].min),
+        max: intersectMax(value.max, b[model].max),
+    }));
+
+const ensureArray = <T>(item: T | T[] = []) => (Array.isArray(item) ? item : [item]);
+
+const filterByCoins = (coins: CoinInfo[]) => {
+    const coinSet = new Set(coins.map(coin => coin.shortcut.toLowerCase()));
+    const coinTypeSet = new Set<string>(coins.map(coin => coin.type));
+
+    return (rule: FirmwareRule) =>
+        (!rule.coin && !rule.coinType) ||
+        ensureArray(rule.coin).some(coinSet.has.bind(coinSet)) ||
+        ensureArray(rule.coinType).some(coinTypeSet.has.bind(coinTypeSet));
+};
+
+const filterByMethods = (methodsOrCapabilities: string[]) => {
+    const methodSet = new Set(methodsOrCapabilities);
+
+    return (rule: FirmwareRule) =>
+        (!rule.methods && !rule.capabilities) ||
+        ensureArray(rule.methods).some(methodSet.has.bind(methodSet)) ||
+        ensureArray(rule.capabilities).some(methodSet.has.bind(methodSet));
+};
+
+const getCoinRules = (coins: CoinInfo[], currentRange: FirmwareRange): FirmwareRange[] =>
+    coins.map(({ support = typedObjectTransformValues(DEFAULT_FIRMWARE_RANGE, () => false) }) => ({
+        ...currentRange,
+        ...typedObjectTransformValues(support, value => ({
+            min: (value || '0') as FirmwareBoundary,
+            max: '0' as const,
+        })),
+    }));
+
+const getConfigRules = (
+    methodsOrCapabilities: string[],
+    coins: CoinInfo[],
+    currentRange: FirmwareRange,
+): FirmwareRange[] =>
+    config.supportedFirmware
+        .filter(filterByCoins(coins))
+        .filter(filterByMethods(methodsOrCapabilities))
+        .map(({ min, max }) =>
+            typedObjectTransformValues(currentRange, (value, key) => ({
+                min: min?.[key] ?? value.min,
+                max: max?.[key] ?? value.max,
+            })),
+        );
+
+const getFirmwareRangeNEW = (
+    methodsOrCapabilities: string[],
+    coins: CoinInfo[],
+    currentRange = DEFAULT_FIRMWARE_RANGE,
+) =>
+    getCoinRules(coins, currentRange)
+        .concat(getConfigRules(methodsOrCapabilities, coins, currentRange))
+        .reduce(intersectRange, currentRange);
+
 export const getFirmwareRange = (
     method: string,
     coinInfo: CoinInfo | null | undefined,
     currentRange: FirmwareRange,
-) => {
-    const range = JSON.parse(JSON.stringify(currentRange)) as FirmwareRange;
-    const models = typedObjectKeys(range);
-    // set minimum required firmware from coins.json (coinInfo)
-    if (coinInfo) {
-        models.forEach(model => {
-            const supportVersion = coinInfo.support ? coinInfo.support[model] : false;
-            if (supportVersion === false) {
-                range[model].min = '0';
-            } else if (
-                range[model].min !== '0' &&
-                typeof supportVersion === 'string' &&
-                versionUtils.isNewer(supportVersion, range[model].min)
-            ) {
-                range[model].min = supportVersion as FirmwareBoundary;
-            }
-        });
-    }
-
-    const coinType = coinInfo?.type;
-    const shortcut = coinInfo?.shortcut.toLowerCase();
-    // find firmware range in config.json
-    const configRules = config.supportedFirmware
-        .filter(rule => {
-            // check if rule applies to requested method
-            if (rule.methods) {
-                return rule.methods.includes(method);
-            }
-            // check if rule applies to capability
-            if (rule.capabilities) {
-                return rule.capabilities.includes(method);
-            }
-
-            // rule doesn't have specified methods
-            // it may be a global rule for coin or coinType
-            return true;
-        })
-        .filter(rule => {
-            // REF_TODO: there is no coinType in config. possibly obsolete code?
-            // probably still useful, we just need to define type for config and not infer it.
-            if (rule.coinType) {
-                // rule for coin type
-                return rule.coinType === coinType;
-            }
-            if (rule.coin) {
-                // rule for coin shortcut
-                return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(shortcut);
-            }
-
-            return true;
-        });
-
-    configRules.forEach(rule => {
-        // override defaults
-        // NOTE:
-        // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
-        if (rule.min) {
-            models.forEach(model => {
-                const modelMin = rule.min?.[model];
-                if (modelMin && range[model].min !== '0') {
-                    if (
-                        modelMin === '0' ||
-                        !versionUtils.isNewerOrEqual(range[model].min, modelMin)
-                    ) {
-                        range[model].min = modelMin as FirmwareBoundary;
-                    }
-                }
-            });
-        }
-        if (rule.max) {
-            models.forEach(model => {
-                const modelMax = rule.max[model];
-                if (modelMax) {
-                    if (
-                        modelMax === '0' ||
-                        range[model].max === '0' ||
-                        versionUtils.isNewerOrEqual(range[model].max, modelMax)
-                    ) {
-                        range[model].max = modelMax;
-                    }
-                }
-            });
-        }
-    });
-
-    return range;
-};
+) => getFirmwareRangeNEW([method], coinInfo ? [coinInfo] : [], currentRange);

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,5 +1,5 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
-import type { CoinInfo, FirmwareRange } from '@trezor/connect-common';
+import type { CoinInfo, FirmwareBoundary, FirmwareRange } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { DeviceModelInternal } from '@trezor/device-utils';
 import { typedObjectKeys, versionUtils } from '@trezor/utils';
@@ -127,7 +127,7 @@ export const getFirmwareRange = (
                 typeof supportVersion === 'string' &&
                 versionUtils.isNewer(supportVersion, range[model].min)
             ) {
-                range[model].min = supportVersion;
+                range[model].min = supportVersion as FirmwareBoundary;
             }
         });
     }
@@ -153,15 +153,12 @@ export const getFirmwareRange = (
         .filter(rule => {
             // REF_TODO: there is no coinType in config. possibly obsolete code?
             // probably still useful, we just need to define type for config and not infer it.
-            // @ts-expect-error
             if (rule.coinType) {
                 // rule for coin type
-                // @ts-expect-error
                 return rule.coinType === coinType;
             }
             if (rule.coin) {
                 // rule for coin shortcut
-                // @ts-expect-error
                 return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(shortcut);
             }
 
@@ -184,14 +181,13 @@ export const getFirmwareRange = (
                         range[model].min === '0' ||
                         !versionUtils.isNewerOrEqual(range[model].min, modelMin)
                     ) {
-                        range[model].min = modelMin;
+                        range[model].min = modelMin as FirmwareBoundary;
                     }
                 }
             });
         }
         if (rule.max) {
             models.forEach(model => {
-                // @ts-expect-error same issue as in coinType above, config needs to be typed not inferred.
                 const modelMax = rule.max[model];
                 if (modelMax) {
                     if (

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -180,7 +180,7 @@ const getConfigRules = (
             })),
         );
 
-const getFirmwareRangeNEW = (
+export const getFirmwareRange = (
     methodsOrCapabilities: string[],
     coins: CoinInfo[],
     currentRange = DEFAULT_FIRMWARE_RANGE,
@@ -188,9 +188,3 @@ const getFirmwareRangeNEW = (
     getCoinRules(coins, currentRange)
         .concat(getConfigRules(methodsOrCapabilities, coins, currentRange))
         .reduce(intersectRange, currentRange);
-
-export const getFirmwareRange = (
-    method: string,
-    coinInfo: CoinInfo | null | undefined,
-    currentRange: FirmwareRange,
-) => getFirmwareRangeNEW([method], coinInfo ? [coinInfo] : [], currentRange);

--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
 import type { CoinInfo, FirmwareBoundary, FirmwareRange } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type { DeviceModelInternal } from '@trezor/device-utils';
 import { typedObjectKeys, versionUtils } from '@trezor/utils';
 
 import { config } from '../../data/config';
@@ -162,8 +161,7 @@ export const getFirmwareRange = (
                 return (typeof rule.coin === 'string' ? [rule.coin] : rule.coin).includes(shortcut);
             }
 
-            // rule for method
-            return rule.methods || rule.capabilities;
+            return true;
         });
 
     configRules.forEach(rule => {
@@ -172,13 +170,10 @@ export const getFirmwareRange = (
         // 0 may be confusing. means: no-support for "min" and unlimited support for "max"
         if (rule.min) {
             models.forEach(model => {
-                const modelMin = (rule.min as Record<DeviceModelInternal, string | undefined>)[
-                    model
-                ];
-                if (modelMin) {
+                const modelMin = rule.min?.[model];
+                if (modelMin && range[model].min !== '0') {
                     if (
                         modelMin === '0' ||
-                        range[model].min === '0' ||
                         !versionUtils.isNewerOrEqual(range[model].min, modelMin)
                     ) {
                         range[model].min = modelMin as FirmwareBoundary;
@@ -193,7 +188,7 @@ export const getFirmwareRange = (
                     if (
                         modelMax === '0' ||
                         range[model].max === '0' ||
-                        !versionUtils.isNewerOrEqual(range[model].max, modelMax)
+                        versionUtils.isNewerOrEqual(range[model].max, modelMax)
                     ) {
                         range[model].max = modelMax;
                     }

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -40,7 +40,7 @@ import { signTx } from './bitcoin/signtx';
 import { signTxLegacy } from './bitcoin/signtxLegacy';
 import { deriveOutputScript, verifyTx } from './bitcoin/signtxVerify';
 import { Discovery } from './common/Discovery';
-import { getFirmwareRange, validateParams } from './common/paramsValidator';
+import { validateParams } from './common/paramsValidator';
 
 type Params = {
     outputs: ComposeOutput[];
@@ -122,8 +122,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         this.useUi = this.useDevice;
 
-        // set required firmware from coinInfo support
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.requiredFirmwareCoins = [coinInfo];
     }
 
     discovery?: Discovery;

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -19,7 +19,7 @@ import { arrayPartition, getSynchronize, versionUtils } from '@trezor/utils';
 
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
-import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import type { AccountDescriptor } from '../device/DeviceCommands';
 import { isUtxoBased } from '../utils/accountUtils';
@@ -112,11 +112,7 @@ export default class DiscoverAccounts extends AbstractMethod<
             // validate backend
             isBackendSupported(coinInfo);
 
-            const firmwareRange = getFirmwareRange(
-                payload.method,
-                coinInfo,
-                DEFAULT_FIRMWARE_RANGE,
-            );
+            const firmwareRange = getFirmwareRange([payload.method], [coinInfo]);
 
             // Take all the defined account types based on requested coin symbol
             const symbolAccounts = ACCOUNT_TYPES.filter(a => a.symbol === symbol);

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -21,7 +21,7 @@ import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { stripHexPrefix } from '../../../utils/formatUtils';
 import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 import {
     decodeEthereumDefinition,
     ethereumNetworkInfoFromDefinition,
@@ -59,10 +59,7 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
 
         super(message, params);
 
-        this.firmwareRange = params.reduce(
-            (prev, { network }) => getFirmwareRange(this.name, network, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ network }) => network);
         this.hasBundle = hasBundle;
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -19,7 +19,7 @@ import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.EthereumGetPublicKey;
@@ -49,10 +49,7 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
 
         super(message, params);
 
-        this.firmwareRange = params.reduce(
-            (prev, { network }) => getFirmwareRange(this.name, network, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ network }) => network);
         this.hasBundle = hasBundle;
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }

--- a/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignMessage.ts
@@ -12,7 +12,6 @@ import { validateModelOneMessageSize } from '../../../device/validateMessageSize
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { hexToText, messageToHex } from '../../../utils/formatUtils';
 import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getEthereumDefinitions } from '../ethereumDefinitions';
 
 type Params = {
@@ -41,7 +40,7 @@ export default class EthereumSignMessage extends AbstractMethod<'ethereumSignMes
         const params = { proto: { address_n, message: messageHex }, readableMessage };
 
         super(message, params);
-        this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
+        this.requiredFirmwareCoins = [network];
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }
 

--- a/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTransaction.ts
@@ -17,7 +17,6 @@ import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { deepTransform, stripHexPrefix } from '../../../utils/formatUtils';
 import { getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import {
     decodeEthereumDefinition,
     ethereumNetworkInfoFromDefinition,
@@ -90,15 +89,13 @@ export default class EthereumSignTransaction extends AbstractMethod<
 
         super(message, params);
 
+        this.requiredFirmwareCoins = [network];
+        this.requiredDeviceCapabilities = ['Capability_Ethereum'];
         // get firmware range depending on used transaction type
         // eip1559 is possible since 2.4.2
-        this.firmwareRange = getFirmwareRange(
-            isEIP1559 ? 'eip1559' : this.name,
-            network,
-            this.firmwareRange,
-        );
-
-        this.requiredDeviceCapabilities = ['Capability_Ethereum'];
+        if (isEIP1559) {
+            this.requiredFirmwareCapabilities = ['eip1559'];
+        }
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignTypedData.ts
@@ -17,7 +17,6 @@ import { getEthereumNetwork } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { messageToHex } from '../../../utils/formatUtils';
 import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getEthereumDefinitions } from '../ethereumDefinitions';
 import { encodeData, getFieldType, parseArrayType } from '../ethereumSignTypedData';
 
@@ -87,17 +86,11 @@ export default class EthereumSignTypedData extends AbstractMethod<'ethereumSignT
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
-
-        this.firmwareRange = getFirmwareRange(this.name, network, this.firmwareRange);
-
+        this.requiredFirmwareCoins = [network];
+        // Only newer firmwares support this feature
+        // Older firmwares will give wrong results / throw errors
         if (params.data.primaryType === 'EIP712Domain') {
-            // Only newer firmwares support this feature
-            // Older firmwares will give wrong results / throw errors
-            this.firmwareRange = getFirmwareRange(
-                'eip712-domain-only',
-                network,
-                this.firmwareRange,
-            );
+            this.requiredFirmwareCapabilities = ['eip712-domain-only'];
         }
     }
 

--- a/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumVerifyMessage.ts
@@ -8,7 +8,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validateModelOneMessageSize } from '../../../device/validateMessageSize';
 import { messageToHex, stripHexPrefix } from '../../../utils/formatUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 export default class EthereumVerifyMessage extends AbstractMethod<
     'ethereumVerifyMessage',
@@ -31,7 +30,6 @@ export default class EthereumVerifyMessage extends AbstractMethod<
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -146,7 +146,6 @@ export const ethereumNetworkInfoFromDefinition = (
     slip44: definition.slip44,
     shortcut: definition.symbol,
     support: {
-        connect: true,
         T1B1: '1.6.2',
         T2T1: '2.0.7',
         T2B1: '2.0.0',

--- a/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
+++ b/packages/connect/src/api/evoluGetDelegatedIdentityKey.ts
@@ -2,7 +2,6 @@ import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
     'evoluGetDelegatedIdentityKey',
@@ -14,7 +13,6 @@ export default class EvoluGetDelegatedIdentityKey extends AbstractMethod<
         super(message, {});
         this.useDevice = true;
         this.useUi = true;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['read'];

--- a/packages/connect/src/api/evoluGetNode.ts
+++ b/packages/connect/src/api/evoluGetNode.ts
@@ -3,7 +3,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class EvoluGetNode extends AbstractMethod<'evoluGetNode', PROTO.EvoluGetNode> {
     hasBundle?: boolean;
@@ -18,7 +17,6 @@ export default class EvoluGetNode extends AbstractMethod<'evoluGetNode', PROTO.E
         };
 
         super(message, params);
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['read'];

--- a/packages/connect/src/api/evoluSignRegistrationRequest.ts
+++ b/packages/connect/src/api/evoluSignRegistrationRequest.ts
@@ -3,7 +3,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class EvoluSignRegistrationRequest extends AbstractMethod<
     'evoluSignRegistrationRequest',
@@ -23,7 +22,6 @@ export default class EvoluSignRegistrationRequest extends AbstractMethod<
         };
 
         super(message, params);
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;
     }
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -12,14 +12,14 @@ import {
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import { bundlify, getFirmwareRange } from './common/paramsValidator';
+import { bundlify } from './common/paramsValidator';
 import type {
     MethodContext,
     MethodMessage,
     MethodPermission,
     MethodReturnType,
 } from '../core/AbstractMethod';
-import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { getAccountLabel } from '../utils/accountUtils';
 import { getSerializedPath, validatePath } from '../utils/pathUtils';
@@ -57,11 +57,7 @@ export default class GetAccountDescriptor extends AbstractMethod<
 
         super(message, params);
 
-        // set firmware range
-        this.firmwareRange = params.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = !this.params.every(batch => batch.suppressBackupWarning);
         this.useDevice = true;
@@ -109,37 +105,6 @@ export default class GetAccountDescriptor extends AbstractMethod<
             view: 'export-account-info' as const,
             label: `Export descriptor for: ${str.join('')}`,
         };
-    }
-
-    // override AbstractMethod function
-    // this is a special case where we want to check firmwareRange in bundle
-    // and return error with bundle indexes
-    checkFirmwareRange() {
-        // check each batch and return error with invalid bundle indexes
-        // find invalid ranges
-        const invalid = [];
-        for (let i = 0; i < this.params.length; i++) {
-            // set FW range for current batch
-            this.firmwareRange = getFirmwareRange(
-                this.name,
-                this.params[i].coinInfo,
-                DEFAULT_FIRMWARE_RANGE,
-            );
-            const exception = super.checkFirmwareRange();
-            if (exception) {
-                invalid.push({
-                    index: i,
-                    exception,
-                    coin: this.params[i].coin,
-                });
-            }
-        }
-        // return invalid ranges in custom error
-        if (invalid.length > 0) {
-            throw ERRORS.TypedError('Method_Discovery_BundleException', JSON.stringify(invalid));
-        }
-
-        return undefined;
     }
 
     async run({ sendCoreMessage }: MethodContext) {

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -18,10 +18,10 @@ import type {
     MethodPermission,
     MethodReturnType,
 } from '../core/AbstractMethod';
-import { AbstractMethod, DEFAULT_FIRMWARE_RANGE } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { Discovery } from './common/Discovery';
-import { bundlify, getFirmwareRange, validateParams } from './common/paramsValidator';
+import { bundlify, validateParams } from './common/paramsValidator';
 import { getAccountLabel, isUtxoBased } from '../utils/accountUtils';
 import { getSerializedPath, validatePath } from '../utils/pathUtils';
 
@@ -99,10 +99,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         this.useDeviceState = willUseDevice;
         this.useUi = willUseDevice;
         this.confirmMissingBackup = !params.every(batch => batch.suppressBackupWarning);
-        this.firmwareRange = params.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
     }
 
     get requiredPermissions(): MethodPermission[] {
@@ -158,38 +155,6 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 view: 'export-account-info' as const,
                 label: `Export info for: ${str.join('')}`,
             };
-        }
-    }
-
-    // override AbstractMethod function
-    // this is a special case where we want to check firmwareRange in bundle
-    // and return error with bundle indexes
-    checkFirmwareRange() {
-        if (this.params.length === 1) {
-            return super.checkFirmwareRange();
-        }
-        // for trusted mode check each batch and return error with invalid bundle indexes
-        // find invalid ranges
-        const invalid = [];
-        for (let i = 0; i < this.params.length; i++) {
-            // set FW range for current batch
-            this.firmwareRange = getFirmwareRange(
-                this.name,
-                this.params[i].coinInfo,
-                DEFAULT_FIRMWARE_RANGE,
-            );
-            const exception = super.checkFirmwareRange();
-            if (exception) {
-                invalid.push({
-                    index: i,
-                    exception,
-                    coin: this.params[i].coin,
-                });
-            }
-        }
-        // return invalid ranges in custom error
-        if (invalid.length > 0) {
-            throw ERRORS.TypedError('Method_Discovery_BundleException', JSON.stringify(invalid));
         }
     }
 

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -6,7 +6,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 import { GetAddress as GetAddressSchema } from '@trezor/connect-common/src/types/api/getAddress';
 import { Assert } from '@trezor/schema-utils';
 
-import { bundlify, getFirmwareRange, validateCoinPath } from './common/paramsValidator';
+import { bundlify, validateCoinPath } from './common/paramsValidator';
 import type {
     MethodContext,
     MethodMessage,
@@ -81,10 +81,7 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
 
         this.hasBundle = hasBundle;
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.firmwareRange = params.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
         this.confirmMissingBackup = true;
     }
 

--- a/packages/connect/src/api/getFirmwareHash.ts
+++ b/packages/connect/src/api/getFirmwareHash.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class GetFirmwareHash extends AbstractMethod<
     'getFirmwareHash',
@@ -21,7 +20,6 @@ export default class GetFirmwareHash extends AbstractMethod<
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/api/getOwnershipId.ts
+++ b/packages/connect/src/api/getOwnershipId.ts
@@ -7,7 +7,7 @@ import {
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import { bundlify, getFirmwareRange } from './common/paramsValidator';
+import { bundlify } from './common/paramsValidator';
 import type {
     MethodContext,
     MethodMessage,
@@ -47,10 +47,7 @@ export default class GetOwnershipId extends AbstractMethod<
 
         super(message, params);
 
-        this.firmwareRange = preprocessed.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = preprocessed.map(({ coinInfo }) => coinInfo);
         this.hasBundle = hasBundle;
     }
     hasBundle?: boolean;

--- a/packages/connect/src/api/getOwnershipProof.ts
+++ b/packages/connect/src/api/getOwnershipProof.ts
@@ -7,7 +7,7 @@ import {
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import { bundlify, getFirmwareRange } from './common/paramsValidator';
+import { bundlify } from './common/paramsValidator';
 import type {
     MethodContext,
     MethodMessage,
@@ -50,10 +50,7 @@ export default class GetOwnershipProof extends AbstractMethod<
 
         super(message, params);
 
-        this.firmwareRange = preprocessed.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = preprocessed.map(({ coinInfo }) => coinInfo);
         this.preauthorized = payload.bundle.some(batch => batch.preauthorized);
         this.hasBundle = hasBundle;
     }

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -18,7 +18,7 @@ import type {
 } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
-import { bundlify, getFirmwareRange, validateCoinPath } from './common/paramsValidator';
+import { bundlify, validateCoinPath } from './common/paramsValidator';
 import { getPublicKeyLabel } from '../utils/accountUtils';
 import { validatePath } from '../utils/pathUtils';
 
@@ -72,10 +72,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
 
         super(message, params);
 
-        this.firmwareRange = params.reduce(
-            (prev, { coinInfo }) => getFirmwareRange(this.name, coinInfo, prev),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = !this.params.every(
             batch => batch.suppressBackupWarning || !batch.proto.show_display,

--- a/packages/connect/src/api/loadDevice.ts
+++ b/packages/connect/src/api/loadDevice.ts
@@ -4,7 +4,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadDevice> {
     constructor(message: MethodMessage<'loadDevice'>) {
@@ -28,7 +27,6 @@ export default class LoadDevice extends AbstractMethod<'loadDevice', PROTO.LoadD
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE];
         this.useDeviceState = false;
         this.skipFinalReload = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/api/monero/api/moneroGetAddress.ts
+++ b/packages/connect/src/api/monero/api/moneroGetAddress.ts
@@ -7,7 +7,7 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.MoneroGetAddress;
@@ -55,11 +55,7 @@ export default class MoneroGetAddress extends AbstractMethod<'moneroGetAddress',
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Monero'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
+++ b/packages/connect/src/api/monero/api/moneroGetWatchKey.ts
@@ -7,7 +7,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.MoneroGetWatchKey;
@@ -36,11 +35,7 @@ export default class MoneroGetWatchKeyMethod extends AbstractMethod<'moneroGetWa
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Monero'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
+++ b/packages/connect/src/api/monero/api/moneroKeyImageSync.ts
@@ -9,7 +9,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 // Encode unsigned integer as varint (LEB128 format)
 function encodeVarint(n: number): Uint8Array {
@@ -111,11 +110,7 @@ export default class MoneroKeyImageSyncMethod extends AbstractMethod<'moneroKeyI
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Monero'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/monero/api/moneroSignTransaction.ts
+++ b/packages/connect/src/api/monero/api/moneroSignTransaction.ts
@@ -9,7 +9,6 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { HD_HARDENED, validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 type Params = {
     address_n: number[];
@@ -183,11 +182,7 @@ export default class MoneroSignTransactionMethod extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Monero'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Monero'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Monero')];
     }
 
     get info() {

--- a/packages/connect/src/api/requestLogin.ts
+++ b/packages/connect/src/api/requestLogin.ts
@@ -7,7 +7,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { DataManager } from '../data/DataManager';
 
 export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.SignIdentity> {
@@ -39,7 +38,6 @@ export default class RequestLogin extends AbstractMethod<'requestLogin', PROTO.S
         };
 
         super(message, params);
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;
     }
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/resetDevice.ts
+++ b/packages/connect/src/api/resetDevice.ts
@@ -9,7 +9,6 @@ import { getRandomInt } from '@trezor/utils';
 import { generateEntropy, verifyEntropy } from '../api/firmware/verifyEntropy';
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { validatePath } from '../utils/pathUtils';
 import { calculateXPubHashes } from './firmware/calculateXPubHash';
 
@@ -39,7 +38,6 @@ export default class ResetDevice extends AbstractMethod<'resetDevice', PROTO.Res
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS];
         this.useDeviceState = false;
         this.skipFinalReload = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -19,7 +19,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.RippleGetAddress;
@@ -54,11 +54,7 @@ export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress',
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Ripple'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Ripple')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
+++ b/packages/connect/src/api/ripple/api/rippleSignTransaction.ts
@@ -8,7 +8,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 
 export default class RippleSignTransaction extends AbstractMethod<
     'rippleSignTransaction',
@@ -40,11 +39,7 @@ export default class RippleSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Ripple'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Ripple')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/setBusy.ts
+++ b/packages/connect/src/api/setBusy.ts
@@ -3,7 +3,6 @@ import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
     constructor(message: MethodMessage<'setBusy'>) {
@@ -15,7 +14,6 @@ export default class SetBusy extends AbstractMethod<'setBusy', PROTO.SetBusy> {
         this.useDeviceState = false;
         this.skipFinalReload = false;
         this.overridePreviousCall = true;
-        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/api/showDeviceTutorial.ts
+++ b/packages/connect/src/api/showDeviceTutorial.ts
@@ -2,12 +2,10 @@ import { UI_REQUEST } from '@trezor/connect-common';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class ShowDeviceTutorial extends AbstractMethod<'showDeviceTutorial'> {
     constructor(message: MethodMessage<'showDeviceTutorial'>) {
         super(message, undefined);
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
         this.useEmptyPassphrase = true;
         this.useDeviceState = false;
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE];

--- a/packages/connect/src/api/signMessage.ts
+++ b/packages/connect/src/api/signMessage.ts
@@ -7,7 +7,7 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange, validateCoinPath } from './common/paramsValidator';
+import { validateCoinPath } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { hexToText, messageToHex } from '../utils/formatUtils';
@@ -51,13 +51,12 @@ export default class SignMessage extends AbstractMethod<'signMessage', Params> {
         super(message, params);
 
         this.coinInfo = coinInfo;
+        this.requiredFirmwareCoins = [coinInfo];
         // firmware range depends on used no_script_type parameter
         // no_script_type is possible since 1.10.4 / 2.4.3
-        this.firmwareRange = getFirmwareRange(
-            payload.no_script_type ? 'signMessageNoScriptType' : this.name,
-            this.coinInfo,
-            this.firmwareRange,
-        );
+        if (payload.no_script_type) {
+            this.requiredFirmwareCapabilities = ['signMessageNoScriptType'];
+        }
     }
 
     coinInfo: BitcoinNetworkInfo | undefined;

--- a/packages/connect/src/api/signTransaction.ts
+++ b/packages/connect/src/api/signTransaction.ts
@@ -36,7 +36,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { getLabel } from '../utils/pathUtils';
 import { getTransactionVbytes } from './bitcoin/transactionBytes';
-import { getFirmwareRange, validateParams } from './common/paramsValidator';
+import { validateParams } from './common/paramsValidator';
 
 type Params = {
     inputs: PROTO.TxInputType[];
@@ -183,8 +183,7 @@ export default class SignTransaction extends AbstractMethod<'signTransaction', P
 
         super(message, params);
 
-        // set required firmware from coinInfo support
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.requiredFirmwareCoins = [coinInfo];
         this.preauthorized = payload.preauthorized;
     }
 

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -17,7 +17,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.SolanaGetAddress;
@@ -51,11 +51,7 @@ export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress',
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -18,7 +18,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 export default class SolanaGetPublicKey extends AbstractMethod<
     'solanaGetPublicKey',
@@ -46,11 +46,7 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         this.hasBundle = hasBundle;
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/solana/api/solanaSignTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaSignTransaction.ts
@@ -39,7 +39,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import { getSolanaTokenDefinition } from '../solanaDefinitions';
 import { SOLANA_BASE_FEE, createTransactionShimFromHex } from '../solanaUtils';
 
@@ -88,11 +87,7 @@ export default class SolanaSignTransaction extends AbstractMethod<'solanaSignTra
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Solana'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Solana'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -19,7 +19,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.StellarGetAddress;
@@ -54,11 +54,7 @@ export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Stellar'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Stellar')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
+++ b/packages/connect/src/api/stellar/api/stellarSignTransaction.ts
@@ -9,7 +9,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import * as helper from '../stellarSignTx';
 
 type Params = {
@@ -46,11 +45,7 @@ export default class StellarSignTransaction extends AbstractMethod<
         super(message, params);
 
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Stellar'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Stellar')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -19,7 +19,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
     proto: PROTO.TezosGetAddress;
@@ -54,11 +54,7 @@ export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', P
         this.useUi = this.getUseUi(this.params, payload.useEventListener);
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -18,7 +18,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify, getFirmwareRange } from '../../common/paramsValidator';
+import { bundlify } from '../../common/paramsValidator';
 
 export default class TezosGetPublicKey extends AbstractMethod<
     'tezosGetPublicKey',
@@ -46,11 +46,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
 
         this.hasBundle = hasBundle;
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
+++ b/packages/connect/src/api/tezos/api/tezosSignTransaction.ts
@@ -8,7 +8,6 @@ import type { MethodMessage, MethodPermission } from '../../../core/AbstractMeth
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { validatePath } from '../../../utils/pathUtils';
-import { getFirmwareRange } from '../../common/paramsValidator';
 import * as helper from '../tezosSignTx';
 
 export default class TezosSignTransaction extends AbstractMethod<
@@ -26,11 +25,7 @@ export default class TezosSignTransaction extends AbstractMethod<
 
         super(message, params);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
-        this.firmwareRange = getFirmwareRange(
-            this.name,
-            getMiscNetwork('Tezos'),
-            this.firmwareRange,
-        );
+        this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/unlockPath.ts
+++ b/packages/connect/src/api/unlockPath.ts
@@ -5,7 +5,6 @@ import { Assert } from '@trezor/schema-utils';
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { validatePath } from '../utils/pathUtils';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.UnlockPath> {
     constructor(message: MethodMessage<'unlockPath'>) {
@@ -20,7 +19,6 @@ export default class UnlockPath extends AbstractMethod<'unlockPath', PROTO.Unloc
         };
 
         super(message, params);
-        this.firmwareRange = getFirmwareRange(this.name, undefined, this.firmwareRange);
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/verifyMessage.ts
+++ b/packages/connect/src/api/verifyMessage.ts
@@ -7,7 +7,6 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { getFirmwareRange } from './common/paramsValidator';
 import { getBitcoinNetwork } from '../data/coinInfo';
 import { validateModelOneMessageSize } from '../device/validateMessageSize';
 import { messageToHex } from '../utils/formatUtils';
@@ -45,8 +44,7 @@ export default class VerifyMessage extends AbstractMethod<'verifyMessage', Param
 
         super(message, params);
 
-        // check required firmware with coinInfo support
-        this.firmwareRange = getFirmwareRange(this.name, coinInfo, this.firmwareRange);
+        this.requiredFirmwareCoins = [coinInfo];
     }
 
     get requiredPermissions(): MethodPermission[] {

--- a/packages/connect/src/api/wipeDevice.ts
+++ b/packages/connect/src/api/wipeDevice.ts
@@ -5,7 +5,6 @@ import { DEVICE, UI_REQUEST } from '@trezor/connect-common';
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import type { Device } from '../device/Device';
-import { getFirmwareRange } from './common/paramsValidator';
 
 export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
     constructor(message: MethodMessage<'wipeDevice'>) {
@@ -14,7 +13,6 @@ export default class WipeDevice extends AbstractMethod<'wipeDevice'> {
         this.allowDeviceMode = [UI_REQUEST.INITIALIZE, UI_REQUEST.SEEDLESS, UI_REQUEST.BOOTLOADER];
         this.useDeviceState = false;
         this.skipFinalReload = false;
-        this.firmwareRange = getFirmwareRange(this.name, null, this.firmwareRange);
     }
     get requiredPermissions(): MethodPermission[] {
         return ['management'];

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -2,19 +2,22 @@ import { ERRORS, UI_REQUEST } from '@trezor/connect-common';
 import type {
     CallMethodPayload,
     CallMethodResponse,
+    CoinInfo,
     CoreEventMessage,
     DeviceState,
-    FirmwareRange,
     PrecomposeResultFinal,
     StaticSessionId,
     UiRequestButtonData,
     UiRequestConfirmation,
 } from '@trezor/connect-common';
 import type { Capability } from '@trezor/protobuf/src/definitions';
-import { versionUtils } from '@trezor/utils';
+import { isNotUndefined, versionUtils } from '@trezor/utils';
 
+import { DEFAULT_FIRMWARE_RANGE, getFirmwareRange } from '../api/common/paramsValidator';
 import type { Device } from '../device/Device';
 import type { UiPromiseCreator } from '../events';
+
+export { DEFAULT_FIRMWARE_RANGE };
 
 export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?: boolean };
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
@@ -46,16 +49,6 @@ export type MethodContext = {
 export type MethodMessage<Name extends CallMethodPayload['method']> = {
     id?: number;
     payload: Payload<Name>;
-};
-
-export const DEFAULT_FIRMWARE_RANGE: FirmwareRange = {
-    UNKNOWN: { min: '1.0.0', max: '0' },
-    T1B1: { min: '1.0.0', max: '0' },
-    T2T1: { min: '2.0.0', max: '0' },
-    T2B1: { min: '2.6.1', max: '0' },
-    T3B1: { min: '2.8.1', max: '0' },
-    T3T1: { min: '2.7.1', max: '0' },
-    T3W1: { min: '2.7.1', max: '0' }, // TODO T3W1
 };
 
 function validateStaticSessionId(input: unknown): StaticSessionId {
@@ -125,7 +118,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     public overridden: boolean;
 
-    public name: Name; // method name
+    public readonly name: Name; // method name
 
     protected get info() {
         return '';
@@ -145,13 +138,13 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     public useEmptyPassphrase: boolean;
 
-    protected firmwareRange: FirmwareRange;
-
     abstract get requiredPermissions(): MethodPermission[];
 
     public allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI_REQUEST.INITIALIZED)
 
     protected requiredDeviceCapabilities: Capability[] = [];
+    protected requiredFirmwareCapabilities: string[] = [];
+    protected requiredFirmwareCoins: (CoinInfo | undefined)[] = [];
 
     public useCardanoDerivation: boolean;
 
@@ -178,7 +171,6 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.allowDeviceMode = [UI_REQUEST.SEEDLESS]; // Allow seedless by default
 
         // default values for all methods
-        this.firmwareRange = DEFAULT_FIRMWARE_RANGE;
         this.useDevice = true;
         this.useDeviceState = true;
         this.useUi = true;
@@ -225,7 +217,11 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         // seedless devices do not offer firmware update - it is not desirable to update something that does not have seed
         if (device.isSeedless()) return;
 
-        const range = this.firmwareRange[device.features.internal_model];
+        const firmwareRange = getFirmwareRange(
+            [this.name, ...this.requiredFirmwareCapabilities],
+            this.requiredFirmwareCoins.filter(isNotUndefined),
+        );
+        const range = firmwareRange[device.features.internal_model];
 
         if (device.firmwareStatus === 'none') {
             return UI_REQUEST.FIRMWARE_NOT_INSTALLED;

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -14,7 +14,9 @@ const bitcoinNetworks: BitcoinNetworkInfo[] = [];
 const ethereumNetworks: EthereumNetworkInfo[] = [];
 const miscNetworks: MiscNetworkInfo[] = [];
 
-export const getBitcoinNetwork = (pathOrName: DerivationPath) => {
+export const getBitcoinNetwork = (
+    pathOrName: DerivationPath,
+): Readonly<BitcoinNetworkInfo> | undefined => {
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
 
@@ -23,38 +25,40 @@ export const getBitcoinNetwork = (pathOrName: DerivationPath) => {
                 n.name.toLowerCase() === name ||
                 n.shortcut.toLowerCase() === name ||
                 n.label.toLowerCase() === name,
-        ) as Readonly<BitcoinNetworkInfo>;
+        );
     }
     const slip44 = fromHardened(pathOrName[1]);
 
-    return bitcoinNetworks.find(n => n.slip44 === slip44) as Readonly<BitcoinNetworkInfo>;
+    return bitcoinNetworks.find(n => n.slip44 === slip44);
 };
 
-export const getEthereumNetwork = (pathOrNetworkSymbol: DerivationPath) => {
+export const getEthereumNetwork = (
+    pathOrNetworkSymbol: DerivationPath,
+): Readonly<EthereumNetworkInfo> | undefined => {
     if (typeof pathOrNetworkSymbol === 'string') {
         const networkSymbol = pathOrNetworkSymbol.toLowerCase();
 
-        return ethereumNetworks.find(
-            network => network.shortcut.toLowerCase() === networkSymbol,
-        ) as Readonly<EthereumNetworkInfo>;
+        return ethereumNetworks.find(network => network.shortcut.toLowerCase() === networkSymbol);
     }
 
     const slip44 = fromHardened(pathOrNetworkSymbol[1]);
 
-    return ethereumNetworks.find(n => n.slip44 === slip44) as Readonly<EthereumNetworkInfo>;
+    return ethereumNetworks.find(n => n.slip44 === slip44);
 };
 
-export const getMiscNetwork = (pathOrName: DerivationPath) => {
+export const getMiscNetwork = (
+    pathOrName: DerivationPath,
+): Readonly<MiscNetworkInfo> | undefined => {
     if (typeof pathOrName === 'string') {
         const name = pathOrName.toLowerCase();
 
         return miscNetworks.find(
             n => n.name.toLowerCase() === name || n.shortcut.toLowerCase() === name,
-        ) as Readonly<MiscNetworkInfo>;
+        );
     }
     const slip44 = fromHardened(pathOrName[1]);
 
-    return miscNetworks.find(n => n.slip44 === slip44) as Readonly<MiscNetworkInfo>;
+    return miscNetworks.find(n => n.slip44 === slip44);
 };
 
 /*

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -1,16 +1,9 @@
-import type { DeviceModelInternal } from '@trezor/device-utils';
+import type { FirmwareRule } from '@trezor/connect-common';
 import { TREZOR_USB_DESCRIPTORS } from '@trezor/transport/src/constants';
 
 type Config = {
     webusb: typeof TREZOR_USB_DESCRIPTORS;
-    supportedFirmware: Array<{
-        coin?: string[];
-        capabilities?: string[];
-        methods?: string[];
-        min: Partial<Record<DeviceModelInternal, string>>;
-        max?: undefined; // NOTE: max field is not used anywhere at the moment, it is here for type compatibility
-        comment?: string[];
-    }>;
+    supportedFirmware: Array<FirmwareRule>;
 };
 
 export const config: Config = {

--- a/packages/utils/src/typedObject.ts
+++ b/packages/utils/src/typedObject.ts
@@ -9,6 +9,14 @@ export const typedObjectFromEntries = <T extends readonly (readonly [string, unk
 ): { [K in T[number] as K[0]]: K[1] } =>
     Object.fromEntries(entries) as { [K in T[number] as K[0]]: K[1] };
 
+export const typedObjectTransformValues = <T extends Record<string, unknown>, U>(
+    obj: T,
+    transform: (value: T[keyof T], key: keyof T) => U,
+): { [K in keyof T]: U } =>
+    Object.fromEntries(
+        Object.entries(obj).map(([key, value]) => [key, transform(value as T[keyof T], key)]),
+    ) as { [K in keyof T]: U };
+
 export const typedObjectKeys = <T extends Record<string, unknown>>(obj: T): Array<keyof T> =>
     Object.keys(obj) as Array<keyof T>;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- https://github.com/trezor/trezor-suite/pull/26368/changes/ca2f9498a5a297d89b8ef412b4cb2dffe1fb4db5 - fix return types of get network utils (because they can return undefined)
- https://github.com/trezor/trezor-suite/pull/26368/changes/2606421b9ec9148e4dcc8076e956bac2463ed0d3 - simplified config mocking in `paramsValidator` unit test 
- https://github.com/trezor/trezor-suite/pull/26368/changes/c12438656722eeb2dafe4f577a3639d731eb08c3 - removed deprecated `connect` field from coin support definitions
- https://github.com/trezor/trezor-suite/pull/26368/changes/82d691c048ee194e1136a84a699067686a04b5e8 - improved typing of `supportedFirmware` config
- https://github.com/trezor/trezor-suite/pull/26368/changes/b6f3f52de59e11d2518e60a78a9c46afed0cb52a - `getFirmwareRange` behavior changed: rule with neither coin nor method is always valid; `max` in rules handles zero value properly
- https://github.com/trezor/trezor-suite/pull/26368/changes/b1d0ba9ab204de79cf0ceb2ff41146c690296425 - added `typedObjectTransformValues` util
- https://github.com/trezor/trezor-suite/pull/26368/changes/e7075b334ec5ef09fd09efacb3317d8c66bd0394 - `getFirmwareRange` polished without behavioral changes
- https://github.com/trezor/trezor-suite/pull/26368/changes/8522ab3206f94d88d6b64147776ec18f56f0da7e - `getFirmwareRange` now handles most of the cases directly in `AbstractMethod`; special cases can set custom `requiredFirmwareCoins` and/or `requiredDeviceCapabilities`; `Method_Discovery_BundleException` removed

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/firmware-validation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/firmware-validation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/firmware-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T10:08:37.602Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T10:07:42.078Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->