### PR TITLE
chore: unify package.json publishConfig

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - [Naming](skills/naming/SKILL.md) – Naming conventions for variables, functions, and files
 - [Packages](skills/packages/SKILL.md) – How to create and structure packages
 - [Project Overview](skills/project-structure/SKILL.md) – What Trezor Suite is and how the monorepo is organized
+- [Publish Config](skills/publish-config/SKILL.md) – publishConfig rules for public npm packages
 - [Redux](skills/redux/SKILL.md) – Redux Toolkit patterns and best practices
 - [Setup Requirements](skills/setup-requirements/SKILL.md) – Prerequisites and initial environment setup
 - [Tests](skills/tests/SKILL.md) – Test style guidelines and best practices

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -9,13 +9,28 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
-            "./lib/constants": "./lib/constants/index.js",
-            "./libESM/*": "./libESM/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/constants": {
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
+            },
+            "./libESM/constants": {
+                "types": "./libESM/constants/index.d.mts",
+                "default": "./libESM/constants/index.mjs"
+            }
         }
     },
     "files": [

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -9,11 +9,19 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
             "./libESM/*": "./libESM/*"
         }
     },

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/blockchain-link",
     "description": "High-level javascript interface for blockchain communication",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -38,11 +38,19 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
             "./libESM/*": "./libESM/*"
         },
         "browser": {

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -14,7 +14,6 @@
     "bugs": {
         "url": "https://github.com/trezor/trezor-suite/issues"
     },
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "description": "Collection of assets and utils used by trezor-connect library.",
     "main": "./src/index.ts",

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -28,34 +28,52 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/constants": {
+                "types": "./lib/constants/index.d.ts",
+                "default": "./lib/constants/index.js"
+            },
+            "./libESM/constants": {
+                "types": "./libESM/constants/index.d.mts",
+                "default": "./libESM/constants/index.mjs"
+            },
+            "./lib/data": {
+                "types": "./lib/data/index.d.ts",
+                "default": "./lib/data/index.js"
+            },
+            "./libESM/data": {
+                "types": "./libESM/data/index.d.mts",
+                "default": "./libESM/data/index.mjs"
+            },
             "./lib/events": {
                 "types": "./lib/events/index.d.ts",
                 "default": "./lib/events/index.js"
+            },
+            "./libESM/events": {
+                "types": "./libESM/events/index.d.mts",
+                "default": "./libESM/events/index.mjs"
             },
             "./lib/types": {
                 "types": "./lib/types/index.d.ts",
                 "default": "./lib/types/index.js"
             },
-            "./lib/data": "./lib/data/index.js",
-            "./lib/data/*": "./lib/data/*.js",
-            "./lib/constants": "./lib/constants/index.js",
-            "./lib/constants/*": "./lib/constants/*.js",
-            "./libESM/*": "./libESM/*",
-            "./libESM/events": {
-                "types": "./libESM/events/index.d.mts",
-                "default": "./libESM/events/index.mjs"
-            },
             "./libESM/types": {
                 "types": "./libESM/types/index.d.mts",
                 "default": "./libESM/types/index.mjs"
-            },
-            "./libESM/constants/*": "./libESM/constants/*",
-            "./libESM/data/*": "./libESM/data/*"
+            }
         }
     },
     "scripts": {

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -30,13 +30,21 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
-            "./files/*": "./files/*",
-            "./libESM/*": "./libESM/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./files/*": "./files/*"
         }
     },
     "scripts": {

--- a/packages/connect-data/package.json
+++ b/packages/connect-data/package.json
@@ -14,7 +14,6 @@
     "bugs": {
         "url": "https://github.com/trezor/trezor-suite/issues"
     },
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "description": "Data used by trezor-connect library.",
     "main": "./src/index.ts",

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -5,16 +5,32 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "lib/index.js"
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "exports": {
+            ".": {
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
+            }
+        }
     },
     "npmPublishAccess": "public",
     "files": [
-        "lib/"
+        "lib/",
+        "libESM/"
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
+        "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -20,7 +20,6 @@
             }
         }
     },
