### PR TITLE
fix(request-manager): add missing constants to ws interceptor

### DIFF
--- a/packages/request-manager/src/interceptor/interceptWebSocket.ts
+++ b/packages/request-manager/src/interceptor/interceptWebSocket.ts
@@ -8,24 +8,34 @@ import { type Interceptor } from './interceptorTypes';
 export const interceptWebSocket: Interceptor = ({ context, validateRequest }) => {
     const OriginalWebSocket = globalThis.WebSocket;
 
-    // Must be a regular function (not an arrow function): when a constructor explicitly returns an
-    // object, `new` uses that returned object instead of `this`.
-    globalThis.WebSocket = function (url: string | URL, protocols?: string | string[]) {
-        const urlString = url.toString();
-        const { hostname } = new URL(urlString);
+    // Object.assign copies the readyState constants (CONNECTING/OPEN/CLOSING/CLOSED) onto the
+    // factory function itself.
+    globalThis.WebSocket = Object.assign(
+        // Must be a regular function (not an arrow function): when a constructor explicitly returns an
+        // object, `new` uses that returned object instead of `this`.
+        function (url: string | URL, protocols?: string | string[]) {
+            const urlString = url.toString();
+            const { hostname } = new URL(urlString);
 
-        validateRequest({ hostname });
+            validateRequest({ hostname });
 
-        if (context.getTorSettings().running) {
-            const agent = context.torIdentities.getIdentity(
-                `WebSocket/${hostname}`,
-                undefined,
-                'https',
-            );
+            if (context.getTorSettings().running) {
+                const agent = context.torIdentities.getIdentity(
+                    `WebSocket/${hostname}`,
+                    undefined,
+                    'https',
+                );
 
-            return new WebSocketNode(urlString, protocols, { agent });
-        }
+                return new WebSocketNode(urlString, protocols, { agent });
+            }
 
-        return new OriginalWebSocket(url, protocols as string);
-    } as unknown as typeof globalThis.WebSocket;
+            return new OriginalWebSocket(url, protocols);
+        },
+        {
+            CONNECTING: WebSocketNode.CONNECTING,
+            OPEN: WebSocketNode.OPEN,
+            CLOSING: WebSocketNode.CLOSING,
+            CLOSED: WebSocketNode.CLOSED,
+        },
+    ) as unknown as typeof globalThis.WebSocket;
 };


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
With the new added missing contants they can be accessible like "WebSocket.OPEN" or "new WebSocket(...).OPEN" in case it is necessary

## Notes for QA
Test that discovery and sending works properly when Tor is enable, specially with Solana.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/intercept-websocket-request-manager&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/intercept-websocket-request-manager&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T06:26:44.432Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T06:25:19.430Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->