### PR TITLE
fix(suite): clear state after connect popup call

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupModals.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupModals.tsx
@@ -12,7 +12,11 @@ import {
     selectModalType,
 } from '@suite/modal';
 import { goto, selectRouteName } from '@suite/router';
-import { connectPopupCallThunkInner, selectConnectPopupCall } from '@suite-common/connect-popup';
+import {
+    connectPopupActions,
+    connectPopupCallThunkInner,
+    selectConnectPopupCall,
+} from '@suite-common/connect-popup';
 import { isDiscoveryInProgress, selectDiscoveryForSelectedDevice } from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
@@ -132,6 +136,10 @@ export const useConnectPopupModals = () => {
                     dispatch(removePreserveModal());
                     dispatch(cancelModal());
                 }
+                // Clear state after allowing everything to update
+                setTimeout(() => {
+                    dispatch(connectPopupActions.clearCall());
+                }, 100);
 
                 return;
             }

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -31,6 +31,8 @@ const rejectPermissions = createAction(`${ACTION_PREFIX}/rejectPermissions`, (pa
 
 const finishCall = createAction(`${ACTION_PREFIX}/finishCall`);
 
+const clearCall = createAction(`${ACTION_PREFIX}/clearCall`);
+
 const confirmAddresses = createAction(
     `${ACTION_PREFIX}/confirmAddresses`,
     (
@@ -106,4 +108,5 @@ export const connectPopupActions = {
     txSimulation,
     setSelectedFee,
     switchDevice,
+    clearCall,
 } as const;

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -103,6 +103,15 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
             .addCase(connectPopupActions.finishCall, state => {
                 if (state.activeCall) state.activeCall.state = 'finished';
             })
+            .addCase(connectPopupActions.clearCall, state => {
+                if (
+                    state.activeCall?.state === 'finished' ||
+                    state.activeCall?.state === 'call-error' ||
+                    state.activeCall?.state === 'error'
+                ) {
+                    state.activeCall = undefined;
+                }
+            })
             .addCase(connectPopupActions.deeplinkCallback, (state, { payload }) => {
                 if (
                     state.activeCall?.state === 'finished' ||


### PR DESCRIPTION
## Description

Clear state after connect popup call. Without this, we apply logic to close modals intended to clean up after the popup call, but it would continue afterwards, which was not intended. 
This was previously causing issues with passphrase flow and potentially certain other flows that check modal state. 

## Notes for QA

See linked issue, check both connect popup and passphrase behaves normally.

## Related Issue

Resolve #26018

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-popup-clear-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-popup-clear-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-popup-clear-state&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T12:14:51.381Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T09:14:25.838Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->