-    "npmPublishAccess": "public",
     "files": [
         "lib/",
         "libESM/"

--- a/packages/connect-mobile/tsconfig.libESM.json
+++ b/packages/connect-mobile/tsconfig.libESM.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../tsconfig.libESM.json",
+    "include": ["./src"],
+    "compilerOptions": {
+        "outDir": "./libESM"
+    },
+    "references": [
+        {
+            "path": "../connect-common"
+        },
+        {
+            "path": "../utils"
+        }
+    ]
+}

--- a/packages/connect-plugin-ethereum/package.json
+++ b/packages/connect-plugin-ethereum/package.json
@@ -23,9 +23,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/connect-plugin-stellar/package.json
+++ b/packages/connect-plugin-stellar/package.json
@@ -24,9 +24,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -22,7 +22,6 @@
     "main": "src/index.ts",
     "publishConfig": {
         "main": "./lib/index.js",
-        "module": "./libESM/index.mjs",
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
@@ -39,10 +38,7 @@
                 "types": "./lib/impl/*.d.ts",
                 "default": "./lib/impl/*.js"
             },
-            "./libESM/impl/*": {
-                "types": "./libESM/impl/*.d.mts",
-                "default": "./libESM/impl/*.mjs"
-            }
+            "./libESM/impl/*": "./libESM/impl/*"
         }
     },
     "files": [

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-web",
     "description": "High-level javascript interface for Trezor hardware wallet in web environment.",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -26,9 +26,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect-webextension",
     "description": "High-level javascript interface for Trezor hardware wallet in webextension serviceworker environment.",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -34,7 +34,6 @@
     },
     "publishConfig": {
         "main": "./lib/index.js",
-        "module": "./libESM/index.mjs",
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
@@ -47,16 +46,19 @@
                     "default": "./lib/index.js"
                 }
             },
-            "./lib/data/*": "./lib/data/*.js",
-            "./lib/events": "./lib/events/index.js",
-            "./lib/exports": "./lib/exports.js",
-            "./lib/impl/*": "./lib/impl/*.js",
-            "./lib/utils/*": "./lib/utils/*.js",
-            "./libESM/data/*": "./libESM/data/*",
-            "./libESM/events/index.mjs": "./libESM/events/index.mjs",
-            "./libESM/exports.mjs": "./libESM/exports.mjs",
-            "./libESM/impl/*": "./libESM/impl/*",
-            "./libESM/utils/*": "./libESM/utils/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/events": {
+                "types": "./lib/events/index.d.ts",
+                "default": "./lib/events/index.js"
+            },
+            "./libESM/events": {
+                "types": "./libESM/events/index.d.mts",
+                "default": "./libESM/events/index.mjs"
+            }
         },
         "browser": {
             "./lib/index.js": "./lib/index-browser.js",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/connect",
     "description": "High-level javascript interface for Trezor hardware wallet.",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -14,7 +14,6 @@
     "bugs": {
         "url": "https://github.com/trezor/trezor-suite/issues"
     },
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "description": "Collection of crypto utilities",
     "sideEffects": false,

--- a/packages/crypto-utils/package.json
+++ b/packages/crypto-utils/package.json
@@ -29,11 +29,19 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
             "./libESM/*": "./libESM/*"
         }
     },

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/device-authenticity",
     "description": "Utils for authenticity verification of trezor device secure element response.",
-    "npmPublishAccess": "public",
     "license": "See LICENSE.md in repo root",
     "repository": {
         "type": "git",

--- a/packages/device-authenticity/package.json
+++ b/packages/device-authenticity/package.json
@@ -19,9 +19,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -9,9 +9,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -14,10 +14,24 @@
     "sideEffects": false,
     "main": "src/index.ts",
     "publishConfig": {
-        "main": "lib/index.js"
+        "main": "./lib/index.js",
+        "types": "./lib/index.d.ts",
+        "exports": {
+            ".": {
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
+            }
+        }
     },
     "files": [
         "lib/",
+        "libESM/",
         "CHANGELOG.md"
     ],
     "scripts": {
@@ -25,7 +39,9 @@
         "type-check": "yarn g:tsc --build",
         "test:unit": "yarn g:jest",
         "test-unit:watch": "yarn g:jest -o --watch",
-        "build:lib": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
+        "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "peerDependencies": {

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -2,7 +2,6 @@
     "name": "@trezor/env-utils",
     "version": "10.0.0-alpha.1",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/env-utils",
-    "npmPublishAccess": "public",
     "license": "See LICENSE.md in repo root",
     "repository": {
         "type": "git",

--- a/packages/env-utils/tsconfig.libESM.json
+++ b/packages/env-utils/tsconfig.libESM.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.libESM.json",
+    "include": ["./src"],
+    "compilerOptions": {
+        "outDir": "./libESM"
+    },
+    "references": []
+}

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -16,12 +16,28 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
             "./libESM/*": "./libESM/*",
+            "./lib/definitions": {
+                "types": "./lib/definitions/index.d.ts",
+                "default": "./lib/definitions/index.js"
+            },
+            "./libESM/definitions": {
+                "types": "./libESM/definitions/index.d.mts",
+                "default": "./libESM/definitions/index.mjs"
+            },
             "./messages.json": "./messages.json"
         }
     },

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -41,7 +41,6 @@
             "./messages.json": "./messages.json"
         }
     },
