### PR TITLE
feat(suite): implement maximum fee behavior for tron

### DIFF
--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
@@ -10,9 +10,14 @@ import { useFeesContext } from '../context/FeesContext';
 export interface CollapsibleFeesHeaderProps {
     label?: TranslationKey;
     typographyStyle: TypographyStyle;
+    supportsAdjustableFees?: boolean;
 }
 
-export function CollapsibleFeesHeader({ label, typographyStyle }: CollapsibleFeesHeaderProps) {
+export function CollapsibleFeesHeader({
+    label,
+    typographyStyle,
+    supportsAdjustableFees,
+}: CollapsibleFeesHeaderProps) {
     const { networkType } = useFeesContext();
 
     const feeTooltipTextId = useMemo(() => {
@@ -32,12 +37,14 @@ export function CollapsibleFeesHeader({ label, typographyStyle }: CollapsibleFee
         switch (networkType) {
             case 'ethereum':
                 return 'MAX_FEE';
+            case 'tron':
+                return supportsAdjustableFees ? 'MAX_FEE' : 'NETWORK_FEE';
             case 'solana':
                 return 'TR_TX_FEE_INCLUDING_RENT';
             default:
                 return 'FEE';
         }
-    }, [networkType]);
+    }, [networkType, supportsAdjustableFees]);
 
     return (
         <Row flexWrap="wrap" justifyContent="space-between" gap={12} minHeight={44}>

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeaderContent.tsx
@@ -31,7 +31,11 @@ export const CollapsibleFeesHeaderContent = ({
             gap={12}
             data-testid="@wallet/fees/collapsible-fees-toggle"
         >
-            <CollapsibleFeesHeader label={label} typographyStyle={headerTypographyStyle} />
+            <CollapsibleFeesHeader
+                label={label}
+                typographyStyle={headerTypographyStyle}
+                supportsAdjustableFees={supportsAdjustableFees}
+            />
             <Row gap={16}>
                 {networkType === 'tron' ? (
                     <TronFee typographyStyle={headerTypographyStyle} />

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/TronFee/TronFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/TronFee/TronFee.tsx
@@ -1,7 +1,11 @@
+import { useWatch } from 'react-hook-form';
+
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
+import { type FormState } from '@suite-common/wallet-types';
 import { calculateTronFeeBreakdown } from '@suite-common/wallet-utils';
 import { LoadingContent } from '@trezor/components';
 import { type TypographyStyle } from '@trezor/theme';
+import { BigNumber } from '@trezor/utils';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -15,9 +19,15 @@ type TronFeeProps = {
 export function TronFee({ typographyStyle }: TronFeeProps) {
     const { networkSymbol, composedLevels, tronResources } = useFeesContext();
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
+    const formFeeLimit = useWatch<FormState, 'feeLimit'>({ name: 'feeLimit' });
 
     const tx = composedLevels?.normal;
-    const fees = calculateTronFeeBreakdown(tx, tronResources, networkSymbol);
+    const estimatedFeeLimit = tx?.type !== 'error' ? tx?.estimatedFeeLimit : undefined;
+    const feeLimitSun =
+        formFeeLimit && estimatedFeeLimit && new BigNumber(formFeeLimit).gt(estimatedFeeLimit)
+            ? formFeeLimit
+            : estimatedFeeLimit;
+    const fees = calculateTronFeeBreakdown(tx, tronResources, networkSymbol, feeLimitSun);
 
     return (
         <LoadingContent

--- a/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tronUtils.test.ts
@@ -1,0 +1,131 @@
+import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
+import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
+
+import { calculateTronFeeBreakdown } from '../tronUtils';
+
+const makeTrc20Tx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
+    ({
+        type: 'nonfinal',
+        feePerByte: '100',
+        bytes: 300,
+        energyConsumed: 1000,
+        token: { name: 'USDT', symbol: 'USDT', decimals: 6, balance: '100000000' },
+        totalSpent: '0',
+        inputs: [],
+        ...overrides,
+    }) as unknown as GeneralPrecomposedTransaction;
+
+const makeNativeTrxTx = (): GeneralPrecomposedTransaction =>
+    ({
+        type: 'nonfinal',
+        bytes: 300,
+        totalSpent: '0',
+        inputs: [],
+    }) as unknown as GeneralPrecomposedTransaction;
+
+const makeTronResources = (
+    overrides: Partial<TronAccountExtraData> = {},
+): TronAccountExtraData => ({
+    availableStakedBandwidth: 0,
+    totalStakedBandwidth: 0,
+    availableFreeBandwidth: 300,
+    totalFreeBandwidth: 300,
+    availableEnergy: 0,
+    totalEnergy: 0,
+    ...overrides,
+});
+
+describe(calculateTronFeeBreakdown.name, () => {
+    it('native TRX: has bandwidth — 0 TRX burned', () => {
+        // Tx: bandwidth: 300
+        // Account: bandwidth: 300, energy: 0
+        // Expected: trxBurned: 0 TRX, coveredBandwidth: 300
+        const result = calculateTronFeeBreakdown(makeNativeTrxTx(), makeTronResources(), 'trx');
+        expect(result?.trxBurned.toNumber()).toBe(0);
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
+    });
+
+    it('native TRX: no bandwidth — TRX burns bandwidth cost', () => {
+        // Tx: bandwidth: 300
+        // Account: bandwidth: 0, energy: 0
+        // Expected: trxBurned: 0.3 TRX, coveredBandwidth: 0
+        const result = calculateTronFeeBreakdown(
+            makeNativeTrxTx(),
+            makeTronResources({ availableFreeBandwidth: 0 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toString()).toBe('0.3');
+        expect(result?.coveredBandwidth.toNumber()).toBe(0);
+    });
+
+    it('TRC-20: has bandwidth, has energy — 0 TRX burned', () => {
+        // Tx: bandwidth: 300, energy: 1000
+        // Account: bandwidth: 300, energy: 1000
+        // Expected: trxBurned: 0 TRX, coveredBandwidth: 300, coveredEnergy: 1000
+        const result = calculateTronFeeBreakdown(
+            makeTrc20Tx(),
+            makeTronResources({ availableEnergy: 1000 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toNumber()).toBe(0);
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
+        expect(result?.coveredEnergy.toNumber()).toBe(1000);
+    });
+
+    it('TRC-20: has bandwidth, partial energy — TRX burns the rest', () => {
+        // Tx: bandwidth: 300, energy: 1000
+        // Account: bandwidth: 300, energy: 400
+        // Expected: trxBurned: 0.06 TRX, coveredBandwidth: 300, coveredEnergy: 400
+        const result = calculateTronFeeBreakdown(
+            makeTrc20Tx(),
+            makeTronResources({ availableEnergy: 400 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toString()).toBe('0.06');
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
+        expect(result?.coveredEnergy.toNumber()).toBe(400);
+    });
+
+    it('TRC-20: has bandwidth, no energy — TRX burns all', () => {
+        // Tx: bandwidth: 300, energy: 1000
+        // Account: bandwidth: 300, energy: 0
+        // Expected: trxBurned: 0.1 TRX, coveredBandwidth: 300, coveredEnergy: 0
+        const result = calculateTronFeeBreakdown(
+            makeTrc20Tx(),
+            makeTronResources({ availableEnergy: 0 }),
+            'trx',
+        );
+        expect(result?.trxBurned.toString()).toBe('0.1');
+        expect(result?.coveredBandwidth.toNumber()).toBe(300);
+        expect(result?.coveredEnergy.toNumber()).toBe(0);
+    });
+
+    it('TRC-20: no bandwidth, has energy — TRX burns bandwidth cost', () => {
+        // Tx: bandwidth: 300, energy: 1000, fee_limit: 0.1 TRX
+        // Account: bandwidth: 0, energy: 1000
+        // Expected: trxBurned: 0.3 TRX, coveredBandwidth: 0, coveredEnergy: 1000
+        const result = calculateTronFeeBreakdown(
+            makeTrc20Tx(),
+            makeTronResources({ availableEnergy: 1000, availableFreeBandwidth: 0 }),
+            'trx',
+            '100000',
+        );
+        expect(result?.trxBurned.toString()).toBe('0.3');
+        expect(result?.coveredBandwidth.toNumber()).toBe(0);
+        expect(result?.coveredEnergy.toNumber()).toBe(1000);
+    });
+
+    it('TRC-20: fee_limit raised 10% with full energy coverage — shows TRX for buffer', () => {
+        // Tx: bandwidth: 300, energy: 1000, fee_limit: 0.11 TRX
+        // Account: bandwidth: 300, energy: 1000
+        // Expected: trxBurned: 0.01 TRX, coveredEnergy: 1000
+        const result = calculateTronFeeBreakdown(
+            makeTrc20Tx(),
+            makeTronResources({ availableEnergy: 1000 }),
+            'trx',
+            '110000',
+        );
+        expect(result?.trxBurned.toString()).toBe('0.01');
+        expect(result?.coveredEnergy.toNumber()).toBe(1000);
+    });
+});

--- a/suite-common/wallet-utils/src/tronUtils.ts
+++ b/suite-common/wallet-utils/src/tronUtils.ts
@@ -13,10 +13,14 @@ export type TronFeeBreakdown = {
     coveredBandwidth: BigNumber;
 };
 
+const toTrx = (sun: BigNumber, symbol: NetworkSymbol) =>
+    new BigNumber(subunitsToUnits({ value: asAmountSubunit(sun), symbol }));
+
 export const calculateTronFeeBreakdown = (
     tx: GeneralPrecomposedTransaction | undefined,
     tronResources: TronAccountExtraData | undefined,
     symbol: NetworkSymbol,
+    feeLimitSunOverride?: string,
 ): TronFeeBreakdown | null => {
     if (!tx || tx.type === 'error' || !('bytes' in tx)) return null;
 
@@ -31,15 +35,32 @@ export const calculateTronFeeBreakdown = (
     const coveredBandwidth = new BigNumber(isBandwidthCovered ? bandwidthBytes : 0);
     const coveredEnergy = new BigNumber(Math.min(availableEnergy, energyConsumed));
 
-    const isTokenTransfer = 'token' in tx && tx.token !== undefined;
-    const totalBurnSun = isTokenTransfer
-        ? new BigNumber(energyConsumed - coveredEnergy.toNumber())
-              .multipliedBy(tx.feePerByte ?? '0')
-              .plus(isBandwidthCovered ? 0 : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE)
-        : new BigNumber(tx.fee);
-    const trxBurned = new BigNumber(
-        subunitsToUnits({ value: asAmountSubunit(totalBurnSun), symbol }),
+    const isTRC20Transfer = 'token' in tx && tx.token !== undefined;
+
+    if (!isTRC20Transfer) {
+        const trxBurned = isBandwidthCovered
+            ? new BigNumber(0)
+            : toTrx(new BigNumber(bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE), symbol);
+
+        return { trxBurned, coveredEnergy, coveredBandwidth };
+    }
+
+    const energyPrice = tx.feePerByte ?? '0';
+    const bandwidthBurnSun = new BigNumber(
+        isBandwidthCovered ? 0 : bandwidthBytes * tronUtils.TRON_BANDWIDTH_SUN_PRICE,
     );
+
+    const feeLimitSun = feeLimitSunOverride != null ? new BigNumber(feeLimitSunOverride) : null;
+
+    const energyBurnSun =
+        feeLimitSun != null
+            ? BigNumber.max(
+                  feeLimitSun.minus(new BigNumber(availableEnergy).multipliedBy(energyPrice)),
+                  0,
+              )
+            : new BigNumber(energyConsumed - coveredEnergy.toNumber()).multipliedBy(energyPrice);
+
+    const trxBurned = toTrx(energyBurnSun.plus(bandwidthBurnSun), symbol);
 
     return { trxBurned, coveredEnergy, coveredBandwidth };
 };

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6143,6 +6143,10 @@ export const messages = defineMessages({
         description: 'Label in Send form for Ethereum network type',
         id: 'MAX_FEE',
     },
+    NETWORK_FEE: {
+        defaultMessage: 'Network fee',
+        id: 'NETWORK_FEE',
+    },
     TO_BE_CALCULATED: {
         defaultMessage: 'To be calculated',
         description: 'Placeholder for (maximum) fee when it could not have been calculated yet',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- "Fee" -> "Network Fee" for TRX transfers
- "Fee" -> "Maximum Fee" for TRC20 transfers (reflect ETH behavior)

Changing the fee limit is now reflected in the maximum fee shown. Also added unit tests for the `calculateTronFeeBreakdown` function.

## Notes for QA

Changing the fee limit should be reflected in the "Maximum fee" section

## Screenshots:

![max-fee](https://github.com/user-attachments/assets/dafb09d9-39ff-4360-8189-b91541c4d423)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-max-fee&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-max-fee&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-max-fee&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:39:09.974Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:37:20.154Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->