### PR TITLE
fix(connect): align Tron contract inputs with official field names

### DIFF
--- a/packages/connect-common/src/types/api/tron/index.ts
+++ b/packages/connect-common/src/types/api/tron/index.ts
@@ -57,7 +57,64 @@ export const TronContracts = Type.Union([
 ]);
 
 export type TronContractsTypes = TronContracts['type'];
-export type TronContractsParameters = TronContracts['parameter']['value'];
+
+const TronFreezeBalanceV2ContractInput = Type.Object({
+    type: Type.Literal('FreezeBalanceV2Contract'),
+    parameter: Type.Object({
+        value: Type.Union([
+            Type.Object({
+                owner_address: Type.String(),
+                frozen_balance: Type.Number(),
+                balance: Type.Optional(Type.Number()),
+                resource: Type.Optional(PROTO.EnumTronResourceCode),
+            }),
+            PROTO.TronFreezeBalanceV2Contract,
+        ]),
+    }),
+});
+
+const TronUnfreezeBalanceV2ContractInput = Type.Object({
+    type: Type.Literal('UnfreezeBalanceV2Contract'),
+    parameter: Type.Object({
+        value: Type.Union([
+            Type.Object({
+                owner_address: Type.String(),
+                unfreeze_balance: Type.Number(),
+                balance: Type.Optional(Type.Number()),
+                resource: Type.Optional(PROTO.EnumTronResourceCode),
+            }),
+            PROTO.TronUnfreezeBalanceV2Contract,
+        ]),
+    }),
+});
+
+const TronVoteWitnessContractInput = Type.Object({
+    type: Type.Literal('VoteWitnessContract'),
+    parameter: Type.Object({
+        value: Type.Union([
+            Type.Object({
+                owner_address: Type.String(),
+                votes: Type.Array(
+                    Type.Object({
+                        vote_address: Type.String(),
+                        vote_count: Type.Number(),
+                    }),
+                ),
+            }),
+            PROTO.TronVoteWitnessContract,
+        ]),
+    }),
+});
+
+export type TronContractInput = Static<typeof TronContractInput>;
+export const TronContractInput = Type.Union([
+    TronTransferContract,
+    TronTriggerSmartContract,
+    TronFreezeBalanceV2ContractInput,
+    TronUnfreezeBalanceV2ContractInput,
+    TronWithdrawExpireUnfreezeContract,
+    TronVoteWitnessContractInput,
+]);
 
 export type TronSignTransaction = Static<typeof TronSignTransaction>;
 export const TronSignTransaction = Type.Object({
@@ -68,7 +125,7 @@ export const TronSignTransaction = Type.Object({
     timestamp: Type.Number(),
     fee_limit: Type.Optional(Type.Number()),
     data: Type.Optional(Type.String()),
-    contract: Type.Array(TronContracts, { length: 1 }),
+    contract: Type.Array(TronContractInput, { length: 1 }),
 });
 
 export type TronSignedTx = Static<typeof TronSignedTx>;

--- a/packages/connect/e2e/__fixtures__/tronSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/tronSignTransaction.ts
@@ -67,7 +67,34 @@ export default {
             legacyResults,
         },
         {
-            description: 'Freeze for energy',
+            description: 'Freeze for energy (official field name)',
+            params: {
+                path: "m/44'/195'/0'/0/0",
+                ref_block_bytes: '7e0b',
+                ref_block_hash: 'ed0f599cb230d512',
+                expiration: 1770551739000,
+                timestamp: 1770551679000,
+                contract: [
+                    {
+                        type: 'FreezeBalanceV2Contract',
+                        parameter: {
+                            value: {
+                                owner_address: '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58',
+                                frozen_balance: 50000000,
+                                resource: 'ENERGY',
+                            },
+                        },
+                    },
+                ],
+            },
+            result: {
+                signature:
+                    '39114ab6d33aafc741057c7245272b286d71fd4242052445cd058170073bbee1534e6752f2d1a305916fbac06fb0803641df604c713ee927e872a0ad972d18d01c',
+            },
+            legacyResults,
+        },
+        {
+            description: 'Freeze for energy (legacy balance field)',
             params: {
                 path: "m/44'/195'/0'/0/0",
                 ref_block_bytes: '7e0b',
@@ -94,7 +121,33 @@ export default {
             legacyResults,
         },
         {
-            description: 'Unfreeze for bandwidth',
+            description: 'Unfreeze for bandwidth (official field name)',
+            params: {
+                path: "m/44'/195'/0'/0/0",
+                ref_block_bytes: 'f2b7',
+                ref_block_hash: 'fb75c38816f843ef',
+                expiration: 1771437825000,
+                timestamp: 1771436565000,
+                contract: [
+                    {
+                        type: 'UnfreezeBalanceV2Contract',
+                        parameter: {
+                            value: {
+                                owner_address: '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58',
+                                unfreeze_balance: 10000000,
+                            },
+                        },
+                    },
+                ],
+            },
+            result: {
+                signature:
+                    'b4d10dbd35e1c4e925f45c38809e648df9936f6e5a9fa49ffd90f6ca81abc0595aa388f797114963a5a2be71b982832112846dfdd5b8125c0bcedb2822047a591b',
+            },
+            legacyResults,
+        },
+        {
+            description: 'Unfreeze for bandwidth (legacy balance field)',
             params: {
                 path: "m/44'/195'/0'/0/0",
                 ref_block_bytes: 'f2b7',

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -1,7 +1,12 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
 
 import { TronSignTransaction as TronSignTransactionSchema } from '@trezor/connect-common';
-import type { PROTO, TronContracts, TronContractsTypes } from '@trezor/connect-common';
+import type {
+    PROTO,
+    TronContractInput,
+    TronContracts,
+    TronContractsTypes,
+} from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
@@ -52,6 +57,8 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
 
         const path = validatePath(payload.path, 3);
 
+        const contract = this.transformContract(payload.contract[0]);
+
         this.params = {
             tx: {
                 address_n: path,
@@ -62,8 +69,66 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
                 fee_limit: payload.fee_limit,
                 data: payload.data,
             },
-            contract: payload.contract[0],
+            contract,
         };
+    }
+
+    // Transform official Tron field names to protobuf field names.
+    private transformContract(input: TronContractInput): TronContracts {
+        switch (input.type) {
+            case 'FreezeBalanceV2Contract': {
+                const { value } = input.parameter;
+
+                return {
+                    type: 'FreezeBalanceV2Contract',
+                    parameter: {
+                        value: {
+                            owner_address: value.owner_address,
+                            balance:
+                                'frozen_balance' in value ? value.frozen_balance : value.balance,
+                            resource: value.resource,
+                        },
+                    },
+                };
+            }
+            case 'UnfreezeBalanceV2Contract': {
+                const { value } = input.parameter;
+
+                return {
+                    type: 'UnfreezeBalanceV2Contract',
+                    parameter: {
+                        value: {
+                            owner_address: value.owner_address,
+                            balance:
+                                'unfreeze_balance' in value
+                                    ? value.unfreeze_balance
+                                    : value.balance,
+                            resource: value.resource,
+                        },
+                    },
+                };
+            }
+            case 'VoteWitnessContract': {
+                const { value } = input.parameter;
+
+                return {
+                    type: 'VoteWitnessContract',
+                    parameter: {
+                        value: {
+                            owner_address: value.owner_address,
+                            votes: value.votes.map(vote => ({
+                                address: 'vote_address' in vote ? vote.vote_address : vote.address,
+                                count: 'vote_count' in vote ? vote.vote_count : vote.count,
+                            })),
+                        },
+                    },
+                };
+            }
+            case 'TransferContract':
+            case 'TriggerSmartContract':
+            case 'WithdrawExpireUnfreezeContract':
+                return input;
+        }
     }
 
     get info() {


### PR DESCRIPTION
## Description

Aligns Tron contract input types with official Tron API field names:
- **VoteWitnessContract**: accepts `vote_address`/`vote_count` instead of protobuf `address`/`count` (breaking change).
- **FreezeBalanceV2Contract**: accepts `frozen_balance` (official) with backwards compat for legacy `balance`.
- **UnfreezeBalanceV2Contract**: accepts `unfreeze_balance` (official) with backwards compat for legacy `balance`.

Inputs are transformed to protobuf field names in `tronSignTransaction.ts` before being sent to the device. 

## Notes for QA

Test Tron signing flows (freeze, unfreeze, vote) with NuFi + TronScan

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tron-input-compat&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tron-input-compat&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T19:55:30.291Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->