### PR TITLE
feat(trading): isolate trading timer updates from form render flow

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/__tests__/mapTradingTimerToTimer.test.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/__tests__/mapTradingTimerToTimer.test.ts
@@ -1,0 +1,30 @@
+import { mapTradingTimerToTimer } from '../mapTradingTimerToTimer';
+import { type TradingTimer } from '../useTradingTimer';
+
+describe('mapTradingTimerToTimer', () => {
+    it('maps trading timer shape to legacy timer shape', () => {
+        const stop = jest.fn();
+        const reset = jest.fn();
+        const loading = jest.fn();
+
+        const tradingTimer: TradingTimer = {
+            secondsElapsed: 17,
+            resetCount: 3,
+            isStopped: false,
+            isLoading: true,
+            stop,
+            reset,
+            loading,
+        };
+
+        const timer = mapTradingTimerToTimer(tradingTimer);
+
+        expect(timer.timeSpent.seconds).toBe(17);
+        expect(timer.resetCount).toBe(3);
+        expect(timer.isStopped).toBe(false);
+        expect(timer.isLoading).toBe(true);
+        expect(timer.stop).toBe(stop);
+        expect(timer.reset).toBe(reset);
+        expect(timer.loading).toBe(loading);
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/common/mapTradingTimerToTimer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/mapTradingTimerToTimer.ts
@@ -1,0 +1,21 @@
+import { type Timer } from '@trezor/react-utils';
+
+import { type TradingTimer } from './useTradingTimer';
+
+export const mapTradingTimerToTimer = (timer: TradingTimer): Timer => {
+    if (!timer) {
+        throw new Error('mapTradingTimerToTimer: timer parameter is required');
+    }
+
+    return {
+        timeSpent: {
+            seconds: timer.secondsElapsed ?? 0,
+        },
+        resetCount: timer.resetCount,
+        isStopped: timer.isStopped,
+        isLoading: timer.isLoading,
+        stop: timer.stop,
+        reset: timer.reset,
+        loading: timer.loading,
+    };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -10,15 +10,17 @@ import {
     isCountrySubdivisionEmpty,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
+import { mapTradingTimerToTimer } from './mapTradingTimerToTimer';
+import { type TradingTimer } from './useTradingTimer';
+
 type TradingBuyUseHandleChangeProps = {
     formValues: TradingBuyFormProps;
     network: Network;
-    timer: Timer;
+    timer: TradingTimer;
     shouldSendInSats: boolean | undefined;
 
     setValue: UseFormSetValue<TradingBuyFormProps>;
@@ -60,7 +62,7 @@ export const useTradingBuyHandleChange = ({
             buyThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 shouldSendInSats,
             }),
         );

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -3,15 +3,17 @@ import { useCallback, useEffect, useRef } from 'react';
 import { events } from '@suite/analytics';
 import { type TradingExchangeFormProps, exchangeThunks } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
+import { mapTradingTimerToTimer } from './mapTradingTimerToTimer';
+import { type TradingTimer } from './useTradingTimer';
+
 type TradingExchangeUseHandleChangeProps = {
     formValues: TradingExchangeFormProps;
     network: Network;
-    timer: Timer;
+    timer: TradingTimer;
     shouldSendInSats: boolean | undefined;
 
     composeRequestCallback: () => void;
@@ -51,7 +53,7 @@ export const useTradingExchangeHandleChange = ({
             exchangeThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 shouldSendInSats,
                 composeRequestCallback,
             }),

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -5,19 +5,20 @@ import {
     INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { type Timer, useTimer } from '@trezor/react-utils';
 
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
 import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
 import { type TradingPageType } from 'src/types/trading/trading';
 
+import { type TradingTimer, useTradingTimer } from './useTradingTimer';
+
 export type UseTradingCommonProps = {
     pageType: TradingPageType;
     isLoading: boolean;
 };
 export interface UseTradingCommonReturnProps {
-    timer: Timer;
+    timer: TradingTimer;
     device: TrezorDevice | undefined;
     checkQuotesTimer: (callback: () => Promise<void>) => void;
 }
@@ -27,7 +28,7 @@ export const useTradingInitializer = ({
     isLoading,
 }: UseTradingCommonProps): UseTradingCommonReturnProps => {
     const dispatch = useDispatch();
-    const timer = useTimer();
+    const timer = useTradingTimer();
     const { device } = useDevice();
 
     const isWindowVisible = useSelector(selectIsWindowVisible);
@@ -53,7 +54,7 @@ export const useTradingInitializer = ({
             }
 
             const hasRefreshIntervalElapsed =
-                timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
+                timer.secondsElapsed >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
 
             if (!hasRefreshIntervalElapsed) {
                 return;

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -10,15 +10,17 @@ import {
     sellThunks,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
+import { mapTradingTimerToTimer } from './mapTradingTimerToTimer';
+import { type TradingTimer } from './useTradingTimer';
+
 type TradingSellUseHandleChangeProps = {
     formValues: TradingSellFormProps;
     network: Network;
-    timer: Timer;
+    timer: TradingTimer;
     shouldSendInSats: boolean | undefined;
 
     setValue: UseFormSetValue<TradingSellFormProps>;
@@ -62,7 +64,7 @@ export const useTradingSellHandleChange = ({
             sellThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 shouldSendInSats,
                 composeRequestCallback,
             }),

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingTimer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingTimer.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+
+type TradingTimerStatus = 'running' | 'loading' | 'stopped';
+
+type TradingTimerState = {
+    status: TradingTimerStatus;
+    resetCount: number;
+};
+
+type TradingTimerAction = { type: 'reset' } | { type: 'stop' } | { type: 'loading' };
+
+const initialState: TradingTimerState = {
+    status: 'running',
+    resetCount: 0,
+};
+
+const tradingTimerReducer = (
+    state: TradingTimerState,
+    action: TradingTimerAction,
+): TradingTimerState => {
+    switch (action.type) {
+        case 'reset':
+            return {
+                ...state,
+                status: 'running',
+                resetCount: state.resetCount + 1,
+            };
+        case 'stop':
+            return {
+                ...state,
+                status: 'stopped',
+            };
+        case 'loading':
+            return {
+                ...state,
+                status: 'loading',
+            };
+        default:
+            return state;
+    }
+};
+
+export type TradingTimer = {
+    secondsElapsed: number;
+    resetCount: number;
+    isStopped: boolean;
+    isLoading: boolean;
+    stop: () => void;
+    reset: () => void;
+    loading: () => void;
+};
+
+export const useTradingTimer = (): TradingTimer => {
+    const [state, dispatch] = useReducer(tradingTimerReducer, initialState);
+    const stateRef = useRef(initialState);
+    const secondsElapsedRef = useRef(0);
+
+    useEffect(() => {
+        stateRef.current = state;
+    }, [state]);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            if (stateRef.current.status === 'stopped' || stateRef.current.status === 'loading') {
+                return;
+            }
+
+            secondsElapsedRef.current += 1;
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, []);
+
+    const stop = useCallback(() => {
+        dispatch({ type: 'stop' });
+    }, []);
+
+    const reset = useCallback(() => {
+        secondsElapsedRef.current = 0;
+        dispatch({ type: 'reset' });
+    }, []);
+
+    const setLoading = useCallback(() => {
+        secondsElapsedRef.current = 0;
+        dispatch({ type: 'loading' });
+    }, []);
+
+    return useMemo(
+        () => ({
+            get secondsElapsed() {
+                return secondsElapsedRef.current;
+            },
+            resetCount: state.resetCount,
+            isStopped: state.status === 'stopped',
+            isLoading: state.status === 'loading',
+            stop,
+            reset,
+            loading: setLoading,
+        }),
+        [state.resetCount, state.status, stop, reset, setLoading],
+    );
+};

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -56,6 +56,7 @@ import {
 } from 'src/types/trading/tradingForm';
 import { createQuoteLink, createTxLink } from 'src/utils/wallet/trading/buyUtils';
 
+import { mapTradingTimerToTimer } from './common/mapTradingTimerToTimer';
 import { useTradingFiatValues } from './common/useTradingFiatValues';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
@@ -296,7 +297,7 @@ export const useTradingBuyForm = ({
         await dispatch(
             buyThunks.selectQuoteThunk({
                 quote,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 returnUrl,
                 loginRequest: form => {
                     dispatch(submitRequestForm(form));
@@ -473,7 +474,13 @@ export const useTradingBuyForm = ({
     }, [isFromRedirect, quotesRequest, dispatch]);
 
     useEffect(() => {
-        checkQuotesTimer(handleChange);
+        const interval = setInterval(() => {
+            checkQuotesTimer(handleChange);
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
     }, [checkQuotesTimer, handleChange]);
 
     useDebounce(

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -75,6 +75,7 @@ import {
 } from 'src/types/trading/tradingForm';
 import { createQuoteLink } from 'src/utils/wallet/trading/exchangeUtils';
 
+import { mapTradingTimerToTimer } from './common/mapTradingTimerToTimer';
 import { useTradingAssetDecimals } from './common/useTradingAssetDecimals';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingPreviousRoute } from './common/useTradingPreviousRoute';
@@ -330,7 +331,7 @@ export const useTradingExchangeForm = ({
         await dispatch(
             exchangeThunks.selectQuoteThunk({
                 quote,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 nextStep: () => {
                     dispatch(goto({ routeName: 'wallet-trading-exchange-confirm' }));
                 },
@@ -771,9 +772,17 @@ export const useTradingExchangeForm = ({
     }, [isFormPage, quotesRequest, dispatch]);
 
     useEffect(() => {
-        if (preselectedQuote || approvalInitiated) return;
+        if (preselectedQuote || approvalInitiated) {
+            return;
+        }
 
-        checkQuotesTimer(handleChange);
+        const interval = setInterval(() => {
+            checkQuotesTimer(handleChange);
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
     }, [checkQuotesTimer, handleChange, preselectedQuote, approvalInitiated]);
 
     useEffect(() => {

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -63,6 +63,7 @@ import { type UseTradingFormCommonProps } from 'src/types/trading/trading';
 import { type TradingSellFormContextProps } from 'src/types/trading/tradingForm';
 import { createQuoteLink } from 'src/utils/wallet/trading/sellUtils';
 
+import { mapTradingTimerToTimer } from './common/mapTradingTimerToTimer';
 import { useTradingAssetDecimals } from './common/useTradingAssetDecimals';
 import { useTradingInitializer } from './common/useTradingInitializer';
 import { useTradingFormAccount } from './useTradingFormAccount';
@@ -376,7 +377,7 @@ export const useTradingSellForm = ({
         await dispatch(
             sellThunks.selectQuoteThunk({
                 quote,
-                timer,
+                timer: mapTradingTimerToTimer(timer),
                 nextStep,
             }),
         );
@@ -576,7 +577,13 @@ export const useTradingSellForm = ({
     }, [isFromRedirect, trade, transactionId, pageType, dispatch]);
 
     useEffect(() => {
-        checkQuotesTimer(handleChange);
+        const interval = setInterval(() => {
+            checkQuotesTimer(handleChange);
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
     }, [checkQuotesTimer, handleChange]);
 
     // Subscribe to blocks for Solana, since they are not fetched globally

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -52,8 +52,8 @@ import {
     type PrecomposedLevelsCardano,
 } from '@suite-common/wallet-types';
 import { type FeeLevel } from '@trezor/connect';
-import { type Timer } from '@trezor/react-utils';
 
+import { type TradingTimer } from 'src/hooks/wallet/trading/form/common/useTradingTimer';
 import { type useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 import { type AppState } from 'src/reducers/store';
 import { type Dispatch, type GetState, type TrezorDevice } from 'src/types/suite';
@@ -106,7 +106,7 @@ interface TradingFormStateProps {
 
 interface TradingCommonFormProps {
     device: TrezorDevice | undefined;
-    timer: Timer;
+    timer: TradingTimer;
     account: Account;
     network: Network;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
-import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
 import { H2 } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx } from '@trezor/theme';
@@ -11,9 +10,10 @@ import {
     getCryptoQuoteAmountProps,
     isTradingExchangeContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
-import { TradingRefreshTime } from 'src/views/wallet/trading/common';
 import { TradingHeaderFilter } from 'src/views/wallet/trading/common/TradingHeader/TradingHeaderFilter';
 import { TradingHeaderSummary } from 'src/views/wallet/trading/common/TradingHeader/TradingHeaderSummary';
+
+import { TradingHeaderRefreshTime } from './TradingHeaderRefreshTime';
 
 const Header = styled.div`
     padding-top: ${spacingsPx.sm};
@@ -76,12 +76,7 @@ export const TradingHeader = ({ title, titleTimer }: TradingHeaderProps) => {
             <HeaderBottom>
                 <TradingHeaderFilter />
                 <HeaderTradingRefreshTime>
-                    <TradingRefreshTime
-                        isLoading={timer.isLoading}
-                        refetchInterval={INVITY_API_RELOAD_QUOTES_AFTER_SECONDS}
-                        seconds={timer.timeSpent.seconds}
-                        label={<Translation id={titleTimer} />}
-                    />
+                    <TradingHeaderRefreshTime timer={timer} titleTimer={titleTimer} />
                 </HeaderTradingRefreshTime>
             </HeaderBottom>
         </Header>

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderRefreshTime.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeaderRefreshTime.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useReducer } from 'react';
+
+import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
+import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
+
+import { type TradingTimer } from 'src/hooks/wallet/trading/form/common/useTradingTimer';
+
+import { TradingRefreshTime } from '../TradingRefreshTime';
+
+type TradingHeaderRefreshTimeProps = {
+    timer: TradingTimer;
+    titleTimer: ExtendedMessageDescriptor['id'];
+};
+
+export const TradingHeaderRefreshTime = ({ timer, titleTimer }: TradingHeaderRefreshTimeProps) => {
+    const [, tick] = useReducer((value: number) => value + 1, 0);
+
+    useEffect(() => {
+        if (timer.isStopped || timer.isLoading) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            tick();
+        }, 1000);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, [timer.isStopped, timer.isLoading, timer.resetCount]);
+
+    return (
+        <TradingRefreshTime
+            isLoading={timer.isLoading}
+            refetchInterval={INVITY_API_RELOAD_QUOTES_AFTER_SECONDS}
+            seconds={timer.secondsElapsed}
+            label={<Translation id={titleTimer} />}
+        />
+    );
+};


### PR DESCRIPTION
## Description

Isolates trading timer updates so timer ticks do not propagate unnecessary re-renders through trading form consumers.

Implemented changes:
- adds useTradingTimer and mapTradingTimerToTimer in common trading form hooks
- updates buy/sell/exchange form hooks to use timer refs instead of passing a changing timer object through form context
- updates initializer and handle-change hooks to consume timer via ref-backed flow
- updates trading form types and header refresh-time rendering to match the new timer wiring
- adds unit coverage for timer-to-UI mapping logic

## Notes for QA

- Open Trading Buy/Sell/Exchange and verify the countdown in header updates every second.
- Trigger quote refresh flow and verify refresh timer/loading behavior is correct (spinner/countdown transitions).
- Change form inputs repeatedly while timer is running and verify values stay stable (no regressions like resets).
- Verify quote timing behavior still works after selecting/changing quotes.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26285

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26285/trading-timer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26285/trading-timer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T06:50:24.590Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T06:48:51.897Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->