### PR TITLE
26422 e2e test for forgetting

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
@@ -64,6 +64,7 @@ export const ConfirmationModal = ({
     isBluetoothConnectedDevice: boolean;
 }) => (
     <Modal
+        data-testid="@settings/device/forget-confirmation-modal"
         onCancel={onCancel}
         heading={<Translation id="TR_FORGET_DEVICE_MODAL_HEADING" />}
         intent="warning"

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
@@ -70,7 +70,7 @@ export const ConfirmationModal = ({
         width={680}
         bottomContent={
             <>
-                <Modal.Button onClick={onConfirm}>
+                <Modal.Button data-testid="@settings/device/forget-confirm" onClick={onConfirm}>
                     <Translation id="TR_FORGET_DEVICE_MODAL_CONFIRM" />
                 </Modal.Button>
                 <Modal.Button intent="neutral" priority="secondary" onClick={onCancel}>

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDevice.tsx
@@ -25,13 +25,14 @@ export const ForgetDevice = () => {
     return (
         <>
             {isModalOpen && <ForgetDeviceModal onCancel={handleModalCancel} />}
-            <SectionItem data-test="@settings/device/forget">
+            <SectionItem data-testid="@settings/device/forget">
                 <TextColumn
                     title={<Translation id="TR_FORGET_DEVICE_HEADING" />}
                     description={<Translation id="TR_FORGET_DEVICE_DESCRIPTION" />}
                 />
                 <ActionColumn>
                     <ActionButton
+                        data-testid="@settings/device/forget-button"
                         onClick={handleClick}
                         intent="warning"
                         isDisabled={hasRunningDiscovery}

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
@@ -52,6 +52,7 @@ export const OsAndTrezorCleanupModal = ({
                     }
                     actions={
                         <Button
+                            data-testid="@settings/device/forget-os-removal-confirm"
                             intent="brand"
                             onClick={() => setOsRemovalConfirmed(true)}
                             size="large"
@@ -74,7 +75,12 @@ export const OsAndTrezorCleanupModal = ({
                         />
                     }
                     actions={
-                        <Button intent="brand" onClick={onTrezorRemovalConfirm} size="large">
+                        <Button
+                            data-testid="@settings/device/forget-trezor-removal-confirm"
+                            intent="brand"
+                            onClick={onTrezorRemovalConfirm}
+                            size="large"
+                        >
                             <Translation id="TR_FORGET_DEVICE_MODAL_IVE_REMOVED_IT" />
                         </Button>
                     }

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/OsAndTrezorCleanupModal.tsx
@@ -24,6 +24,7 @@ export const OsAndTrezorCleanupModal = ({
 
     return (
         <Modal
+            data-testid="@settings/device/forget-cleanup-modal"
             onCancel={onCancel}
             heading={<Translation id="TR_FORGET_DEVICE_MODAL_FINISH_HEADING" />}
             width={600}

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/RemoveFromBluetoothSettingsModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/RemoveFromBluetoothSettingsModal.tsx
@@ -27,7 +27,12 @@ export const RemoveFromBluetoothSettingsModal = ({
                     <Modal.Button onClick={handleOpenBluetoothSettings}>
                         <Translation id="TR_BLUETOOTH_OPEN_BLUETOOTH_SETTINGS" />
                     </Modal.Button>
-                    <Modal.Button intent="neutral" priority="secondary" onClick={onGotIt}>
+                    <Modal.Button
+                        data-testid="@settings/device/forget-bt-removal-got-it"
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={onGotIt}
+                    >
                         <Translation id="TR_GOT_IT" />
                     </Modal.Button>
                 </>

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/RemoveFromBluetoothSettingsModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/RemoveFromBluetoothSettingsModal.tsx
@@ -19,6 +19,7 @@ export const RemoveFromBluetoothSettingsModal = ({
 
     return (
         <Modal
+            data-testid="@settings/device/forget-bt-removal-modal"
             onCancel={onCancel}
             heading={<Translation id="TR_FORGET_DEVICE_MODAL_FINISH_HEADING" />}
             width={600}

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/UnplugDeviceModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/UnplugDeviceModal.tsx
@@ -35,7 +35,7 @@ export const UnplugDeviceModal = ({
     }, [onCancel, onDisconnect]);
 
     return (
-        <Modal width={400} height={420}>
+        <Modal data-testid="@settings/device/forget-unplug-modal" width={400} height={420}>
             <Column gap={24} alignItems="center">
                 <DisconnectTrezorSvg />
                 <Column gap={8} alignItems="center">

--- a/suite/e2e/support/pageObjects/settings/deviceTab.ts
+++ b/suite/e2e/support/pageObjects/settings/deviceTab.ts
@@ -15,6 +15,17 @@ export class DeviceTab {
     readonly firmwareReconnectDevice: Locator;
     readonly autoconnectSwitch: Locator;
 
+    // Forget device flow
+    readonly forgetDeviceButton: Locator;
+    readonly forgetConfirmButton: Locator;
+    readonly forgetConfirmationModal: Locator;
+    readonly forgetCleanupModal: Locator;
+    readonly forgetUnplugModal: Locator;
+    readonly forgetBtRemovalModal: Locator;
+    readonly forgetOsRemovalConfirmButton: Locator;
+    readonly forgetTrezorRemovalConfirmButton: Locator;
+    readonly forgetBtRemovalGotItButton: Locator;
+
     constructor(private readonly page: Page) {
         this.createMultiShareBackupButton = page.getByTestId(
             '@settings/device/create-multi-share-backup-button',
@@ -35,6 +46,25 @@ export class DeviceTab {
         this.firmwareConfirmSeedButton = page.getByTestId('@firmware/confirm-seed-button');
         this.firmwareReconnectDevice = page.getByTestId('@firmware/reconnect-device');
         this.autoconnectSwitch = page.getByTestId('@settings/device/thp-autoconnect');
+
+        // Forget device flow
+        this.forgetDeviceButton = page.getByTestId('@settings/device/forget-button');
+        this.forgetConfirmButton = page.getByTestId('@settings/device/forget-confirm');
+        this.forgetConfirmationModal = page.getByTestId(
+            '@settings/device/forget-confirmation-modal',
+        );
+        this.forgetCleanupModal = page.getByTestId('@settings/device/forget-cleanup-modal');
+        this.forgetUnplugModal = page.getByTestId('@settings/device/forget-unplug-modal');
+        this.forgetBtRemovalModal = page.getByTestId('@settings/device/forget-bt-removal-modal');
+        this.forgetOsRemovalConfirmButton = page.getByTestId(
+            '@settings/device/forget-os-removal-confirm',
+        );
+        this.forgetTrezorRemovalConfirmButton = page.getByTestId(
+            '@settings/device/forget-trezor-removal-confirm',
+        );
+        this.forgetBtRemovalGotItButton = page.getByTestId(
+            '@settings/device/forget-bt-removal-got-it',
+        );
     }
 
     @step()

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '../../support/fixtures';
 
 test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
-test.describe('Forget TS5 connected via cable', { tag: ['@T3T1', '@desktopOnly'] }, () => {
+test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
     test('User can forget a cable-connected TS5 after unplugging and no wallet is remembered', async ({
         onboardingPage,
         settingsPage,
@@ -35,6 +35,49 @@ test.describe('Forget TS5 connected via cable', { tag: ['@T3T1', '@desktopOnly']
                 .getByTestId('@settings/device/forget-unplug-modal')
                 .waitFor({ state: 'visible' });
             await device.powerOff();
+        });
+
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+
+    test('User can forget a disconnected TS5 immediately and no wallet is remembered', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
+
+        await test.step('Power off emulator to simulate disconnected device', async () => {
+            await device.powerOff();
+        });
+
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
+
+        await test.step('Click Forget device button', async () => {
+            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+            await page.getByTestId('@settings/device/forget-button').click();
+        });
+
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            // ImmediateForgetFlow: ConfirmationModal → forget immediately
+            await page
+                .getByTestId('@settings/device/forget-confirmation-modal')
+                .waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-confirm').click();
         });
 
         await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -44,7 +44,7 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         });
     });
 
-    test('User can forget a disconnected TS5 immediately and no wallet is remembered', async ({
+    test('User can forget an already disconnected TS5 immediately without unplug modal', async ({
         onboardingPage,
         settingsPage,
         page,
@@ -52,7 +52,7 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
     }) => {
         await onboardingPage.completeOnboarding();
 
-        await test.step('Power off emulator to simulate disconnected device', async () => {
+        await test.step('Disconnect device', async () => {
             await device.powerOff();
         });
 
@@ -65,7 +65,7 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
             await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
-        await test.step('Confirm forget in the confirmation modal', async () => {
+        await test.step('Confirm forget — no unplug modal should appear', async () => {
             await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
             await settingsPage.deviceTab.forgetConfirmButton.click();
         });

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -22,14 +22,18 @@ test.describe('Forget TS5 connected via cable', { tag: ['@T3T1', '@desktopOnly']
 
         await test.step('Confirm forget in the confirmation modal', async () => {
             // ConnectedCableForgetFlow step 1: ConfirmationModal
-            await page.modal.waitFor({ state: 'visible' });
+            await page
+                .getByTestId('@settings/device/forget-confirmation-modal')
+                .waitFor({ state: 'visible' });
             await page.getByTestId('@settings/device/forget-confirm').click();
         });
 
         await test.step('Unplug device to complete forget', async () => {
             // ConnectedCableForgetFlow step 2: UnplugDeviceModal
             // Power off the emulator to simulate unplugging the cable
-            await page.modal.waitFor({ state: 'visible' });
+            await page
+                .getByTestId('@settings/device/forget-unplug-modal')
+                .waitFor({ state: 'visible' });
             await device.powerOff();
         });
 

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -16,24 +16,17 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Click Forget device button', async () => {
-            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-            await page.getByTestId('@settings/device/forget-button').click();
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
         await test.step('Confirm forget in the confirmation modal', async () => {
-            // ConnectedCableForgetFlow step 1: ConfirmationModal
-            await page
-                .getByTestId('@settings/device/forget-confirmation-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-confirm').click();
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
         });
 
         await test.step('Unplug device to complete forget', async () => {
-            // ConnectedCableForgetFlow step 2: UnplugDeviceModal
-            // Power off the emulator to simulate unplugging the cable
-            await page
-                .getByTestId('@settings/device/forget-unplug-modal')
-                .waitFor({ state: 'visible' });
+            await expect(settingsPage.deviceTab.forgetUnplugModal).toBeVisible();
             await device.powerOff();
         });
 
@@ -68,16 +61,13 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Click Forget device button', async () => {
-            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-            await page.getByTestId('@settings/device/forget-button').click();
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
         await test.step('Confirm forget in the confirmation modal', async () => {
-            // ImmediateForgetFlow: ConfirmationModal → forget immediately
-            await page
-                .getByTestId('@settings/device/forget-confirmation-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-confirm').click();
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
         });
 
         await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '../../support/fixtures';
+
+test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+test.describe('Forget TS5 connected via cable', { tag: ['@T3T1', '@desktopOnly'] }, () => {
+    test('User can forget a cable-connected TS5 after unplugging and no wallet is remembered', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
+
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
+
+        await test.step('Click Forget device button', async () => {
+            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+            await page.getByTestId('@settings/device/forget-button').click();
+        });
+
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            // ConnectedCableForgetFlow step 1: ConfirmationModal
+            await page.modal.waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-confirm').click();
+        });
+
+        await test.step('Unplug device to complete forget', async () => {
+            // ConnectedCableForgetFlow step 2: UnplugDeviceModal
+            // Power off the emulator to simulate unplugging the cable
+            await page.modal.waitFor({ state: 'visible' });
+            await device.powerOff();
+        });
+
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+});

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -31,14 +31,14 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Verify landing on starting screen', async () => {
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
 
         await test.step('Reload and verify no wallet is remembered', async () => {
             await page.reload();
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
@@ -71,14 +71,14 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Verify landing on starting screen', async () => {
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
 
         await test.step('Reload and verify no wallet is remembered', async () => {
             await page.reload();
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });

--- a/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
+++ b/suite/e2e/tests/settings/t3t1-forget-cable-device.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '../../support/fixtures';
 
-test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
-
 test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
     test('User can forget a cable-connected TS5 after unplugging and no wallet is remembered', async ({
         onboardingPage,
@@ -52,8 +50,9 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
     }) => {
         await onboardingPage.completeOnboarding();
 
-        await test.step('Disconnect device', async () => {
+        await test.step('Disconnect device and wait for it to be recognized', async () => {
             await device.powerOff();
+            await page.expectReduxObjectToEqual('device.selectedDevice.connected', false);
         });
 
         await test.step('Navigate to device settings', async () => {
@@ -68,6 +67,7 @@ test.describe('Forget TS5', { tag: ['@T3T1', '@desktopOnly'] }, () => {
         await test.step('Confirm forget — no unplug modal should appear', async () => {
             await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
             await settingsPage.deviceTab.forgetConfirmButton.click();
+            await expect(settingsPage.deviceTab.forgetUnplugModal).toBeHidden();
         });
 
         await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -169,7 +169,11 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
 
         await test.step('Disconnect device and wait for it to be recognized', async () => {
             await device.powerOff();
-            await page.expectReduxObjectToEqual('device.selectedDevice.connected', false);
+            // T3W1 may either set connected=false or remove selectedDevice entirely on disconnect
+            await expect(async () => {
+                const connected = await page.getReduxObject('device.selectedDevice.connected');
+                expect(connected === false || connected === undefined).toBe(true);
+            }).toPass({ timeout: 15_000 });
         });
 
         await test.step('Navigate to device settings', async () => {

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -97,14 +97,14 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Verify landing on starting screen', async () => {
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
 
         await test.step('Reload and verify no wallet is remembered', async () => {
             await page.reload();
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
@@ -142,14 +142,14 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Verify landing on starting screen', async () => {
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
 
         await test.step('Reload and verify no wallet is remembered', async () => {
             await page.reload();
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -3,24 +3,22 @@ import { expect, test } from '../../support/fixtures';
 test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
 test.describe(
-    'Forget TS7 currently connected via Bluetooth',
+    'Forget TS7 with Bluetooth credentials (offline)',
     { tag: ['@T3W1', '@desktopOnly'] },
     () => {
         /**
-         * Tests the forget flow for a TS7 that is currently connected via Bluetooth
-         * (thp-bt-connected flow).
+         * Tests the forget flow for a TS7 that was previously connected via Bluetooth
+         * but is currently offline (thp-bt-known flow).
          *
-         * Since the emulator connects via USB, we:
+         * We cannot simulate a live BT connection because the emulator continuously
+         * sends USB device events that overwrite any descriptor patches. Instead we:
          * 1. Complete onboarding with the emulator
-         * 2. Dispatch a deviceChanged action with descriptor.apiType='bluetooth'
-         *    so the device appears BT-connected in the store
-         * 3. Inject a known BT device entry
-         * 4. Click "Forget device" → triggers ThpBtConnectedForgetFlow
-         * 5. After confirming, power off emulator so bleUnpair gets Device_Disconnected
-         *    (which the flow treats as a successful unpair)
-         * 6. Complete the BT removal modal and verify the device is forgotten
+         * 2. Power off the emulator so no events overwrite our state
+         * 3. Inject BT state (known device + persistent data)
+         * 4. Walk through the thp-bt-known flow: Confirmation → OS cleanup → Trezor cleanup → forget
+         * 5. Verify the device is fully forgotten after reload
          */
-        test('User can forget a BT-connected TS7 and no wallet is remembered', async ({
+        test('User can forget a TS7 with BT credentials and no wallet is remembered', async ({
             onboardingPage,
             settingsPage,
             page,
@@ -28,64 +26,57 @@ test.describe(
         }) => {
             await onboardingPage.completeOnboarding();
 
-            await test.step('Make device appear as BT-connected', async () => {
+            const deviceId: string = await test.step('Get device ID from Redux', async () => {
                 await page.ensureStoreOnDesktop();
 
-                await page.evaluate(() => {
-                    const state = window.store.getState();
-                    const { selectedDevice } = state.device;
-                    if (!selectedDevice) {
-                        throw new Error('No selected device found');
-                    }
-
-                    const devId = selectedDevice.id;
-
-                    // The reducer ignores BT descriptor changes when a USB device
-                    // is already connected (prioritizes USB). We need to patch the
-                    // descriptor directly on both selectedDevice and the devices array
-                    // so that getIsDeviceConnectedViaBluetooth returns true.
-                    selectedDevice.descriptor = {
-                        ...selectedDevice.descriptor,
-                        apiType: 'bluetooth',
-                    };
-
-                    // Set BT adapter as enabled
-                    window.store.dispatch({
-                        type: '@suite/bluetooth/adapter-event',
-                        payload: { status: 'enabled' },
-                    });
-
-                    // Add a known BT device linked to the emulator device
-                    window.store.dispatch({
-                        type: '@suite/bluetooth/known-devices-update',
-                        payload: {
-                            knownDevices: [
-                                {
-                                    id: 'fake-bt-device-001',
-                                    name: 'Trezor Safe 7',
-                                    manufacturerData: {
-                                        deviceModel: 'T3W1',
-                                        deviceColor: 0,
-                                    },
-                                    lastUpdatedTimestamp: Date.now(),
-                                    connectionStatus: { type: 'connected' },
-                                    deviceId: devId,
-                                },
-                            ],
-                        },
-                    });
-                });
+                return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
             });
 
-            await test.step('Verify device is seen as BT-connected in Redux', async () => {
-                const apiType = await page.evaluate(
-                    () => window.store.getState().device.selectedDevice?.descriptor?.apiType,
+            await test.step('Power off emulator to stop USB events', async () => {
+                await device.powerOff();
+            });
+
+            await test.step('Inject Bluetooth state', async () => {
+                await page.evaluate(
+                    ({ deviceId: devId }) => {
+                        // Set BT adapter as enabled
+                        window.store.dispatch({
+                            type: '@suite/bluetooth/adapter-event',
+                            payload: { status: 'enabled' },
+                        });
+
+                        // Add a known BT device linked to the emulator device
+                        window.store.dispatch({
+                            type: '@suite/bluetooth/known-devices-update',
+                            payload: {
+                                knownDevices: [
+                                    {
+                                        id: 'fake-bt-device-001',
+                                        name: 'Trezor Safe 7',
+                                        manufacturerData: {
+                                            deviceModel: 'T3W1',
+                                            deviceColor: 0,
+                                        },
+                                        lastUpdatedTimestamp: Date.now(),
+                                        connectionStatus: { type: 'disconnected' },
+                                        deviceId: devId,
+                                    },
+                                ],
+                            },
+                        });
+
+                        // Set lastConnectedVia to 'bluetooth' in persistent device data
+                        const entry = window.store
+                            .getState()
+                            .device.persistentDeviceData?.find(
+                                (d: { device_id: string }) => d.device_id === devId,
+                            );
+                        if (entry) {
+                            entry.lastConnectedVia = 'bluetooth';
+                        }
+                    },
+                    { deviceId },
                 );
-                if (apiType !== 'bluetooth') {
-                    throw new Error(
-                        `Expected descriptor.apiType to be 'bluetooth', got '${apiType}'`,
-                    );
-                }
             });
 
             await test.step('Navigate to device settings', async () => {
@@ -97,21 +88,20 @@ test.describe(
                 await page.getByTestId('@settings/device/forget-button').click();
             });
 
-            await test.step('Confirm forget and power off device to simulate BT disconnect', async () => {
-                // ThpBtConnectedForgetFlow step 1: ConfirmationModal
+            await test.step('Confirm forget in the confirmation modal', async () => {
+                // ThpBtKnownForgetFlow step 1: ConfirmationModal
                 await page.modal.waitFor({ state: 'visible' });
                 await page.getByTestId('@settings/device/forget-confirm').click();
-
-                // Power off immediately so bleUnpair gets Device_Disconnected,
-                // which the catch block handles and proceeds to bt-removal step
-                await device.powerOff();
             });
 
-            await test.step('Complete BT removal modal', async () => {
-                // ThpBtConnectedForgetFlow step 2: RemoveFromBluetoothSettingsModal
-                await page
-                    .getByTestId('@settings/device/forget-bt-removal-got-it')
-                    .click({ timeout: 30_000 });
+            await test.step('Complete OS removal step', async () => {
+                // ThpBtKnownForgetFlow step 2: OsAndTrezorCleanupModal
+                await page.modal.waitFor({ state: 'visible' });
+                await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
+            });
+
+            await test.step('Complete Trezor removal step', async () => {
+                await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
             });
 
             await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '../../support/fixtures';
 
-test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
-
 test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
     /**
      * Tests the forget flow for a TS7 that was previously connected via Bluetooth
@@ -169,8 +167,9 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
     }) => {
         await onboardingPage.completeOnboarding();
 
-        await test.step('Disconnect device', async () => {
+        await test.step('Disconnect device and wait for it to be recognized', async () => {
             await device.powerOff();
+            await page.expectReduxObjectToEqual('device.selectedDevice.connected', false);
         });
 
         await test.step('Navigate to device settings', async () => {
@@ -185,6 +184,7 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         await test.step('Confirm forget — no unplug modal should appear', async () => {
             await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
             await settingsPage.deviceTab.forgetConfirmButton.click();
+            await expect(settingsPage.deviceTab.forgetUnplugModal).toBeHidden();
         });
 
         await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '../../support/fixtures';
+
+test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+test.describe(
+    'Forget TS7 currently connected via Bluetooth',
+    { tag: ['@T3W1', '@desktopOnly'] },
+    () => {
+        /**
+         * Tests the forget flow for a TS7 that is currently connected via Bluetooth
+         * (thp-bt-connected flow).
+         *
+         * Since the emulator connects via USB, we:
+         * 1. Complete onboarding with the emulator
+         * 2. Dispatch a deviceChanged action with descriptor.apiType='bluetooth'
+         *    so the device appears BT-connected in the store
+         * 3. Inject a known BT device entry
+         * 4. Click "Forget device" → triggers ThpBtConnectedForgetFlow
+         * 5. After confirming, power off emulator so bleUnpair gets Device_Disconnected
+         *    (which the flow treats as a successful unpair)
+         * 6. Complete the BT removal modal and verify the device is forgotten
+         */
+        test('User can forget a BT-connected TS7 and no wallet is remembered', async ({
+            onboardingPage,
+            settingsPage,
+            page,
+            device,
+        }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Make device appear as BT-connected', async () => {
+                await page.ensureStoreOnDesktop();
+
+                await page.evaluate(() => {
+                    const state = window.store.getState();
+                    const { selectedDevice } = state.device;
+                    if (!selectedDevice) {
+                        throw new Error('No selected device found');
+                    }
+
+                    const devId = selectedDevice.id;
+
+                    // The reducer ignores BT descriptor changes when a USB device
+                    // is already connected (prioritizes USB). We need to patch the
+                    // descriptor directly on both selectedDevice and the devices array
+                    // so that getIsDeviceConnectedViaBluetooth returns true.
+                    selectedDevice.descriptor = {
+                        ...selectedDevice.descriptor,
+                        apiType: 'bluetooth',
+                    };
+
+                    // Set BT adapter as enabled
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/adapter-event',
+                        payload: { status: 'enabled' },
+                    });
+
+                    // Add a known BT device linked to the emulator device
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/known-devices-update',
+                        payload: {
+                            knownDevices: [
+                                {
+                                    id: 'fake-bt-device-001',
+                                    name: 'Trezor Safe 7',
+                                    manufacturerData: {
+                                        deviceModel: 'T3W1',
+                                        deviceColor: 0,
+                                    },
+                                    lastUpdatedTimestamp: Date.now(),
+                                    connectionStatus: { type: 'connected' },
+                                    deviceId: devId,
+                                },
+                            ],
+                        },
+                    });
+                });
+            });
+
+            await test.step('Verify device is seen as BT-connected in Redux', async () => {
+                const apiType = await page.evaluate(
+                    () => window.store.getState().device.selectedDevice?.descriptor?.apiType,
+                );
+                if (apiType !== 'bluetooth') {
+                    throw new Error(
+                        `Expected descriptor.apiType to be 'bluetooth', got '${apiType}'`,
+                    );
+                }
+            });
+
+            await test.step('Navigate to device settings', async () => {
+                await settingsPage.navigateTo('device');
+            });
+
+            await test.step('Click Forget device button', async () => {
+                await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+                await page.getByTestId('@settings/device/forget-button').click();
+            });
+
+            await test.step('Confirm forget and power off device to simulate BT disconnect', async () => {
+                // ThpBtConnectedForgetFlow step 1: ConfirmationModal
+                await page.modal.waitFor({ state: 'visible' });
+                await page.getByTestId('@settings/device/forget-confirm').click();
+
+                // Power off immediately so bleUnpair gets Device_Disconnected,
+                // which the catch block handles and proceeds to bt-removal step
+                await device.powerOff();
+            });
+
+            await test.step('Complete BT removal modal', async () => {
+                // ThpBtConnectedForgetFlow step 2: RemoveFromBluetoothSettingsModal
+                await page
+                    .getByTestId('@settings/device/forget-bt-removal-got-it')
+                    .click({ timeout: 30_000 });
+            });
+
+            await test.step('Verify landing on starting screen', async () => {
+                await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                    timeout: 30_000,
+                });
+            });
+
+            await test.step('Reload and verify no wallet is remembered', async () => {
+                await page.reload();
+                await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                    timeout: 30_000,
+                });
+            });
+        });
+    },
+);

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -26,7 +26,7 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         const deviceId: string = await test.step('Get device ID from Redux', async () => {
             await page.ensureStoreOnDesktop();
 
-            return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
+            return page.getReduxObject('device.selectedDevice.id');
         });
 
         await test.step('Power off emulator to stop USB events', async () => {
@@ -36,13 +36,11 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         await test.step('Inject Bluetooth state', async () => {
             await page.evaluate(
                 ({ deviceId: devId }) => {
-                    // Set BT adapter as enabled
                     window.store.dispatch({
                         type: '@suite/bluetooth/adapter-event',
                         payload: { status: 'enabled' },
                     });
 
-                    // Add a known BT device linked to the emulator device
                     window.store.dispatch({
                         type: '@suite/bluetooth/known-devices-update',
                         payload: {
@@ -62,7 +60,6 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
                         },
                     });
 
-                    // Set lastConnectedVia to 'bluetooth' in persistent device data
                     const entry = window.store
                         .getState()
                         .device.persistentDeviceData?.find(
@@ -81,28 +78,22 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Click Forget device button', async () => {
-            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-            await page.getByTestId('@settings/device/forget-button').click();
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
         await test.step('Confirm forget in the confirmation modal', async () => {
-            // ThpBtKnownForgetFlow step 1: ConfirmationModal
-            await page
-                .getByTestId('@settings/device/forget-confirmation-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-confirm').click();
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
         });
 
         await test.step('Complete OS removal step', async () => {
-            // ThpBtKnownForgetFlow step 2: OsAndTrezorCleanupModal
-            await page
-                .getByTestId('@settings/device/forget-cleanup-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
+            await expect(settingsPage.deviceTab.forgetCleanupModal).toBeVisible();
+            await settingsPage.deviceTab.forgetOsRemovalConfirmButton.click();
         });
 
         await test.step('Complete Trezor removal step', async () => {
-            await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
+            await settingsPage.deviceTab.forgetTrezorRemovalConfirmButton.click();
         });
 
         await test.step('Verify landing on starting screen', async () => {
@@ -141,16 +132,13 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
         });
 
         await test.step('Click Forget device button', async () => {
-            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-            await page.getByTestId('@settings/device/forget-button').click();
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
         await test.step('Confirm forget in the confirmation modal', async () => {
-            // ImmediateForgetFlow: ConfirmationModal → forget immediately
-            await page
-                .getByTestId('@settings/device/forget-confirmation-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-confirm').click();
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
         });
 
         await test.step('Verify landing on starting screen', async () => {

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -90,13 +90,17 @@ test.describe(
 
             await test.step('Confirm forget in the confirmation modal', async () => {
                 // ThpBtKnownForgetFlow step 1: ConfirmationModal
-                await page.modal.waitFor({ state: 'visible' });
+                await page
+                    .getByTestId('@settings/device/forget-confirmation-modal')
+                    .waitFor({ state: 'visible' });
                 await page.getByTestId('@settings/device/forget-confirm').click();
             });
 
             await test.step('Complete OS removal step', async () => {
                 // ThpBtKnownForgetFlow step 2: OsAndTrezorCleanupModal
-                await page.modal.waitFor({ state: 'visible' });
+                await page
+                    .getByTestId('@settings/device/forget-cleanup-modal')
+                    .waitFor({ state: 'visible' });
                 await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
             });
 

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -2,124 +2,168 @@ import { expect, test } from '../../support/fixtures';
 
 test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
 
-test.describe(
-    'Forget TS7 with Bluetooth credentials (offline)',
-    { tag: ['@T3W1', '@desktopOnly'] },
-    () => {
-        /**
-         * Tests the forget flow for a TS7 that was previously connected via Bluetooth
-         * but is currently offline (thp-bt-known flow).
-         *
-         * We cannot simulate a live BT connection because the emulator continuously
-         * sends USB device events that overwrite any descriptor patches. Instead we:
-         * 1. Complete onboarding with the emulator
-         * 2. Power off the emulator so no events overwrite our state
-         * 3. Inject BT state (known device + persistent data)
-         * 4. Walk through the thp-bt-known flow: Confirmation → OS cleanup → Trezor cleanup → forget
-         * 5. Verify the device is fully forgotten after reload
-         */
-        test('User can forget a TS7 with BT credentials and no wallet is remembered', async ({
-            onboardingPage,
-            settingsPage,
-            page,
-            device,
-        }) => {
-            await onboardingPage.completeOnboarding();
+test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
+    /**
+     * Tests the forget flow for a TS7 that was previously connected via Bluetooth
+     * but is currently offline (thp-bt-known flow).
+     *
+     * We cannot simulate a live BT connection because the emulator continuously
+     * sends USB device events that overwrite any descriptor patches. Instead we:
+     * 1. Complete onboarding with the emulator
+     * 2. Power off the emulator so no events overwrite our state
+     * 3. Inject BT state (known device + persistent data)
+     * 4. Walk through the thp-bt-known flow: Confirmation → OS cleanup → Trezor cleanup → forget
+     * 5. Verify the device is fully forgotten after reload
+     */
+    test('User can forget a TS7 with BT credentials and no wallet is remembered', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
 
-            const deviceId: string = await test.step('Get device ID from Redux', async () => {
-                await page.ensureStoreOnDesktop();
+        const deviceId: string = await test.step('Get device ID from Redux', async () => {
+            await page.ensureStoreOnDesktop();
 
-                return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
-            });
+            return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
+        });
 
-            await test.step('Power off emulator to stop USB events', async () => {
-                await device.powerOff();
-            });
+        await test.step('Power off emulator to stop USB events', async () => {
+            await device.powerOff();
+        });
 
-            await test.step('Inject Bluetooth state', async () => {
-                await page.evaluate(
-                    ({ deviceId: devId }) => {
-                        // Set BT adapter as enabled
-                        window.store.dispatch({
-                            type: '@suite/bluetooth/adapter-event',
-                            payload: { status: 'enabled' },
-                        });
+        await test.step('Inject Bluetooth state', async () => {
+            await page.evaluate(
+                ({ deviceId: devId }) => {
+                    // Set BT adapter as enabled
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/adapter-event',
+                        payload: { status: 'enabled' },
+                    });
 
-                        // Add a known BT device linked to the emulator device
-                        window.store.dispatch({
-                            type: '@suite/bluetooth/known-devices-update',
-                            payload: {
-                                knownDevices: [
-                                    {
-                                        id: 'fake-bt-device-001',
-                                        name: 'Trezor Safe 7',
-                                        manufacturerData: {
-                                            deviceModel: 'T3W1',
-                                            deviceColor: 0,
-                                        },
-                                        lastUpdatedTimestamp: Date.now(),
-                                        connectionStatus: { type: 'disconnected' },
-                                        deviceId: devId,
+                    // Add a known BT device linked to the emulator device
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/known-devices-update',
+                        payload: {
+                            knownDevices: [
+                                {
+                                    id: 'fake-bt-device-001',
+                                    name: 'Trezor Safe 7',
+                                    manufacturerData: {
+                                        deviceModel: 'T3W1',
+                                        deviceColor: 0,
                                     },
-                                ],
-                            },
-                        });
+                                    lastUpdatedTimestamp: Date.now(),
+                                    connectionStatus: { type: 'disconnected' },
+                                    deviceId: devId,
+                                },
+                            ],
+                        },
+                    });
 
-                        // Set lastConnectedVia to 'bluetooth' in persistent device data
-                        const entry = window.store
-                            .getState()
-                            .device.persistentDeviceData?.find(
-                                (d: { device_id: string }) => d.device_id === devId,
-                            );
-                        if (entry) {
-                            entry.lastConnectedVia = 'bluetooth';
-                        }
-                    },
-                    { deviceId },
-                );
-            });
+                    // Set lastConnectedVia to 'bluetooth' in persistent device data
+                    const entry = window.store
+                        .getState()
+                        .device.persistentDeviceData?.find(
+                            (d: { device_id: string }) => d.device_id === devId,
+                        );
+                    if (entry) {
+                        entry.lastConnectedVia = 'bluetooth';
+                    }
+                },
+                { deviceId },
+            );
+        });
 
-            await test.step('Navigate to device settings', async () => {
-                await settingsPage.navigateTo('device');
-            });
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
 
-            await test.step('Click Forget device button', async () => {
-                await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-                await page.getByTestId('@settings/device/forget-button').click();
-            });
+        await test.step('Click Forget device button', async () => {
+            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+            await page.getByTestId('@settings/device/forget-button').click();
+        });
 
-            await test.step('Confirm forget in the confirmation modal', async () => {
-                // ThpBtKnownForgetFlow step 1: ConfirmationModal
-                await page
-                    .getByTestId('@settings/device/forget-confirmation-modal')
-                    .waitFor({ state: 'visible' });
-                await page.getByTestId('@settings/device/forget-confirm').click();
-            });
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            // ThpBtKnownForgetFlow step 1: ConfirmationModal
+            await page
+                .getByTestId('@settings/device/forget-confirmation-modal')
+                .waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-confirm').click();
+        });
 
-            await test.step('Complete OS removal step', async () => {
-                // ThpBtKnownForgetFlow step 2: OsAndTrezorCleanupModal
-                await page
-                    .getByTestId('@settings/device/forget-cleanup-modal')
-                    .waitFor({ state: 'visible' });
-                await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
-            });
+        await test.step('Complete OS removal step', async () => {
+            // ThpBtKnownForgetFlow step 2: OsAndTrezorCleanupModal
+            await page
+                .getByTestId('@settings/device/forget-cleanup-modal')
+                .waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
+        });
 
-            await test.step('Complete Trezor removal step', async () => {
-                await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
-            });
+        await test.step('Complete Trezor removal step', async () => {
+            await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
+        });
 
-            await test.step('Verify landing on starting screen', async () => {
-                await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
-                    timeout: 30_000,
-                });
-            });
-
-            await test.step('Reload and verify no wallet is remembered', async () => {
-                await page.reload();
-                await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
-                    timeout: 30_000,
-                });
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
             });
         });
-    },
-);
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+
+    /**
+     * Tests the forget flow for a disconnected TS7 with no Bluetooth credentials
+     * (thp-disconnected → ImmediateForgetFlow).
+     * Confirmation → forget immediately, no unplug or cleanup steps.
+     */
+    test('User can forget a disconnected TS7 without BT credentials immediately', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
+
+        await test.step('Power off emulator to simulate disconnected device', async () => {
+            await device.powerOff();
+        });
+
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
+
+        await test.step('Click Forget device button', async () => {
+            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+            await page.getByTestId('@settings/device/forget-button').click();
+        });
+
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            // ImmediateForgetFlow: ConfirmationModal → forget immediately
+            await page
+                .getByTestId('@settings/device/forget-confirmation-modal')
+                .waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-confirm').click();
+        });
+
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+});

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-connected-device.test.ts
@@ -111,11 +111,11 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
     });
 
     /**
-     * Tests the forget flow for a disconnected TS7 with no Bluetooth credentials
-     * (thp-disconnected → ImmediateForgetFlow).
-     * Confirmation → forget immediately, no unplug or cleanup steps.
+     * Tests the forget flow for a TS7 without Bluetooth credentials,
+     * connected via cable. After confirmation, the unplug modal appears
+     * and the device is disconnected to complete the forget.
      */
-    test('User can forget a disconnected TS7 without BT credentials immediately', async ({
+    test('User can forget a cable-connected TS7 without BT credentials after unplugging', async ({
         onboardingPage,
         settingsPage,
         page,
@@ -123,7 +123,53 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
     }) => {
         await onboardingPage.completeOnboarding();
 
-        await test.step('Power off emulator to simulate disconnected device', async () => {
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
+
+        await test.step('Click Forget device button', async () => {
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
+        });
+
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
+        });
+
+        await test.step('Wait for unplug modal and disconnect device', async () => {
+            await expect(settingsPage.deviceTab.forgetUnplugModal).toBeVisible();
+            await device.powerOff();
+        });
+
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(onboardingPage.welcomeBody).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(onboardingPage.welcomeBody).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+
+    /**
+     * Tests the forget flow for an already disconnected TS7 without BT credentials
+     * (thp-disconnected → ImmediateForgetFlow).
+     * No unplug modal should appear — forget happens immediately after confirmation.
+     */
+    test('User can forget an already disconnected TS7 immediately without unplug modal', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
+
+        await test.step('Disconnect device', async () => {
             await device.powerOff();
         });
 
@@ -136,7 +182,7 @@ test.describe('Forget TS7', { tag: ['@T3W1', '@desktopOnly'] }, () => {
             await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
-        await test.step('Confirm forget in the confirmation modal', async () => {
+        await test.step('Confirm forget — no unplug modal should appear', async () => {
             await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
             await settingsPage.deviceTab.forgetConfirmButton.click();
         });

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
@@ -96,14 +96,14 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
         });
 
         await test.step('Verify landing on starting screen', async () => {
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });
 
         await test.step('Reload and verify no wallet is remembered', async () => {
             await page.reload();
-            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+            await expect(onboardingPage.welcomeBody).toBeVisible({
                 timeout: 30_000,
             });
         });

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '../../support/fixtures';
+
+test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
+
+test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@desktopOnly'] }, () => {
+    /**
+     * Tests the forget flow for a TS7 connected via cable that also has
+     * Bluetooth credentials (thp-cable-connected flow).
+     *
+     * Since the emulator cannot simulate a real Bluetooth connection, we:
+     * 1. Complete onboarding with the emulator (USB-connected TS7)
+     * 2. Inject BT state (known device + persistent data) to simulate BT history
+     * 3. Walk through the forget flow: Confirmation → OS cleanup → Trezor cleanup → Unplug → forget
+     * 4. Verify the device is fully forgotten after reload
+     */
+    test('User can forget a TS7 with BT credentials and no wallet is remembered', async ({
+        onboardingPage,
+        settingsPage,
+        page,
+        device,
+    }) => {
+        await onboardingPage.completeOnboarding();
+
+        const deviceId: string = await test.step('Get device ID from Redux', async () => {
+            await page.ensureStoreOnDesktop();
+
+            return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
+        });
+
+        await test.step('Inject Bluetooth state to simulate known BT device', async () => {
+            await page.evaluate(
+                ({ deviceId: devId }) => {
+                    // Set BT adapter as enabled
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/adapter-event',
+                        payload: { status: 'enabled' },
+                    });
+
+                    // Add a known BT device linked to the emulator device
+                    window.store.dispatch({
+                        type: '@suite/bluetooth/known-devices-update',
+                        payload: {
+                            knownDevices: [
+                                {
+                                    id: 'fake-bt-device-001',
+                                    name: 'Trezor Safe 7',
+                                    manufacturerData: {
+                                        deviceModel: 'T3W1',
+                                        deviceColor: 0,
+                                    },
+                                    lastUpdatedTimestamp: Date.now(),
+                                    connectionStatus: { type: 'disconnected' },
+                                    deviceId: devId,
+                                },
+                            ],
+                        },
+                    });
+
+                    // Set lastConnectedVia to 'bluetooth' in persistent device data
+                    const entry = window.store
+                        .getState()
+                        .device.persistentDeviceData?.find(
+                            (d: { device_id: string }) => d.device_id === devId,
+                        );
+                    if (entry) {
+                        entry.lastConnectedVia = 'bluetooth';
+                    }
+                },
+                { deviceId },
+            );
+        });
+
+        await test.step('Navigate to device settings', async () => {
+            await settingsPage.navigateTo('device');
+        });
+
+        await test.step('Click Forget device button', async () => {
+            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
+            await page.getByTestId('@settings/device/forget-button').click();
+        });
+
+        await test.step('Confirm forget in the confirmation modal', async () => {
+            // ThpCableConnectedForgetFlow step 1: ConfirmationModal
+            await page.modal.waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-confirm').click();
+        });
+
+        await test.step('Complete OS removal step', async () => {
+            // ThpCableConnectedForgetFlow step 2: OsAndTrezorCleanupModal
+            await page.modal.waitFor({ state: 'visible' });
+            await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
+        });
+
+        await test.step('Complete Trezor removal step', async () => {
+            await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
+        });
+
+        await test.step('Unplug device to complete forget', async () => {
+            // ThpCableConnectedForgetFlow step 3: UnplugDeviceModal
+            // Power off the emulator to simulate unplugging
+            await page.modal.waitFor({ state: 'visible' });
+            await device.powerOff();
+        });
+
+        await test.step('Verify landing on starting screen', async () => {
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+
+        await test.step('Reload and verify no wallet is remembered', async () => {
+            await page.reload();
+            await expect(page.getByTestId('@welcome-layout/body')).toBeVisible({
+                timeout: 30_000,
+            });
+        });
+    });
+});

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
@@ -81,13 +81,17 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
 
         await test.step('Confirm forget in the confirmation modal', async () => {
             // ThpCableConnectedForgetFlow step 1: ConfirmationModal
-            await page.modal.waitFor({ state: 'visible' });
+            await page
+                .getByTestId('@settings/device/forget-confirmation-modal')
+                .waitFor({ state: 'visible' });
             await page.getByTestId('@settings/device/forget-confirm').click();
         });
 
         await test.step('Complete OS removal step', async () => {
             // ThpCableConnectedForgetFlow step 2: OsAndTrezorCleanupModal
-            await page.modal.waitFor({ state: 'visible' });
+            await page
+                .getByTestId('@settings/device/forget-cleanup-modal')
+                .waitFor({ state: 'visible' });
             await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
         });
 
@@ -97,8 +101,9 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
 
         await test.step('Unplug device to complete forget', async () => {
             // ThpCableConnectedForgetFlow step 3: UnplugDeviceModal
-            // Power off the emulator to simulate unplugging
-            await page.modal.waitFor({ state: 'visible' });
+            await page
+                .getByTestId('@settings/device/forget-unplug-modal')
+                .waitFor({ state: 'visible' });
             await device.powerOff();
         });
 

--- a/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
+++ b/suite/e2e/tests/settings/t3w1-forget-bluetooth-device.test.ts
@@ -24,19 +24,17 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
         const deviceId: string = await test.step('Get device ID from Redux', async () => {
             await page.ensureStoreOnDesktop();
 
-            return page.evaluate(() => window.store.getState().device.selectedDevice?.id);
+            return page.getReduxObject('device.selectedDevice.id');
         });
 
         await test.step('Inject Bluetooth state to simulate known BT device', async () => {
             await page.evaluate(
                 ({ deviceId: devId }) => {
-                    // Set BT adapter as enabled
                     window.store.dispatch({
                         type: '@suite/bluetooth/adapter-event',
                         payload: { status: 'enabled' },
                     });
 
-                    // Add a known BT device linked to the emulator device
                     window.store.dispatch({
                         type: '@suite/bluetooth/known-devices-update',
                         payload: {
@@ -56,7 +54,6 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
                         },
                     });
 
-                    // Set lastConnectedVia to 'bluetooth' in persistent device data
                     const entry = window.store
                         .getState()
                         .device.persistentDeviceData?.find(
@@ -75,35 +72,26 @@ test.describe('Forget TS7 with Bluetooth credentials', { tag: ['@T3W1', '@deskto
         });
 
         await test.step('Click Forget device button', async () => {
-            await page.getByTestId('@settings/device/forget-button').scrollIntoViewIfNeeded();
-            await page.getByTestId('@settings/device/forget-button').click();
+            await settingsPage.deviceTab.forgetDeviceButton.scrollIntoViewIfNeeded();
+            await settingsPage.deviceTab.forgetDeviceButton.click();
         });
 
         await test.step('Confirm forget in the confirmation modal', async () => {
-            // ThpCableConnectedForgetFlow step 1: ConfirmationModal
-            await page
-                .getByTestId('@settings/device/forget-confirmation-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-confirm').click();
+            await expect(settingsPage.deviceTab.forgetConfirmationModal).toBeVisible();
+            await settingsPage.deviceTab.forgetConfirmButton.click();
         });
 
         await test.step('Complete OS removal step', async () => {
-            // ThpCableConnectedForgetFlow step 2: OsAndTrezorCleanupModal
-            await page
-                .getByTestId('@settings/device/forget-cleanup-modal')
-                .waitFor({ state: 'visible' });
-            await page.getByTestId('@settings/device/forget-os-removal-confirm').click();
+            await expect(settingsPage.deviceTab.forgetCleanupModal).toBeVisible();
+            await settingsPage.deviceTab.forgetOsRemovalConfirmButton.click();
         });
 
         await test.step('Complete Trezor removal step', async () => {
-            await page.getByTestId('@settings/device/forget-trezor-removal-confirm').click();
+            await settingsPage.deviceTab.forgetTrezorRemovalConfirmButton.click();
         });
 
         await test.step('Unplug device to complete forget', async () => {
-            // ThpCableConnectedForgetFlow step 3: UnplugDeviceModal
-            await page
-                .getByTestId('@settings/device/forget-unplug-modal')
-                .waitFor({ state: 'visible' });
+            await expect(settingsPage.deviceTab.forgetUnplugModal).toBeVisible();
             await device.powerOff();
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Vibed simple test cases for the at least 2 scenarios - when the device is just non-thp and when a THP device is connected and has been earileir connected with BT

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26422

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=26422-e2e-test-for-forgetting&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=26422-e2e-test-for-forgetting&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T12:58:16.948Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T10:41:03.526Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->