### PR TITLE
Chore: bump electron builder Wine docker version

### DIFF
--- a/.github/workflows/build-desktop-apps.yml
+++ b/.github/workflows/build-desktop-apps.yml
@@ -129,7 +129,7 @@ jobs:
     env:
       platform: win
     container:
-      image: electronuserland/builder:18-wine
+      image: electronuserland/builder:22-wine
       options: --user 1001
     steps:
       - name: Checkout code
@@ -155,7 +155,7 @@ jobs:
       - name: Build ${{env.platform}} suite-desktop
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-        # TODO solve caching here as well: the container interferes with file permissions due to the --user 1001 option and cache/restore fails.
+        # Caching would be beneficial here as well, maybe not possible: the container interferes actions/cache (even in docker root mode).
         run: |
           yarn workspace @trezor/suite-desktop build:${{env.platform}}
           bash packages/suite-desktop-core/scripts/gnupg-sign.sh


### PR DESCRIPTION
## Description

Maintenance for Electron Windows build, which is powered by the electron-builder:Wine docker container:

- update the docker from node 18 to node 22
  - skipping 20, which we have forgotten, this has not been bumped in a long time :grimacing:
  - [24 does not exist yet](https://hub.docker.com/r/electronuserland/builder/tags?name=24-wine), 22 is newest

I tested the build artifact in VM windows :heavy_check_mark: 

## Notes for QA

Test [Windows build in CI](https://github.com/trezor/trezor-suite/actions/runs/24083301198): the .exe installs and runs.
Can be done as part of regular release checks :slightly_smiling_face: 