### PR TITLE
SuiteSync - Do not connect to remote relay with NoQuota

### DIFF
--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -93,8 +93,8 @@ export const createEnsureStorage =
         const resolvedStorage =
             storage ?? (await deps.createSuiteStorage({ suiteSyncOwner: owner }));
 
-        // Set the relay URL if quota is allocated or if storage was not yet initialized.
-        if (quotaResult.success || quotaResult.error.type === 'WriteModeRequiredForAllocation') {
+        // Only connect to the relay if quota is actually allocated.
+        if (quotaResult.success) {
             await resolvedStorage.updateRelayUrl(deps.getRelayUrl());
         }
 

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -176,37 +176,6 @@ describe(createEnsureStorage.name, () => {
         });
     });
 
-    it('does update relay URL when ensureQuota fails on WriteModeRequiredForAllocation', async () => {
-        const device = mockSuiteDevice();
-        const updateRelayUrl = mock(() => Promise.resolve());
-        const newStorage = createSuiteSyncStorageMock({ updateRelayUrl });
-
-        const deps = createMockDeps<EnsureStorageDeps>({
-            getRelayUrl: () => 'wss://default-relay.example.com',
-            getOwnerHasAllowance: null,
-            suiteSyncStorageRepository: {
-                get: () => null,
-                set: mock(() => {}),
-                delete: null,
-            },
-            createSuiteStorage: () => Promise.resolve(newStorage),
-            refreshSuiteSyncKeys: () =>
-                Promise.resolve(ok({ owner: OWNER_ABCD, delegatedKey: DELEGATED_KEY })),
-            ensureQuota: () =>
-                Promise.resolve(err({ type: 'WriteModeRequiredForAllocation' as const })),
-            getDeviceForStaticSessionId: () => device,
-        });
-
-        const result = await createEnsureStorage(deps)({
-            deviceStaticSessionId,
-            isWriteMode: true,
-        });
-
-        expect(result).toEqual(ok(newStorage));
-        expect(deps.createSuiteStorage).toHaveBeenCalled();
-        expect(updateRelayUrl).toHaveBeenCalled();
-    });
-
     it('creates and stores new storage when all dependencies succeed', async () => {
         const device = mockSuiteDevice();
         const newStorage = createSuiteSyncStorageMock({


### PR DESCRIPTION
Before we were connecting to the remote relay, even tho we have a quota, this was done to check for possible data on the relay and no quota on QM. We want to change it, since QM is single source of truth when using Trezor servers.

**changes**:
- removed check for `WriteModeRequiredForAllocation` as a condition for updating relay URL

## Notes for QA

**Happy paths**
- Fresh wallet, Suite Sync, no labels/quota — no relay connection attempt expected
- Wallet with existing quota — relay connects normally; sync behavior unchanged

**Edge cases**
- Fresh wallet opened repeatedly before first label — still no relay/websocket attempt
- Desktop and web fresh-wallet flow — behavior consistent on both platforms

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25539


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync/do-not-connect-to-relay-without-quota&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync/do-not-connect-to-relay-without-quota&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync/do-not-connect-to-relay-without-quota&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-06T21:25:00.015Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-06T21:22:59.735Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->