### PR TITLE
chore(connect): pass device identity instead of full device object to…

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -139,7 +139,11 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
     try {
         const response = await method.run();
 
-        return createResponseMessage(method.responseID, true, response, device);
+        return createResponseMessage(method.responseID, true, response, {
+            path: device.getUniquePath(),
+            state: device.getState(),
+            instance: device.getInstance(),
+        });
     } catch (error) {
         return Promise.reject(error);
     }

--- a/packages/connect/src/events/call.ts
+++ b/packages/connect/src/events/call.ts
@@ -2,8 +2,8 @@ import type { SerializedError } from '@trezor/connect-common/src/constants/error
 import { serializeError } from '@trezor/connect-common/src/constants/errors';
 
 import type { CORE_CALL } from './core-call';
+import type { DeviceState, DeviceUniquePath } from '../types';
 import type { TrezorConnect, TrezorConnectManagement } from '../types/api';
-import type { IDevice } from '../types/idevice';
 import type { CommonParams, DeviceIdentity } from '../types/params';
 
 // conditionally unwrap TrezorConnect api method Success<T> response
@@ -90,15 +90,10 @@ export const createResponseMessage = (
     id: number,
     success: boolean,
     payload: any,
-    device?: IDevice,
+    deviceIdentity:
+        | { path: DeviceUniquePath; state?: DeviceState; instance: number }
+        | undefined = undefined,
 ): MethodResponseMessage => {
-    const deviceIdentity = device
-        ? {
-              path: device?.getUniquePath(),
-              state: device?.getState(),
-              instance: device?.getInstance(),
-          }
-        : undefined;
     if (success)
         return {
             event: RESPONSE_EVENT,


### PR DESCRIPTION
… createResponseMessage

As discussed with @szymonlesisz in #26141

It is better to pass only relevant fields to reduce coupling. See this note https://github.com/trezor/trezor-suite/pull/26141#discussion_r3027240871

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore-pass-device-identity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore-pass-device-identity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T11:15:25.472Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->