### PR TITLE
feat(connect): return transaction bytes from tronComposeTransaction

### DIFF
--- a/packages/connect-common/src/types/api/tron/index.ts
+++ b/packages/connect-common/src/types/api/tron/index.ts
@@ -74,22 +74,15 @@ export const TronSignTransaction = Type.Object({
 export type TronSignedTx = Static<typeof TronSignedTx>;
 export const TronSignedTx = Type.Object({
     signature: Type.String(),
+    serializedTx: Type.Optional(Type.String()),
 });
 
 export type TronComposeTransaction = Static<typeof TronComposeTransaction>;
 export const TronComposeTransaction = Type.Object({
-    from: Type.String(),
-    to: Type.String(),
-    amount: Type.String(), // in SUN for native TRX, token subunits for TRC-20
+    contract: TronContracts,
     blockHash: Type.String(),
     blockHeight: Type.Number(),
-    token: Type.Optional(
-        Type.Object({
-            contract: Type.String(),
-            data: Type.String(), // calldata hex (without 0x)
-            feeLimit: Type.Optional(Type.Number()), // in SUN; absent means no fee_limit field in tx
-        }),
-    ),
+    fee_limit: Type.Optional(Type.Number()),
 });
 
 export type TronComposedTransaction = Static<typeof TronComposedTransaction>;
@@ -99,4 +92,5 @@ export const TronComposedTransaction = Type.Object({
     ref_block_hash: Type.String(),
     expiration: Type.Number(),
     timestamp: Type.Number(),
+    bandwidth: Type.Number(),
 });

--- a/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
+++ b/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
@@ -1,24 +1,14 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
-import { tronUtils } from '@trezor/blockchain-link-utils';
-
 import {
-    encodeBroadcastTransaction,
-    encodeTransferRawData,
     estimateTronTransferBandwidth,
     estimateTronTrc20Bandwidth,
-} from '../tronEncode';
+} from '../estimateTronBandwidth';
+import { encodeBroadcastTransaction, encodeTransferRawData } from '../tronEncode';
 import { TransactionType } from '../tronProtobuf';
 
-const OWNER_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('41f2cd810c48c401d392ead3c6e1e1cb9f57750a58'),
-)!;
-const TO_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('4141f82674a30ae1328745d08afe2d1a0a24195283'),
-)!;
-const CONTRACT_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('4142a1e39aefa49290f2b3f9ed688d7cecf86cd6e0'),
-)!;
+const OWNER_ADDRESS = '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58';
+const TO_ADDRESS = '4141f82674a30ae1328745d08afe2d1a0a24195283';
 
 const TRX_TRANSFER = {
     from: OWNER_ADDRESS,
@@ -33,14 +23,7 @@ const TRX_TRANSFER = {
 };
 
 const TRC20_TRIGGER = {
-    from: OWNER_ADDRESS,
-    contractAddress: CONTRACT_ADDRESS,
     data: 'a9059cbb000000000000000000000000d093f24888ab06073a4bdffbb8107db1ea9dc0a000000000000000000000000000000000000000000000000000000000013bb450',
-    feeLimit: 50_000_000,
-    refBlockBytes: 'dae0',
-    refBlockHash: '9ab5c70b3a11405f',
-    expiration: 1766454906000,
-    timestamp: 1766453046721,
 };
 
 describe('tron/estimateTronTransferBandwidth', () => {
@@ -51,7 +34,7 @@ describe('tron/estimateTronTransferBandwidth', () => {
 
 describe('tron/estimateTronTrc20Bandwidth', () => {
     it('returns the expected bandwidth for a TRC-20 trigger', () => {
-        expect(estimateTronTrc20Bandwidth(String(TRC20_TRIGGER.feeLimit))).toBe(345);
+        expect(estimateTronTrc20Bandwidth(TRC20_TRIGGER.data)).toBe(345);
     });
 });
 

--- a/packages/connect/src/api/tron/__tests__/tronParse.test.ts
+++ b/packages/connect/src/api/tron/__tests__/tronParse.test.ts
@@ -1,20 +1,12 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
-import { tronUtils } from '@trezor/blockchain-link-utils';
-
 import { encodeTransferRawData, encodeTriggerSmartContractRawData } from '../tronEncode';
 import { parseTronTransaction } from '../tronParse';
 import { AnyType, TransactionRawType } from '../tronProtobuf';
 
-const OWNER_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('41f2cd810c48c401d392ead3c6e1e1cb9f57750a58'),
-)!;
-const TO_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('4141f82674a30ae1328745d08afe2d1a0a24195283'),
-)!;
-const CONTRACT_ADDRESS = tronUtils.tronBytesToAddress(
-    hexToBytes('4142a1e39aefa49290f2b3f9ed688d7cecf86cd6e0'),
-)!;
+const OWNER_ADDRESS = '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58';
+const TO_ADDRESS = '4141f82674a30ae1328745d08afe2d1a0a24195283';
+const CONTRACT_ADDRESS = '4142a1e39aefa49290f2b3f9ed688d7cecf86cd6e0';
 
 const TRX_TRANSFER = {
     from: OWNER_ADDRESS,

--- a/packages/connect/src/api/tron/api/tronComposeTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronComposeTransaction.ts
@@ -5,7 +5,7 @@ import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
-import { encodeTransferRawData, encodeTriggerSmartContractRawData } from '../tronEncode';
+import { TRON_BANDWIDTH_FORMULA_OVERHEAD, encodeTronContractRawData } from '../tronEncode';
 
 export default class TronComposeTransaction extends AbstractMethod<
     'tronComposeTransaction',
@@ -35,7 +35,7 @@ export default class TronComposeTransaction extends AbstractMethod<
 
     // eslint-disable-next-line require-await
     async run() {
-        const { from, to, amount, blockHash, blockHeight, token } = this.params;
+        const { contract, blockHash, blockHeight, fee_limit } = this.params;
 
         const ref_block_bytes = blockHeight.toString(16).padStart(16, '0').slice(12, 16);
         const ref_block_hash = blockHash.replace(/^0x/, '').slice(16, 32);
@@ -43,26 +43,13 @@ export default class TronComposeTransaction extends AbstractMethod<
         const timestamp = Date.now();
         const expiration = timestamp + 60 * 60 * 1000; // 1 hour
 
-        const rawData = token
-            ? encodeTriggerSmartContractRawData({
-                  from,
-                  contractAddress: token.contract,
-                  data: token.data,
-                  refBlockBytes: ref_block_bytes,
-                  refBlockHash: ref_block_hash,
-                  expiration,
-                  timestamp,
-                  feeLimit: token.feeLimit ?? 0,
-              })
-            : encodeTransferRawData({
-                  from,
-                  to,
-                  amount,
-                  refBlockBytes: ref_block_bytes,
-                  refBlockHash: ref_block_hash,
-                  expiration,
-                  timestamp,
-              });
+        const rawData = encodeTronContractRawData(contract, {
+            ref_block_bytes,
+            ref_block_hash,
+            expiration,
+            timestamp,
+            fee_limit,
+        });
 
         return {
             rawDataHex: bytesToHex(rawData),
@@ -70,6 +57,7 @@ export default class TronComposeTransaction extends AbstractMethod<
             ref_block_hash,
             expiration,
             timestamp,
+            bandwidth: rawData.length + TRON_BANDWIDTH_FORMULA_OVERHEAD,
         };
     }
 }

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -1,11 +1,14 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
+
 import { TronSignTransaction as TronSignTransactionSchema } from '@trezor/connect-common';
-import type { PROTO, TronContractsParameters, TronContractsTypes } from '@trezor/connect-common';
+import type { PROTO, TronContracts, TronContractsTypes } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
 import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validatePath } from '../../../utils/pathUtils';
+import { encodeBroadcastTransaction, encodeTronContractRawData } from '../tronEncode';
 
 const contractMapping = {
     TransferContract: 'TronTransferContract',
@@ -18,8 +21,7 @@ const contractMapping = {
 
 type Params = {
     tx: PROTO.TronSignTx;
-    contractType: TronContractsTypes;
-    contract: TronContractsParameters;
+    contract: TronContracts;
 };
 
 export default class TronSignTransaction extends AbstractMethod<'tronSignTransaction', Params> {
@@ -60,8 +62,7 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
                 fee_limit: payload.fee_limit,
                 data: payload.data,
             },
-            contractType: payload.contract[0].type,
-            contract: payload.contract[0].parameter.value,
+            contract: payload.contract[0],
         };
     }
 
@@ -75,11 +76,21 @@ export default class TronSignTransaction extends AbstractMethod<'tronSignTransac
         await cmd.typedCall('TronSignTx', 'TronContractRequest', this.params.tx);
 
         const { message } = await cmd.typedCall(
-            contractMapping[this.params.contractType],
+            contractMapping[this.params.contract.type],
             'TronSignature',
-            this.params.contract,
+            this.params.contract.parameter.value,
         );
 
-        return { signature: message.signature };
+        const { signature } = message;
+
+        let serializedTx: string | undefined;
+        try {
+            const rawData = encodeTronContractRawData(this.params.contract, this.params.tx);
+            serializedTx = encodeBroadcastTransaction(bytesToHex(rawData), signature);
+        } catch {
+            // unsupported contract type
+        }
+
+        return { signature, serializedTx };
     }
 }

