### PR TITLE
fix(suite): hide network reserve banner when send max is not used

### DIFF
--- a/packages/suite/src/hooks/wallet/useSendFormCompose.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormCompose.ts
@@ -233,6 +233,8 @@ export const useSendFormCompose = ({
                 setAmount(setMaxOutputId, composed.max);
                 setShowReserveBanner(true);
                 setDraftSaveRequest(true);
+            } else {
+                setShowReserveBanner(false);
             }
             setLoading(false);
         },


### PR DESCRIPTION
## Description

Fix network reserve banner showing when send max is turned off.

## Related Issue

Resolve #25986 

## Screenshots:

https://github.com/user-attachments/assets/35b89211-c745-48d4-a580-30d6bce90d67



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-max-network-reserve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-max-network-reserve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-02T15:40:59.066Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-03T10:56:17.742Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->