### PR TITLE
Non zero balance tracking

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -16,6 +16,7 @@ import {
 import {
     accountsActions,
     changeCoinVisibility,
+    reportWalletBalanceThunk,
     selectEnabledNetworks,
 } from '@suite-common/wallet-core';
 import { getAvailableAccountTypes, prepareNewAccountPayload } from '@suite-common/wallet-utils';
@@ -218,6 +219,7 @@ export const AddAccountModal = ({
             dispatch(accountsActions.changeAccountVisibility(account));
         }
 
+        dispatch(reportWalletBalanceThunk());
         onConfirm?.();
 
         onAddAccount?.(account);
@@ -264,6 +266,7 @@ export const AddAccountModal = ({
                 }
 
                 dispatch(accountsActions.createAccount(newAccount));
+                dispatch(reportWalletBalanceThunk());
                 onConfirm?.();
             }
         }

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -55,7 +55,6 @@ import { hasVisibleTokens } from 'src/utils/wallet/tokenUtils';
 const analyticsMiddleware = createMiddlewareWithExtraDeps(
     (action: Action, { extra, next, dispatch, getState }) => {
         const prevRouterUrl = selectRouterUrl(getState());
-
         // NOTE: pass action on, keep the result
         const result = next(action);
 

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -27,4 +27,5 @@ export enum EventType {
     WalletConnectSessionRequest = 'wallet-connect/session-request',
     // eslint-disable-next-line local-rules/analytics-event-name
     CoinDiscovery = 'coin_discovery',
+    AccountsBalance = 'accounts/balance',
 }

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -17,3 +17,4 @@ export { walletConnectProposalRejectedEvent } from './walletConnectProposalRejec
 export { walletConnectSessionRequestEvent } from './walletConnectSessionRequestEvent';
 export { coinDiscoveryEvent } from './coinDiscoveryEvent';
 export { suiteSyncLabelCreatedEvent } from './suiteSyncLabelCreatedEvent';
+export { walletBalanceEvent } from './walletBalanceEvent';

--- a/suite-common/analytics/src/events/walletBalanceEvent.ts
+++ b/suite-common/analytics/src/events/walletBalanceEvent.ts
@@ -1,0 +1,20 @@
+import { EventType } from '../constants';
+import type { AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    nonZeroBalance: AttributeDef<number>;
+};
+
+export const walletBalanceEvent: EventDef<Attributes, EventType.AccountsBalance> = {
+    name: EventType.AccountsBalance,
+    descriptionTrigger:
+        'Fired after app start and whenever the total balance state (some balance | no balance) changes.',
+    changelog: [{ version: '26.5.1', notes: 'added' }],
+
+    attributes: {
+        nonZeroBalance: {
+            changelog: [{ version: '26.5.1', notes: 'added' }],
+            description: 'Number of accounts with non-zero balance',
+        },
+    },
+};

--- a/suite-common/analytics/src/events/walletBalanceEvent.ts
+++ b/suite-common/analytics/src/events/walletBalanceEvent.ts
@@ -8,7 +8,7 @@ type Attributes = {
 export const walletBalanceEvent: EventDef<Attributes, EventType.AccountsBalance> = {
     name: EventType.AccountsBalance,
     descriptionTrigger:
-        'Fired after app start and whenever the total balance state (some balance | no balance) changes.',
+        'Fired on app start and after discovery. Fires first time when balances are known and then debounced to fire at most once per 10 minutes.',
     changelog: [{ version: '26.5.1', notes: 'added' }],
 
     attributes: {

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -45,6 +45,7 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
+        "lodash": "^4.18.1",
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
         "react-redux": "9.2.0",

--- a/suite-common/wallet-core/package.json
+++ b/suite-common/wallet-core/package.json
@@ -34,6 +34,7 @@
         "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
+        "@trezor/analytics-uploader": "workspace:*",
         "@trezor/blockchain-link": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/blockchain-link-utils": "workspace:*",

--- a/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
+++ b/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
@@ -6,7 +6,7 @@ import { type Analytics } from '@trezor/analytics-uploader';
 
 import { selectAccounts } from './accountsSelectors';
 
-const DEBOUNCE_MS = 10 * 60 * 1000; // 10 minutes
+const DEBOUNCE_MS = 5 * 60 * 1000; // 5 minutes
 
 const countNonZeroBalanceAccounts = (accounts: Account[]) =>
     accounts.filter(a => Number(a.balance) > 0).length;

--- a/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
+++ b/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
@@ -1,0 +1,41 @@
+import { type AnalyticsSharedEvents, events } from '@suite-common/analytics';
+import { type Account } from '@suite-common/wallet-types';
+import { type Analytics } from '@trezor/analytics-uploader';
+
+import { selectAccounts } from './accountsSelectors';
+
+const countNonZeroBalanceAccounts = (accounts: Account[]) =>
+    accounts.filter(a => Number(a.balance) > 0).length;
+
+export const reportWalletBalanceState = ({
+    accounts,
+    analytics,
+}: {
+    accounts: Account[];
+    analytics: Analytics<AnalyticsSharedEvents>;
+}) => {
+    analytics.report({
+        type: events.walletBalanceEvent.name,
+        payload: { nonZeroBalance: countNonZeroBalanceAccounts(accounts) },
+    });
+};
+
+export const reportWalletBalanceChangeIfNeeded = ({
+    prevAccounts,
+    getState,
+    analytics,
+}: {
+    prevAccounts: Account[];
+    getState: () => { wallet: { accounts: Account[] } };
+    analytics: Analytics<AnalyticsSharedEvents>;
+}) => {
+    const prevCount = countNonZeroBalanceAccounts(prevAccounts);
+    const nextCount = countNonZeroBalanceAccounts(selectAccounts(getState()));
+
+    if (prevCount !== nextCount) {
+        analytics.report({
+            type: events.walletBalanceEvent.name,
+            payload: { nonZeroBalance: nextCount },
+        });
+    }
+};

--- a/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
+++ b/suite-common/wallet-core/src/accounts/accountBalanceAnalytics.ts
@@ -1,41 +1,37 @@
+import debounce from 'lodash/debounce';
+
 import { type AnalyticsSharedEvents, events } from '@suite-common/analytics';
 import { type Account } from '@suite-common/wallet-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 
 import { selectAccounts } from './accountsSelectors';
 
+const DEBOUNCE_MS = 10 * 60 * 1000; // 10 minutes
+
 const countNonZeroBalanceAccounts = (accounts: Account[]) =>
     accounts.filter(a => Number(a.balance) > 0).length;
 
-export const reportWalletBalanceState = ({
-    accounts,
-    analytics,
-}: {
-    accounts: Account[];
-    analytics: Analytics<AnalyticsSharedEvents>;
-}) => {
-    analytics.report({
-        type: events.walletBalanceEvent.name,
-        payload: { nonZeroBalance: countNonZeroBalanceAccounts(accounts) },
-    });
-};
-
-export const reportWalletBalanceChangeIfNeeded = ({
-    prevAccounts,
-    getState,
-    analytics,
-}: {
-    prevAccounts: Account[];
+type ReportParams = {
     getState: () => { wallet: { accounts: Account[] } };
     analytics: Analytics<AnalyticsSharedEvents>;
-}) => {
-    const prevCount = countNonZeroBalanceAccounts(prevAccounts);
-    const nextCount = countNonZeroBalanceAccounts(selectAccounts(getState()));
+};
 
-    if (prevCount !== nextCount) {
+/**
+ * Report wallet balance state with leading + trailing debounce.
+ *
+ * First call fires immediately (leading edge). Subsequent calls within
+ * 10 minutes are debounced — a trailing event fires 10 minutes after
+ * the last call to capture the settled state.
+ */
+export const reportWalletBalanceDebounced = debounce(
+    ({ getState, analytics }: ReportParams) => {
         analytics.report({
             type: events.walletBalanceEvent.name,
-            payload: { nonZeroBalance: nextCount },
+            payload: {
+                nonZeroBalance: countNonZeroBalanceAccounts(selectAccounts(getState())),
+            },
         });
-    }
-};
+    },
+    DEBOUNCE_MS,
+    { leading: true, trailing: true },
+);

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -17,10 +17,9 @@ import {
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type AccountInfo, type TokenInfo } from '@trezor/connect';
 
-import { reportWalletBalanceChangeIfNeeded } from './accountBalanceAnalytics';
 import { accountsActions } from './accountsActions';
 import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
-import { selectAccountByKey, selectAccounts } from './accountsSelectors';
+import { selectAccountByKey } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
@@ -73,7 +72,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -127,7 +126,6 @@ export const fetchAndUpdateAccountThunk = createThunk(
 
         if (response.success) {
             const { payload } = response;
-            const prevAccounts = selectAccounts(getState());
             const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
 
             const analyze = analyzeTransactions(payload.history.transactions || [], accountTxs, {
@@ -187,12 +185,6 @@ export const fetchAndUpdateAccountThunk = createThunk(
             } else {
                 dispatch(accountsActions.updateAccountRefreshTimestamp(account));
             }
-
-            reportWalletBalanceChangeIfNeeded({
-                prevAccounts,
-                getState,
-                analytics: extra.services.analytics,
-            });
         }
     },
 );

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -17,9 +17,10 @@ import {
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type AccountInfo, type TokenInfo } from '@trezor/connect';
 
+import { reportWalletBalanceChangeIfNeeded } from './accountBalanceAnalytics';
 import { accountsActions } from './accountsActions';
 import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
-import { selectAccountByKey } from './accountsSelectors';
+import { selectAccountByKey, selectAccounts } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
@@ -72,7 +73,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -126,6 +127,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
 
         if (response.success) {
             const { payload } = response;
+            const prevAccounts = selectAccounts(getState());
             const blockHeight = selectBlockchainHeightBySymbol(getState(), account.symbol);
 
             const analyze = analyzeTransactions(payload.history.transactions || [], accountTxs, {
@@ -185,6 +187,12 @@ export const fetchAndUpdateAccountThunk = createThunk(
             } else {
                 dispatch(accountsActions.updateAccountRefreshTimestamp(account));
             }
+
+            reportWalletBalanceChangeIfNeeded({
+                prevAccounts,
+                getState,
+                analytics: extra.services.analytics,
+            });
         }
     },
 );

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -69,11 +69,21 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
     return tokens;
 };
 
+export const reportWalletBalanceThunk = createThunk(
+    `${ACCOUNTS_MODULE_PREFIX}/reportWalletBalance`,
+    (_, { getState, extra }) => {
+        reportWalletBalanceDebounced({
+            getState,
+            analytics: extra.services.analytics,
+        });
+    },
+);
+
 // Left here for clarity, but shouldn't be called anywhere but in blockchainActions.syncAccounts
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -187,20 +197,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
                 dispatch(accountsActions.updateAccountRefreshTimestamp(account));
             }
 
-            reportWalletBalanceDebounced({
-                getState,
-                analytics: extra.services.analytics,
-            });
+            dispatch(reportWalletBalanceThunk());
         }
-    },
-);
-
-export const reportWalletBalanceThunk = createThunk(
-    `${ACCOUNTS_MODULE_PREFIX}/reportWalletBalance`,
-    (_, { getState, extra }) => {
-        reportWalletBalanceDebounced({
-            getState,
-            analytics: extra.services.analytics,
-        });
     },
 );

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -194,3 +194,13 @@ export const fetchAndUpdateAccountThunk = createThunk(
         }
     },
 );
