### PR TITLE
fix(suite-native): suite sync selectors

### DIFF
--- a/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.ts
+++ b/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.ts
@@ -1,8 +1,13 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type SuiteSyncAccount } from '@suite-common/suite-sync-storage';
 import { type Account } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 
+import {
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+} from '../../suiteSyncSelectors';
 import { type SuiteSyncDataRootState } from '../suiteSyncDataReducer';
 import { findSuiteSyncAccountLabel } from './findSuiteSyncAccountLabel';
 import { selectSuiteSyncAccounts } from './selectSuiteSyncAccounts';
@@ -11,32 +16,40 @@ export type AccountWithSuiteSyncLabel = Account & {
     label: string | null;
 };
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+type AccountsWithSuiteSyncLabelRootState = SuiteSyncDataRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState;
+
+const createMemoizedSelector =
+    createWeakMapSelector.withTypes<AccountsWithSuiteSyncLabelRootState>();
 
 const mapAccountsToSuiteSyncLabel = (
     accounts: readonly Account[],
     suiteSyncAccountLabels: SuiteSyncAccount[],
+    isSuiteSyncEnabled: boolean,
 ): AccountWithSuiteSyncLabel[] =>
-    accounts.map(account => ({
-        ...account,
-        label:
-            findSuiteSyncAccountLabel({
-                accounts: suiteSyncAccountLabels,
-                accountDescriptor: account.descriptor,
-                networkSymbol: account.symbol,
-            })?.label ??
-            // account.accountLabel ??
-            null,
-    }));
+    returnStableArrayIfEmpty(
+        accounts.map(account => ({
+            ...account,
+            label: isSuiteSyncEnabled
+                ? (findSuiteSyncAccountLabel({
+                      accounts: suiteSyncAccountLabels,
+                      accountDescriptor: account.descriptor,
+                      networkSymbol: account.symbol,
+                  })?.label ?? null)
+                : null,
+        })),
+    );
 
 export const selectAccountsWithSuiteSyncLabel = createMemoizedSelector(
     [
-        (_state: SuiteSyncDataRootState, accounts: readonly Account[]) => accounts,
+        (_state: AccountsWithSuiteSyncLabelRootState, accounts: readonly Account[]) => accounts,
         (
-            state: SuiteSyncDataRootState,
+            state: AccountsWithSuiteSyncLabelRootState,
             _accounts: readonly Account[],
             deviceStaticSessionId: StaticSessionId | null,
         ) => selectSuiteSyncAccounts(state, deviceStaticSessionId),
+        selectIsSuiteSyncEnabled,
     ],
     mapAccountsToSuiteSyncLabel,
 );

--- a/suite-common/suite-sync/src/data/account/selectSuiteSyncAccountLabel.ts
+++ b/suite-common/suite-sync/src/data/account/selectSuiteSyncAccountLabel.ts
@@ -1,30 +1,45 @@
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
 
 import { type SuiteSyncDataRootState } from '../suiteSyncDataReducer';
 import { findSuiteSyncAccountLabel } from './findSuiteSyncAccountLabel';
+import {
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+} from '../../suiteSyncSelectors';
 import { selectAllAccountsForWallet } from '../wallet/suiteSyncWalletSelectors';
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+type SuiteSyncAccountLabelRootState = SuiteSyncDataRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState;
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncAccountLabelRootState>();
 
 export const selectSuiteSyncAccountLabel = createMemoizedSelector(
     [
-        (state: SuiteSyncDataRootState, walletDescriptor: WalletDescriptor | null) =>
+        (state: SuiteSyncAccountLabelRootState, walletDescriptor: WalletDescriptor | null) =>
             selectAllAccountsForWallet(state, walletDescriptor),
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncAccountLabelRootState,
             _walletDescriptor: WalletDescriptor | null,
             accountDescriptor: AccountDescriptor,
         ) => accountDescriptor,
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncAccountLabelRootState,
             _walletDescriptor: WalletDescriptor | null,
             _accountDescriptor: AccountDescriptor,
             networkSymbol: NetworkSymbol,
         ) => networkSymbol,
+        selectIsSuiteSyncEnabled,
     ],
-    (accountLabels, accountDescriptor, networkSymbol) =>
-        findSuiteSyncAccountLabel({ accounts: accountLabels, accountDescriptor, networkSymbol })
-            ?.label ?? null,
+    (accountLabels, accountDescriptor, networkSymbol, isSuiteSyncEnabled) => {
+        if (!isSuiteSyncEnabled) return null;
+
+        return (
+            findSuiteSyncAccountLabel({ accounts: accountLabels, accountDescriptor, networkSymbol })
+                ?.label ?? null
+        );
+    },
 );

