### PR TITLE
fix(suite): SuiteSyncServer copy

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6304,6 +6304,10 @@ export const messages = defineMessages({
             'Sync your labels via Trezor servers by default. Connect to your own server for more privacy and control.',
         id: 'TR_LABELING_SERVERS_DESCRIPTION',
     },
+    TR_LABELING_SYNCED_THROUGH_CUSTOM_SERVER: {
+        defaultMessage: 'Label synced through your custom server',
+        id: 'TR_LABELING_SYNCED_THROUGH_CUSTOM_SERVER',
+    },
     TR_LABELING_SERVERS_CHANGE: {
         defaultMessage: 'Change server',
         id: 'TR_LABELING_SERVERS_CHANGE',

--- a/suite/suite-sync/src/SuiteSyncServers.tsx
+++ b/suite/suite-sync/src/SuiteSyncServers.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
+import { selectSuiteSyncCustomRelayUrl } from '@suite-common/suite-sync';
 import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
@@ -12,6 +14,8 @@ type SuiteSyncServersProps = {
 
 export const SuiteSyncServers = ({ suiteSync }: SuiteSyncServersProps) => {
     const [isSelectServerOpen, setShowChangeServerModal] = useState(false);
+    const customRelayUrl = useSelector(selectSuiteSyncCustomRelayUrl);
+    const isCustomServer = !!customRelayUrl;
 
     const toggleSelectServer = () => {
         setShowChangeServerModal(!isSelectServerOpen);
@@ -24,7 +28,15 @@ export const SuiteSyncServers = ({ suiteSync }: SuiteSyncServersProps) => {
             )}
             <SectionItem data-testid="@settings/labeling-servers">
                 <TextColumn
-                    title={<Translation id="TR_LABELING_SYNCED_THROUGH_TREZOR_SERVERS" />}
+                    title={
+                        <Translation
+                            id={
+                                isCustomServer
+                                    ? 'TR_LABELING_SYNCED_THROUGH_CUSTOM_SERVER'
+                                    : 'TR_LABELING_SYNCED_THROUGH_TREZOR_SERVERS'
+                            }
+                        />
+                    }
                     description={<Translation id="TR_LABELING_SERVERS_DESCRIPTION" />}
                 />
                 <ActionColumn>


### PR DESCRIPTION
Fix so that the copy is being updated based of the server that the Suite Sync uses.

## Notes for QA

**Happy paths**                                                                                                                                                                                                             
  - Settings → Labeling, default Trezor servers - title shows "Synced through Trezor servers (default)"                                                                                                                   
  - Settings → Labeling, switch to custom relay URL via Change server - title updates to "Label synced through your custom server"                                                                                        
  - Switch back from custom to default - title reverts to Trezor servers copy                                                                                                                                             
  - Description text unchanged in both states
  
**Edge cases**                                                                                                                                                                                                              
  - Reload Suite with custom relay URL persisted - title still reflects custom server                                                                                                                                     
  - Invalid/empty custom URL submission - title stays on previous valid state                                                                                                                                             
  - Toggle between default/custom multiple times - no stale title


## Screenshots:
<img width="1157" height="299" alt="Screenshot 2026-04-08 at 1 10 21" src="https://github.com/user-attachments/assets/8d40fa5e-dd26-4d7f-ad15-59020b1d12fe" />
<img width="1155" height="275" alt="Screenshot 2026-04-08 at 1 10 31" src="https://github.com/user-attachments/assets/07fd53b3-9964-4bb4-8394-15bae6415676" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/ss/server-copy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/ss/server-copy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-07T23:19:28.538Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-07T23:18:59.400Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->