### PR TITLE
fix: make sure that the backup steps action is dispatched only once

### DIFF
--- a/packages/suite/src/components/backup/BackupSeedCards.tsx
+++ b/packages/suite/src/components/backup/BackupSeedCards.tsx
@@ -51,6 +51,9 @@ export const BackupSeedCards = () => {
                                     onChange={event => {
                                         event.preventDefault();
                                     }}
+                                    onClick={event => {
+                                        event.preventDefault();
+                                    }}
                                 />
                                 <Icon name={item.icon} size={24} />
                             </Row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug that caused inability to check the checkboxes on the backup.
Likely it hasn't been caught by E2E as these directly interact with the dom? 

## Notes for QA

Please check that it works as expected (check the videos linked below)

## Related Issue

Bug described here: https://supercut.ai/share/zablockibuilds/wAyIIZ7pFo-juJXYof6q2K

## Screenshots:
Before - the event is dispatched twice when you click the checkboxes, preventing proper toggling

https://github.com/user-attachments/assets/541ab33c-3443-40b7-be1f-d3639077beff




After - the event is dispatched properly once, and works well when clicked on the checkboxes

https://github.com/user-attachments/assets/47836fc3-5d5f-4b05-9556-c1b6d1ad96a0







<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-backup-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:10:53.616Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->