--- a/packages/connect/src/api/tron/estimateTronBandwidth.ts
+++ b/packages/connect/src/api/tron/estimateTronBandwidth.ts
@@ -1,0 +1,66 @@
+import type { TronContracts } from '@trezor/connect-common/src/types/api/tron';
+
+import { TRON_BANDWIDTH_FORMULA_OVERHEAD, encodeTronContractRawData } from './tronEncode';
+
+const TRON_DUMMY_ADDRESS = '410000000000000000000000000000000000000000'; // Tron zero address
+const TRON_DUMMY_BLOCK_BYTES = '0000';
+const TRON_DUMMY_BLOCK_HASH = '0000000000000000';
+const TRON_DUMMY_TIMESTAMP = 1700000000000;
+const TRON_DUMMY_FEE_LIMIT = 50_000_000;
+
+const DUMMY_BLOCK_PARAMS = {
+    ref_block_bytes: TRON_DUMMY_BLOCK_BYTES,
+    ref_block_hash: TRON_DUMMY_BLOCK_HASH,
+    expiration: TRON_DUMMY_TIMESTAMP + 3_600_000,
+    timestamp: TRON_DUMMY_TIMESTAMP,
+    fee_limit: TRON_DUMMY_FEE_LIMIT,
+};
+
+export const estimateTronTransferBandwidth = (amountInSun: string): number => {
+    const rawData = encodeTronContractRawData(
+        {
+            type: 'TransferContract',
+            parameter: {
+                value: {
+                    owner_address: TRON_DUMMY_ADDRESS,
+                    to_address: TRON_DUMMY_ADDRESS,
+                    amount: amountInSun,
+                },
+            },
+        },
+        DUMMY_BLOCK_PARAMS,
+    );
+
+    return rawData.length + TRON_BANDWIDTH_FORMULA_OVERHEAD;
+};
+
+export const estimateTronTrc20Bandwidth = (data: string): number => {
+    const rawData = encodeTronContractRawData(
+        {
+            type: 'TriggerSmartContract',
+            parameter: {
+                value: {
+                    owner_address: TRON_DUMMY_ADDRESS,
+                    contract_address: TRON_DUMMY_ADDRESS,
+                    data,
+                },
+            },
+        },
+        DUMMY_BLOCK_PARAMS,
+    );
+
+    return rawData.length + TRON_BANDWIDTH_FORMULA_OVERHEAD;
+};
+
+export const estimateTronBandwidth = (contract: TronContracts): number => {
+    switch (contract.type) {
+        case 'TransferContract':
+            return estimateTronTransferBandwidth(String(contract.parameter.value.amount ?? 0));
+
+        case 'TriggerSmartContract':
+            return estimateTronTrc20Bandwidth(contract.parameter.value.data ?? '');
+
+        default:
+            throw new Error(`Unsupported contract type for bandwidth estimation: ${contract.type}`);
+    }
+};

