### PR TITLE
refactor(common): move DAC result to persistentDeviceData

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -321,6 +321,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     deviceActions.connectDevice,
                     deviceActions.deviceChanged,
                     deviceActions.setEntropyCheckResult,
+                    deviceActions.setDeviceAuthenticityResult,
                     deviceActions.clearDevicePersistentData,
                     deviceActions.forgetDevicePersistentData,
                 )(action)

--- a/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
+++ b/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.ts
@@ -48,7 +48,12 @@ export const checkDeviceAuthenticityThunk = createThunk<
                   { valid: false, error: result.error.message }
                 : // or internal error (then skip the check by storing undefined)
                   undefined;
-            dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: storedResult }));
+            dispatch(
+                deviceActions.setDeviceAuthenticityResult({
+                    deviceId: device.id,
+                    result: storedResult,
+                }),
+            );
 
             return rejectWithValue(storedResult);
         }
@@ -78,7 +83,12 @@ export const checkDeviceAuthenticityThunk = createThunk<
                 }),
             );
 
-            dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: storedResult }));
+            dispatch(
+                deviceActions.setDeviceAuthenticityResult({
+                    deviceId: device.id,
+                    result: storedResult,
+                }),
+            );
 
             return rejectWithValue(storedResult);
         }
@@ -87,7 +97,12 @@ export const checkDeviceAuthenticityThunk = createThunk<
         if (!skipSuccessToast) {
             dispatch(notificationsActions.addToast({ type: 'device-authenticity-success' }));
         }
