### PR TITLE
fix(suite-native): patch expo-device to include missing Apple devices

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -11,6 +11,10 @@
 
 ---
 
+## expo-device
+
+Fixes https://github.com/trezor/trezor-suite/issues/26487.
+
 ## expo-modules-core
 
 Native-only, but does not break any CI.

--- a/patches/expo-device+55.0.9.patch
+++ b/patches/expo-device+55.0.9.patch
@@ -1,0 +1,102 @@
+diff --git a/node_modules/expo-device/ios/UIDevice.swift b/node_modules/expo-device/ios/UIDevice.swift
+index 3a00a8d..336c648 100644
+--- a/node_modules/expo-device/ios/UIDevice.swift
++++ b/node_modules/expo-device/ios/UIDevice.swift
+@@ -96,6 +96,8 @@ public extension UIDevice {
+         return ExpoDeviceType(modelName: "iPhone 16 Pro", deviceYearClass: 2024)
+       case "iPhone17,2":
+         return ExpoDeviceType(modelName: "iPhone 16 Pro Max", deviceYearClass: 2024)
++      case "iPhone17,5":
++        return ExpoDeviceType(modelName: "iPhone 16e", deviceYearClass: 2025)
+       case "iPhone18,1":
+         return ExpoDeviceType(modelName: "iPhone 17 Pro", deviceYearClass: 2025)
+       case "iPhone18,2":
+@@ -104,8 +106,10 @@ public extension UIDevice {
+         return ExpoDeviceType(modelName: "iPhone 17", deviceYearClass: 2025)
+       case "iPhone18,4":
+         return ExpoDeviceType(modelName: "iPhone Air", deviceYearClass: 2025)
++      case "iPhone18,5":
++        return ExpoDeviceType(modelName: "iPhone 17e", deviceYearClass: 2026)
+       case "iPhone8,4":
+-        return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
++        return ExpoDeviceType(modelName: "iPhone SE (1st generation)", deviceYearClass: 2016)
+       case "iPhone12,8":
+         return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
+       case "iPhone14,6":
+@@ -122,6 +126,8 @@ public extension UIDevice {
+         return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
+       case "iPad13,18", "iPad13,19":
+         return ExpoDeviceType(modelName: "iPad (10th generation)", deviceYearClass: 2022)
++      case "iPad15,7", "iPad15,8":
++        return ExpoDeviceType(modelName: "iPad (A16)", deviceYearClass: 2025)
+       case "iPad5,3", "iPad5,4":
+         return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
+       case "iPad11,3", "iPad11,4":
+@@ -131,15 +137,25 @@ public extension UIDevice {
+       case "iPad13,16", "iPad13,17":
+         return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
+       case "iPad14,8", "iPad14,9":
+-        return ExpoDeviceType(modelName: "iPad Air (11-inch) (6th generation)", deviceYearClass: 2024)
+-      case "iPad 14,10", "iPad 14,11":
+-        return ExpoDeviceType(modelName: "iPad Air (13-inch) (6th generation)", deviceYearClass: 2024)
++        return ExpoDeviceType(modelName: "iPad Air 11-inch (M2)", deviceYearClass: 2024)
++      case "iPad14,10", "iPad14,11":
++        return ExpoDeviceType(modelName: "iPad Air 13-inch (M2)", deviceYearClass: 2024)
++      case "iPad15,3", "iPad15,4":
++        return ExpoDeviceType(modelName: "iPad Air 11-inch (M3)", deviceYearClass: 2025)
++      case "iPad15,5", "iPad15,6":
++        return ExpoDeviceType(modelName: "iPad Air 13-inch (M3)", deviceYearClass: 2025)
++      case "iPad16,8", "iPad16,9":
++        return ExpoDeviceType(modelName: "iPad Air 11-inch (M4)", deviceYearClass: 2026)
++      case "iPad16,10", "iPad16,11":
++        return ExpoDeviceType(modelName: "iPad Air 13-inch (M4)", deviceYearClass: 2026)
+       case "iPad5,1", "iPad5,2":
+         return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
+       case "iPad11,1", "iPad11,2":
+         return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
+       case "iPad14,1", "iPad14,2":
+         return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
++      case "iPad16,1", "iPad16,2":
++        return ExpoDeviceType(modelName: "iPad mini (A17 Pro)", deviceYearClass: 2024)
+       case "iPad6,3", "iPad6,4":
+         return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
+       case "iPad7,3", "iPad7,4":
+@@ -151,7 +167,7 @@ public extension UIDevice {
+       case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
+         return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
+       case "iPad14,3-A", "iPad14,3-B", "iPad14,4-A", "iPad14,4-B":
+-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (4rd generation)", deviceYearClass: 2022)
++        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (4th generation)", deviceYearClass: 2022)
+       case "iPad6,7", "iPad6,8":
+         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
+       case "iPad7,1", "iPad7,2":
+@@ -164,10 +180,14 @@ public extension UIDevice {
+         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
+       case "iPad14,5-A", "iPad14,5-B", "iPad14,6-A", "iPad14,6-B":
+         return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (6th generation)", deviceYearClass: 2022)
+-      case "iPad16,3", "iPad16,4":
+-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (7th generation)", deviceYearClass: 2024)
+-      case "iPad16,5", "iPad16,6":
+-        return ExpoDeviceType(modelName: "iPad Pro (13-inch) (7th generation)", deviceYearClass: 2024)
++      case "iPad16,3-A", "iPad16,3-B", "iPad16,4-A", "iPad16,4-B":
++        return ExpoDeviceType(modelName: "iPad Pro 11-inch (M4)", deviceYearClass: 2024)
++      case "iPad16,5-A", "iPad16,5-B", "iPad16,6-A", "iPad16,6-B":
++        return ExpoDeviceType(modelName: "iPad Pro 13-inch (M4)", deviceYearClass: 2024)
++      case "iPad17,1-A", "iPad17,1-B", "iPad17,2-A", "iPad17,2-B":
++        return ExpoDeviceType(modelName: "iPad Pro 11-inch (M5)", deviceYearClass: 2025)
++      case "iPad17,3-A", "iPad17,3-B", "iPad17,4-A", "iPad17,4-B":
++        return ExpoDeviceType(modelName: "iPad Pro 13-inch (M5)", deviceYearClass: 2025)
+       case "i386", "x86_64", "arm64":
+         return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
+       default:
+@@ -179,6 +199,10 @@ public extension UIDevice {
+         return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
+       case "AppleTV6,2":
+         return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
++      case "AppleTV11,1":
++        return ExpoDeviceType(modelName: "Apple TV 4K (2nd generation)", deviceYearClass: 2021)
++      case "AppleTV14,1":
++        return ExpoDeviceType(modelName: "Apple TV 4K (3rd generation)", deviceYearClass: 2022)
+       case "i386", "x86_64":
+         return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
+       default:


### PR DESCRIPTION
Temporary patch until the official release with the fix is available.

## Notes for QA

Needs to be verified using a physical device as the Simulator is reported as `Simulator iOS`.

## Related Issue

Resolve #26487

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/expo-device-patch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/expo-device-patch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-09T16:20:24.715Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-09T16:19:00.028Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->