### PR TITLE
fix(support): always include utm_passphrase param in support chat URL

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -686,9 +686,7 @@ export const selectSupportChatDeviceUtmParams = createMemoizedSelector(
             result.utm_rev = firmwareRevision;
         }
 
-        if (isDeviceUsingPassphrase) {
-            result.utm_passphrase = isDeviceUsingPassphrase ? 'true' : 'false';
-        }
+        result.utm_passphrase = isDeviceUsingPassphrase ? 'true' : 'false';
 
         return result;
     },

--- a/suite-common/support/src/selectors.ts
+++ b/suite-common/support/src/selectors.ts
@@ -49,9 +49,7 @@ export const selectSupportChatUrl = createMemoizedSelector(
             if (firmwareRevision) {
                 deviceUtmParams.utm_rev = firmwareRevision;
             }
-            if (isDeviceUsingPassphrase) {
-                deviceUtmParams.utm_passphrase = isDeviceUsingPassphrase ? 'true' : 'false';
-            }
+            deviceUtmParams.utm_passphrase = isDeviceUsingPassphrase ? 'true' : 'false';
         }
 
         return withUtmParams(supportChatUrl, deviceUtmParams);


### PR DESCRIPTION
Previously, utm_passphrase was only appended when a passphrase was active. Now it always sends 'true' or 'false' so the support team can explicitly distinguish Standard vs Passphrase wallets.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA
Just adds the UTM paramters to the help links
## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26364

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=26364-utm-passphrase-wallet-defaul&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=26364-utm-passphrase-wallet-defaul&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26364-utm-passphrase-wallet-defaul&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T07:25:17.189Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T07:22:43.869Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->