### PR TITLE
feat(suite): allow users to change fee limit for trc20 transfers

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -11,6 +11,7 @@ import {
     type CollapsibleFeesHeaderContentProps,
 } from './CollapsibleFeesHeaderContent';
 import { CustomFee } from './CustomFee/CustomFee';
+import { CustomFeeTron } from './CustomFee/CustomFeeTron';
 import { StandardFee } from './StandardFee/StandardFee';
 import { FeesContext, type FeesContextType, type TronResources } from '../context/FeesContext';
 import { useTransactionMaxFee } from './hooks/useTransactionMaxFee';
@@ -40,7 +41,18 @@ export function CollapsibleFees({
         name: 'selectedFee',
         defaultValue: 'normal',
     });
-    const supportsAdjustableFees = networkType !== 'solana' && networkType !== 'tron';
+
+    const isTrc20Transfer = useMemo(() => {
+        if (networkType !== 'tron' || composedLevels == null) return false;
+        const { normal } = composedLevels;
+
+        return (
+            normal != null && normal.type !== 'error' && 'token' in normal && normal.token != null
+        );
+    }, [networkType, composedLevels]);
+
+    const supportsAdjustableFees =
+        networkType !== 'solana' && (networkType !== 'tron' || isTrc20Transfer);
     const isCustomFee = supportsAdjustableFees && selectedFee === 'custom';
 
     // when fees are loading, feeInfo.levels = [], but CustomFee requires at least the 'normal' level to have some default