+
+export const reportWalletBalanceThunk = createThunk(
+    `${ACCOUNTS_MODULE_PREFIX}/reportWalletBalance`,
+    (_, { getState, extra }) => {
+        reportWalletBalanceDebounced({
+            getState,
+            analytics: extra.services.analytics,
+        });
+    },
+);

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -17,6 +17,7 @@ import {
 } from '@suite-common/wallet-utils';
 import TrezorConnect, { type AccountInfo, type TokenInfo } from '@trezor/connect';
 
+import { reportWalletBalanceDebounced } from './accountBalanceAnalytics';
 import { accountsActions } from './accountsActions';
 import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
 import { selectAccountByKey } from './accountsSelectors';
@@ -72,7 +73,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
 // as we usually want to update all accounts for a single coin at once
 export const fetchAndUpdateAccountThunk = createThunk(
     `${ACCOUNTS_MODULE_PREFIX}/fetchAndUpdateAccountThunk`,
-    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState }) => {
+    async ({ accountKey }: { accountKey: AccountKey }, { dispatch, getState, extra }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
         if (!account || account.failed || account.accountType === 'placeholder') return;
@@ -185,6 +186,11 @@ export const fetchAndUpdateAccountThunk = createThunk(
             } else {
                 dispatch(accountsActions.updateAccountRefreshTimestamp(account));
             }
+
+            reportWalletBalanceDebounced({
+                getState,
+                analytics: extra.services.analytics,
+            });
         }
     },
 );

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -33,6 +33,7 @@ import { arrayDistinct, arrayToDictionary } from '@trezor/utils';
 
 import { BLOCKCHAIN_MODULE_PREFIX, blockchainActions } from './blockchainActions';
 import { selectBlockchainState, selectNetworkBlockchainInfo } from './blockchainReducer';
