### PR TITLE
chore: unify deps versions

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -171,7 +171,7 @@
         "vite-plugin-wasm": "^3.6.0",
         "vitest": "^4.1.0",
         "vm-browserify": "^1.1.2",
-        "web3-utils": "^4.3.2",
+        "web3-utils": "^4.3.3",
         "ws": "^8.18.0"
     },
     "peerDependencies": {

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -19,11 +19,11 @@
         "@trezor/utils": "workspace:*",
         "node-fetch": "2.6.7",
         "socks-proxy-agent": "8.0.5",
-        "ws": "8.18.0"
+        "ws": "^8.18.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "@types/node-fetch": "2.6.12",
-        "ts-node": "10.9.2"
+        "@types/node-fetch": "^2.6.12",
+        "ts-node": "^10.9.2"
     }
 }

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -152,7 +152,7 @@
         "redux-thunk": "^3.1.0",
         "semver": "^7.7.1",
         "styled-components": "^6.3.9",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     },
     "devDependencies": {
         "@testing-library/react": "^16.3.2",

--- a/suite-common/staking/package.json
+++ b/suite-common/staking/package.json
@@ -23,6 +23,6 @@
         "@trezor/connect-common": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     }
 }

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -47,6 +47,6 @@
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
         "react-redux": "9.2.0",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     }
 }

--- a/suite-common/wallet-utils/package.json
+++ b/suite-common/wallet-utils/package.json
@@ -36,6 +36,6 @@
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
         "web3-eth-abi": "^4.4.1",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     }
 }

--- a/suite-native/formatters/package.json
+++ b/suite-native/formatters/package.json
@@ -31,7 +31,7 @@
         "react": "19.2.4",
         "react-native": "0.83.2",
         "react-redux": "9.2.0",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     },
     "devDependencies": {
         "@suite-common/wallet-types": "workspace:*",

--- a/suite-native/module-connect-popup/package.json
+++ b/suite-native/module-connect-popup/package.json
@@ -46,6 +46,6 @@
         "react-native": "0.83.2",
         "react-native-reanimated": "~4.2.1",
         "react-redux": "9.2.0",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     }
 }

--- a/suite-native/module-send/package.json
+++ b/suite-native/module-send/package.json
@@ -62,7 +62,7 @@
         "react-native-reanimated": "~4.2.1",
         "react-native-svg": "15.15.3",
         "react-redux": "9.2.0",
-        "web3-utils": "^4.3.2"
+        "web3-utils": "^4.3.3"
     },
     "devDependencies": {
         "@suite-native/test-utils": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11076,7 +11076,7 @@ __metadata:
     "@trezor/connect-common": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -11490,7 +11490,7 @@ __metadata:
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -11537,7 +11537,7 @@ __metadata:
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     web3-eth-abi: "npm:^4.4.1"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -12432,7 +12432,7 @@ __metadata:
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -12920,7 +12920,7 @@ __metadata:
     react-native: "npm:0.83.2"
     react-native-reanimated: "npm:~4.2.1"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -13307,7 +13307,7 @@ __metadata:
     react-native-reanimated: "npm:~4.2.1"
     react-native-svg: "npm:15.15.3"
     react-redux: "npm:9.2.0"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -15394,7 +15394,7 @@ __metadata:
     vite-plugin-wasm: "npm:^3.6.0"
     vitest: "npm:^4.1.0"
     vm-browserify: "npm:^1.1.2"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
     ws: "npm:^8.18.0"
   peerDependencies:
     tslib: ^2.6.2
@@ -15608,11 +15608,11 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/node-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
-    "@types/node-fetch": "npm:2.6.12"
+    "@types/node-fetch": "npm:^2.6.12"
     node-fetch: "npm:2.6.7"
     socks-proxy-agent: "npm:8.0.5"
-    ts-node: "npm:10.9.2"
-    ws: "npm:8.18.0"
+    ts-node: "npm:^10.9.2"
+    ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft
 
@@ -16127,7 +16127,7 @@ __metadata:
     styled-components: "npm:^6.3.9"
     stylelint: "npm:^17.1.1"
     stylelint-config-standard: "npm:^40.0.0"
-    web3-utils: "npm:^4.3.2"
+    web3-utils: "npm:^4.3.3"
   languageName: unknown
   linkType: soft
 
@@ -17208,16 +17208,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/a8c743501036f494bb8b26ee04ce914c9cce88955d9ba48ff77d2b5b1bc403d4d99804dbf02238c1491fa93e2242983b1492ad8c2b39755dabd68683dada9e8f
-  languageName: node
-  linkType: hard
-
-"@types/node-fetch@npm:2.6.12":
-  version: 2.6.12
-  resolution: "@types/node-fetch@npm:2.6.12"
-  dependencies:
-    "@types/node": "npm:*"
-    form-data: "npm:^4.0.0"
-  checksum: 10/8107c479da83a3114fcbfa882eba95ee5175cccb5e4dd53f737a96f2559ae6262f662176b8457c1656de09ec393cc7b20a266c077e4bfb21e929976e1cf4d0f9
   languageName: node
   linkType: hard
 
@@ -43576,7 +43566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:10.9.2, ts-node@npm:^10.9.2":
+"ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:
@@ -45689,7 +45679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web3-utils@npm:^4.0.7, web3-utils@npm:^4.3.0, web3-utils@npm:^4.3.1, web3-utils@npm:^4.3.2, web3-utils@npm:^4.3.3":
+"web3-utils@npm:^4.0.7, web3-utils@npm:^4.3.0, web3-utils@npm:^4.3.1, web3-utils@npm:^4.3.3":
   version: 4.3.3
   resolution: "web3-utils@npm:4.3.3"
   dependencies:


### PR DESCRIPTION
a cherry-pick from #26412

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unify-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unify-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=unify-deps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T09:45:33.411Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T09:44:17.384Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->