@@ -84,34 +96,40 @@ export function CollapsibleFees({
                 {supportsAdjustableFees && (
                     <Collapsible.Content overflow="unset" onClick={ev => ev.stopPropagation()}>
                         <Column gap={16}>
-                            <Column gap={16}>
-                                {!isCustomFee && <StandardFee />}
-                                {isCustomFee && <CustomFee showCurrentFee={!rbfForm} />}
-                            </Column>
+                            {isTrc20Transfer ? (
+                                <CustomFeeTron />
+                            ) : (
+                                <>
+                                    <Column gap={16}>
+                                        {!isCustomFee && <StandardFee />}
+                                        {isCustomFee && <CustomFee showCurrentFee={!rbfForm} />}
+                                    </Column>
 
-                            <Row justifyContent="center" margin={{ bottom: 8 }}>
-                                {isCustomFee && (
-                                    <Button
-                                        intent="neutral"
-                                        priority="secondary"
-                                        onClick={() => changeFeeLevel('normal')}
-                                        data-testid="@wallet/fees/select-standard-fee"
-                                    >
-                                        <Translation id="FEE_LEVEL_STANDARD" />
-                                    </Button>
-                                )}
-                                {!isCustomFee && hasNormalFeeLevel && (
-                                    <TextButton
-                                        onClick={() => changeFeeLevel('custom')}
-                                        data-testid="@wallet/fees/select-custom-fee"
-                                        intent="neutral"
-                                        size="small"
-                                        isUnderlined
-                                    >
-                                        <Translation id="FEE_LEVEL_ADVANCED" />
-                                    </TextButton>
-                                )}
-                            </Row>
+                                    <Row justifyContent="center" margin={{ bottom: 8 }}>
+                                        {isCustomFee && (
+                                            <Button
+                                                intent="neutral"
+                                                priority="secondary"
+                                                onClick={() => changeFeeLevel('normal')}
+                                                data-testid="@wallet/fees/select-standard-fee"
+                                            >
+                                                <Translation id="FEE_LEVEL_STANDARD" />
+                                            </Button>
+                                        )}
+                                        {!isCustomFee && hasNormalFeeLevel && (
+                                            <TextButton
+                                                onClick={() => changeFeeLevel('custom')}
+                                                data-testid="@wallet/fees/select-custom-fee"
+                                                intent="neutral"
+                                                size="small"
+                                                isUnderlined
+                                            >
+                                                <Translation id="FEE_LEVEL_ADVANCED" />
+                                            </TextButton>
+                                        )}
+                                    </Row>
+                                </>
+                            )}
                         </Column>
                     </Collapsible.Content>
                 )}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -45,5 +45,9 @@ export const CollapsibleFeesHeaderContent = ({
         </Row>
     );
 
-    return isOpen !== undefined ? content : <Collapsible.Toggle>{content}</Collapsible.Toggle>;
+    return isOpen !== undefined || !supportsAdjustableFees ? (
+        content
+    ) : (
+        <Collapsible.Toggle>{content}</Collapsible.Toggle>
+    );
 };

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from 'react';
+import { useFormContext, useFormState } from 'react-hook-form';
+import { useSelector } from 'react-redux';
+
+import { Translation, useTranslation } from '@suite/intl';
+import { selectLanguage } from '@suite/settings';
+import { type FormState } from '@suite-common/wallet-types';
+import { isInteger } from '@suite-common/wallet-utils';
+import { NumberInput } from '@trezor/product-components';
+import { BigNumber } from '@trezor/utils';
+
+import { InputError } from 'src/components/wallet';
+
+import { FEE_LIMIT } from './constants';
+
+export const CustomFeeTron = () => {
+    const locale = useSelector(selectLanguage);
+    const { translationString } = useTranslation();
+
+    const { control, getValues, setValue } = useFormContext<FormState>();
+    const { errors } = useFormState<FormState>();
+
+    const estimatedFeeLimit = getValues('estimatedFeeLimit');
+
+    useEffect(() => {
+        if (getValues(FEE_LIMIT) === '' && estimatedFeeLimit) {
+            setValue(FEE_LIMIT, estimatedFeeLimit);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const feeLimitRules = {
+        required: translationString('CUSTOM_FEE_IS_NOT_SET'),
+        validate: {
+            integer: (value: string) => {
+                if (!isInteger(value)) {
+                    return translationString('CUSTOM_FEE_IS_NOT_INTEGER');
+                }
+            },
+            feeLimit: (value: string) => {
+                if (estimatedFeeLimit && new BigNumber(value).lt(estimatedFeeLimit)) {
+                    return translationString('TR_TRON_FEE_LIMIT_BELOW_RECOMMENDED');
+                }
+            },
+        },
+    };
+
+    const useRecommendedButtonProps =
+        errors.feeLimit?.type === 'feeLimit'
+            ? {
+                  onClick: () =>
+                      estimatedFeeLimit &&
+                      setValue(FEE_LIMIT, estimatedFeeLimit, { shouldValidate: true }),
+                  text: translationString('CUSTOM_FEE_USE_RECOMMENDED'),
+              }
+            : undefined;
+
+    return (
+        <NumberInput
+            label={<Translation id="TR_TRON_FEE_LIMIT" />}
+            locale={locale}
+            control={control}
+            hasError={!!errors.feeLimit}
+            name={FEE_LIMIT}
+            data-testid={FEE_LIMIT}
+            rules={feeLimitRules}
+            bottomText={
+                errors.feeLimit?.message ? (
+                    <InputError
+                        message={errors.feeLimit.message}
+                        buttonProps={useRecommendedButtonProps}
+                    />
+                ) : null
+            }
+        />
+    );
+};

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/StandardFee.tsx
@@ -26,6 +26,9 @@ export const StandardFee = () => {
         case 'ethereum':
             return <EthereumFeeCards feeOptions={feeOptions} />;
 
+        case 'tron':
+            return null;
+
         default:
             return <MiscFeeCards feeOptions={feeOptions} />;
     }

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -80,11 +80,11 @@ export const ReviewButton = () => {
     const isLowAnonymity =
         Array.isArray(errors.outputs) &&
         errors.outputs.some(output => isLowAnonymityWarning(output));
-
     const possibleToSubmit =
         composedTx?.type === 'final' &&
         online &&
         !isLowAnonymity &&
+        !errors.feeLimit &&
         (isDeviceConnected ? !isLocked() : true);
 
     const confirmationRequired =

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -300,9 +300,20 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
             }).toString();
         }
 
+        if (tokenInfo && tx.type !== 'error') {
+            tx.estimatedFeeLimit = tx.fee;
+        }
+
         return { normal: tx };
     },
 );
+
+const getTrc20FeeLimitSun = (feeLimit: string, estimatedFee: string): number | undefined => {
+    if (feeLimit !== '') return Number(feeLimit);
+    if (estimatedFee !== '') return Number(estimatedFee);
+
+    return undefined;
+};
 
 export const signTronSendFormTransactionThunk = createThunk<
     { serializedTx: string },
@@ -354,6 +365,10 @@ export const signTronSendFormTransactionThunk = createThunk<
             tokenData = calldataResult.data.slice(2); // strip the "0x" prefix; firmware expects raw hex
         }
 
