### PR TITLE
feat: use shardOwener instead of appOwner [DO BOT MERGE] [BREAKING CHANGE]

### DIFF
--- a/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
+++ b/suite-common/suite-sync-evolu/src/createEvoluInstance.ts
@@ -1,4 +1,5 @@
-import { AppName, type Evolu, type Run, createEvolu, getOrThrow } from '@evolu/common';
+import { AppName, createEvolu, deriveShardOwner, getOrThrow } from '@evolu/common';
+import { type Evolu, type Run, type ShardOwner } from '@evolu/common';
 import { type EvoluPlatformDeps } from '@evolu/common/local-first';
 
 import { type SuiteSyncOwner } from '@suite-common/suite-sync-storage';
@@ -15,9 +16,10 @@ type CreateEvoluInstanceFactoryDeps = {
     run: Run<EvoluPlatformDeps>;
 };
 
-export type CreateEvoluInstance = (params: {
-    suiteSyncOwner: SuiteSyncOwner;
-}) => Promise<Evolu<typeof Schema>>;
+export type CreateEvoluInstance = (params: { suiteSyncOwner: SuiteSyncOwner }) => Promise<{
+    evolu: Evolu<typeof Schema>;
+    shardOwner: ShardOwner;
+}>;
 
 export type CreateEvoluInstanceDep = {
     createEvoluInstance: CreateEvoluInstance;
@@ -26,13 +28,15 @@ export type CreateEvoluInstanceDep = {
 export const createEvoluInstanceFactory =
     (deps: CreateEvoluInstanceFactoryDeps): CreateEvoluInstance =>
     async ({ suiteSyncOwner }) => {
-        const owner = createEvoluAppOwnerFromTrezorData({ data: suiteSyncOwner.ownerSecret });
+        const appOwner = createEvoluAppOwnerFromTrezorData({ data: suiteSyncOwner.ownerSecret });
 
-        if (!owner.ok) {
-            console.error(owner.error);
+        if (!appOwner.ok) {
+            console.error(appOwner.error);
 
-            throw owner.error;
+            throw appOwner.error;
         }
+
+        const shardOwner = deriveShardOwner(appOwner.value, ['trezor-suite', '1']);
 
         const appName = AppName.from(`trezor-suite-v${VERSION}`);
 
@@ -42,15 +46,20 @@ export const createEvoluInstanceFactory =
             throw appName.error;
         }
 
-        return getOrThrow(
+        const evolu = getOrThrow(
             await deps.run(
                 createEvolu(Schema, {
                     appName: appName.value,
                     // Intentionally no transport, transport will be passed
                     // later on, so we can change the RelayUrl at any time.
                     transports: [],
-                    appOwner: owner.value,
+                    appOwner: appOwner.value,
                 }),
             ),
         );
+
+        return {
+            evolu,
+            shardOwner,
+        };
     };

--- a/suite-common/suite-sync-evolu/src/data/accountTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/accountTable.ts
@@ -4,6 +4,7 @@ import {
     NonEmptyString100,
     NonEmptyString1000,
     type QueryRows,
+    type ShardOwner,
     createIdFromString,
     createQueryBuilder,
     id,
@@ -47,7 +48,10 @@ export const AccountTableSchema = {
 const createQuery = createQueryBuilder(AccountTableSchema);
 
 export class EvoluAccountTable implements AccountTable {
-    constructor(private evolu: Evolu<typeof AccountTableSchema>) {}
+    constructor(
+        private evolu: Evolu<typeof AccountTableSchema>,
+        private shardOwner: ShardOwner,
+    ) {}
 
     update = ({ networkSymbol, accountDescriptor, label }: SuiteSyncAccount) => {
         const idResult = AccountEvoluId.from(
@@ -69,12 +73,15 @@ export class EvoluAccountTable implements AccountTable {
             return err(createSuiteSyncUpdateError({ caused: validated.error }));
         }
 
-        this.evolu.upsert('account', validated.value);
+        this.evolu.upsert('account', validated.value, { ownerId: this.shardOwner.id });
 
         return ok();
     };
 
-    private getQuery = () => createQuery(db => db.selectFrom('account').selectAll());
+    private getQuery = () =>
+        createQuery(db =>
+            db.selectFrom('account').where('ownerId', '=', this.shardOwner.id).selectAll(),
+        );
 
     subscribe = ({ onChange }: EntityListener<SuiteSyncAccount>) => {
         const query = this.getQuery();

--- a/suite-common/suite-sync-evolu/src/data/addressTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/addressTable.ts
@@ -3,6 +3,7 @@ import {
     type InferRow,
     NonEmptyString1000,
     type QueryRows,
+    type ShardOwner,
     createIdFromString,
     createQueryBuilder,
     id,
@@ -50,7 +51,10 @@ export const AddressTableSchema = {
 const createQuery = createQueryBuilder(AddressTableSchema);
 
 export class AddressEvoluTable implements AddressTable {
-    constructor(private evolu: Evolu<typeof AddressTableSchema>) {}
+    constructor(
+        private evolu: Evolu<typeof AddressTableSchema>,
+        private shardOwner: ShardOwner,
+    ) {}
 
     update = ({ address, label, accountDescriptor, networkSymbol }: SuiteSyncAddress) => {
         const idResult = createAddressEvoluId(address, networkSymbol);
@@ -71,12 +75,15 @@ export class AddressEvoluTable implements AddressTable {
             return err(createSuiteSyncUpdateError({ caused: validated.error }));
         }
 
-        this.evolu.upsert('address', validated.value);
+        this.evolu.upsert('address', validated.value, { ownerId: this.shardOwner.id });
 
         return ok();
     };
 
-    private getQuery = () => createQuery(db => db.selectFrom('address').selectAll());
+    private getQuery = () =>
+        createQuery(db =>
+            db.selectFrom('address').where('ownerId', '=', this.shardOwner.id).selectAll(),
+        );
 
     subscribe = ({ onChange }: EntityListener<SuiteSyncAddress>) => {
         const query = this.getQuery();

--- a/suite-common/suite-sync-evolu/src/data/outputTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/outputTable.ts
@@ -3,6 +3,7 @@ import {
     type InferRow,
     NonEmptyString1000,
     type QueryRows,
+    type ShardOwner,
     createIdFromString,
     createQueryBuilder,
     id,
@@ -54,7 +55,10 @@ export const OutputTableSchema = {
 const createQuery = createQueryBuilder(OutputTableSchema);
 
 export class OutputEvoluTable implements OutputTable {
-    constructor(private evolu: Evolu<typeof OutputTableSchema>) {}
+    constructor(
+        private evolu: Evolu<typeof OutputTableSchema>,
+        private shardOwner: ShardOwner,
+    ) {}
 
     update = ({ txId, txTargetId, label, accountDescriptor, networkSymbol }: SuiteSyncOutput) => {
         const idResult = OutputEvoluId.from(
@@ -78,12 +82,15 @@ export class OutputEvoluTable implements OutputTable {
             return err(createSuiteSyncUpdateError({ caused: validated.error }));
         }
 
-        this.evolu.upsert('output', validated.value);
+        this.evolu.upsert('output', validated.value, { ownerId: this.shardOwner.id });
 
         return ok();
     };
 
-    private getQuery = () => createQuery(db => db.selectFrom('output').selectAll());
+    private getQuery = () =>
+        createQuery(db =>
+            db.selectFrom('output').where('ownerId', '=', this.shardOwner.id).selectAll(),
+        );
 
     subscribe = ({ onChange }: EntityListener<SuiteSyncOutput>) => {
         const query = this.getQuery();

--- a/suite-common/suite-sync-evolu/src/data/walletTable.ts
+++ b/suite-common/suite-sync-evolu/src/data/walletTable.ts
@@ -3,6 +3,7 @@ import {
     type InferRow,
     NonEmptyString1000,
     type QueryRows,
+    type ShardOwner,
     createIdFromString,
     createQueryBuilder,
     id,
@@ -41,9 +42,15 @@ export const WalletTableSchema = {
 const createQuery = createQueryBuilder(WalletTableSchema);
 
 export class EvoluWalletTable implements WalletTable {
-    constructor(private evolu: Evolu<typeof WalletTableSchema>) {}
+    constructor(
+        private evolu: Evolu<typeof WalletTableSchema>,
+        private shardOwner: ShardOwner,
+    ) {}
 
-    private getQuery = () => createQuery(db => db.selectFrom('wallet').selectAll());
+    private getQuery = () =>
+        createQuery(db =>
+            db.selectFrom('wallet').where('ownerId', '=', this.shardOwner.id).selectAll(),
+        );
 
     update = ({ walletDescriptor, label }: SuiteSyncWallet) => {
         const idResult = WalletLabelId.from(createIdFromString(walletDescriptor));
@@ -64,7 +71,7 @@ export class EvoluWalletTable implements WalletTable {
             return err(createSuiteSyncUpdateError({ caused: validated.error }));
         }
 
-        this.evolu.upsert('wallet', validated.value);
+        this.evolu.upsert('wallet', validated.value, { ownerId: this.shardOwner.id });
 
         return ok();
     };

--- a/suite-common/suite-sync-evolu/src/evoluStorage.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.ts
@@ -25,16 +25,16 @@ export const createEvoluStorageFactory =
 
         let unuseOwner = () => {};
 
-        const evolu = await deps.createEvoluInstance({
+        const { evolu, shardOwner } = await deps.createEvoluInstance({
             suiteSyncOwner,
         });
 
         const updateRelayUrl = async (url: string) => {
-            const owner = await evolu.appOwner;
+            const appOwner = await evolu.appOwner;
 
             unuseOwner();
-            unuseOwner = evolu.useOwner(owner, [
-                createOwnerWebSocketTransport({ url, ownerId: owner.id }),
+            unuseOwner = evolu.useOwner(appOwner, [
+                createOwnerWebSocketTransport({ url, ownerId: appOwner.id }),
             ]);
         };
 
@@ -42,11 +42,19 @@ export const createEvoluStorageFactory =
             data: {
                 accounts: new EvoluAccountTable(
                     evolu as unknown as Evolu<typeof AccountTableSchema>,
+                    shardOwner,
                 ),
-                wallets: new EvoluWalletTable(evolu as unknown as Evolu<typeof WalletTableSchema>),
-                outputs: new OutputEvoluTable(evolu as unknown as Evolu<typeof OutputTableSchema>),
+                wallets: new EvoluWalletTable(
+                    evolu as unknown as Evolu<typeof WalletTableSchema>,
+                    shardOwner,
+                ),
+                outputs: new OutputEvoluTable(
+                    evolu as unknown as Evolu<typeof OutputTableSchema>,
+                    shardOwner,
+                ),
                 addresses: new AddressEvoluTable(
                     evolu as unknown as Evolu<typeof AddressTableSchema>,
+                    shardOwner,
                 ),
             },
 

--- a/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
+++ b/suite-common/suite-sync-evolu/tests/createEvoluStorageFactory.test.ts
@@ -1,4 +1,4 @@
-import { Run, testCreateWebSocket } from '@evolu/common';
+import { type Evolu, OwnerId, Run, createQueryBuilder, testCreateWebSocket } from '@evolu/common';
 import { EvoluPlatformDeps } from '@evolu/common/local-first';
 
 import {
@@ -16,6 +16,7 @@ import { createDeferred } from '@trezor/utils';
 import { testCreateRunWithEvoluDeps } from '../mocks/testCreateRunWithEvoluDeps';
 import { createEvoluInstanceFactory } from '../src/createEvoluInstance';
 import { createEvoluStorageFactory } from '../src/evoluStorage';
+import { Schema } from '../src/schema';
 
 const suiteSyncOwner: SuiteSyncOwner = {
     ownerId: asSuiteSyncOwnerId('yg0UgROParTpm60ltI3hDw'),
@@ -24,10 +25,35 @@ const suiteSyncOwner: SuiteSyncOwner = {
     ),
 };
 
-const createTestStorage = async (run: Run<EvoluPlatformDeps>) => {
-    const createEvoluInstance = createEvoluInstanceFactory({ run });
+const createQuery = createQueryBuilder(Schema);
 
-    return await createEvoluStorageFactory({ createEvoluInstance })({ suiteSyncOwner });
+const createTestStorage = async (run: Run<EvoluPlatformDeps>) => {
+    const instance = await createEvoluInstanceFactory({ run })({ suiteSyncOwner });
+    const storage = await createEvoluStorageFactory({
+        createEvoluInstance: () => Promise.resolve(instance),
+    })({ suiteSyncOwner });
+
+    return {
+        ...instance,
+        storage,
+    };
+};
+
+type ExpectOwnerIdToUseShardOwnerParams = {
+    evolu: Evolu<typeof Schema>;
+    ownerId: OwnerId | null;
+    expectedOwnerId: OwnerId;
+};
+
+const expectOwnerIdToUseShardOwner = async ({
+    evolu,
+    ownerId: rowOwnerId,
+    expectedOwnerId: shardOwnerId,
+}: ExpectOwnerIdToUseShardOwnerParams) => {
+    const appOwnerId = (await evolu.appOwner).id;
+
+    expect(rowOwnerId).toBe(shardOwnerId);
+    expect(rowOwnerId).not.toBe(appOwnerId);
 };
 
 describe(createEvoluStorageFactory.name, () => {
@@ -35,7 +61,7 @@ describe(createEvoluStorageFactory.name, () => {
         await using run = await testCreateRunWithEvoluDeps({
             createWebSocket: testCreateWebSocket({ throwOnCreate: true }),
         });
-        const storage = await createTestStorage(run);
+        const { evolu, shardOwner, storage } = await createTestStorage(run);
         const receivedWallets: SuiteSyncWallet[][] = [];
         const resolved = createDeferred<void>();
 
@@ -50,6 +76,7 @@ describe(createEvoluStorageFactory.name, () => {
             walletDescriptor: asWalletDescriptor('xpub123'),
             label: 'My Bitcoin Wallet',
         });
+
         expect(updateResult.success).toBe(true);
 
         await resolved.promise;
@@ -59,6 +86,15 @@ describe(createEvoluStorageFactory.name, () => {
             [{ label: 'My Bitcoin Wallet', walletDescriptor: 'xpub123' }],
         ]);
 
+        const rows = await evolu.loadQuery(createQuery(db => db.selectFrom('wallet').selectAll()));
+
+        expect(rows).toHaveLength(1);
+        await expectOwnerIdToUseShardOwner({
+            evolu,
+            ownerId: rows[0].ownerId,
+            expectedOwnerId: shardOwner.id,
+        });
+
         unsubscribe();
         await storage.dispose();
     });
@@ -67,7 +103,7 @@ describe(createEvoluStorageFactory.name, () => {
         await using run = await testCreateRunWithEvoluDeps({
             createWebSocket: testCreateWebSocket({ throwOnCreate: true }),
         });
-        const storage = await createTestStorage(run);
+        const { evolu, shardOwner, storage } = await createTestStorage(run);
 
         const receivedAccounts: SuiteSyncAccount[][] = [];
         const resolved = createDeferred<void>();
@@ -84,6 +120,7 @@ describe(createEvoluStorageFactory.name, () => {
             networkSymbol: 'btc',
             label: 'My Bitcoin Account',
         });
+
         expect(updateResult.success).toBe(true);
 
         await resolved.promise;
@@ -100,6 +137,15 @@ describe(createEvoluStorageFactory.name, () => {
             ],
         ]);
 
+        const rows = await evolu.loadQuery(createQuery(db => db.selectFrom('account').selectAll()));
+
+        expect(rows).toHaveLength(1);
+        await expectOwnerIdToUseShardOwner({
+            evolu,
+            ownerId: rows[0].ownerId,
+            expectedOwnerId: shardOwner.id,
+        });
+
         unsubscribe();
         await storage.dispose();
     });
@@ -108,7 +154,7 @@ describe(createEvoluStorageFactory.name, () => {
         await using run = await testCreateRunWithEvoluDeps({
             createWebSocket: testCreateWebSocket({ throwOnCreate: true }),
         });
-        const storage = await createTestStorage(run);
+        const { evolu, shardOwner, storage } = await createTestStorage(run);
 
         const receivedAddresses: SuiteSyncAddress[][] = [];
         const resolved = createDeferred<void>();
@@ -126,6 +172,7 @@ describe(createEvoluStorageFactory.name, () => {
             accountDescriptor: asAccountDescriptor('xpub123'),
             networkSymbol: 'btc',
         });
+
         expect(updateResult.success).toBe(true);
 
         await resolved.promise;
@@ -143,6 +190,15 @@ describe(createEvoluStorageFactory.name, () => {
             ],
         ]);
 
+        const rows = await evolu.loadQuery(createQuery(db => db.selectFrom('address').selectAll()));
+
+        expect(rows).toHaveLength(1);
+        await expectOwnerIdToUseShardOwner({
+            evolu,
+            ownerId: rows[0].ownerId,
+            expectedOwnerId: shardOwner.id,
+        });
+
         unsubscribe();
         await storage.dispose();
     });
@@ -151,7 +207,7 @@ describe(createEvoluStorageFactory.name, () => {
         await using run = await testCreateRunWithEvoluDeps({
             createWebSocket: testCreateWebSocket({ throwOnCreate: true }),
         });
-        const storage = await createTestStorage(run);
+        const { evolu, shardOwner, storage } = await createTestStorage(run);
 
         const receivedOutputs: SuiteSyncOutput[][] = [];
         const resolved = createDeferred<void>();
@@ -170,6 +226,7 @@ describe(createEvoluStorageFactory.name, () => {
             accountDescriptor: asAccountDescriptor('xpub123'),
             networkSymbol: 'btc',
         });
+
         expect(updateResult.success).toBe(true);
 
         await resolved.promise;
@@ -187,6 +244,15 @@ describe(createEvoluStorageFactory.name, () => {
                 },
             ],
         ]);
+
+        const rows = await evolu.loadQuery(createQuery(db => db.selectFrom('output').selectAll()));
+
+        expect(rows).toHaveLength(1);
+        await expectOwnerIdToUseShardOwner({
+            evolu,
+            ownerId: rows[0].ownerId,
+            expectedOwnerId: shardOwner.id,
+        });
 
         unsubscribe();
         await storage.dispose();


### PR DESCRIPTION
Use `ShardOwner` instead of the `AppOwner`. 

This is prerequisite for the key rotation for Suite Sync. 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=shardOwner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=shardOwner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=shardOwner&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T14:22:55.993Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T14:20:51.567Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->