### PR TITLE
feat(trading): add boundary guards for country and send errors

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -21,12 +21,12 @@ import {
     type TradingExchangeAmountLimitProps,
     type TradingExchangeFormProps,
     type TradingExchangeType,
-    type TradingSendRejectedProps,
     type TradingSignAndPushSendFormTransactionProps,
     type TradingTransactionExchange,
     cryptoIdToNetwork,
     exchangeThunks,
     invityAPI,
+    isSendRejectedError,
     isSendingEvmNativeToken,
     selectTradingComposedTransactionInfo,
     selectTradingExchangeAmountLimits,
@@ -455,13 +455,15 @@ export const useTradingExchangeForm = ({
 
             return true;
         } catch (e) {
-            const errorTyped = e as TradingSendRejectedProps<TranslationKey>;
+            if (!isSendRejectedError<TranslationKey>(e)) {
+                return false;
+            }
 
-            if (errorTyped.type !== 'sign-transaction-timeout') {
+            if (e.type !== 'sign-transaction-timeout') {
                 dispatch(
                     notificationsActions.addToast({
-                        type: errorTyped.type,
-                        error: translationString(errorTyped.error.id, errorTyped.error.values),
+                        type: e.type,
+                        error: translationString(e.error.id, e.error.values),
                     }),
                 );
             }

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -18,10 +18,10 @@ import {
     type TradingAmountLimitProps,
     type TradingSellFormProps,
     type TradingSellType,
-    type TradingSendRejectedProps,
     type TradingSignAndPushSendFormTransactionProps,
     type TradingTransactionSell,
     getTradingQuotesByPaymentMethod,
+    isSendRejectedError,
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
     selectTradingPaymentMethods,
@@ -453,13 +453,15 @@ export const useTradingSellForm = ({
 
             return true;
         } catch (e) {
-            const errorTyped = e as TradingSendRejectedProps<TranslationKey>;
+            if (!isSendRejectedError<TranslationKey>(e)) {
+                return false;
+            }
 
-            if (errorTyped.type !== 'sign-transaction-timeout') {
+            if (e.type !== 'sign-transaction-timeout') {
                 dispatch(
                     notificationsActions.addToast({
-                        type: errorTyped.type,
-                        error: translationString(errorTyped.error.id, errorTyped.error.values),
+                        type: e.type,
+                        error: translationString(e.error.id, e.error.values),
                     }),
                 );
             }

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -34,6 +34,7 @@ export * from './utils/exchange/exchangeUtils';
 export * from './utils/sell/sellUtils';
 export * from './utils/signature/signatureUtils';
 export * from './utils/countryUtils';
+export * from './utils/typeGuards';
 export * from './utils/numberUtils';
 export { getOtcProvidersByCountry, useFetchOtc } from './queries';
 export * from './invityAPI';

--- a/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
+++ b/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
@@ -6,6 +6,7 @@ import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { type BuyInfo } from '../../reducers/buyReducer';
 import { regional } from '../../regional';
+import { toTradingCountryCode } from '../../utils/countryUtils';
 
 export const loadBuyInfoThunk = createThunk<BuyInfo>(
     `${TRADING_BUY_THUNK_PREFIX}/loadInfo`,
@@ -41,7 +42,10 @@ export const loadBuyInfoThunk = createThunk<BuyInfo>(
         });
 
         return fulfillWithValue({
-            buyInfo,
+            buyInfo: {
+                ...buyInfo,
+                country: toTradingCountryCode(buyInfo.country),
+            },
             providerInfos,
             supportedFiatCurrencies,
             supportedCryptoCurrencies,

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -6,7 +6,7 @@ import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { type SellInfo } from '../../reducers/sellReducer';
 import { regional } from '../../regional';
-import { type TradingCountryCode } from '../../types';
+import { toTradingCountryCode } from '../../utils/countryUtils';
 
 export const loadSellInfoThunk = createThunk<SellInfo>(
     `${TRADING_SELL_THUNK_PREFIX}/loadInfo`,
@@ -40,7 +40,7 @@ export const loadSellInfoThunk = createThunk<SellInfo>(
             providerInfos,
             supportedFiatCurrencies: [...new Set(supportedFiatCurrencies)],
             supportedCryptoCurrencies: [...new Set(supportedCryptoCurrencies)],
-            country: sellList.country as TradingCountryCode,
+            country: toTradingCountryCode(sellList.country),
             countrySubdivision: sellList.subdivision,
         });
     },

--- a/suite-common/trading/src/utils/__tests__/countryUtils.test.ts
+++ b/suite-common/trading/src/utils/__tests__/countryUtils.test.ts
@@ -7,6 +7,7 @@ import {
     isCountryCode,
     isCountrySubdivisionEmpty,
     isCountrySubdivisionRequired,
+    toTradingCountryCode,
 } from '../countryUtils';
 
 describe('countryUtils', () => {
@@ -19,6 +20,23 @@ describe('countryUtils', () => {
 
         it('returns false for invalid country code', () => {
             expect(isCountryCode('INVALID')).toBe(false);
+        });
+    });
+
+    describe('toTradingCountryCode', () => {
+        it('returns known country code', () => {
+            expect(toTradingCountryCode('US')).toBe('US');
+        });
+
+        it('returns worldwide region country code', () => {
+            expect(toTradingCountryCode('XX')).toBe('XX');
+            expect(toTradingCountryCode('T1')).toBe('T1');
+        });
+
+        it('returns unknown fallback for invalid value', () => {
+            expect(toTradingCountryCode('INVALID')).toBe('unknown');
+            expect(toTradingCountryCode(undefined)).toBe('unknown');
+            expect(toTradingCountryCode(123)).toBe('unknown');
         });
     });
 

--- a/suite-common/trading/src/utils/__tests__/typeGuards.test.ts
+++ b/suite-common/trading/src/utils/__tests__/typeGuards.test.ts
@@ -1,0 +1,62 @@
+import { isSendRejectedError } from '../typeGuards';
+
+describe('typeGuards', () => {
+    describe('isSendRejectedError', () => {
+        it('returns true for valid trading send rejected error', () => {
+            expect(
+                isSendRejectedError({
+                    type: 'error',
+                    error: {
+                        id: 'TR_GENERIC_ERROR',
+                        values: { foo: 'bar' },
+                    },
+                }),
+            ).toBe(true);
+        });
+
+        it('returns true for valid error without values', () => {
+            expect(
+                isSendRejectedError({
+                    type: 'sign-transaction-timeout',
+                    error: {
+                        id: 'TR_TIMEOUT',
+                    },
+                }),
+            ).toBe(true);
+        });
+
+        it('returns false for invalid shape', () => {
+            expect(isSendRejectedError(undefined)).toBe(false);
+            expect(
+                isSendRejectedError({
+                    type: 'error',
+                }),
+            ).toBe(false);
+            expect(
+                isSendRejectedError({
+                    type: 'invalid-type',
+                    error: {
+                        id: 'TR_GENERIC_ERROR',
+                    },
+                }),
+            ).toBe(false);
+            expect(
+                isSendRejectedError({
+                    type: 'error',
+                    error: {
+                        id: 123,
+                    },
+                }),
+            ).toBe(false);
+            expect(
+                isSendRejectedError({
+                    type: 'error',
+                    error: {
+                        id: 'TR_GENERIC_ERROR',
+                        values: 'invalid',
+                    },
+                }),
+            ).toBe(false);
+        });
+    });
+});

--- a/suite-common/trading/src/utils/countryUtils.ts
+++ b/suite-common/trading/src/utils/countryUtils.ts
@@ -6,8 +6,23 @@ import {
     subdivisionsByCountry,
 } from '@suite-common/geolocation';
 
+import { regional } from '../regional';
+import { type TradingCountryCode } from '../types';
+
 export const isCountryCode = (countryCode: string): countryCode is CountryCode =>
     countryCode in countries || countryCode === 'XX' || countryCode === 'T1';
+
+export const toTradingCountryCode = (countryCode: unknown): TradingCountryCode => {
+    if (countryCode === regional.UNKNOWN_COUNTRY) {
+        return countryCode;
+    }
+
+    if (typeof countryCode === 'string' && isCountryCode(countryCode)) {
+        return countryCode;
+    }
+
+    return regional.UNKNOWN_COUNTRY;
+};
 
 export const hasCountrySubdivisions = (
     countryCode: CountryCode,

--- a/suite-common/trading/src/utils/typeGuards.ts
+++ b/suite-common/trading/src/utils/typeGuards.ts
@@ -1,0 +1,39 @@
+import { isArrayMember } from '@trezor/utils';
+
+import { type TradingSendRejectedProps } from '../types';
+
+const TRADING_SEND_REJECTED_TYPES = ['error', 'sign-tx-error', 'sign-transaction-timeout'] as const;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null;
+
+export const isSendRejectedError = <TranslationKey extends string = string>(
+    error: unknown,
+): error is TradingSendRejectedProps<TranslationKey> => {
+    if (!isObject(error)) {
+        return false;
+    }
+
+    const { type, error: errorData } = error;
+
+    if (typeof type !== 'string' || !isArrayMember(type, TRADING_SEND_REJECTED_TYPES)) {
+        return false;
+    }
+
+    if (!isObject(errorData)) {
+        return false;
+    }
+
+    if (typeof errorData.id !== 'string') {
+        return false;
+    }
+
+    if (
+        errorData.values !== undefined &&
+        (typeof errorData.values !== 'object' || errorData.values === null)
+    ) {
+        return false;
+    }
+
+    return true;
+};


### PR DESCRIPTION
## Description

- add `toTradingCountryCode` and use it at trading API boundaries in buy/sell load info thunks
- add `isSendRejectedError` guard and replace unsafe send-rejected casts in sell/exchange form error handling
- export the new guard and add unit tests for both new helpers

## Notes for QA

Just dev thing

## Related Issue

Resolve #26286

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26286/trading-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26286/trading-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/26286/trading-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:41:23.726Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:40:13.190Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->