### PR TITLE
fix: activate XLM token in trading

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
@@ -25,12 +25,13 @@ export const useTradingStellarActivateToken = ({
         initialData: [],
     });
 
-    const { contractAddress: selectedAssetContractAddress } =
+    const { network: selectedAssetNetwork, contractAddress: selectedAssetContractAddress } =
         cryptoIdToNetworkAndContractAddress(receiveCryptoId);
 
-    const inactiveToken = inactiveTokens?.find(
-        token => token.contract === selectedAssetContractAddress,
-    );
+    const inactiveToken =
+        selectedAssetNetwork?.networkType === 'stellar'
+            ? inactiveTokens?.find(token => token.contract === selectedAssetContractAddress)
+            : undefined;
 
     const onModalOpen = () => setIsModalOpen(true);
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingStellarActivateToken.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingStellarActivateToken.test.ts
@@ -103,6 +103,7 @@ describe('useTradingStellarActivateToken', () => {
         mockSelectExchangeSelectedReceiveAccount.mockReturnValue({ account: { key: ACCOUNT_KEY } });
 
         mockCryptoIdToNetworkAndContractAddress.mockReturnValue({
+            network: { networkType: 'stellar' },
             contractAddress: TOKEN_CONTRACT,
         });
 

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.tsx
@@ -44,12 +44,13 @@ export const useTradingStellarActivateToken = ({
 
     const selectedReceiveAccount = useSelector(selectExchangeSelectedReceiveAccount);
 
-    const { contractAddress: receiveContractAddress } =
+    const { network: receiveNetwork, contractAddress: receiveContractAddress } =
         cryptoIdToNetworkAndContractAddress(receiveCryptoId);
 
     const { inactiveTokens } = useInactiveStellarTokens(selectedReceiveAccount?.account.key);
 
     const isReceivingInactiveStellarToken =
+        receiveNetwork?.networkType === 'stellar' &&
         !!quote &&
         !!selectedReceiveAccount &&
         !!receiveContractAddress &&


### PR DESCRIPTION
## Description

This PR fixes a bug where e.g. swap form navigates to Stellar token activation even though the swap network is Ethereum.

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 15 07 49" src="https://github.com/user-attachments/assets/2d24d07c-d08d-487c-93c4-cd7c689b5c5c" />
</td>
<td>
<img width="1206" height="2622" alt="Screenshot 2026-04-07 at 15 07 54" src="https://github.com/user-attachments/assets/75d9d24a-750b-473c-8a63-9f310f03bb60" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/xlm-activate-token&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/xlm-activate-token&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/xlm-activate-token&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:38:20.918Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:37:52.906Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->