### PR TITLE
fix(suite): force yield transaction polling

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -1,0 +1,64 @@
+import { useEffect } from 'react';
+
+import {
+    fetchAndUpdateAccountThunk,
+    selectConvertedNetworkFeeInfo,
+    selectTransactionByAccountKeyAndTxid,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { isPending } from '@suite-common/wallet-utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+const DEFAULT_PENDING_TX_POLL_INTERVAL_MS = 3_000;
+const MIN_PENDING_TX_POLL_INTERVAL_MS = 2_000;
+const BLOCK_TIME_TO_POLL_INTERVAL_RATIO = 2;
+
+const getPollIntervalMs = (blockTime: number | undefined): number => {
+    if (!blockTime) return DEFAULT_PENDING_TX_POLL_INTERVAL_MS;
+
+    return Math.max(
+        (blockTime / BLOCK_TIME_TO_POLL_INTERVAL_RATIO) * 60 * 1000,
+        MIN_PENDING_TX_POLL_INTERVAL_MS,
+    );
+};
+
+type PendingTransaction = {
+    txid: string;
+};
+
+type UseYieldPendingTransactionTrackingProps = {
+    account: Account;
+    pendingTransaction: PendingTransaction | null;
+};
+
+export const useYieldPendingTransactionTracking = ({
+    account,
+    pendingTransaction,
+}: UseYieldPendingTransactionTrackingProps) => {
+    const dispatch = useDispatch();
+    const trackedPendingTransaction = useSelector(state =>
+        pendingTransaction
+            ? selectTransactionByAccountKeyAndTxid(state, account.key, pendingTransaction.txid)
+            : null,
+    );
+    const feeInfo = useSelector(state => selectConvertedNetworkFeeInfo(state, account.symbol));
+    const pollIntervalMs = getPollIntervalMs(feeInfo?.blockTime);
+
+    // Keep polling even before the tx appears in wallet.transactions.
+    const isCurrentlyPending =
+        !!pendingTransaction &&
+        (!trackedPendingTransaction || isPending(trackedPendingTransaction));
+
+    useEffect(() => {
+        if (!isCurrentlyPending) {
+            return;
+        }
+
+        const interval = setInterval(() => {
+            dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+        }, pollIntervalMs);
+
+        return () => clearInterval(interval);
+    }, [account.key, dispatch, isCurrentlyPending, pollIntervalMs]);
+};


### PR DESCRIPTION
## Description

Adds a forced transaction refresh path for yield pending transaction polling to keep approve, revoke, supply and withdraw status updates responsive.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #25647


## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-transaction-polling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-transaction-polling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-transaction-polling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T11:33:26.393Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T11:31:33.873Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->