### PR TITLE
fix(suite): apply discrete mode blur to staking and yield dashboard a…

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
@@ -4,6 +4,8 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenSymbol } from '@suite-common/wallet-types';
 import { H4, type TextProps } from '@trezor/components';
 
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
 type EarnRewardsAmountProps = {
     symbol: NetworkSymbol | TokenSymbol;
     rewards: string;
@@ -32,13 +34,16 @@ export const EarnRewardsAmount = ({
 
     return (
         <H4 intent={intent} priority={priority} isDisabled={isDisabled}>
-            {CryptoAmountFormatter.format(rewards, {
-                symbol,
-                isBalance: true,
-                withSymbol: true,
-                isEllipsisAppended: false,
-                maxDisplayedDecimals: 8,
-            })}
+            <HiddenPlaceholder>
+                <CryptoAmountFormatter
+                    value={rewards}
+                    symbol={symbol}
+                    isBalance
+                    withSymbol
+                    isEllipsisAppended={false}
+                    maxDisplayedDecimals={8}
+                />
+            </HiddenPlaceholder>
         </H4>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -23,6 +23,7 @@ import {
 import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
@@ -165,13 +166,15 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
                                 intent="neutral"
                                 priority="secondary"
                             >
-                                <Translation
-                                    id="TR_EARN_STAKING_DASHBOARD_STAKED"
-                                    values={{
-                                        amount: formatCryptoAmount(stakingBalance),
-                                        displaySymbol,
-                                    }}
-                                />
+                                <HiddenPlaceholder>
+                                    <Translation
+                                        id="TR_EARN_STAKING_DASHBOARD_STAKED"
+                                        values={{
+                                            amount: formatCryptoAmount(stakingBalance),
+                                            displaySymbol,
+                                        }}
+                                    />
+                                </HiddenPlaceholder>
                             </Paragraph>
                         )}
                     </Column>
@@ -205,13 +208,15 @@ export const EarnStakingAccountRow = ({ account }: { account: Account }) => {
 
                     {!isCardanoNetworkType && apy && (
                         <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
-                            <Translation
-                                id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                values={{
-                                    amount: formatCryptoAmount(accountBalance),
-                                    displaySymbol,
-                                }}
-                            />
+                            <HiddenPlaceholder>
+                                <Translation
+                                    id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                                    values={{
+                                        amount: formatCryptoAmount(accountBalance),
+                                        displaySymbol,
+                                    }}
+                                />
+                            </HiddenPlaceholder>
                         </Paragraph>
                     )}
                 </Column>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -12,6 +12,7 @@ import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
 import { useDispatch } from 'src/hooks/suite';
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
@@ -184,13 +185,15 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                                         intent="neutral"
                                         priority="secondary"
                                     >
-                                        <Translation
-                                            id="TR_EARN_YIELD_DASHBOARD_SUPPLIED"
-                                            values={{
-                                                amount: formattedSuppliedAmount,
-                                                displaySymbol: opportunity.suppliedSymbol,
-                                            }}
-                                        />
+                                        <HiddenPlaceholder>
+                                            <Translation
+                                                id="TR_EARN_YIELD_DASHBOARD_SUPPLIED"
+                                                values={{
+                                                    amount: formattedSuppliedAmount,
+                                                    displaySymbol: opportunity.suppliedSymbol,
+                                                }}
+                                            />
+                                        </HiddenPlaceholder>
                                     </Paragraph>
                                 )}
                             </Column>
@@ -221,13 +224,15 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
                                     intent="neutral"
                                     priority="secondary"
                                 >
-                                    <Translation
-                                        id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
-                                        values={{
-                                            amount: formattedAdditionalSupplyAmount,
-                                            displaySymbol: opportunity.suppliedSymbol,
-                                        }}
-                                    />
+                                    <HiddenPlaceholder>
+                                        <Translation
+                                            id="TR_EARN_STAKING_DASHBOARD_IF_YOU_ADD"
+                                            values={{
+                                                amount: formattedAdditionalSupplyAmount,
+                                                displaySymbol: opportunity.suppliedSymbol,
+                                            }}
+                                        />
+                                    </HiddenPlaceholder>
                                 </Paragraph>
                             </Column>
                         )}


### PR DESCRIPTION
…mounts

Crypto amounts in the earn dashboard tables were not blurred in discrete mode because they used CryptoAmountFormatter.format() which bypasses the redaction context. Wrap sensitive values with HiddenPlaceholder to ensure consistent privacy behavior across the dashboard.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25939

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25939-discrete-mode-incomplete&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25939-discrete-mode-incomplete&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:25:29.816Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:24:14.765Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->