### PR TITLE
Output descriptor BIP 380

### DIFF
--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -25,10 +25,12 @@ export const HELP = `@trezor/connect CLI arguments:
     --passphrase=<value>                      Use passphrase (default: empty)
 
   Method (default: GetAddress)
-    --method <name>                           Run TrezorConnect method
+    --method=<name>                           Run TrezorConnect method
                                                 --method=none (retrieve device Features and exit)
                                                 --method=fw-update
                                                 --method=get-credentials
+                                                --method=get-account-info
+                                                --method=get-account-descriptor
 `;
 
 // read and parse application arguments

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -107,6 +107,18 @@ const runTestCase = async (device: Device) => {
         result = await fwUpdate(device);
     } else if (method === 'get-credentials') {
         result = await TrezorConnect.thpGetCredentials({ device });
+    } else if (method === 'get-account-info') {
+        result = await TrezorConnect.getAccountInfo({
+            device,
+            coin: 'btc',
+            path: "m/84'/0'/0'",
+        });
+    } else if (method === 'get-account-descriptor') {
+        result = await TrezorConnect.getAccountDescriptor({
+            device,
+            coin: 'btc',
+            path: "m/84'/0'/0'",
+        });
     } else {
         result = await TrezorConnect.getAddress({
             device,

--- a/packages/connect-common/src/types/account.ts
+++ b/packages/connect-common/src/types/account.ts
@@ -18,6 +18,7 @@ export interface AccountInfo extends AccountInfoBase {
     legacyXpub?: string; // bitcoin-like descriptor in legacy format (xpub) used by labeling (metadata)
     utxo?: AccountUtxo[]; // bitcoin utxo
     descriptorChecksum?: string;
+    outputDescriptorBip380?: string; // Optional bitcoin only
 }
 
 export interface DiscoveryAccount {

--- a/packages/connect-common/src/types/api/getAccountDescriptor.ts
+++ b/packages/connect-common/src/types/api/getAccountDescriptor.ts
@@ -17,6 +17,7 @@ export interface GetAccountDescriptorResponse {
     descriptor: string;
     path: string;
     legacyXpub?: string; // bitcoin-like descriptor in legacy format (xpub) used by labeling (metadata)
+    outputDescriptorBip380?: string; // Optional bitcoin only
 }
 
 export declare function getAccountDescriptor(

--- a/packages/connect-common/src/types/api/getPublicKey.ts
+++ b/packages/connect-common/src/types/api/getPublicKey.ts
@@ -35,6 +35,7 @@ export const HDNodeResponse = Type.Intersect([
         descriptorChecksum: Type.Optional(Type.String()),
         chainCode: Type.String(),
         fingerprint: Type.Number(),
+        rootFingerprint: Type.Optional(Type.Number()),
         depth: Type.Number(),
         descriptor: Type.Optional(Type.String()),
     }),

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -22,7 +22,8 @@ import type {
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getCoinInfo } from '../data/coinInfo';
 import { getAccountLabel } from '../utils/accountUtils';
-import { getSerializedPath, validatePath } from '../utils/pathUtils';
+import { buildOutputDescriptor } from '../utils/buildOutputDescriptor';
+import { fromHardened, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
 
 type Request = GetAccountDescriptorParams & { address_n: number[]; coinInfo: CoinInfo };
 
@@ -133,7 +134,13 @@ export default class GetAccountDescriptor extends AbstractMethod<
             if (this.disposed) break;
 
             try {
-                const { descriptor, address_n, legacyXpub } = await this.getDevice()
+                const {
+                    descriptor,
+                    address_n,
+                    legacyXpub,
+                    outputDescriptorBip380,
+                    rootFingerprint,
+                } = await this.getDevice()
                     .getCommands()
                     .getAccountDescriptor(
                         request.coinInfo,
@@ -145,6 +152,20 @@ export default class GetAccountDescriptor extends AbstractMethod<
                     descriptor,
                     path: getSerializedPath(address_n),
                     legacyXpub,
+                    // outputDescriptorBip380 is provided by firmware >= 2.6.5.
+                    // For older firmware, build it from the available data (bitcoin only).
+                    outputDescriptorBip380:
+                        outputDescriptorBip380 ??
+                        (request.coinInfo.type === 'bitcoin' && legacyXpub
+                            ? buildOutputDescriptor({
+                                  coin: request.coinInfo.name,
+                                  account: fromHardened(address_n[2]),
+                                  purpose: fromHardened(address_n[0]),
+                                  scriptType: getScriptType(address_n),
+                                  xpub: legacyXpub,
+                                  rootFingerprint,
+                              })
+                            : undefined),
                 };
                 sendProgress(i, response);
                 responses.push(response);

--- a/packages/connect/src/api/getAccountDescriptor.ts
+++ b/packages/connect/src/api/getAccountDescriptor.ts
@@ -140,7 +140,8 @@ export default class GetAccountDescriptor extends AbstractMethod<
                         request.address_n,
                         request.derivationType,
                     );
-                const response = {
+
+                const response: GetAccountDescriptorResponse = {
                     descriptor,
                     path: getSerializedPath(address_n),
                     legacyXpub,

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -25,7 +25,8 @@ import { Discovery } from './common/Discovery';
 import { bundlify, validateParams } from './common/paramsValidator';
 import { requestExistingAccounts } from './common/requestExistingAccounts';
 import { getAccountLabel, isUtxoBased } from '../utils/accountUtils';
-import { getSerializedPath, validatePath } from '../utils/pathUtils';
+import { buildOutputDescriptor } from '../utils/buildOutputDescriptor';
+import { fromHardened, getScriptType, getSerializedPath, validatePath } from '../utils/pathUtils';
 
 type Request = GetAccountInfoParams & { address_n: number[]; coinInfo: CoinInfo };
 
@@ -187,6 +188,8 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             let { descriptor } = request;
             let legacyXpub: string | undefined;
             let descriptorChecksum: string | undefined;
+            let rootFingerprint: number | undefined;
+            let outputDescriptorBip380: string | undefined;
 
             if (this.disposed) break;
 
@@ -200,6 +203,21 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                         descriptor = accountDescriptor.descriptor;
                         legacyXpub = accountDescriptor.legacyXpub;
                         descriptorChecksum = accountDescriptor.descriptorChecksum;
+                        rootFingerprint = accountDescriptor.rootFingerprint;
+                        // outputDescriptorBip380 is provided by firmware >= 2.6.5.
+                        // For older firmware, build it from the available data (bitcoin only).
+                        outputDescriptorBip380 =
+                            accountDescriptor.outputDescriptorBip380 ??
+                            (request.coinInfo.type === 'bitcoin' && legacyXpub
+                                ? buildOutputDescriptor({
+                                      coin: request.coinInfo.name,
+                                      account: fromHardened(address_n[2]),
+                                      purpose: fromHardened(address_n[0]),
+                                      scriptType: getScriptType(address_n),
+                                      xpub: legacyXpub,
+                                      rootFingerprint,
+                                  })
+                                : undefined);
                     }
                 } catch (error) {
                     if (this.hasBundle) {
@@ -266,6 +284,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     legacyXpub,
                     utxo,
                     descriptorChecksum,
+                    outputDescriptorBip380,
                 };
                 responses.push(account);
 

--- a/packages/connect/src/device/DeviceCommands.ts
+++ b/packages/connect/src/device/DeviceCommands.ts
@@ -25,6 +25,9 @@ export type AccountDescriptor = {
     legacyXpub?: string;
     address_n: number[];
     descriptorChecksum?: string;
+    fingerprint?: number;
+    rootFingerprint?: number;
+    outputDescriptorBip380?: string;
 };
 
 export const DeviceCommands = (deviceTypedCall: TypedCallProvider) => {
@@ -103,6 +106,7 @@ export const DeviceCommands = (deviceTypedCall: TypedCallProvider) => {
             chainCode: publicKey.node.chain_code,
             publicKey: publicKey.node.public_key,
             fingerprint: publicKey.node.fingerprint,
+            rootFingerprint: publicKey.root_fingerprint,
             depth: publicKey.node.depth,
             descriptor: publicKey.descriptor,
         };
@@ -203,6 +207,9 @@ export const DeviceCommands = (deviceTypedCall: TypedCallProvider) => {
                 legacyXpub: resp.xpub,
                 address_n,
                 descriptorChecksum: resp.descriptorChecksum,
+                fingerprint: resp.fingerprint,
+                rootFingerprint: resp.rootFingerprint,
+                outputDescriptorBip380: resp.descriptor,
             };
         }
         if (coinInfo.type === 'ethereum') {

--- a/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
+++ b/packages/connect/src/utils/__tests__/buildOutputDescriptor.test.ts
@@ -1,0 +1,198 @@
+import { buildOutputDescriptor } from '../buildOutputDescriptor';
+
+const XPUB =
+    'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF';
+
+describe('utils/buildOutputDescriptor', () => {
+    describe('passthrough', () => {
+        it('returns descriptor as-is when provided', () => {
+            // When a descriptor is passed in, the function immediately returns it as-is — no checksum validation, no parsing, nothing.
+            const precomputed = 'wpkh([00000000/84h/0h/0]xpub.../<0;1>/*)#checksum';
+            expect(buildOutputDescriptor({ account: 0, xpub: XPUB, descriptor: precomputed })).toBe(
+                precomputed,
+            );
+        });
+    });
+
+    describe('script type inference from purpose', () => {
+        it('infers SPENDADDRESS from purpose 44', () => {
+            const result = buildOutputDescriptor({ account: 0, purpose: 44, xpub: XPUB });
+            expect(result).toMatch(/^pkh\(/);
+        });
+
+        it('infers SPENDP2SHWITNESS from purpose 49', () => {
+            const result = buildOutputDescriptor({ account: 0, purpose: 49, xpub: XPUB });
+            expect(result).toMatch(/^sh\(wpkh\(/);
+        });
+
+        it('infers SPENDWITNESS from purpose 84', () => {
+            const result = buildOutputDescriptor({ account: 0, purpose: 84, xpub: XPUB });
+            expect(result).toMatch(/^wpkh\(/);
+        });
+
+        it('infers SPENDTAPROOT from purpose 86', () => {
+            const result = buildOutputDescriptor({ account: 0, purpose: 86, xpub: XPUB });
+            expect(result).toMatch(/^tr\(/);
+        });
+    });
+
+    describe('purpose inference from scriptType', () => {
+        it('defaults to SPENDADDRESS when neither purpose nor scriptType given', () => {
+            const result = buildOutputDescriptor({ account: 0, xpub: XPUB });
+            expect(result).toMatch(/^pkh\(/);
+            expect(result).toContain('/44h/0h/0h');
+        });
+
+        it('infers purpose 49 from SPENDP2SHWITNESS', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDP2SHWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/49h/0h/0h');
+        });
+
+        it('infers purpose 84 from SPENDWITNESS', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/84h/0h/0h');
+        });
+    });
+
+    describe('path construction', () => {
+        it('uses coin_type 0 for Bitcoin', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                coin: 'Bitcoin',
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/84h/0h/0h');
+        });
+
+        it('uses coin_type 1 for Testnet', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                coin: 'Testnet',
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/84h/1h/0h');
+        });
+
+        it('uses coin_type 1 for Regtest', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                coin: 'Regtest',
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/84h/1h/0h');
+        });
+
+        it('uses the correct account index', () => {
+            const result = buildOutputDescriptor({
+                account: 2,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('/84h/0h/2h');
+        });
+
+        it('encodes rootFingerprint as 8-char hex', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+                rootFingerprint: 0xdeadbeef,
+            });
+            expect(result).toContain('[deadbeef/');
+        });
+
+        it('zero-pads rootFingerprint to 8 chars', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+                rootFingerprint: 1,
+            });
+            expect(result).toContain('[00000001/');
+        });
+
+        it('defaults rootFingerprint to 00000000 when not provided', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toContain('[00000000/');
+        });
+    });
+
+    describe('SLIP25', () => {
+        it('appends /1h for SLIP25 taproot', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                purpose: 10025,
+                scriptType: 'SPENDTAPROOT',
+                xpub: XPUB,
+            });
+            expect(result).toEqual(
+                'tr([00000000/10025h/0h/0h/1h]xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/<0;1>/*)#zqcxnytn',
+            );
+        });
+
+        it('returns undefined for SLIP25 with non-taproot script type', () => {
+            expect(
+                buildOutputDescriptor({
+                    account: 0,
+                    purpose: 10025,
+                    scriptType: 'SPENDWITNESS',
+                    xpub: XPUB,
+                }),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('checksum', () => {
+        it('appends a #checksum suffix', () => {
+            const result = buildOutputDescriptor({
+                account: 0,
+                scriptType: 'SPENDWITNESS',
+                xpub: XPUB,
+            });
+            expect(result).toMatch(/#[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{8}$/);
+        });
+    });
+
+    describe('invalid inputs return undefined', () => {
+        it('returns undefined for unsupported coin', () => {
+            expect(
+                buildOutputDescriptor({
+                    account: 0,
+                    coin: 'Ethereum',
+                    scriptType: 'SPENDWITNESS',
+                    xpub: XPUB,
+                }),
+            ).toBeUndefined();
+        });
+
+        it('returns undefined for unknown purpose', () => {
+            expect(buildOutputDescriptor({ account: 0, purpose: 999, xpub: XPUB })).toBeUndefined();
+        });
+
+        it('returns undefined when purpose and scriptType are mismatched', () => {
+            expect(
+                buildOutputDescriptor({
+                    account: 0,
+                    purpose: 84,
+                    scriptType: 'SPENDADDRESS',
+                    xpub: XPUB,
+                }),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/packages/connect/src/utils/buildOutputDescriptor.ts
+++ b/packages/connect/src/utils/buildOutputDescriptor.ts
@@ -1,0 +1,85 @@
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { addDescriptorChecksum } from '@trezor/utxo-lib';
+
+const PURPOSE_BIP44 = 44;
+const PURPOSE_BIP49 = 49;
+const PURPOSE_BIP84 = 84;
+const PURPOSE_BIP86 = 86;
+const PURPOSE_SLIP25 = 10025;
+
+const SCRIPT_TYPE_TO_PURPOSES: Partial<Record<PROTO.InternalInputScriptType, number[]>> = {
+    SPENDADDRESS: [PURPOSE_BIP44],
+    SPENDP2SHWITNESS: [PURPOSE_BIP49],
+    SPENDWITNESS: [PURPOSE_BIP84],
+    SPENDTAPROOT: [PURPOSE_BIP86, PURPOSE_SLIP25],
+};
+
+const PURPOSE_TO_SCRIPT_TYPE: Record<number, PROTO.InternalInputScriptType> = {
+    [PURPOSE_BIP44]: 'SPENDADDRESS',
+    [PURPOSE_BIP49]: 'SPENDP2SHWITNESS',
+    [PURPOSE_BIP84]: 'SPENDWITNESS',
+    [PURPOSE_BIP86]: 'SPENDTAPROOT',
+    [PURPOSE_SLIP25]: 'SPENDTAPROOT',
+};
+
+type BuildOutputDescriptorBip380Params = {
+    coin?: string;
+    account: number;
+    purpose?: number;
+    scriptType?: PROTO.InternalInputScriptType;
+    xpub: string;
+    rootFingerprint?: number;
+    descriptor?: string;
+};
+
+export const buildOutputDescriptor = ({
+    coin,
+    account,
+    purpose,
+    scriptType,
+    xpub,
+    rootFingerprint,
+    descriptor,
+}: BuildOutputDescriptorBip380Params): string | undefined => {
+    if (descriptor !== undefined) return descriptor;
+
+    if (purpose === undefined) {
+        scriptType ??= 'SPENDADDRESS';
+        purpose = SCRIPT_TYPE_TO_PURPOSES[scriptType]?.[0];
+        if (purpose === undefined) return undefined;
+    } else if (scriptType === undefined) {
+        scriptType = PURPOSE_TO_SCRIPT_TYPE[purpose];
+        // If we cannot build properly the output descriptor we return undefined.
+        if (!scriptType) return undefined;
+    } else if (!SCRIPT_TYPE_TO_PURPOSES[scriptType]?.includes(purpose)) {
+        return undefined;
+    }
+
+    const COIN_TYPE: Record<string, number> = { Bitcoin: 0, Testnet: 1, Regtest: 1 };
+    const coinType = COIN_TYPE[coin ?? 'Bitcoin'];
+    if (coinType === undefined) {
+        return undefined;
+    }
+
+    let path = `m/${purpose}h/${coinType}h/${account}h`;
+    if (purpose === PURPOSE_SLIP25) {
+        if (scriptType === 'SPENDTAPROOT') {
+            path += '/1h';
+        } else {
+            return undefined;
+        }
+    }
+
+    const fmtMap: Record<Exclude<PROTO.InternalInputScriptType, 'SPENDMULTISIG'>, string> = {
+        SPENDADDRESS: 'pkh({})',
+        SPENDP2SHWITNESS: 'sh(wpkh({}))',
+        SPENDWITNESS: 'wpkh({})',
+        SPENDTAPROOT: 'tr({})',
+    };
+
+    const fmt = fmtMap[scriptType as Exclude<PROTO.InternalInputScriptType, 'SPENDMULTISIG'>];
+    const fingerprint = rootFingerprint ?? 0;
+    const inner = `[${fingerprint.toString(16).padStart(8, '0')}${path.slice(1)}]${xpub}/<0;1>/*`;
+
+    return addDescriptorChecksum(fmt.replace('{}', inner));
+};

--- a/packages/utxo-lib/src/descriptors/checksum.ts
+++ b/packages/utxo-lib/src/descriptors/checksum.ts
@@ -1,0 +1,81 @@
+// https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#checksum
+
+const INPUT_CHARSET =
+    '0123456789()[],\'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#"\\ ';
+const CHECKSUM_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const GENERATOR = [0xf5dee51989n, 0xa9fdca3312n, 0x1bab10e32dn, 0x3706b1677an, 0x644d626ffdn];
+
+/** Internal: computes the descriptor checksum polymod over a symbol sequence. */
+const descsumsPolymod = (symbols: bigint[]): bigint => {
+    let chk = 1n;
+    for (const value of symbols) {
+        const top = chk >> 35n;
+        chk = ((chk & 0x7ffffffffn) << 5n) ^ value;
+        for (let i = 0; i < 5; i++) {
+            chk ^= (top >> BigInt(i)) & 1n ? GENERATOR[i] : 0n;
+        }
+    }
+
+    return chk;
+};
+
+/** Internal: expands a descriptor string into its symbol sequence. Returns null for invalid chars. */
+const descsumsExpand = (s: string): bigint[] | null => {
+    const groups: number[] = [];
+    const symbols: bigint[] = [];
+    for (const c of s) {
+        const v = INPUT_CHARSET.indexOf(c);
+        if (v === -1) return null;
+        symbols.push(BigInt(v & 31));
+        groups.push(v >> 5);
+        if (groups.length === 3) {
+            symbols.push(BigInt(groups[0] * 9 + groups[1] * 3 + groups[2]));
+            groups.length = 0;
+        }
+    }
+    if (groups.length === 1) symbols.push(BigInt(groups[0]));
+    else if (groups.length === 2) symbols.push(BigInt(groups[0] * 3 + groups[1]));
+
+    return symbols;
+};
+
+/**
+ * Computes the 8-character BIP-380 checksum for a descriptor string (without '#' prefix).
+ * Throws if the descriptor contains characters outside the allowed charset.
+ */
+export const getDescriptorChecksum = (desc: string): string => {
+    const symbols = descsumsExpand(desc);
+    if (symbols === null) throw new Error(`Invalid character in descriptor: ${desc}`);
+
+    const checksum = descsumsPolymod([...symbols, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n]) ^ 1n;
+
+    return Array.from(
+        { length: 8 },
+        (_, i) => CHECKSUM_CHARSET[Number((checksum >> BigInt(5 * (7 - i))) & 31n)],
+    ).join('');
+};
+
+/**
+ * Appends a `#<checksum>` suffix to a descriptor string, as defined by BIP-380.
+ * Throws if the descriptor contains characters outside the allowed charset.
+ */
+export const addDescriptorChecksum = (desc: string): string =>
+    `${desc}#${getDescriptorChecksum(desc)}`;
+
+/**
+ * Verifies that the checksum appended to a descriptor string is correct.
+ * Expects the format `<desc>#<8-char-checksum>`.
+ */
+export const verifyDescriptorChecksum = (s: string): boolean => {
+    if (s[s.length - 9] !== '#') return false;
+    const checksumStr = s.slice(-8);
+    if (!checksumStr.split('').every(c => CHECKSUM_CHARSET.includes(c))) return false;
+    const symbols = descsumsExpand(s.slice(0, -9));
+    if (symbols === null) return false;
+    const checksumSymbols = [
+        ...symbols,
+        ...checksumStr.split('').map(c => BigInt(CHECKSUM_CHARSET.indexOf(c))),
+    ];
+
+    return descsumsPolymod(checksumSymbols) === 1n;
+};

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -4,6 +4,7 @@ import * as bufferutils from './bufferutils';
 import { composeTx } from './compose';
 import * as crypto from './crypto';
 import { deriveAddresses, getXpubOrDescriptorInfo } from './derivation';
+import { addDescriptorChecksum } from './descriptors/checksum';
 import { createAddressCache, discovery } from './discovery';
 import * as networks from './networks';
 import * as payments from './payments';
@@ -26,6 +27,7 @@ export {
     discovery,
     createAddressCache,
     TxWeightCalculator,
+    addDescriptorChecksum,
 };
 
 export type { PaymentType } from './derivation';

--- a/packages/utxo-lib/tests/descriptors/checksum.test.ts
+++ b/packages/utxo-lib/tests/descriptors/checksum.test.ts
@@ -1,0 +1,108 @@
+// Test vectors from https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#test-vectors
+
+import {
+    addDescriptorChecksum,
+    getDescriptorChecksum,
+    verifyDescriptorChecksum,
+} from '../../src/descriptors/checksum';
+
+describe('getDescriptorChecksum', () => {
+    it('computes checksum for raw(deadbeef)', () => {
+        expect(getDescriptorChecksum('raw(deadbeef)')).toBe('89f8spxm');
+    });
+
+    it('throws for a descriptor containing an invalid character', () => {
+        expect(() => getDescriptorChecksum('raw(Ü)')).toThrow('Invalid character in descriptor');
+    });
+
+    // Round-trip: the checksum of the same input is always identical
+    it('is deterministic', () => {
+        const desc =
+            '[deadbeef/0h/1h/2h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/3/4/5/*';
+        expect(getDescriptorChecksum(desc)).toBe(getDescriptorChecksum(desc));
+    });
+
+    it('with receive and change descriptor (BIP389)', () => {
+        const fromAllSeed =
+            'wpkh([5c9e228d/84h/0h/0h]xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/<0;1>/*)';
+        const expectedChecksum = 'u9auedf8';
+        expect(getDescriptorChecksum(fromAllSeed)).toBe(expectedChecksum);
+    });
+
+    it('with received descriptor (Bitcoin Core)', () => {
+        const fromAllSeed =
+            'wpkh([5c9e228d/84h/0h/0h]xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/0/*)';
+        const expectedChecksum = 'vyj8qz0q';
+        expect(getDescriptorChecksum(fromAllSeed)).toBe(expectedChecksum);
+    });
+
+    it('with change descriptor (Bitcoin Core)', () => {
+        const fromAllSeed =
+            'wpkh([5c9e228d/84h/0h/0h]xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/1/*)';
+        const expectedChecksum = 'ashxahlc';
+        expect(getDescriptorChecksum(fromAllSeed)).toBe(expectedChecksum);
+    });
+});
+
+describe('addDescriptorChecksum', () => {
+    it('appends #<checksum> to raw(deadbeef)', () => {
+        expect(addDescriptorChecksum('raw(deadbeef)')).toBe('raw(deadbeef)#89f8spxm');
+    });
+
+    it('output always passes verifyDescriptorChecksum', () => {
+        const expressions = [
+            '0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600',
+            '[deadbeef/0h/0h/0h]0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600',
+            "[deadbeef/0'/0'/0']0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600",
+            'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+            '[deadbeef/0h/1h/2h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+            '[deadbeef/0h/1h/2h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/3/4/5',
+            '[deadbeef/0h/1h/2h]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/3/4/5/*',
+            'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/3h/4h/5h/*',
+            'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/3h/4h/5h/*h',
+        ];
+        for (const expr of expressions) {
+            expect(verifyDescriptorChecksum(addDescriptorChecksum(expr))).toBe(true);
+        }
+    });
+});
+
+describe('verifyDescriptorChecksum', () => {
+    describe('valid', () => {
+        it('accepts raw(deadbeef)#89f8spxm', () => {
+            expect(verifyDescriptorChecksum('raw(deadbeef)#89f8spxm')).toBe(true);
+        });
+    });
+
+    describe('invalid', () => {
+        it('rejects when there is no checksum', () => {
+            expect(verifyDescriptorChecksum('raw(deadbeef)')).toBe(false);
+        });
+
+        it('rejects when checksum is missing after #', () => {
+            expect(verifyDescriptorChecksum('raw(deadbeef)#')).toBe(false);
+        });
+
+        it('rejects a checksum that is too short (7 chars)', () => {
+            expect(verifyDescriptorChecksum('raw(deadbeef)#89f8spx')).toBe(false);
+        });
+
+        it('rejects a checksum that is too long (9 chars)', () => {
+            expect(verifyDescriptorChecksum('raw(deadbeef)#89f8spxmx')).toBe(false);
+        });
+
+        it('rejects when the payload has been altered', () => {
+            // deedbeef vs deadbeef
+            expect(verifyDescriptorChecksum('raw(deedbeef)#89f8spxm')).toBe(false);
+        });
+
+        it('rejects when the checksum contains invalid characters', () => {
+            // second char is '#' which is not in CHECKSUM_CHARSET
+            expect(verifyDescriptorChecksum('raw(deedbeef)##9f8spxm')).toBe(false);
+        });
+
+        it('rejects when the payload contains characters outside INPUT_CHARSET', () => {
+            expect(verifyDescriptorChecksum('raw(Ü)#00000000')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Exporting output descriptors generated by Trezor devices in Trezor Connect as in BIP 380. Since those output descriptors are generated by the device only on FW >= 2.6.5. but we can build it in Connect when it is missing in the device this PR is also adding the fallback option of building the output descriptor in TrezorConnect when device does not provide it.

The name `outputDescriptorBip380` I added for the payload I honestly do not like, it is ugly but since we already have `descriptor` that uses slip32, I found this naming that clearly explains what it is the less confusing and therefore opted for it. That being said I accept ideas of improvement.

## Notes for QA
It can be tested in Connect Explorer or with Connect CLI by running the command below:

```
yarn workspace @trezor/connect-cli cli --method=get-account-info
```
Should provide payload like below including `outputDescriptorBip380`:

```
{
  id: 1,
  success: true,
  payload: {
    path: "m/84'/0'/0'",
    descriptor: 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
    .....
    legacyXpub: 'xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF',
    utxo: undefined,
    descriptorChecksum: undefined,
    outputDescriptorBip380: 'wpkh([5c9e228d/84h/0h/0h]xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF/<0;1>/*)#u9auedf8'
  },
  device: {
    ....
  }
}
```

Where `outputDescriptorBip380` is the new added param.


## Related Issue

Related https://github.com/trezor/trezor-suite/issues/23797

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-descriptor-output-bip-380&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-descriptor-output-bip-380&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-descriptor-output-bip-380&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T14:42:25.799Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T15:30:24.154Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-descriptor-output-bip-380/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-descriptor-output-bip-380/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->