### PR TITLE
fix(suite-native): move suite sync out of experimental features

### DIFF
--- a/suite-native/labeling/src/selectors.ts
+++ b/suite-native/labeling/src/selectors.ts
@@ -5,6 +5,7 @@ import {
     type WithSuiteSyncAndDeviceState,
     getIsSuiteSyncLabelingActionEnabled,
     selectSuiteSyncAccountLabel as selectAccountLabelLocalFirst,
+    selectIsSuiteSyncFeatureAvailable,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -23,14 +24,19 @@ export type CombinedLabelingState = SuiteSyncDataRootState &
 export const selectIsLabellingAllowed = (
     state: WithSuiteSyncAndDeviceState & SettingsSliceRootState & MessageSystemRootState,
 ) => {
+    const isSuiteSyncFeatureAvailable = selectIsSuiteSyncFeatureAvailable(state);
     const device = selectSelectedDevice(state);
 
-    const suiteSyncInteraction = selectSuiteSyncInteraction(
-        state,
-        device?.state?.staticSessionId ?? null,
-    );
+    if (isSuiteSyncFeatureAvailable) {
+        const suiteSyncInteraction = selectSuiteSyncInteraction(
+            state,
+            device?.state?.staticSessionId ?? null,
+        );
 
-    return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
+        return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
+    }
+
+    return false;
 };
 
 export const selectAccountLabel = (

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { useAtomValue } from 'jotai';
 
+import { selectIsSuiteSyncFeatureAvailable } from '@suite-common/suite-sync';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { TitledSection } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -20,6 +21,7 @@ import { useSettingsNavigateTo } from '../navigation/useSettingsNavigateTo';
 export const FeaturesSettings = () => {
     const isDevButtonVisible = useAtomValue(isDevButtonVisibleAtom);
     const hasDiscovery = useSelector(selectHasRunningDiscovery);
+    const isSuiteSyncFeatureAvailable = useSelector(selectIsSuiteSyncFeatureAvailable);
 
     const navigation = useNavigation<StackNavigationProps<RootStackParamList, RootStackRoutes>>();
     const navigateTo = useSettingsNavigateTo();
@@ -50,6 +52,15 @@ export const FeaturesSettings = () => {
                 isDisabled={hasDiscovery}
                 testID="@settings/coin-enabling"
             />
+            {isSuiteSyncFeatureAvailable && (
+                <AppSettingsCardWithIconLayout
+                    icon="arrowsClockwise"
+                    title={<Translation id="moduleSettings.items.features.suiteSync.title" />}
+                    subtitle={<Translation id="moduleSettings.items.features.suiteSync.subtitle" />}
+                    onPress={() => navigateTo(SettingsStackRoutes.SettingsSuiteSync)}
+                    testID="@settings/suite-sync"
+                />
+            )}
             <AppSettingsCardWithIconLayout
                 icon="shieldWarning"
                 title={<Translation id="moduleSettings.items.features.advanced.title" />}

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -15,6 +15,7 @@ import { SettingsCoinEnablingScreen } from '../screens/SettingsCoinEnablingScree
 import { SettingsExperimentalScreen } from '../screens/SettingsExperimentalScreen';
 import { SettingsPreferencesScreen } from '../screens/SettingsPreferencesScreen';
 import { SettingsPrivacyScreen } from '../screens/SettingsPrivacyScreen';
+import { SettingsSuiteSyncScreen } from '../screens/SettingsSuiteSyncScreen';
 import { SettingsSupportScreen } from '../screens/SettingsSupportScreen';
 import { TurnOffDeviceAuthenticityCheckScreen } from '../screens/TurnOffDeviceAuthenticityCheckScreen';
 import { TurnOffFirmwareAuthenticityCheckScreen } from '../screens/TurnOffFirmwareAuthenticityCheckScreen';
@@ -53,6 +54,11 @@ export const SettingsStackNavigator = () => (
             options={{ title: SettingsStackRoutes.SettingsCoinEnabling }}
             name={SettingsStackRoutes.SettingsCoinEnabling}
             component={SettingsCoinEnablingScreen}
+        />
+        <SettingsStack.Screen
+            options={{ title: SettingsStackRoutes.SettingsSuiteSync }}
+            name={SettingsStackRoutes.SettingsSuiteSync}
+            component={SettingsSuiteSyncScreen}
         />
         <SettingsStack.Screen
             name={SettingsStackRoutes.SettingsAdvanced}

--- a/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsExperimentalScreen.tsx
@@ -4,7 +4,6 @@ import { useOpenLink } from '@suite-native/link';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
 
-import { ToggleSuiteSyncCard } from '../components/ToggleSuiteSyncCard';
 import { ToggleTronCard } from '../components/ToggleTronCard';
 
 export const SettingsExperimentalScreen = () => {
@@ -34,7 +33,6 @@ export const SettingsExperimentalScreen = () => {
             }
         >
             <VStack spacing="sp16">
-                <ToggleSuiteSyncCard />
                 <ToggleTronCard />
             </VStack>
         </Screen>

--- a/suite-native/module-settings/src/screens/SettingsSuiteSyncScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsSuiteSyncScreen.tsx
@@ -1,0 +1,24 @@
+import { VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+import { SuiteSyncRelayUrlCard } from '../components/SuiteSyncRelayUrlCard';
+import { ToggleSuiteSyncCard } from '../components/ToggleSuiteSyncCard';
+
+export const SettingsSuiteSyncScreen = () => (
+    <Screen
+        header={
+            <DynamicScreenHeader
+                title={<Translation id="moduleSettings.items.features.suiteSync.title" />}
+                subtitle={
+                    <Translation id="moduleSettings.items.features.suiteSync.screenSubtitle" />
+                }
+            />
+        }
+    >
+        <VStack spacing="sp16">
+            <ToggleSuiteSyncCard />
+            <SuiteSyncRelayUrlCard />
+        </VStack>
+    </Screen>
+);

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -104,6 +104,7 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsSupport]: undefined;
     [SettingsStackRoutes.SettingsAppLog]: undefined;
     [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
+    [SettingsStackRoutes.SettingsSuiteSync]: undefined;
     [SettingsStackRoutes.SettingsAdvanced]: undefined;
     [SettingsStackRoutes.SettingsExperimental]: undefined;
     [SettingsStackRoutes.TurnOffDeviceAuthenticityCheck]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -254,6 +254,7 @@ export enum SettingsStackRoutes {
     SettingsSupport = 'SettingsSupport',
     SettingsAppLog = 'SettingsAppLog',
     SettingsCoinEnabling = 'SettingsCoinEnabling',
+    SettingsSuiteSync = 'SettingsSuiteSync',
     SettingsAdvanced = 'SettingsAdvanced',
     SettingsExperimental = 'SettingsExperimental',
     TurnOffDeviceAuthenticityCheck = 'TurnOffDeviceAuthenticityCheck',


### PR DESCRIPTION
## Description

This PR fixes an issue caused by rebase - moves Suite Sync out of experimental features on mobile.

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 11 07 38" src="https://github.com/user-attachments/assets/6556d13c-1615-47dc-8cb4-95188e2d1362" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 11 07 40" src="https://github.com/user-attachments/assets/b5df40bc-86ef-41c0-8702-2c4246d0ae6f" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync-experimental&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->