### PR TITLE
refactor(suite-sync): clarify ensure service responsibilities

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/createEnsureQuota.ts
+++ b/suite-common/suite-sync-quota-manager/src/createEnsureQuota.ts
@@ -37,6 +37,10 @@ export type EnsureQuotaDep = {
     ensureQuota: EnsureQuota;
 };
 
+/**
+ * Responsibility:
+ * - Ensure relay quota is allocated before write-capable Suite Sync operations proceed.
+ */
 export const createEnsureQuota =
     (deps: EnsureQuotaDeps): EnsureQuota =>
     async ({ deviceStaticSessionId, delegatedKey, owner, isWriteMode }) => {

--- a/suite-common/suite-sync-types/src/data/ensureSubscribedStorage.ts
+++ b/suite-common/suite-sync-types/src/data/ensureSubscribedStorage.ts
@@ -4,10 +4,10 @@ import { type WalletDescriptor } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 import { type Result } from '@trezor/type-utils';
 
+import { type SuiteSyncUnavailableOnDeviceErrorType } from '../ensureSuiteSyncKeys';
 import { type WriteModeRequiredForAllocationErrType } from '../quotaManager/quotaManagerTypes';
-import { type SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
 
-type SubscribeSuiteSyncDataParams = {
+type EnsureSubscribedStorageParams = {
     deviceStaticSessionId: StaticSessionId;
     isWriteMode: boolean;
 };
@@ -28,8 +28,8 @@ export type SuiteSyncListenerDep = {
     suiteSyncListener: SuiteSyncListener;
 };
 
-export type SubscribeSuiteSyncData = (
-    params: SubscribeSuiteSyncDataParams,
+export type EnsureSubscribedStorage = (
+    params: EnsureSubscribedStorageParams,
 ) => Promise<
     Result<
         SuiteSyncStorage,
@@ -40,6 +40,6 @@ export type SubscribeSuiteSyncData = (
     >
 >;
 
-export type SubscribeSuiteSyncDataDep = {
-    ensureSubscribeSuiteSyncData: SubscribeSuiteSyncData;
+export type EnsureSubscribedStorageDep = {
+    ensureSubscribedStorage: EnsureSubscribedStorage;
 };

--- a/suite-common/suite-sync-types/src/ensureSuiteSyncKeys.ts
+++ b/suite-common/suite-sync-types/src/ensureSuiteSyncKeys.ts
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/suite-types';
 import { type Result } from '@trezor/type-utils';
 
-type RefreshSuiteSyncKeysParams = {
+type EnsureSuiteSyncKeysParams = {
     device: TrezorDevice;
 };
 
@@ -21,20 +21,20 @@ export type SuiteSyncUnavailableOnDeviceErrorType = {
     type: 'SuiteSyncUnavailableOnDeviceError';
 };
 
-export type RefreshSuiteSyncKeysResult = {
+export type EnsureSuiteSyncKeysResult = {
     owner: SuiteSyncOwner;
     delegatedKey: DelegatedIdentityKey;
 };
 
-export type RefreshSuiteSyncKeys = (
-    params: RefreshSuiteSyncKeysParams,
+export type EnsureSuiteSyncKeys = (
+    params: EnsureSuiteSyncKeysParams,
 ) => Promise<
     Result<
-        RefreshSuiteSyncKeysResult,
+        EnsureSuiteSyncKeysResult,
         SuiteSyncUnavailableOnDeviceErrorType | DeviceErrorType | DeviceCancelledErrType
     >
 >;
 
-export type RefreshSuiteSyncKeysDep = {
-    refreshSuiteSyncKeys: RefreshSuiteSyncKeys;
+export type EnsureSuiteSyncKeysDep = {
+    ensureSuiteSyncKeys: EnsureSuiteSyncKeys;
 };

--- a/suite-common/suite-sync-types/src/index.ts
+++ b/suite-common/suite-sync-types/src/index.ts
@@ -8,14 +8,14 @@ export type {
 } from './storage/suiteSyncStorageRepository';
 
 export type {
-    RefreshSuiteSyncKeys,
-    RefreshSuiteSyncKeysDep,
-    RefreshSuiteSyncKeysResult,
-} from './refreshSuiteSyncKeys';
+    EnsureSuiteSyncKeys,
+    EnsureSuiteSyncKeysDep,
+    EnsureSuiteSyncKeysResult,
+} from './ensureSuiteSyncKeys';
 export type { WriteModeRequiredForAllocationErrType } from './quotaManager/quotaManagerTypes';
 export type { TurnOffSuiteSyncDep, TurnOffSuiteSync } from './turnOffSuiteSync';
 export type { TurnOnSuiteSyncDep, TurnOnSuiteSync } from './turnOnSuiteSync';
-export type { SuiteSyncUnavailableOnDeviceErrorType } from './refreshSuiteSyncKeys';
+export type { SuiteSyncUnavailableOnDeviceErrorType } from './ensureSuiteSyncKeys';
 export type { ChangeRelayUrl, ChangeRelayUrlDep } from './relay/changeRelayUrl';
 export type { ProofOfDelegatedSignFailed } from './getProofOfDelegatedIdentity';
 
@@ -46,10 +46,10 @@ export type {
 export type {
     Subscriptions,
     SuiteSyncListener,
-    SubscribeSuiteSyncData,
-    SubscribeSuiteSyncDataDep,
+    EnsureSubscribedStorage,
+    EnsureSubscribedStorageDep,
     SuiteSyncListenerDep,
-} from './data/subscribeSuiteSyncData';
+} from './data/ensureSubscribedStorage';
 
 // Labeling
 export type {

--- a/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts
@@ -3,8 +3,8 @@ import { type DeviceCancelledErrType, type DeviceErrorType } from '@suite-common
 import { type StaticSessionId } from '@trezor/connect';
 import { type Result } from '@trezor/type-utils';
 
+import { type SuiteSyncUnavailableOnDeviceErrorType } from '../ensureSuiteSyncKeys';
 import { type WriteModeRequiredForAllocationErrType } from '../quotaManager/quotaManagerTypes';
-import { type SuiteSyncUnavailableOnDeviceErrorType } from '../refreshSuiteSyncKeys';
 
 export type SuiteSyncFirmwareUpgradeNeededDeviceErrorType = {
     type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType';

--- a/suite-common/suite-sync/README.md
+++ b/suite-common/suite-sync/README.md
@@ -6,7 +6,7 @@ Except for `@suite-common/suite-sync-evolu`. Evolu MUST NOT be imported here dir
 responsibilities:
 
 - Containing state of the Suite Sync feature itself (flags, relay URL, ...) ⇒ `suiteSyncReducer.ts`
-- Providing implementation for getting keys from the device. ⇒ `createRefreshSuiteSyncKeys.ts`
+- Providing implementation for ensuring keys are available for a device. ⇒ `createEnsureSuiteSyncKeys.ts`
 - Subscribing & unsubscribing from Storages (abstracted Evolu Instances) ⇒ `storage`
 - Keeping mirror of all Evolu data in Redux ⇒ `data`
 - Making sure Suite Sync Owner and its Secrets are properly encrypted ⇒ `owner`

--- a/suite-common/suite-sync/src/__tests__/createEnsureSuiteSyncKeys.test.ts
+++ b/suite-common/suite-sync/src/__tests__/createEnsureSuiteSyncKeys.test.ts
@@ -8,9 +8,9 @@ import { type TrezorDevice, asDelegatedIdentityKey } from '@suite-common/suite-t
 import { ok } from '@trezor/type-utils';
 
 import {
-    type RefreshSuiteSyncKeysDeps,
-    createRefreshSuiteSync,
-} from '../createRefreshSuiteSyncKeys';
+    type EnsureSuiteSyncKeysDeps,
+    createEnsureSuiteSyncKeys,
+} from '../createEnsureSuiteSyncKeys';
 import { type GetDeviceForStaticSessionId } from '../getDeviceForStaticSessionId';
 
 const createMockDeps = () =>
@@ -23,7 +23,7 @@ const createMockDeps = () =>
         getDeviceForStaticSessionId: mockNotExpected<GetDeviceForStaticSessionId>(
             'getDeviceForStaticSessionId',
         ),
-    }) satisfies RefreshSuiteSyncKeysDeps;
+    }) satisfies EnsureSuiteSyncKeysDeps;
 
 const OWNER_1 = {
     ownerId: asSuiteSyncOwnerId('new-owner-id'),
@@ -53,11 +53,11 @@ const createDevice = (
         ...overrides,
     }) as unknown as TrezorDevice;
 
-describe(createRefreshSuiteSync.name, () => {
+describe(createEnsureSuiteSyncKeys.name, () => {
     it('fails with "unable to get keys" when device is not initialized', async () => {
         const deps = createMockDeps();
-        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
-        const result = await refreshSuiteSyncKeys({
+        const ensureSuiteSyncKeys = createEnsureSuiteSyncKeys(deps);
+        const result = await ensureSuiteSyncKeys({
             device: createDevice({}, null),
         });
 
@@ -76,8 +76,8 @@ describe(createRefreshSuiteSync.name, () => {
         const mockDevice = createDevice();
         deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
 
-        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
-        const result = await refreshSuiteSyncKeys({
+        const ensureSuiteSyncKeys = createEnsureSuiteSyncKeys(deps);
+        const result = await ensureSuiteSyncKeys({
             device: mockDevice,
         });
 
@@ -102,8 +102,8 @@ describe(createRefreshSuiteSync.name, () => {
         const mockDevice = createDevice();
         deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
 
-        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
-        await refreshSuiteSyncKeys({
+        const ensureSuiteSyncKeys = createEnsureSuiteSyncKeys(deps);
+        await ensureSuiteSyncKeys({
             device: mockDevice,
         });
 
@@ -129,8 +129,8 @@ describe(createRefreshSuiteSync.name, () => {
         const mockDevice = createDevice();
         deps.getDeviceForStaticSessionId.mockImplementation(() => mockDevice);
 
-        const refreshSuiteSyncKeys = createRefreshSuiteSync(deps);
-        const result = await refreshSuiteSyncKeys({
+        const ensureSuiteSyncKeys = createEnsureSuiteSyncKeys(deps);
+        const result = await ensureSuiteSyncKeys({
             device: mockDevice,
         });
 

--- a/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
@@ -5,7 +5,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
 import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from '../createTurnOnSuiteSync';
 import { updateSuiteSyncEnabled } from '../suiteSyncSlice';
 

--- a/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.ts
+++ b/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.ts
@@ -3,8 +3,8 @@ import { type Dispatch } from '@reduxjs/toolkit';
 import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
 import { isTrezorDeviceWithState } from '@suite-common/device';
 import {
+    type EnsureSuiteSyncKeys,
     type EnsureSuiteSyncOwnerDep,
-    type RefreshSuiteSyncKeys,
     type SuiteSyncUnavailableOnDeviceErrorType,
 } from '@suite-common/suite-sync-types';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -20,22 +20,27 @@ export const SuiteSyncUnavailableOnDeviceError = (): SuiteSyncUnavailableOnDevic
     type: 'SuiteSyncUnavailableOnDeviceError',
 });
 
-export type RefreshSuiteSyncKeysDeps = {
+export type EnsureSuiteSyncKeysDeps = {
     dispatch: Dispatch;
 } & EnsureSuiteSyncOwnerDep &
     EnsureDelegatedIdentityKeyDep &
     GetDeviceForStaticSessionIdDep;
 
-export const createRefreshSuiteSync =
-    (deps: RefreshSuiteSyncKeysDeps): RefreshSuiteSyncKeys =>
-    async ({ device }): ReturnType<RefreshSuiteSyncKeys> => {
+/**
+ * Responsibility:
+ * - Ensure the delegated key and Suite Sync owner are available for a device.
+ * - Refresh the device reference after Connect may rotate the session id.
+ */
+export const createEnsureSuiteSyncKeys =
+    (deps: EnsureSuiteSyncKeysDeps): EnsureSuiteSyncKeys =>
+    async ({ device }): ReturnType<EnsureSuiteSyncKeys> => {
         if (!device || !isTrezorDeviceWithState(device)) {
             return err(SuiteSyncUnavailableOnDeviceError());
         }
 
         const deviceStaticId = device.state.staticSessionId;
 
-        const getDelegatedIdentityKeys = async () => {
+        const ensureKeys = async () => {
             const delegatedKeyResult = await deps.ensureDelegatedIdentityKey({ device });
 
             if (!delegatedKeyResult.success) {
@@ -61,7 +66,7 @@ export const createRefreshSuiteSync =
             return ok({ owner: ownerResult.payload, delegatedKey: delegatedKeyResult.payload });
         };
 
-        const result = await getDelegatedIdentityKeys();
+        const result = await ensureKeys();
 
         if (!result.success) {
             const errType = result.error.type;

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -13,12 +13,12 @@ import {
 import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { type Analytics } from '@trezor/analytics-uploader';
 
-import { createRefreshSuiteSync } from './createRefreshSuiteSyncKeys';
+import { createEnsureSuiteSyncKeys } from './createEnsureSuiteSyncKeys';
 import { createTurnOffSuiteSync } from './createTurnOffSuiteSync';
 import { createTurnOnSuiteSync } from './createTurnOnSuiteSync';
 import { selectSuiteSyncAccountLabel } from './data/account/selectSuiteSyncAccountLabel';
 import { selectSuiteSyncAddressLabel } from './data/address/suiteSyncAddressSelectors';
-import { createEnsureSubscribeSuiteSyncData } from './data/createEnsureSubscribeSuiteSyncData';
+import { createEnsureSubscribedStorage } from './data/createEnsureSubscribedStorage';
 import { createSuiteSyncListener } from './data/createSuiteSyncListener';
 import { createUpdateAccountLabel } from './data/labeling/createUpdateAccountLabel';
 import { createUpdateAddressLabel } from './data/labeling/createUpdateAddressLabel';
@@ -92,7 +92,7 @@ export const createSuiteSyncCompositionRoot = (
     const getDeviceForStaticSessionId: GetDeviceForStaticSessionId = deviceStaticId =>
         selectDeviceByStaticSessionId(deps.getState(), deviceStaticId) ?? null;
 
-    const refreshSuiteSyncKeys = createRefreshSuiteSync({
+    const ensureSuiteSyncKeys = createEnsureSuiteSyncKeys({
         dispatch: deps.dispatch,
         ensureDelegatedIdentityKey: deps.ensureDelegatedIdentityKey,
         ensureSuiteSyncOwner,
@@ -107,7 +107,7 @@ export const createSuiteSyncCompositionRoot = (
     });
 
     const ensureStorage = createEnsureStorage({
-        refreshSuiteSyncKeys,
+        ensureSuiteSyncKeys,
         ensureQuota,
         suiteSyncStorageRepository,
         createSuiteStorage: deps.createSuiteStorage,
@@ -120,7 +120,7 @@ export const createSuiteSyncCompositionRoot = (
         dispatch: deps.dispatch,
     });
 
-    const ensureSubscribeSuiteSyncData = createEnsureSubscribeSuiteSyncData({
+    const ensureSubscribedStorage = createEnsureSubscribedStorage({
         subscriptionStorage,
         ensureStorage,
         suiteSyncListener,
@@ -130,8 +130,8 @@ export const createSuiteSyncCompositionRoot = (
         dispatch: deps.dispatch,
         ensureWalletSuiteSyncOn: createEnsureWalletSuiteSyncOn({
             getState: deps.getState,
-            refreshSuiteSyncKeys,
-            ensureSubscribeSuiteSyncData,
+            ensureSuiteSyncKeys,
+            ensureSubscribedStorage,
             subscriptionStorage,
         }),
     });

--- a/suite-common/suite-sync/src/data/__tests__/createEnsureSubscribedStorage.test.ts
+++ b/suite-common/suite-sync/src/data/__tests__/createEnsureSubscribedStorage.test.ts
@@ -15,13 +15,13 @@ import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../createEnsureSuiteSyncKeys';
 import { createStorageIdFromDeviceStaticSessionId } from '../../storage/createStorageIdFromDeviceStaticSessionId';
 import { createSubscriptionStorage } from '../../storage/createSubscriptionStorage';
 import {
-    type CreateSubscribeSuiteSyncDataDeps,
-    createEnsureSubscribeSuiteSyncData,
-} from '../createEnsureSubscribeSuiteSyncData';
+    type CreateEnsureSubscribedStorageDeps,
+    createEnsureSubscribedStorage,
+} from '../createEnsureSubscribedStorage';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 
@@ -74,19 +74,19 @@ const createStorageWithEmitters = (storageEmitter: StorageSubscriptions) =>
         },
     });
 
-describe(createEnsureSubscribeSuiteSyncData.name, () => {
+describe(createEnsureSubscribedStorage.name, () => {
     it('fails when storage is not available', async () => {
         const suiteSyncListener = createListenerMock();
         const storageResult = err(SuiteSyncUnavailableOnDeviceError());
 
-        const deps = createMockDeps<CreateSubscribeSuiteSyncDataDeps>({
+        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(storageResult),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,
         });
 
-        const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
+        const ensureSubscribedStorage = createEnsureSubscribedStorage(deps);
+        const result = await ensureSubscribedStorage({ deviceStaticSessionId, isWriteMode: false });
 
         expect(deps.ensureStorage).toHaveBeenCalledWith({
             deviceStaticSessionId,
@@ -112,14 +112,14 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
             unsubscribe: jest.fn(),
         });
 
-        const deps = createMockDeps<CreateSubscribeSuiteSyncDataDeps>({
+        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage,
             suiteSyncListener,
         });
 
-        const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
+        const ensureSubscribedStorage = createEnsureSubscribedStorage(deps);
+        const result = await ensureSubscribedStorage({ deviceStaticSessionId, isWriteMode: false });
 
         expect(deps.ensureStorage).toHaveBeenCalledWith({
             deviceStaticSessionId,
@@ -137,14 +137,14 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
             outputs: { subscribe: () => () => {} },
         });
 
-        const deps = createMockDeps<CreateSubscribeSuiteSyncDataDeps>({
+        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,
         });
 
-        const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
-        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
+        const ensureSubscribedStorage = createEnsureSubscribedStorage(deps);
+        const result = await ensureSubscribedStorage({ deviceStaticSessionId, isWriteMode: false });
 
         expect(deps.ensureStorage).toHaveBeenCalledWith({
             deviceStaticSessionId,
@@ -170,15 +170,15 @@ describe(createEnsureSubscribeSuiteSyncData.name, () => {
 
         const storage = createStorageWithEmitters(storageEmitters);
 
-        const deps = createMockDeps<CreateSubscribeSuiteSyncDataDeps>({
+        const deps = createMockDeps<CreateEnsureSubscribedStorageDeps>({
             ensureStorage: () => Promise.resolve(ok(storage)),
             subscriptionStorage: createSubscriptionStorage(),
             suiteSyncListener,
         });
 
-        const subscribeLabeling = createEnsureSubscribeSuiteSyncData(deps);
+        const ensureSubscribedStorage = createEnsureSubscribedStorage(deps);
 
-        const result = await subscribeLabeling({ deviceStaticSessionId, isWriteMode: false });
+        const result = await ensureSubscribedStorage({ deviceStaticSessionId, isWriteMode: false });
 
         expect(result.success).toBe(true);
 

--- a/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.ts
@@ -1,6 +1,6 @@
 import { type SuiteSyncSchema } from '@suite-common/suite-sync-storage';
 import {
-    type SubscribeSuiteSyncData,
+    type EnsureSubscribedStorage,
     type SubscriptionStorageDep,
     type SuiteSyncListenerDep,
 } from '@suite-common/suite-sync-types';
@@ -11,13 +11,17 @@ import { typedObjectValues } from '@trezor/utils';
 import { type EnsureStorageDep } from '../storage/createEnsureStorage';
 import { createStorageIdFromDeviceStaticSessionId } from '../storage/createStorageIdFromDeviceStaticSessionId';
 
-export type CreateSubscribeSuiteSyncDataDeps = EnsureStorageDep &
+export type CreateEnsureSubscribedStorageDeps = EnsureStorageDep &
     SubscriptionStorageDep &
     SuiteSyncListenerDep;
 
-export const createEnsureSubscribeSuiteSyncData =
-    (deps: CreateSubscribeSuiteSyncDataDeps): SubscribeSuiteSyncData =>
-    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<SubscribeSuiteSyncData> => {
+/**
+ * Responsibility:
+ * - Ensure storage changes are subscribed to Redux-facing listeners exactly once.
+ */
+export const createEnsureSubscribedStorage =
+    (deps: CreateEnsureSubscribedStorageDeps): EnsureSubscribedStorage =>
+    async ({ deviceStaticSessionId, isWriteMode }): ReturnType<EnsureSubscribedStorage> => {
         const storageResult = await deps.ensureStorage({
             deviceStaticSessionId,
             isWriteMode,

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateAccountLabel.test.ts
@@ -5,7 +5,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 import { type UpdateAccountLabelDeps, createUpdateAccountLabel } from '../createUpdateAccountLabel';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateAddressLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateAddressLabel.test.ts
@@ -6,7 +6,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 import type { UpdateAddressLabelDeps } from '../createUpdateAddressLabel';
 import { createUpdateAddressLabel } from '../createUpdateAddressLabel';
 

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateOutputLabel.test.ts
@@ -6,7 +6,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 import type { UpdateOutputLabelDeps } from '../createUpdateOutputLabel';
 import { createUpdateOutputLabel } from '../createUpdateOutputLabel';
 

--- a/suite-common/suite-sync/src/data/labeling/tests/createUpdateWalletLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/tests/createUpdateWalletLabel.test.ts
@@ -5,7 +5,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 import { type UpdateWalletLabelDeps, createUpdateWalletLabel } from '../createUpdateWalletLabel';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.ts
@@ -9,6 +9,11 @@ export type CreateEnsureSuiteSyncOwnerDeps = RetrieveSuiteSyncOwnerKeysDep &
     LoadSuiteSyncOwnerFromStateDep &
     SaveSuiteSyncOwnerDep;
 
+/**
+ * Responsibility:
+ * - Ensure the Suite Sync owner exists in encrypted state storage.
+ * - Retrieve and persist the owner only when it is not cached already.
+ */
 export const createEnsureSuiteSyncOwner =
     (deps: CreateEnsureSuiteSyncOwnerDeps): EnsureSuiteSyncOwner =>
     async ({ device, delegatedKey }) => {

--- a/suite-common/suite-sync/src/storage/createEnsureStorage.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureStorage.ts
@@ -7,7 +7,7 @@ import {
     type SuiteSyncStorage,
 } from '@suite-common/suite-sync-storage';
 import {
-    type RefreshSuiteSyncKeysDep,
+    type EnsureSuiteSyncKeysDep,
     type SuiteSyncStorageRepositoryDep,
     type SuiteSyncUnavailableOnDeviceErrorType,
     type WriteModeRequiredForAllocationErrType,
@@ -19,14 +19,14 @@ import { type Result, err, ok } from '@trezor/type-utils';
 import { isNotNull } from '@trezor/utils';
 
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
-import { SuiteSyncUnavailableOnDeviceError } from '../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
 import { type GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
 
 export type EnsureStorageDeps = {
     getRelayUrl: () => string;
 } & SuiteSyncStorageRepositoryDep &
     CreateSuiteStorageDep &
-    RefreshSuiteSyncKeysDep &
+    EnsureSuiteSyncKeysDep &
     GetDeviceForStaticSessionIdDep &
     GetOwnerHasAllowanceDep &
     EnsureQuotaDep;
@@ -52,20 +52,25 @@ export type EnsureStorageDep = {
     ensureStorage: CreateEnsureStorage;
 };
 
+/**
+ * Responsibility:
+ * - Ensure the Suite Sync storage abstraction exists for the wallet.
+ * - Orchestrate prerequisites such as keys and quota before the storage is used.
+ */
 export const createEnsureStorage =
     (deps: EnsureStorageDeps): CreateEnsureStorage =>
     async ({ deviceStaticSessionId, isWriteMode }): ReturnType<CreateEnsureStorage> => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
         const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
-        const storage = deps.suiteSyncStorageRepository.get(storageId);
+        const existingStorage = deps.suiteSyncStorageRepository.get(storageId);
 
         // Return cached storage if it exists and user has owner quota.
         // We intentionally skip the isWriteMode check here because deps.ensureQuota also refreshes
         // the owner quota from QM server (we do it so other user devices can allocate more quota, thus here it would be outdated).
 
-        if (isNotNull(storage) && deps.getOwnerHasAllowance(walletDescriptor)) {
-            return ok(storage);
+        if (isNotNull(existingStorage) && deps.getOwnerHasAllowance(walletDescriptor)) {
+            return ok(existingStorage);
         }
 
         const device = deps.getDeviceForStaticSessionId(deviceStaticSessionId);
@@ -74,7 +79,7 @@ export const createEnsureStorage =
             return err(SuiteSyncUnavailableOnDeviceError());
         }
 
-        const keysResult = await deps.refreshSuiteSyncKeys({ device });
+        const keysResult = await deps.ensureSuiteSyncKeys({ device });
 
         if (!keysResult.success) {
             return keysResult;
@@ -82,6 +87,10 @@ export const createEnsureStorage =
 
         const { owner, delegatedKey } = keysResult.payload;
 
+        const storage =
+            existingStorage ?? (await deps.createSuiteStorage({ suiteSyncOwner: owner }));
+
+        // We need to call this even for isWriteMode because this also register device
         const quotaResult = await deps.ensureQuota({
             deviceStaticSessionId,
             delegatedKey,
@@ -89,18 +98,20 @@ export const createEnsureStorage =
             isWriteMode,
         });
 
-        // correct approach would be to create a new storage anyway, but currently there is bug regarding the dispose function
-        const resolvedStorage =
-            storage ?? (await deps.createSuiteStorage({ suiteSyncOwner: owner }));
+        // `WriteModeRequiredForAllocation` means we won't connect Storage to server,
+        // but other errors are bad and need to be propagated
+        if (!quotaResult.success && quotaResult.error.type !== 'WriteModeRequiredForAllocation') {
+            return err(quotaResult.error);
+        }
 
         // Only connect to the relay if quota is actually allocated.
         if (quotaResult.success) {
-            await resolvedStorage.updateRelayUrl(deps.getRelayUrl());
+            await storage.updateRelayUrl(deps.getRelayUrl());
         }
 
-        if (!isNotNull(storage)) {
-            deps.suiteSyncStorageRepository.set(storageId, resolvedStorage);
+        if (!isNotNull(existingStorage)) {
+            deps.suiteSyncStorageRepository.set(storageId, storage);
         }
 
-        return ok(resolvedStorage);
+        return ok(storage);
     };

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOn.ts
@@ -1,8 +1,8 @@
 import { isTrezorDeviceWithState, selectDeviceByStaticSessionId } from '@suite-common/device';
 import {
+    type EnsureSubscribedStorageDep,
+    type EnsureSuiteSyncKeysDep,
     type EnsureWalletSuiteSyncOn,
-    type RefreshSuiteSyncKeysDep,
-    type SubscribeSuiteSyncDataDep,
     type SubscriptionStorageDep,
 } from '@suite-common/suite-sync-types';
 import { err } from '@trezor/type-utils';
@@ -11,10 +11,14 @@ import { isFwUpgradeNeededForSuiteSync, isSuiteSyncSupportedByDevice } from '../
 
 export type EnsureWalletSuiteSyncOnDeps = {
     getState: () => any;
-} & SubscribeSuiteSyncDataDep &
-    RefreshSuiteSyncKeysDep &
+} & EnsureSubscribedStorageDep &
+    EnsureSuiteSyncKeysDep &
     SubscriptionStorageDep;
 
+/**
+ * Responsibility:
+ * - Run top-level eligibility checks before starting Suite Sync for a wallet.
+ */
 export const createEnsureWalletSuiteSyncOn =
     (deps: EnsureWalletSuiteSyncOnDeps): EnsureWalletSuiteSyncOn =>
     async ({ deviceStaticSessionId, isWriteMode }) => {
@@ -31,7 +35,7 @@ export const createEnsureWalletSuiteSyncOn =
             return err({ type: 'SuiteSyncUnavailableOnDeviceError' });
         }
 
-        return await deps.ensureSubscribeSuiteSyncData({
+        return await deps.ensureSubscribedStorage({
             deviceStaticSessionId,
             isWriteMode,
         });

--- a/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureStorage.test.ts
@@ -10,7 +10,7 @@ import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../createEnsureSuiteSyncKeys';
 import type { EnsureStorageDeps } from '../createEnsureStorage';
 import { createEnsureStorage } from '../createEnsureStorage';
 
@@ -36,7 +36,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: null,
-            refreshSuiteSyncKeys: null,
+            ensureSuiteSyncKeys: null,
             ensureQuota: null,
             getDeviceForStaticSessionId: null,
         });
@@ -49,7 +49,7 @@ describe(createEnsureStorage.name, () => {
         expect(result).toEqual(ok(existingStorage));
         expect(deps.suiteSyncStorageRepository.get).toHaveBeenCalled();
         expect(deps.createSuiteStorage).not.toHaveBeenCalled();
-        expect(deps.refreshSuiteSyncKeys).not.toHaveBeenCalled();
+        expect(deps.ensureSuiteSyncKeys).not.toHaveBeenCalled();
         expect(deps.getDeviceForStaticSessionId).not.toHaveBeenCalled();
     });
 
@@ -68,7 +68,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: null,
-            refreshSuiteSyncKeys: () =>
+            ensureSuiteSyncKeys: () =>
                 Promise.resolve(ok({ owner: OWNER_ABCD, delegatedKey: DELEGATED_KEY })),
             ensureQuota: () => Promise.resolve(ok(undefined)),
             getDeviceForStaticSessionId: () => device,
@@ -82,7 +82,7 @@ describe(createEnsureStorage.name, () => {
         expect(result).toEqual(ok(existingStorage));
         expect(deps.suiteSyncStorageRepository.get).toHaveBeenCalled();
         expect(deps.createSuiteStorage).not.toHaveBeenCalled();
-        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalled();
+        expect(deps.ensureSuiteSyncKeys).toHaveBeenCalled();
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalled();
     });
 
@@ -96,7 +96,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: null,
-            refreshSuiteSyncKeys: null,
+            ensureSuiteSyncKeys: null,
             ensureQuota: null,
             getDeviceForStaticSessionId: () => null,
         });
@@ -109,11 +109,11 @@ describe(createEnsureStorage.name, () => {
         expect(result.success).toBe(false);
         expect(!result.success && result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
-        expect(deps.refreshSuiteSyncKeys).not.toHaveBeenCalled();
+        expect(deps.ensureSuiteSyncKeys).not.toHaveBeenCalled();
         expect(deps.createSuiteStorage).not.toHaveBeenCalled();
     });
 
-    it('returns error when refreshSuiteSyncKeys fails', async () => {
+    it('returns error when ensureSuiteSyncKeys fails', async () => {
         const device = mockSuiteDevice();
         const refreshError = err(SuiteSyncUnavailableOnDeviceError());
 
@@ -126,7 +126,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: null,
-            refreshSuiteSyncKeys: () => Promise.resolve(refreshError),
+            ensureSuiteSyncKeys: () => Promise.resolve(refreshError),
             ensureQuota: null,
             getDeviceForStaticSessionId: () => device,
         });
@@ -138,11 +138,11 @@ describe(createEnsureStorage.name, () => {
 
         expect(result).toBe(refreshError);
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
-        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.ensureSuiteSyncKeys).toHaveBeenCalledWith({ device });
         expect(deps.createSuiteStorage).not.toHaveBeenCalled();
     });
 
-    it('calls ensureQuota with correct params after refreshSuiteSyncKeys succeeds', async () => {
+    it('calls ensureQuota with correct params after ensureSuiteSyncKeys succeeds', async () => {
         const device = mockSuiteDevice();
         const newStorage = createSuiteSyncStorageMock({
             updateRelayUrl: mock(() => Promise.resolve()),
@@ -157,7 +157,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
-            refreshSuiteSyncKeys: () =>
+            ensureSuiteSyncKeys: () =>
                 Promise.resolve(ok({ owner: OWNER_ABCD, delegatedKey: DELEGATED_KEY })),
             ensureQuota: () => Promise.resolve(ok(undefined)),
             getDeviceForStaticSessionId: () => device,
@@ -191,7 +191,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
-            refreshSuiteSyncKeys: () =>
+            ensureSuiteSyncKeys: () =>
                 Promise.resolve(ok({ owner: OWNER_ABCD, delegatedKey: DELEGATED_KEY })),
             ensureQuota: () => Promise.resolve(ok(undefined)),
             getDeviceForStaticSessionId: () => device,
@@ -204,7 +204,7 @@ describe(createEnsureStorage.name, () => {
 
         expect(result).toEqual(ok(newStorage));
         expect(deps.getDeviceForStaticSessionId).toHaveBeenCalledWith(deviceStaticSessionId);
-        expect(deps.refreshSuiteSyncKeys).toHaveBeenCalledWith({ device });
+        expect(deps.ensureSuiteSyncKeys).toHaveBeenCalledWith({ device });
         expect(deps.createSuiteStorage).toHaveBeenCalledWith({
             suiteSyncOwner: OWNER_ABCD,
         });
@@ -228,7 +228,7 @@ describe(createEnsureStorage.name, () => {
                 delete: null,
             },
             createSuiteStorage: () => Promise.resolve(newStorage),
-            refreshSuiteSyncKeys: () =>
+            ensureSuiteSyncKeys: () =>
                 Promise.resolve(ok({ owner: OWNER_ABCD, delegatedKey: DELEGATED_KEY })),
             ensureQuota: () => Promise.resolve(ok(undefined)),
             getDeviceForStaticSessionId: () => device,

--- a/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOn.test.ts
@@ -6,7 +6,7 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import type { StaticSessionId, UnavailableCapabilities } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
-import { SuiteSyncUnavailableOnDeviceError } from '../../createRefreshSuiteSyncKeys';
+import { SuiteSyncUnavailableOnDeviceError } from '../../createEnsureSuiteSyncKeys';
 import type { EnsureWalletSuiteSyncOnDeps } from '../createEnsureWalletSuiteSyncOn';
 import { createEnsureWalletSuiteSyncOn } from '../createEnsureWalletSuiteSyncOn';
 import { createSubscriptionStorageMock } from '../createSubscriptionStorage.mock';
@@ -26,9 +26,9 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
     it('returns error when device is not found in state', async () => {
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([]),
-            ensureSubscribeSuiteSyncData: null,
+            ensureSubscribedStorage: null,
             subscriptionStorage: createSubscriptionStorageMock(),
-            refreshSuiteSyncKeys: null,
+            ensureSuiteSyncKeys: null,
         });
 
         const result = await createEnsureWalletSuiteSyncOn(deps)({
@@ -40,7 +40,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
         if (!result.success) {
             expect(result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
         }
-        expect(deps.ensureSubscribeSuiteSyncData).not.toHaveBeenCalled();
+        expect(deps.ensureSubscribedStorage).not.toHaveBeenCalled();
     });
 
     it('returns error when Suite Sync is not supported by device', async () => {
@@ -48,8 +48,8 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([mockSuiteDevice({ unavailableCapabilities })]),
-            refreshSuiteSyncKeys: null,
-            ensureSubscribeSuiteSyncData: null,
+            ensureSuiteSyncKeys: null,
+            ensureSubscribedStorage: null,
             subscriptionStorage: createSubscriptionStorageMock(),
         });
 
@@ -62,16 +62,16 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
         if (!result.success) {
             expect(result.error.type).toBe('SuiteSyncUnavailableOnDeviceError');
         }
-        expect(deps.ensureSubscribeSuiteSyncData).not.toHaveBeenCalled();
+        expect(deps.ensureSubscribedStorage).not.toHaveBeenCalled();
     });
 
-    it('calls ensureSubscribeSuiteSyncData when wallet is eligible', async () => {
+    it('calls ensureSubscribedStorage when wallet is eligible', async () => {
         const ensureResult = ok({ data: {} } as any);
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([DEVICE_123]),
-            refreshSuiteSyncKeys: null,
-            ensureSubscribeSuiteSyncData: () => Promise.resolve(ensureResult),
+            ensureSuiteSyncKeys: null,
+            ensureSubscribedStorage: () => Promise.resolve(ensureResult),
             subscriptionStorage: createSubscriptionStorageMock(),
         });
 
@@ -80,20 +80,20 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             isWriteMode: false,
         });
 
-        expect(deps.ensureSubscribeSuiteSyncData).toHaveBeenCalledWith({
+        expect(deps.ensureSubscribedStorage).toHaveBeenCalledWith({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
             isWriteMode: false,
         });
         expect(result).toBe(ensureResult);
     });
 
-    it('propagates ensureSubscribeSuiteSyncData error', async () => {
+    it('propagates ensureSubscribedStorage error', async () => {
         const ensureResult = err(SuiteSyncUnavailableOnDeviceError());
 
         const deps = createMockDeps<EnsureWalletSuiteSyncOnDeps>({
             getState: () => createMockState([DEVICE_123]),
-            refreshSuiteSyncKeys: null,
-            ensureSubscribeSuiteSyncData: () => Promise.resolve(ensureResult),
+            ensureSuiteSyncKeys: null,
+            ensureSubscribedStorage: () => Promise.resolve(ensureResult),
             subscriptionStorage: createSubscriptionStorageMock(),
         });
 
@@ -102,7 +102,7 @@ describe(createEnsureWalletSuiteSyncOn.name, () => {
             isWriteMode: false,
         });
 
-        expect(deps.ensureSubscribeSuiteSyncData).toHaveBeenCalledWith({
+        expect(deps.ensureSubscribedStorage).toHaveBeenCalledWith({
             deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
             isWriteMode: false,
         });


### PR DESCRIPTION
Cleanup of the naming of the services in Suite Sync, unify naming.

```mermaid
flowchart TD
    A["turnOnSuiteSync"] --> B["ensureWalletSuiteSyncOn\n(error-handling decorator)"]
    B --> C["ensureWalletSuiteSyncOn\n(core service)"]
    C --> D["ensureSubscribedStorage"]
    D --> E["ensureStorage"]
    E --> F["ensureSuiteSyncKeys"]
    E --> G["ensureQuota"]
    F --> H["ensureDelegatedIdentityKey"]
    F --> I["ensureSuiteSyncOwner"]

    subgraph QM["quota-manager DI root"]
        G
    end
```

## Testing
Nothing to test, only code naming improvements.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=separate-quota-from-keys-getter-v3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=separate-quota-from-keys-getter-v3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=separate-quota-from-keys-getter-v3&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T10:55:38.649Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T10:14:31.692Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->