### PR TITLE
Manual trade tests native

### DIFF
--- a/suite-native/app/e2e/support/reporter/annotations.ts
+++ b/suite-native/app/e2e/support/reporter/annotations.ts
@@ -5,10 +5,16 @@ import { TestDetailsAnnotation, TestReportProviderBase, TestStatus } from '@trez
 // Class used by our GitHub Reporter to extract metadata from the test and its run
 export class TestReportProvider extends TestReportProviderBase {
     private readonly test: TestResult;
+    private readonly assertionResult: TestResult['testResults'][number];
 
-    constructor(test: TestResult, metadata: TestDetailsAnnotation[]) {
+    constructor(
+        test: TestResult,
+        assertionResult: TestResult['testResults'][number],
+        metadata: TestDetailsAnnotation[],
+    ) {
         super();
         this.test = test;
+        this.assertionResult = assertionResult;
 
         for (const annotation of metadata) {
             if (!annotation.description) {
@@ -20,11 +26,7 @@ export class TestReportProvider extends TestReportProviderBase {
 
     // Platform-specific implementations
     get testTitle(): string {
-        if (!this.test.testResults.length) {
-            throw new Error('Test results are empty');
-        }
-
-        return this.test.testResults[0]?.title;
+        return this.assertionResult.title;
     }
 
     get testProject(): string {
@@ -38,11 +40,11 @@ export class TestReportProvider extends TestReportProviderBase {
             return TestStatus.Todo;
         }
 
-        if (this.test.testResults[0]?.status === 'passed') {
+        if (this.assertionResult.status === 'passed') {
             return TestStatus.AutoPass;
         }
 
-        if (this.test.testResults[0]?.status === 'failed') {
+        if (this.assertionResult.status === 'failed') {
             return TestStatus.AutoFail;
         }
 
@@ -55,12 +57,12 @@ export class TestReportProvider extends TestReportProviderBase {
     }
 
     get isRetryAttempt(): boolean {
-        return this.test.testResults.length > 1;
+        return (this.assertionResult.invocations ?? 1) > 1;
     }
 
     get id(): string {
-        // For Jest/Native, we use testFilePath as the unique identifier
-        return this.test.testFilePath;
+        // For Jest/Native, combine file path and full test title to uniquely identify test case.
+        return `${this.test.testFilePath}::${this.assertionResult.fullName}`;
     }
 
     get filePath(): string {

--- a/suite-native/app/e2e/support/reporter/gitHubReporter.ts
+++ b/suite-native/app/e2e/support/reporter/gitHubReporter.ts
@@ -12,16 +12,17 @@ class GitHubReporter extends GitHubReporterBase implements LoggingFunctions {
         await this.init();
     }
 
-    // Processes test completion by creating a GitHub issue with test results and metadata
-    // eslint-disable-next-line require-await
+    // Processes test completion by creating a GitHub issue per finished test case
     async onTestResult(_test: Test, testResult: TestResult): Promise<void> {
-        const testTitle = testResult.testResults[0]?.title;
-        this.log(`Processing test end for "${testTitle}"`);
-        const metadata = readMetadataForTest(testTitle);
-        // this.log(`Metadata for test "${testTitle}":`, metadata);
-        const report = new TestReportProvider(testResult, metadata);
+        for (const assertionResult of testResult.testResults) {
+            const testTitle = assertionResult.title;
 
-        return this.processTestResult(report);
+            this.log(`Processing test end for "${testTitle}"`);
+            const metadata = readMetadataForTest(testTitle);
+            const report = new TestReportProvider(testResult, assertionResult, metadata);
+
+            await this.processTestResult(report);
+        }
     }
 
     async onRunComplete(): Promise<void> {

--- a/suite-native/app/e2e/tests/manual/trading/btc-transactions-buy.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/btc-transactions-buy.test.ts
@@ -1,0 +1,33 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Buy BTC',
+        {
+            testCase: 'Verifies that a user can buy BTC in the mobile trading flow.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a wallet connected'],
+            steps: [
+                'Open Trade tab and select Buy',
+                'Select wallet/account in the header selector if needed',
+                'Fill fiat amount input',
+                'Fill crypto amount input',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select asset to buy (if different from default)',
+                'Select country and try changing it',
+                'Select payment method',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and verify transition to next step',
+            ],
+            category: TestCategory.Buy,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/btc-transactions-sell.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/btc-transactions-sell.test.ts
@@ -1,0 +1,33 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Sell BTC',
+        {
+            testCase: 'Verifies that a user can sell BTC in the mobile trading flow.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a funded BTC wallet'],
+            steps: [
+                'Open Trade tab and select Sell',
+                'Select wallet/account in the header selector if needed',
+                'Select asset to sell (if not default)',
+                'Fill fiat amount input',
+                'Fill crypto amount input',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select receive method (payment method)',
+                'Select country',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and verify transition to next step',
+                'On the next step verify fee level options are available',
+            ],
+            category: TestCategory.Sell,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/eth-transactions-swap-ETH.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/eth-transactions-swap-ETH.test.ts
@@ -1,0 +1,67 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Perform token swap',
+        {
+            testCase: 'Verifies that a user can perform a token swap in the mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a funded Ethereum wallet',
+            ],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Select token to swap from and token to swap to',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and proceed to confirmation',
+                'Confirm on Trezor and send transaction',
+                'Verify transaction is confirmed',
+                'Check transaction history for swap transaction',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+
+    it(
+        'Perform Ethereum-only swap',
+        {
+            testCase: 'Verifies that a user can perform an Ethereum-only swap in the mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a funded Ethereum wallet',
+            ],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Select Ethereum as from asset and random token as to asset',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and proceed to confirmation',
+                'Confirm on Trezor and send transaction',
+                'Verify transaction is confirmed',
+                'Check transaction history for swap transaction',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/solana-transactions-swap-cex.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/solana-transactions-swap-cex.test.ts
@@ -1,0 +1,63 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Swap SOL via CEX',
+        {
+            testCase: 'Verifies that a user can swap SOL via CEX in the mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a funded Solana wallet',
+            ],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Select from asset as SOL',
+                'Select to asset as a token',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and proceed with the swap flow',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+
+    it(
+        'Swap SPL Token via CEX',
+        {
+            testCase: 'Verifies that a user can swap SPL token via CEX in the mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a funded Solana wallet containing SPL tokens',
+            ],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Select from asset as an SPL token',
+                'Select to asset as a target coin',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and proceed with the swap flow',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.High,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/swap-cross-chain-all-cex.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/swap-cross-chain-all-cex.test.ts
@@ -1,0 +1,59 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Swap BTC -> ETH (Non-EVM <-> EVM)',
+        {
+            testCase: 'Verifies cross-chain CEX swap from Bitcoin to Ethereum in mobile app.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a funded BTC wallet'],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select to asset as ETH (Ethereum)',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Select a CEX offer',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and verify transition to next step',
+                'On the next step verify fee level options are available',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+
+    it(
+        'Swap LTC -> XLM (Non-EVM <-> Non-EVM)',
+        {
+            testCase: 'Verifies cross-chain CEX swap from Litecoin to XLM in mobile app.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a funded LTC wallet'],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Fill crypto amount',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select to asset as XLM (Stellar)',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Select a CEX offer',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and verify transition to next step',
+                'On the next step verify fee level options are available',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/swap-cross-chain-evm-dex.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/swap-cross-chain-evm-dex.test.ts
@@ -1,0 +1,32 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Swap ETH (Ethereum) -> BNB (BSC)',
+        {
+            testCase: 'Verifies cross-chain DEX swap between Ethereum and BSC in mobile app.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a funded ETH wallet'],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Fill crypto amount and fiat amount and use fraction buttons',
+                'Verify Continue is disabled when required fields are missing and enabled when form is valid',
+                'Select to asset as BNB (BSC) or token on BSC',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Select a DEX offer',
+                'Verify Trade history action is present',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Tap Continue and verify transition to next step',
+                'On the next step verify fee level options are available',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/trading-form-inputs.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/trading-form-inputs.test.ts
@@ -1,0 +1,91 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Buy form inputs validation',
+        {
+            testCase: 'Verifies robustness of Buy form inputs in mobile app.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a wallet connected'],
+            steps: [
+                'Open Trade tab and select Buy',
+                'Select wallet/account in the header selector if needed',
+                'Verify Trade history action is present',
+                'Verify Continue is disabled before valid required inputs are provided',
+                'Try entering values below minimum limits and verify amount error',
+                'Try entering values above maximum limits and verify amount error',
+                'Switch currency and verify form updates correctly',
+                'Switch asset to buy and verify form updates correctly',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Select receive account and verify validation when no account is selected',
+                'Verify Continue is enabled only when all required fields are valid',
+            ],
+            category: TestCategory.Buy,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+
+    it(
+        'Sell form inputs validation',
+        {
+            testCase: 'Verifies robustness of Sell form inputs in mobile app.',
+            prerequisites: ['Seeded Trezor device', 'Trezor Suite Lite with a funded wallet'],
+            steps: [
+                'Open Trade tab and select Sell',
+                'Select wallet/account in the header selector if needed',
+                'Verify Trade history action is present',
+                'Verify Continue is disabled before valid required inputs are provided',
+                'Try entering crypto values exceeding balance and verify error message',
+                'Try entering fiat values exceeding balance and verify error message',
+                'Use both fiat and crypto amount inputs',
+                'Switch currency and verify form updates correctly',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Verify Continue is enabled only when all required fields are valid',
+                'Tap Continue and on next step select different fee levels and verify total updates',
+            ],
+            category: TestCategory.Sell,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+
+    it(
+        'Swap form inputs validation',
+        {
+            testCase: 'Verifies robustness of Swap form inputs in mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a funded wallet',
+                'Coin availability for swap',
+            ],
+            steps: [
+                'Open Trade tab and select Swap',
+                'Select wallet/account in the header selector if needed',
+                'Verify Trade history action is present',
+                'Verify Continue is disabled before valid required inputs are provided',
+                'Fill out crypto amount',
+                'Select a different to asset',
+                'Verify rate estimation updates',
+                'Try entering crypto values exceeding balance and verify error message',
+                'Try entering fiat values exceeding balance and verify error message',
+                'Select receive account and verify validation when no account is selected',
+                'Open Provider button and verify provider list and filters are available',
+                'Verify KYC or identity warning updates when changing provider',
+                'Verify provider terms link at the bottom matches selected provider',
+                'Verify Continue is enabled only when all required fields are valid',
+            ],
+            category: TestCategory.Swap,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/trading/trading-offers-selection.test.ts
+++ b/suite-native/app/e2e/tests/manual/trading/trading-offers-selection.test.ts
@@ -1,0 +1,33 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Compare all offers functionality',
+        {
+            testCase: 'Verifies the Compare all offers flow in mobile app.',
+            prerequisites: [
+                'Seeded Trezor device',
+                'Trezor Suite Lite with a wallet connected',
+                'Proceed through Buy, Sell, or Swap form and tap Continue to reach offers selection',
+            ],
+            steps: [
+                'Observe offers loading state',
+                'Verify offers are loaded and displayed',
+                'Verify Trade history action is present',
+                'Open Provider button and verify provider list is displayed',
+                'Sort offers by best rate or lowest fee (if available)',
+                'Filter by provider type (CEX and DEX where available)',
+                'Filter by KYC options (if available)',
+                'Check one offer details including fee and rate breakdown',
+                'Select one offer and verify transition to provider confirmation flow',
+                'Wait for offers refresh and verify list updates',
+            ],
+            category: TestCategory.General,
+            priority: TestPriority.Medium,
+            stream: TestStream.Trade,
+        },
+        async () => {},
+    );
+});


### PR DESCRIPTION
This PR adds manual E2E trading test templates for Suite Native and fixes GitHub reporter behavior for Jest files containing multiple test cases.

## What Is Included

1. New manual trading templates for Buy, Sell, Swap, cross-chain scenarios, form input validation, and offers selection in `suite-native/app/e2e/tests/manual/trading`.
2. Reporter fix to process and upload each test case separately (not only one per file) in:
   - `suite-native/app/e2e/support/reporter/gitHubReporter.ts`
   - `suite-native/app/e2e/support/reporter/annotations.ts`

## Outcome

1. Manual trading coverage is added for mobile flows.
2. Multi-case files now produce multiple GitHub report items correctly.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=manual-trade-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=manual-trade-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=manual-trade-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:08:03.006Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:06:09.710Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->