### PR TITLE
fix(trading): refresh buy offers after fiat currency change

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -396,12 +396,7 @@ export const useTradingBuyForm = ({
             return;
         }
 
-        if (
-            !values.cryptoSelect ||
-            !values.countrySelect ||
-            !values.receiveAddress ||
-            !values.currencySelect
-        ) {
+        if (!values.cryptoSelect || !values.countrySelect || !values.currencySelect) {
             return;
         }
 


### PR DESCRIPTION
## Description

- remove the `receiveAddress` requirement from Buy form offer-refresh guard
- keep offer refresh gated by selected crypto, country, and fiat currency only
- fix the case where switching fiat currency on an asset without receive address did not trigger refreshed offers

## Notes for QA

- In Trading -> Buy, select an asset that does not have a receive address yet, then switch fiat currency and verify offers refresh (loading + updated offer list).
- Repeat fiat currency switch on an asset with a receive address and verify behavior is unchanged.

## Related Issue

Resolve #26406

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26406-buy-fiat-switch-refresh&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26406-buy-fiat-switch-refresh&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T09:19:36.379Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T09:17:52.783Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->