--- a/suite-common/suite-sync/src/data/address/suiteSyncAddressSelectors.ts
+++ b/suite-common/suite-sync/src/data/address/suiteSyncAddressSelectors.ts
@@ -1,56 +1,82 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import type { SuiteSyncAddress } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 
+import {
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+} from '../../suiteSyncSelectors';
 import { type SuiteSyncDataRootState } from '../suiteSyncDataReducer';
 import { selectAllAddressesForWallet } from '../wallet/suiteSyncWalletSelectors';
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+type SuiteSyncAddressRootState = SuiteSyncDataRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState;
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncAddressRootState>();
 
 export const selectSuiteSyncAccountAddressesByAccount = createMemoizedSelector(
     [
-        (state: SuiteSyncDataRootState, walletDescriptor: WalletDescriptor) =>
+        (state: SuiteSyncAddressRootState, walletDescriptor: WalletDescriptor) =>
             selectAllAddressesForWallet(state, walletDescriptor),
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncAddressRootState,
             _walletDescriptor: WalletDescriptor,
             accountDescriptor: AccountDescriptor,
         ) => accountDescriptor,
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncAddressRootState,
             _walletDescriptor: WalletDescriptor,
             _accountDescriptor: AccountDescriptor,
             networkSymbol: NetworkSymbol,
         ) => networkSymbol,
+        selectIsSuiteSyncEnabled,
     ],
-    (walletAddresses, accountDescriptor, networkSymbol) =>
-        walletAddresses.filter(
-            address =>
-                address.accountDescriptor === accountDescriptor &&
-                address.networkSymbol === networkSymbol,
-        ),
+    (walletAddresses, accountDescriptor, networkSymbol, isSuiteSyncEnabled) => {
+        if (!isSuiteSyncEnabled) {
+            return returnStableArrayIfEmpty<SuiteSyncAddress>();
+        }
+
+        return returnStableArrayIfEmpty(
+            walletAddresses.filter(
+                address =>
+                    address.accountDescriptor === accountDescriptor &&
+                    address.networkSymbol === networkSymbol,
+            ),
+        );
+    },
 );
 
 export const selectSuiteSyncAddressLabel = createMemoizedSelector(
     [
-        (state: SuiteSyncDataRootState, deviceStaticId: StaticSessionId) => {
+        (state: SuiteSyncAddressRootState, deviceStaticId: StaticSessionId) => {
             const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticId);
 
             return selectAllAddressesForWallet(state, walletDescriptor);
         },
-        (_state: SuiteSyncDataRootState, _deviceStaticId: StaticSessionId, address: string) =>
+        (_state: SuiteSyncAddressRootState, _deviceStaticId: StaticSessionId, address: string) =>
             address,
+        selectIsSuiteSyncEnabled,
     ],
-    (walletAddresses, address) =>
-        walletAddresses.find(addr => addr.address === address)?.label ?? null,
+    (walletAddresses, address, isSuiteSyncEnabled) => {
+        if (!isSuiteSyncEnabled) return null;
+
+        return walletAddresses.find(addr => addr.address === address)?.label ?? null;
+    },
 );
 
 export const selectSuiteSyncAddressLabels = (
-    state: SuiteSyncDataRootState,
+    state: SuiteSyncAddressRootState,
     deviceStaticId: StaticSessionId,
 ) => {
+    if (!selectIsSuiteSyncEnabled(state)) {
+        return returnStableArrayIfEmpty<SuiteSyncAddress>();
+    }
+
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticId);
 
     return selectAllAddressesForWallet(state, walletDescriptor);

--- a/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
+++ b/suite-common/suite-sync/src/data/labeling/selectAllLabelsForAccount.ts
@@ -1,8 +1,10 @@
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import type { SuiteSyncAddress, SuiteSyncOutput } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, WalletDescriptor } from '@suite-common/wallet-types';
 
+import { type WithSuiteSyncAndDeviceState } from '../../suiteSyncSelectors';
 import { selectSuiteSyncAccountLabel } from '../account/selectSuiteSyncAccountLabel';
 import { selectSuiteSyncAccountAddressesByAccount } from '../address/suiteSyncAddressSelectors';
 import { selectSuiteSyncOutputLabelsByAccount } from '../output/suiteSyncOutputSelectors';