-        dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: storedResult }));
+        dispatch(
+            deviceActions.setDeviceAuthenticityResult({
+                deviceId: device.id,
+                result: storedResult,
+            }),
+        );
 
         return fulfillWithValue(storedResult);
     },

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -155,7 +155,7 @@ const setDiscovered = createAction(
 
 const setDeviceAuthenticityResult = createAction(
     `${DEVICE_MODULE_PREFIX}/setDeviceAuthenticityResult`,
-    (payload: { device: TrezorDevice; result: StoredAuthenticateDeviceResult }) => ({
+    (payload: { deviceId: TrezorDevice['id']; result: StoredAuthenticateDeviceResult }) => ({
         payload,
     }),
 );

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -35,7 +35,6 @@ export type DeviceReducerState = {
     persistentDeviceData: PersistentDeviceData[]; // is an array since there is not a single primary id, device can be matched by various criteria
 
     selectedDevice?: TrezorDevice;
-    deviceAuthenticity?: Record<string, StoredAuthenticateDeviceResult>;
     dismissedSecurityChecks?: {
         firmwareAuthenticity?: string[];
     };
@@ -554,14 +553,15 @@ const removeButtonRequests = (
 
 export const setDeviceAuthenticity = (
     draft: DeviceReducerState,
-    device: TrezorDevice,
+    deviceId: TrezorDevice['id'],
     result?: StoredAuthenticateDeviceResult,
 ) => {
-    if (!device.id) return;
-    draft.deviceAuthenticity = {
-        ...draft.deviceAuthenticity,
-        [device.id]: result,
-    };
+    const data = draft.persistentDeviceData.find(
+        persistentDeviceData => persistentDeviceData.device_id === deviceId,
+    );
+    // expected to exist; device must have been connected or changed for this action to happen
+    if (data === undefined) return;
+    data.authenticityResult = result;
 };
 
 // called after successful wipeDevice
@@ -664,7 +664,8 @@ export const prepareDeviceReducer = createReducerWithExtraDeps(
                 state.selectedDevice = payload;
             })
             .addCase(deviceActions.setDeviceAuthenticityResult, (state, { payload }) => {
-                setDeviceAuthenticity(state, payload.device, payload.result);
+                // nullish deviceId is impossible unless meta checks (id) are disabled. If it is nullish, it's no-op.
+                setDeviceAuthenticity(state, payload.deviceId, payload.result);
             })
             .addCase(deviceActions.dismissFirmwareAuthenticityCheck, (state, { payload }) => {
                 if (!state.dismissedSecurityChecks) {

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -332,11 +332,15 @@ export const selectDeviceById = createMemoizedSelector(
     (devices, deviceId) => devices.find(device => device.id === deviceId),
 );
 
-export const selectDeviceAuthenticity = (state: DeviceRootState) => state.device.deviceAuthenticity;
+export const selectDeviceAuthenticity = (state: DeviceRootState) =>
+    state.device.persistentDeviceData;
 
 export const selectDeviceAuthenticityByDeviceId = createMemoizedSelector(
-    [(_state, deviceId: TrezorDevice['id']) => deviceId, selectDeviceAuthenticity],
-    (deviceId, deviceAuthenticity) => (deviceId ? deviceAuthenticity?.[deviceId] : undefined),
+    [(_state: DeviceRootState, deviceId: TrezorDevice['id']) => deviceId, selectDeviceAuthenticity],
+    (deviceId, persistentDeviceData) =>
+        deviceId
+            ? persistentDeviceData.find(data => data.device_id === deviceId)?.authenticityResult
+            : undefined,
 );
 
 export const selectIsFirmwareAuthenticityCheckDismissed = createMemoizedSelector(

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -102,7 +102,7 @@ export type PersistentDeviceData = Pick<AcquiredDevice, PersistedDeviceKey> &
         lastEntropyCheckResult?: EntropyCheckResult;
         delegatedIdentityKey: EncryptedHex<DelegatedIdentityKey> | null;
         descriptor?: AcquiredDevice['descriptor'];
-        // TODO move deviceAuthenticity to this object and newly introduce persistence
+        authenticityResult?: StoredAuthenticateDeviceResult;
     };
 
 export type TrezorDeviceWithState = AcquiredDevice & {

--- a/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
+++ b/suite-native/device/src/__tests__/deviceConnectionFixtures.ts
@@ -2,7 +2,7 @@ import { type UnknownAction } from '@reduxjs/toolkit';
 
 import { deviceActions, prepareDeviceReducer } from '@suite-common/device';
 import { prepareMessageSystemReducer } from '@suite-common/message-system';
-import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { defaultDevicePersistentData, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { prepareThpReducer } from '@suite-common/thp';
 import { prepareWalletSettingsReducer } from '@suite-common/wallet-core';
@@ -362,9 +362,12 @@ export const deviceConnectCompromisedFixtures: NavigationFixture[] = [
             },
             device: {
                 selectedDevice: mockSuiteDevice(),
-                deviceAuthenticity: {
-                    [mockSuiteDevice().id ?? '']: { valid: false, error: 'foo' },
-                },
+                persistentDeviceData: [
+                    {
+                        ...defaultDevicePersistentData,
+                        authenticityResult: { valid: false, error: 'ROOT_PUBKEY_NOT_FOUND' },
+                    },
+                ],
             },
         }),
         action: {

--- a/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
+++ b/suite-native/device/src/hooks/useDeviceAuthenticityCheck.ts
@@ -154,7 +154,12 @@ export const useDeviceAuthenticityCheck = () => {
             }
 
             // Clear previous result
-            dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: undefined }));
+            dispatch(
+                deviceActions.setDeviceAuthenticityResult({
+                    deviceId: device.id,
+                    result: undefined,
+                }),
+            );
 
             const deviceAccessResponse = await requestPrioritizedDeviceAccess(() =>
                 TrezorConnect.authenticateDevice({
@@ -180,7 +185,12 @@ export const useDeviceAuthenticityCheck = () => {
 
             const storedResult: StoredAuthenticateDeviceResult = createStoredResult(result);
 
-            dispatch(deviceActions.setDeviceAuthenticityResult({ device, result: storedResult }));
+            dispatch(
+                deviceActions.setDeviceAuthenticityResult({
+                    deviceId: device.id,
+                    result: storedResult,
+                }),
+            );
 
             if (storedResult?.valid === false) {
                 handleFailure();


### PR DESCRIPTION
## Description

Migrate `state.device.deviceAuthenticity` to `persistentDeviceData` so that it is persisted across sessions.

This already fixes some edge-cases, see screenshots.

:information_source: Next steps: Refactor the logic on desktop, which currently is hardcoded in between navigation and onboarding, and it shall be much simpler than now. Before we decided to persist device metadata, current solution has been a good compromise to do as much work as possible without the persistence.

## Notes for QA

Test Device authenticity check in onboarding:
- Both mobile & desktop
- A device without wallet that: passes and another that fails (debug provisioning or bootloader-unlocked)
- After getting the result, reload the application with the same device.
- Should not get stuck in any loop or unexpcted behavior, and the changed cases (see screenshots) should work

## Related Issue

Preparation for https://github.com/trezor/trezor-suite-private/issues/148

## Screenshots:

The edge case that I'm handling here: fail DAC, and then create wallet somewhere else, and then reconnect.

**Before**: neither [mobile](https://github.com/user-attachments/assets/d2985136-15a0-49c3-b344-97a98b0c0c8d) nor [desktop](https://github.com/user-attachments/assets/1c3bc2f9-2a4b-4af0-b4e0-377aa11b4ff1) remember the failure → the device now has a wallet, so DAC is **not** prompted. 

**After**: [mobile remembers failure](https://github.com/user-attachments/assets/75ea0187-f98a-41e8-a428-37c798a01aed) :heavy_check_mark:  while desktop only remembers DAC was not completed [and prompts it](https://github.com/user-attachments/assets/b20748fe-a51b-476e-bf9f-20ac4034a38a) :heavy_check_mark: that's enough from security standpoint, but FYI I intend to refactor the logic → like mobile.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/DAC-result-persistence&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/DAC-result-persistence&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/DAC-result-persistence&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:10:49.050Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:53:07.924Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->