### PR TITLE
Manual tests for Connect in QA sanity runs

### DIFF
--- a/packages/e2e-utils/src/enums/testAnnotations.ts
+++ b/packages/e2e-utils/src/enums/testAnnotations.ts
@@ -41,6 +41,8 @@ export enum TestCategory {
     Buy = 'Buy',
     Sell = 'Sell',
     Swap = 'Swap',
+    TrezorConnect = 'Trezor Connect',
+    WalletConnect = 'WalletConnect',
     NotCategorized = 'Not Categorized',
 }
 
@@ -68,6 +70,7 @@ export enum TestStream {
     Engagement = 'Engagement', // do not use for new tests
     Growth = 'Growth',
     Firmware = 'Firmware',
+    Connect = 'Connect',
     NotDefined = 'Not Defined',
 }
 

--- a/suite/e2e/tests/manual/connect/connect-briskett-desktop.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-briskett-desktop.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Briskett Tezos wallet', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Briskett and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Briskett wallet with Trezor',
+                prerequisites: [
+                    'Seeded Trezor device with funded wallet',
+                    'Trezor Suite with a funded wallet connected',
+                ],
+                steps: [
+                    'open https://briskett.app/',
+                    'click Connect Trezor',
+                    'Grant permissions in Trezor Suite popup',
+                    'Export accounts and confirm on Trezor',
+                    'validate that account is successfully imported',
+                    'validate that Trezor is in Connected status is top left corner',
+                    'send transaction',
+                    'Grant permissions, review transaction and confirm on the device',
+                    'validate that transaction is successful in Briskett and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Low,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-cakewallet-android.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-cakewallet-android.test.ts
@@ -1,0 +1,42 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+//add bitcoin tron
+
+test.describe.skip('Cake Wallet Android app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Cake Wallet on Android and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Verifies that a user can use Cake Wallet mobile app with Trezor on Android',
+                prerequisites: [
+                    'Seeded Trezor device with funded wallet',
+                    'Cake Wallet mobile app',
+                    'Trezor Suite with a funded wallet connected',
+                ],
+                steps: [
+                    'open Cake Wallet mobile app',
+                    'select Restore Wallet',
+                    'select Restore from hardware wallet',
+                    'select Trezor',
+                    'select Ethereum and click Next',
+                    'observe Trezor Suite opened and validate that Trezor is in Connected status',
+                    'Grant permissions in Trezor Suite and confirm on the device',
+                    'Export accounts',
+                    'in Cake Wallet, select account to import',
+                    'validate that account with correct balance is present in Cake Wallet',
+                    'send transaction (ETH, BTC, TRX) in Cake Wallet',
+                    'Grant permissions, review transaction and confirm on the device',
+                    'Swipe to send in Cake Wallet',
+                    'validate that transaction is successful in Cake Wallet and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-cakewallet-ios.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-cakewallet-ios.test.ts
@@ -1,0 +1,40 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Cake Wallet iOS app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Cake Wallet on iOS and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Cake Wallet mobile app with Trezor on iOS',
+                prerequisites: [
+                    'Seeded Trezor device with funded wallet',
+                    'Cake Wallet mobile app',
+                    'Trezor Suite with a funded wallet connected',
+                ],
+                steps: [
+                    'open Cake Wallet mobile app',
+                    'select Restore Wallet',
+                    'select Restore from hardware wallet',
+                    'select Trezor',
+                    'select Ethereum and click Next',
+                    'observe Trezor Suite opened and validate that Trezor is in Connected status',
+                    'Grant permissions in Trezor Suite and confirm on the device',
+                    'Export accounts',
+                    'in Cake Wallet, select account to import',
+                    'validate that account with correct balance is present in Cake Wallet',
+                    'send transaction (ETH, BTC, TRX) in Cake Wallet',
+                    'Grant permissions, review transaction and confirm on the device',
+                    'Swipe to send in Cake Wallet',
+                    'validate that transaction is successful in Cake Wallet and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-explorer-suite.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-explorer-suite.test.ts
@@ -1,0 +1,47 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Trezor Connect Explorer', { tag: ['@group=manual'] }, () => {
+    test(
+        'Test Trezor Connect Explorer methods',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Trezor Connect',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'opened Trezor Suite with wallet connected',
+                ],
+                steps: [
+                    'navigate to the "https://dev.suite.sldev.cz/connect/develop/" or "https://connect.trezor.io/9/"',
+                    'select Bitcoin "getAdderess" method, and in Method testing tool click "Get address"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ethereum "getPublicKey" method, and in Method testing tool click "Get public key"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ethereum "signMessage" method, fill in the Message to sign field and click "Sign message"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Solana "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Cardano "getAddress" method, fill in the required fields and click "Get address"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Tron "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ripple "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-explorer-web-popup.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-explorer-web-popup.test.ts
@@ -1,0 +1,47 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Trezor Connect Explorer', { tag: ['@group=manual'] }, () => {
+    test(
+        'Test Trezor Connect Explorer methods',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Trezor Connect',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'no Trezor Suite opened or running in the background',
+                ],
+                steps: [
+                    'navigate to the "https://dev.suite.sldev.cz/connect/develop/" or "https://connect.trezor.io/9/"',
+                    'select Bitcoin "getAdderess" method, and in Method testing tool click "Get address"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ethereum "getPublicKey" method, and in Method testing tool click "Get public key"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ethereum "signMessage" method, fill in the Message to sign field and click "Sign message"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Solana "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Cardano "getAddress" method, fill in the required fields and click "Get address"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Tron "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                    'select Ripple "signTransaction" method, fill in the required fields and click "Sign transaction"',
+                    'Grant permissions in Trezor Suite popup',
+                    'confirm the action on the device and validate that the Response result is True',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-jupiter-android.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-jupiter-android.test.ts
@@ -1,0 +1,36 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Jupiter Android app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Jupiter Android app and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Jupiter Android app with Trezor',
+                prerequisites: [
+                    'Seeded Trezor device with funded wallet',
+                    'Jupiter Android app with created software wallet',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'open Jupiter Android app',
+                    'click Add/Connect Account',
+                    'select Other options (Ledger, Trezor & Watch Account)',
+                    'select Trezor',
+                    'Grant permissions in Trezor Suite popup, export accounts and confirm on the device',
+                    'validate that correct wallet is connected in Jupiter app',
+                    'perform any transaction in Jupiter app (eg. swap or send SOL to another own address)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Jupiter app and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-jupiter-ios.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-jupiter-ios.test.ts
@@ -1,0 +1,36 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Jupiter iOS app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Jupiter iOS app and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Jupiter iOS app with Trezor',
+                prerequisites: [
+                    'Seeded Trezor device with funded wallet',
+                    'Jupiter iOS app with created software wallet',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'open Jupiter iOS app',
+                    'click Add/Connect Account',
+                    'select Other options (Ledger, Trezor & Watch Account)',
+                    'select Trezor',
+                    'Grant permissions in Trezor Suite popup, export accounts and confirm on the device',
+                    'validate that correct wallet is connected in Jupiter app',
+                    'perform any transaction in Jupiter app (eg. swap or send SOL to another own address)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Jupiter app and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-metamask-desktop.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-metamask-desktop.test.ts
@@ -1,0 +1,33 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('MetaMask Chrome extension', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to MetaMask and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use MetaMask with Trezor',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'open MetaMask Chrome extension',
+                    'Add wallet, Add a hardware wallet, select Trezor and click Continue',
+                    'Grant permissions in Trezor Suite popup, export accounts and confirm on the device',
+                    'validate that correct wallet is connected in MetaMask',
+                    'perform any transaction in MetaMask (eg. send transaction to another own address)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in MetaMask and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-mobile-exodus.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-mobile-exodus.test.ts
@@ -1,0 +1,35 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Exodus mobile app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Exodus and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Exodus mobile app with Trezor',
+                prerequisites: ['Seeded Trezor device with funded wallet'],
+                steps: [
+                    'open Exodus mobile app',
+                    'click Exodus logo in top left corner',
+                    'open “Settings and More”',
+                    'open Settings',
+                    'click “Connect Trezor”',
+                    'click Continue',
+                    'allow permissions',
+                    'on TS7, click “Pair new device”',
+                    'finish THP pairing',
+                    'enter passphrase',
+                    'observe “Trezor Connected”, click Continue and exit Settings',
+                    'validate that accounts with correct balance are loaded',
+                    'send transaction',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Low,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-nufi.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-nufi.test.ts
@@ -1,0 +1,39 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - Uniswap
+
+test.describe.skip('Nu.fi wallet in Chrome', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to nu.fi wallet and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Trezor Connect with nu.fi wallet',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'open nu.fi Chrome extension',
+                    'add new Trezor device or use saved wallet',
+                    'select Solana account and send transaction to yourself',
+                    'Grant permissions in Trezor Suite and confirm transaction on the device',
+                    'validate that transaction is successful in nu.fi and transaction details are correct in Trezor Suite',
+                    'select Cardano account and send transaction to yourself',
+                    'Grant permissions in Trezor Suite and confirm transaction on the device',
+                    'validate that transaction is successful in nu.fi and transaction details are correct in Trezor Suite',
+                    'select Tron account and send transaction to yourself',
+                    'Grant permissions in Trezor Suite and confirm transaction on the device',
+                    'validate that transaction is successful in nu.fi and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-rabby-android.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-rabby-android.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Rabby Android app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Rabby Android app and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Rabby Android app with Trezor',
+                prerequisites: ['Seeded Trezor device with funded wallet'],
+                steps: [
+                    'open Rabby Android app',
+                    'click wallet icon in top right corner',
+                    'click Hardware Wallet',
+                    'click Trezor',
+                    'Authenticate to open Trezor Suite',
+                    'in Trezor Suite connect new TS7 or select already connected TS7',
+                    'finish THP pairing',
+                    'enter passphrase',
+                    'confirm "Export accounts"',
+                    'select accounts in "Import more wallets" Rabby modal',
+                    'click "View wallets" and validate that accounts with correct balance are present',
+                    'send transaction',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-rabby-desktop.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-rabby-desktop.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Rabby Chrome extension', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Rabby and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Rabby Chrome extension with Trezor',
+                prerequisites: ['Seeded Trezor device with funded wallet'],
+                steps: [
+                    'open Rabby mobile app',
+                    'click wallet icon in top right corner',
+                    'click Hardware Wallet',
+                    'click Trezor',
+                    'Authenticate to open Trezor Suite',
+                    'in Trezor Suite connect new TS7 or select already connected TS7',
+                    'finish THP pairing',
+                    'enter passphrase',
+                    'confirm "Export accounts"',
+                    'select accounts in "Import more wallets" Rabby modal',
+                    'click "View wallets" and validate that accounts with correct balance are present',
+                    'send transaction',
+                    'go to https://metamask.github.io/test-dapp/',
+                    'connect Rabby wallet',
+                    'sign Typed Data V4 transaction and confirm on the device',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-rabby-ios.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-rabby-ios.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Rabby iOS app', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Rabby iOS app and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Rabby iOS app with Trezor',
+                prerequisites: ['Seeded Trezor device with funded wallet'],
+                steps: [
+                    'open Rabby iOS app',
+                    'click wallet icon in top right corner',
+                    'click Hardware Wallet',
+                    'click Trezor',
+                    'Authenticate to open Trezor Suite',
+                    'in Trezor Suite connect new TS7 or select already connected TS7',
+                    'finish THP pairing',
+                    'enter passphrase',
+                    'confirm "Export accounts"',
+                    'select accounts in "Import more wallets" Rabby modal',
+                    'click "View wallets" and validate that accounts with correct balance are present',
+                    'send transaction',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/connect-ronin-desktop.test.ts
+++ b/suite/e2e/tests/manual/connect/connect-ronin-desktop.test.ts
@@ -1,0 +1,38 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+test.describe.skip('Ronin Chrome extension', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Ronin and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Ronin Chrome extension with Trezor',
+                prerequisites: ['Seeded Trezor device with funded wallet'],
+                steps: [
+                    'open Ronin Chrome extension',
+                    'click burger menu in top right corner',
+                    'click Manage Wallet',
+                    'click Import with Hardware Wallet',
+                    'Select Trezor, click Connect Wallet',
+                    'Authenticate to open Trezor Suite',
+                    'in Trezor Suite connect new TS7 or select already connected TS7',
+                    'finish THP pairing',
+                    'enter passphrase',
+                    'Grant permissions and confirm "Export accounts"',
+                    'select accounts in "Wallets ready to Import" Ronin modal',
+                    'click "View wallets" and validate that accounts with correct balance are present',
+                    'send transaction',
+                    'go to https://metamask.github.io/test-dapp/',
+                    'connect Ronin wallet',
+                    'sign Typed Data V4 transaction and confirm on the device',
+                ],
+                category: TestCategory.TrezorConnect,
+                priority: TestPriority.Low,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-evm-1inch.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-evm-1inch.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - 1inch
+
+test.describe.skip('WalletConnect with 1inch', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to 1inch with WalletConnect and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use WalletConnect with 1inch',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'navigate to the "https://1inch.com/swap"',
+                    'in top right corner click "Connect Wallet"',
+                    'Select "WalletConnect" from the list and copy the WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from 1inch to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet is connected in 1inch',
+                    'perform any transaction in 1inch (eg. stablecoin swap)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in 1inch and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-evm-hyperliquid.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-evm-hyperliquid.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - Hyperliquid
+
+test.describe.skip('WalletConnect with Hyperliquid', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Hyperliquid with WalletConnect and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use WalletConnect with Hyperliquid',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'navigate to the "https://app.hyperliquid.xyz/"',
+                    'in top right corner click "Connect"',
+                    'Select "WalletConnect" from the list and copy the WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from Hyperliquid to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet is connected in Hyperliquid',
+                    'perform any transaction in Hyperliquid (eg. buy or sell some asset)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Hyperliquid and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-evm-morpho.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-evm-morpho.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - Morpho
+
+test.describe.skip('WalletConnect with Morpho', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Morpho with WalletConnect and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use WalletConnect with Morpho',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'navigate to the "https://app.morpho.org/vaults"',
+                    'in top right corner click "Connect Wallet"',
+                    'Select "Trezor Suite" from the list and copy WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from Morpho to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet (address) is connected in Morpho',
+                    'perform transaction in Morpho (eg. deposite, withdraw USDC from vault)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Morpho and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-evm-uniswap.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-evm-uniswap.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - Uniswap
+
+test.describe.skip('WalletConnect with Uniswap', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Uniswap with WalletConnect and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use WalletConnect with Uniswap',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'navigate to the "https://app.uniswap.org/"',
+                    'in top right corner click "Connect"',
+                    'Select "WalletConnect" from the list and copy the WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from Uniswap to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet is connected in Uniswap',
+                    'perform any transaction in Uniswap (eg. send transaction to another own address)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Uniswap and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-jupiter.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-jupiter.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - Jupiter
+
+test.describe.skip('WalletConnect with Jupiter', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to Jupiter with WalletConnect and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use WalletConnect with Jupiter',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Solana accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'navigate to the "https://jup.ag/"',
+                    'in top right corner click "Connect"',
+                    'Select "QR (WalletConnect)" from the list and copy the WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from Jupiter to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet is connected in Jupiter',
+                    'perform any transaction in Jupiter (eg. swap tokens)',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in Jupiter and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.High,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});

--- a/suite/e2e/tests/manual/connect/wallet-connect-safewallet.test.ts
+++ b/suite/e2e/tests/manual/connect/wallet-connect-safewallet.test.ts
@@ -1,0 +1,37 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { test } from '../../../support/fixtures';
+import { createTestAnnotation } from '../../../support/reporters/annotations';
+
+// WalletConnect - SafeWallet
+
+test.describe.skip('WalletConnect with SafeWallet', { tag: ['@group=manual'] }, () => {
+    test(
+        'Connect Trezor to SafeWallet and sign transactions',
+        {
+            annotation: createTestAnnotation({
+                testCase: 'Verifies that a user can use Trezor Connect with SafeWallet',
+                prerequisites: [
+                    'Seeded Trezor device',
+                    'Trezor Suite with a funded wallet connected',
+                    'Ethereum and EVM accounts activated in Trezor Suite',
+                ],
+                steps: [
+                    'open https://app.safe.global/',
+                    'click Connect wallet',
+                    'Select WalletConnect from the list and copy the WalletConnect link',
+                    'open Trezor Suite, go to Settings, Connected apps and click +Add with WalletConnect',
+                    'paste WalletConnect link from SafeWallet to Trezor Suite and click "Confirm"',
+                    'validate that correct wallet is connected in SafeWallet',
+                    'send transaction in SafeWallet',
+                    'confirm transaction details in Trezor Suite and confirm on the device',
+                    'validate that transaction is successful in SafeWallet and transaction details are correct in Trezor Suite',
+                ],
+                category: TestCategory.WalletConnect,
+                priority: TestPriority.Critical,
+                stream: TestStream.Connect,
+            }),
+        },
+        async () => {},
+    );
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Only adding manual tests to include Connect into desktop Suite release testing.

<!--- Describe your changes in detail -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-manual-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-manual-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T13:01:18.297Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T09:16:05.822Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->