+        const tokenFeeLimitSun = token
+            ? getTrc20FeeLimitSun(formState.feeLimit, precomposedTransaction.fee)
+            : undefined;
+
         const composed = await TrezorConnect.tronComposeTransaction({
             from: selectedAccount.descriptor,
             to: token ? token.contract : output.address,
@@ -364,9 +379,7 @@ export const signTronSendFormTransactionThunk = createThunk<
                 ? {
                       contract: token.contract,
                       data: tokenData ?? '',
-                      feeLimit: precomposedTransaction.fee
-                          ? Number(precomposedTransaction.fee)
-                          : undefined,
+                      feeLimit: tokenFeeLimitSun,
                   }
                 : undefined,
         });
@@ -431,11 +444,7 @@ export const signTronSendFormTransactionThunk = createThunk<
             ref_block_hash,
             expiration,
             timestamp,
-            // fee_limit is in SUN (not energy units); use the total estimated fee as the cap
-            fee_limit:
-                token && precomposedTransaction.fee
-                    ? Number(precomposedTransaction.fee)
-                    : undefined,
+            fee_limit: tokenFeeLimitSun,
             contract,
         });
 

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -63,8 +63,8 @@ export interface FormState {
     maxPriorityFeePerGas?: string; // ethereum eip1559 only
     maxFeePerGas?: string; // ethereum eip1559 only
     baseFeePerGas?: string; // ethereum eip1559 only
-    feeLimit: string; // ethereum only (gasLimit)
-    estimatedFeeLimit?: string; // ethereum only (gasLimit)
+    feeLimit: string; // ethereum: gas limit; tron: fee_limit cap in SUN for TRC-20 transfers
+    estimatedFeeLimit?: string; // ethereum: estimated gas limit; tron: estimated fee_limit cap in SUN for TRC-20 transfers
 
     /**
      * Fee that was paid by chained transactions. To perform RBF transaction (bump fee or cancel)

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5341,6 +5341,14 @@ export const messages = defineMessages({
         id: 'TR_TRON_FEE_ENERGY',
         defaultMessage: '{count} energy',
     },
+    TR_TRON_FEE_LIMIT: {
+        id: 'TR_TRON_FEE_LIMIT',
+        defaultMessage: 'Energy fee limit (SUN)',
+    },
+    TR_TRON_FEE_LIMIT_BELOW_RECOMMENDED: {
+        id: 'TR_TRON_FEE_LIMIT_BELOW_RECOMMENDED',
+        defaultMessage: 'Fee limit too low',
+    },
     TR_EXPERIMENTAL_TRON_VIEW_ONLY: {
         id: 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
         defaultMessage: 'Tron (Beta)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements an options for users to set custom fee limit value when sending TRC20 tokens

## Notes for QA

## Related Issue

## Screenshots:

<img width="1029" height="939" alt="image" src="https://github.com/user-attachments/assets/55aecee7-4240-44c5-877f-41bd0cb557a3" />

<img width="1044" height="990" alt="image" src="https://github.com/user-attachments/assets/b98cb6b9-51bf-4868-adad-db86d81b8553" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-custom-fee-limit&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-custom-fee-limit&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-custom-fee-limit&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T12:47:42.828Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-06T12:46:37.609Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->