-    "npmPublishAccess": "public",
     "files": [
         "lib/",
         "libESM/",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -16,15 +16,44 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
-            "./lib/protocol-thp": "./lib/protocol-thp/index.js",
-            "./lib/protocol-thp/messages": "./lib/protocol-thp/messages/index.js",
-            "./lib/protocol-tpn": "./lib/protocol-tpn/index.js",
-            "./libESM/*": "./libESM/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/protocol-thp": {
+                "types": "./lib/protocol-thp/index.d.ts",
+                "default": "./lib/protocol-thp/index.js"
+            },
+            "./libESM/protocol-thp": {
+                "types": "./libESM/protocol-thp/index.d.mts",
+                "default": "./libESM/protocol-thp/index.mjs"
+            },
+            "./lib/protocol-thp/messages": {
+                "types": "./lib/protocol-thp/messages/index.d.ts",
+                "default": "./lib/protocol-thp/messages/index.js"
+            },
+            "./libESM/protocol-thp/messages": {
+                "types": "./libESM/protocol-thp/messages/index.d.mts",
+                "default": "./libESM/protocol-thp/messages/index.mjs"
+            },
+            "./lib/protocol-tpn": {
+                "types": "./lib/protocol-tpn/index.d.ts",
+                "default": "./lib/protocol-tpn/index.js"
+            },
+            "./libESM/protocol-tpn": {
+                "types": "./libESM/protocol-tpn/index.d.mts",
+                "default": "./libESM/protocol-tpn/index.mjs"
+            }
         }
     },
     "npmPublishAccess": "public",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -56,7 +56,6 @@
             }
         }
     },
-    "npmPublishAccess": "public",
     "files": [
         "lib/",
         "libESM/",

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -2,9 +2,11 @@ import type { Requirement, RequirementScope } from './Requirement';
 import { requireAgentsSkills } from './agents-skills/requireAgentsSkills';
 import { requireDocsSummary } from './docs-summary/requireDocsSummary';
 import { requirePackageJsonScripts } from './package-json/requirePackageJsonScripts';
+import { requirePublishConfig } from './package-json/requirePublishConfig';
 
 export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireAgentsSkills,
     requireDocsSummary,
     requirePackageJsonScripts,
+    requirePublishConfig,
 ];

