### PR TITLE
feat(suite): stablecoin yield – update nutshell & consent modal content

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -102,7 +102,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
             openModal({
                 type: 'earn-in-a-nutshell',
                 flow: EarnFlow.Yield,
-                provider: EarnProvider.YieldXyz,
+                provider: EarnProvider.Morpho,
                 account: opportunity.account,
                 analyticsStep: 'earn-dashboard',
                 yieldContext: {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { RewardDtoYieldSource } from '@suite-common/earn-api';
 import {
     EarnFlow,
     type EarnModalAction,
@@ -9,15 +10,16 @@ import { type Account } from '@suite-common/wallet-types';
 import { isStakingNetworkType } from '@suite-common/wallet-utils';
 import { Divider } from '@trezor/components';
 
+import { getApyPercent } from 'src/components/earn/utils/earnApyUtils';
+
 import { EarnInANutshellModalLayout } from './components/EarnInANutshellModalLayout';
 import {
     type EarnInANutshellProcess,
     EarnInANutshellProcesses,
 } from './components/EarnInANutshellProcesses';
-import { EarnInANutshellWithdrawalBadge } from './components/EarnInANutshellWithdrawalBadge';
-import { EarnSupplyingInfo } from './components/EarnSupplyingInfo';
-import { EarnWithdrawingInfo } from './components/EarnWithdrawingInfo';
 import { YieldEarnInANutshellHighlights } from './components/YieldEarnInANutshellHighlights';
+import { YieldSupplyingInfo } from './components/YieldSupplyingInfo';
+import { YieldWithdrawingInfo } from './components/YieldWithdrawingInfo';
 import { useEarnInANutshell } from './hooks/useEarnInANutshell';
 
 interface YieldEarnInANutshellModalProps {
@@ -35,7 +37,7 @@ export const YieldEarnInANutshellModal = ({
     actionType,
     yieldContext,
 }: YieldEarnInANutshellModalProps) => {
-    const { handleAction, onCancelClick, unstakingPeriod } = useEarnInANutshell({
+    const { handleAction, onCancelClick, vault } = useEarnInANutshell({
         flow: EarnFlow.Yield,
         provider,
         onCancel,
@@ -46,16 +48,24 @@ export const YieldEarnInANutshellModal = ({
 
     if (!isStakingNetworkType(account.networkType)) return null;
 
+    const supplySymbol = vault?.token.symbol ?? '';
+    const vaultSymbol = vault?.outputToken?.symbol;
+    const rewardsSymbols = vault?.rewardRate.components
+        .filter(c => c.yieldSource === RewardDtoYieldSource.protocol_incentive)
+        .map(c => c.token.symbol);
+    const yieldApy =
+        vault?.rewardRate?.total != null ? getApyPercent(vault.rewardRate.total) : null;
+
     const processes: EarnInANutshellProcess[] = [
         {
             heading: <Translation id="TR_EARN_SUPPLYING_PROCESS" />,
             badge: <Translation id="TR_TX_FEE" />,
-            content: <EarnSupplyingInfo account={account} flow={EarnFlow.Yield} />,
+            content: <YieldSupplyingInfo apy={yieldApy} />,
         },
         {
             heading: <Translation id="TR_EARN_WITHDRAWING_PROCESS" />,
-            badge: <EarnInANutshellWithdrawalBadge networkType={account.networkType} />,
-            content: <EarnWithdrawingInfo account={account} flow={EarnFlow.Yield} />,
+            badge: <Translation id="TR_TX_FEE" />,
+            content: <YieldWithdrawingInfo supplySymbol={supplySymbol} />,
         },
     ];
 
@@ -67,9 +77,9 @@ export const YieldEarnInANutshellModal = ({
             onAction={handleAction}
         >
             <YieldEarnInANutshellHighlights
-                networkType={account.networkType}
-                networkSymbol={account.symbol}
-                unstakingPeriod={unstakingPeriod}
+                supplySymbol={supplySymbol}
+                vaultSymbol={vaultSymbol}
+                rewardsSymbols={rewardsSymbols}
             />
             <Divider margin={{ top: 24, bottom: 16 }} />
             <EarnInANutshellProcesses items={processes} />

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
@@ -1,10 +1,6 @@
+import { FormattedList } from 'react-intl';
+
 import { Translation } from '@suite/intl';
-import {
-    type NetworkSymbol,
-    type StakingNetworkType,
-    getNetworkDisplaySymbol,
-} from '@suite-common/wallet-config';
-import { exhaustive } from '@trezor/type-utils';
 
 import {
     type EarnInANutshellHighlight,
@@ -12,114 +8,58 @@ import {
 } from './EarnInANutshellHighlights';
 
 interface YieldEarnInANutshellHighlightsProps {
-    networkType: StakingNetworkType;
-    networkSymbol: NetworkSymbol;
-    unstakingPeriod?: number;
+    supplySymbol: string;
+    vaultSymbol?: string;
+    rewardsSymbols?: string[];
 }
 
 export const YieldEarnInANutshellHighlights = ({
-    networkType,
-    networkSymbol,
-    unstakingPeriod,
+    supplySymbol,
+    vaultSymbol,
+    rewardsSymbols,
 }: YieldEarnInANutshellHighlightsProps) => {
-    const networkDisplaySymbol = getNetworkDisplaySymbol(networkSymbol);
-
-    const highlights: EarnInANutshellHighlight[] = (() => {
-        switch (networkType) {
-            case 'ethereum':
-                return [
-                    {
-                        icon: 'lockSimple',
-                        content: (
-                            <Translation
-                                id="TR_EARN_STAKED_AMOUNT_LOCKED"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'handCoins',
-                        content: (
-                            <Translation
-                                id="TR_EARN_STAKE_REWARDS"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'arrowBendDoubleUpLeft',
-                        content: (
-                            <Translation
-                                id="TR_EARN_ETH_UNSTAKING_TAKES"
-                                values={{ count: unstakingPeriod }}
-                            />
-                        ),
-                    },
-                ];
-            case 'solana':
-                return [
-                    {
-                        icon: 'lockSimple',
-                        content: (
-                            <Translation
-                                id="TR_EARN_STAKED_AMOUNT_LOCKED"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'handCoins',
-                        content: (
-                            <Translation
-                                id="TR_EARN_STAKE_REWARDS"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'arrowBendDoubleUpLeft',
-                        content: (
-                            <Translation
-                                id="TR_EARN_SOL_UNSTAKING_TAKES"
-                                values={{ count: unstakingPeriod }}
-                            />
-                        ),
-                    },
-                ];
-            case 'cardano':
-                return [
-                    {
-                        icon: 'wallet',
-                        content: (
-                            <Translation
-                                id="TR_EARN_YOUR_FUNDS_STAY_ACCESSIBLE"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'handCoins',
-                        content: (
-                            <Translation
-                                id="TR_EARN_STAKE_ALL_YOUR_FUNDS_IS_STAKED"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                    {
-                        icon: 'scroll',
-                        content: (
-                            <Translation
-                                id="TR_EARN_RETURNABLE_DEPOSIT_IS_REQUIRED"
-                                values={{ networkDisplaySymbol }}
-                            />
-                        ),
-                    },
-                ];
-            default:
-                return exhaustive(networkType);
-        }
-    })();
+    const highlights: EarnInANutshellHighlight[] = [
+        {
+            icon: 'lockSimple',
+            content: (
+                <Translation id="TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED" values={{ supplySymbol }} />
+            ),
+        },
+        {
+            icon: 'handCoins',
+            content: <Translation id="TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST" />,
+        },
+        ...(vaultSymbol !== undefined
+            ? [
+                  {
+                      icon: 'coins' as const,
+                      content: (
+                          <Translation
+                              id="TR_EARN_YIELD_NUTSHELL_VAULT_TOKENS"
+                              values={{ supplySymbol, vaultSymbol }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
+        ...(rewardsSymbols !== undefined && rewardsSymbols.length > 0
+            ? [
+                  {
+                      icon: 'plusCircle' as const,
+                      content: (
+                          <Translation
+                              id="TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS"
+                              values={{
+                                  rewardsSymbol: (
+                                      <FormattedList type="conjunction" value={rewardsSymbols} />
+                                  ),
+                              }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
+    ];
 
     return <EarnInANutshellHighlights items={highlights} />;
 };

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldSupplyingInfo.tsx
@@ -1,0 +1,29 @@
+import { Translation } from '@suite/intl';
+import { BulletList } from '@trezor/components';
+
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+
+import { EarnInfoRow } from './EarnInfoRow';
+
+interface YieldSupplyingInfoProps {
+    apy: number | null;
+}
+
+export const YieldSupplyingInfo = ({ apy }: YieldSupplyingInfoProps) => (
+    <BulletList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
+        <EarnInfoRow
+            heading={<Translation id="TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION" />}
+            content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+        />
+        <EarnInfoRow
+            heading={<Translation id="TR_EARN_SIGN_SUPPLYING_TRANSACTION" />}
+            content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+        />
+        {apy !== null && (
+            <EarnInfoRow
+                heading={<Translation id="TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK" />}
+                content={{ text: <ApyValue apy={apy} /> }}
+            />
+        )}
+    </BulletList>
+);

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
@@ -1,0 +1,23 @@
+import { Translation } from '@suite/intl';
+import { BulletList } from '@trezor/components';
+
+import { EarnInfoRow } from './EarnInfoRow';
+
+interface YieldWithdrawingInfoProps {
+    supplySymbol: string;
+}
+
+export const YieldWithdrawingInfo = ({ supplySymbol }: YieldWithdrawingInfoProps) => (
+    <BulletList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
+        <EarnInfoRow
+            heading={<Translation id="TR_EARN_SIGN_WITHDRAWAL_TRANSACTION" />}
+            content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+        />
+        <EarnInfoRow
+            heading={
+                <Translation id="TR_EARN_YIELD_RECEIVE_IN_ACCOUNT" values={{ supplySymbol }} />
+            }
+            content={{ text: <Translation id="TR_EARN_INSTANTLY" /> }}
+        />
+    </BulletList>
+);

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/hooks/useEarnInANutshell.ts
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
+
 import { openModal } from '@suite/modal';
+import { type YieldDto, useAllYieldOpportunities } from '@suite-common/earn-api';
 import {
     type EarnFlow,
     type EarnModalAction,
@@ -33,6 +36,14 @@ export const useEarnInANutshell = ({
     const validatorsQueueData = useSelector(selectEthValidatorsQueue);
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
     const unstakingPeriod = getUnstakingPeriodInDays(account.networkType, validatorsQueueData);
+
+    const { yieldOpportunities } = useAllYieldOpportunities();
+
+    const yieldContextId = yieldContext?.id;
+    const vault: YieldDto | undefined = useMemo(
+        () => yieldOpportunities.find(opportunity => opportunity.id === yieldContextId),
+        [yieldOpportunities, yieldContextId],
+    );
 
     const dispatch = useDispatch();
     const analytics = useAnalytics();
@@ -78,6 +89,7 @@ export const useEarnInANutshell = ({
     return {
         unstakingPeriod,
         apy,
+        vault,
         handleAction,
         onCancelClick,
     };

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -73,7 +73,7 @@ export const YieldEarnProviderConsentModal = ({
             banners={
                 <YieldProviderConsentBanners
                     networkType={account.networkType}
-                    displaySymbol={displaySymbol}
+                    displaySymbol={supplySymbol}
                     providerName={providerName}
                 />
             }

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/components/YieldProviderConsentBanners.tsx
@@ -47,6 +47,16 @@ export const YieldProviderConsentBanners = ({
                             />
                         }
                     />
+                    <Banner
+                        icon="warningCircleFilled"
+                        intent="info"
+                        description={
+                            <Translation
+                                id="TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK"
+                                values={{ providerName }}
+                            />
+                        }
+                    />
                 </>
             );
         default:

--- a/packages/suite/src/components/earn/utils/getEarnProviderName.ts
+++ b/packages/suite/src/components/earn/utils/getEarnProviderName.ts
@@ -5,8 +5,8 @@ export const getEarnProviderName = (provider: EarnProvider): string => {
     switch (provider) {
         case EarnProvider.Everstake:
             return 'Everstake';
-        case EarnProvider.YieldXyz:
-            return 'Yield.xyz';
+        case EarnProvider.Morpho:
+            return 'Morpho';
         default:
             return exhaustive(provider);
     }

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -43,7 +43,7 @@ export const YieldPageHeader = ({ analyticsStep }: YieldPageHeaderProps) => {
             openModal({
                 type: 'earn-in-a-nutshell',
                 flow: EarnFlow.Yield,
-                provider: EarnProvider.YieldXyz,
+                provider: EarnProvider.Morpho,
                 account,
                 analyticsStep,
                 actionType: 'close',

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -8,7 +8,7 @@ export type StakeModalFlow = EarnFlow.Stake | EarnFlow.UpdateProvider;
 
 export enum EarnProvider {
     Everstake = 'everstake',
-    YieldXyz = 'yield-xyz',
+    Morpho = 'morpho',
 }
 
 export type EarnYieldContext = {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9724,6 +9724,41 @@ export const messages = defineMessages({
         id: 'TR_EARN_SUPPLYING_IN_A_NUTSHELL',
         defaultMessage: 'Supplying in a nutshell',
     },
+    TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED: {
+        id: 'TR_EARN_YIELD_NUTSHELL_AMOUNT_LOCKED',
+        defaultMessage:
+            'The supplied amount of {supplySymbol} is locked until you withdraw it. Withdrawal is instant.',
+    },
+    TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST: {
+        id: 'TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST',
+        defaultMessage: 'We then invest your yield so you benefit from compound interest.',
+    },
+    TR_EARN_YIELD_NUTSHELL_VAULT_TOKENS: {
+        id: 'TR_EARN_YIELD_NUTSHELL_VAULT_TOKENS',
+        defaultMessage:
+            'Deposit {supplySymbol} to receive {vaultSymbol} tokens. These tokens represent your vault position.',
+    },
+    TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS: {
+        id: 'TR_EARN_YIELD_NUTSHELL_PROTOCOL_REWARDS',
+        defaultMessage:
+            'You will earn {rewardsSymbol} tokens as rewards. These must be claimed separately.',
+    },
+    TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION: {
+        id: 'TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION',
+        defaultMessage: 'Approve spending transaction',
+    },
+    TR_EARN_SIGN_SUPPLYING_TRANSACTION: {
+        id: 'TR_EARN_SIGN_SUPPLYING_TRANSACTION',
+        defaultMessage: 'Sign supplying transaction',
+    },
+    TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK: {
+        id: 'TR_EARN_YIELD_EARN_REWARDS_EACH_BLOCK',
+        defaultMessage: 'Earn rewards with each mined block',
+    },
+    TR_EARN_YIELD_RECEIVE_IN_ACCOUNT: {
+        id: 'TR_EARN_YIELD_RECEIVE_IN_ACCOUNT',
+        defaultMessage: 'Receive {supplySymbol} in account',
+    },
     TR_EARN_STAKING_PROCESS: {
         id: 'TR_EARN_STAKING_PROCESS',
         defaultMessage: 'Staking process',
@@ -9745,6 +9780,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_SUPPLY_PROVIDER_NO_LIABILITY',
         defaultMessage:
             "When supplying, the responsibility for your funds' security transitions from your Trezor to {providerName}.",
+    },
+    TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK: {
+        id: 'TR_EARN_SUPPLY_PROVIDER_SMART_CONTRACT_RISK',
+        defaultMessage:
+            'Supplying assets involves smart contract risks. {providerName} applies rigorous security measures, but cannot guarantee against all losses.',
     },
     TR_EARN_CONSENT_TO_SUPPLY_WITH_PROVIDER: {
         id: 'TR_EARN_CONSENT_TO_SUPPLY_WITH_PROVIDER',


### PR DESCRIPTION
## Description

Replaces staking-specific content in the **Morpho** yield modal flow with vault-driven data from `YieldDto`.

- rename `EarnProvider.YieldXyz` → `EarnProvider.Morpho`
- update "Supplying in a nutshell" and consent modal content to reflect the Morpho vault flow instead of reusing staking-specific copy

## Notes for QA

- Check staking for every network.
- Check Stablecoin yield for USDT and USDC. **Gauntlet USDT Prime Morpho V2 Vault** has a MORPHO token (so there should be 4 highlights).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26269

## Screenshots:

<img width="484" height="776" alt="image" src="https://github.com/user-attachments/assets/5774ada4-a23c-4611-bf64-5bcd525bc9e3" />

<img width="634" height="507" alt="image" src="https://github.com/user-attachments/assets/09bc3b57-5dd6-49d1-acf6-9cb643b5c212" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-stablecoin-yield-modal-content&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-stablecoin-yield-modal-content&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-stablecoin-yield-modal-content&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T11:52:35.266Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:41:39.267Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->