### PR TITLE
Revert "fix(alerts): await async button handlers before closing sheet"

### DIFF
--- a/suite-native/alerts/src/components/AlertSheet.tsx
+++ b/suite-native/alerts/src/components/AlertSheet.tsx
@@ -93,12 +93,12 @@ export const AlertSheet = ({ alert }: AlertSheetProps) => {
     } = alert;
 
     const handlePressPrimaryButton = async () => {
-        await onPressPrimaryButton?.();
+        onPressPrimaryButton?.();
         await closeSheetAnimated();
     };
 
     const handlePressSecondaryButton = async () => {
-        await onPressSecondaryButton?.();
+        onPressSecondaryButton?.();
         await closeSheetAnimated();
     };
 

--- a/suite-native/module-settings/src/components/useContactSupportAlert.tsx
+++ b/suite-native/module-settings/src/components/useContactSupportAlert.tsx
@@ -23,10 +23,10 @@ export const useContactSupportAlert = () => {
                 <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.primaryButton" />
             ),
             primaryButtonViewRight: 'arrowLineUpRight',
-            onPressPrimaryButton: async () => {
+            onPressPrimaryButton: () => {
                 if (appendixRef.current) {
                     // We need to access the URL via a ref to ensure it's always up to date, even if the value changes while the alert is already displayed.
-                    await openLink(appendixRef.current.getSupportChatUrl());
+                    openLink(appendixRef.current.getSupportChatUrl());
                 }
             },
             secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,


### PR DESCRIPTION
This reverts commit 9fbd5d385281b38b0b41b2e595ff36ad20ad1cb4.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reverting commit which added await for the primary button press on the alert. This is problematic in all alerts that handle asynchronous device calls, which can take forever. 

It was added to improve usability on contact support alert sheet, but since this commit introduced bug along the way, I'm reverting. Wondering whether we should create an issue for Alert refactor so it handles these cases. Initially, I implemented if/else in the alert to handle both scenarios, but IMO it's not worth it for the alert to behave like this in one specific scenario and all other cases be handled differently. @PeKne I'll leave that to you whether you feel it's worth looking into more. IMO it isn't.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26383


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/alert-async&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->