### PR TITLE
chore: describe how to patch a package

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "g:depcheck": "cd $INIT_CWD && depcheck",
         "_______ Commands _______": "Useful commands and scripts.",
         "nx:show-affected": "yarn nx show projects --affected",
-        "patch": "yarn patch-package",
         "convert-figma-palette": "yarn tsx ./scripts/convertFigmaPalette.ts",
         "update-project-references": "yarn tsx ./scripts/updateProjectReferences.ts",
         "generate-icons": "yarn workspace @suite-common/icons generate-icons",

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,13 +1,23 @@
 # Patches
 
-👉 **README, I'M IMPORTANT:**
+### 👉 README, I'M IMPORTANT
 
 - Whenever you create or remove a patch, make sure to create/remove a brief explanation why.
 - Remove the patch as soon as we can update to a version that no longer requires the patch.
-- Known problem: `patch-packages` does not work well with `yarn workspaces focus`.
-    - Check cases in github action `yml`s where both are used.
-    - Check for problematic packages, e.g. `electron-builder` patched when `suite-native/app` is focused
-    - A quick hotfix can be as simple as `rm patches/some.patch` in the `yml` (patches are temporary anyway)
+
+### 👉 Creating a patch
+
+1. Temporarily remove `resolutions` starting with `"###` from the main `package.json`.
+    - This ensures `patch-package` doesn't fail with a buffer dump error.
+2. Modify the desired package in the local `node_modules` directory.
+3. Run `yarn patch-package <name_of_package>` to create a patch file.
+4. Revert the changes in `package.json`.
+
+It's a known issue that `patch-package` does not work well with `yarn workspaces focus`.
+
+- Check cases in GitHub action `yml`s where both are used.
+- Check for problematic packages, e.g. `electron-builder` patched when `suite-native/app` is focused.
+- A quick hotfix can be as simple as `rm patches/some.patch` in the `yml` (patches are temporary anyway).
 
 ---
 


### PR DESCRIPTION
- Script `patch` removed as it's shadowed by `yarn patch`.
- Added instructions for creating a patch.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/patches-docs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/patches-docs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T10:34:29.473Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T10:33:04.742Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->