### PR TITLE
fix(suite): security check layout

### DIFF
--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -348,7 +348,7 @@ export const SecurityCheck = () => {
 
     if (isAuthenticityCheckStep) {
         return (
-            <Box padding={{ top: 40 }}>
+            <Box padding={{ top: 40 }} width="100%">
                 <DeviceAuthenticityStep
                     goToNext={() => goToSuiteOrNextDevice(() => setIsAuthenticityCheckStep(false))}
                 />


### PR DESCRIPTION
## Notes for QA

Fixed width of the succesful security check layout.

## Screenshots:
<img width="1032" height="526" alt="image" src="https://github.com/user-attachments/assets/f4886410-08b7-418e-83e2-a16c2e347c7f" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/security-check-layout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/security-check-layout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T09:29:04.761Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T09:27:27.682Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->