### PR TITLE
chore: remove exactOptionalPropertyTypes:true, it causes problem, we shall figure out how to turn it as it is needed in Evolu but for now, it makes the life hard

### DIFF
--- a/suite-common/delegated-identity-key-types/tsconfig.json
+++ b/suite-common/delegated-identity-key-types/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         { "path": "../suite-types" },

--- a/suite-common/delegated-identity-key/tsconfig.json
+++ b/suite-common/delegated-identity-key/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         {

--- a/suite-common/platform-encryption/tsconfig.json
+++ b/suite-common/platform-encryption/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         { "path": "../../packages/type-utils" }

--- a/suite-common/suite-rbf-labels-migrations-types/tsconfig.json
+++ b/suite-common/suite-rbf-labels-migrations-types/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         { "path": "../suite-sync-storage" },

--- a/suite-common/suite-rbf-labels-migrations/tsconfig.json
+++ b/suite-common/suite-rbf-labels-migrations/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         { "path": "../dependency-injection" },

--- a/suite-native/platform-encryption-native/tsconfig.json
+++ b/suite-native/platform-encryption-native/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         {

--- a/suite/platform-encryption-electron/tsconfig.json
+++ b/suite/platform-encryption-electron/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         {

--- a/suite/platform-encryption-webauthn/tsconfig.json
+++ b/suite/platform-encryption-webauthn/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "libDev"
     },
     "references": [
         {

--- a/suite/suite-sync/tsconfig.json
+++ b/suite/suite-sync/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "./libDev",
-        "exactOptionalPropertyTypes": true
+        "outDir": "./libDev"
     },
     "include": [".", "**/*.json"],
     "references": [


### PR DESCRIPTION
Will be needed for: https://github.com/trezor/trezor-suite/pull/26077

Nothing to test, only code (TS) improvement

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-exactOptionalPropertyTypes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-exactOptionalPropertyTypes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-exactOptionalPropertyTypes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T12:21:19.324Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T12:20:25.573Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->