### PR TITLE
Fix backup type reference

### DIFF
--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -28,9 +28,9 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
                 strength: 128,
             };
         case '12-words':
-            return { backup_type: PROTO.BackupType.Bip39, strength: 128 };
+            return { backup_type: PROTO.Enum_BackupType.Bip39, strength: 128 };
         case '24-words':
-            return { backup_type: PROTO.BackupType.Bip39, strength: 256 };
+            return { backup_type: PROTO.Enum_BackupType.Bip39, strength: 256 };
         default:
             return exhaustive(walletBackupType);
     }

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -19,12 +19,12 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
     switch (walletBackupType) {
         case 'shamir-single':
             return {
-                backup_type: 3,
+                backup_type: PROTO.Enum_BackupType.Slip39_Single_Extendable,
                 strength: 128,
             };
         case 'shamir-advanced':
             return {
-                backup_type: 4,
+                backup_type: PROTO.Enum_BackupType.Slip39_Basic_Extendable,
                 strength: 128,
             };
         case '12-words':


### PR DESCRIPTION
while working on #26141 I've detected this little room for improvement.

<img width="601" height="358" alt="image" src="https://github.com/user-attachments/assets/70d63291-0caa-4e48-8fec-3945687d2878" />

<img width="543" height="429" alt="image" src="https://github.com/user-attachments/assets/1a2aabbc-89f3-4747-bda5-90c3dac331fa" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-backup-type-reference&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->