### PR TITLE
Unpair forget UI fixes followup

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ConfirmationModal.tsx
@@ -10,14 +10,25 @@ const ConfirmationContent = ({
 }) => (
     <Card paddingType="normal">
         <List gap={24}>
-            <List.Item bulletComponent={<Icon name="linkBreak" priority="secondary" size={20} />}>
+            <List.Item
+                bulletComponent={
+                    <Icon name="linkBreak" intent="neutral" priority="secondary" size={20} />
+                }
+            >
                 <Paragraph intent="neutral" priority="secondary">
                     <Translation id="TR_FORGET_DEVICE_MODAL_BULLET_FORGET" />
                 </Paragraph>
             </List.Item>
             {isBluetoothDevice && (
                 <List.Item
-                    bulletComponent={<Icon name="bluetoothSlash" priority="secondary" size={20} />}
+                    bulletComponent={
+                        <Icon
+                            name="bluetoothSlash"
+                            intent="neutral"
+                            priority="secondary"
+                            size={20}
+                        />
+                    }
                 >
                     <Paragraph intent="neutral" priority="secondary">
                         {isBluetoothConnectedDevice ? (
@@ -28,7 +39,11 @@ const ConfirmationContent = ({
                     </Paragraph>
                 </List.Item>
             )}
-            <List.Item bulletComponent={<Icon name="scroll" priority="secondary" size={20} />}>
+            <List.Item
+                bulletComponent={
+                    <Icon name="scroll" intent="neutral" priority="secondary" size={20} />
+                }
+            >
                 <Paragraph intent="neutral" priority="secondary">
                     <Translation id="TR_FORGET_DEVICE_MODAL_BULLET_NOT_WIPE" />
                 </Paragraph>

--- a/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDeviceFlows.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ForgetDevice/ForgetDeviceFlows.tsx
@@ -24,9 +24,7 @@ export const ImmediateForgetFlow = ({ onCancel }: ForgetFlowProps) => {
     return (
         <ConfirmationModal
             onConfirm={() => {
-                forgetDevice({
-                    toastType: null,
-                });
+                forgetDevice();
                 dispatch(goto({ routeName: 'suite-index' }));
                 onCancel();
             }}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -4625,7 +4625,7 @@ export const messages = defineMessages({
     },
     TR_FORGET_DEVICE_MODAL_DISCONNECT_SUBTITLE: {
         id: 'TR_FORGET_DEVICE_MODAL_DISCONNECT_SUBTITLE',
-        defaultMessage: 'Disconnect your Trezor from your phone.',
+        defaultMessage: 'Disconnect your Trezor from the computer.',
     },
     RECEIVE_TITLE: {
         id: 'RECEIVE_TITLE',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

thes are follow up fixes after the merge of unpair and forget

## Notes for QA

From the Design v 3.0 https://www.figma.com/design/mq0EzN9PldTmHKKPfijEco/Dashboard?node-id=4849-1432&t=5XT4mo3iALfSJY9l-0

## Related Issue

Resolve fixes here: https://www.figma.com/design/mq0EzN9PldTmHKKPfijEco/Dashboard?node-id=4849-1432&t=5XT4mo3iALfSJY9l-0

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unpair-forget-ui-fixes-followup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unpair-forget-ui-fixes-followup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T08:38:51.671Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T09:06:42.055Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->