### PR TITLE
feat(suite): add notification variant for yield supply, withdraw and claim

### DIFF
--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -26,8 +26,12 @@ const shouldDisplayAssetLogo = ({ notificationType, token }: ShouldDisplayAssetL
     const isApprovalType = notificationType === 'tx-approved' || notificationType === 'tx-revoked';
     const isTransferTokenType =
         notificationType === 'tx-sent' || notificationType === 'tx-received';
+    const isYieldType =
+        notificationType === 'tx-yield-supply' ||
+        notificationType === 'tx-yield-withdraw' ||
+        notificationType === 'tx-yield-claim';
 
-    return (isApprovalType || isTransferTokenType) && !!token;
+    return (isApprovalType || isTransferTokenType || isYieldType) && !!token;
 };
 
 export const TransactionIcon = ({

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -15,14 +15,13 @@ const meta: Meta<typeof TransactionNotification> = {
 export default meta;
 
 type Story = StoryObj<typeof TransactionNotification>;
-type TransactionNotificationType = TransactionNotificationProps['notificationType'];
 
 type TransactionToastStoryArgs = {
-    notificationType: TransactionNotificationType;
+    notificationType: TransactionNotificationProps['notificationType'];
 };
 
 const transactionNotificationConfig: Record<
-    TransactionNotificationType,
+    TransactionNotificationProps['notificationType'],
     {
         toastIcon?: IconName;
         intent: ToastProps['intent'];
@@ -136,6 +135,54 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'tx-yield-supply': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Supplied from Base #1',
+        amount: '150 USDC',
+        transaction: {
+            notificationType: 'tx-yield-supply',
+            symbol: 'base',
+            accountSymbol: 'base',
+            token: {
+                contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                name: 'USD Coin',
+                symbol: 'USDC',
+            },
+        },
+    },
+    'tx-yield-withdraw': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Withdrawn from Base #1',
+        amount: '150 USDC',
+        transaction: {
+            notificationType: 'tx-yield-withdraw',
+            symbol: 'base',
+            accountSymbol: 'base',
+            token: {
+                contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                name: 'USD Coin',
+                symbol: 'USDC',
+            },
+        },
+    },
+    'tx-yield-claim': {
+        toastIcon: 'arrowUp',
+        intent: 'brand',
+        message: 'Claimed from Base #1',
+        amount: '150 USDC',
+        transaction: {
+            notificationType: 'tx-yield-claim',
+            symbol: 'base',
+            accountSymbol: 'base',
+            token: {
+                contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+                name: 'USD Coin',
+                symbol: 'USDC',
+            },
+        },
+    },
 };
 
 export const Default: Story = {
@@ -162,16 +209,9 @@ export const InToast: StoryObj<TransactionToastStoryArgs> = {
             control: {
                 type: 'select',
             },
-            options: [
-                'tx-sent',
-                'tx-received',
-                'tx-revoked',
-                'tx-claimed',
-                'tx-unstaked',
-                'tx-staked',
-                'tx-approved',
-                'tx-confirmed',
-            ],
+            options: Object.keys(
+                transactionNotificationConfig,
+            ) as (keyof typeof transactionNotificationConfig)[],
         },
     },
     render: ({ notificationType }) => {

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -24,7 +24,10 @@ export type TransactionNotificationType =
     | 'tx-unstaked'
     | 'tx-claimed'
     | 'tx-approved'
-    | 'tx-revoked';
+    | 'tx-revoked'
+    | 'tx-yield-supply'
+    | 'tx-yield-withdraw'
+    | 'tx-yield-claim';
 
 type TransactionNotificationWithToken = Extract<
     NotificationEntry,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -555,6 +555,51 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-yield-supply':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_YIELD_SUPPLY"
+                    messageValues={{
+                        amount: notification.formattedAmount,
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
+        case 'tx-yield-withdraw':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_YIELD_WITHDRAW"
+                    messageValues={{
+                        amount: notification.formattedAmount,
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
+        case 'tx-yield-claim':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon="arrowUp"
+                    variant="success"
+                    message="TOAST_TX_YIELD_CLAIM"
+                    messageValues={{
+                        amount: notification.formattedAmount,
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'successful-claim':
             return renderNotificationView(render, notification, {
                 variant: 'success',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -62,6 +62,18 @@ type ClaimedTransactionNotification = {
     type: 'tx-claimed';
 } & TransactionNotificationPayload;
 
+type YieldSupplyTransactionNotification = {
+    type: 'tx-yield-supply';
+} & TransactionNotificationPayload;
+
+type YieldWithdrawTransactionNotification = {
+    type: 'tx-yield-withdraw';
+} & TransactionNotificationPayload;
+
+type YieldClaimTransactionNotification = {
+    type: 'tx-yield-claim';
+} & TransactionNotificationPayload;
+
 export type ErrorToastPayload = {
     type:
         | 'error'
@@ -176,6 +188,9 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | StakedTransactionNotification
     | UnstakedTransactionNotification
     | ClaimedTransactionNotification
+    | YieldSupplyTransactionNotification
+    | YieldWithdrawTransactionNotification
+    | YieldClaimTransactionNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10133,6 +10133,18 @@ export const messages = defineMessages({
         id: 'TOAST_TX_CLAIMED',
         defaultMessage: 'Claimed from {account}',
     },
+    TOAST_TX_YIELD_SUPPLY: {
+        id: 'TOAST_TX_YIELD_SUPPLY',
+        defaultMessage: 'Supply broadcasted from {account}',
+    },
+    TOAST_TX_YIELD_WITHDRAW: {
+        id: 'TOAST_TX_YIELD_WITHDRAW',
+        defaultMessage: 'Withdrawal broadcasted from {account}',
+    },
+    TOAST_TX_YIELD_CLAIM: {
+        id: 'TOAST_TX_YIELD_CLAIM',
+        defaultMessage: 'Claim broadcasted from {account}',
+    },
     TOAST_SUCCESSFUL_CLAIM: {
         id: 'TOAST_SUCCESSFUL_CLAIM',
         defaultMessage: '{networkDisplaySymbol} claimed successfully',


### PR DESCRIPTION
## Description

Adds toast notification variants for yield supply, withdraw, and claim transactions — rendered via TransactionRenderer with dedicated translation keys and Storybook stories.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25025

## Screenshots:

<img width="429" height="110" alt="image" src="https://github.com/user-attachments/assets/25a58163-ff8e-4e6b-b431-eb2bccd77801" />

<img width="417" height="105" alt="image" src="https://github.com/user-attachments/assets/fd718df3-3331-43e5-91f4-4ca2863e753a" />

<img width="426" height="111" alt="image" src="https://github.com/user-attachments/assets/4f5f39b3-bc50-41bb-b972-65f7b25d8d09" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-yield-notifications&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-yield-notifications&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-yield-notifications&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T12:22:42.394Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T12:20:17.828Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->