### PR TITLE
fix(suite-native): remove success toast for interactive forget device

### DIFF
--- a/suite-native/module-device-settings/src/hooks/useForgetDevice.ts
+++ b/suite-native/module-device-settings/src/hooks/useForgetDevice.ts
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import { selectIsDeviceConnected, selectIsDeviceConnectedViaBluetooth } from '@suite-common/device';
-import { type ForgetDeviceThunkParams, forgetDeviceThunk } from '@suite-common/wallet-core';
+import { forgetDeviceThunk } from '@suite-common/wallet-core';
 import { selectIsKnownBluetoothDevice, useBluetoothDevice } from '@suite-native/bluetooth';
 import { useTranslate } from '@suite-native/intl';
 import {
@@ -37,28 +37,25 @@ export const useForgetDevice = () => {
     const isKnownBluetoothDevice = useSelector(selectIsKnownBluetoothDevice);
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
-    const forgetDeviceAndShowSuccessToast = async (params?: ForgetDeviceThunkParams) => {
-        await dispatch(forgetDeviceThunk(params));
-        showToast({
-            icon: 'check',
-            variant: 'default',
-            message: translate('moduleDeviceSettings.forgetDevice.successToast'),
-        });
-    };
-
-    const forgetDeviceAndHandleNavigation = () => {
+    const forgetDeviceAndHandleNavigation = async () => {
         if (isDeviceConnected) {
             dispatch(forgetDeviceThunk({ isOsUnpairingFinished: true }));
             navigation.navigate(DeviceSettingsStackRoutes.ForgetDeviceStack, {
                 screen: ForgetDeviceStackRoutes.ForgetDeviceFinish,
             });
         } else {
-            forgetDeviceAndShowSuccessToast({ isOsUnpairingFinished: true });
+            // Awaited to ensure the home screen is already updated.
+            await dispatch(forgetDeviceThunk({ isOsUnpairingFinished: true }));
             navigation.popTo(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.HomeStack,
                 params: {
                     screen: HomeStackRoutes.Home,
                 },
+            });
+            showToast({
+                icon: 'check',
+                variant: 'default',
+                message: translate('moduleDeviceSettings.forgetDevice.successToast'),
             });
         }
     };
@@ -69,7 +66,7 @@ export const useForgetDevice = () => {
                 screen: ForgetDeviceStackRoutes.ForgetDeviceConfirmation,
             });
             unpairBluetoothDevice({
-                onSuccess: forgetDeviceAndShowSuccessToast,
+                onSuccess: () => dispatch(forgetDeviceThunk()),
                 onCancel: navigation.goBack,
             });
         } else if (isKnownBluetoothDevice) {


### PR DESCRIPTION
Follow-up for #25127 requested by [Mihovil](https://www.figma.com/design/mq0EzN9PldTmHKKPfijEco/Dashboard?node-id=4841-559&t=DOQk6QS0TsIY6H5m-4).

Showing the success toast after the OS unpairing alert is dismissed is quite a challenge since the alert is also shown in other scenarios (e.g. wipe device). Since the user is confirming the action on the device and sees a success message there, we decided it's easier to not show the toast at all in this specific case.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/forget-device-remove-toast&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->