### PR TITLE
Connect explorer cleanup

### DIFF
--- a/packages/connect-explorer-theme/package.json
+++ b/packages/connect-explorer-theme/package.json
@@ -19,7 +19,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "peerDependencies": {
-        "next": ">=9.5.3",
+        "next": ">=15.0.0",
         "nextra": "^2.13.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"

--- a/packages/connect-explorer-theme/src/contexts/config.tsx
+++ b/packages/connect-explorer-theme/src/contexts/config.tsx
@@ -92,12 +92,8 @@ export const ConfigProvider = ({
         isValidated = true;
     }
     const extendedConfig: Config = {
-        newNextLinkBehavior: false,
         ...theme,
         flexsearch: pageOpts.flexsearch,
-        ...(typeof pageOpts.newNextLinkBehavior === 'boolean' && {
-            newNextLinkBehavior: pageOpts.newNextLinkBehavior,
-        }),
         title: pageOpts.title,
         frontMatter: pageOpts.frontMatter,
     };

--- a/packages/connect-explorer-theme/src/contexts/useConfig.tsx
+++ b/packages/connect-explorer-theme/src/contexts/useConfig.tsx
@@ -4,7 +4,7 @@ import type { FrontMatter, PageOpts } from 'nextra';
 
 import type { DocsThemeConfig } from '../schema';
 export type Config<FrontMatterType = FrontMatter> = DocsThemeConfig &
-    Pick<PageOpts<FrontMatterType>, 'flexsearch' | 'newNextLinkBehavior' | 'title' | 'frontMatter'>;
+    Pick<PageOpts<FrontMatterType>, 'flexsearch' | 'title' | 'frontMatter'>;
 export const ConfigContext = createContext<Config>({} as Config);
 export function useConfig<FrontMatterType = FrontMatter>() {
     return useContext<Config<FrontMatterType>>(ConfigContext);

--- a/packages/connect-explorer/src/components/LinkButton.tsx
+++ b/packages/connect-explorer/src/components/LinkButton.tsx
@@ -1,0 +1,35 @@
+import type { ComponentProps } from 'react';
+
+import { useRouter } from 'next/router';
+
+import { Button } from '@trezor/components';
+
+type LinkButtonProps = Omit<ComponentProps<typeof Button>, 'target'> & {
+    href: string;
+};
+
+const isExternal = (href: string) => /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//');
+
+export const LinkButton = ({ href, children, onClick, ...props }: LinkButtonProps) => {
+    const router = useRouter();
+    const external = isExternal(href);
+    const resolvedHref = external ? href : `${router.basePath}${href}`;
+
+    return (
+        <Button
+            {...props}
+            href={resolvedHref}
+            target="_self"
+            onClick={e => {
+                onClick?.(e);
+                if (e.defaultPrevented) return;
+                if (external) return;
+                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+                e.preventDefault();
+                void router.push(href);
+            }}
+        >
+            {children}
+        </Button>
+    );
+};

--- a/packages/connect-explorer/src/pages/index.mdx
+++ b/packages/connect-explorer/src/pages/index.mdx
@@ -3,7 +3,6 @@ auto_sections: false
 icon: lightning
 ---
 
-import Link from 'next/link';
 import { Card, Cards, Steps, Tabs } from 'nextra/components';
 
 import { Button, CollapsibleBox } from '@trezor/components';
@@ -21,6 +20,7 @@ import {
     SdkTag,
     SectionCard,
 } from '../components/IndexPageComponents';
+import { LinkButton } from '../components/LinkButton';
 import ZoomableIllustration from '../components/ZoomableIllustration';
 import IconExtension from '../components/icons/IconExtension';
 import IconMobile from '../components/icons/IconMobile';
@@ -80,17 +80,14 @@ import IconWeb from '../components/icons/IconWeb';
         <IconNode />
         <SdkName>Node.js</SdkName>
         <SdkTag></SdkTag>
-        <Link href="/readme/connect" passHref legacyBehavior>
-            <Button
-                intent="neutral"
-                priority="secondary"
-                size="small"
-                iconLeft="bookOpenText"
-                target="_self"
-                href="#">
-                README
-            </Button>
-        </Link>
+        <LinkButton
+            intent="neutral"
+            priority="secondary"
+            size="small"
+            iconLeft="bookOpenText"
+            href="/readme/connect">
+            README
+        </LinkButton>
         <Button
             intent="neutral"
             priority="secondary"
@@ -179,17 +176,14 @@ import IconWeb from '../components/icons/IconWeb';
         <IconWeb />
         <SdkName>Web</SdkName>
         <SdkTag>DOM required</SdkTag>
-        <Link href="/readme/connect-web" passHref legacyBehavior>
-            <Button
-                intent="neutral"
-                priority="secondary"
-                size="small"
-                iconLeft="bookOpenText"
-                target="_self"
-                href="#">
-                README
-            </Button>
-        </Link>
+        <LinkButton
+            intent="neutral"
+            priority="secondary"
+            size="small"
+            iconLeft="bookOpenText"
+            href="/readme/connect-web">
+            README
+        </LinkButton>
         <Button
             intent="neutral"
             priority="secondary"
@@ -293,17 +287,14 @@ import IconWeb from '../components/icons/IconWeb';
         <IconExtension />
         <SdkName>Web extension</SdkName>
         <SdkTag>Using service worker</SdkTag>
-        <Link href="/readme/connect-webextension" passHref legacyBehavior>
-            <Button
-                intent="neutral"
-                priority="secondary"
-                size="small"
-                iconLeft="bookOpenText"
-                target="_self"
-                href="#">
-                README
-            </Button>
-        </Link>
+        <LinkButton
+            intent="neutral"
+            priority="secondary"
+            size="small"
+            iconLeft="bookOpenText"
+            href="/readme/connect-webextension">
+            README
+        </LinkButton>
         <Button
             intent="neutral"
             priority="secondary"
@@ -329,18 +320,15 @@ import IconWeb from '../components/icons/IconWeb';
             allowing secure connection to Trezor hardware wallets.
             By the end, you'll have a fully functional web extension.
 
-            <Link href="/guides/webextension-implementation-tutorial" passHref legacyBehavior>
-                <Button
-                    intent="neutral"
-                    priority="secondary"
-                    className="nx-mt-4 nx-mb-8"
-                    size="small"
-                    iconLeft="bookOpenText"
-                    target="_self"
-                    href="#">
-                    Open Tutorial  →
-                </Button>
-            </Link>
+            <LinkButton
+                intent="neutral"
+                priority="secondary"
+                className="nx-mt-4 nx-mb-8"
+                size="small"
+                iconLeft="bookOpenText"
+                href="/guides/webextension-implementation-tutorial">
+                Open Tutorial  →
+            </LinkButton>
         </SdkDescription>
         <ExamplesAside>
             <ExampleHeading>Examples:</ExampleHeading>
@@ -426,17 +414,14 @@ import IconWeb from '../components/icons/IconWeb';
         <IconMobile />
         <SdkName>Mobile</SdkName>
         <SdkTag>Using deep linking</SdkTag>
-        <Link href="/readme/connect-mobile" passHref legacyBehavior>
-            <Button
-                intent="neutral"
-                priority="secondary"
-                size="small"
-                iconLeft="bookOpenText"
-                target="_self"
-                href="#">
-                README
-            </Button>
-        </Link>
+        <LinkButton
+            intent="neutral"
+            priority="secondary"
+            size="small"
+            iconLeft="bookOpenText"
+            href="/readme/connect-mobile">
+            README
+        </LinkButton>
         <Button
             intent="neutral"
             priority="secondary"
@@ -463,18 +448,15 @@ import IconWeb from '../components/icons/IconWeb';
 
             This can be done by implementing the following specification.
 
-            <Link href="/details/deeplinking" passHref legacyBehavior>
-                <Button
-                    intent="neutral"
-                    priority="secondary"
-                    className="nx-mt-4 nx-mb-8"
-                    size="small"
-                    iconRight="arrowRight"
-                    target="_self"
-                    href="#">
-                    Deep linking specification
-                </Button>
-            </Link>
+            <LinkButton
+                intent="neutral"
+                priority="secondary"
+                className="nx-mt-4 nx-mb-8"
+                size="small"
+                iconRight="arrowRight"
+                href="/details/deeplinking">
+                Deep linking specification
+            </LinkButton>
 
         </SdkDescription>
         <ExamplesAside>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15806,7 +15806,7 @@ __metadata:
     tailwindcss: "npm:^3.4.10"
     zod: "npm:4.3.6"
   peerDependencies:
-    next: ">=9.5.3"
+    next: ">=15.0.0"
     nextra: ^2.13.4
     react: 19.2.4
     react-dom: 19.2.4


### PR DESCRIPTION
Resolves the `legacyBehavior` deprecation warning from the Next.js dev server in `connect-explorer`, plus a related cleanup in `connect-explorer-theme` based on review feedback.

## Changes

**`connect-explorer`**
- Remove `<Link legacyBehavior>` wrappers in `index.mdx` (the deprecated pattern that wrapped `<Button>` in `<a>` to forward `href`)
- Add a `LinkButton` component for SPA-like internal navigation. It styles like `Button` but uses `next/router` to keep client-side routing — falls back to native browser behavior on modifier-key clicks (Ctrl/Cmd-click → new tab) and skips routing for external URLs (`https:`, `mailto:`, etc.)

**`connect-explorer-theme`** (post-`legacyBehavior` cleanup follow-ups)
- Bump `next` peer dependency from `>=9.5.3` to `>=15.0.0`. The previous bound was misleading: after removing the `nextVersion > 12` legacy branch in `Anchor`, the package depends on the post-Next-13 Link API, and the React 19 peer already requires Next 15+
- Drop the unused `newNextLinkBehavior` config flag from `Config`/`ConfigProvider` — it was set but never read after the legacyBehavior cleanup

## Preview

Connect Explorer build (PR branch): https://dev.suite.sldev.cz/connect/connect-explorer-cleanup/

## Possible follow-up

`LinkButton` carries a small amount of custom logic (manual `basePath` prefix, `router.push`, external-URL guard) because `@trezor/components` `Button` does not support polymorphic composition. A cleaner long-term path would be to add an `asChild` prop (Radix Slot pattern, like shadcn/ui) to `Button`/`IconButton`/`TextButton`. Usage would then be:

```tsx
<Button asChild intent="neutral" iconLeft="bookOpenText">
    <Link href="/readme/connect">README</Link>
</Button>
```

This would:
- Drop the `LinkButton` wrapper entirely
- Work transparently with `next/link`, `react-router`, or any custom anchor
- Add `@radix-ui/react-slot` (~1 KB, zero deps) to `@trezor/components`

Out of scope for this PR (touches shared design-system code, would need separate review). Filed here for context.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-explorer-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Send Eth > User can initiate ethereum sending | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T17:25:40.836Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-explorer-cleanup/web/](https://dev.suite.sldev.cz/suite-web/connect-explorer-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->