### PR TITLE
fix(suite-native): alert

### DIFF
--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -1,4 +1,11 @@
-import { AppName, type Evolu, type Run, createEvolu, getOrThrow } from '@evolu/common';
+import {
+    type AbortError,
+    AppName,
+    type Evolu,
+    type Result,
+    type Run,
+    createEvolu,
+} from '@evolu/common';
 import { type EvoluPlatformDeps } from '@evolu/common/local-first';
 
 import { type SuiteSyncOwner } from '@suite-common/suite-sync-storage';
@@ -17,8 +24,7 @@ type CreateEvoluInstanceFactoryDeps = {
 
 export type CreateEvoluInstance = (params: {
     suiteSyncOwner: SuiteSyncOwner;
-}) => Promise<Evolu<typeof Schema>>;
-
+}) => Promise<Result<Evolu<typeof Schema>, AbortError>>;
 export type CreateEvoluInstanceDep = {
     createEvoluInstance: CreateEvoluInstance;
 };
@@ -42,15 +48,13 @@ export const createEvoluInstanceFactory =
             throw appName.error;
         }
 
-        return getOrThrow(
-            await deps.run(
-                createEvolu(Schema, {
-                    appName: appName.value,
-                    // Intentionally no transport, transport will be passed
-                    // later on, so we can change the RelayUrl at any time.
-                    transports: [],
-                    appOwner: owner.value,
-                }),
-            ),
+        return await deps.run(
+            createEvolu(Schema, {
+                appName: appName.value,
+                // Intentionally no transport, transport will be passed
+                // later on, so we can change the RelayUrl at any time.
+                transports: [],
+                appOwner: owner.value,
+            }),
         );
     };

--- a/suite-common/suite-sync-evolu/src/data/addressTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/addressTable.ts
@@ -127,7 +127,16 @@ export class AddressEvoluTable implements AddressTable {
             const deviceLabels = this.evolu.getQueryRows(query);
             process(deviceLabels);
         });
-        this.evolu.loadQuery(query).then(process);
+
+        console.log('start');
+        this.evolu
+            .loadQuery(query)
+            .then(labels => {
+                console.log('tada');
+                process(labels);
+            })
+            .catch(() => console.log('e'));
+        console.log('end');
 
         return unsubscribe;
     };

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -25,9 +25,15 @@ export const createEvoluStorageFactory =
 
         let unuseOwner = () => {};
 
-        const evolu = await deps.createEvoluInstance({
+        const evoluResult = await deps.createEvoluInstance({
             suiteSyncOwner,
         });
+
+        if (!evoluResult.ok) {
+            throw evoluResult.error;
+        }
+
+        const evolu = evoluResult.value;
 
         const updateRelayUrl = async (url: string) => {
             const owner = await evolu.appOwner;
@@ -51,10 +57,9 @@ export const createEvoluStorageFactory =
             },
 
             updateRelayUrl,
-            dispose: async () => {
+            dispose: async (): Promise<void> => {
                 unuseOwner();
-                evolu[Symbol.asyncDispose]();
-                await Promise.resolve();
+                await evolu[Symbol.asyncDispose]();
             },
         };
     };

--- a/suite-common/suite-sync-types/src/storage/turnOffSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync-types/src/storage/turnOffSuiteSyncForWallet.ts
@@ -2,7 +2,7 @@ import { type StaticSessionId } from '@trezor/connect';
 
 export type TurnOffSuiteSyncForWallet = (params: {
     deviceStaticSessionId: StaticSessionId;
-}) => Promise<void>;
+}) => void;
 
 export type TurnOffSuiteSyncForWalletDep = {
     turnOffSuiteSyncForWallet: TurnOffSuiteSyncForWallet;

--- a/suite-common/suite-sync/src/data/createEnsureSubscribeSuiteSyncData.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribeSuiteSyncData.ts
@@ -18,12 +18,15 @@ export type CreateSubscribeSuiteSyncDataDeps = EnsureStorageDep &
 export const createEnsureSubscribeSuiteSyncData =
     (deps: CreateSubscribeSuiteSyncDataDeps): SubscribeSuiteSyncData =>
     async ({ deviceStaticSessionId, isWriteMode }): ReturnType<SubscribeSuiteSyncData> => {
+        console.log('createEnsureSubscribeSuiteSyncData#1');
         const storageResult = await deps.ensureStorage({
             deviceStaticSessionId,
             isWriteMode,
         });
 
         if (!storageResult.success) {
+            console.log('createEnsureSubscribeSuiteSyncData#2 !storageResult.success');
+
             return storageResult;
         }
 
@@ -32,6 +35,10 @@ export const createEnsureSubscribeSuiteSyncData =
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
 
         if (deps.subscriptionStorage.has(storageId)) {
+            console.log(
+                'createEnsureSubscribeSuiteSyncData#3 deps.subscriptionStorage.has(storageId)',
+            );
+
             return storageResult;
         }
 
@@ -65,6 +72,8 @@ export const createEnsureSubscribeSuiteSyncData =
                 listener.onUnsubscribe({ walletDescriptor });
             },
         });
