### PR TITLE
feat(suite): create UI for Tron account activation fee

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
@@ -1,7 +1,12 @@
 import { useTranslation } from '@suite/intl';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
-import { calculateTronFeeBreakdown } from '@suite-common/wallet-utils';
+import {
+    asAmountSubunit,
+    calculateTronFeeBreakdown,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
 import { Note } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite';
 import { type Account } from 'src/types/wallet';
@@ -21,13 +26,27 @@ export const TransactionReviewTronFeeNotes = ({
     const { trxBurned, coveredEnergy, coveredBandwidth } =
         calculateTronFeeBreakdown(tx, tronResources, account.symbol) ?? {};
 
+    const accountActivationFee = 'accountActivationFee' in tx ? tx.accountActivationFee : undefined;
+
+    const totalTrxBurned =
+        trxBurned && accountActivationFee
+            ? trxBurned.plus(
+                  new BigNumber(
+                      subunitsToUnits({
+                          value: asAmountSubunit(new BigNumber(accountActivationFee)),
+                          symbol: account.symbol,
+                      }),
+                  ),
+              )
+            : trxBurned;
+
     return (
         <>
-            {trxBurned && !trxBurned.isZero() && (
+            {totalTrxBurned && !totalTrxBurned.isZero() && (
                 <Note iconName="receipt">
                     <FormattedCryptoAmount
                         disableHiddenPlaceholder
-                        value={trxBurned.toString()}
+                        value={totalTrxBurned.toString()}
                         symbol={account.symbol}
                     />
                 </Note>

--- a/packages/suite/src/views/wallet/send/Outputs/Outputs.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Outputs.tsx
@@ -15,6 +15,7 @@ import { Amount } from './Amount/Amount';
 import { CardanoMinAmountInfo } from './CardanoMinAmountInfo';
 import { OpReturn } from './OpReturn';
 import { TokenSelect } from './TokenSelect/TokenSelect';
+import { TronNewAccountInfo } from './TronNewAccountInfo';
 import { DestinationTag } from '../Options/MiscNetworkOptions/DestinationTag';
 
 const Container = styled.div<{ $height: number }>`
@@ -99,6 +100,7 @@ export const Outputs = ({ disableAnim }: OutputsProps) => {
                                             {outputs.length === 1 && isSendingTokens && (
                                                 <CardanoMinAmountInfo />
                                             )}
+                                            <TronNewAccountInfo />
                                             <DestinationTag networkSymbol={symbol} />
                                         </Column>
                                     )}

--- a/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
@@ -1,0 +1,52 @@
+import { Translation } from '@suite/intl';
+import { formatNetworkAmount } from '@suite-common/wallet-utils';
+import { InfoItem, Tooltip } from '@trezor/components';
+
+import { FormattedCryptoAmount } from 'src/components/suite';
+import { useSendFormContext } from 'src/hooks/wallet';
+
+export const TronNewAccountInfo = () => {
+    const {
+        account: { symbol, networkType },
+        composedLevels,
+        getValues,
+    } = useSendFormContext();
+
+    if (networkType !== 'tron') return null;
+
+    const selectedFee = getValues().selectedFee || 'normal';
+    const transactionInfo = composedLevels ? composedLevels[selectedFee] : undefined;
+    const hasTransactionInfo = transactionInfo !== undefined && transactionInfo.type !== 'error';
+
+    if (!hasTransactionInfo) return null;
+
+    const accountActivationFee =
+        'accountActivationFee' in transactionInfo
+            ? transactionInfo.accountActivationFee
+            : undefined;
+
+    if (!accountActivationFee) return null;
+
+    return (
+        <InfoItem
+            direction="row"
+            typographyStyle="body-md"
+            priority="primary"
+            label={
+                <Tooltip
+                    hasIcon
+                    maxWidth={328}
+                    content={<Translation id="TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP" />}
+                >
+                    <Translation id="TR_TRON_ACCOUNT_ACTIVATION_FEE" />
+                </Tooltip>
+            }
+        >
+            <FormattedCryptoAmount
+                disableHiddenPlaceholder
+                value={formatNetworkAmount(accountActivationFee, symbol)}
+                symbol={symbol}
+            />
+        </InfoItem>
+    );
+};

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -133,9 +133,8 @@ const calculateTrxTransfer = (
     bytes: number,
 ): PrecomposedTransaction => {
     const baseFeeInSun = feeLevel.feePerTx || '0';
-    const totalFeeInSun = isNewAccount
-        ? new BigNumber(baseFeeInSun).plus(TRON_ACCOUNT_ACTIVATION_FEE_SUN).toString()
-        : baseFeeInSun;
+    const activationFeeInSun = isNewAccount ? TRON_ACCOUNT_ACTIVATION_FEE_SUN : 0;
+    const totalFeeInSun = new BigNumber(baseFeeInSun).plus(activationFeeInSun).toString();
     const isSendMax = output.type === 'send-max' || output.type === 'send-max-noaddress';
 
     let amount: string;
@@ -160,7 +159,8 @@ const calculateTrxTransfer = (
         type: 'nonfinal' as const,
         totalSpent: calculateTotal(amount, totalFeeInSun),
         max,
-        fee: totalFeeInSun,
+        fee: baseFeeInSun,
+        accountActivationFee: isNewAccount ? String(TRON_ACCOUNT_ACTIVATION_FEE_SUN) : undefined,
         feePerByte: feeLevel.feePerUnit,
         bytes,
         inputs: [],

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -146,6 +146,7 @@ export type PrecomposedTransactionNonFinal = PrecomposedTransactionConnectRespon
     estimatedFeeLimit?: string;
     token?: TokenInfo;
     energyConsumed?: number;
+    accountActivationFee?: string;
 };
 
 // base of PrecomposedTransactionFinal
@@ -155,6 +156,7 @@ type PrecomposedTransactionBase = PrecomposedTransactionConnectResponseFinal & {
     estimatedFeeLimit?: string;
     token?: TokenInfo;
     energyConsumed?: number;
+    accountActivationFee?: string;
     /** override the network's native token
      * used with EVMs that are used via Connect, but not natively supported in Suite */
     nativeToken?: TokenInfo;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5398,6 +5398,14 @@ export const messages = defineMessages({
         id: 'TR_FEE_LIMIT',
         defaultMessage: 'Fee limit',
     },
+    TR_TRON_ACCOUNT_ACTIVATION_FEE: {
+        id: 'TR_TRON_ACCOUNT_ACTIVATION_FEE',
+        defaultMessage: 'Activation fee',
+    },
+    TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP: {
+        id: 'TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP',
+        defaultMessage: 'New TRON accounts require a one-time 1 TRX network fee to activate.',
+    },
     TR_EXPERIMENTAL_TRON_VIEW_ONLY: {
         id: 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
         defaultMessage: 'Tron (Beta)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added new UI to better represent Tron account activation fee

## Notes for QA


## Screenshots:
<img width="748" height="832" alt="image" src="https://github.com/user-attachments/assets/ca75a792-e41e-4263-9ef4-690c73ba5d99" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-activation-fee-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-activation-fee-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-activation-fee-ui&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T13:45:34.895Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T13:44:24.920Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->