+import { reportWalletBalanceDebounced } from '../accounts/accountBalanceAnalytics';
 import { selectAccounts } from '../accounts/accountsSelectors';
 import { fetchAndUpdateAccountThunk } from '../accounts/accountsThunks';
 import { preloadFeeInfoThunk } from '../fees/feesThunks';
@@ -91,7 +92,7 @@ export const setCustomBackendThunk = createThunk(
 
 export const initBlockchainThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/initBlockchainThunk`,
-    async (_, { dispatch, getState }) => {
+    async (_, { dispatch, getState, extra }) => {
         await dispatch(preloadFeeInfoThunk());
 
         // Load custom blockbook backend
@@ -114,6 +115,11 @@ export const initBlockchainThunk = createThunk(
 
         const promises = symbols.map(symbol => dispatch(reconnectBlockchainThunk({ symbol })));
         await Promise.all(promises);
+
+        reportWalletBalanceDebounced({
+            getState,
+            analytics: extra.services.analytics,
+        });
 
         // continue suite initialization
     },

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -33,9 +33,8 @@ import { arrayDistinct, arrayToDictionary } from '@trezor/utils';
 
 import { BLOCKCHAIN_MODULE_PREFIX, blockchainActions } from './blockchainActions';
 import { selectBlockchainState, selectNetworkBlockchainInfo } from './blockchainReducer';
-import { reportWalletBalanceDebounced } from '../accounts/accountBalanceAnalytics';
 import { selectAccounts } from '../accounts/accountsSelectors';
-import { fetchAndUpdateAccountThunk } from '../accounts/accountsThunks';
+import { fetchAndUpdateAccountThunk, reportWalletBalanceThunk } from '../accounts/accountsThunks';
 import { preloadFeeInfoThunk } from '../fees/feesThunks';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 
@@ -92,7 +91,7 @@ export const setCustomBackendThunk = createThunk(
 
 export const initBlockchainThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/initBlockchainThunk`,
-    async (_, { dispatch, getState, extra }) => {
+    async (_, { dispatch, getState }) => {
         await dispatch(preloadFeeInfoThunk());
 
         // Load custom blockbook backend
@@ -116,10 +115,7 @@ export const initBlockchainThunk = createThunk(
         const promises = symbols.map(symbol => dispatch(reconnectBlockchainThunk({ symbol })));
         await Promise.all(promises);
 
-        reportWalletBalanceDebounced({
-            getState,
-            analytics: extra.services.analytics,
-        });
+        dispatch(reportWalletBalanceThunk());
 
         // continue suite initialization
     },

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -53,6 +53,7 @@ import { BigNumber, typedObjectEntries } from '@trezor/utils';
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
+import { reportWalletBalanceState } from '../accounts/accountBalanceAnalytics';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
@@ -339,6 +340,11 @@ const completeDiscovery = (
 
     trackCompleteDiscoveryResult(deviceState.staticSessionId, {
         getState,
+        analytics,
+    });
+
+    reportWalletBalanceState({
+        accounts: selectAccountsByDeviceState(getState(), deviceState.staticSessionId),
         analytics,
     });
 };

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -53,9 +53,9 @@ import { BigNumber, typedObjectEntries } from '@trezor/utils';
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
-import { reportWalletBalanceDebounced } from '../accounts/accountBalanceAnalytics';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
+import { reportWalletBalanceThunk } from '../accounts/accountsThunks';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
 import { selectIsDeviceAutoEjectEnabled } from '../settings/walletSettingsReducer';
 
@@ -343,10 +343,7 @@ const completeDiscovery = (
         analytics,
     });
 
-    reportWalletBalanceDebounced({
-        getState,
-        analytics,
-    });
+    dispatch(reportWalletBalanceThunk());
 };
 
 export const cancelDiscoveryThunk = createThunk(
@@ -814,10 +811,7 @@ export const runAdditionalDiscoveryThunk = createThunk(
                 analytics: extra.services.analytics,
             });
 
-            reportWalletBalanceDebounced({
-                getState,
-                analytics: extra.services.analytics,
-            });
+            dispatch(reportWalletBalanceThunk());
         }
     },
 );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -813,6 +813,11 @@ export const runAdditionalDiscoveryThunk = createThunk(
                 getState,
                 analytics: extra.services.analytics,
             });
