### PR TITLE
ci: split native tests into trading and rest groups

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -117,7 +117,15 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        test-task: [suite, native]
+        include:
+          - test-task: suite
+            test-command: yarn test:unit:suite --output-style=stream
+          - test-task: native-trading
+            test-command: >-
+              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading,@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --output-style=stream; else echo "No affected trading native unit-test projects"; fi
+          - test-task: native-rest
+            test-command: >-
+              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --output-style=stream
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -128,7 +136,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: yarn test:unit:${{ matrix.test-task }} --output-style=stream
+        run: ${{ matrix.test-command }}
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -119,16 +119,26 @@ jobs:
       matrix:
         include:
           - test-task: suite
+            step-timeout-minutes: 35
             test-command: yarn test:unit:suite --output-style=stream
           - test-task: native-module-trading
+            step-timeout-minutes: 55
             test-command: >-
               AFFECTED_MODULE_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading' --sep=,) && if [[ -n "$AFFECTED_MODULE_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_MODULE_TRADING_PROJECTS" --parallel=1 --output-style=stream; else echo "No affected module-trading unit-test projects"; fi
+            diagnostic-command: >-
+              AFFECTED_MODULE_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading' --sep=,) && if [[ -n "$AFFECTED_MODULE_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_MODULE_TRADING_PROJECTS" --parallel=1 --output-style=stream -- --detectOpenHandles --logHeapUsage; else echo "No affected module-trading unit-test projects"; fi
           - test-task: native-trading-rest
+            step-timeout-minutes: 35
             test-command: >-
               AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --parallel=1 --output-style=stream; else echo "No affected trading native unit-test projects"; fi
+            diagnostic-command: >-
+              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --parallel=1 --output-style=stream -- --detectOpenHandles --logHeapUsage; else echo "No affected trading native unit-test projects"; fi
           - test-task: native-rest
+            step-timeout-minutes: 35
             test-command: >-
               yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --parallel=1 --output-style=stream
+            diagnostic-command: >-
+              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --parallel=1 --output-style=stream -- --detectOpenHandles --logHeapUsage
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -139,7 +149,16 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: ${{ matrix.test-command }}
+        timeout-minutes: ${{ matrix.step-timeout-minutes }}
+        run: |
+          if [[ "${{ matrix.test-task }}" == native-* ]]; then
+            if ! ${{ matrix.test-command }}; then
+              echo "Native unit tests failed. Retrying once with Jest diagnostics..."
+              ${{ matrix.diagnostic-command }}
+            fi
+          else
+            ${{ matrix.test-command }}
+          fi
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -125,10 +125,10 @@ jobs:
               AFFECTED_MODULE_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading' --sep=,) && if [[ -n "$AFFECTED_MODULE_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_MODULE_TRADING_PROJECTS" --parallel=1 --output-style=stream; else echo "No affected module-trading unit-test projects"; fi
           - test-task: native-trading-rest
             test-command: >-
-              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --parallel=2 --output-style=stream; else echo "No affected trading native unit-test projects"; fi
+              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --parallel=1 --output-style=stream; else echo "No affected trading native unit-test projects"; fi
           - test-task: native-rest
             test-command: >-
-              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --parallel=2 --output-style=stream
+              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --parallel=1 --output-style=stream
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -120,12 +120,15 @@ jobs:
         include:
           - test-task: suite
             test-command: yarn test:unit:suite --output-style=stream
-          - test-task: native-trading
+          - test-task: native-module-trading
             test-command: >-
-              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading,@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --output-style=stream; else echo "No affected trading native unit-test projects"; fi
+              AFFECTED_MODULE_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/module-trading' --sep=,) && if [[ -n "$AFFECTED_MODULE_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_MODULE_TRADING_PROJECTS" --parallel=1 --output-style=stream; else echo "No affected module-trading unit-test projects"; fi
+          - test-task: native-trading-rest
+            test-command: >-
+              AFFECTED_TRADING_PROJECTS=$(yarn nx show projects --affected --withTarget=test:unit --projects='@suite-native/trading-*' --sep=,) && if [[ -n "$AFFECTED_TRADING_PROJECTS" ]]; then yarn nx run-many --target=test:unit --projects="$AFFECTED_TRADING_PROJECTS" --parallel=2 --output-style=stream; else echo "No affected trading native unit-test projects"; fi
           - test-task: native-rest
             test-command: >-
-              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --output-style=stream
+              yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading,@suite-native/trading-*' --parallel=2 --output-style=stream
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -48,10 +48,8 @@ module.exports = {
         '<rootDir>/../../suite-native/connection-status/src/jestSetup.js',
         '<rootDir>/../../suite-native/react-native-graph/src/jestSetup.js',
         '<rootDir>/../../suite-native/atoms/src/jestSetup.jsx',
-        '<rootDir>/../../suite-native/module-trading/src/jest.setup.tsx',
         '<rootDir>/../../suite-native/module-connect-popup/src/jest.setup.ts',
         '<rootDir>/../../suite-native/module-device-onboarding/src/jest.setup.ts',
         '<rootDir>/../../suite-native/config/src/jest.setup.ts',
-        '<rootDir>/../../suite-native/intl/src/jest.setup.ts',
     ],
 };

--- a/suite-native/atoms/jest.config.js
+++ b/suite-native/atoms/jest.config.js
@@ -8,4 +8,5 @@ const baseConfig = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    setupFiles: [...baseConfig.setupFiles, '<rootDir>/../../suite-native/atoms/src/jestSetup.jsx'],
 };

--- a/suite-native/intl/jest.config.js
+++ b/suite-native/intl/jest.config.js
@@ -8,4 +8,5 @@ const baseConfig = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    setupFiles: [...baseConfig.setupFiles, '<rootDir>/../../suite-native/intl/src/jest.setup.ts'],
 };

--- a/suite-native/module-trading/jest.config.js
+++ b/suite-native/module-trading/jest.config.js
@@ -2,6 +2,10 @@ const baseConfig = require('../../jest.config.native');
 
 module.exports = {
     ...baseConfig,
+    setupFiles: [
+        ...baseConfig.setupFiles,
+        '<rootDir>/../../suite-native/module-trading/src/jest.setup.tsx',
+    ],
     coverageThreshold: {
         global: {
             statements: 80,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=speed-up-native-tests-1&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=speed-up-native-tests-1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=speed-up-native-tests-1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T18:15:29.489Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T14:10:47.771Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->