### PR TITLE
feat(connect): skip discovery by requesting existing accounts from Suite

### DIFF
--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -53,6 +53,7 @@ export const UI_REQUEST = {
 
     BUNDLE_PROGRESS: 'ui-bundle_progress',
     ADDRESS_VALIDATION: 'ui-address_validation',
+    REQUEST_DISCOVERY_ACCOUNTS: 'ui-request_discovery_accounts',
 } as const;
 
 export type UiRequestWithoutPayload =
@@ -206,14 +207,22 @@ export interface FirmwareException {
 
 export interface UiRequestSelectAccount {
     type: typeof UI_REQUEST.SELECT_ACCOUNT;
-    payload: {
-        type: 'start' | 'progress' | 'end';
-        coinInfo: CoinInfo;
-        accountTypes?: DiscoveryAccountType[];
-        defaultAccountType?: DiscoveryAccountType;
-        accounts?: DiscoveryAccount[];
-        preventEmpty?: boolean;
-    };
+    payload:
+        | {
+              type: 'start' | 'progress' | 'end';
+              coinInfo: CoinInfo;
+              accountTypes?: DiscoveryAccountType[];
+              defaultAccountType?: DiscoveryAccountType;
+              accounts?: DiscoveryAccount[];
+              preventEmpty?: boolean;
+          }
+        | {
+              type: 'complete';
+              coinInfo: CoinInfo;
+              accountTypes: DiscoveryAccountType[];
+              defaultAccountType?: DiscoveryAccountType;
+              accounts: DiscoveryAccount[];
+          };
 }
 
 export interface UiRequestSelectFee {
@@ -278,6 +287,13 @@ export interface FirmwareDisconnect {
     };
 }
 
+export interface UiRequestDiscoveryAccounts {
+    type: typeof UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS;
+    payload: {
+        coinInfo: CoinInfo;
+    };
+}
+
 export type UiEvent =
     | UiRequestWithoutPayload
     | UiRequestDeviceAction
@@ -295,7 +311,8 @@ export type UiEvent =
     | FirmwareReconnect
     | FirmwareDisconnect
     | UiRequestAddressValidation
-    | UiRequestFirmwareDownloaded;
+    | UiRequestFirmwareDownloaded
+    | UiRequestDiscoveryAccounts;
 
 export type UiEventMessage = UiEvent & { event: typeof UI_EVENT };
 

--- a/packages/connect-common/src/events/ui-response.ts
+++ b/packages/connect-common/src/events/ui-response.ts
@@ -1,5 +1,6 @@
 import type { ThpPairingMethod } from '@trezor/protocol';
 
+import type { DiscoveryAccount } from '../types/account';
 import type { LocalFirmwares } from '../types/settings';
 
 /*
@@ -15,6 +16,7 @@ export const UI_RESPONSE = {
     RECEIVE_ACCOUNT: 'ui-receive_account',
     RECEIVE_FEE: 'ui-receive_fee',
     RECEIVE_WORD: 'ui-receive_word',
+    RECEIVE_DISCOVERY_ACCOUNTS: 'ui-receive_discovery_accounts',
 } as const;
 
 export interface UiResponseConfirmation {
@@ -78,6 +80,11 @@ export interface UiResponseFee {
           };
 }
 
+export interface UiResponseDiscoveryAccounts {
+    type: typeof UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS;
+    payload: { accounts: DiscoveryAccount[] } | null;
+}
+
 export type UiResponseEvent =
     | UiResponseConfirmation
     | UiResponsePin
@@ -86,4 +93,5 @@ export type UiResponseEvent =
     | UiResponseThpPairingTag
     | UiResponseAccount
     | UiResponseFee
-    | UiResponseFirmwares;
+    | UiResponseFirmwares
+    | UiResponseDiscoveryAccounts;

--- a/packages/connect/src/api/common/requestExistingAccounts.ts
+++ b/packages/connect/src/api/common/requestExistingAccounts.ts
@@ -1,0 +1,49 @@
+import {
+    type CoinInfo,
+    type CoreEventMessage,
+    type DiscoveryAccount,
+    UI_REQUEST,
+    UI_RESPONSE,
+    type UiResponseDiscoveryAccounts,
+    createUiMessage,
+} from '@trezor/connect-common';
+import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+
+import type { UiPromiseCreator } from '../../events/ui-promise';
+import type { IDevice } from '../../types/idevice';
+
+const REQUEST_TIMEOUT_MS = 200;
+
+/**
+ * Sends UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS to the host (e.g. Suite) and waits for a response.
+ * If the host provides existing accounts, returns them. Otherwise returns null so the caller
+ * can fall back to device discovery.
+ */
+export const requestExistingAccounts = async ({
+    postMessage,
+    createUiPromise,
+    device,
+    coinInfo,
+}: {
+    postMessage: (message: CoreEventMessage) => void;
+    createUiPromise: UiPromiseCreator;
+    device: IDevice;
+    coinInfo: CoinInfo;
+}): Promise<DiscoveryAccount[] | null> => {
+    const dfd = createUiPromise(UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS, device);
+
+    postMessage(createUiMessage(UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS, { coinInfo }));
+
+    const result = await Promise.race([
+        dfd.promise.then((response: UiResponseDiscoveryAccounts) => response.payload),
+        resolveAfter(REQUEST_TIMEOUT_MS).then(() => null),
+    ]);
+
+    if (result === null) {
+        dfd.reject(new Error('No discovery accounts handler'));
+
+        return null;
+    }
+
+    return result.accounts.length > 0 ? result.accounts : null;
+};

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -23,6 +23,7 @@ import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trez
 import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
+import { requestExistingAccounts } from './common/requestExistingAccounts';
 import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';
 import { formatAmount } from '../utils/formatUtils';
 import * as pathUtils from '../utils/pathUtils';
@@ -231,6 +232,54 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
     private async selectAccount(context: MethodContext) {
         const { coinInfo } = this.params;
         const blockchain = await this.getBlockchain(context.sendCoreMessage);
+
+        // Try to get existing accounts from the host (e.g. Suite) to skip device discovery
+        if (!this.discovery) {
+            const existingAccounts = await requestExistingAccounts({
+                postMessage: context.sendCoreMessage,
+                createUiPromise: context.createUiPromise,
+                device: this.getDevice(),
+                coinInfo,
+            });
+
+            if (existingAccounts) {
+                return this.selectFromExistingAccounts(existingAccounts, blockchain, context);
+            }
+        }
+
+        return this.selectFromDiscovery(blockchain, context);
+    }
+
+    private async selectFromExistingAccounts(
+        accounts: DiscoveryAccount[],
+        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
+        context: MethodContext,
+    ) {
+        const { coinInfo } = this.params;
+        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
+
+        context.sendCoreMessage(
+            createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
+                type: 'complete',
+                accountTypes: [...new Set(accounts.map(a => a.type))],
+                coinInfo,
+                accounts,
+            }),
+        );
+
+        const uiResp = await dfd.promise;
+        const account = accounts[uiResp.payload];
+        this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
+        const utxo = await blockchain.getAccountUtxo(account.descriptor);
+
+        return { account, utxo };
+    }
+
+    private async selectFromDiscovery(
+        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
+        context: MethodContext,
+    ) {
+        const { coinInfo } = this.params;
         const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
 
         if (this.discovery && this.discovery.completed) {
@@ -247,12 +296,8 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             const account = discovery.accounts[uiResp.payload];
             const utxo = await blockchain.getAccountUtxo(account.descriptor);
 
-            return {
-                account,
-                utxo,
-            };
+            return { account, utxo };
         }
-        // initialize backend
 
         const discovery =
             this.discovery ||
@@ -267,7 +312,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             context.sendCoreMessage(
                 createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
                     type: 'progress',
-                    // preventEmpty: true,
                     coinInfo,
                     accounts,
                 }),
