### PR TITLE
test(e2e-native): fixes suite sync tests

### DIFF
--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -16,6 +16,7 @@ services:
       - "18021:18021" # bitcoin-d rpc port
 
   quota-db:
+    container_name: quota-db
     image: postgres
     environment:
       POSTGRES_USER: suite-sync
@@ -30,6 +31,7 @@ services:
       retries: 5
 
   suite-sync:
+    container_name: suite-sync
     image: ghcr.io/trezor/suite-sync:main
     environment:
       POSTGRES_GATE_USER: suite-sync

--- a/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
+++ b/suite-common/e2e-evolu-client/src/baseEvoluClient.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import {
     AppName,
     type Evolu,
@@ -31,8 +33,36 @@ const EVOLU_LOCAL_SERVER_NOT_RUNNING_ERROR =
 
 export const createQuery = createQueryBuilder(Schema);
 
+const REPO_ROOT = path.resolve(__dirname, '../../../');
+
+export const logToRelayDocker = (message: string) => {
+    try {
+        execFileSync(
+            'docker',
+            [
+                'compose',
+                '-f',
+                'docker/docker-compose.suite-ci-e2e.yml',
+                'exec',
+                '-T',
+                '-e',
+                `MARKER=${message}`,
+                'suite-sync',
+                'sh',
+                '-c',
+                'echo "[TEST] $MARKER" > /proc/1/fd/1',
+            ],
+            { cwd: REPO_ROOT },
+        );
+    } catch (e) {
+        // Non-fatal: marker logging should not break tests
+        console.warn('[logToRelayDocker] failed:', e);
+    }
+};
+
 export class BaseEvoluClient {
     private _evolu?: Evolu<typeof Schema>;
+    private _ownerId?: string;
 
     async init({ ownerSecret, relayUrl = RELAY_URL }: EvoluClientInitParams) {
         const run = createNodeEvoluDeps();
@@ -40,6 +70,10 @@ export class BaseEvoluClient {
         if (!owner.ok) {
             throw new Error(`Failed to parse owner: ${JSON.stringify(owner.error)}`);
         }
+
+        this._ownerId = owner.value.id;
+        console.log('[EvoluClient] init ownerId:', this._ownerId);
+        logToRelayDocker(`EVOLU INIT: ownerId=${this._ownerId}`);
 
         const sanitizedOwnerId = owner.value.id.replaceAll('_', '-');
         const appName = AppName.orThrow(`trezor-suite-e2e-${sanitizedOwnerId}`);
@@ -71,6 +105,7 @@ export class BaseEvoluClient {
     }
 
     writeTo<T extends TableName>(table: T, object: MutationValues<(typeof Schema)[T], 'upsert'>) {
+        console.log(`[EvoluClient] writeTo table=${table}:`, JSON.stringify(object));
         this.evolu.upsert(table, object as any);
     }
 
@@ -82,8 +117,9 @@ export class BaseEvoluClient {
 
         return this.evolu.subscribeQuery(query)(() => {
             const rows = this.evolu.getQueryRows(query);
-            console.error(
-                `Evolu subscription update for table "${table}": ${JSON.stringify(rows, null, 2)}`,
+            console.log(
+                `[EvoluClient] sync update table=${table}: ${rows.length} rows`,
+                rows.length > 0 ? JSON.stringify(rows) : '(empty)',
             );
         });
     }
@@ -94,7 +130,24 @@ export class BaseEvoluClient {
             db.selectFrom(table).where('ownerId', '=', ownerId).selectAll(),
         );
 
-        return await this.evolu.loadQuery(query);
+        const rows = await this.evolu.loadQuery(query);
+        console.log(
+            `[EvoluClient] readFrom table=${table}: ${rows.length} rows`,
+            rows.length > 0 ? JSON.stringify(rows) : '(empty)',
+        );
+
+        return rows;
+    }
+
+    async dispose() {
+        console.log('[EvoluClient] dispose START ownerId:', this._ownerId);
+        logToRelayDocker(`EVOLU DISPOSE START: ownerId=${this._ownerId}`);
+        if (this._evolu) {
+            await this._evolu[Symbol.asyncDispose]();
+            this._evolu = undefined;
+        }
+        console.log('[EvoluClient] dispose DONE ownerId:', this._ownerId);
+        this._ownerId = undefined;
     }
 }
 
@@ -107,8 +160,6 @@ const QUOTA_PUBLIC_KEY =
 const QUOTA_TOTAL_STORAGE_SIZE = 1048576;
 const QUOTA_UNSPENT_STORAGE_SIZE = 1038090;
 const QUOTA_DB_CREDENTIALS = '-U suite-sync -d suite-sync-gate';
-
-const REPO_ROOT = path.resolve(__dirname, '../../../');
 
 const waitForRelayReady = async (maxWaitMs = 30_000) => {
     const pollIntervalMs = 500;

--- a/suite-common/e2e-evolu-client/src/createEvoluNodeDeps.ts
+++ b/suite-common/e2e-evolu-client/src/createEvoluNodeDeps.ts
@@ -25,9 +25,8 @@ import {
 import BetterSqlite3, { type Statement } from 'better-sqlite3';
 import { WebSocket } from 'ws';
 
-const createSqliteDriver: CreateSqliteDriver = (_name, options) => () => {
-    const filename = options?.mode === 'memory' ? ':memory:' : `${_name}.db`;
-    const db = new BetterSqlite3(filename);
+const createSqliteDriver: CreateSqliteDriver = () => () => {
+    const db = new BetterSqlite3(':memory:');
     let isDisposed = false;
 
     const cache = createPreparedStatementsCache<Statement>(sql => db.prepare(sql), lazyVoid);

--- a/suite-common/e2e-evolu-client/src/index.ts
+++ b/suite-common/e2e-evolu-client/src/index.ts
@@ -5,6 +5,7 @@ export {
     wipeAndRestartEvoluRelayServer,
     checkEvoluRelayServerRunning,
     seedQuotaManagerData,
+    logToRelayDocker,
 } from './baseEvoluClient';
 export type { EvoluClientInitParams } from './baseEvoluClient';
 export {

--- a/suite-native/app/e2e/pageObjects/settingsActions.ts
+++ b/suite-native/app/e2e/pageObjects/settingsActions.ts
@@ -21,7 +21,8 @@ type SettingsOptions =
     | 'trading'
     | 'wallet-connect'
     | 'connect-permissions'
-    | 'advanced';
+    | 'advanced'
+    | 'experimental';
 
 class SettingsActions {
     async openSection(option: SettingsOptions) {
@@ -107,28 +108,25 @@ class SettingsActions {
         const saveSuiteSyncUrl = element(by.id('@suiteSync/custom-relay-url-save-button'));
         await scrollUntilVisible(saveSuiteSyncUrl);
         await element(by.id('@suiteSync/custom-relay-url-input')).replaceText(url);
-        // Workaround: close keyboard by clicking on section header before tapping Save
-        await element(by.id('@suiteSync/header')).tap();
-        await element(by.id('@suiteSync/custom-relay-url-save-button')).tap();
+        await saveSuiteSyncUrl.tap();
 
-        const enforceQuotaManagerSwitcher = element(by.id('@suiteSyncQuotaManager/save-button'));
-        await scrollUntilVisible(enforceQuotaManagerSwitcher);
-        await element(by.id('@suiteSyncQuotaManager/url-input')).replaceText(quotaUrl);
-        await enforceQuotaManagerSwitcher.tap();
-
+        const saveQuotaManagerUrl = element(by.id('@suiteSyncQuotaManager/save-button'));
         const enforceQuotaManager = element(by.id('@suiteSyncQuotaManager/enforce-switch'));
         await scrollUntilVisible(enforceQuotaManager);
+        await element(by.id('@suiteSyncQuotaManager/url-input')).replaceText(quotaUrl);
+        await saveQuotaManagerUrl.tap();
         await enforceQuotaManager.tap();
 
         await onTabBar.tapBackButton();
 
         await this.openSection('suite-sync');
         await wait(1000);
-        await element(by.id('settings/suite-sync-touchable-row')).tap();
+        const suiteSyncToggle = element(by.id('settings/suite-sync-touchable-row'));
+        await suiteSyncToggle.tap();
         await wait(1000);
         await waitForVisible(by.id('@continue-on-trezor'));
         await TrezorUserEnvLink.pressYes();
-        await waitForVisible(by.id('settings/suite-sync-touchable-row'));
+        await waitForVisible(suiteSyncToggle);
     }
 }
 

--- a/suite-native/app/e2e/support/utils.ts
+++ b/suite-native/app/e2e/support/utils.ts
@@ -25,7 +25,7 @@ const SCROLL_VISIBILITY_THRESHOLD = platform === 'android' ? 100 : undefined;
 
 export const RETRY_CONF = {
     attempts: 5,
-    gap: 500,
+    gap: 2_000,
 };
 
 export const wait = async (ms: number) => {

--- a/suite-native/app/e2e/tests/suiteSync.test.ts
+++ b/suite-native/app/e2e/tests/suiteSync.test.ts
@@ -1,3 +1,4 @@
+import { expect as jestExpect } from '@jest/globals';
 import { expect as detoxExpect } from 'detox';
 import { diff } from 'jest-diff';
 import { isEqual, omit } from 'lodash';
@@ -6,6 +7,7 @@ import {
     BaseEvoluClient,
     checkEvoluRelayServerRunning,
     immuneFixtures,
+    logToRelayDocker,
     seedQuotaManagerData,
     wipeAndRestartEvoluRelayServer,
 } from '@suite-common/e2e-evolu-client';
@@ -73,19 +75,24 @@ const preloadedState = preparePreloadedReduxState(
     deviceChecksDisabledState,
 );
 
-// FIXME
-describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
+describe('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
     let evoluClient: NativeEvoluClient;
 
     beforeEach(async () => {
         await checkEvoluRelayServerRunning();
-        await wipeAndRestartEvoluRelayServer();
-
-        evoluClient = new NativeEvoluClient();
-
+        logToRelayDocker(`STARTING: ${jestExpect.getState().currentTestName!}`);
         await openApp({ args: { preloadedState } });
+        logToRelayDocker(`APP RESTARTED: ${jestExpect.getState().currentTestName!}`);
+        await wipeAndRestartEvoluRelayServer();
+        logToRelayDocker(`RELAY WIPED: ${jestExpect.getState().currentTestName!}`);
+        evoluClient = new NativeEvoluClient();
         await prepareTrezorEmulator({ seed: 'mnemonic_immune' });
         await onDeviceManager.assertDeviceSwitcherState({ title: 'Connected' });
+    }, 240_000);
+
+    afterEach(async () => {
+        await evoluClient?.dispose();
+        logToRelayDocker(`FINISHED: ${jestExpect.getState().currentTestName!}`);
     });
 
     test('Create new labels', async () => {
@@ -147,7 +154,7 @@ describe.skip('Suite Sync - Labelling [@androidOnly @T3T1 @smoke]', () => {
 
         // Verify labels were synced to the relay
         await evoluClient.init({ ownerSecret: immuneFixtures.ownerSecret });
-        await evoluClient.expectInTable('account', [expectedAccountData]);
+        await evoluClient.expectInTable('account', [expectedAccountData], { timeout: 30_000 });
         await evoluClient.expectInTable('address', [expectedAddressData]);
         await evoluClient.expectInTable('output', [expectedOutputData]);
     });

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -129,7 +129,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     evoluClient: async ({}, use) => {
         await checkEvoluRelayServerRunning();
-        await use(new EvoluClient());
+        const evoluClient = new EvoluClient();
+        await use(evoluClient);
+        await evoluClient.dispose();
     },
 });
 

--- a/suite/e2e/support/helpers/evoluClient.ts
+++ b/suite/e2e/support/helpers/evoluClient.ts
@@ -47,6 +47,11 @@ export class EvoluClient extends BaseEvoluClient {
     }
 
     @step()
+    override async dispose() {
+        await super.dispose();
+    }
+
+    @step()
     async debugReadAllTablesAndThrow() {
         const allDataPromise = allTables.map(async table => await this.readFrom(table));
         await expect(async () => {


### PR DESCRIPTION
Fixes native suite sync test setup and renables tests.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-e2e-native-reenable-suite-sync&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-e2e-native-reenable-suite-sync&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test-e2e-native-reenable-suite-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Account metadata > dropbox - watches files over time | 🤖 auto |
| Account metadata > google - watches files over time | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-04T13:22:07.655Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-04T13:20:32.208Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->