### PR TITLE
feat(e2e): add swap history test suite for trading transactions

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCryptoAmount.tsx
@@ -17,12 +17,14 @@ export interface TradingCryptoAmountProps {
     amount?: string | number;
     cryptoId: CryptoId;
     displayLogo?: boolean;
+    testId?: string;
 }
 
 export const TradingCryptoAmount = ({
     amount,
     cryptoId,
     displayLogo,
+    testId,
 }: TradingCryptoAmountProps) => {
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoId);
@@ -52,7 +54,7 @@ export const TradingCryptoAmount = ({
                     value={amount}
                     symbol={coinSymbol}
                     contractAddress={contractAddress}
-                    data-testid="@trading/offers/quote/crypto-amount"
+                    data-testid={testId ?? '@trading/offers/quote/crypto-amount'}
                 />
             </Row>
         </TradingTestWrapper>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchangeSidebar.tsx
@@ -66,6 +66,8 @@ export const TradingDetailExchangeSidebar = ({
                     label="TR_TRADING_YOU_PAY"
                     currency={trade.send}
                     amount={trade.sendStringAmount}
+                    cryptoAmountTestId="@trading/transaction/detail/send-amount"
+                    accountInfoTestId="@trading/transaction/detail/send-account"
                 />
 
                 <TradingInfoItem
@@ -76,6 +78,8 @@ export const TradingDetailExchangeSidebar = ({
                     amount={trade.receiveStringAmount}
                     receiveAddress={trade.receiveAddress}
                     isReceive
+                    cryptoAmountTestId="@trading/transaction/detail/receive-amount"
+                    accountInfoTestId="@trading/transaction/detail/receive-account"
                 />
 
                 <Column gap={12}>

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailProviderInfo.tsx
@@ -58,7 +58,9 @@ export const TradingDetailProviderInfo = ({
                 {orderId && (
                     <InfoItem label={<Translation id="TR_TRADE_ID" />} direction="row">
                         <Row gap={12}>
-                            <Text>{orderId}</Text>
+                            <Text data-testid="@trading/transaction/detail/order-id">
+                                {orderId}
+                            </Text>
                             <Button
                                 size="small"
                                 intent="neutral"

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -24,6 +24,8 @@ interface TradingInfoItemProps {
     amount?: string;
     isReceive?: boolean;
     receiveAddress?: string;
+    cryptoAmountTestId?: string;
+    accountInfoTestId?: string;
 }
 
 export const TradingInfoItem = ({
@@ -34,6 +36,8 @@ export const TradingInfoItem = ({
     currency,
     amount,
     receiveAddress,
+    cryptoAmountTestId,
+    accountInfoTestId,
 }: TradingInfoItemProps) => {
     const { translationString } = useTranslation();
     const { createAssetOptionFromCryptoId } = useTradingAssets();
@@ -74,7 +78,7 @@ export const TradingInfoItem = ({
                         priority="secondary"
                         typographyStyle="body-sm"
                         as="div"
-                        data-testid={`${testIdPrefix}-account`}
+                        data-testid={accountInfoTestId ?? `${testIdPrefix}-account`}
                     >
                         <Row>
                             {accountLabelPrefix}&nbsp;
@@ -138,7 +142,11 @@ export const TradingInfoItem = ({
                             </Column>
                         </Row>
                         <Column alignItems="flex-end">
-                            <TradingCryptoAmount amount={amount} cryptoId={currency} />
+                            <TradingCryptoAmount
+                                amount={amount}
+                                cryptoId={currency}
+                                testId={cryptoAmountTestId}
+                            />
 
                             {currencyInfo?.symbol && (
                                 <Text

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionAmounts.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionAmounts.tsx
@@ -50,12 +50,14 @@ export const TradingTransactionAmounts = ({ trade }: TradingTransactionAmountsPr
                     value={sendStringAmount}
                     symbol={sendCoinSymbol}
                     contractAddress={sendContractAddress}
+                    data-testid="@trading/transactions/send/amount"
                 />
                 <Arrow />
                 <FormattedCryptoAmount
                     value={receiveStringAmount}
                     symbol={receiveCoinSymbol}
                     contractAddress={receiveContractAddress}
+                    data-testid="@trading/transactions/receive/amount"
                 />
             </Row>
         );

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionContainer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionContainer.tsx
@@ -9,17 +9,19 @@ interface TradingTransactionContainerProps {
     TradeDetail: JSX.Element;
     TradeProviders: JSX.Element;
     TradeButton: JSX.Element;
+    'data-testid'?: string;
 }
 
 export const TradingTransactionContainer = ({
     TradeDetail,
     TradeProviders,
     TradeButton,
+    'data-testid': dataTestId,
 }: TradingTransactionContainerProps) => {
     const { isBelowDesktop, isBelowMobile } = useLayoutSize();
 
     return (
-        <Card fillType="flat" margin={{ bottom: spacings.lg }}>
+        <Card fillType="flat" margin={{ bottom: spacings.lg }} data-testid={dataTestId}>
             <Row flexWrap={isBelowDesktop ? 'wrap' : undefined}>
                 <Column flex="auto" width={isBelowDesktop ? 'calc(100% - 180px)' : '100%'}>
                     {TradeDetail}

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransaction/TradingTransactionInfo.tsx
@@ -25,7 +25,9 @@ export const TradingTransactionInfo = ({ trade }: TradingTransactionInfoProps) =
             margin={{ top: spacings.xs }}
         >
             {tradeType}
-            <FormattedDate value={date} date time />
+            <span data-testid="@trading/transactions/date">
+                <FormattedDate value={date} date time />
+            </span>
             <TradingTransactionStatus trade={trade} />
         </InfoSegments>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionExchange.tsx
@@ -41,6 +41,7 @@ export const TradingTransactionExchange = ({
 
     return (
         <TradingTransactionContainer
+            data-testid={`@trading/transactions/list/swap-transaction/${trade.data.orderId}`}
             TradeDetail={
                 <>
                     <TradingTransactionAmounts trade={trade} />
@@ -52,7 +53,13 @@ export const TradingTransactionExchange = ({
                 <TradingTransactionProvider exchange={trade.data.exchange} providers={providers} />
             }
             TradeButton={
-                <Button size="small" intent="neutral" priority="secondary" onClick={viewDetail}>
+                <Button
+                    size="small"
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={viewDetail}
+                    data-testid="@trading/transactions/view-details-button"
+                >
                     <Translation id="TR_TRADING_VIEW_DETAILS" />
                 </Button>
             }

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.tsx
@@ -84,7 +84,7 @@ export const TradingTransactionsList = () => {
             {!isEmpty && (
                 <>
                     <Header>
-                        <H3>
+                        <H3 data-testid="@trading/transactions/heading">
                             <Translation id="TR_TRADING_LAST_TRANSACTIONS" />
                         </H3>
                         <TransactionCount data-testid="@trading/transactions/count">

--- a/suite/e2e/fixtures/invity/swap/swap-history.ts
+++ b/suite/e2e/fixtures/invity/swap/swap-history.ts
@@ -1,0 +1,83 @@
+// Seeded trade data for swap history E2E tests.
+// We intentionally provide three exchanges with different final/ongoing statuses
+// so the history list shows Approved + Rejected + Pending states.
+
+export type SwapHistoryItem = {
+    orderId: string;
+    date: string;
+    sendSymbol: string;
+    data: {
+        exchange: string;
+        orderId: string;
+        status: string;
+        send: string;
+        sendAddress: string;
+        sendStringAmount: string;
+        receive: string;
+        receiveAddress: string;
+        receiveStringAmount: string;
+        statusUrl: string;
+    };
+};
+
+// Successful swap: Ethereum → Bitcoin via Changelly
+export const SUCCESS_TRADE: SwapHistoryItem = {
+    orderId: '1017bde774cfdf577ace',
+    date: '2025-12-17T15:16:41.156Z',
+    sendSymbol: 'eth',
+    data: {
+        exchange: 'changelly',
+        orderId: '1017bde774cfdf577ace',
+        status: 'SUCCESS',
+        send: 'ethereum',
+        sendAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        sendStringAmount: '0.5',
+        receive: 'bitcoin',
+        receiveAddress: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+        receiveStringAmount: '0.00265848',
+        statusUrl: 'https://changelly.io/transaction/1017bde774cfdf577ace',
+    },
+} as const;
+
+// Failed swap: Litecoin → Ethereum via ChangeNow
+export const FAILED_TRADE: SwapHistoryItem = {
+    orderId: 'f4a2c1e9b3d07e5f6a8b',
+    date: '2025-12-16T08:30:00.000Z',
+    sendSymbol: 'ltc',
+    data: {
+        exchange: 'changenow',
+        orderId: 'f4a2c1e9b3d07e5f6a8b',
+        status: 'ERROR',
+        send: 'litecoin',
+        sendAddress: 'LcDpKhDmqCWigwRMBFcgVPbNfzjmCVWHPb',
+        sendStringAmount: '12',
+        receive: 'ethereum',
+        receiveAddress: '0x8Ba1f109551bD432803012645Ac136ddd64DBA72',
+        receiveStringAmount: '5.12345678',
+        statusUrl: 'https://changenow.io/exchange/txs/f4a2c1e9b3d07e5f6a8b',
+    },
+} as const;
+
+// Pending swap: Bitcoin → Litecoin via SideShift
+export const PENDING_TRADE: SwapHistoryItem = {
+    orderId: 'a3c5e7f9b1d2e4f60789',
+    date: '2025-12-15T12:00:00.000Z',
+    sendSymbol: 'btc',
+    data: {
+        exchange: 'sideshift',
+        orderId: 'a3c5e7f9b1d2e4f60789',
+        status: 'CONFIRMING',
+        send: 'bitcoin',
+        sendAddress: '3FZbgi29cpjq2GjdwV8eyHuJJnkLtktZc5',
+        sendStringAmount: '0.00050000',
+        receive: 'litecoin',
+        receiveAddress: 'LcDpKhDmqCWigwRMBFcgVPbNfzjmCVWHPb',
+        receiveStringAmount: '0.35',
+        statusUrl: 'https://sideshift.ai/orders/a3c5e7f9b1d2e4f60789',
+    },
+} as const;
+
+// `sendSymbol` is the network symbol (as stored in wallet accounts)
+// corresponding to the Invity `send` crypto ID. It is used to look up the
+// correct `sendAccountKey` when seeding trades into Redux.
+export const SEEDED_TRADES = [SUCCESS_TRADE, FAILED_TRADE, PENDING_TRADE];

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -25,6 +25,7 @@ import { TradingPage } from './pageObjects/trading/tradingPage';
 import { TrezorInput } from './pageObjects/trezorInput';
 import { WalletPage } from './pageObjects/walletPage';
 import { suiteBaseTest } from './testExtends/suiteBaseFixture';
+import { TradingStoreFixture } from './tradingStore';
 
 type Fixtures = {
     dashboardPage: DashboardPage;
@@ -43,6 +44,7 @@ type Fixtures = {
     analytics: AnalyticsFixture;
     analyticsHelper: AnalyticsHelper;
     indexedDb: IndexedDbFixture;
+    tradingStore: TradingStoreFixture;
     metadataMock: MetadataMock;
     blockbookMock: BlockbookMock;
     solanaStakingMock: SolanaStakingMock;
@@ -101,6 +103,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     indexedDb: async ({ page }, use) => {
         await use(new IndexedDbFixture(page));
+    },
+    tradingStore: async ({ page }, use) => {
+        await use(new TradingStoreFixture(page));
     },
     metadataMock: async ({ page }, use) => {
         const metadataMock = new MetadataMock(page);

--- a/suite/e2e/support/indexedDb.ts
+++ b/suite/e2e/support/indexedDb.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export class IndexedDbFixture {
     constructor(private page: Page) {}

--- a/suite/e2e/support/pageObjects/trading/swapTransactionRow.ts
+++ b/suite/e2e/support/pageObjects/trading/swapTransactionRow.ts
@@ -1,0 +1,25 @@
+import { Locator, Page } from '@playwright/test';
+
+export class TradingSwapTransactionRow {
+    readonly root: Locator;
+    readonly provider: Locator;
+    readonly orderId: Locator;
+    readonly status: Locator;
+    readonly sendAmount: Locator;
+    readonly receiveAmount: Locator;
+    readonly date: Locator;
+    readonly viewDetailsButton: Locator;
+
+    constructor(page: Page, tradeOrderId: string) {
+        this.root = page.getByTestId(`@trading/transactions/list/swap-transaction/${tradeOrderId}`);
+        this.provider = this.root.getByTestId('@trading/offers/quote/provider');
+        this.orderId = this.root.getByTestId('@trading/transaction-id');
+        this.status = this.root.getByTestId('@trading/transactions/status');
+        this.sendAmount = this.root.getByTestId('@trading/transactions/send/amount-with-symbol');
+        this.receiveAmount = this.root.getByTestId(
+            '@trading/transactions/receive/amount-with-symbol',
+        );
+        this.date = this.root.getByTestId('@trading/transactions/date');
+        this.viewDetailsButton = this.root.getByTestId('@trading/transactions/view-details-button');
+    }
+}

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -6,6 +6,7 @@ import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { TradingAssetPicker } from './assetsModal';
 import { TradingConfirmationModal } from './confirmationModal';
+import { TradingTransactionsSection } from './transactionsSection';
 import { DevicePrompt } from '../devicePrompt';
 import { FeeSection } from './feeSection';
 import { TradingFormInputs } from './formInputs';
@@ -47,6 +48,8 @@ export class TradingPage {
 
     // Transactions
     readonly transactionDetailStatus: Locator;
+    readonly transactionDetail: Locator;
+    readonly transactions: TradingTransactionsSection;
 
     // Swap toast notifications
     readonly swapToastSendAccount: Locator;
@@ -82,8 +85,9 @@ export class TradingPage {
         this.sendBalance = this.page.getByTestId('outputs.0.token');
         this.setMax = this.page.getByTestId('outputs.0.setMax');
 
-        // Transactions
         this.transactionDetailStatus = this.page.getByTestId('@trading/transaction/detail/status');
+        this.transactionDetail = this.page.getByTestId('@trading/transaction/detail');
+        this.transactions = new TradingTransactionsSection(page);
 
         // Swap toast notifications
         this.swapToastSendAccount = this.page.getByTestId('@toast/tx-exchange/send-account');

--- a/suite/e2e/support/pageObjects/trading/transactionDetailSidebar.ts
+++ b/suite/e2e/support/pageObjects/trading/transactionDetailSidebar.ts
@@ -6,24 +6,38 @@ export class TransactionDetailSidebar {
     readonly sendAccount: Locator;
     readonly sendAssetName: Locator;
     readonly sendNetworkName: Locator;
+    readonly sendAmount: Locator;
     readonly receiveSection: Locator;
     readonly receiveAccount: Locator;
     readonly receiveAssetName: Locator;
     readonly receiveNetworkName: Locator;
+    readonly receiveAmount: Locator;
     readonly cryptoAmounts: Locator;
+    readonly statusCard: Locator;
+    readonly providerInStatusCard: Locator;
+    readonly orderIdInStatusCard: Locator;
 
     constructor(page: Page) {
         this.container = page.getByTestId('@trading/transaction/detail/sidebar');
         this.sendSection = this.container.getByTestId('@trading/detail/send-info');
-        this.sendAccount = this.container.getByTestId('@trading/detail/send-account');
+        this.sendAccount = this.container.getByTestId('@trading/transaction/detail/send-account');
         this.sendAssetName = this.container.getByTestId('@trading/detail/send-asset-name');
         this.sendNetworkName = this.container.getByTestId('@trading/detail/send-network-name');
+        this.sendAmount = this.sendSection.getByTestId('@trading/form/info/crypto-amount');
         this.receiveSection = this.container.getByTestId('@trading/detail/receive-info');
-        this.receiveAccount = this.container.getByTestId('@trading/detail/receive-account');
+        this.receiveAccount = this.container.getByTestId(
+            '@trading/transaction/detail/receive-account',
+        );
         this.receiveAssetName = this.container.getByTestId('@trading/detail/receive-asset-name');
         this.receiveNetworkName = this.container.getByTestId(
             '@trading/detail/receive-network-name',
         );
+        this.receiveAmount = this.receiveSection.getByTestId('@trading/form/info/crypto-amount');
         this.cryptoAmounts = this.container.getByTestId('@trading/form/info/crypto-amount');
+        this.statusCard = page.getByTestId('@trading/transaction/detail/status-card');
+        this.providerInStatusCard = this.statusCard.getByTestId('@trading/form/info/provider');
+        this.orderIdInStatusCard = this.statusCard.getByTestId(
+            '@trading/transaction/detail/order-id',
+        );
     }
 }

--- a/suite/e2e/support/pageObjects/trading/transactionsSection.ts
+++ b/suite/e2e/support/pageObjects/trading/transactionsSection.ts
@@ -1,0 +1,29 @@
+import { Locator, Page } from '@playwright/test';
+
+import { TradingSwapTransactionRow } from './swapTransactionRow';
+
+export class TradingTransactionsSection {
+    readonly menuButton: Locator;
+    readonly heading: Locator;
+    readonly count: Locator;
+    readonly list: Locator;
+    readonly allSwapRows: Locator;
+
+    constructor(private page: Page) {
+        this.menuButton = page.getByTestId('@trading/menu/wallet-trading-transactions');
+        this.heading = page.getByTestId('@trading/transactions/heading');
+        this.count = page.getByTestId('@trading/transactions/count');
+        this.list = page.getByTestId('@trading/transactions/list');
+        this.allSwapRows = this.list.locator(
+            '[data-testid^="@trading/transactions/list/swap-transaction/"]',
+        );
+    }
+
+    swapTransactionRow(orderId: string): TradingSwapTransactionRow {
+        return new TradingSwapTransactionRow(this.page, orderId);
+    }
+
+    swapRowAt(index: number): Locator {
+        return this.allSwapRows.nth(index);
+    }
+}

--- a/suite/e2e/support/tradingStore.ts
+++ b/suite/e2e/support/tradingStore.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+
+import { SwapHistoryItem } from '../fixtures/invity/swap/swap-history';
+
+export class TradingStoreFixture {
+    constructor(private page: Page) {}
+
+    async insertSwapHistory(trades: SwapHistoryItem[]) {
+        await this.page.evaluate(inputTrades => {
+            const accounts = window.store.getState().wallet.accounts as Array<{
+                key: string;
+                symbol: string;
+            }>;
+            const accountKeyBySymbol = new Map(
+                accounts.map(account => [account.symbol, account.key]),
+            );
+
+            for (const trade of inputTrades) {
+                window.store.dispatch({
+                    type: '@trading/saveTrade',
+                    payload: {
+                        tradeType: 'exchange',
+                        key: trade.orderId,
+                        date: trade.date,
+                        sendAccountKey: accountKeyBySymbol.get(trade.sendSymbol)!,
+                        data: trade.data,
+                    },
+                });
+            }
+        }, trades);
+    }
+}

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -1,0 +1,173 @@
+import { messages } from '@suite/intl';
+import { cryptoIdToSymbol } from '@suite-common/trading';
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { invityEndpoint } from '../../fixtures/invity';
+import { SEEDED_TRADES } from '../../fixtures/invity/swap/swap-history';
+import { expect, test } from '../../support/fixtures';
+
+test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic' } });
+
+    test.beforeEach(async ({ page, onboardingPage, settingsPage, tradingStore }) => {
+        // The app periodically calls `/exchange/watch/*` to refresh trade status.
+        // For this test we keep status stable by echoing the current status from
+        // the request body, so seeded `CONFIRMING` remains `Pending` in UI.
+        await page.route(invityEndpoint.swapWatch, async route => {
+            const body = route.request().postDataJSON() as { status?: string } | null;
+            await route.fulfill({ json: { status: body?.status ?? 'SUCCESS' } });
+        });
+
+        await onboardingPage.completeOnboarding();
+        await settingsPage.changeNetworks({ enableNetworks: ['ltc'] });
+        await tradingStore.insertSwapHistory(SEEDED_TRADES);
+    });
+
+    test('View swap order history details', async ({ walletPage, tradingPage }) => {
+        await test.step('Navigate to swap/exchange trading section', async () => {
+            await walletPage.openSwapTrading({ symbol: 'btc' });
+        });
+
+        await test.step('Open trading transactions history', async () => {
+            await tradingPage.transactions.menuButton.click();
+
+            await expect(tradingPage.transactions.heading).toHaveTranslation(
+                'TR_TRADING_LAST_TRANSACTIONS',
+            );
+        });
+
+        await test.step('Verify trades are ordered by date descending', async () => {
+            const expectedOrderedIds = [...SEEDED_TRADES]
+                .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+                .map(t => t.orderId);
+
+            await expect(tradingPage.transactions.allSwapRows).toHaveCount(
+                expectedOrderedIds.length,
+            );
+
+            for (const [index, orderId] of expectedOrderedIds.entries()) {
+                await expect(tradingPage.transactions.swapRowAt(index)).toHaveAttribute(
+                    'data-testid',
+                    `@trading/transactions/list/swap-transaction/${orderId}`,
+                );
+            }
+        });
+
+        await test.step('Verify trade appears in history list', async () => {
+            const statusTranslationKeys = {
+                SUCCESS: 'TR_EXCHANGE_STATUS_SUCCESS',
+                ERROR: 'TR_EXCHANGE_STATUS_ERROR',
+                CONFIRMING: 'TR_EXCHANGE_STATUS_CONFIRMING',
+            } as const;
+
+            await expect(tradingPage.transactions.count).toHaveTranslation(
+                'TR_TRADING_SWAP_COUNTER',
+                { values: { totalSwaps: SEEDED_TRADES.length } },
+            );
+
+            for (const trade of SEEDED_TRADES) {
+                type StatusKey = keyof typeof statusTranslationKeys;
+                const row = tradingPage.transactions.swapTransactionRow(trade.orderId);
+                const receiveSymbol = (
+                    cryptoIdToSymbol(
+                        trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0],
+                    ) ?? trade.data.receive
+                ).toUpperCase();
+
+                await expect(row.root).toBeVisible();
+                await expect.soft(row.provider).toHaveText(trade.data.exchange, {
+                    ignoreCase: true,
+                });
+                await expect
+                    .soft(row.orderId)
+                    .toHaveText(
+                        `${messages['TR_TRADING_TRANS_ID'].defaultMessage} ${trade.orderId}`,
+                    );
+                await expect
+                    .soft(row.status)
+                    .toHaveTranslation(statusTranslationKeys[trade.data.status as StatusKey]);
+                await expect
+                    .soft(row.sendAmount)
+                    .toHaveText(
+                        `${localizeNumber(trade.data.sendStringAmount)} ${trade.sendSymbol.toUpperCase()}`,
+                    );
+                await expect
+                    .soft(row.receiveAmount)
+                    .toHaveText(
+                        `${localizeNumber(trade.data.receiveStringAmount)} ${receiveSymbol}`,
+                    );
+                const expectedDate = new Intl.DateTimeFormat('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    hourCycle: 'h23',
+                }).format(new Date(trade.date));
+                await expect.soft(row.date).toHaveText(expectedDate);
+            }
+        });
+        const detailStatusTranslationKeys = {
+            SUCCESS: 'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
+            ERROR: 'TR_EXCHANGE_DETAIL_ERROR_TITLE',
+            CONFIRMING: 'TR_EXCHANGE_DETAIL_SENDING_TRANSACTION',
+        } as const;
+
+        for (const trade of SEEDED_TRADES) {
+            const receiveSymbol = (
+                cryptoIdToSymbol(trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0]) ??
+                trade.data.receive
+            ).toUpperCase();
+
+            await test.step(`Open detail for trade ${trade.orderId}`, async () => {
+                await tradingPage.transactions
+                    .swapTransactionRow(trade.orderId)
+                    .viewDetailsButton.click();
+            });
+
+            await test.step(`Verify detail page for trade ${trade.orderId}`, async () => {
+                type DetailStatusKey = keyof typeof detailStatusTranslationKeys;
+
+                await expect(tradingPage.transactionDetail).toBeVisible();
+                await expect
+                    .soft(tradingPage.transactionDetailStatus)
+                    .toHaveTranslation(
+                        detailStatusTranslationKeys[trade.data.status as DetailStatusKey],
+                    );
+
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.sendAmount)
+                    .toHaveText(
+                        `${localizeNumber(trade.data.sendStringAmount)} ${trade.sendSymbol.toUpperCase()}`,
+                    );
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.receiveAmount)
+                    .toHaveText(
+                        `${localizeNumber(trade.data.receiveStringAmount)} ${receiveSymbol}`,
+                    );
+
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.providerInStatusCard)
+                    .toBeVisible();
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.providerInStatusCard)
+                    .toHaveText(trade.data.exchange, { ignoreCase: true });
+
+                await expect
+                    .soft(tradingPage.transactionDetailSidebar.orderIdInStatusCard)
+                    .toHaveText(trade.orderId);
+
+                await expect(tradingPage.transactionDetailSidebar.sendAccount).toContainText(
+                    getNetwork(trade.sendSymbol as NetworkSymbol).name,
+                );
+                await expect(tradingPage.transactionDetailSidebar.receiveAccount).toBeVisible();
+            });
+
+            await test.step(`Navigate back to transaction list`, async () => {
+                await tradingPage.transactions.menuButton.click();
+                await expect(tradingPage.transactions.heading).toBeVisible();
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Description

Adds an automated E2E test suite that verifies the swap transaction history in the Trading section. The test seeds mock trade data into IndexedDB and validates the full UI flow: the transactions list view (ordering, row content, status, amounts, dates) and the detail view (status, send/receive amounts, provider, order ID, accounts).

<img width="1916" height="1020" alt="image" src="https://github.com/user-attachments/assets/a2d6fa54-e880-44d0-ae29-60c7d771df06" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-swap-history&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-swap-history&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T11:16:57.077Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T12:22:41.523Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->