### PR TITLE
fix: suite-sync available vs enabled

### DIFF
--- a/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/SuiteSyncBanner.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectIsDeviceConnected } from '@suite-common/device';
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type WithSuiteSyncAndDeviceState,
     selectHasDeviceSuiteSyncError,
@@ -93,8 +94,9 @@ export const SuiteSyncBanner = ({ deviceStaticSessionId }: SuiteSyncBannerProps)
     const hasSuiteSyncError = useSelector((state: WithSuiteSyncAndDeviceState) =>
         selectHasDeviceSuiteSyncError(state, deviceStaticSessionId),
     );
-    const suiteSyncInteraction = useSelector((state: WithSuiteSyncAndDeviceState) =>
-        selectSuiteSyncInteraction(state, deviceStaticSessionId),
+    const suiteSyncInteraction = useSelector(
+        (state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
+            selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
 

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
@@ -126,11 +126,22 @@ describe(selectIsLabelActionEnabled.name, () => {
     const testLabelActionEnabled = ({
         unavailableCapabilities,
         isSuiteSyncFeatureEnabled,
+        isSuiteSyncEnabled = false,
     }: {
         unavailableCapabilities: UnavailableCapabilities;
         isSuiteSyncFeatureEnabled: boolean;
+        isSuiteSyncEnabled?: boolean;
     }) => {
-        const state = createMockState({ unavailableCapabilities }, {}, isSuiteSyncFeatureEnabled);
+        const state = createMockState(
+            { unavailableCapabilities },
+            {
+                settings: {
+                    ...initialSuiteSyncDesktopState.settings,
+                    isSuiteSyncEnabled,
+                },
+            },
+            isSuiteSyncFeatureEnabled,
+        );
 
         return selectIsLabelActionEnabled(state, DEVICE_STATIC_SESSION_ID_123, 'address-123');
     };
@@ -139,6 +150,7 @@ describe(selectIsLabelActionEnabled.name, () => {
         const result = testLabelActionEnabled({
             unavailableCapabilities: { evolu: 'update-required' },
             isSuiteSyncFeatureEnabled: true,
+            isSuiteSyncEnabled: true,
         });
 
         expect(result).toBe(true);
@@ -148,6 +160,7 @@ describe(selectIsLabelActionEnabled.name, () => {
         const result = testLabelActionEnabled({
             unavailableCapabilities: { evolu: 'no-capability' },
             isSuiteSyncFeatureEnabled: true,
+            isSuiteSyncEnabled: true,
         });
 
         expect(result).toBe(false);
@@ -184,6 +197,18 @@ describe(selectIsLabelActionEnabled.name, () => {
         const result = testLabelActionEnabled({
             unavailableCapabilities: {},
             isSuiteSyncFeatureEnabled: false,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('falls back to legacy labeling when Suite Sync feature is available but disabled', () => {
+        mocked(selectIsLabelingAvailableForEntity).mockReturnValue(true);
+        mocked(selectIsLabelingInitPossible).mockReturnValue(false);
+
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: true,
         });
 
         expect(result).toBe(true);

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
@@ -8,7 +8,6 @@ import {
     type WithSuiteSyncAndDeviceState,
     getIsSuiteSyncLabelingActionEnabled,
     selectIsSuiteSyncEnabled,
-    selectIsSuiteSyncFeatureAvailable,
 } from '@suite-common/suite-sync';
 import { type StaticSessionId } from '@trezor/connect';
 
@@ -29,6 +28,15 @@ export const selectIsLabelActionEnabled = (
 ): boolean => {
     const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
 
+    if (isSuiteSyncEnabled) {
+        const suiteSyncInteraction = selectDesktopSuiteSyncInteraction(
+            state,
+            deviceStaticSessionId,
+        );
+
+        return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
+    }
+
     // If Evolu is enabled, we do not want to allow for enabling Legacy Labeling just by
     // clicking on the stuff.
     const isLegacyLabelingInitPossible = !isSuiteSyncEnabled && selectIsLabelingInitPossible(state);
@@ -37,17 +45,6 @@ export const selectIsLabelActionEnabled = (
         legacyEntityKey,
         deviceStaticSessionId,
     );
-
-    const isSuiteSyncFeatureEnabled = selectIsSuiteSyncFeatureAvailable(state);
-
-    if (isSuiteSyncFeatureEnabled) {
-        const suiteSyncInteraction = selectDesktopSuiteSyncInteraction(
-            state,
-            deviceStaticSessionId,
-        );
-
-        return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
-    }
 
     return isLegacyLabelingEnabled || isLegacyLabelingInitPossible;
 };

--- a/suite-common/suite-sync/src/__tests__/suiteSyncSelectors.test.ts
+++ b/suite-common/suite-sync/src/__tests__/suiteSyncSelectors.test.ts
@@ -1,4 +1,8 @@
 import { deviceReducerInitialState } from '@suite-common/device';
+import {
+    type MessageSystemRootState,
+    messageSystemInitialState,
+} from '@suite-common/message-system';
 import { asEncryptedHex } from '@suite-common/platform-encryption';
 import type { SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
@@ -13,7 +17,7 @@ const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
 const createMockState = (
     deviceOverrides: Parameters<typeof mockSuiteDevice>[0] = {},
     suiteSyncOverrides: Partial<SuiteSyncState> = {},
-): WithSuiteSyncAndDeviceState => ({
+): WithSuiteSyncAndDeviceState & MessageSystemRootState => ({
     device: {
         ...deviceReducerInitialState,
         devices: [
@@ -27,6 +31,7 @@ const createMockState = (
         ...initialSuiteSyncState,
         ...suiteSyncOverrides,
     },
+    messageSystem: messageSystemInitialState,
 });
 
 describe(selectSuiteSyncInteraction.name, () => {

--- a/suite-common/suite-sync/src/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.ts
@@ -20,8 +20,14 @@ export type WithSuiteSyncState = {
 
 export type WithSuiteSyncAndDeviceState = WithSuiteSyncState & DeviceRootState;
 
-export const selectIsSuiteSyncEnabled = (state: WithSuiteSyncAndDeviceState): boolean =>
-    state.suiteSync.settings.isSuiteSyncEnabled;
+/** Suite Sync is enabled by default; the message system can remotely disable it via `settings.suiteSync`. */
+export const selectIsSuiteSyncFeatureAvailable = (state: MessageSystemRootState) =>
+    selectIsFeatureEnabled(state, Feature.suiteSync, true);
+
+export const selectIsSuiteSyncEnabled = (
+    state: WithSuiteSyncAndDeviceState & MessageSystemRootState,
+): boolean =>
+    state.suiteSync.settings.isSuiteSyncEnabled && selectIsSuiteSyncFeatureAvailable(state);
 
 export const selectIsSuiteSyncDebugEnabled = (state: WithSuiteSyncAndDeviceState): boolean =>
     state.suiteSync.settings.isSuiteSyncDebugEnabled;
@@ -46,7 +52,7 @@ export const selectSuiteSyncOwnerForDeviceStaticId = (
         : null;
 
 export const selectSuiteSyncInteraction = (
-    state: WithSuiteSyncAndDeviceState,
+    state: WithSuiteSyncAndDeviceState & MessageSystemRootState,
     deviceStaticSessionId: StaticSessionId | null,
 ): SuiteSyncInteraction | null => {
     if (deviceStaticSessionId === null) {
@@ -90,7 +96,3 @@ export const selectHasDeviceSuiteSyncError = (
 
     return state.suiteSync.suiteSyncErrors[deviceStaticSessionId] !== undefined;
 };
-
-/** Suite Sync is enabled by default; the message system can remotely disable it via `settings.suiteSync`. */
-export const selectIsSuiteSyncFeatureAvailable = (state: MessageSystemRootState) =>
-    selectIsFeatureEnabled(state, Feature.suiteSync, true);

--- a/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectDeviceStaticSessionId } from '@suite-common/device';
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type WithSuiteSyncAndDeviceState,
     selectSuiteSyncInteraction,
@@ -36,8 +37,9 @@ export const useTurnOnSuiteSyncGuard = () => {
         >();
     const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
 
-    const suiteSyncInteraction = useSelector((state: WithSuiteSyncAndDeviceState) =>
-        selectSuiteSyncInteraction(state, deviceStaticSessionId),
+    const suiteSyncInteraction = useSelector(
+        (state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
+            selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
 
     const showSuiteSyncFirmwareUpgradeAlert = () => {

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -54,7 +54,7 @@ export const selectShouldDisplaySuiteSyncAlert = createMemoizedSelector(
         (state: WithSuiteSyncState & DeviceRootState) =>
             selectHasDeviceSuiteSyncError(state, selectDeviceStaticSessionId(state)),
         selectIsDeviceConnected,
-        (state: WithSuiteSyncState & DeviceRootState) =>
+        (state: WithSuiteSyncState & DeviceRootState & MessageSystemRootState) =>
             selectSuiteSyncInteraction(state, selectDeviceStaticSessionId(state)),
     ],
     (hasSuiteSyncError, isDeviceConnected, interactionNeeded) =>
@@ -63,7 +63,7 @@ export const selectShouldDisplaySuiteSyncAlert = createMemoizedSelector(
 
 export const selectShouldDisplaySuiteSyncFirmwareUpdateAlert = createMemoizedSelector(
     [
-        (state: WithSuiteSyncState & DeviceRootState) =>
+        (state: WithSuiteSyncState & DeviceRootState & MessageSystemRootState) =>
             selectSuiteSyncInteraction(state, selectDeviceStaticSessionId(state)),
     ],
     interactionNeeded => interactionNeeded === 'firmware-upgrade-needed',


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-suite/issues/26427



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=levacy-not-working&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=levacy-not-working&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=levacy-not-working&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:57:26.272Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T13:56:09.183Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->