### PR TITLE
fix(suite-native): fix WalletBackupSheet footer overlapping scroll content

### DIFF
--- a/suite-native/module-device-onboarding/src/components/WalletBackupSheet/WalletBackupSheet.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupSheet/WalletBackupSheet.tsx
@@ -11,10 +11,6 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { WalletBackupCard } from './WalletBackupCard/WalletBackupCard';
 import { WalletBackupSheetFooter } from './WalletBackupSheetFooter';
 
-const containerStyle = prepareNativeStyle(utils => ({
-    marginBottom: utils.spacings.sp32,
-}));
-
 const legacyButtonStyle = prepareNativeStyle(utils => ({
     alignSelf: 'center',
     marginTop: utils.spacings.sp32,
@@ -56,7 +52,6 @@ export const WalletBackupSheet = ({
             title={translate('moduleDeviceOnboarding.walletBackupSheet.title')}
             ref={ref}
             footer={<WalletBackupSheetFooter selectedType={selectedType} onSubmit={onCloseModal} />}
-            style={applyStyle(containerStyle)}
             isCloseDisplayed
         >
             <VStack spacing="sp16">


### PR DESCRIPTION
## Description

`WalletBackupSheet` passed `style={{ marginBottom: sp32 }}` to `BottomSheetModal`. After trezor/trezor-suite#25519 started forwarding `style` via `...rest` to `BottomSheetModalContent`, it overrode the calculated `marginBottom: bottomInset + sp16` (which accounts for the footer button height), causing the "Continue" button to cover the last card's content.

Fix: remove the unused `containerStyle` — bottom spacing is already handled by `BottomSheetModalContent`.

## Notes for QA

Open the wallet backup type bottom sheet and scroll to the bottom — the "24-word backup" card should be fully visible above the "Continue" button.

## Related Issue
Closes #26378

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/wallet-backup-sheet-padding&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->