### PR TITLE
Fix network reserve banner + correct dust phishing anchor

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
@@ -47,7 +47,7 @@ export const DustPhishing = () => {
     };
 
     return (
-        <SettingsSectionItem anchorId={SettingsAnchor.NetworkReserve}>
+        <SettingsSectionItem anchorId={SettingsAnchor.DustPhishing}>
             <TextColumn
                 title={<Translation id="TR_DUST_PHISHING" />}
                 description={<Translation id="TR_DUST_PHISHING_DESCRIPTION" />}

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -182,6 +182,10 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
         setMax(outputId, isSendMaxActive, clearInput);
         composeTransaction(amountName);
+
+        if (isSendMaxActive) {
+            setShowReserveBanner(false);
+        }
     };
 
     const sendMaxSwitch = (

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -35,6 +35,7 @@ export const SettingsAnchor = {
     AutoEject: '@general-settings/auto-eject',
     MevProtection: '@general-settings/mev-protection',
     NetworkReserve: '@general-settings/network-reserve',
+    DustPhishing: '@general-settings/dust-phishing',
 
     BackupFailed: '@device-settings/backup-failed',
     BackupRecoverySeed: '@device-settings/backup-recovery-seed',


### PR DESCRIPTION
## Description

This PR:

- fixes edge case on Solana where network reserve banner was persistent
- fixes dust phishing settings anchor

## Related Issue

Resolve #25986 

## Screenshots:

https://github.com/user-attachments/assets/ced8d7c6-f85a-4bf8-8176-bf619edb039f

https://github.com/user-attachments/assets/9ab93893-2344-4009-b3e3-d3abb8fb2d5c

https://github.com/user-attachments/assets/24aed3cb-d273-410f-8850-65834dbf950c




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/network-reserve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/network-reserve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T18:13:22.510Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-06T18:12:04.806Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->