### PR TITLE
feat(suite): align tron send tx review modal with device

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -183,6 +183,9 @@ export const TransactionReviewModalBodyInner = ({
     };
 
     const isCancelRbfAction = isRbfCancelTransaction(precomposedTx);
+    const showSummary =
+        !(isBumpFeeRbfAction && networkType === 'bitcoin') &&
+        !(networkType === 'tron' && !precomposedTx.feeLimit);
 
     const isTxExpired = hasTxValidityExpired(deadline);
 
@@ -229,7 +232,7 @@ export const TransactionReviewModalBodyInner = ({
         <ConnectModalBackdrop canSwitchDevice>
             {!isRbfConfirmedError && (
                 <TransactionReviewModalConfirmOnDevice
-                    outputs={outputs}
+                    totalSteps={outputs.length + (showSummary ? 1 : 0)}
                     serializedTx={serializedTx}
                     isSending={isSending}
                     reviewStep={reviewStep}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalConfirmOnDevice.tsx
@@ -3,11 +3,10 @@ import { useSelector } from 'react-redux';
 import { Translation } from '@suite/intl';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type SerializedTx } from '@suite-common/wallet-core';
-import { type ReviewOutput } from '@suite-common/wallet-types';
 import { ConfirmOnDevicePill } from '@trezor/product-components';
 
 type TransactionReviewModalConfirmOnDeviceProps = {
-    outputs: ReviewOutput[];
+    totalSteps: number;
     serializedTx: SerializedTx | undefined;
     isSending: boolean;
     reviewStep: number;
@@ -15,7 +14,7 @@ type TransactionReviewModalConfirmOnDeviceProps = {
 };
 
 export const TransactionReviewModalConfirmOnDevice = ({
-    outputs,
+    totalSteps,
     serializedTx,
     isSending,
     reviewStep,
@@ -29,8 +28,8 @@ export const TransactionReviewModalConfirmOnDevice = ({
     return (
         <ConfirmOnDevicePill
             title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-            steps={outputs.length + 1}
-            activeStep={serializedTx ? outputs.length + 2 : offsetReviewStep}
+            steps={totalSteps}
+            activeStep={serializedTx ? totalSteps + 1 : Math.min(offsetReviewStep, totalSteps)}
             deviceModelInternal={deviceModelInternal}
             deviceUnitColor={device?.features?.unit_color}
             successText={<Translation id="TR_CONFIRMED_TX" />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -25,6 +25,7 @@ import type { Account } from 'src/types/wallet';
 
 import { TransactionReviewOutput } from './TransactionReviewOutput';
 import { TransactionReviewTotalOutput } from './TransactionReviewTotalOutput';
+import { TransactionReviewTronFeeLimitOutput } from './TransactionReviewTronFeeLimitOutput';
 import { TransactionReviewVerifyAddress } from './TransactionReviewVerifyAddress';
 import { getTransactionReviewState } from './getTransactionReviewState';
 
@@ -186,7 +187,7 @@ export const TransactionReviewOutputList = ({
                 );
             })}
 
-            {!(isRbfAction && networkType === 'bitcoin') && (
+            {!(isRbfAction && networkType === 'bitcoin') && networkType !== 'tron' && (
                 <Wrapper ref={totalOutputRef}>
                     <Column gap={spacings.sm}>
                         {isMultirecipient && summaryIndex === -1 && (
@@ -203,6 +204,17 @@ export const TransactionReviewOutputList = ({
                             isRbf={isRbfAction}
                         />
                     </Column>
+                </Wrapper>
+            )}
+
+            {networkType === 'tron' && 'token' in precomposedTx && precomposedTx.token && (
+                <Wrapper ref={totalOutputRef}>
+                    <TransactionReviewTronFeeLimitOutput
+                        account={account}
+                        state={reviewState}
+                        precomposedForm={precomposedForm}
+                        precomposedTx={precomposedTx}
+                    />
                 </Wrapper>
             )}
         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTronFeeLimitOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTronFeeLimitOutput.tsx
@@ -1,0 +1,57 @@
+import { Translation } from '@suite/intl';
+import { selectLanguage } from '@suite/settings';
+import {
+    type FormState,
+    type GeneralPrecomposedTransactionFinal,
+    type StakeFormState,
+} from '@suite-common/wallet-types';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+import { type Account } from 'src/types/wallet';
+
+import {
+    TransactionReviewOutputElement,
+    type TransactionReviewOutputElementProps,
+} from './TransactionReviewOutputElement';
+
+type TransactionReviewTronFeeLimitOutputProps = {
+    state: TransactionReviewOutputElementProps['state'];
+    precomposedForm: FormState | StakeFormState;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
+    account: Account;
+};
+
+export const TransactionReviewTronFeeLimitOutput = ({
+    state,
+    precomposedForm,
+    precomposedTx,
+    account,
+}: TransactionReviewTronFeeLimitOutputProps) => {
+    const locale = useSelector(selectLanguage);
+
+    if (!('token' in precomposedTx) || !precomposedTx.token) {
+        return null;
+    }
+
+    const feeLimitSun =
+        precomposedForm.feeLimit !== ''
+            ? precomposedForm.feeLimit
+            : (precomposedTx.estimatedFeeLimit ?? precomposedTx.fee);
+
+    return (
+        <TransactionReviewOutputElement
+            title={<Translation id="TR_SUMMARY" />}
+            account={account}
+            lines={[
+                {
+                    id: 'fee-limit',
+                    label: <Translation id="TR_FEE_LIMIT" />,
+                    value: `${localizeNumber(feeLimitSun, locale)} SUN`,
+                    type: 'default',
+                },
+            ]}
+            state={state}
+        />
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5365,6 +5365,10 @@ export const messages = defineMessages({
         id: 'TR_TRON_FEE_LIMIT_BELOW_RECOMMENDED',
         defaultMessage: 'Fee limit too low',
     },
+    TR_FEE_LIMIT: {
+        id: 'TR_FEE_LIMIT',
+        defaultMessage: 'Fee limit',
+    },
     TR_EXPERIMENTAL_TRON_VIEW_ONLY: {
         id: 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
         defaultMessage: 'Tron (Beta)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aligns the transaction review modal with what the device displays when sending TRX/TRC-20 tokens. For TRX native transfers, the "Total including fee" step is removed. For TRC-20 transfers, it is replaced with a "Fee limit" step showing the `fee_limit` value in SUN.

## Notes for QA

Tx review modal steps should be aligned with the device (all networks!)

## Screenshots:

### TRX transfer

<img width="627" height="568" alt="image" src="https://github.com/user-attachments/assets/625edb23-ddd9-47d9-963b-6aa710ad36f1" />

### TRC20

<img width="627" height="658" alt="image" src="https://github.com/user-attachments/assets/bb81eeed-a01f-4b18-967f-4daf0ff4dc27" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T12:40:13.609Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T12:38:56.810Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->