### PR TITLE
fix(suite): avoid app restart when changing Trade API debug server

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TradeApi.tsx
@@ -3,7 +3,6 @@ import { type InvityServerEnvironment, invityAPI } from '@suite-common/trading';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { reloadApp } from 'src/utils/suite/reload';
 
 export const TradeApi = () => {
     const invityServerEnvironment = useSelector(selectInvityServerEnvironment);
@@ -22,8 +21,7 @@ export const TradeApi = () => {
     const handleChange = (item: { value: InvityServerEnvironment; label: string }) => {
         dispatch(suiteSettingsActions.setDebugMode({ invityServerEnvironment: item.value }));
         invityAPI.setInvityServersEnvironment(item.value);
-        // reload the Suite to reinitialize everything, with a slight delay to let the browser save the settings
-        reloadApp(100);
+        invityAPI.resetCurrentAccount();
     };
 
     return (

--- a/suite-common/trading/src/__tests__/invityAPI.test.ts
+++ b/suite-common/trading/src/__tests__/invityAPI.test.ts
@@ -44,6 +44,22 @@ describe('InvityAPI', () => {
         expect(descriptor).toEqual('test-account');
     });
 
+    describe('resetCurrentAccount', () => {
+        it('should clear the account descriptor', () => {
+            invityAPI.resetCurrentAccount();
+
+            expect(invityAPI.getCurrentAccountDescriptor()).toBeUndefined();
+        });
+
+        it('should recreate the descriptor and api key after createInvityAPIKey is called', () => {
+            invityAPI.resetCurrentAccount();
+            invityAPI.createInvityAPIKey(accountDescriptor);
+
+            expect(invityAPI.getCurrentAccountDescriptor()).toEqual(accountDescriptor);
+            expect(typeof invityAPI.getCurrentApiKey()).toBe('string');
+        });
+    });
+
     describe('getInvityAPIKey', () => {
         it('should return the default API', () => {
             expect(typeof invityAPI['getInvityAPIKey']()).toBe('string');

--- a/suite-common/trading/src/invityAPI.ts
+++ b/suite-common/trading/src/invityAPI.ts
@@ -90,8 +90,8 @@ class InvityAPI {
     // otc service
     private readonly OTC_INFO = '/api/v2/otc';
 
-    private static accountDescriptor: string;
-    private static apiKey: string;
+    private static accountDescriptor: string | undefined;
+    private static apiKey: string | undefined;
 
     private getInvityAPIKey() {
         if (!InvityAPI.apiKey) {
@@ -120,6 +120,10 @@ class InvityAPI {
             InvityAPI.apiKey = hash.digest('hex');
             InvityAPI.accountDescriptor = accountDescriptor;
         }
+    }
+
+    resetCurrentAccount() {
+        InvityAPI.accountDescriptor = undefined;
     }
 
     setInvityServersEnvironment(serverEnvironment: InvityServerEnvironment) {


### PR DESCRIPTION
## Summary

- Removes the `reloadApp(100)` call that caused a full desktop app restart when switching the Invity server environment in **Settings > Debug > Trade API**
- Adds `invityAPI.resetCurrentAccount()` which clears the cached account descriptor — this causes `loadInitialDataThunk` to see `isDifferentAccount = true` on the next trade form visit and re-fetch all provider data from the newly selected server
- Widens `InvityAPI.accountDescriptor` static field type from `string` to `string | undefined` to support the reset (the `apiKey` field is intentionally left intact to avoid throwing errors on any in-flight requests)

## How it works

Previously, switching servers required a full restart to invalidate cached `buyInfo`/`exchangeInfo`/`sellInfo`. Now:
1. `setInvityServersEnvironment()` updates the singleton URL immediately
2. `resetCurrentAccount()` clears the static `accountDescriptor` field
3. Next navigation to buy/sell/exchange triggers `loadInitialDataThunk`, which finds `isDifferentAccount = true`, re-reads the environment from Redux, and re-fetches all provider data from the new server

## Test plan

- [ ] Open Settings > Debug > Trade API, switch server environment
- [ ] Confirm app does **not** restart
- [ ] Navigate to buy/sell/exchange form — confirm network requests hit the new server URL

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-api-no-restart&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T18:03:17.216Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->