### PR TITLE
fix(suite): lower z-index of settings tooltip below modal backdrop

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
@@ -5,6 +5,7 @@ import { SettingsAnchor, goto, selectRouteName } from '@suite/router';
 import { selectIsDeviceInitialized } from '@suite-common/device';
 import { Button, Column, Link, Paragraph, Text, Tooltip } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
+import { zIndices } from '@trezor/theme';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
@@ -76,6 +77,7 @@ export const SettingsWithTooltip: FC<NavigationItemProps> = props => {
             hasArrow
             placement="bottom-start"
             tooltipMaxWidth={210}
+            zIndex={zIndices.popover}
         >
             <NavigationItem {...props} />
         </Tooltip>


### PR DESCRIPTION
The "Power user?" tooltip in the sidebar uses the default tooltip z-index of 60, which places it above the modal backdrop (z-index 40). This makes the tooltip visible on top of modals when it shouldn't be.

The fix sets the tooltip's z-index to `zIndices.popover` (35), which keeps it above regular page content but below modals.

Closes #26530