### PR TITLE
chore(migration): split feature feedback into 26.4.0.2.ts

### DIFF
--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Storage changelog
 
-## 26.4.0.1
+## 26.4.0.2
 
 - rename `experimentalFeedback` object store to `featureFeedback`
+
+## 26.4.0.1
+
+- ensure `descriptor.apiType` is set to `usb` for remembered devices from old Suite versions
 
 ## 26.4.0
 

--- a/packages/suite/src/storage/migrations/versions/26.3.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/26.3.0.1.ts
@@ -3,6 +3,6 @@ import { createMigration } from '@suite/idb-migration-utils';
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
 export default createMigration<SuiteDBSchema>('26.3.0.1', db => {
-    // @ts-expect-error experimentalFeedback was renamed to featureFeedback in 26.4.0.1
+    // @ts-expect-error experimentalFeedback was renamed to featureFeedback in 26.4.0.2
     db.createObjectStore('experimentalFeedback');
 });

--- a/packages/suite/src/storage/migrations/versions/26.4.0.1.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.1.ts
@@ -1,5 +1,4 @@
 import { createMigration } from '@suite/idb-migration-utils';
-import { type FeatureFeedbackState } from '@suite-common/feedback';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
@@ -23,26 +22,4 @@ export default createMigration<SuiteDBSchema>('26.4.0.1', async (db, tx) => {
             return device;
         }
     });
-
-    if (!db.objectStoreNames.contains('featureFeedback')) {
-        db.createObjectStore('featureFeedback');
-    }
-
-    // @ts-expect-error experimentalFeedback no longer exists in the schema
-    if (db.objectStoreNames.contains('experimentalFeedback')) {
-        const oldStore = tx.objectStore(
-            // @ts-expect-error experimentalFeedback no longer exists in the schema
-            'experimentalFeedback',
-        );
-        const oldData = (await oldStore.get('experimentalFeedback')) as
-            | FeatureFeedbackState
-            | undefined;
-
-        if (oldData) {
-            tx.objectStore('featureFeedback').put(oldData, 'featureFeedback');
-        }
-
-        // @ts-expect-error experimentalFeedback no longer exists in the schema
-        db.deleteObjectStore('experimentalFeedback');
-    }
 });

--- a/packages/suite/src/storage/migrations/versions/26.4.0.2.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.2.ts
@@ -1,0 +1,28 @@
+import { createMigration } from '@suite/idb-migration-utils';
+import { type FeatureFeedbackState } from '@suite-common/feedback';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('26.4.0.2', async (db, tx) => {
+    if (!db.objectStoreNames.contains('featureFeedback')) {
+        db.createObjectStore('featureFeedback');
+    }
+
+    // @ts-expect-error experimentalFeedback no longer exists in the schema
+    if (db.objectStoreNames.contains('experimentalFeedback')) {
+        const oldStore = tx.objectStore(
+            // @ts-expect-error experimentalFeedback no longer exists in the schema
+            'experimentalFeedback',
+        );
+        const oldData = (await oldStore.get('experimentalFeedback')) as
+            | FeatureFeedbackState
+            | undefined;
+
+        if (oldData) {
+            tx.objectStore('featureFeedback').put(oldData, 'featureFeedback');
+        }
+
+        // @ts-expect-error experimentalFeedback no longer exists in the schema
+        db.deleteObjectStore('experimentalFeedback');
+    }
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -17,3 +17,4 @@ export { default as m26_3_0 } from './26.3.0';
 export { default as m26_3_0_1 } from './26.3.0.1';
 export { default as m26_4_0 } from './26.4.0';
 export { default as m26_4_0_1 } from './26.4.0.1';
+export { default as m26_4_0_2 } from './26.4.0.2';


### PR DESCRIPTION
Fix of rebase which merged 2 migrations.

No need for cherry-pick, split just for DX.

## Notes for QA
- no need for testing


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/split/migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/split/migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-08T22:04:20.368Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-08T22:02:43.683Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->