### PR TITLE
feat(suite): add message system support for yield supply and withdraw

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnFeatureDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnFeatureDisabledBanner.tsx
@@ -1,0 +1,16 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import { Banner } from '@trezor/components';
+
+type EarnFeatureDisabledBannerProps = {
+    content?: ReactNode;
+};
+
+export const EarnFeatureDisabledBanner = ({ content }: EarnFeatureDisabledBannerProps) => (
+    <Banner
+        icon="warning"
+        intent="warning"
+        description={content ?? <Translation id="TR_EARN_NOT_AVAILABLE" />}
+    />
+);

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
 import { DashboardAnchor, useAnchor } from '@suite/router';
+import { Context } from '@suite-common/message-system';
 import { type StakingNetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectAccountIsStakingActive,
@@ -12,19 +13,24 @@ import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
 import { Button, Card, Column, Table } from '@trezor/components';
 import { OutlineHighlight } from '@trezor/product-components';
 
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemEarnDashboard } from 'src/hooks/suite/useMessageSystemEarnDashboard';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 import { EarnStakingAccountRow } from './EarnStakingAccountRow';
 import { EarnStakingActivateRow } from './EarnStakingActivateRow';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
+import { EarnFeatureDisabledBanner } from '../common/EarnFeatureDisabledBanner';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
 import { useCryptoCurrentRate } from './hooks/useCryptoCurrencyRate';
 import { useStakingAccountsVisibility } from './hooks/useStakingAccountsVisibility';
 
 export const EarnStakingTable = () => {
     const { anchorRef, shouldHighlight } = useAnchor(DashboardAnchor.Staking);
+    const { isDisabled: isStakingDashboardDisabled, content } =
+        useMessageSystemEarnDashboard('staking');
 
     const ethCurrentRate = useCryptoCurrentRate('eth');
     const solCurrentRate = useCryptoCurrentRate('sol');
@@ -93,12 +99,17 @@ export const EarnStakingTable = () => {
         return null;
     }
 
-    if (isEthStakingDisabled && isSolStakingDisabled && isAdaStakingDisabled) {
+    if (
+        !isStakingDashboardDisabled &&
+        isEthStakingDisabled &&
+        isSolStakingDisabled &&
+        isAdaStakingDisabled
+    ) {
         return null;
     }
 
     const badge = getEarnDashboardBadgeState({
-        isSectionActive: isStakingActive,
+        isSectionActive: !isStakingDashboardDisabled && isStakingActive,
         isSectionOutdated: stakingAccounts.some(account =>
             isCardanoStakedWithFiveBinaries(account),
         ),
@@ -108,40 +119,57 @@ export const EarnStakingTable = () => {
     });
 
     return (
-        <OutlineHighlight shouldHighlight={shouldHighlight}>
-            <EarnDashboardSection
-                titleId="TR_EARN_STAKING_DASHBOARD_TITLE"
-                subheadingId="TR_EARN_STAKING_DASHBOARD_TEXT"
-                provider="everstake"
-                statusBadge={badge}
-                sectionRef={anchorRef}
-            >
-                <Column gap={16} alignItems="center">
-                    <Card paddingType="none">
-                        <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                            <EarnDashboardTableHeader
-                                showRewardsColumns={!stakingAccountsNotActivated}
-                            />
+        <Column gap={16}>
+            <ContextMessage context={Context.getEarnDashboard('staking')} />
 
-                            <Table.Body>
-                                {displayedAccounts.map(account => (
-                                    <EarnStakingAccountRow account={account} key={account.key} />
-                                ))}
+            <OutlineHighlight shouldHighlight={shouldHighlight}>
+                <EarnDashboardSection
+                    titleId="TR_EARN_STAKING_DASHBOARD_TITLE"
+                    subheadingId="TR_EARN_STAKING_DASHBOARD_TEXT"
+                    provider="everstake"
+                    statusBadge={badge}
+                    sectionRef={anchorRef}
+                >
+                    {isStakingDashboardDisabled ? (
+                        <EarnFeatureDisabledBanner content={content} />
+                    ) : (
+                        <Column gap={16} alignItems="center">
+                            <Card paddingType="none">
+                                <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                                    <EarnDashboardTableHeader
+                                        showRewardsColumns={!stakingAccountsNotActivated}
+                                    />
 
-                                {ethNotActivated && <EarnStakingActivateRow symbol="eth" />}
-                                {adaNotActivated && <EarnStakingActivateRow symbol="ada" />}
-                                {solNotActivated && <EarnStakingActivateRow symbol="sol" />}
-                            </Table.Body>
-                        </Table>
-                    </Card>
+                                    <Table.Body>
+                                        {displayedAccounts.map(account => (
+                                            <EarnStakingAccountRow
+                                                account={account}
+                                                key={account.key}
+                                            />
+                                        ))}
 
-                    {isExpandable && (
-                        <Button intent="neutral" priority="secondary" onClick={toggleExpanded}>
-                            <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
-                        </Button>
+                                        {ethNotActivated && <EarnStakingActivateRow symbol="eth" />}
+                                        {adaNotActivated && <EarnStakingActivateRow symbol="ada" />}
+                                        {solNotActivated && <EarnStakingActivateRow symbol="sol" />}
+                                    </Table.Body>
+                                </Table>
+                            </Card>
+
+                            {isExpandable && (
+                                <Button
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={toggleExpanded}
+                                >
+                                    <Translation
+                                        id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'}
+                                    />
+                                </Button>
+                            )}
+                        </Column>
                     )}
-                </Column>
-            </EarnDashboardSection>
-        </OutlineHighlight>
+                </EarnDashboardSection>
+            </OutlineHighlight>
+        </Column>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type YieldDto } from '@suite-common/earn-api';
+import { Context } from '@suite-common/message-system';
 import { NORMAL_ACCOUNT_TYPE } from '@suite-common/wallet-config';
 import {
     selectDeviceSupportedNetworks,
@@ -9,7 +10,9 @@ import {
 } from '@suite-common/wallet-core';
 import { Button, Card, Column, Table } from '@trezor/components';
 
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemEarnDashboard } from 'src/hooks/suite/useMessageSystemEarnDashboard';
 
 import { EarnYieldTableBody } from './EarnYieldTableBody';
 import { useAllYieldOpportunities } from './hooks/useAllYieldOpportunities';
@@ -17,19 +20,24 @@ import { useYieldAccountsVisibility } from './hooks/useYieldAccountsVisibility';
 import { useYieldTableData } from './hooks/useYieldTableData';
 import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
+import { EarnFeatureDisabledBanner } from '../common/EarnFeatureDisabledBanner';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
 
 const isYieldOpportunityAvailable = (vault: YieldDto) =>
     !vault.metadata.underMaintenance && !vault.metadata.deprecated;
 
 export const EarnYieldTable = () => {
+    const { isDisabled: isYieldDashboardDisabled, content } =
+        useMessageSystemEarnDashboard('yield');
     const visibleAccounts = useSelector(selectVisibleDeviceAccounts);
     const normalAccounts = useMemo(
         () => visibleAccounts.filter(account => account.accountType === NORMAL_ACCOUNT_TYPE),
         [visibleAccounts],
     );
     const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
-    const { yieldOpportunities, isYieldOpportunitiesLoading } = useAllYieldOpportunities();
+    const { yieldOpportunities, isYieldOpportunitiesLoading } = useAllYieldOpportunities({
+        enabled: !isYieldDashboardDisabled,
+    });
     const availableVaults = useMemo(
         () => yieldOpportunities.filter(isYieldOpportunityAvailable),
         [yieldOpportunities],
@@ -56,36 +64,50 @@ export const EarnYieldTable = () => {
     } = useYieldAccountsVisibility({ yieldAccountOpportunities });
 
     const badge = getEarnDashboardBadgeState({
-        isSectionActive: isYieldActive,
+        isSectionActive: !isYieldDashboardDisabled && isYieldActive,
         activeLabelId: 'TR_EARN_DASHBOARD_ACTIVE',
         notActiveLabelId: 'TR_EARN_DASHBOARD_NOT_ACTIVE',
     });
 
     return (
-        <EarnDashboardSection
-            titleId="TR_EARN_STABLECOIN_YIELD_TITLE"
-            subheadingId="TR_EARN_YIELD_DASHBOARD_TEXT"
-            provider="morpho"
-            statusBadge={badge}
-        >
-            <Column gap={16} alignItems="center">
-                <Card paddingType="none">
-                    <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                        <EarnDashboardTableHeader />
-                        <EarnYieldTableBody
-                            isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
-                            yieldAccountOpportunities={displayedYieldAccountOpportunities}
-                            yieldInactiveVaultOpportunities={yieldInactiveVaultOpportunities}
-                        />
-                    </Table>
-                </Card>
+        <Column gap={16}>
+            <ContextMessage context={Context.getEarnDashboard('yield')} />
 
-                {hasHiddenYieldAccountOpportunities && (
-                    <Button intent="neutral" priority="secondary" onClick={toggleIsExpanded}>
-                        <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
-                    </Button>
+            <EarnDashboardSection
+                titleId="TR_EARN_STABLECOIN_YIELD_TITLE"
+                subheadingId="TR_EARN_YIELD_DASHBOARD_TEXT"
+                provider="morpho"
+                statusBadge={badge}
+            >
+                {isYieldDashboardDisabled ? (
+                    <EarnFeatureDisabledBanner content={content} />
+                ) : (
+                    <Column gap={16} alignItems="center">
+                        <Card paddingType="none">
+                            <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                                <EarnDashboardTableHeader />
+                                <EarnYieldTableBody
+                                    isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                                    yieldAccountOpportunities={displayedYieldAccountOpportunities}
+                                    yieldInactiveVaultOpportunities={
+                                        yieldInactiveVaultOpportunities
+                                    }
+                                />
+                            </Table>
+                        </Card>
+
+                        {hasHiddenYieldAccountOpportunities && (
+                            <Button
+                                intent="neutral"
+                                priority="secondary"
+                                onClick={toggleIsExpanded}
+                            >
+                                <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
+                            </Button>
+                        )}
+                    </Column>
                 )}
-            </Column>
-        </EarnDashboardSection>
+            </EarnDashboardSection>
+        </Column>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useAllYieldOpportunities.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useAllYieldOpportunities.ts
@@ -36,7 +36,7 @@ const getAllYieldOpportunities = async ({ limit }: { limit: number }) => {
     return allItems;
 };
 
-export const useAllYieldOpportunities = () => {
+export const useAllYieldOpportunities = ({ enabled = true }: { enabled?: boolean } = {}) => {
     const yieldOpportunitiesQuery = useQuery({
         queryKey: desktopQueryKeys.yieldOpportunities({
             limit: YIELD_OPPORTUNITIES_PAGE_SIZE,
@@ -45,6 +45,7 @@ export const useAllYieldOpportunities = () => {
             getAllYieldOpportunities({
                 limit: YIELD_OPPORTUNITIES_PAGE_SIZE,
             }),
+        enabled,
         staleTime: STALE_TIME,
     });
 

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -1,8 +1,9 @@
 import { Translation } from '@suite/intl';
+import type { YieldFlowType } from '@suite-common/suite-types';
 import { Button, Column } from '@trezor/components';
 
 import { YieldAmountCard } from './YieldAmountCard';
-import type { YieldFlowDisplayToken, YieldFlowType } from './types';
+import type { YieldFlowDisplayToken } from './types';
 
 const actionStepTranslationMap = {
     supply: {

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -1,9 +1,10 @@
 import { Translation } from '@suite/intl';
+import type { YieldFlowType } from '@suite-common/suite-types';
 import { Button, Column } from '@trezor/components';
 
 import { YieldAmountCard } from './YieldAmountCard';
 import { YieldApprovedAmountCard } from './YieldApprovedAmountCard';
-import type { YieldFlowDisplayToken, YieldFlowType } from './types';
+import type { YieldFlowDisplayToken } from './types';
 
 const approveStepTranslationMap = {
     supply: {

--- a/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
@@ -1,0 +1,23 @@
+import { type ReactNode } from 'react';
+
+import { Translation } from '@suite/intl';
+import type { YieldFlowType } from '@suite-common/suite-types';
+import { Banner } from '@trezor/components';
+
+type YieldDisabledBannerProps = {
+    type: YieldFlowType;
+    content?: ReactNode;
+};
+
+const yieldDisabledMessageMap = {
+    supply: 'TR_EARN_YIELD_SUPPLY_DISABLED',
+    withdraw: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
+} as const;
+
+export const YieldDisabledBanner = ({ type, content }: YieldDisabledBannerProps) => (
+    <Banner
+        icon="warning"
+        intent="warning"
+        description={content ?? <Translation id={yieldDisabledMessageMap[type]} />}
+    />
+);

--- a/packages/suite/src/components/earn/yield/common/types.ts
+++ b/packages/suite/src/components/earn/yield/common/types.ts
@@ -1,9 +1,5 @@
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 
-export const YIELD_FLOW_TYPES = ['supply', 'withdraw'] as const;
-
-export type YieldFlowType = (typeof YIELD_FLOW_TYPES)[number];
-
 export const YIELD_FLOW_STEPS = ['approve', 'action', 'complete'] as const;
 
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];

--- a/packages/suite/src/components/earn/yield/supply/YieldSupply.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupply.tsx
@@ -1,10 +1,18 @@
 import { FormProvider } from 'react-hook-form';
 
+import { Context } from '@suite-common/message-system';
+import { Column } from '@trezor/components';
+
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
+
 import { YieldSupplyForm } from './YieldSupplyForm';
 import { useYieldSupply } from './useYieldSupply';
 import { YieldSupplyContext } from './useYieldSupplyContext';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 
 export const YieldSupply = () => {
+    const { isDisabled, content } = useMessageSystemYield('supply');
     const yieldSupplyContextValues = useYieldSupply();
 
     if (!yieldSupplyContextValues) {
@@ -12,10 +20,17 @@ export const YieldSupply = () => {
     }
 
     return (
-        <YieldSupplyContext.Provider value={yieldSupplyContextValues}>
-            <FormProvider {...yieldSupplyContextValues.methods}>
-                <YieldSupplyForm />
-            </FormProvider>
-        </YieldSupplyContext.Provider>
+        <Column gap={24}>
+            <ContextMessage context={Context.getEarnYield('supply')} />
+            {isDisabled ? (
+                <YieldDisabledBanner type="supply" content={content} />
+            ) : (
+                <YieldSupplyContext.Provider value={yieldSupplyContextValues}>
+                    <FormProvider {...yieldSupplyContextValues.methods}>
+                        <YieldSupplyForm />
+                    </FormProvider>
+                </YieldSupplyContext.Provider>
+            )}
+        </Column>
     );
 };

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
@@ -1,10 +1,18 @@
 import { FormProvider } from 'react-hook-form';
 
+import { Context } from '@suite-common/message-system';
+import { Column } from '@trezor/components';
+
+import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
+
 import { YieldWithdrawForm } from './YieldWithdrawForm';
 import { useYieldWithdraw } from './useYieldWithdraw';
 import { YieldWithdrawContext } from './useYieldWithdrawContext';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 
 export const YieldWithdraw = () => {
+    const { isDisabled, content } = useMessageSystemYield('withdraw');
     const yieldWithdrawContextValues = useYieldWithdraw();
 
     if (!yieldWithdrawContextValues) {
@@ -12,10 +20,17 @@ export const YieldWithdraw = () => {
     }
 
     return (
-        <YieldWithdrawContext.Provider value={yieldWithdrawContextValues}>
-            <FormProvider {...yieldWithdrawContextValues.methods}>
-                <YieldWithdrawForm />
-            </FormProvider>
-        </YieldWithdrawContext.Provider>
+        <Column gap={24}>
+            <ContextMessage context={Context.getEarnYield('withdraw')} />
+            {isDisabled ? (
+                <YieldDisabledBanner type="withdraw" content={content} />
+            ) : (
+                <YieldWithdrawContext.Provider value={yieldWithdrawContextValues}>
+                    <FormProvider {...yieldWithdrawContextValues.methods}>
+                        <YieldWithdrawForm />
+                    </FormProvider>
+                </YieldWithdrawContext.Provider>
+            )}
+        </Column>
     );
 };

--- a/packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemEarnDashboard.ts
@@ -1,0 +1,27 @@
+import { selectLanguage } from '@suite/settings';
+import {
+    Feature,
+    selectFeatureMessageContent,
+    selectIsFeatureDisabled,
+} from '@suite-common/message-system';
+
+import { useSelector } from './useSelector';
+
+type EarnDashboardType = keyof typeof Feature.earn.dashboard;
+
+export const useMessageSystemEarnDashboard = (type: EarnDashboardType) => {
+    const language = useSelector(selectLanguage);
+
+    const isDisabled = useSelector(state =>
+        selectIsFeatureDisabled(state, Feature.earn.dashboard[type]),
+    );
+
+    const content = useSelector(state =>
+        selectFeatureMessageContent(state, Feature.earn.dashboard[type], language),
+    );
+
+    return {
+        isDisabled,
+        content,
+    };
+};

--- a/packages/suite/src/hooks/suite/useMessageSystemYield.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemYield.ts
@@ -1,0 +1,26 @@
+import { selectLanguage } from '@suite/settings';
+import {
+    Feature,
+    selectFeatureMessageContent,
+    selectIsFeatureDisabled,
+} from '@suite-common/message-system';
+import type { YieldFlowType } from '@suite-common/suite-types';
+
+import { useSelector } from './useSelector';
+
+export const useMessageSystemYield = (type: YieldFlowType) => {
+    const language = useSelector(selectLanguage);
+
+    const isDisabled = useSelector(state =>
+        selectIsFeatureDisabled(state, Feature.earn.yield[type]),
+    );
+
+    const content = useSelector(state =>
+        selectFeatureMessageContent(state, Feature.earn.yield[type], language),
+    );
+
+    return {
+        isDisabled,
+        content,
+    };
+};

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -786,6 +786,10 @@
         "tradingType": {
             "type": "string",
             "enum": ["buy", "sell", "exchange"]
+        },
+        "yieldFlowType": {
+            "type": "string",
+            "enum": ["supply", "withdraw"]
         }
     }
 }

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -58,6 +58,15 @@ describe('Message system types', () => {
             );
         });
 
+        describe('getEarnDashboard', () => {
+            it.each([
+                ['staking', 'earn.dashboard.staking'],
+                ['yield', 'earn.dashboard.yield'],
+            ] as const)('getEarnDashboard(%s) → %s', (type, expected) => {
+                expect(Context.getEarnDashboard(type)).toBe(expected);
+            });
+        });
+
         describe('getEarnYield', () => {
             it.each([
                 ['supply', 'earn.yield.supply'],

--- a/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemTypes.test.ts
@@ -58,6 +58,15 @@ describe('Message system types', () => {
             );
         });
 
+        describe('getEarnYield', () => {
+            it.each([
+                ['supply', 'earn.yield.supply'],
+                ['withdraw', 'earn.yield.withdraw'],
+            ] as const)('getEarnYield(%s) → %s', (type, expected) => {
+                expect(Context.getEarnYield(type)).toBe(expected);
+            });
+        });
+
         describe('getSettings', () => {
             it.each([
                 ['general', 'settings.general'],

--- a/suite-common/message-system/src/messageSystemConstants.ts
+++ b/suite-common/message-system/src/messageSystemConstants.ts
@@ -63,6 +63,10 @@ export const CONTEXT_PATTERNS = {
         pattern: 'trading.{type}',
         regex: /^trading\.(buy|sell|exchange)$/,
     },
+    getEarnDashboard: {
+        pattern: 'earn.dashboard.{type}',
+        regex: /^earn\.dashboard\.(staking|yield)$/,
+    },
     getEarnYield: {
         pattern: 'earn.yield.{type}',
         regex: /^earn\.yield\.(supply|withdraw)$/,

--- a/suite-common/message-system/src/messageSystemConstants.ts
+++ b/suite-common/message-system/src/messageSystemConstants.ts
@@ -63,6 +63,10 @@ export const CONTEXT_PATTERNS = {
         pattern: 'trading.{type}',
         regex: /^trading\.(buy|sell|exchange)$/,
     },
+    getEarnYield: {
+        pattern: 'earn.yield.{type}',
+        regex: /^earn\.yield\.(supply|withdraw)$/,
+    },
     getSettings: {
         pattern: 'settings.{category}',
         regex: /^settings\.(general|device|networks|debug)$/,

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -7,6 +7,8 @@ import type {
 } from '@suite-common/suite-types';
 import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
+type EarnDashboardType = 'staking' | 'yield';
+
 export type MessageState = { [key in Category]: boolean };
 
 export type MessageSystemConfigSource = 'remote' | 'local';
@@ -90,10 +92,14 @@ export const Feature = {
         slip24: 'trading.slip24',
     },
     earn: {
+        dashboard: {
+            staking: 'earn.dashboard.staking',
+            yield: 'earn.dashboard.yield',
+        } as const satisfies Record<EarnDashboardType, string>,
         yield: {
             supply: 'earn.yield.supply',
             withdraw: 'earn.yield.withdraw',
-        },
+        } as const satisfies Record<YieldFlowType, string>,
     },
     mevProtection: 'settings.mevProtection',
     suiteSync: 'settings.suiteSync',
@@ -126,6 +132,8 @@ const getStakingContext = (networkSymbol: StakingNetworkSymbol) =>
 
 const getTradingContext = (type: TradingType) => `trading.${type}` as const;
 
+const getEarnDashboardContext = (type: EarnDashboardType) => `earn.dashboard.${type}` as const;
+
 const getEarnYieldContext = (type: YieldFlowType) => `earn.yield.${type}` as const;
 
 export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
@@ -146,6 +154,7 @@ const getLegalContext = (key: LegalContextKey) => `legal.${key}` as const;
  * - `getAccounts('btc', 'legacy')` → 'accounts.btc.legacy'
  * - `getStaking('eth')` → 'accounts.eth.staking'
  * - `getTrading('buy')` → 'trading.buy'
+ * - `getEarnDashboard('yield')` → 'earn.dashboard.yield'
  * - `getEarnYield('supply')` → 'earn.yield.supply'
  * - `getSettings('device')` → 'settings.device'
 
@@ -155,6 +164,7 @@ export const Context = {
     getAccount: getAccountContext,
     getStaking: getStakingContext,
     getTrading: getTradingContext,
+    getEarnDashboard: getEarnDashboardContext,
     getEarnYield: getEarnYieldContext,
     getSettings: getSettingsContext,
     getLegal: getLegalContext,

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -3,6 +3,7 @@ import type {
     ExperimentsItem,
     MessageSystem,
     TradingType,
+    YieldFlowType,
 } from '@suite-common/suite-types';
 import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
 
@@ -88,6 +89,12 @@ export const Feature = {
         survey: 'trading.survey',
         slip24: 'trading.slip24',
     },
+    earn: {
+        yield: {
+            supply: 'earn.yield.supply',
+            withdraw: 'earn.yield.withdraw',
+        },
+    },
     mevProtection: 'settings.mevProtection',
     suiteSync: 'settings.suiteSync',
 
@@ -119,6 +126,8 @@ const getStakingContext = (networkSymbol: StakingNetworkSymbol) =>
 
 const getTradingContext = (type: TradingType) => `trading.${type}` as const;
 
+const getEarnYieldContext = (type: YieldFlowType) => `earn.yield.${type}` as const;
+
 export type SettingsCategory = 'general' | 'device' | 'networks' | 'debug';
 const getSettingsContext = (category: SettingsCategory) => `settings.${category}` as const;
 
@@ -137,6 +146,7 @@ const getLegalContext = (key: LegalContextKey) => `legal.${key}` as const;
  * - `getAccounts('btc', 'legacy')` → 'accounts.btc.legacy'
  * - `getStaking('eth')` → 'accounts.eth.staking'
  * - `getTrading('buy')` → 'trading.buy'
+ * - `getEarnYield('supply')` → 'earn.yield.supply'
  * - `getSettings('device')` → 'settings.device'
 
  */
@@ -145,6 +155,7 @@ export const Context = {
     getAccount: getAccountContext,
     getStaking: getStakingContext,
     getTrading: getTradingContext,
+    getEarnYield: getEarnYieldContext,
     getSettings: getSettingsContext,
     getLegal: getLegalContext,
 } as const;

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -303,6 +303,11 @@ export type CTAAction = 'internal-link' | 'external-link';
  * via the `definition` "tradingType".
  */
 export type TradingType = 'buy' | 'sell' | 'exchange';
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "yieldFlowType".
+ */
+export type YieldFlowType = 'supply' | 'withdraw';
 
 /**
  * JSON schema of the Trezor Suite messaging system.

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9377,6 +9377,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_BACK_TO_OVERVIEW',
         defaultMessage: 'Back to overview',
     },
+    TR_EARN_YIELD_SUPPLY_DISABLED: {
+        id: 'TR_EARN_YIELD_SUPPLY_DISABLED',
+        defaultMessage: 'Supply is currently disabled.',
+    },
+    TR_EARN_YIELD_WITHDRAW_DISABLED: {
+        id: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
+        defaultMessage: 'Withdrawal is currently disabled.',
+    },
     TR_EARN_STABLECOIN_YIELD_TITLE: {
         id: 'TR_EARN_STABLECOIN_YIELD_TITLE',
         defaultMessage: 'Stablecoin yield',


### PR DESCRIPTION
## Description

- add Feature.yield.supply/withdraw flags and Context.getEarn to messageSystemTypes
- integrate ContextMessage banner and feature disable check into YieldSupply and YieldWithdraw

## Notes for QA

### Stablecoin Yield flow

```
{
  "conditions": [
    {
      "environment": {
        "desktop": "*",
        "mobile": "!",
        "web": "*"
      }
    }
  ],
  "message": {
    "id": "a1b2c3d4-0000-0000-0000-yield-supply01",
    "priority": 100,
    "dismissible": false,
    "variant": "warning",
    "category": "feature",
    "content": {
      "en": "Yield supply is temporarily disabled.",
      "cs": "Yield supply je dočasně zakázáno.",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    },
    "feature": [
      {
        "domain": "earn.yield.supply",
        "flag": false
      }
    ]
  }
}
```

```
{
  "conditions": [
    {
      "environment": {
        "desktop": "*",
        "mobile": "!",
        "web": "*"
      }
    }
  ],
  "message": {
    "id": "a1b2c3d4-0000-0000-0000-yield-wdraw01",
    "priority": 100,
    "dismissible": false,
    "variant": "warning",
    "category": "feature",
    "content": {
      "en": "Yield withdrawal is temporarily disabled.",
      "cs": "Výběr z yieldu je dočasně zakázán.",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    },
    "feature": [
      {
        "domain": "earn.yield.withdraw",
        "flag": false
      }
    ]
  }
}
```

```
{
  "conditions": [
    {
      "environment": {
        "desktop": "*",
        "mobile": "!",
        "web": "*"
      }
    }
  ],
  "message": {
    "id": "a1b2c3d4-0000-0000-0000-earn-ctx-sup1",
    "priority": 50,
    "dismissible": true,
    "variant": "info",
    "category": "context",
    "content": {
      "en": "Yield supply is temporarily limited due to ongoing maintenance.",
      "cs": "Yield supply je dočasně omezeno z důvodu údržby.",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    },
    "context": {
      "domain": "earn.yield.supply"
    }
  }
}
```

### Dashboard

```
{
  "conditions": [
    {
      "environment": {
        "desktop": "*",
        "mobile": "!",
        "web": "*"
      }
    }
  ],
  "message": {
    "id": "test-earn-dashboard-yield-feature",
    "priority": 91,
    "dismissible": false,
    "variant": "warning",
    "category": "feature",
    "content": {
      "en": "Earn yield dashboard is disabled for testing.",
      "cs": "Earn yield dashboard je pro testovani vypnuty.",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    },
    "feature": [
      {
        "domain": "earn.dashboard.yield",
        "flag": false
      }
    ]
  }
}
```

```
{
  "conditions": [
    {
      "environment": {
        "desktop": "*",
        "mobile": "!",
        "web": "*"
      }
    }
  ],
  "message": {
    "id": "test-earn-dashboard-yield-context",
    "priority": 90,
    "dismissible": true,
    "variant": "info",
    "category": "context",
    "content": {
      "en": "Testing context message for the Earn yield dashboard.",
      "cs": "Testovaci kontextova zprava pro Earn yield dashboard.",
      "es": "",
      "de": "",
      "fr": "",
      "pt": ""
    },
    "context": {
      "domain": "earn.dashboard.yield"
    }
  }
}
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25739

## Screenshots:

<img width="1314" height="634" alt="image" src="https://github.com/user-attachments/assets/7efbe906-cf6d-4f16-a53e-d87b05db36fd" />

<img width="1318" height="455" alt="image" src="https://github.com/user-attachments/assets/e53e17fc-9856-4005-b39b-ebe1bc51e430" />

<img width="1236" height="484" alt="image" src="https://github.com/user-attachments/assets/4aed3a64-11aa-4a68-984c-1058c90e1d8e" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-stablecoin-yield-message-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-stablecoin-yield-message-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-stablecoin-yield-message-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:29:46.062Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:27:54.944Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->