### PR TITLE
fix: correct error message when device is unsuported for Suite Sync

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -61,7 +61,7 @@
   "FEE_LEVEL_STANDARD": "Select standard fee",
   "FIRMWARE_CONNECT_IN_NORMAL_MODEL_NO_BUTTON": "Don't hold any buttons while connecting the cable.",
   "FIRMWARE_NEEDS_UPGRADE_FOR_SUITE_SYNC": "Upgrade your Trezor's firmware to use Suite Sync.",
-  "FIRMWARE_UNSUPPORTED_DEVICE_SUITE_SYNC": "The device {name} isn’t compatible with Suite Sync. Suite Sync supports Trezor Safe 3, 5, and 7 devices.",
+  "FIRMWARE_UNSUPPORTED_DEVICE_SUITE_SYNC": "Suite Sync supports Trezor Safe 3, 5, and 7 devices.",
   "FIRMWARE_USER_HAS_SEED_CHECKBOX_DESC": "Yes, I do.",
   "FIRMWARE_USER_TAKES_RESPONSIBILITY_CHECKBOX_DESC": "I accept the risk.",
   "FW_CAPABILITY_CONNECT_OUTDATED": "Application update required",

--- a/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
@@ -170,7 +170,6 @@ export const Labeling = ({
             )}
             <SuiteSyncInteractionsTooltip
                 suiteSyncInteraction={!legacyMetadataState.enabled ? suiteSyncInteraction : null}
-                deviceStaticSessionId={deviceStaticSessionId}
             >
                 <EditableText
                     onSubmit={onSubmit ?? handleSubmit}

--- a/packages/suite/src/components/suite/labeling/Labeling/SuiteSyncInteractionsTooltip.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/SuiteSyncInteractionsTooltip.tsx
@@ -1,35 +1,19 @@
 import { type ReactNode } from 'react';
 
 import { Translation, type TranslationKey } from '@suite/intl';
-import { selectDeviceByStaticSessionId, selectDeviceLabelOrNameById } from '@suite-common/device';
 import { type SuiteSyncInteraction } from '@suite-common/suite-sync';
 import { Text, Tooltip } from '@trezor/components';
-import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
-
-import { useSelector } from '../../../../hooks/suite';
 
 type LabelingDisabledTooltipProps = {
     suiteSyncInteraction: SuiteSyncInteraction | null;
     children: ReactNode;
-    deviceStaticSessionId: StaticSessionId;
 };
 
 export const SuiteSyncInteractionsTooltip = ({
     suiteSyncInteraction,
     children,
-    deviceStaticSessionId,
 }: LabelingDisabledTooltipProps) => {
-    const device = useSelector(state =>
-        deviceStaticSessionId !== null
-            ? selectDeviceByStaticSessionId(state, deviceStaticSessionId)
-            : undefined,
-    );
-
-    const deviceLabel = useSelector(state =>
-        device !== undefined ? selectDeviceLabelOrNameById(state, device.id) : null,
-    );
-
     if (suiteSyncInteraction === null) {
         return children;
     }
@@ -53,10 +37,7 @@ export const SuiteSyncInteractionsTooltip = ({
                 <Tooltip
                     content={
                         <Text>
-                            <Translation
-                                id={translationMap[suiteSyncInteraction]}
-                                values={{ name: deviceLabel }}
-                            />
+                            <Translation id={translationMap[suiteSyncInteraction]} />
                         </Text>
                     }
                 >

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6343,8 +6343,7 @@ export const messages = defineMessages({
     },
     FIRMWARE_UNSUPPORTED_DEVICE_SUITE_SYNC: {
         id: 'FIRMWARE_UNSUPPORTED_DEVICE_SUITE_SYNC',
-        defaultMessage:
-            'The device {name} isn’t compatible with Suite Sync. Suite Sync supports Trezor Safe 3, 5, and 7 devices.',
+        defaultMessage: 'Suite Sync supports Trezor Safe 3, 5, and 7 devices.',
     },
     TR_DISABLED_SWITCH_TOOLTIP: {
         id: 'TR_DISABLED_SWITCH_TOOLTIP',


### PR DESCRIPTION
<img width="537" height="201" alt="image" src="https://github.com/user-attachments/assets/9b3817ed-4132-43a1-ae3c-4f84883fccf2" />
<img width="806" height="296" alt="image" src="https://github.com/user-attachments/assets/3f3971f7-d924-44f4-ac3f-a87440ff5ec9" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-text-sute-sync-not-supported&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-text-sute-sync-not-supported&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:57:23.478Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:56:04.013Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->