### PR TITLE
feat(connect): add VoteWitnessContract support for Tron signing

### DIFF
--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -1,3 +1,4 @@
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { PROTO } from '../../../constants';
@@ -6,6 +7,15 @@ import { AbstractMethod } from '../../../core/AbstractMethod';
 import type { TronContractsParameters, TronContractsTypes } from '../../../types/api/tron';
 import { TronSignTransaction as TronSignTransactionSchema } from '../../../types/api/tron';
 import { validatePath } from '../../../utils/pathUtils';
+
+const contractMapping = {
+    TransferContract: 'TronTransferContract',
+    TriggerSmartContract: 'TronTriggerSmartContract',
+    FreezeBalanceV2Contract: 'TronFreezeBalanceV2Contract',
+    UnfreezeBalanceV2Contract: 'TronUnfreezeBalanceV2Contract',
+    WithdrawExpireUnfreezeContract: 'TronWithdrawUnfreeze',
+    VoteWitnessContract: 'TronVoteWitnessContract',
+} as const satisfies Record<TronContractsTypes, PROTO.MessageKey>;
 
 type Params = {
     tx: PROTO.TronSignTx;
@@ -28,6 +38,15 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
 
     init() {
         const { payload } = this;
+
+        const contractType = payload.contract?.[0]?.type;
+        if (!contractType || !(contractType in contractMapping)) {
+            throw ERRORS.TypedError(
+                'Method_InvalidParameter',
+                `Unsupported Tron contract type: ${contractType ?? 'undefined'}`,
+            );
+        }
+
         Assert(TronSignTransactionSchema, payload);
 
         const path = validatePath(payload.path, 3);
@@ -55,14 +74,6 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
         const cmd = this.getDevice().getCommands();
 
         await cmd.typedCall('TronSignTx', 'TronContractRequest', this.params.tx);
-
-        const contractMapping = {
-            TransferContract: 'TronTransferContract',
-            TriggerSmartContract: 'TronTriggerSmartContract',
-            FreezeBalanceV2Contract: 'TronFreezeBalanceV2Contract',
-            UnfreezeBalanceV2Contract: 'TronUnfreezeBalanceV2Contract',
-            WithdrawExpireUnfreezeContract: 'TronWithdrawUnfreeze',
-        } as const;
 
         const { message } = await cmd.typedCall(
             contractMapping[this.params.contractType],

--- a/packages/connect/src/types/api/tron/index.ts
+++ b/packages/connect/src/types/api/tron/index.ts
@@ -39,6 +39,13 @@ const TronWithdrawExpireUnfreezeContract = Type.Object({
     }),
 });
 
+const TronVoteWitnessContract = Type.Object({
+    type: Type.Literal('VoteWitnessContract'),
+    parameter: Type.Object({
+        value: PROTO.TronVoteWitnessContract,
+    }),
+});
+
 export type TronContracts = Static<typeof TronContracts>;
 export const TronContracts = Type.Union([
     TronTransferContract,
@@ -46,6 +53,7 @@ export const TronContracts = Type.Union([
     TronFreezeBalanceV2Contract,
     TronUnfreezeBalanceV2Contract,
     TronWithdrawExpireUnfreezeContract,
+    TronVoteWitnessContract,
 ]);
 
 export type TronContractsTypes = TronContracts['type'];


### PR DESCRIPTION
## Description

Allow voting in Tron following FW PR https://github.com/trezor/trezor-firmware/pull/6524

Also improve error handling by showing a custom message for unknown contract types

## Notes for QA

@EuryShadow was testing via Tronscan with staging-Nufi

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-tron-vote-witness&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-tron-vote-witness&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T18:52:41.949Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->