### PR TITLE
ci(connect): stricter checks

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -8,6 +8,16 @@ on:
     branches: [release/connect/**]
   pull_request:
     paths:
+      - "packages/connect-common/**"
+      - "packages/connect-data/**"
+      - "packages/connect-mobile/**"
+      - "packages/connect-web/**"
+      - "packages/connect-webextension/**"
+      - "packages/connect/**"
+      - "scripts/ci/helpers.ts"
+      - "scripts/ci/pack-packages.ts"
+      - "scripts/publish/**"
+      - "packages/connect/e2e/test-connect-local.sh"
       - ".github/workflows/test-connect-misc.yml"
   workflow_dispatch:
 
@@ -69,7 +79,7 @@ jobs:
 
       - name: Check exports
         # Fow now only testing @trezor/connect-web
-        run: npx --yes @arethetypeswrong/cli --pack ./tmp/packed-packages/trezor-connect-web.tgz 
+        run: npx --yes @arethetypeswrong/cli --pack ./tmp/packed-packages/trezor-connect-web.tgz
 
       - name: Test local install
         run: ./packages/connect/e2e/test-connect-local.sh

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -43,10 +43,10 @@
             "./libESM/*": "./libESM/*"
         },
         "browser": {
-            "./lib/pinger/ping": "./lib/pinger/ping.browser.ts",
-            "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser.ts",
-            "./lib/transports/udp": "./lib/transports/udp.browser.ts",
-            "./lib/transports/webusb": "./lib/transports/webusb.browser.ts"
+            "./lib/pinger/ping": "./lib/pinger/ping.browser.js",
+            "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser.js",
+            "./lib/transports/udp": "./lib/transports/udp.browser.js",
+            "./lib/transports/webusb": "./lib/transports/webusb.browser.js"
         },
         "react-native": {
             "./lib/transports/nodeusb": "./lib/transports/nodeusb.browser.js",

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -30,9 +30,7 @@
                 "import": "./libESM/index.mjs",
                 "require": "./lib/index.js",
                 "types": "./lib/index.d.ts"
-            },
-            "./lib/impl/*": "./lib/impl/*.js",
-            "./libESM/impl/*": "./libESM/impl/*"
+            }
         },
         "browser": {
             "ws": "./lib/ws-browser.js"

--- a/scripts/ci/pack-packages.ts
+++ b/scripts/ci/pack-packages.ts
@@ -15,12 +15,116 @@ const __dirname = import.meta.dirname;
 const ROOT_DIR = path.resolve(__dirname, '..', '..');
 const OUTPUT_DIR = path.join(ROOT_DIR, 'tmp/packed-packages');
 
+const walkFiles = async (directory: string): Promise<string[]> => {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    const files = await Promise.all(
+        entries.map(async entry => {
+            const fullPath = path.join(directory, entry.name);
+            if (entry.isDirectory()) {
+                return walkFiles(fullPath);
+            }
+
+            return [fullPath];
+        }),
+    );
+
+    return files.flat();
+};
+
+const escapeRegex = (value: string) => value.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+
+const pathPatternToRegExp = (relativePattern: string) => {
+    const normalized = relativePattern.replaceAll('\\', '/');
+    const escaped = escapeRegex(normalized).replaceAll('*', '.*');
+
+    return new RegExp(`^${escaped}$`);
+};
+
+const collectPublishTargets = (value: unknown): string[] => {
+    if (typeof value === 'string') {
+        return [value];
+    }
+
+    if (!value || typeof value !== 'object') {
+        return [];
+    }
+
+    return Object.values(value).flatMap(collectPublishTargets);
+};
+
+const validatePackagePublishTargets = async (pkg: string) => {
+    const packageDir = path.join(ROOT_DIR, 'packages', pkg);
+    const packageJsonPath = path.join(packageDir, 'package.json');
+    const rawPackageJson = await fs.promises.readFile(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(rawPackageJson);
+
+    const publishConfig = packageJson.publishConfig ?? {};
+    const sections = [publishConfig.exports, publishConfig.browser, publishConfig['react-native']];
+    const allTargets = sections
+        .flatMap(collectPublishTargets)
+        .filter((target): target is string => typeof target === 'string')
+        .filter(target => target.startsWith('./lib') || target.startsWith('lib'));
+
+    if (allTargets.length === 0) {
+        return [] as string[];
+    }
+
+    const builtFiles = await walkFiles(packageDir);
+    const builtFilesRelative = builtFiles.map(file =>
+        path.relative(packageDir, file).replaceAll('\\', '/'),
+    );
+
+    const missingTargets = allTargets.filter(target => {
+        const relativeTarget = target.replace(/^\.\//, '').replaceAll('\\', '/');
+        const matcher = pathPatternToRegExp(relativeTarget);
+
+        return !builtFilesRelative.some(file => matcher.test(file));
+    });
+
+    return Array.from(new Set(missingTargets)).sort();
+};
+
+const validatePublishTargets = async (packages: string[]) => {
+    console.log('\nValidating publishConfig targets against built files...');
+
+    const failures: { pkg: string; missingTargets: string[] }[] = [];
+
+    for (const pkg of packages) {
+        const missingTargets = await validatePackagePublishTargets(pkg);
+        if (missingTargets.length > 0) {
+            failures.push({ pkg, missingTargets });
+        }
+    }
+
+    if (failures.length === 0) {
+        console.log('Publish target validation passed.');
+
+        return;
+    }
+
+    console.error('\nPublish target validation failed:');
+    failures.forEach(({ pkg, missingTargets }) => {
+        console.error(`  - ${pkg}`);
+        missingTargets.forEach(target => {
+            console.error(`    - missing target: ${target}`);
+        });
+    });
+
+    throw new Error('One or more publishConfig targets do not match built files.');
+};
+
 const buildAllPackages = async () => {
     // Get dependencies for connect.
     const connectDeps = (await getPackageDependencies('connect')).update;
 
     const PACKAGES = [
-        ...new Set([...connectDeps, 'connect', 'connect-web', 'connect-webextension']),
+        ...new Set([
+            ...connectDeps,
+            'connect',
+            'connect-web',
+            'connect-webextension',
+            'connect-mobile',
+        ]),
     ];
 
     if (await existsDirectory(OUTPUT_DIR)) {
@@ -80,6 +184,12 @@ const buildAllPackages = async () => {
     const overridesPath = path.join(OUTPUT_DIR, 'overrides.json');
     await writeFile(overridesPath, JSON.stringify(overrides, null, 2));
     console.log(`\nGenerated overrides.json with ${results.success.length} packages`);
+
+    if (results.failed.length > 0) {
+        throw new Error('Packaging failed for one or more packages.');
+    }
+
+    await validatePublishTargets(results.success);
 };
 
 buildAllPackages();


### PR DESCRIPTION
looking for ways how to protect myself against breaking connect in #26141

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=stricter-connect-ci&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=stricter-connect-ci&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T16:02:31.843Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-06T16:00:46.471Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->