@@ -311,10 +355,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
         const utxo = await blockchain.getAccountUtxo(account.descriptor);
 
-        return {
-            account,
-            utxo,
-        };
+        return { account, utxo };
     }
 
     private async selectFee(

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -6,12 +6,13 @@ import type {
     AccountUtxo,
     CoinInfo,
     DerivationPath,
+    DiscoveryAccount,
     GetAccountInfo as GetAccountInfoParams,
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { resolveAfter } from '@trezor/utils/src/resolveAfter';
 
-import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import { type Blockchain, initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
 import type {
     MethodContext,
     MethodMessage,
@@ -22,6 +23,7 @@ import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { Discovery } from './common/Discovery';
 import { bundlify, validateParams } from './common/paramsValidator';
+import { requestExistingAccounts } from './common/requestExistingAccounts';
 import { getAccountLabel, isUtxoBased } from '../utils/accountUtils';
 import { getSerializedPath, validatePath } from '../utils/pathUtils';
 
@@ -285,8 +287,51 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
     }
 
     private async discover(request: Request, context: MethodContext) {
-        const { coinInfo, identity, defaultAccountType, derivationType } = request;
+        const { coinInfo, identity } = request;
         const blockchain = await initBlockchain(coinInfo, context.sendCoreMessage, identity);
+
+        // Try to get existing accounts from the host (e.g. Suite) to skip device discovery
+        const existingAccounts = await requestExistingAccounts({
+            postMessage: context.sendCoreMessage,
+            createUiPromise: context.createUiPromise,
+            device: this.getDevice(),
+            coinInfo,
+        });
+
+        if (existingAccounts) {
+            return this.selectExistingAccount(existingAccounts, request, blockchain, context);
+        }
+
+        return this.runDiscovery(request, blockchain, context);
+    }
+
+    private async selectExistingAccount(
+        accounts: DiscoveryAccount[],
+        request: Request,
+        blockchain: Blockchain,
+        context: MethodContext,
+    ) {
+        const { coinInfo, defaultAccountType } = request;
+        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
+
+        context.sendCoreMessage(
+            createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
+                type: 'complete',
+                accountTypes: [...new Set(accounts.map(a => a.type))],
+                defaultAccountType,
+                coinInfo,
+                accounts,
+            }),
+        );
+
+        const uiResp = await dfd.promise;
+        const account = accounts[uiResp.payload];
+
+        return this.fetchAccountInfo(account, request, blockchain);
+    }
+
+    private async runDiscovery(request: Request, blockchain: Blockchain, context: MethodContext) {
+        const { coinInfo, defaultAccountType, derivationType } = request;
         const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
 
         const discovery = new Discovery({
@@ -337,6 +382,16 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
         if (!discovery.completed) {
             await resolveAfter(501); // temporary solution, TODO: immediately resolve will cause "device call in progress"
         }
+
+        return this.fetchAccountInfo(account, request, blockchain);
+    }
+
+    private async fetchAccountInfo(
+        account: DiscoveryAccount,
+        request: Request,
+        blockchain: Blockchain,
+    ) {
+        const { coinInfo } = request;
 
         // get account info from backend
         const info = await blockchain.getAccountInfo({

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -792,6 +792,7 @@ export class Core extends EventEmitter {
             case UI_RESPONSE.RECEIVE_ACCOUNT:
             case UI_RESPONSE.RECEIVE_FEE:
             case UI_RESPONSE.RECEIVE_WORD:
+            case UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS:
                 this.uiPromises.resolve(message);
                 break;
             case UI_RESPONSE.RECEIVE_FIRMWARE: {

--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -11,7 +11,7 @@
     "description": "Trezor data",
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "build:lib": "yarn browser-detection & yarn favicon && yarn guide-pull-content",
+        "build:lib": "yarn browser-detection && yarn favicon && yarn guide-pull-content",
         "browser-detection": "webpack --config ./browser-detection.webpack.ts",
         "favicon": "webpack --config ./favicon.webpack.ts",
         "guide-pull-content": "yarn tsx ./src/guide/index.ts",

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectAccountModal.tsx
@@ -155,7 +155,7 @@ export const SelectAccountModal = ({ data }: SelectAccountModalProps) => {
                                         </Table.Row>
                                     );
                                 })}
-                                {data.type !== 'end' && (
+                                {data.type !== 'end' && data.type !== 'complete' && (
                                     <Table.Row>
                                         <Table.Cell>
                                             <SkeletonRectangle width="100px" animate />

--- a/suite-common/connect-popup/src/connectPopupMiddleware.ts
+++ b/suite-common/connect-popup/src/connectPopupMiddleware.ts
@@ -1,9 +1,88 @@
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { UI_REQUEST } from '@trezor/connect';
+import { type Bip43Path, type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    selectDeviceAccountsByNetworkSymbol,
+    selectDiscoveryForSelectedDevice,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import TrezorConnect, {
+    type CoinInfo,
+    type DiscoveryAccount,
+    type DiscoveryAccountType,
+    UI_REQUEST,
+    UI_RESPONSE,
+} from '@trezor/connect';
+
+// Matches the order used by Discovery: p2wpkh → p2tr → p2sh → p2pkh
+const ACCOUNT_TYPE_ORDER = [
+    'p2wpkh',
+    'p2tr',
+    'p2sh',
+    'p2pkh',
+] as const satisfies readonly DiscoveryAccountType[];
+
+const getDiscoveryAccountType = (path: Bip43Path): DiscoveryAccountType => {
+    const purpose = path.split('/')[1]?.replaceAll("'", '');
+    switch (purpose) {
+        case '86':
+        case '10025':
+            return 'p2tr';
+        case '84':
+            return 'p2wpkh';
+        case '49':
+            return 'p2sh';
+        default:
+            return 'p2pkh';
+    }
+};
+
+const getHDPath = (path: Bip43Path): number[] =>
+    path
+        .split('/')
+        .filter(p => p !== 'm')
+        .map(p => {
+            const hardened = p.endsWith("'");
+            const index = parseInt(p.replaceAll("'", ''), 10);
+
+            return hardened ? index + 0x80000000 : index;
+        });
+
+const accountToDiscoveryAccount = (account: Account, coinInfo: CoinInfo): DiscoveryAccount => {
+    const address_n = getHDPath(account.path);
+
+    return {
+        type: getDiscoveryAccountType(account.path),
+        label: `Account #${account.index + 1}`,
+        descriptor: account.descriptor,
+        address_n,
+        empty: account.empty,
+        balance: `${account.formattedBalance} ${coinInfo.shortcut}`,
+        addresses: account.addresses,
+        descriptorChecksum: account.descriptorChecksum,
+    };
+};
+
+const buildDiscoveryAccounts = (accounts: Account[], coinInfo: CoinInfo): DiscoveryAccount[] => {
+    const result: DiscoveryAccount[] = [];
+
+    for (const type of ACCOUNT_TYPE_ORDER) {
+        const typeAccounts = accounts
+            .filter(a => getDiscoveryAccountType(a.path) === type)
+            .sort((a, b) => a.index - b.index);
+
+        for (const account of typeAccounts) {
+            result.push(accountToDiscoveryAccount(account, coinInfo));
+            // Discovery shows accounts up to and including the first empty one per type
+            if (account.empty) break;
+        }
+    }
+
+    return result;
+};
 
 export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next }) => {
+    async (action, { dispatch, next, getState }) => {
         await next(action);
 
         if (action.type === UI_REQUEST.INSUFFICIENT_FUNDS) {
@@ -12,6 +91,34 @@ export const prepareConnectPopupMiddleware = createMiddlewareWithExtraDeps(
                     type: 'not-enough-funds-error',
                 }),
             );
+        }
+
+        if (action.type === UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS) {
+            const discovery = selectDiscoveryForSelectedDevice(getState());
+
+            if (discovery?.status !== 'complete') {
+                // Discovery hasn't completed — send null so Connect falls back
+                // to its own on-device discovery instead of using partial data.
+                TrezorConnect.uiResponse({
+                    type: UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS,
+                    payload: null,
+                });
+
+                return action;
+            }
+
+            const { coinInfo } = action.payload;
+            const symbol = coinInfo.shortcut.toLowerCase() as NetworkSymbol;
+            const allAccounts = selectDeviceAccountsByNetworkSymbol(getState(), symbol);
+            // Exclude coinjoin accounts — they use SLIP-25 paths and unlockPath which
+            // Connect's Discovery does not produce and DiscoveryAccount does not support.
+            const accounts = allAccounts.filter(a => a.backendType !== 'coinjoin');
+            const discoveryAccounts = buildDiscoveryAccounts(accounts, coinInfo);
+
+            TrezorConnect.uiResponse({
+                type: UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS,
+                payload: discoveryAccounts.length > 0 ? { accounts: discoveryAccounts } : null,
+            });
         }
 
         return action;


### PR DESCRIPTION
## Description

Adds a new `UI_REQUEST.REQUEST_DISCOVERY_ACCOUNTS` / `UI_RESPONSE.RECEIVE_DISCOVERY_ACCOUNTS` message that allows Connect to ask Suite for accounts already in its Redux store, skipping device discovery entirely when calling `getAccountInfo` or `composeTransaction`. 

Suite's `connectPopupMiddleware` handles the request by converting wallet accounts to `DiscoveryAccount` format, matching Discovery's ordering (`p2wpkh → p2tr → p2sh → p2pkh`) and including one empty account per type. A 1500ms timeout in `requestExistingAccounts` ensures automatic fallback to normal device discovery when no handler is registered (e.g. standalone Connect usage). A new `'complete'` payload type is added to `SELECT_ACCOUNT` so all account data can be sent in a single message when accounts are pre-loaded.

## Notes for QA

- When calling `getAccountInfo` or `composeTransaction` through Suite without a descriptor/path, the account selector should load immediately from Suite's existing state instead of running device discovery.
- When calling Connect standalone or account is not enabled - fall back to normal device discovery

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-discovery-from-existing-suite&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-discovery-from-existing-suite&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-discovery-from-existing-suite&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T10:50:03.375Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T12:29:04.465Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->