### PR TITLE
feat: bump evolu version

### DIFF
--- a/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/QuotaManagerSettings.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import {
     DEFAULT_QUOTA_MANAGER_URL,
+    DEV_QUOTA_MANAGER_URL,
+    PRODUCTION_QUOTA_MANAGER_URL,
     enforceQuotaManagerUpdated,
     eraseFetchedData,
     selectEnforceQuotaManager,
@@ -10,11 +12,13 @@ import {
     selectRegisteredDevices,
     updateQuotaManagerBaseUrl,
 } from '@suite-common/suite-sync-quota-manager';
-import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
+import { Button, ButtonGroup, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+
+const LOCAL_QUOTA_MANAGER_URL = 'http://127.0.0.1:4001/quota-manager/';
 
 export const QuotaManagerSettings = () => {
     const dispatch = useDispatch();
@@ -27,18 +31,13 @@ export const QuotaManagerSettings = () => {
 
     const [isUpdateUrlLoading, setIsUpdateUrlLoading] = useState(false);
 
-    const onQuotaManagerBaseUrlSave = () => {
+    const onQuotaManagerBaseUrlSave = (baseUrl = quotaManagerUrl) => {
         setIsUpdateUrlLoading(true);
 
-        const normalizedUrl =
-            quotaManagerUrl.trim() === '' ? DEFAULT_QUOTA_MANAGER_URL : quotaManagerUrl;
+        const normalizedUrl = baseUrl.trim() === '' ? DEFAULT_QUOTA_MANAGER_URL : baseUrl;
 
         setQuotaManagerUrl(normalizedUrl);
-        dispatch(
-            updateQuotaManagerBaseUrl({
-                baseUrl: normalizedUrl,
-            }),
-        );
+        dispatch(updateQuotaManagerBaseUrl({ baseUrl: normalizedUrl }));
 
         // fake ui loading delay
         setTimeout(() => {
@@ -47,6 +46,11 @@ export const QuotaManagerSettings = () => {
     };
 
     const onEraseFetchedData = () => dispatch(eraseFetchedData());
+
+    const onQuotaManagerUrlPresetClick = (baseUrl: string) => {
+        setQuotaManagerUrl(baseUrl);
+        onQuotaManagerBaseUrlSave(baseUrl);
+    };
 
     const onToggleEnforceQuotaManager = () =>
         dispatch(
@@ -69,7 +73,7 @@ export const QuotaManagerSettings = () => {
                             rightContent={
                                 <Button
                                     data-testid="@settings/debug/quota-manager-url-save-button"
-                                    onClick={onQuotaManagerBaseUrlSave}
+                                    onClick={() => onQuotaManagerBaseUrlSave()}
                                     size="small"
                                     isLoading={isUpdateUrlLoading}
                                 >
@@ -80,6 +84,33 @@ export const QuotaManagerSettings = () => {
                         <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
                             Default is: <Code>{DEFAULT_QUOTA_MANAGER_URL}</Code>
                         </Text>
+                        <ButtonGroup size="small" priority="secondary">
+                            <Button
+                                intent="critical"
+                                isDisabled={isUpdateUrlLoading}
+                                onClick={() =>
+                                    onQuotaManagerUrlPresetClick(PRODUCTION_QUOTA_MANAGER_URL)
+                                }
+                            >
+                                Production
+                            </Button>
+                            <Button
+                                intent="brand"
+                                isDisabled={isUpdateUrlLoading}
+                                onClick={() => onQuotaManagerUrlPresetClick(DEV_QUOTA_MANAGER_URL)}
+                            >
+                                Dev
+                            </Button>
+                            <Button
+                                intent="info"
+                                isDisabled={isUpdateUrlLoading}
+                                onClick={() =>
+                                    onQuotaManagerUrlPresetClick(LOCAL_QUOTA_MANAGER_URL)
+                                }
+                            >
+                                Local
+                            </Button>
+                        </ButtonGroup>
                     </Column>
                 </ActionColumn>
             </SectionItem>

--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -15,7 +15,7 @@
         "ws": "^8.18.0"
     },
     "devDependencies": {
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@suite-common/suite-sync-evolu": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite-common/suite-sync-evolu/package.json
+++ b/suite-common/suite-sync-evolu/package.json
@@ -12,7 +12,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@suite-common/suite-sync-storage": "workspace:*",
         "@suite-common/suite-sync-types": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
@@ -21,7 +21,7 @@
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {
-        "@evolu/nodejs": "3.0.0-next.0",
+        "@evolu/nodejs": "3.0.0-next.1",
         "@trezor/eslint": "workspace:*"
     }
 }

--- a/suite-common/suite-sync-quota-manager/src/constants.ts
+++ b/suite-common/suite-sync-quota-manager/src/constants.ts
@@ -16,9 +16,13 @@ export const DEFAULT_ACCOUNT_SIZE_QUOTA = Math.round(DEFAULT_DEVICE_SIZE_QUOTA /
  */
 export const DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA = DEFAULT_ACCOUNT_SIZE_QUOTA;
 
+export const PRODUCTION_QUOTA_MANAGER_URL = 'https://suite-sync.trezor.io/quota-manager/';
+
+export const DEV_QUOTA_MANAGER_URL = 'https://suite-sync-dev.suite.sldev.cz/quota-manager/';
+
 export const DEFAULT_QUOTA_MANAGER_URL = isCodesignBuild()
-    ? 'https://suite-sync.trezor.io/quota-manager/'
-    : 'https://suite-sync-dev.suite.sldev.cz/quota-manager/';
+    ? PRODUCTION_QUOTA_MANAGER_URL
+    : DEV_QUOTA_MANAGER_URL;
 
 /**
  * Header used for signing add space to owner requests.

--- a/suite-common/suite-sync-quota-manager/src/index.ts
+++ b/suite-common/suite-sync-quota-manager/src/index.ts
@@ -57,6 +57,11 @@ export {
 /**
  * Constants.
  */
-export { DEFAULT_DEVICE_SIZE_QUOTA, DEFAULT_QUOTA_MANAGER_URL } from './constants';
+export {
+    DEFAULT_DEVICE_SIZE_QUOTA,
+    DEFAULT_QUOTA_MANAGER_URL,
+    DEV_QUOTA_MANAGER_URL,
+    PRODUCTION_QUOTA_MANAGER_URL,
+} from './constants';
 
 export { getAccountIncrementSizeQuota } from './util/getAccountIncrementSizeQuota';

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -23,7 +23,12 @@ export {
     setSuiteSyncOwner,
 } from './suiteSyncSlice';
 export type { SuiteSyncState, SuiteSyncSettings } from './suiteSyncSlice';
-export { DEFAULT_SUITE_SYNC_RELAY_URL, SUITE_SYNC_RELAY_SERVERS } from './relay/relayUrl';
+export {
+    DEFAULT_SUITE_SYNC_RELAY_URL,
+    DEFAULT_SUITE_SYNC_RELAY_URL_DEV,
+    DEFAULT_SUITE_SYNC_RELAY_URL_PROD,
+    SUITE_SYNC_RELAY_SERVERS,
+} from './relay/relayUrl';
 export type {
     SuiteSyncServerTypeSelectValue,
     SuiteSyncServerTypeOption,

--- a/suite-common/suite-sync/src/relay/relayUrl.ts
+++ b/suite-common/suite-sync/src/relay/relayUrl.ts
@@ -1,7 +1,7 @@
 import { isCodesignBuild } from '@trezor/env-utils';
 
-const DEFAULT_SUITE_SYNC_RELAY_URL_DEV = 'https://suite-sync-dev.suite.sldev.cz/evolu/';
-const DEFAULT_SUITE_SYNC_RELAY_URL_PROD = 'https://suite-sync.trezor.io/evolu/';
+export const DEFAULT_SUITE_SYNC_RELAY_URL_DEV = 'https://suite-sync-dev.suite.sldev.cz/evolu/';
+export const DEFAULT_SUITE_SYNC_RELAY_URL_PROD = 'https://suite-sync.trezor.io/evolu/';
 
 export const SUITE_SYNC_RELAY_SERVERS = [
     DEFAULT_SUITE_SYNC_RELAY_URL_DEV,

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@bitcoinerlab/secp256k1": "1.2.0",
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@evolu/react-native": "15.0.0-next.0",
         "@exodus/patch-broken-hermes-typed-arrays": "^1.0.0-alpha.1",
         "@gorhom/bottom-sheet": "5.2.8",

--- a/suite-native/suite-sync/package.json
+++ b/suite-native/suite-sync/package.json
@@ -12,7 +12,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@evolu/react-native": "15.0.0-next.0",
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/delegated-identity-key-types": "workspace:*",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@currents/playwright": "^1.21.2",
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@playwright/browser-chromium": "1.57.0",
         "@playwright/browser-firefox": "1.57.0",
         "@playwright/browser-webkit": "1.57.0",

--- a/suite/suite-sync/package.json
+++ b/suite/suite-sync/package.json
@@ -11,7 +11,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@evolu/common": "8.0.0-next.0",
+        "@evolu/common": "8.0.0-next.1",
         "@evolu/web": "3.0.0-next.0",
         "@hookform/resolvers": "^3.3.4",
         "@reduxjs/toolkit": "2.11.2",

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -3,18 +3,22 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
     DEFAULT_SUITE_SYNC_RELAY_URL,
+    DEFAULT_SUITE_SYNC_RELAY_URL_DEV,
+    DEFAULT_SUITE_SYNC_RELAY_URL_PROD,
     selectIsSuiteSyncDebugEnabled,
     selectIsSuiteSyncFeatureAvailable,
     selectSuiteSyncRelayUrl,
     updateSuiteSyncDebugEnabled,
 } from '@suite-common/suite-sync';
 import { type SuiteSync } from '@suite-common/suite-sync-types';
-import { Button, Checkbox, Code, Column, Input, Text } from '@trezor/components';
+import { Button, ButtonGroup, Checkbox, Code, Column, Input, Text } from '@trezor/components';
 import { ActionColumn, SectionItem, SettingsSection, TextColumn } from '@trezor/product-components';
 import { type BreakpointFlags } from '@trezor/theme';
 import { spacings } from '@trezor/theme';
 
 const selectIsBelowLaptop = (state: { window: BreakpointFlags }) => state.window.isBelowLaptop;
+
+const LOCAL_SUITE_SYNC_RELAY_URL = 'http://127.0.0.1:4000/evolu/';
 
 type SuiteSyncSettingsProps = {
     suiteSync: SuiteSync;
@@ -33,22 +37,25 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
     const [relayUrl, setRelayUrl] = useState(suiteSyncRelayUrl ?? '');
 
     const handleToggleSuiteSyncDebug = () => {
-        dispatch(
-            updateSuiteSyncDebugEnabled({
-                isEnabled: !isSuiteSyncDebugEnabled,
-            }),
-        );
+        dispatch(updateSuiteSyncDebugEnabled({ isEnabled: !isSuiteSyncDebugEnabled }));
     };
 
-    const onRelayUrlSave = async () => {
+    const onRelayUrlSave = async (url = relayUrl) => {
         setIsLoading(true);
 
-        await suiteSync.changeRelayUrl({ relayUrl });
+        setRelayUrl(url);
+
+        await suiteSync.changeRelayUrl({ relayUrl: url });
 
         // Fake it, to make some UI interaction for the user
         setTimeout(() => {
             setIsLoading(false);
         }, 300);
+    };
+
+    const onRelayUrlPresetClick = (url: string) => {
+        setRelayUrl(url);
+        void onRelayUrlSave(url);
     };
 
     if (!isSuiteSyncFeatureEnabled) return null;
@@ -68,7 +75,7 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                                 <Button
                                     data-testid="@settings/debug/suite-sync/save-button"
                                     isLoading={isLoading}
-                                    onClick={onRelayUrlSave}
+                                    onClick={() => onRelayUrlSave()}
                                     size="small"
                                 >
                                     Save
@@ -78,6 +85,33 @@ export const SuiteSyncSettings = ({ suiteSync }: SuiteSyncSettingsProps) => {
                         <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
                             Default is: <Code>{DEFAULT_SUITE_SYNC_RELAY_URL}</Code>
                         </Text>
+                        <ButtonGroup size="small" priority="secondary">
+                            <Button
+                                intent="critical"
+                                isDisabled={isLoading}
+                                onClick={() =>
+                                    onRelayUrlPresetClick(DEFAULT_SUITE_SYNC_RELAY_URL_PROD)
+                                }
+                            >
+                                Production
+                            </Button>
+                            <Button
+                                intent="brand"
+                                isDisabled={isLoading}
+                                onClick={() =>
+                                    onRelayUrlPresetClick(DEFAULT_SUITE_SYNC_RELAY_URL_DEV)
+                                }
+                            >
+                                Dev
+                            </Button>
+                            <Button
+                                intent="info"
+                                isDisabled={isLoading}
+                                onClick={() => onRelayUrlPresetClick(LOCAL_SUITE_SYNC_RELAY_URL)}
+                            >
+                                Local
+                            </Button>
+                        </ButtonGroup>
                     </Column>
                 </ActionColumn>
             </SectionItem>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3879,9 +3879,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@evolu/common@npm:8.0.0-next.0":
-  version: 8.0.0-next.0
-  resolution: "@evolu/common@npm:8.0.0-next.0"
+"@evolu/common@npm:8.0.0-next.1":
+  version: 8.0.0-next.1
+  resolution: "@evolu/common@npm:8.0.0-next.1"
   dependencies:
     "@noble/ciphers": "npm:^2.1.1"
     "@noble/hashes": "npm:^2.0.1"
@@ -3889,19 +3889,19 @@ __metadata:
     kysely: "npm:^0.28.15"
     msgpackr: "npm:^1.11.8"
     random: "npm:^5.4.1"
-  checksum: 10/030b931b0b45d7e598283046b432ddb37eec4726cf4b90657c2c0bd79f373c7776bc253144c01c4ddce26364003ac94d7b9538954bcedfb5edfa14e856de5cb4
+  checksum: 10/6bd9c5e9a4fd2d2f09bbcd57a66c55626086a932d918254ce94394c65e39ee3492716fffc3c603155c4061c10a831950e5a2709035c9562092e32677b1ab17cf
   languageName: node
   linkType: hard
 
-"@evolu/nodejs@npm:3.0.0-next.0":
-  version: 3.0.0-next.0
-  resolution: "@evolu/nodejs@npm:3.0.0-next.0"
+"@evolu/nodejs@npm:3.0.0-next.1":
+  version: 3.0.0-next.1
+  resolution: "@evolu/nodejs@npm:3.0.0-next.1"
   dependencies:
     better-sqlite3: "npm:^12.6.2"
     ws: "npm:^8.19.0"
   peerDependencies:
     "@evolu/common": ^8.0.0-next.0
-  checksum: 10/915ef6430baab1bba264e0cc71190f5b565bbbf93c1f31dfc02070c5be91de59b466041cf5bd418eb3f621e48eb888e6eeedcb98c488df5702b3399390378762
+  checksum: 10/74033b87898199e1099f41f9beba5a1114770e0c8763405a73053575860871336571b35db9eaa9d68dbb4ad0aecfc462c5afd7b26400718fd13c53a0687f8cb3
   languageName: node
   linkType: hard
 
@@ -10719,7 +10719,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/e2e-evolu-client@workspace:suite-common/e2e-evolu-client"
   dependencies:
-    "@evolu/common": "npm:8.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
     "@suite-common/suite-sync-evolu": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -11127,8 +11127,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/suite-sync-evolu@workspace:suite-common/suite-sync-evolu"
   dependencies:
-    "@evolu/common": "npm:8.0.0-next.0"
-    "@evolu/nodejs": "npm:3.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
+    "@evolu/nodejs": "npm:3.0.0-next.1"
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/suite-sync-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -11706,7 +11706,7 @@ __metadata:
     "@bitcoinerlab/secp256k1": "npm:1.2.0"
     "@config-plugins/detox": "npm:^11.0.0"
     "@currents/cmd": "npm:^1.9.4"
-    "@evolu/common": "npm:8.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
     "@evolu/react-native": "npm:15.0.0-next.0"
     "@exodus/patch-broken-hermes-typed-arrays": "npm:^1.0.0-alpha.1"
     "@gorhom/bottom-sheet": "npm:5.2.8"
@@ -13910,7 +13910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/suite-sync@workspace:suite-native/suite-sync"
   dependencies:
-    "@evolu/common": "npm:8.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
     "@evolu/react-native": "npm:15.0.0-next.0"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/delegated-identity-key-types": "workspace:*"
@@ -14612,7 +14612,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite/suite-sync@workspace:suite/suite-sync"
   dependencies:
-    "@evolu/common": "npm:8.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
     "@evolu/web": "npm:3.0.0-next.0"
     "@hookform/resolvers": "npm:^3.3.4"
     "@reduxjs/toolkit": "npm:2.11.2"
@@ -15873,7 +15873,7 @@ __metadata:
   resolution: "@trezor/suite-e2e@workspace:suite/e2e"
   dependencies:
     "@currents/playwright": "npm:^1.21.2"
-    "@evolu/common": "npm:8.0.0-next.0"
+    "@evolu/common": "npm:8.0.0-next.1"
     "@playwright/browser-chromium": "npm:1.57.0"
     "@playwright/browser-firefox": "npm:1.57.0"
     "@playwright/browser-webkit": "npm:1.57.0"


### PR DESCRIPTION


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=bump-evolu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=bump-evolu&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=bump-evolu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T10:41:52.729Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T10:43:01.647Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->