### PR TITLE
fix: do not show incompatible warning when legacy labeling is on

### DIFF
--- a/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
@@ -169,7 +169,7 @@ export const Labeling = ({
                 />
             )}
             <SuiteSyncInteractionsTooltip
-                suiteSyncInteraction={suiteSyncInteraction}
+                suiteSyncInteraction={!legacyMetadataState.enabled ? suiteSyncInteraction : null}
                 deviceStaticSessionId={deviceStaticSessionId}
             >
                 <EditableText


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/26427

Very straightforward fix, just ignore any suite-sync tooltip if legacy is enabled

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-t1-tt-suite-sync-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-t1-tt-suite-sync-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:26:21.639Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:23:59.185Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->