--- a/packages/connect/src/api/tron/tronEncode.ts
+++ b/packages/connect/src/api/tron/tronEncode.ts
@@ -1,6 +1,6 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
-import { tronUtils } from '@trezor/blockchain-link-utils';
+import type { TronContracts } from '@trezor/connect-common/src/types/api/tron';
 
 import {
     AnyType,
@@ -33,9 +33,8 @@ export const encodeTransferRawData = ({
     expiration,
     timestamp,
 }: EncodeTransferRawDataParams): Uint8Array => {
-    const ownerBytes = tronUtils.tronAddressToBytes(from);
-    const toBytes = tronUtils.tronAddressToBytes(to);
-    if (!ownerBytes || !toBytes) throw new Error('Invalid Tron address checksum.');
+    const ownerBytes = hexToBytes(from);
+    const toBytes = hexToBytes(to);
 
     const contractBytes = TransferContractType.encode(
         TransferContractType.fromObject({
@@ -85,9 +84,8 @@ export const encodeTriggerSmartContractRawData = ({
     timestamp,
     feeLimit,
 }: EncodeTriggerSmartContractRawDataParams): Uint8Array => {
-    const ownerBytes = tronUtils.tronAddressToBytes(from);
-    const contractAddressBytes = tronUtils.tronAddressToBytes(contractAddress);
-    if (!ownerBytes || !contractAddressBytes) throw new Error('Invalid Tron address checksum.');
+    const ownerBytes = hexToBytes(from);
+    const contractAddressBytes = hexToBytes(contractAddress);
 
     const contractBytes = TriggerSmartContractType.encode(
         TriggerSmartContractType.fromObject({
@@ -118,40 +116,55 @@ export const encodeTriggerSmartContractRawData = ({
 };
 
 // DATA_HEX_PROTOBUF_EXTRA + MAX_RESULT_SIZE_IN_TX + A_SIGNATURE
-const TRON_BANDWIDTH_FORMULA_OVERHEAD = 3 + 64 + 67;
+export const TRON_BANDWIDTH_FORMULA_OVERHEAD = 3 + 64 + 67;
 
-const TRON_DUMMY_ADDRESS = 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb'; // Tron zero address
-const TRON_DUMMY_BLOCK_BYTES = '0000';
-const TRON_DUMMY_BLOCK_HASH = '0000000000000000';
-const TRON_DUMMY_TIMESTAMP = 1700000000000;
-
-export const estimateTronTransferBandwidth = (amountInSun: string): number => {
-    const rawData = encodeTransferRawData({
-        from: TRON_DUMMY_ADDRESS,
-        to: TRON_DUMMY_ADDRESS,
-        amount: amountInSun,
-        refBlockBytes: TRON_DUMMY_BLOCK_BYTES,
-        refBlockHash: TRON_DUMMY_BLOCK_HASH,
-        expiration: TRON_DUMMY_TIMESTAMP + 3_600_000,
-        timestamp: TRON_DUMMY_TIMESTAMP,
-    });
-
-    return rawData.length + TRON_BANDWIDTH_FORMULA_OVERHEAD;
+type BlockParams = {
+    ref_block_bytes: string;
+    ref_block_hash: string;
+    expiration: number;
+    timestamp: number;
+    fee_limit?: number;
 };
 
-export const estimateTronTrc20Bandwidth = (feeLimitInSun: string): number => {
-    const rawData = encodeTriggerSmartContractRawData({
-        from: TRON_DUMMY_ADDRESS,
-        contractAddress: TRON_DUMMY_ADDRESS,
-        data: '00'.repeat(68), // TRC-20 transfer calldata is always 68 bytes
-        refBlockBytes: TRON_DUMMY_BLOCK_BYTES,
-        refBlockHash: TRON_DUMMY_BLOCK_HASH,
-        expiration: TRON_DUMMY_TIMESTAMP + 3_600_000,
-        timestamp: TRON_DUMMY_TIMESTAMP,
-        feeLimit: Number(feeLimitInSun),
-    });
+export const encodeTronContractRawData = (
+    contract: TronContracts,
+    blockParams: BlockParams,
+): Uint8Array => {
+    const { ref_block_bytes, ref_block_hash, expiration, timestamp, fee_limit } = blockParams;
 
-    return rawData.length + TRON_BANDWIDTH_FORMULA_OVERHEAD;
+    switch (contract.type) {
+        case 'TransferContract': {
+            const { owner_address, to_address, amount } = contract.parameter.value;
+
+            return encodeTransferRawData({
+                from: owner_address ?? '',
+                to: to_address ?? '',
+                amount: String(amount ?? 0),
+                refBlockBytes: ref_block_bytes,
+                refBlockHash: ref_block_hash,
+                expiration,
+                timestamp,
+            });
+        }
+        case 'TriggerSmartContract': {
+            const { owner_address, contract_address, data } = contract.parameter.value;
+
+            return encodeTriggerSmartContractRawData({
+                from: owner_address ?? '',
+                contractAddress: contract_address ?? '',
+                data: data ?? '',
+                refBlockBytes: ref_block_bytes,
+                refBlockHash: ref_block_hash,
+                expiration,
+                timestamp,
+                feeLimit: fee_limit ?? 0,
+            });
+        }
+        default:
+            throw new Error(
+                `Unsupported contract type for encoding: ${(contract as { type: string }).type}`,
+            );
+    }
 };
 
 export const encodeBroadcastTransaction = (rawDataHex: string, signatureHex: string): string =>

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -25,11 +25,6 @@ import {
 import { type BlockchainLinkResponse } from '@trezor/blockchain-link';
 import { tronUtils } from '@trezor/blockchain-link-utils';
 import TrezorConnect, { type TokenInfo } from '@trezor/connect';
-import {
-    encodeBroadcastTransaction,
-    estimateTronTransferBandwidth,
-    estimateTronTrc20Bandwidth,
-} from '@trezor/connect/src/api/tron/tronEncode';
 import { BigNumber } from '@trezor/utils';
 
 import { SEND_MODULE_PREFIX } from './sendFormConstants';
@@ -72,6 +67,7 @@ const calculateTrc20Transfer = (
     feeLevel: EstimateFeeLevel,
     token: TokenInfo,
     networkSymbol: NetworkSymbol,
+    bytes: number,
 ): PrecomposedTransaction => {
     const totalFeeInSun = feeLevel.feePerTx || '0';
     const isSendMax = output.type === 'send-max' || output.type === 'send-max-noaddress';
@@ -109,7 +105,7 @@ const calculateTrc20Transfer = (
         feePerByte: feeLevel.feePerUnit,
         feeLimit: feeLevel.feeLimit, // energy cap in energy units; fee_limit in the signed tx uses the equivalent in SUN (feeLimit × feePerUnit)
         energyConsumed,
-        bytes: estimateTronTrc20Bandwidth(totalFeeInSun),
+        bytes,
         inputs: [],
         token,
     };
@@ -134,6 +130,7 @@ const calculateTrxTransfer = (
     output: ExternalOutput,
     feeLevel: EstimateFeeLevel,
     isNewAccount: boolean,
+    bytes: number,
 ): PrecomposedTransaction => {
     const baseFeeInSun = feeLevel.feePerTx || '0';
     const totalFeeInSun = isNewAccount
@@ -165,7 +162,7 @@ const calculateTrxTransfer = (
         max,
         fee: totalFeeInSun,
         feePerByte: feeLevel.feePerUnit,
-        bytes: estimateTronTransferBandwidth(amount),
+        bytes,
         inputs: [],
     };
 
@@ -198,12 +195,13 @@ const calculate = (
     output: ExternalOutput,
     feeLevel: EstimateFeeLevel,
     networkSymbol: NetworkSymbol,
+    bytes: number,
     token?: TokenInfo,
     isNewAccount?: boolean,
 ): PrecomposedTransaction =>
     token
-        ? calculateTrc20Transfer(availableBalance, output, feeLevel, token, networkSymbol)
-        : calculateTrxTransfer(availableBalance, output, feeLevel, isNewAccount ?? false);
+        ? calculateTrc20Transfer(availableBalance, output, feeLevel, token, networkSymbol, bytes)
+        : calculateTrxTransfer(availableBalance, output, feeLevel, isNewAccount ?? false, bytes);
 
 export const composeTronTransactionFeeLevelsThunk = createThunk<
     PrecomposedLevels,
@@ -245,8 +243,58 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
 
         let feeLevel: EstimateFeeLevel;
 
+        const ownerHex = tronUtils.tronAddressToHex(account.descriptor) ?? '';
+
+        // Dummy block values — block fields are fixed-size in protobuf so bandwidth is identical
+        // to what we'd get with real block data.
+        const DUMMY_BLOCK_HASH = '0'.repeat(64);
+        const DUMMY_BLOCK_HEIGHT = 0;
+
+        const contract = tokenInfo
+            ? {
+                  type: 'TriggerSmartContract' as const,
+                  parameter: {
+                      value: {
+                          owner_address: ownerHex,
+                          contract_address: tronUtils.tronAddressToHex(tokenInfo.contract) ?? '',
+                          data:
+                              getTronEstimateFeeParams(
+                                  to,
+                                  amountForEstimation,
+                                  tokenInfo,
+                              ).data?.slice(2) ?? '',
+                      },
+                  },
+              }
+            : {
+                  type: 'TransferContract' as const,
+                  parameter: {
+                      value: {
+                          owner_address: ownerHex,
+                          to_address: tronUtils.tronAddressToHex(to) ?? '',
+                          amount: amountForEstimation,
+                      },
+                  },
+              };
+
+        const bandwidthEstimate = await TrezorConnect.tronComposeTransaction({
+            contract,
+            blockHash: DUMMY_BLOCK_HASH,
+            blockHeight: DUMMY_BLOCK_HEIGHT,
+        });
+
+        if (!bandwidthEstimate.success) {
+            return rejectWithValue({
+                error: 'fee-levels-compose-failed',
+                message: bandwidthEstimate.error.message,
+            });
+        }
+
+        const bytes = bandwidthEstimate.payload.bandwidth;
+
         if (tokenInfo) {
             const estimateFeeParams = getTronEstimateFeeParams(to, amountForEstimation, tokenInfo);
+
             const estimatedFee = await TrezorConnect.blockchainEstimateFee({
                 coin: account.symbol,
                 identity: getAccountIdentity(account),
@@ -267,7 +315,6 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
 
             feeLevel = estimatedFee.payload.levels[0];
         } else {
-            const bytes = estimateTronTransferBandwidth(amountForEstimation);
             const availableBandwidth = Math.max(
                 account.misc?.tronResources?.availableStakedBandwidth ?? 0,
                 account.misc?.tronResources?.availableFreeBandwidth ?? 0,
@@ -289,6 +336,7 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
             output,
             feeLevel,
             account.symbol,
+            bytes,
             tokenInfo,
             isNewAccount,
         );
@@ -369,31 +417,6 @@ export const signTronSendFormTransactionThunk = createThunk<
             ? getTrc20FeeLimitSun(formState.feeLimit, precomposedTransaction.fee)
             : undefined;
 
-        const composed = await TrezorConnect.tronComposeTransaction({
-            from: selectedAccount.descriptor,
-            to: token ? token.contract : output.address,
-            amount: amountInSubunits,
-            blockHash,
-            blockHeight,
-            token: token
-                ? {
-                      contract: token.contract,
-                      data: tokenData ?? '',
-                      feeLimit: tokenFeeLimitSun,
-                  }
-                : undefined,
-        });
-
-        if (!composed.success) {
-            return rejectWithValue({
-                error: 'sign-transaction-failed',
-                message: composed.error.message,
-            });
-        }
-
-        const { rawDataHex, ref_block_bytes, ref_block_hash, expiration, timestamp } =
-            composed.payload;
-
         const ownerHex = tronUtils.tronAddressToHex(selectedAccount.descriptor);
         const recipientHex = token
             ? tronUtils.tronAddressToHex(token.contract)
@@ -407,30 +430,42 @@ export const signTronSendFormTransactionThunk = createThunk<
         }
 
         const contract = token
-            ? [
-                  {
-                      type: 'TriggerSmartContract' as const,
-                      parameter: {
-                          value: {
-                              owner_address: ownerHex,
-                              contract_address: recipientHex,
-                              data: tokenData!,
-                          },
+            ? {
+                  type: 'TriggerSmartContract' as const,
+                  parameter: {
+                      value: {
+                          owner_address: ownerHex,
+                          contract_address: recipientHex,
+                          data: tokenData!,
                       },
                   },
-              ]
-            : [
-                  {
-                      type: 'TransferContract' as const,
-                      parameter: {
-                          value: {
-                              owner_address: ownerHex,
-                              to_address: recipientHex,
-                              amount: amountInSubunits,
-                          },
+              }
+            : {
+                  type: 'TransferContract' as const,
+                  parameter: {
+                      value: {
+                          owner_address: ownerHex,
+                          to_address: recipientHex,
+                          amount: amountInSubunits,
                       },
                   },
-              ];
+              };
+
+        const composed = await TrezorConnect.tronComposeTransaction({
+            contract,
+            blockHash,
+            blockHeight,
+            fee_limit: tokenFeeLimitSun,
+        });
+
+        if (!composed.success) {
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: composed.error.message,
+            });
+        }
+
+        const { ref_block_bytes, ref_block_hash, expiration, timestamp } = composed.payload;
 
         const signed = await TrezorConnect.tronSignTransaction({
             device: {
@@ -445,7 +480,7 @@ export const signTronSendFormTransactionThunk = createThunk<
             expiration,
             timestamp,
             fee_limit: tokenFeeLimitSun,
-            contract,
+            contract: [contract],
         });
 
         if (!signed.success) {
@@ -455,6 +490,13 @@ export const signTronSendFormTransactionThunk = createThunk<
             });
         }
 
-        return { serializedTx: encodeBroadcastTransaction(rawDataHex, signed.payload.signature) };
+        if (!signed.payload.serializedTx) {
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: 'Failed to serialize transaction.',
+            });
+        }
+
+        return { serializedTx: signed.payload.serializedTx };
     },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tron fee estimation was silently failing in the desktop app. The root cause was Electron's renderer CSP (script-src 'self', no unsafe-eval) blocking protobufjs, which uses eval internally at module load time. 

So all protobuf usage is moved out of the renderer into the Connect main process (no CSP restrictions), communicating via the existing IPC channel.


## Notes for QA

Tron fees should work in built app as well now.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-fee-estimation-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-fee-estimation-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-fee-estimation-desktop&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T21:14:30.234Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T17:12:12.591Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->