### PR TITLE
refactor(suite): update onboarding coachmark

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
@@ -3,7 +3,7 @@ import { type FC, useState } from 'react';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor, goto, selectRouteName } from '@suite/router';
 import { selectIsDeviceInitialized } from '@suite-common/device';
-import { Button, Column, Icon, Link, Paragraph, Row, Text, Tooltip } from '@trezor/components';
+import { Button, Column, Link, Paragraph, Text, Tooltip } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -24,50 +24,48 @@ export const SettingsWithTooltip: FC<NavigationItemProps> = props => {
         <Tooltip
             isOpen={isTooltipOpen}
             content={
-                <Column padding={8} gap={16}>
-                    <Row gap={10}>
-                        <Icon name="lightning" size={32} intent="brand" />
-                        <Paragraph textWrap="pretty">
-                            <Translation
-                                id={
-                                    isDesktop()
-                                        ? 'TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP'
-                                        : 'TR_SETTINGS_TOOLTIP_DESCRIPTION_WEB'
-                                }
-                                values={{
-                                    strong: chunks => (
-                                        <Text typographyStyle="body-sm-strong">{chunks}</Text>
-                                    ),
-                                    tor: chunks => (
-                                        <Link
-                                            onClick={() =>
-                                                dispatch(
-                                                    goto({
-                                                        routeName: 'settings-index',
-                                                        anchor: SettingsAnchor.Tor,
-                                                    }),
-                                                )
-                                            }
-                                        >
-                                            {chunks}
-                                        </Link>
-                                    ),
-                                    networks: chunks => (
-                                        <Link
-                                            onClick={() =>
-                                                dispatch(goto({ routeName: 'settings-coins' }))
-                                            }
-                                        >
-                                            {chunks}
-                                        </Link>
-                                    ),
-                                }}
-                            />
-                        </Paragraph>
-                    </Row>
+                <Column padding={2} gap={6}>
+                    <Paragraph textWrap="pretty">
+                        <Translation
+                            id={
+                                isDesktop()
+                                    ? 'TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP'
+                                    : 'TR_SETTINGS_TOOLTIP_DESCRIPTION_WEB'
+                            }
+                            values={{
+                                strong: chunks => (
+                                    <Text typographyStyle="body-sm-strong">{chunks}</Text>
+                                ),
+                                tor: chunks => (
+                                    <Link
+                                        onClick={() =>
+                                            dispatch(
+                                                goto({
+                                                    routeName: 'settings-index',
+                                                    anchor: SettingsAnchor.Tor,
+                                                }),
+                                            )
+                                        }
+                                    >
+                                        {chunks}
+                                    </Link>
+                                ),
+                                networks: chunks => (
+                                    <Link
+                                        onClick={() =>
+                                            dispatch(goto({ routeName: 'settings-coins' }))
+                                        }
+                                    >
+                                        {chunks}
+                                    </Link>
+                                ),
+                            }}
+                        />
+                    </Paragraph>
                     <Button
                         size="small"
-                        intent="brand"
+                        intent="neutral"
+                        priority="secondary"
                         onClick={handleTooltipClose}
                         margin={{ left: 'auto' }}
                     >
@@ -77,7 +75,7 @@ export const SettingsWithTooltip: FC<NavigationItemProps> = props => {
             }
             hasArrow
             placement="bottom-start"
-            tooltipMaxWidth={240}
+            tooltipMaxWidth={210}
         >
             <NavigationItem {...props} />
         </Tooltip>


### PR DESCRIPTION
## Notes for QA

Updated onboarding coachmark design.

## Screenshots:
<img width="299" height="281" alt="image" src="https://github.com/user-attachments/assets/2a072052-8e83-41f4-aa88-b171a8afb411" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/onboarding-coachmark&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/onboarding-coachmark&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T07:40:40.180Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T07:39:08.079Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->