+
+        console.log('subscribed');
 
         return ok(storageResult.payload);
     };

--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -89,9 +89,9 @@ export const createEnsureStorage =
             isWriteMode,
         });
 
-        // correct approach would be to create a new storage anyway, but currently there is bug regarding the dispose function
-        const resolvedStorage =
-            storage ?? (await deps.createSuiteStorage({ suiteSyncOwner: owner }));
+        console.log('before new storage');
+        const resolvedStorage = await deps.createSuiteStorage({ suiteSyncOwner: owner });
+        console.log('after new storage');
 
         // Only connect to the relay if quota is actually allocated.
         if (quotaResult.success) {

--- a/suite-native/alerts/src/alertsAtoms.ts
+++ b/suite-native/alerts/src/alertsAtoms.ts
@@ -32,6 +32,7 @@ export type Alert = {
     secondaryButtonTitle?: ReactNode;
     secondaryButtonVariant?: ButtonColorScheme;
     onPressSecondaryButton?: () => void;
+    shouldExecuteCallbackBeforeClosing?: boolean;
     appendix?: ReactNode;
     testID?: string;
     titleSpacing?: NativeSpacing;

--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -90,16 +90,27 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
         secondaryButtonVariant = 'tertiaryElevation1',
         appendix,
         testID,
+        shouldExecuteCallbackBeforeClosing = false,
     } = alert;
 
     const handlePressPrimaryButton = async () => {
-        await onPressPrimaryButton?.();
-        await closeSheetAnimated();
+        if (shouldExecuteCallbackBeforeClosing) {
+            onPressPrimaryButton?.();
+            await closeSheetAnimated();
+        } else {
+            await closeSheetAnimated();
+            await onPressPrimaryButton?.();
+        }
     };
 
     const handlePressSecondaryButton = async () => {
-        await onPressSecondaryButton?.();
-        await closeSheetAnimated();
+        if (shouldExecuteCallbackBeforeClosing) {
+            onPressSecondaryButton?.();
+            await closeSheetAnimated();
+        } else {
+            await closeSheetAnimated();
+            await onPressSecondaryButton?.();
+        }
     };
 
     return (

--- a/suite-native/app/globalPolyfills.js
+++ b/suite-native/app/globalPolyfills.js
@@ -41,6 +41,7 @@ isSupersetOf.shim();
 symmetricDifference.shim();
 union.shim();
 
+// TODO understand this
 // Evolu requires Explicit Resource Management polyfills (Symbol.dispose, Symbol.asyncDispose,
 // AsyncDisposableStack, etc.) that Hermes doesn't support natively yet.
 installReactNativePolyfills();
@@ -51,6 +52,8 @@ if (typeof Promise.try !== 'function') {
         return new Promise(resolve => resolve(callbackfn(...args)));
     };
 }
+
+console.log(globalThis.AsyncDisposableStack);
 
 // Promise.withResolvers is an ES2024 feature that may not be supported by Hermes.
 if (typeof Promise.withResolvers !== 'function') {

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -25,16 +25,14 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
 
     if (!isLabellingAllowed) return null;
 
+    const handlePress = () => {
+        Keyboard.dismiss();
+        handleAddLabel(openModal);
+    };
+
     return (
         <>
-            <TextButton
-                onPress={() => {
-                    Keyboard.dismiss();
-                    handleAddLabel(openModal);
-                }}
-                viewRight="pencil"
-                testID={testID}
-            >
+            <TextButton onPress={handlePress} viewRight="pencil" testID={testID}>
                 {label ?? <Translation id="suiteSync.addLabel" />}
             </TextButton>
             <BottomSheetModal

--- a/suite-native/module-settings/src/components/useContactSupportAlert.tsx
+++ b/suite-native/module-settings/src/components/useContactSupportAlert.tsx
@@ -30,6 +30,7 @@ export const useContactSupportAlert = () => {
                 }
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+            shouldExecuteCallbackBeforeClosing: true,
             testID: '@contact-support-alert',
         });
     }, [showAlert, openLink]);

--- a/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
+++ b/suite-native/suite-sync/src/createSuiteSyncNativeCompositionRoot.ts
@@ -31,7 +31,7 @@ export const createSuiteSyncNativeCompositionRoot = (
     deps: SuiteSyncNativeCompositionRootDeps,
 ): SuiteSync => {
     const console = createConsole({
-        level: 'warn',
+        level: 'debug',
         formatter: createConsoleFormatter()({ timestampFormat: 'absolute' }),
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/alert&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/alert&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/alert&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T12:39:58.310Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T12:38:56.163Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->