### PR TITLE
fix(suite-native): manage Electrum connection based on app state

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -221,6 +221,11 @@ export const selectBlockchainBlockInfoBySymbol = createMemoizedSelector(
     }),
 );
 
+export const selectBlockchainBackendType = createMemoizedSelector(
+    [selectNetworkBlockchainInfo],
+    blockchain => blockchain.backends.selected,
+);
+
 export const selectEnabledCustomBackends = createMemoizedSelector(
     [selectBlockchainState, selectEnabledNetworks],
     (blockchainState, enabledNetworks) =>

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -57,6 +57,7 @@
         "@suite-native/app-init": "workspace:*",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/biometrics": "workspace:*",
+        "@suite-native/blockchain": "workspace:*",
         "@suite-native/bluetooth": "workspace:*",
         "@suite-native/config": "workspace:*",
         "@suite-native/connection-status": "workspace:*",

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { selectSelectedDevice } from '@suite-common/device';
 import { useReportDeviceCompromised } from '@suite-common/firmware-authenticity';
+import { useBlockchainConnectionManager } from '@suite-native/blockchain';
 import { useBluetoothAdapter } from '@suite-native/bluetooth';
 import {
     useDetectDeviceError,
@@ -19,6 +20,7 @@ import { useConnectPopupNavigation } from '@suite-native/module-connect-popup';
 export const useGlobalHooks = () => {
     const device = useSelector(selectSelectedDevice);
 
+    useBlockchainConnectionManager();
     useConnectPopupNavigation();
 
     useBluetoothAdapter();

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -32,6 +32,7 @@
         { "path": "../app-init" },
         { "path": "../atoms" },
         { "path": "../biometrics" },
+        { "path": "../blockchain" },
         { "path": "../bluetooth" },
         { "path": "../config" },
         { "path": "../connection-status" },

--- a/suite-native/blockchain/package.json
+++ b/suite-native/blockchain/package.json
@@ -11,11 +11,15 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@reduxjs/toolkit": "2.11.2",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/utils": "workspace:*"
+        "@trezor/utils": "workspace:*",
+        "react": "19.2.4",
+        "react-native": "0.83.2",
+        "react-redux": "9.2.0"
     }
 }

--- a/suite-native/blockchain/redux.d.ts
+++ b/suite-native/blockchain/redux.d.ts
@@ -1,0 +1,11 @@
+import { AsyncThunkAction, ThunkAction } from '@reduxjs/toolkit';
+
+declare module 'redux' {
+    export interface Dispatch<A extends Action = AnyAction> {
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+
+        <ReturnType = any, State = any, ExtraThunkArg = any>(
+            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,
+        ): ReturnType;
+    }
+}

--- a/suite-native/blockchain/src/index.ts
+++ b/suite-native/blockchain/src/index.ts
@@ -1,2 +1,3 @@
 export { blockchainMiddleware } from './blockchainMiddleware';
 export { syncAllAccountsWithBlockchainThunk } from './blockchainThunks';
+export * from './useBlockchainConnectionManager';

--- a/suite-native/blockchain/src/useBlockchainConnectionManager.ts
+++ b/suite-native/blockchain/src/useBlockchainConnectionManager.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { useDispatch, useSelector } from 'react-redux';
+
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type BlockchainRootState,
+    reconnectBlockchainThunk,
+    selectBlockchainBackendType,
+} from '@suite-common/wallet-core';
+import TrezorConnect from '@trezor/connect';
+
+// No other networks need managing at the moment.
+const symbol: NetworkSymbol = 'btc';
+
+export const useBlockchainConnectionManager = () => {
+    const dispatch = useDispatch();
+
+    const blockchainBackendType = useSelector((state: BlockchainRootState) =>
+        selectBlockchainBackendType(state, symbol),
+    );
+
+    useEffect(() => {
+        if (blockchainBackendType === 'electrum') {
+            // ElectrumClient tries to keep its server connection alive, which causes issues when
+            // the mobile app is moved to the background. Since the app is eventually suspended and
+            // the connection closed, the app later crashes when it tries to use an already closed
+            // connection. So we need to manage the connection based on the app state.
+            const subscription = AppState.addEventListener('change', nextAppState => {
+                if (nextAppState === 'background') {
+                    TrezorConnect.blockchainDisconnect({ coin: symbol });
+                } else if (nextAppState === 'active') {
+                    dispatch(reconnectBlockchainThunk({ symbol }));
+                }
+            });
+
+            return () => {
+                subscription.remove();
+            };
+        }
+    }, [blockchainBackendType, dispatch]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -11733,6 +11733,7 @@ __metadata:
     "@suite-native/app-init": "workspace:*"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/biometrics": "workspace:*"
+    "@suite-native/blockchain": "workspace:*"
     "@suite-native/bluetooth": "workspace:*"
     "@suite-native/config": "workspace:*"
     "@suite-native/connection-status": "workspace:*"
@@ -11980,12 +11981,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/blockchain@workspace:suite-native/blockchain"
   dependencies:
+    "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/utils": "workspace:*"
+    react: "npm:19.2.4"
+    react-native: "npm:0.83.2"
+    react-redux: "npm:9.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`ElectrumClient` tries to keep its server connection alive, which causes issues when the mobile app is moved to the background. Since the app is eventually suspended and the connection closed, the app later crashes when it tries to use an already closed connection. So we need to manage the connection based on the app state.

## Related Issue

Resolve #26432

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/electrum-backend-in-background&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/electrum-backend-in-background&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/electrum-backend-in-background&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:16:49.207Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:15:07.459Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->