@@ -20,7 +22,11 @@ export type AllLabelsForAccount = {
     outputLabels: SuiteSyncOutput[];
 };
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+type AllLabelsForAccountRootState = SuiteSyncDataRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState;
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<AllLabelsForAccountRootState>();
 
 export const selectAllLabelsForAccount = createMemoizedSelector(
     [

--- a/suite-common/suite-sync/src/data/output/suiteSyncOutputSelectors.ts
+++ b/suite-common/suite-sync/src/data/output/suiteSyncOutputSelectors.ts
@@ -1,43 +1,60 @@
-import { createWeakMapSelector } from '@suite-common/redux-utils';
-import { createSuiteSyncOutputId } from '@suite-common/suite-sync-storage';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import { type SuiteSyncOutput, createSuiteSyncOutputId } from '@suite-common/suite-sync-storage';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { AccountDescriptor, TxTargetId, WalletDescriptor } from '@suite-common/wallet-types';
 import { parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 
+import {
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+} from '../../suiteSyncSelectors';
 import { type SuiteSyncDataRootState } from '../suiteSyncDataReducer';
 import { selectAllOutputsForWallet } from '../wallet/suiteSyncWalletSelectors';
 
-const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
+type SuiteSyncOutputRootState = SuiteSyncDataRootState &
+    WithSuiteSyncAndDeviceState &
+    MessageSystemRootState;
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncOutputRootState>();
 
 export const selectSuiteSyncOutputLabelsByAccount = createMemoizedSelector(
     [
-        (state: SuiteSyncDataRootState, walletDescriptor: WalletDescriptor) =>
+        (state: SuiteSyncOutputRootState, walletDescriptor: WalletDescriptor) =>
             selectAllOutputsForWallet(state, walletDescriptor),
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncOutputRootState,
             _walletDescriptor: WalletDescriptor,
             accountDescriptor: AccountDescriptor,
         ) => accountDescriptor,
         (
-            _state: SuiteSyncDataRootState,
+            _state: SuiteSyncOutputRootState,
             _walletDescriptor: WalletDescriptor,
             _accountDescriptor: AccountDescriptor,
             networkSymbol: NetworkSymbol,
         ) => networkSymbol,
+        selectIsSuiteSyncEnabled,
     ],
-    (outputs, accountDescriptor, networkSymbol) =>
-        outputs.filter(
-            output =>
-                output.accountDescriptor === accountDescriptor &&
-                output.networkSymbol === networkSymbol,
-        ),
+    (outputs, accountDescriptor, networkSymbol, isSuiteSyncEnabled) => {
+        if (!isSuiteSyncEnabled) {
+            return returnStableArrayIfEmpty<SuiteSyncOutput>();
+        }
+
+        return returnStableArrayIfEmpty(
+            outputs.filter(
+                output =>
+                    output.accountDescriptor === accountDescriptor &&
+                    output.networkSymbol === networkSymbol,
+            ),
+        );
+    },
 );
 
 export const selectSuiteSyncOutputLabel = createMemoizedSelector(
     [
         (
-            state: SuiteSyncDataRootState,
+            state: SuiteSyncOutputRootState,
             _txId: string,
             _txOutputId: TxTargetId,
             deviceStaticSessionId: StaticSessionId,
@@ -46,10 +63,13 @@ export const selectSuiteSyncOutputLabel = createMemoizedSelector(
 
             return selectAllOutputsForWallet(state, walletDescriptor);
         },
-        (_state: SuiteSyncDataRootState, txId: string) => txId,
-        (_state: SuiteSyncDataRootState, _txId: string, txOutputId: TxTargetId) => txOutputId,
+        (_state: SuiteSyncOutputRootState, txId: string) => txId,
+        (_state: SuiteSyncOutputRootState, _txId: string, txOutputId: TxTargetId) => txOutputId,
+        selectIsSuiteSyncEnabled,
     ],
-    (outputs, txId, txOutputId) => {
+    (outputs, txId, txOutputId, isSuiteSyncEnabled) => {
+        if (!isSuiteSyncEnabled) return null;
+
         const id = createSuiteSyncOutputId(txId, txOutputId);
 
         return outputs.find(output => output.id === id)?.label ?? null;
@@ -57,9 +77,13 @@ export const selectSuiteSyncOutputLabel = createMemoizedSelector(
 );
 
 export const selectSuiteSyncOutputLabels = (
-    state: SuiteSyncDataRootState,
+    state: SuiteSyncOutputRootState,
     deviceStaticId: StaticSessionId,
 ) => {
+    if (!selectIsSuiteSyncEnabled(state)) {
+        return returnStableArrayIfEmpty<SuiteSyncOutput>();
+    }
+
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticId);
 
     return selectAllOutputsForWallet(state, walletDescriptor);

--- a/suite-common/suite-sync/src/data/wallet/suiteSyncWalletSelectors.ts
+++ b/suite-common/suite-sync/src/data/wallet/suiteSyncWalletSelectors.ts
@@ -1,3 +1,4 @@
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import {
     type SuiteSyncAccount,
@@ -7,6 +8,10 @@ import {
 import { type WalletDescriptor } from '@suite-common/wallet-types';
 import { typedObjectValues } from '@trezor/utils';
 
+import {
+    type WithSuiteSyncAndDeviceState,
+    selectIsSuiteSyncEnabled,
+} from '../../suiteSyncSelectors';
 import { type SuiteSyncDataRootState, type WalletData } from '../suiteSyncDataReducer';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<SuiteSyncDataRootState>();
@@ -51,9 +56,13 @@ export const selectAllOutputsForWallet = createMemoizedSelector(
 );
 
 export const selectSuiteSyncWalletLabel = (
-    state: SuiteSyncDataRootState,
+    state: SuiteSyncDataRootState & WithSuiteSyncAndDeviceState & MessageSystemRootState,
     walletDescriptor: WalletDescriptor,
 ) => {
+    if (!selectIsSuiteSyncEnabled(state)) {
+        return null;
+    }
+
     const walletData = selectWalletById(state, walletDescriptor);
 
     return walletData?.wallet.label ?? null;


### PR DESCRIPTION
- if suite sync is disabled by message system, suite sync selectors will return default values so that we don't have to remove them

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync/suite-sync-selectors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->