### PR TITLE
fix(trading): update swap receive address when asset changes

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -110,6 +110,7 @@ export const useTradingReceiveAddress = ({
 
     const canAddSuiteAccount = !!(device?.connected && isSupportedNetwork);
     const canUseNonSuiteAccount = nonSuiteAccount;
+    const hasSuiteReceiveAccount = !!suiteReceiveAccounts?.length;
 
     const selectSuiteAccount = useCallback(
         (account: Account) => {
@@ -144,7 +145,7 @@ export const useTradingReceiveAddress = ({
         setHasSelectionInitialized(false);
         methods.setValue('address', '', { shouldValidate: false });
         methods.setValue('extraField', '', { shouldValidate: false });
-    }, [symbol, methods]);
+    }, [cryptoId, methods]);
 
     useEffect(() => {
         if (!sendAccountKey || hasSelectionInitialized) {
@@ -181,6 +182,21 @@ export const useTradingReceiveAddress = ({
         if (!symbol) return;
         if (hasSelectionInitialized) return;
 
+        if (!hasSuiteReceiveAccount) {
+            if (canUseNonSuiteAccount) {
+                selectNonSuiteAddress('');
+
+                return;
+            }
+
+            methods.setValue('address', '', { shouldValidate: true });
+            methods.setValue('extraField', '', { shouldValidate: true });
+            setSelectedAccount(undefined);
+            setHasSelectionInitialized(true);
+
+            return;
+        }
+
         if (persistedReceiveAccountKey) {
             const matchingAccount = suiteReceiveAccounts?.find(
                 account => account.key === persistedReceiveAccountKey,
@@ -194,10 +210,16 @@ export const useTradingReceiveAddress = ({
         }
 
         if (persistedReceiveAddress && canUseNonSuiteAccount && symbol) {
-            const isValidForCurrentSymbol = addressValidator.validate(
-                persistedReceiveAddress,
-                symbol,
-            );
+            let isValidForCurrentSymbol = false;
+
+            try {
+                isValidForCurrentSymbol = addressValidator.validate(
+                    persistedReceiveAddress,
+                    symbol,
+                );
+            } catch {
+                isValidForCurrentSymbol = false;
+            }
 
             if (isValidForCurrentSymbol) {
                 selectNonSuiteAddress(persistedReceiveAddress);
@@ -259,6 +281,7 @@ export const useTradingReceiveAddress = ({
         selectSuiteAccount,
         selectNonSuiteAddress,
         canUseNonSuiteAccount,
+        hasSuiteReceiveAccount,
         hasSelectionInitialized,
         methods,
     ]);

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
@@ -41,7 +41,15 @@ export const TradingReceiveAddressModal = () => {
             if (cryptoId) {
                 const symbol =
                     cryptoIdToNetwork(cryptoId)?.symbol ?? cryptoIdToNativeCoinSymbol(cryptoId);
-                if (value && !addressValidator.validate(value, symbol)) {
+                let isValid = true;
+
+                try {
+                    isValid = value ? addressValidator.validate(value, symbol) : true;
+                } catch {
+                    isValid = false;
+                }
+
+                if (!isValid) {
                     return translationString('TR_EXCHANGE_RECEIVING_ADDRESS_INVALID');
                 }
             }


### PR DESCRIPTION
## Description

- Reinitialize swap receive address selection when the receive asset changes by resetting state on cryptoId changes.
- Avoid carrying over stale receive addresses when no matching Suite receive account exists for the newly selected asset.
- Handle receive address validator exceptions so invalid network/address combinations consistently fail validation.

## Notes for QA

- In Wallet -> Trading -> Swap, choose a From/To pair, then change the To asset to a different network and confirm the receive address is updated/reset instead of staying on the previous asset address.
- Open the receive address modal, paste an address from a different network, and confirm you get an invalid receiving address validation error.
- Switch back to an asset where a previously used valid non-suite receive address exists and confirm it can still be selected.

## Related Issue

Resolve #26457

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26457-swap-receive-address-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26457-swap-receive-address-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T08:13:20.988Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T08:11:47.470Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->