+
+            reportWalletBalanceDebounced({
+                getState,
+                analytics: extra.services.analytics,
+            });
         }
     },
 );

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -53,7 +53,7 @@ import { BigNumber, typedObjectEntries } from '@trezor/utils';
 import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import { selectDeviceThunk } from './selectDeviceThunk';
-import { reportWalletBalanceState } from '../accounts/accountBalanceAnalytics';
+import { reportWalletBalanceDebounced } from '../accounts/accountBalanceAnalytics';
 import { type CreateAccountActionProps, accountsActions } from '../accounts/accountsActions';
 import { selectAccountsByDeviceState } from '../accounts/accountsSelectors';
 import { selectAccountsToBeForgotten, selectDiscoveryAccountsParam } from '../selectors';
@@ -343,8 +343,8 @@ const completeDiscovery = (
         analytics,
     });
 
-    reportWalletBalanceState({
-        accounts: selectAccountsByDeviceState(getState(), deviceState.staticSessionId),
+    reportWalletBalanceDebounced({
+        getState,
         analytics,
     });
 };

--- a/suite-common/wallet-core/tsconfig.json
+++ b/suite-common/wallet-core/tsconfig.json
@@ -23,6 +23,9 @@
         { "path": "../wallet-types" },
         { "path": "../wallet-utils" },
         {
+            "path": "../../packages/analytics-uploader"
+        },
+        {
             "path": "../../packages/blockchain-link"
         },
         {

--- a/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
+++ b/suite-native/module-add-accounts/src/hooks/useAddCoinAccount.ts
@@ -19,6 +19,7 @@ import {
 import {
     type AccountsRootState,
     accountsActions,
+    reportWalletBalanceThunk,
     selectDeviceAccounts,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -376,6 +377,7 @@ export const useAddCoinAccount = () => {
         }
 
         dispatch(accountsActions.createAccount(newAccountPayload));
+        dispatch(reportWalletBalanceThunk());
         navigateToSuccessorScreen({
             flowType,
             symbol,
@@ -436,6 +438,7 @@ export const useAddCoinAccount = () => {
             // the account should already exist, but be invisible, so make it visible
             if (firstHiddenEmptyAccount && !firstHiddenEmptyAccount.failed) {
                 dispatch(accountsActions.changeAccountVisibility(firstHiddenEmptyAccount));
+                dispatch(reportWalletBalanceThunk());
                 navigateToSuccessorScreen({
                     flowType,
                     symbol,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11733,6 +11733,7 @@ __metadata:
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
+    "@trezor/analytics-uploader": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/blockchain-link-utils": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11744,6 +11744,7 @@ __metadata:
     "@trezor/protobuf": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
+    lodash: "npm:^4.18.1"
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     react-redux: "npm:9.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

A new tracking event `accounts/balance` should be sent when balances or accounts change and should track non zero ones.

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/24044 https://github.com/trezor/trezor-suite/issues/24042

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=24044-non-zero-accounts-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=24044-non-zero-accounts-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=24044-non-zero-accounts-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T13:25:54.195Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T13:24:38.076Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->