### PR TITLE
fix(trading): restore receive account selection across EVM switches

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { type CryptoId } from 'invity-api';
@@ -91,6 +91,8 @@ export const useTradingReceiveAddress = ({
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState<boolean | undefined>(undefined);
 
+    const prevCryptoIdRef = useRef<CryptoId | undefined>(undefined);
+
     const receiveAccount = useSelector(state => selectAccountByKey(state, selectedAccount?.key));
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
@@ -141,13 +143,6 @@ export const useTradingReceiveAddress = ({
     );
 
     useEffect(() => {
-        setSelectedAccount(undefined);
-        setHasSelectionInitialized(false);
-        methods.setValue('address', '', { shouldValidate: false });
-        methods.setValue('extraField', '', { shouldValidate: false });
-    }, [cryptoId, methods]);
-
-    useEffect(() => {
         if (!sendAccountKey || hasSelectionInitialized) {
             return; // Don't override user selection
         }
@@ -179,8 +174,18 @@ export const useTradingReceiveAddress = ({
     ]);
 
     useEffect(() => {
+        const isNewAsset = prevCryptoIdRef.current !== cryptoId;
+
+        if (isNewAsset) {
+            prevCryptoIdRef.current = cryptoId;
+            setSelectedAccount(undefined);
+            setHasSelectionInitialized(false);
+            methods.setValue('address', '', { shouldValidate: false });
+            methods.setValue('extraField', '', { shouldValidate: false });
+        }
+
         if (!symbol) return;
-        if (hasSelectionInitialized) return;
+        if (hasSelectionInitialized && !isNewAsset) return;
 
         if (!hasSuiteReceiveAccount) {
             if (canUseNonSuiteAccount) {
@@ -197,7 +202,7 @@ export const useTradingReceiveAddress = ({
             return;
         }
 
-        if (persistedReceiveAccountKey) {
+        if (!isNewAsset && persistedReceiveAccountKey) {
             const matchingAccount = suiteReceiveAccounts?.find(
                 account => account.key === persistedReceiveAccountKey,
             );
@@ -209,7 +214,7 @@ export const useTradingReceiveAddress = ({
             }
         }
 
-        if (persistedReceiveAddress && canUseNonSuiteAccount && symbol) {
+        if (!isNewAsset && persistedReceiveAddress && canUseNonSuiteAccount && symbol) {
             let isValidForCurrentSymbol = false;
 
             try {
@@ -270,6 +275,7 @@ export const useTradingReceiveAddress = ({
         setSelectedAccount(undefined);
         setHasSelectionInitialized(true);
     }, [
+        cryptoId,
         type,
         symbol,
         accounts,


### PR DESCRIPTION
## Description

- track crypto asset transitions explicitly and reset receive-address selection only when the target asset actually changes
- prevent persisted non-suite receive address/account from being reused immediately after switching to a different asset
- allow the form to reinitialize to the correct suite account when switching ETH -> enabled EVM network -> ETH

## Notes for QA

1. Open Trading swap and set To = Ethereum; verify receive field shows the suite account (e.g. Ethereum).
2. Switch To to Arbitrum One (enabled in coin settings); verify receive field is initialized from the Arbitrum suite account (account association preserved), not stuck on raw non-suite address mode.
3. Switch back To = Ethereum; verify receive field returns to Ethereum suite account naming and does not remain in non-suite address mode.
4. Optional regression check: enter a manual non-suite address, keep the same asset, and verify the selection persists for that same asset.

## Related Issue

Resolve #26457

## Screenshots:

N/A

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26457-trading-evm-receive-account-recovery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26457-trading-evm-receive-account-recovery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T12:28:58.381Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T12:27:33.198Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->