### PR TITLE
Phishing - redesign dust phishing settings

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -148,8 +148,12 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 }
             }
 
-            if (phishingActions.setDustThreshold.match(action)) {
-                api.dispatch(storageActions.savePhishingMetadata(action.payload));
+            if (phishingActions.setDustPhishing.match(action)) {
+                api.dispatch(
+                    storageActions.savePhishingMetadata({
+                        dustPhishing: action.payload,
+                    }),
+                );
             }
 
             if (

--- a/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DustPhishing.tsx
@@ -1,9 +1,13 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { SettingsAnchor } from '@suite/router';
-import { phishingActions, selectPhishingDustThreshold } from '@suite-common/wallet-core';
-import { Button, Column, Input } from '@trezor/components';
+import {
+    phishingActions,
+    selectDustPhishingIsEnabled,
+    selectDustPhishingThreshold,
+} from '@suite-common/wallet-core';
+import { Button, Input, Row, Switch, Text } from '@trezor/components';
 import { ActionColumn, TextColumn } from '@trezor/product-components';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
@@ -12,12 +16,19 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 export const DustPhishing = () => {
     const dispatch = useDispatch();
 
-    const phishingDustThreshold = useSelector(selectPhishingDustThreshold);
+    const dustPhishingIsEnabled = useSelector(selectDustPhishingIsEnabled);
+    const dustPhishingThreshold = useSelector(selectDustPhishingThreshold);
 
-    const [dustThreshold, setDustThreshold] = useState(phishingDustThreshold ?? '');
+    const [dustThreshold, setDustThreshold] = useState(dustPhishingThreshold);
+
+    useEffect(() => {
+        setDustThreshold(dustPhishingThreshold);
+    }, [dustPhishingIsEnabled, dustPhishingThreshold]);
 
     const errorMessage = useMemo(() => {
-        if (dustThreshold.trim() === '') return undefined;
+        if (dustThreshold.trim() === '') {
+            return 'TR_DUST_PHISHING_ERROR_EMPTY';
+        }
 
         const number = Number(dustThreshold.trim());
 
@@ -32,48 +43,76 @@ export const DustPhishing = () => {
         return undefined;
     }, [dustThreshold]);
 
-    const isSame = dustThreshold.trim() === (phishingDustThreshold ?? '');
-    const isButtonDisabled = !!errorMessage || isSame;
-    const isTurningOff = dustThreshold.trim() === '' && !isSame;
+    const isSame = dustThreshold.trim() === dustPhishingThreshold;
+    const isDisabled = !!errorMessage || isSame;
 
-    const onSaveClick = () => {
-        if (isButtonDisabled) return;
-
+    const onConfirm = () => {
+        if (isDisabled) return;
         dispatch(
-            phishingActions.setDustThreshold({
-                dustThreshold: dustThreshold.trim() === '' ? undefined : dustThreshold.trim(),
+            phishingActions.setDustPhishing({
+                isEnabled: dustPhishingIsEnabled,
+                dustThreshold: dustThreshold.trim(),
+            }),
+        );
+    };
+
+    const onSwitchChange = (value: boolean) => {
+        dispatch(
+            phishingActions.setDustPhishing({
+                isEnabled: value,
+                dustThreshold: dustPhishingThreshold,
             }),
         );
     };
 
     return (
-        <SettingsSectionItem anchorId={SettingsAnchor.DustPhishing}>
-            <TextColumn
-                title={<Translation id="TR_DUST_PHISHING" />}
-                description={<Translation id="TR_DUST_PHISHING_DESCRIPTION" />}
-            />
-            <ActionColumn>
-                <Column gap={4}>
-                    <Input
-                        value={dustThreshold}
-                        placeholder="e.g. 0.005"
-                        onChange={e => setDustThreshold(e.target.value)}
-                        hasError={!!errorMessage}
-                        rightContent={
-                            <Button
-                                onClick={onSaveClick}
-                                intent={isTurningOff ? 'warning' : 'brand'}
-                                priority="primary"
-                                size="small"
-                                isDisabled={isButtonDisabled}
-                            >
-                                <Translation id={isTurningOff ? 'TR_TURN_OFF' : 'TR_SAVE'} />
-                            </Button>
-                        }
-                        bottomText={errorMessage ? <Translation id={errorMessage} /> : undefined}
+        <>
+            <SettingsSectionItem anchorId={SettingsAnchor.DustPhishing}>
+                <TextColumn
+                    title={<Translation id="TR_DUST_PHISHING_PROTECTION" />}
+                    description={<Translation id="TR_DUST_PHISHING_PROTECTION_DESCRIPTION" />}
+                />
+                <ActionColumn>
+                    <Switch
+                        isChecked={dustPhishingIsEnabled}
+                        onChange={onSwitchChange}
+                        data-testid="@settings/auto-eject-switch"
                     />
-                </Column>
-            </ActionColumn>
-        </SettingsSectionItem>
+                </ActionColumn>
+            </SettingsSectionItem>
+
+            {dustPhishingIsEnabled && (
+                <SettingsSectionItem anchorId={SettingsAnchor.DustPhishingThreshold}>
+                    <TextColumn
+                        title={<Translation id="TR_DUST_PHISHING_THRESHOLD" />}
+                        description={<Translation id="TR_DUST_PHISHING_THRESHOLD_DESCRIPTION" />}
+                    />
+                    <ActionColumn>
+                        <Row gap={6} alignItems="start">
+                            <Input
+                                value={dustThreshold}
+                                size="small"
+                                onChange={e => setDustThreshold(e.target.value)}
+                                hasError={!!errorMessage}
+                                bottomText={
+                                    errorMessage ? <Translation id={errorMessage} /> : undefined
+                                }
+                                rightContent={<Text color="textSubdued">USD</Text>}
+                                width={125}
+                            />
+
+                            <Button
+                                size="medium"
+                                intent="brand"
+                                onClick={onConfirm}
+                                isDisabled={isDisabled}
+                            >
+                                <Translation id="TR_SAVE" />
+                            </Button>
+                        </Row>
+                    </ActionColumn>
+                </SettingsSectionItem>
+            )}
+        </>
     );
 };

--- a/suite-common/wallet-core/src/phishing/phishingActions.ts
+++ b/suite-common/wallet-core/src/phishing/phishingActions.ts
@@ -2,11 +2,11 @@ import { createAction } from '@reduxjs/toolkit';
 
 export const PHISHING_MODULE_PREFIX = '@common/wallet-core/phishing';
 
-const setDustThreshold = createAction(
-    `${PHISHING_MODULE_PREFIX}/setDustThreshold`,
-    (payload: { dustThreshold?: string }) => ({ payload }),
+const setDustPhishing = createAction(
+    `${PHISHING_MODULE_PREFIX}/setDustPhishing`,
+    (payload: { isEnabled: boolean; dustThreshold: string }) => ({ payload }),
 );
 
 export const phishingActions = {
-    setDustThreshold,
+    setDustPhishing,
 } as const;

--- a/suite-common/wallet-core/src/phishing/phishingReducer.ts
+++ b/suite-common/wallet-core/src/phishing/phishingReducer.ts
@@ -5,15 +5,18 @@ import { phishingActions } from './phishingActions';
 import { type PhishingState } from './phishingReducerTypes';
 
 export const phishingInitialState: PhishingState = {
-    dustThreshold: DUST_PHISHING_THRESHOLD,
+    dustPhishing: {
+        isEnabled: true,
+        dustThreshold: DUST_PHISHING_THRESHOLD,
+    },
 };
 
 export const preparePhishingReducer = createReducerWithExtraDeps(
     phishingInitialState,
     (builder, extra) => {
         builder
-            .addCase(phishingActions.setDustThreshold, (state, { payload }) => {
-                state.dustThreshold = payload.dustThreshold;
+            .addCase(phishingActions.setDustPhishing, (state, { payload }) => {
+                state.dustPhishing = payload;
             })
             .addMatcher(
                 action => action.type === extra.actionTypes.storageLoad,

--- a/suite-common/wallet-core/src/phishing/phishingReducerTypes.ts
+++ b/suite-common/wallet-core/src/phishing/phishingReducerTypes.ts
@@ -1,5 +1,8 @@
 export interface PhishingState {
-    dustThreshold?: string;
+    dustPhishing: {
+        isEnabled: boolean;
+        dustThreshold: string;
+    };
 }
 
 export interface PhishingRootState {

--- a/suite-common/wallet-core/src/phishing/phishingSelectors.ts
+++ b/suite-common/wallet-core/src/phishing/phishingSelectors.ts
@@ -1,4 +1,7 @@
 import { type PhishingRootState } from './phishingReducerTypes';
 
-export const selectPhishingDustThreshold = (state: PhishingRootState) =>
-    state.wallet.phishing.dustThreshold;
+export const selectDustPhishingThreshold = (state: PhishingRootState) =>
+    state.wallet.phishing.dustPhishing.dustThreshold;
+
+export const selectDustPhishingIsEnabled = (state: PhishingRootState) =>
+    state.wallet.phishing.dustPhishing.isEnabled;

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -40,7 +40,10 @@ import {
 import { selectHistoricFiatRates } from '../fiat-rates/fiatRatesSelectors';
 import type { FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
 import { type PhishingRootState } from '../phishing/phishingReducerTypes';
-import { selectPhishingDustThreshold } from '../phishing/phishingSelectors';
+import {
+    selectDustPhishingIsEnabled,
+    selectDustPhishingThreshold,
+} from '../phishing/phishingSelectors';
 import { isAccountStakingActive } from '../stake/stakeUtils';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<
@@ -196,7 +199,9 @@ export const selectIsPhishingTransaction = (
     const { tokenDefinitions, txsMarkedAsNotScam, historicRates } =
         selectPhishingTransactionsContext(state, accountKey, transaction.symbol);
 
-    const dustThreshold = selectPhishingDustThreshold(state);
+    const dustPhishingIsEnabled = selectDustPhishingIsEnabled(state);
+    const dustPhishingThreshold = selectDustPhishingThreshold(state);
+    const dustThreshold = dustPhishingIsEnabled ? dustPhishingThreshold : undefined;
 
     return isPhishingTransaction({
         transaction,

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1087,10 +1087,6 @@ export const messages = {
                     title: 'Coins',
                     subtitle: 'Manage assets that you want to use',
                 },
-                phishing: {
-                    title: 'Phishing',
-                    subtitle: 'Manage phishing detection settings',
-                },
                 suiteSync: {
                     title: 'Suite Sync',
                     subtitle: 'Sync data across your devices',
@@ -1372,24 +1368,6 @@ export const messages = {
                 description: 'Otherwise the app won’t show you anything.',
             },
         },
-        phishing: {
-            settings: {
-                title: 'Phishing',
-                subtitle: 'Manage your phishing detection settings',
-                save: 'Save',
-                turnOff: 'Turn off',
-                placeholder: 'Enter dust threshold in USD',
-            },
-            dustThreshold: {
-                title: 'Dust phishing threshold',
-                subtitle:
-                    'Adjust the dust threshold for phishing detection. Currently, the dust threshold can only be defined in USD currency. Leaving this field empty will turn off dust amount detection.',
-                errors: {
-                    number: 'Please enter a valid number',
-                    positive: 'Dust threshold must be a positive number',
-                },
-            },
-        },
         viewOnly: {
             wallet: {
                 standard: 'Standard wallet',
@@ -1470,6 +1448,22 @@ export const messages = {
                 title: 'MEV Protection',
                 subtitle:
                     'Stay safe and secure fair prices by preventing others from interfering with your transactions. Available on {supportedNetworks}.',
+            },
+            dustPhishing: {
+                title: 'Dust phishing protection',
+                subtitle:
+                    'Hide suspicious micro transactions used in scams from your transaction history.',
+                enableProtection: 'Enable protection',
+                dustThresholdTitle: 'Dust phishing threshold',
+                dustThresholdDescription:
+                    'Transactions below this amount are marked as suspicious and hidden.',
+                save: 'Save',
+                placeholder: 'Enter dust threshold in USD',
+                errors: {
+                    empty: 'Dust threshold is required',
+                    number: 'Please enter a valid number',
+                    positive: 'Dust threshold must be a positive number',
+                },
             },
             bitcoinBackends: {
                 title: 'Bitcoin backends',

--- a/suite-native/module-settings/src/components/DustPhishingThresholdCard.tsx
+++ b/suite-native/module-settings/src/components/DustPhishingThresholdCard.tsx
@@ -1,117 +1,18 @@
-import { useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { PressableCardWithIconLayout } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { SettingsStackRoutes } from '@suite-native/navigation';
 
-import { yup } from '@suite-common/validators';
-import { phishingActions, selectPhishingDustThreshold } from '@suite-common/wallet-core';
-import { Box, Button, Card, HStack, type InputType, Text, VStack } from '@suite-native/atoms';
-import { Form, TextInputField, useForm } from '@suite-native/forms';
-import { Icon } from '@suite-native/icons';
-import { type Translate, Translation, useTranslate } from '@suite-native/intl';
-
-const validateIsNumber = (value?: string) => {
-    if (!value || value.trim() === '') return true;
-    const number = Number(value.trim());
-
-    return !isNaN(number);
-};
-
-const validateIsPositiveNumber = (value?: string) => {
-    if (!value || value.trim() === '') return true;
-    const number = Number(value.trim());
-
-    return !isNaN(number) && number > 0;
-};
-
-const getDustThresholdValidation = (translate: Translate) =>
-    yup
-        .string()
-        .test({
-            name: 'is-valid-number',
-            message: translate('moduleSettings.phishing.dustThreshold.errors.number'),
-            test: validateIsNumber,
-        })
-        .test({
-            name: 'is-positive-number',
-            message: translate('moduleSettings.phishing.dustThreshold.errors.positive'),
-            test: validateIsPositiveNumber,
-        });
+import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 
 export const DustPhishingThresholdCard = () => {
-    const dispatch = useDispatch();
-    const { translate } = useTranslate();
-
-    const phishingDustThreshold = useSelector(selectPhishingDustThreshold);
-    const dustThresholdInputRef = useRef<InputType>(null);
-
-    const form = useForm<{ dustThreshold: string }>({
-        mode: 'onChange',
-        defaultValues: {
-            dustThreshold: phishingDustThreshold ?? '',
-        },
-        validation: yup.object({
-            dustThreshold: getDustThresholdValidation(translate),
-        }),
-    });
-
-    const dustThreshold = form.watch('dustThreshold');
-
-    const errorMessage = form.formState.errors.dustThreshold?.message;
-    const isSame = dustThreshold.trim() === (phishingDustThreshold ?? '');
-    const isDisabled = !!errorMessage || isSame;
-    const isTurningOff = dustThreshold.trim() === '' && !isSame;
-
-    const onSubmit = form.handleSubmit(values => {
-        if (isDisabled) return;
-        dispatch(phishingActions.setDustThreshold({ dustThreshold: values.dustThreshold.trim() }));
-        dustThresholdInputRef.current?.blur();
-    });
+    const navigateTo = useSettingsNavigateTo();
 
     return (
-        <Card borderColor="borderElevation1" noPadding>
-            <HStack margin="sp16" spacing="sp12">
-                <Box marginVertical="sp2">
-                    <Icon name="warning" size="mediumLarge" />
-                </Box>
-                <VStack flex={1}>
-                    <HStack justifyContent="space-between" flex={1}>
-                        <VStack flex={1} spacing="sp2">
-                            <Text variant="body-md-strong">
-                                <Translation id="moduleSettings.phishing.dustThreshold.title" />
-                            </Text>
-
-                            <Text variant="body-sm" color="textSubdued">
-                                <Translation id="moduleSettings.phishing.dustThreshold.subtitle" />
-                            </Text>
-                        </VStack>
-                    </HStack>
-
-                    <Form form={form}>
-                        <VStack>
-                            <TextInputField
-                                name="dustThreshold"
-                                label={translate('moduleSettings.phishing.settings.placeholder')}
-                                ref={dustThresholdInputRef}
-                            />
-
-                            {!isDisabled && (
-                                <Button
-                                    colorScheme={isTurningOff ? 'yellowBold' : 'primary'}
-                                    size="small"
-                                    onPress={onSubmit}
-                                >
-                                    <Translation
-                                        id={
-                                            isTurningOff
-                                                ? 'moduleSettings.phishing.settings.turnOff'
-                                                : 'moduleSettings.phishing.settings.save'
-                                        }
-                                    />
-                                </Button>
-                            )}
-                        </VStack>
-                    </Form>
-                </VStack>
-            </HStack>
-        </Card>
+        <PressableCardWithIconLayout
+            icon="detective"
+            title={<Translation id="moduleSettings.advanced.dustPhishing.title" />}
+            description={<Translation id="moduleSettings.advanced.dustPhishing.subtitle" />}
+            onPress={() => navigateTo(SettingsStackRoutes.SettingsDustPhishing)}
+        />
     );
 };

--- a/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
+++ b/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
@@ -1,0 +1,72 @@
+import { useSelector } from 'react-redux';
+
+import { yup } from '@suite-common/validators';
+import { selectDustPhishingThreshold } from '@suite-common/wallet-core';
+import { useForm } from '@suite-native/forms';
+import { type Translate, useTranslate } from '@suite-native/intl';
+
+const validateIsEmpty = (value?: string) => {
+    if (!value || value.trim() === '') return false;
+
+    return true;
+};
+
+const validateIsNumber = (value?: string) => {
+    if (!value || value.trim() === '') return false;
+    const number = Number(value.trim());
+
+    return !isNaN(number);
+};
+
+const validateIsPositiveNumber = (value?: string) => {
+    if (!value || value.trim() === '') return false;
+    const number = Number(value.trim());
+
+    return !isNaN(number) && number > 0;
+};
+
+const getDustThresholdValidation = (translate: Translate) =>
+    yup
+        .string()
+        .test({
+            name: 'is-empty',
+            message: translate('moduleSettings.advanced.dustPhishing.errors.empty'),
+            test: validateIsEmpty,
+        })
+        .test({
+            name: 'is-valid-number',
+            message: translate('moduleSettings.advanced.dustPhishing.errors.number'),
+            test: validateIsNumber,
+        })
+        .test({
+            name: 'is-positive-number',
+            message: translate('moduleSettings.advanced.dustPhishing.errors.positive'),
+            test: validateIsPositiveNumber,
+        });
+
+export const useDustPhishingForm = () => {
+    const { translate } = useTranslate();
+
+    const dustPhishingThreshold = useSelector(selectDustPhishingThreshold);
+
+    const form = useForm<{ dustThreshold: string }>({
+        mode: 'onChange',
+        defaultValues: {
+            dustThreshold: dustPhishingThreshold ?? '',
+        },
+        validation: yup.object({
+            dustThreshold: getDustThresholdValidation(translate),
+        }),
+    });
+
+    const dustThreshold = form.watch('dustThreshold');
+
+    const { isValid } = form.formState;
+    const isSame = dustThreshold.trim() === dustPhishingThreshold;
+    const isDisabled = !isValid || isSame;
+
+    return {
+        form,
+        isDisabled,
+    };
+};

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -12,6 +12,7 @@ import { SettingsAdvancedScreen } from '../screens/SettingsAdvancedScreen';
 import { SettingsAppLogScreen } from '../screens/SettingsAppLogScreen';
 import { SettingsAutoEjectScreen } from '../screens/SettingsAutoEjectScreen';
 import { SettingsCoinEnablingScreen } from '../screens/SettingsCoinEnablingScreen';
+import { SettingsDustPhishingScreen } from '../screens/SettingsDustPhishingScreen';
 import { SettingsExperimentalScreen } from '../screens/SettingsExperimentalScreen';
 import { SettingsPreferencesScreen } from '../screens/SettingsPreferencesScreen';
 import { SettingsPrivacyScreen } from '../screens/SettingsPrivacyScreen';
@@ -63,6 +64,10 @@ export const SettingsStackNavigator = () => (
         <SettingsStack.Screen
             name={SettingsStackRoutes.SettingsAdvanced}
             component={SettingsAdvancedScreen}
+        />
+        <SettingsStack.Screen
+            name={SettingsStackRoutes.SettingsDustPhishing}
+            component={SettingsDustPhishingScreen}
         />
         <SettingsStack.Screen
             name={SettingsStackRoutes.SettingsExperimental}

--- a/suite-native/module-settings/src/screens/SettingsDustPhishingScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsDustPhishingScreen.tsx
@@ -1,0 +1,124 @@
+import { Keyboard } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+
+import {
+    phishingActions,
+    selectDustPhishingIsEnabled,
+    selectDustPhishingThreshold,
+} from '@suite-common/wallet-core';
+import { Button, Card, HStack, PressableOpacity, Switch, Text, VStack } from '@suite-native/atoms';
+import { Form, TextInputField } from '@suite-native/forms';
+import { Translation, useTranslate } from '@suite-native/intl';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+import { useDustPhishingForm } from '../hooks/useDustPhishingForm';
+
+export const SettingsDustPhishingScreen = () => {
+    const dispatch = useDispatch();
+    const { translate } = useTranslate();
+
+    const dustPhishingIsEnabled = useSelector(selectDustPhishingIsEnabled);
+    const dustPhishingThreshold = useSelector(selectDustPhishingThreshold);
+
+    const { form, isDisabled } = useDustPhishingForm();
+
+    const onSubmit = form.handleSubmit(values => {
+        if (isDisabled) return;
+
+        dispatch(
+            phishingActions.setDustPhishing({
+                isEnabled: dustPhishingIsEnabled,
+                dustThreshold: values.dustThreshold.trim(),
+            }),
+        );
+
+        Keyboard.dismiss();
+    });
+
+    const onSwitchChange = (value: boolean) => {
+        dispatch(
+            phishingActions.setDustPhishing({
+                isEnabled: value,
+                dustThreshold: dustPhishingThreshold,
+            }),
+        );
+
+        form.setValue('dustThreshold', dustPhishingThreshold);
+        form.trigger('dustThreshold');
+    };
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title={<Translation id="moduleSettings.advanced.dustPhishing.title" />}
+                    subtitle={<Translation id="moduleSettings.advanced.dustPhishing.subtitle" />}
+                />
+            }
+        >
+            <VStack spacing="sp16">
+                <Card borderColor="borderElevation1" noPadding>
+                    <PressableOpacity
+                        onPress={() => onSwitchChange(!dustPhishingIsEnabled)}
+                        accessibilityLabel=""
+                        accessibilityRole="switch"
+                        accessibilityState={{ checked: true }}
+                    >
+                        <HStack margin="sp16" spacing="sp12">
+                            <VStack flex={1}>
+                                <HStack justifyContent="space-between" flex={1}>
+                                    <Text variant="body-md-strong">
+                                        <Translation id="moduleSettings.advanced.dustPhishing.enableProtection" />
+                                    </Text>
+                                    <Switch
+                                        isChecked={dustPhishingIsEnabled}
+                                        onChange={onSwitchChange}
+                                    />
+                                </HStack>
+                            </VStack>
+                        </HStack>
+                    </PressableOpacity>
+                </Card>
+
+                {dustPhishingIsEnabled && (
+                    <Card borderColor="borderElevation1" noPadding>
+                        <VStack margin="sp16" spacing="sp12">
+                            <HStack justifyContent="space-between" flex={1}>
+                                <VStack flex={1} spacing="sp2">
+                                    <Text variant="body-md-strong">
+                                        <Translation id="moduleSettings.advanced.dustPhishing.dustThresholdTitle" />
+                                    </Text>
+
+                                    <Text variant="body-sm" color="textSubdued">
+                                        <Translation id="moduleSettings.advanced.dustPhishing.dustThresholdDescription" />
+                                    </Text>
+                                </VStack>
+                            </HStack>
+
+                            <Form form={form}>
+                                <VStack>
+                                    <TextInputField
+                                        name="dustThreshold"
+                                        label={translate(
+                                            'moduleSettings.advanced.dustPhishing.placeholder',
+                                        )}
+                                    />
+
+                                    {!isDisabled && (
+                                        <Button
+                                            colorScheme="primary"
+                                            size="small"
+                                            onPress={onSubmit}
+                                        >
+                                            <Translation id="moduleSettings.advanced.dustPhishing.save" />
+                                        </Button>
+                                    )}
+                                </VStack>
+                            </Form>
+                        </VStack>
+                    </Card>
+                )}
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -106,6 +106,7 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
     [SettingsStackRoutes.SettingsSuiteSync]: undefined;
     [SettingsStackRoutes.SettingsAdvanced]: undefined;
+    [SettingsStackRoutes.SettingsDustPhishing]: undefined;
     [SettingsStackRoutes.SettingsExperimental]: undefined;
     [SettingsStackRoutes.TurnOffDeviceAuthenticityCheck]: undefined;
     [SettingsStackRoutes.TurnOffFirmwareAuthenticityCheck]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -256,6 +256,7 @@ export enum SettingsStackRoutes {
     SettingsCoinEnabling = 'SettingsCoinEnabling',
     SettingsSuiteSync = 'SettingsSuiteSync',
     SettingsAdvanced = 'SettingsAdvanced',
+    SettingsDustPhishing = 'SettingsDustPhishing',
     SettingsExperimental = 'SettingsExperimental',
     TurnOffDeviceAuthenticityCheck = 'TurnOffDeviceAuthenticityCheck',
     TurnOffFirmwareAuthenticityCheck = 'TurnOffFirmwareAuthenticityCheck',

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -155,7 +155,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
 
     const phishingPersistedReducer = preparePersistReducer({
         reducer: phishingReducer,
-        persistedKeys: ['dustThreshold'],
+        persistedKeys: ['dustPhishing'],
         key: 'phishingMetadata',
         version: 1,
         storage: deps.mmkvStorage,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2544,14 +2544,22 @@ export const messages = defineMessages({
             'Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.',
         id: 'TR_NETWORK_RESERVE_DESCRIPTION',
     },
-    TR_DUST_PHISHING: {
-        id: 'TR_DUST_PHISHING',
+    TR_DUST_PHISHING_PROTECTION: {
+        defaultMessage: 'Dust phishing protection',
+        id: 'TR_DUST_PHISHING_PROTECTION',
+    },
+    TR_DUST_PHISHING_PROTECTION_DESCRIPTION: {
+        defaultMessage:
+            'Hide suspicious micro transactions used in scams from your transaction history.',
+        id: 'TR_DUST_PHISHING_PROTECTION_DESCRIPTION',
+    },
+    TR_DUST_PHISHING_THRESHOLD: {
+        id: 'TR_DUST_PHISHING_THRESHOLD',
         defaultMessage: 'Dust phishing threshold',
     },
-    TR_DUST_PHISHING_DESCRIPTION: {
-        id: 'TR_DUST_PHISHING_DESCRIPTION',
-        defaultMessage:
-            'Adjust the dust threshold for phishing detection. Currently, the dust threshold can only be defined in USD currency. Leaving this field empty will turn off dust amount detection.',
+    TR_DUST_PHISHING_THRESHOLD_DESCRIPTION: {
+        id: 'TR_DUST_PHISHING_THRESHOLD_DESCRIPTION',
+        defaultMessage: 'Transactions below this amount are marked as suspicious and hidden.',
     },
     TR_DUST_PHISHING_ERROR_NUMBER: {
         id: 'TR_DUST_PHISHING_ERROR_NUMBER',
@@ -2560,6 +2568,10 @@ export const messages = defineMessages({
     TR_DUST_PHISHING_ERROR_POSITIVE: {
         id: 'TR_DUST_PHISHING_ERROR_POSITIVE',
         defaultMessage: 'Dust threshold must be a positive number',
+    },
+    TR_DUST_PHISHING_ERROR_EMPTY: {
+        id: 'TR_DUST_PHISHING_ERROR_EMPTY',
+        defaultMessage: 'Dust threshold cannot be empty',
     },
     TR_CONFIRM_AUTO_EJECT: {
         defaultMessage: 'Enable auto-eject',

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -36,6 +36,7 @@ export const SettingsAnchor = {
     MevProtection: '@general-settings/mev-protection',
     NetworkReserve: '@general-settings/network-reserve',
     DustPhishing: '@general-settings/dust-phishing',
+    DustPhishingThreshold: '@general-settings/dust-phishing-threshold',
 
     BackupFailed: '@device-settings/backup-failed',
     BackupRecoverySeed: '@device-settings/backup-recovery-seed',


### PR DESCRIPTION
## Description

Redesign dust phishing threshold settings.

## Screenshots:

<img width="100%" alt="Screenshot 2026-04-07 at 13 17 48" src="https://github.com/user-attachments/assets/df3d20f0-5abe-49ce-9ae3-b39cd576d47a" />

<img width="100%" alt="Screenshot 2026-04-07 at 13 17 57" src="https://github.com/user-attachments/assets/566e4140-e3d6-4621-bfc5-2ff864d5c493" />

<img width="100%" alt="Screenshot 2026-04-07 at 13 18 02" src="https://github.com/user-attachments/assets/40d16f27-ba0a-4ac3-929b-d58804153921" />

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 13 12 31" src="https://github.com/user-attachments/assets/e5c362f9-a890-4a7f-9292-2f6e1d215404" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 13 12 35" src="https://github.com/user-attachments/assets/89ad3d8a-112c-4a46-a4a3-43697f069141" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 13 12 38" src="https://github.com/user-attachments/assets/3423f1d6-0835-4b84-b7d7-11463bd64a09" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 13 12 43" src="https://github.com/user-attachments/assets/1f46b31e-b472-441d-a5cc-23a90a9c34ca" />
</td>
</tr>
</table>


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/dust-phishing-settings&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/dust-phishing-settings&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/dust-phishing-settings&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T07:12:19.756Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:46:02.759Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->