### PR TITLE
fix(suite-native): use correct layout in iOS system unpairing alert

### DIFF
--- a/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
+++ b/suite-native/bluetooth/src/components/SystemUnpairingAlertIosInstructions.tsx
@@ -1,30 +1,18 @@
-import { BottomSheetListItem, Box, Text, VStack } from '@suite-native/atoms';
-import { Translation, type TxKeyPath } from '@suite-native/intl';
+import { BottomSheetListItem, VStack } from '@suite-native/atoms';
 
-type SystemUnpairingAlertIosInstructionsProps = {
-    translationKey: TxKeyPath;
-};
-
-export const SystemUnpairingAlertIosInstructions = ({
-    translationKey,
-}: SystemUnpairingAlertIosInstructionsProps) => (
-    <Box>
-        <Text>
-            <Translation id={translationKey} />
-        </Text>
-        <VStack paddingTop="sp24">
-            <BottomSheetListItem
-                iconNumber={1}
-                translationKey="bluetooth.alerts.unpairingInstructions.step1"
-            />
-            <BottomSheetListItem
-                iconNumber={2}
-                translationKey="bluetooth.alerts.unpairingInstructions.step2"
-            />
-            <BottomSheetListItem
-                iconNumber={3}
-                translationKey="bluetooth.alerts.unpairingInstructions.step3"
-            />
-        </VStack>
-    </Box>
+export const SystemUnpairingAlertIosInstructions = () => (
+    <VStack>
+        <BottomSheetListItem
+            iconNumber={1}
+            translationKey="bluetooth.alerts.unpairingInstructions.step1"
+        />
+        <BottomSheetListItem
+            iconNumber={2}
+            translationKey="bluetooth.alerts.unpairingInstructions.step2"
+        />
+        <BottomSheetListItem
+            iconNumber={3}
+            translationKey="bluetooth.alerts.unpairingInstructions.step3"
+        />
+    </VStack>
 );

--- a/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
+++ b/suite-native/bluetooth/src/hooks/useBluetoothPlatformSpecificAlerts.ios.tsx
@@ -26,9 +26,8 @@ export const useBluetoothPlatformSpecificAlerts = () => {
     const showPairingFailedAlert = useCallback(() => {
         showAlert({
             title: translate('bluetooth.alerts.pairingFailed.title'),
-            description: (
-                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.pairingFailed.description" />
-            ),
+            description: translate('bluetooth.alerts.pairingFailed.description'),
+            appendix: <SystemUnpairingAlertIosInstructions />,
             primaryButtonTitle: translate('generic.buttons.gotIt'),
         });
     }, [showAlert, translate]);
@@ -37,9 +36,8 @@ export const useBluetoothPlatformSpecificAlerts = () => {
         showAlert({
             title: translate('bluetooth.alerts.systemUnpairing.title'),
             textAlign: 'left',
-            description: (
-                <SystemUnpairingAlertIosInstructions translationKey="bluetooth.alerts.systemUnpairing.description" />
-            ),
+            description: translate('bluetooth.alerts.systemUnpairing.description'),
+            appendix: <SystemUnpairingAlertIosInstructions />,
             primaryButtonTitle: translate('generic.buttons.gotIt'),
             onPressPrimaryButton: () => {
                 dispatch(bluetoothActions.setIsDeviceOsUnpairingRequired(false));


### PR DESCRIPTION
Follow-up for #25127 requested by [Mihovil](https://www.figma.com/design/mq0EzN9PldTmHKKPfijEco/Dashboard?node-id=4841-559&t=DOQk6QS0TsIY6H5m-4).

### Screenshots

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/4114ce67-47e5-43f1-842c-845589dc156e" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/fbdbabbf-7149-4616-9bf2-69a5683df89d" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/ios-system-unpairing-alert&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->