### PR TITLE
chore: upgrade type-fest from 4.24.0 to 5.5.0 across monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "typescript": "5.8.3",
         "prettier": "3.8.1",
         "react-native": "0.83.2",
-        "type-fest": "4.24.0",
+        "type-fest": "5.5.0",
         "bcrypto": "5.4.0",
         "react": "19.2.4",
         "electron": "40.8.5",

--- a/suite-native/atoms/package.json
+++ b/suite-native/atoms/package.json
@@ -43,7 +43,7 @@
         "react-native-svg": "15.15.3",
         "react-redux": "9.2.0",
         "storybook": "^10.2.8",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"

--- a/suite-native/device/package.json
+++ b/suite-native/device/package.json
@@ -69,6 +69,6 @@
         "react-native-svg": "15.15.3",
         "react-redux": "9.2.0",
         "semver": "^7.7.1",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     }
 }

--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -19,7 +19,7 @@
         "react-hook-form": "^7.71.2",
         "react-native": "0.83.2",
         "react-native-reanimated": "~4.2.1",
-        "type-fest": "4.24.0",
+        "type-fest": "5.5.0",
         "yup": "1.7.1"
     }
 }

--- a/suite-native/link/package.json
+++ b/suite-native/link/package.json
@@ -16,7 +16,7 @@
         "@trezor/theme": "workspace:*",
         "@trezor/urls": "workspace:*",
         "react": "19.2.4",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     },
     "peerDependencies": {
         "react-native": "*",

--- a/suite-native/navigation/package.json
+++ b/suite-native/navigation/package.json
@@ -45,6 +45,6 @@
         "react-native-reanimated": "~4.2.1",
         "react-native-safe-area-context": "5.6.2",
         "react-redux": "9.2.0",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     }
 }

--- a/suite-native/receive/package.json
+++ b/suite-native/receive/package.json
@@ -52,6 +52,6 @@
         "react-native-gesture-handler": "2.30.0",
         "react-native-reanimated": "~4.2.1",
         "react-redux": "9.2.0",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     }
 }

--- a/suite-native/trading-atoms/package.json
+++ b/suite-native/trading-atoms/package.json
@@ -31,7 +31,7 @@
         "react-native": "0.83.2",
         "react-native-gesture-handler": "2.30.0",
         "react-native-reanimated": "~4.2.1",
-        "type-fest": "4.24.0"
+        "type-fest": "5.5.0"
     },
     "devDependencies": {
         "@suite-common/wallet-types": "workspace:*",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -71,7 +71,7 @@
         "lodash": "^4.18.1",
         "react-intl": "^8.1.3",
         "tsx": "^4.21.0",
-        "type-fest": "^5.4.1",
+        "type-fest": "5.5.0",
         "xvfb-maybe": "^0.2.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11956,7 +11956,7 @@ __metadata:
     react-native-svg: "npm:15.15.3"
     react-redux: "npm:9.2.0"
     storybook: "npm:^10.2.8"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -12287,7 +12287,7 @@ __metadata:
     react-native-svg: "npm:15.15.3"
     react-redux: "npm:9.2.0"
     semver: "npm:^7.7.1"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -12448,7 +12448,7 @@ __metadata:
     react-hook-form: "npm:^7.71.2"
     react-native: "npm:0.83.2"
     react-native-reanimated: "npm:~4.2.1"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
     yup: "npm:1.7.1"
   languageName: unknown
   linkType: soft
@@ -12617,7 +12617,7 @@ __metadata:
     "@trezor/theme": "workspace:*"
     "@trezor/urls": "workspace:*"
     react: "npm:19.2.4"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   peerDependencies:
     react-native: "*"
     react-native-reanimated: "*"
@@ -13566,7 +13566,7 @@ __metadata:
     react-native-reanimated: "npm:~4.2.1"
     react-native-safe-area-context: "npm:5.6.2"
     react-redux: "npm:9.2.0"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -13685,7 +13685,7 @@ __metadata:
     react-native-gesture-handler: "npm:2.30.0"
     react-native-reanimated: "npm:~4.2.1"
     react-redux: "npm:9.2.0"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -14079,7 +14079,7 @@ __metadata:
     react-native: "npm:0.83.2"
     react-native-gesture-handler: "npm:2.30.0"
     react-native-reanimated: "npm:~4.2.1"
-    type-fest: "npm:4.24.0"
+    type-fest: "npm:5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -15923,7 +15923,7 @@ __metadata:
     lodash: "npm:^4.18.1"
     react-intl: "npm:^8.1.3"
     tsx: "npm:^4.21.0"
-    type-fest: "npm:^5.4.1"
+    type-fest: "npm:5.5.0"
     xvfb-maybe: "npm:^0.2.1"
   languageName: unknown
   linkType: soft
@@ -42858,6 +42858,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10/e37653df3e495daa7ea7790cb161b810b00075bba2e4d6c93fb06a709e747e3ae9da11a120d0489833203926511b39e038a2affbd9d279cfb7a2f3fcccd30b5d
+  languageName: node
+  linkType: hard
+
 "tailwindcss@npm:^3.4.10":
   version: 3.4.10
   resolution: "tailwindcss@npm:3.4.10"
@@ -43788,10 +43795,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:4.24.0":
-  version: 4.24.0
-  resolution: "type-fest@npm:4.24.0"
-  checksum: 10/60efd6ec71f5113ef0a0fcabe61fc722bb2520ea082bc23e4b4dfb44204234dc691560a5e837f939160d7c18b410ed8fae32ddb752d57bed009248e0f61dce6b
+"type-fest@npm:5.5.0":
+  version: 5.5.0
+  resolution: "type-fest@npm:5.5.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10/b5423e991f29dd8cb6ba1bf613f6ab95065673706bf6ffbc8319a457256af8e9844de013801b4ab94572cee32eb35e3ebc9ff67db2bd4b2937cc153a2b91a093
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is part of an effort to unify libs versions across the monorepo.So that we don't need to introduce exceptions to the checks that will prevent version drifts in the future https://github.com/trezor/trezor-suite/pull/26412/changes#diff-a76b77f8d1b7268dc10ebd8bf950e48ea6b04072c5c2f08879d0493d2eb826c2R18

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-type-fest&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-type-fest&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=update-type-fest&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T12:45:28.571Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T12:43:48.931Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->