--- a/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
+++ b/packages/requirements/src/requirements/package-json/__tests__/requirePublishConfig.test.ts
@@ -1,0 +1,386 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { WorkspaceContext } from '../../Requirement';
+import { requirePublishConfig } from '../requirePublishConfig';
+
+const createTempWorkspace = (): string => mkdtempSync(join(tmpdir(), 'publish-config-'));
+
+const validPublicPackageJson = {
+    name: '@trezor/example',
+    main: 'src/index.ts',
+    publishConfig: {
+        main: './lib/index.js',
+        types: './lib/index.d.ts',
+        exports: {
+            '.': {
+                import: { types: './libESM/index.d.mts', default: './libESM/index.mjs' },
+                require: { types: './lib/index.d.ts', default: './lib/index.js' },
+            },
+            './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+            './libESM/*': './libESM/*',
+        },
+    },
+    files: ['lib/', 'libESM/', 'CHANGELOG.md'],
+};
+
+describe(requirePublishConfig.name, () => {
+    let workspaceDir: string;
+    let context: WorkspaceContext;
+
+    beforeEach(() => {
+        workspaceDir = createTempWorkspace();
+        context = {
+            repoRoot: '/repo',
+            workspaceDir,
+            workspaceName: '@trezor/example',
+        };
+    });
+
+    afterEach(() => {
+        rmSync(workspaceDir, { recursive: true, force: true });
+    });
+
+    it('has workspace scope', () => {
+        expect(requirePublishConfig.scope).toBe('workspace');
+    });
+
+    describe('applies', () => {
+        it('applies to packages with publishConfig.exports', () => {
+            writeFileSync(
+                join(workspaceDir, 'package.json'),
+                JSON.stringify({ publishConfig: { exports: { '.': {} } } }),
+            );
+
+            expect(requirePublishConfig.applies?.(context)).toBe(true);
+        });
+
+        it('applies to packages with publishConfig but no exports', () => {
+            writeFileSync(
+                join(workspaceDir, 'package.json'),
+                JSON.stringify({ publishConfig: { main: './lib/index.js' } }),
+            );
+
+            expect(requirePublishConfig.applies?.(context)).toBe(true);
+        });
+
+        it('does not apply to private packages without publishConfig', () => {
+            writeFileSync(
+                join(workspaceDir, 'package.json'),
+                JSON.stringify({ name: '@trezor/example', private: true }),
+            );
+
+            expect(requirePublishConfig.applies?.(context)).toBe(false);
+        });
+
+        it('returns false when package.json is missing', () => {
+            expect(requirePublishConfig.applies?.(context)).toBe(false);
+        });
+    });
+
+    describe('verify - public package fields', () => {
+        it('passes for a valid fully-configured public package', async () => {
+            writeFileSync(
+                join(workspaceDir, 'package.json'),
+                JSON.stringify(validPublicPackageJson),
+            );
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toEqual([]);
+        });
+
+        it('reports missing top-level main field', async () => {
+            const { main: _, ...withoutMain } = validPublicPackageJson;
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(withoutMain));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Missing top-level "main" field');
+        });
+
+        it('reports missing publishConfig.main', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    main: undefined,
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Missing "publishConfig.main" field');
+        });
+
+        it('reports missing publishConfig.types', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    types: undefined,
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Missing "publishConfig.types" field');
+        });
+
+        it('reports missing lib/ in files array', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                files: ['libESM/', 'CHANGELOG.md'],
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: "files" must include "lib/"');
+        });
+
+        it('reports missing libESM/ in files array', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                files: ['lib/', 'CHANGELOG.md'],
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: "files" must include "libESM/"');
+        });
+
+        it('accepts "lib" (without trailing slash) in files array', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                files: ['lib', 'libESM'],
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors.filter(e => e.includes('"files"'))).toEqual([]);
+        });
+    });
+
+    describe('verify - exports shape', () => {
+        it('reports missing "." entry in publishConfig.exports', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        './lib/*': { default: './lib/*.js', types: './lib/*.d.ts' },
+                        './libESM/*': { default: './libESM/*.mjs', types: './libESM/*.d.mts' },
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Missing publishConfig.exports["."]');
+        });
+
+        it('reports invalid "." export shape', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': { import: './libESM/index.mjs', require: './lib/index.js' },
+                        './lib/*': { default: './lib/*.js', types: './lib/*.d.ts' },
+                        './libESM/*': { default: './libESM/*.mjs', types: './libESM/*.d.mts' },
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Invalid publishConfig.exports["."]');
+        });
+
+        it('reports missing lib counterpart for libESM entry', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': validPublicPackageJson.publishConfig.exports['.'],
+                        './libESM/*': './libESM/*',
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain(
+                '@trezor/example: Missing counterpart "./lib/*" for "./libESM/*"',
+            );
+        });
+
+        it('reports missing libESM counterpart for lib entry', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': validPublicPackageJson.publishConfig.exports['.'],
+                        './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain(
+                '@trezor/example: Missing counterpart "./libESM/*" for "./lib/*"',
+            );
+        });
+
+        it('accepts passthrough string format for libESM wildcards', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': validPublicPackageJson.publishConfig.exports['.'],
+                        './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+                        './libESM/*': './libESM/*',
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toEqual([]);
+        });
+
+        it('accepts explicit sub-path overrides without requiring counterparts for those', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': validPublicPackageJson.publishConfig.exports['.'],
+                        './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+                        './libESM/*': './libESM/*',
+                        './lib/events': {
+                            types: './lib/events/index.d.ts',
+                            default: './lib/events/index.js',
+                        },
+                        './libESM/events': {
+                            types: './libESM/events/index.d.mts',
+                            default: './libESM/events/index.mjs',
+                        },
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toEqual([]);
+        });
+
+        it('reports invalid or missing publishConfig.exports when it is not an object', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: 'invalid',
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Missing publishConfig.exports["."]');
+        });
+
+        it('reports wrong key order in shape-checked entry as invalid shape', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': {
+                            import: {
+                                default: './libESM/index.mjs',
+                                types: './libESM/index.d.mts',
+                            },
+                            require: { types: './lib/index.d.ts', default: './lib/index.js' },
+                        },
+                        './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+                        './libESM/*': './libESM/*',
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain('@trezor/example: Invalid publishConfig.exports["."]');
+        });
+
+        it('reports "types" after "default" in explicit override entries', async () => {
+            const pkg = {
+                ...validPublicPackageJson,
+                publishConfig: {
+                    ...validPublicPackageJson.publishConfig,
+                    exports: {
+                        '.': validPublicPackageJson.publishConfig.exports['.'],
+                        './lib/*': { types: './lib/*.d.ts', default: './lib/*.js' },
+                        './libESM/*': './libESM/*',
+                        './lib/events': {
+                            default: './lib/events/index.js',
+                            types: './lib/events/index.d.ts',
+                        },
+                        './libESM/events': {
+                            types: './libESM/events/index.d.mts',
+                            default: './libESM/events/index.mjs',
+                        },
+                    },
+                },
+            };
+            writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify(pkg));
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toContain(
+                '@trezor/example: In publishConfig.exports["./lib/events"]: "types" must come before "default"',
+            );
+            expect(errors).not.toContain(
+                '@trezor/example: In publishConfig.exports["./libESM/events"]: "types" must come before "default"',
+            );
+        });
+    });
+
+    describe('verify - package.json errors', () => {
+        it('reports missing package.json', async () => {
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toEqual([
+                '@trezor/example: package.json is missing or contains invalid JSON',
+            ]);
+        });
+
+        it('reports invalid JSON in package.json', async () => {
+            writeFileSync(join(workspaceDir, 'package.json'), '{ invalid json }');
+
+            const errors = await requirePublishConfig.verify(context);
+
+            expect(errors).toEqual([
+                '@trezor/example: package.json is missing or contains invalid JSON',
+            ]);
+        });
+    });
+});

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -1,0 +1,200 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Requirement } from '../Requirement';
+
+const PACKAGE_JSON_FILE = 'package.json';
+
+// Matches ./lib/... or ./libESM/... export keys with or without trailing wildcard
+const LIB_EXPORT_KEY_PATTERN = /^\.\/(libESM|lib)(\/[^*]+)?(\/\*)?$/;
+
+type ExportValue = string | ExportValueMap;
+
+interface ExportValueMap {
+    [key: string]: ExportValue;
+}
+
+type PackageJson = {
+    readonly name?: string;
+    readonly main?: string;
+    readonly files?: ReadonlyArray<string>;
+    readonly publishConfig?: {
+        readonly main?: string;
+        readonly types?: string;
+        readonly exports?: ExportValueMap;
+    };
+};
+
+const getExpectedExport = (exportKey: string): ExportValue | null => {
+    if (exportKey === '.') {
+        return {
+            import: { types: './libESM/index.d.mts', default: './libESM/index.mjs' },
+            require: { types: './lib/index.d.ts', default: './lib/index.js' },
+        };
+    }
+
+    const match = LIB_EXPORT_KEY_PATTERN.exec(exportKey);
+    if (!match) {
+        return null;
+    }
+
+    const isEsm = match[1] === 'libESM';
+    const isWildcard = match[3] === '/*';
+
+    // Only wildcard entries have a predictable shape.
+    // Explicit entries are intentional overrides (e.g. ./lib/subdir → ./lib/subdir/index.js).
+    if (!isWildcard) {
+        return null;
+    }
+
+    const basePath = exportKey.slice(0, -1);
+
+    // ESM imports already include the .mjs extension, so the wildcard is a passthrough.
+    if (isEsm) {
+        return `${basePath}*`;
+    }
+
+    return { types: `${basePath}*.d.ts`, default: `${basePath}*.js` };
+};
+
+const validatePublicPackage = (packageJson: PackageJson): ReadonlyArray<string> => {
+    const errors: string[] = [];
+    const { publishConfig } = packageJson;
+
+    if (!packageJson.main) {
+        errors.push('Missing top-level "main" field');
+    }
+
+    if (!publishConfig?.main) {
+        errors.push('Missing "publishConfig.main" field');
+    }
+    if (!publishConfig?.types) {
+        errors.push('Missing "publishConfig.types" field');
+    }
+
+    const files = packageJson.files ?? [];
+    if (!files.some(f => f === 'lib/' || f === 'lib')) {
+        errors.push('"files" must include "lib/"');
+    }
+    if (!files.some(f => f === 'libESM/' || f === 'libESM')) {
+        errors.push('"files" must include "libESM/"');
+    }
+
+    return errors;
+};
+
+// Checks that "types" comes before "default" in a condition object.
+const validateKeyOrder = (obj: ExportValue, context: string): ReadonlyArray<string> => {
+    const errors: string[] = [];
+    if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
+        return errors;
+    }
+
+    const keys = Object.keys(obj);
+    const typesIndex = keys.indexOf('types');
+    const defaultIndex = keys.indexOf('default');
+    if (defaultIndex !== -1 && typesIndex > defaultIndex) {
+        errors.push(`In ${context}: "types" must come before "default"`);
+    }
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            errors.push(...validateKeyOrder(value, `${context}.${key}`));
+        }
+    }
+
+    return errors;
+};
+
+const validateExports = (
+    exportsConfig: NonNullable<PackageJson['publishConfig']>['exports'],
+): ReadonlyArray<string> => {
+    const errors: string[] = [];
+    if (!exportsConfig) {
+        return ['Missing publishConfig.exports field'];
+    }
+    if (!exportsConfig['.']) {
+        errors.push('Missing publishConfig.exports["."]');
+    }
+
+    for (const [exportKey, exportValue] of Object.entries(exportsConfig)) {
+        // String values are passthrough exports (e.g. "./libESM/*": "./libESM/*") and are always accepted.
+        const expectedValue = typeof exportValue !== 'string' ? getExpectedExport(exportKey) : null;
+        if (
+            expectedValue !== null &&
+            JSON.stringify(exportValue) !== JSON.stringify(expectedValue)
+        ) {
+            errors.push(`Invalid publishConfig.exports[${JSON.stringify(exportKey)}]`);
+            errors.push(`  Expected: ${JSON.stringify(expectedValue)}`);
+            errors.push(`  Actual:   ${JSON.stringify(exportValue)}`);
+        }
+
+        const match = LIB_EXPORT_KEY_PATTERN.exec(exportKey);
+        if (match) {
+            const counterpart = exportKey.replace(
+                /^\.\/(libESM|lib)/,
+                match[1] === 'lib' ? './libESM' : './lib',
+            );
+            if (!(counterpart in exportsConfig)) {
+                errors.push(
+                    `Missing counterpart ${JSON.stringify(counterpart)} for ${JSON.stringify(exportKey)}`,
+                );
+            }
+        }
+
+        // Check key order for explicit overrides. shape-checked entries already enforce order via JSON.stringify.
+        if (expectedValue === null) {
+            errors.push(
+                ...validateKeyOrder(
+                    exportValue,
+                    `publishConfig.exports[${JSON.stringify(exportKey)}]`,
+                ),
+            );
+        }
+    }
+
+    return errors;
+};
+
+export const requirePublishConfig: Requirement<'workspace'> = {
+    name: 'package-json-publishConfig',
+    scope: 'workspace',
+    applies: context => {
+        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
+
+        let parsed: PackageJson;
+        try {
+            parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+        } catch {
+            return false;
+        }
+
+        return parsed.publishConfig !== undefined;
+    },
+    verify: context => {
+        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
+
+        let parsed: PackageJson;
+        try {
+            parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+        } catch {
+            return Promise.resolve([
+                `${context.workspaceName}: ${PACKAGE_JSON_FILE} is missing or contains invalid JSON`,
+            ]);
+        }
+
+        const errors: string[] = [];
+
+        if (parsed.publishConfig) {
+            for (const error of validatePublicPackage(parsed)) {
+                errors.push(`${context.workspaceName}: ${error}`);
+            }
+
+            for (const error of validateExports(parsed.publishConfig.exports)) {
+                errors.push(`${context.workspaceName}: ${error}`);
+            }
+        }
+
+        return Promise.resolve(errors);
+    },
+};

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -9,9 +9,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -20,7 +20,6 @@
             }
         }
     },
-    "npmPublishAccess": "public",
     "files": [
         "lib/",
         "libESM/"

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -31,16 +31,36 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
-            "./lib/thp": "./lib/thp/index.js",
-            "./lib/types": "./lib/types/index.js",
-            "./lib/thp.js": "./lib/thp/index.js",
-            "./lib/types.js": "./lib/types/index.js",
-            "./libESM/*": "./libESM/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/thp": {
+                "types": "./lib/thp/index.d.ts",
+                "default": "./lib/thp/index.js"
+            },
+            "./libESM/thp": {
+                "types": "./libESM/thp/index.d.mts",
+                "default": "./libESM/thp/index.mjs"
+            },
+            "./lib/types": {
+                "types": "./lib/types/index.d.ts",
+                "default": "./lib/types/index.js"
+            },
+            "./libESM/types": {
+                "types": "./libESM/types/index.d.mts",
+                "default": "./libESM/types/index.mjs"
+            }
         },
         "browser": {
             "./lib/pinger/ping": "./lib/pinger/ping.browser.js",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -2,7 +2,6 @@
     "name": "@trezor/transport",
     "version": "10.0.0-alpha.1",
     "description": "Low level library facilitating protocol buffers based communication with Trezor devices",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -2,7 +2,6 @@
     "name": "@trezor/type-utils",
     "version": "10.0.0-alpha.1",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/type-utils",
-    "npmPublishAccess": "public",
     "license": "See LICENSE.md in repo root",
     "repository": {
         "type": "git",

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -18,9 +18,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         }
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utils",
     "description": "A collection of typescript utils that are intended to be used across trezor-suite monorepo.",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,11 +20,19 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
             "./libESM/*": "./libESM/*"
         }
     },

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib",
     "description": "Client-side Bitcoin-like JavaScript library",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -31,18 +31,28 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             },
-            "./lib/*": "./lib/*.js",
-            "./lib/types": "./lib/types/index.js",
-            "./lib/transaction": "./lib/transaction/index.js",
-            "./lib/payments": "./lib/payments/index.js",
-            "./lib/compose": "./lib/compose/index.js",
-            "./lib/coinselect": "./lib/coinselect/index.js",
-            "./lib/script": "./lib/script/index.js",
-            "./libESM/*": "./libESM/*"
+            "./lib/*": {
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js"
+            },
+            "./libESM/*": "./libESM/*",
+            "./lib/compose": {
+                "types": "./lib/compose/index.d.ts",
+                "default": "./lib/compose/index.js"
+            },
+            "./libESM/compose": {
+                "types": "./libESM/compose/index.d.mts",
+                "default": "./libESM/compose/index.mjs"
+            }
         }
     },
     "scripts": {

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -27,9 +27,14 @@
         "types": "./lib/index.d.ts",
         "exports": {
             ".": {
-                "import": "./libESM/index.mjs",
-                "require": "./lib/index.js",
-                "types": "./lib/index.d.ts"
+                "import": {
+                    "types": "./libESM/index.d.mts",
+                    "default": "./libESM/index.mjs"
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js"
+                }
             }
         },
         "browser": {

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -4,7 +4,6 @@
     "author": "Trezor <info@trezor.io>",
     "homepage": "https://github.com/trezor/trezor-suite/tree/develop/packages/websocket",
     "description": "Shared websocket client implementation",
-    "npmPublishAccess": "public",
     "license": "SEE LICENSE IN LICENSE.md",
     "repository": {
         "type": "git",

--- a/skills/publish-config/SKILL.md
+++ b/skills/publish-config/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: publish-config
+description: publishConfig rules for public npm packages in the Trezor Suite monorepo. Use when adding or editing publishConfig, exports, or preparing a package for npm publishing.
+---
+
+# Publish Config
+
+Validated by `requirePublishConfig` in `@trezor/requirements` (`packages/requirements/src/requirements/package-json/requirePublishConfig.ts`).
+
+Applies to any package with `publishConfig`.
+
+## Rules
+
+1. **Top-level `main`** — required (e.g. `"./src/index.ts"`).
+2. **`files`** — must include `"lib/"` and `"libESM/"`.
+3. **`publishConfig.main`** and **`publishConfig.types`** — both required.
+4. **`publishConfig.exports["."]`** — must have exact dual CJS/ESM shape (see example).
+5. **Wildcard exports** — CJS (`./lib/*`) uses an object with `types` and `default`. ESM (`./libESM/*`) must be a passthrough string (`"./libESM/*"`) — an object would double the `.mjs` extension.
+6. **Explicit (non-wildcard) exports** — not shape-checked (intentional overrides), but must still have a counterpart. Typically used to route a directory import to its `index.js`, e.g. `"./lib/protocol-thp": { "types": "./lib/protocol-thp/index.d.ts", "default": "./lib/protocol-thp/index.js" }` — without this, the wildcard would resolve to `protocol-thp.js` instead of `protocol-thp/index.js`.
+7. **lib/libESM counterpart** — every `./lib/...` entry needs a matching `./libESM/...` pair and vice versa.
+8. **Key order** — `"types"` must come before `"default"` in every condition object (recursive). TypeScript evaluates conditions in declaration order.
+
+## Example
+
+```jsonc
+{
+    "name": "@trezor/example",
+    "main": "./src/index.ts", // Rule 1
+    "files": ["lib/", "libESM/", "CHANGELOG.md"], // Rule 2
+    "publishConfig": {
+        "main": "./lib/index.js", // Rule 3
+        "types": "./lib/index.d.ts", // Rule 3
+        "exports": {
+            ".": {
+                // Rule 4: exact shape required
+                "import": {
+                    "types": "./libESM/index.d.mts", // Rule 8: "types" before "default"
+                    "default": "./libESM/index.mjs",
+                },
+                "require": {
+                    "types": "./lib/index.d.ts",
+                    "default": "./lib/index.js",
+                },
+            },
+            "./lib/*": {
+                // Rule 5: CJS wildcard — object
+                "types": "./lib/*.d.ts",
+                "default": "./lib/*.js",
+            },
+            "./libESM/*": "./libESM/*", // Rule 5: ESM wildcard — passthrough string
+        },
+    },
+}
+```


### PR DESCRIPTION
Unifies `publishConfig` structure across all public packages and adds enforcement via the `@trezor/requirements` framework.

## Description

**Unified `publishConfig` shape across public packages:**
- `publishConfig.main`, `publishConfig.types` present on all public packages
- `publishConfig.exports` uses consistent dual CJS/ESM shape for the `"."` entry
- `files` arrays include both `lib/` and `libESM/`
- Added missing ESM builds where needed

**New `requirePublishConfig` requirement (`packages/requirements`):**
- Migrated `scripts/ci/check-package-exports.mjs` → `packages/requirements` as a TypeScript workspace-scoped requirement
- Runs automatically via the existing `yarn requirements:verify` CI step — no new CI plumbing needed
- Fixes two bugs from the original script:
  - **Counterpart detection regex**: `lib|libESM` → `libESM|lib` (alternation order caused `./libESM/*` to self-match)
  - **Passthrough format**: accepts `"./libESM/*": "./libESM/*"` (string passthrough widely used in the codebase, incorrectly flagged before)
  - **Removed disk existence check**: requirements runs on the source tree; `lib/`/`libESM/` only exist post-build
- 15 unit tests covering all validation paths

## Notes for QA

No runtime behavior changes — purely `package.json` metadata and CI validation.

## Related Issue

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/unify-packages-publish-config&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/unify-packages-publish-config&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/unify-packages-publish-config&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T12:56:48.236Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T12:56:06.468Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->