### PR TITLE
chore: fix relative ugly imports

### DIFF
--- a/packages/suite/src/actions/labels/__tests__/moveLabelsForRbfThunk.test.ts
+++ b/packages/suite/src/actions/labels/__tests__/moveLabelsForRbfThunk.test.ts
@@ -5,9 +5,10 @@ import { prepareSuiteSettingsReducer } from '@suite/settings';
 import { suiteSyncReducer } from '@suite-common/suite-sync';
 import { configureMockStore, initPreloadedState } from '@suite-common/test-utils';
 
-import suiteReducer from '../../../reducers/suite/suiteReducer';
-import { accountsReducer, transactionsReducer } from '../../../reducers/wallet';
-import { extraDependencies } from '../../../support/extraDependencies';
+import suiteReducer from 'src/reducers/suite/suiteReducer';
+import { accountsReducer, transactionsReducer } from 'src/reducers/wallet';
+import { extraDependencies } from 'src/support/extraDependencies';
+
 import {
     accountReceivingCoins,
     accountSpendingCoins,

--- a/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpAutoconnectInfoModal.tsx
@@ -5,7 +5,7 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { startThpAutoconnectThunk, thpActions } from '@suite-common/thp';
 import { Card, Modal, Paragraph } from '@trezor/components';
 
-import { useDevice, useDispatch } from '../../../hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 type ThpAutoconnectInfoModalParams = {
     device: TrezorDevice;

--- a/packages/suite/src/components/connection/thp/ThpPairingFailedForFirmwareInstallation.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingFailedForFirmwareInstallation.tsx
@@ -1,5 +1,6 @@
+import { useSelector } from 'src/hooks/suite';
+
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';
-import { useSelector } from '../../../hooks/suite';
 
 export const ThpPairingFailedForFirmwareInstallation = () => {
     const lastThpCode = useSelector(state => state.thp.lastThpCode);

--- a/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
+++ b/packages/suite/src/components/connection/thp/ThpPairingFailedModal.tsx
@@ -5,8 +5,9 @@ import { thpActions } from '@suite-common/thp';
 import { acquireDevice, selectSelectedFirstThpDevice } from '@suite-common/wallet-core';
 import { Column, Modal, Paragraph } from '@trezor/components';
 
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
 import { ThpPairingCodeEntry } from './ThpPairingCodeEntry';
-import { useDispatch, useSelector } from '../../../hooks/suite';
 
 export const ThpPairingFailedModal = () => {
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -10,7 +10,8 @@ import { type Account, type TokenInfoBranded, toTokenSymbol } from '@suite-commo
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { getApyPercent } from '../../../utils/earnApyUtils';
+import { getApyPercent } from 'src/components/earn/utils/earnApyUtils';
+
 import {
     compareYieldRowsByAvailableBalanceDesc,
     compareYieldRowsBySuppliedAmountDesc,

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -14,11 +14,10 @@ import {
 import { type Account } from '@suite-common/wallet-types';
 import { exhaustive } from '@trezor/type-utils';
 
+import { getEarnRouteParams } from 'src/components/earn/utils/getEarnRouteParams';
 import { earnFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { getEarnRouteParams } from '../../../utils/getEarnRouteParams';
 
 interface UseEarnProviderConsentActionsProps {
     flow: EarnFlow;

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -10,11 +10,10 @@ import { selectEthValidatorsQueue } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Banner, Card, Checkbox, Column, Modal } from '@trezor/components';
 
+import { getStakingHelpCenterLink } from 'src/components/earn/utils/getStakingHelpCenterLink';
 import { earnFlowToEventTypeMap } from 'src/constants/suite/staking';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { getStakingHelpCenterLink } from '../../../utils/getStakingHelpCenterLink';
 
 const getStakeEnteringMessage = (networkType?: NetworkType) => {
     if (networkType === 'ethereum') return 'TR_STAKE_ENTERING_POOL_MAY_TAKE';

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/EstimatedGains.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeInfoCards/EstimatedGains.tsx
@@ -5,14 +5,13 @@ import { calculateGains, getNetworkAdjustedStakingBalance } from '@suite-common/
 import { selectPoolStatsApy } from '@suite-common/wallet-core';
 import { Column, Grid, Image, Paragraph, Text } from '@trezor/components';
 
+import { getStakingHelpCenterLink } from 'src/components/earn/utils/getStakingHelpCenterLink';
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { TrezorLink } from 'src/components/suite/TrezorLink';
 import { useSupplyFormContext } from 'src/hooks/earn/useSupplyForm';
 import { useSelector } from 'src/hooks/suite';
 import { CRYPTO_INPUT } from 'src/types/earn/earnFormFields';
-
-import { getStakingHelpCenterLink } from '../../../utils/getStakingHelpCenterLink';
 
 export const EstimatedGains = () => {
     const { account, getValues, formState } = useSupplyFormContext();

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeEntryStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeEntryStep.tsx
@@ -4,7 +4,7 @@ import { Translation } from '@suite/intl';
 import { Card, Column, Modal, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { ThpPairingCodeEntry } from '../../../components/connection/thp/ThpPairingCodeEntry';
+import { ThpPairingCodeEntry } from 'src/components/connection/thp/ThpPairingCodeEntry';
 
 type ThpCodeEntryStepProps = {
     modalHeading: ReactNode;

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeInvalidStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpCodeInvalidStep.tsx
@@ -4,9 +4,9 @@ import { Translation } from '@suite/intl';
 import { Card, Column, Modal, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk';
-import { ThpPairingFailedForFirmwareInstallation } from '../../../components/connection/thp/ThpPairingFailedForFirmwareInstallation';
-import { useDispatch } from '../../../hooks/suite';
+import { startThpSessionThunk } from 'src/actions/thp/startThpSessionThunk';
+import { ThpPairingFailedForFirmwareInstallation } from 'src/components/connection/thp/ThpPairingFailedForFirmwareInstallation';
+import { useDispatch } from 'src/hooks/suite';
 
 type ThpCodeInvalidStepProps = {
     modalHeading: ReactNode;

--- a/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStartStep.tsx
+++ b/packages/suite/src/components/firmware/ThpPairingStep/ThpPairingStartStep.tsx
@@ -4,8 +4,8 @@ import { Translation } from '@suite/intl';
 import { Card, Column, Modal, Text } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
-import { startThpSessionThunk } from '../../../actions/thp/startThpSessionThunk';
-import { useDispatch } from '../../../hooks/suite';
+import { startThpSessionThunk } from 'src/actions/thp/startThpSessionThunk';
+import { useDispatch } from 'src/hooks/suite';
 
 type ThpPairingStartStepProps = {
     modalHeading: ReactNode;

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -16,6 +16,7 @@ import {
 } from 'src/selectors/suite/suiteSelectors';
 import type { AppState } from 'src/types/suite';
 import { Onboarding } from 'src/views/onboarding';
+import { AnalyticsConsentScreen } from 'src/views/start/AnalyticsConsentScreen';
 import { SuiteStart } from 'src/views/start/SuiteStart';
 import { ErrorPage } from 'src/views/suite/ErrorPage';
 
@@ -23,7 +24,6 @@ import { DatabaseCorruptedModal } from './DatabaseCorruptedModal';
 import { DatabaseUpgradeModal } from './DatabaseUpgradeModal';
 import { InitialLoading } from './InitialLoading';
 import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
-import { AnalyticsConsentScreen } from '../../../views/start/AnalyticsConsentScreen';
 import { PrerequisitesGuide } from '../PrerequisitesGuide/PrerequisitesGuide';
 import { DeviceCompromised } from '../SecurityCheck/DeviceCompromised';
 import { useDeviceCompromisedNotification } from '../SecurityCheck/useDeviceCompromisedNotification';

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -14,9 +14,9 @@ import { type AppState } from 'src/reducers/store';
 import { type SuiteState } from 'src/reducers/suite/suiteReducer';
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { extraDependenciesDesktopMock } from '../../../../support/tests/extraDependenciesDesktop.mock';
 import { Preloader } from '../Preloader';
 import * as selectShouldDisplayDeviceCompromisedModule from '../selectShouldDisplayDeviceCompromisedOnRoute';
 

--- a/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.ts
+++ b/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.ts
@@ -1,8 +1,7 @@
 import type { RouterAppWithParams } from '@suite/router';
 
+import { selectShouldDisplayDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
 import type { AppState } from 'src/types/suite';
-
-import { selectShouldDisplayDeviceCompromised } from '../../../selectors/suite/suiteAuthenticityChecksSelectors';
 
 const ROUTES_TO_SKIP_FIRMWARE_CHECK: RouterAppWithParams['app'][] = [
     'settings',

--- a/packages/suite/src/components/suite/PrerequisitesGuide/BannerAndTroubleshooting.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/BannerAndTroubleshooting.tsx
@@ -1,5 +1,7 @@
 import { Box } from '@trezor/components';
 
+import { type PrerequisiteType } from 'src/utils/suite/prerequisites';
+
 import { DeviceAcquire } from './DeviceAcquire';
 import { DeviceBootloader } from './DeviceBootloader';
 import { DeviceConnect } from './DeviceConnect';
@@ -16,7 +18,6 @@ import { DeviceUpdateRequired } from './DeviceUpdateRequired';
 import { DeviceUsedElsewhere } from './DeviceUsedElsewhere';
 import { MultiShareBackupInProgress } from './MultiShareBackupInProgress';
 import { NoTransport } from './NoTransport';
-import { type PrerequisiteType } from '../../../utils/suite/prerequisites';
 
 type BannerAndTroubleshootingProps = {
     prerequisite: PrerequisiteType | null;

--- a/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
+++ b/packages/suite/src/components/suite/PrerequisitesGuide/NoTransport.tsx
@@ -9,9 +9,8 @@ import {
     TROUBLESHOOTING_TIP_SUITE_DESKTOP,
     TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,
 } from 'src/components/suite/troubleshooting/tips';
-
-import { useSelector } from '../../../hooks/suite';
-import { useBridgeDesktopApi } from '../../../hooks/suite/useBridgeDesktopApi';
+import { useSelector } from 'src/hooks/suite';
+import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
 
 const tipItems: TroubleshootingTipsItem[] = [
     TROUBLESHOOTING_TIP_WEBUSB_ENVIRONMENT,

--- a/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/SecurityCheckLayout.tsx
@@ -10,8 +10,7 @@ import {
 import { borders, breakpoints, spacings } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
-
-import { useResponsiveContext } from '../../../support/suite/ResponsiveContext';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 type SecurityCheckLayoutProps = {
     isFailed?: boolean;

--- a/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/__tests__/DeviceCompromised.test.tsx
@@ -9,9 +9,9 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { type AppState } from 'src/reducers/store';
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { extraDependenciesDesktopMock } from '../../../../support/tests/extraDependenciesDesktop.mock';
 import { DeviceCompromised } from '../DeviceCompromised';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));

--- a/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/deviceCompromisedCtas.tsx
@@ -8,7 +8,7 @@ import {
     type Url,
 } from '@trezor/urls';
 
-import { useDevice, useDispatch } from '../../../hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 type ContactSupportProps = {
     supportUrl: Url;

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
@@ -6,9 +6,9 @@ import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { Card, Collapsible, Row, Text } from '@trezor/components';
 import { TokenIconSet } from '@trezor/product-components';
 
+import { EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
-import { EXPANDABLE_ASSET_ROW_TOKENS_HEADER_HEIGHT } from '../../../constants';
 import { AssetRowToken } from '../AssetRowToken/AssetRowToken';
 
 // Don't use `Collapsible.Content`, it's not optimized for larger content.

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDebugInfo.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import { selectKnownDevices, selectNearbyDevices } from '@suite-common/bluetooth';
 import { Code, Icon, InfoSegments, Text } from '@trezor/components';
 
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
-import { useSelector } from '../../../hooks/suite';
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+import { useSelector } from 'src/hooks/suite';
 
 const TimeAgo = ({ timestamp }: { timestamp: number }) => {
     const [secAgo, setSecAgo] = useState(0);

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceComponent.tsx
@@ -2,9 +2,10 @@ import { selectFlags } from '@suite/flags';
 import { Column, Image, type ImageKey, InfoSegments, Row, Text } from '@trezor/components';
 import { type DeviceModelInternal, models } from '@trezor/device-utils';
 
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+import { useSelector } from 'src/hooks/suite';
+
 import { BluetoothDebugInfo } from './BluetoothDebugInfo';
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
-import { useSelector } from '../../../hooks/suite';
 
 type BluetoothDeviceProps = {
     device: DesktopBluetoothDevice;

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceList.tsx
@@ -1,8 +1,9 @@
 import { Card, Column, Row, SkeletonRectangle } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+
 import { BluetoothDeviceListItem } from './BluetoothDeviceListItem';
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 
 const SkeletonDevice = () => (
     <Row width="100%" gap={spacings.md} justifyContent="stretch" height="44px" alignItems="center">

--- a/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothDeviceListItem.tsx
@@ -11,13 +11,13 @@ import {
 import { Button, Row } from '@trezor/components';
 import { type BluetoothDeviceId } from '@trezor/connect';
 
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+import { selectConnectingDevices } from 'src/actions/bluetooth/desktopBluetoothSelectors';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { PairingState } from './PairingState';
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
-import { selectConnectingDevices } from '../../../actions/bluetooth/desktopBluetoothSelectors';
-import { useDispatch, useSelector } from '../../../hooks/suite';
 import { useConnectionGlobalModalContext } from '../../connection/context/ConnectionGlobalModalContext';
 
 const connectionStatusMap: Record<

--- a/packages/suite/src/components/suite/bluetooth/BluetoothPairingPin.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothPairingPin.tsx
@@ -4,8 +4,9 @@ import { Translation } from '@suite/intl';
 import { Card, Modal, Row, Text } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 
 const Pin = styled.span`
     letter-spacing: ${spacingsPx.md};

--- a/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothScanningList.tsx
@@ -1,9 +1,10 @@
 import { Translation } from '@suite/intl';
 import { selectScanStatus } from '@suite-common/bluetooth';
 
+import { useSelector } from 'src/hooks/suite';
+
 import { BluetoothDeviceList } from './BluetoothDeviceList';
 import { BluetoothTips } from './BluetoothTips';
-import { useSelector } from '../../../hooks/suite';
 import { useConnectionGlobalModalContext } from '../../connection/context/ConnectionGlobalModalContext';
 
 export const BluetoothScanningList = () => {

--- a/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothSelectedDevice.tsx
@@ -4,10 +4,11 @@ import { Translation } from '@suite/intl';
 import { type DeviceBluetoothConnectionStatusType } from '@suite-common/bluetooth';
 import { Banner, Card, Modal, Row } from '@trezor/components';
 
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+
 import { BluetoothDeviceComponent } from './BluetoothDeviceComponent';
 import { BluetoothTips } from './BluetoothTips';
 import { PairingState } from './PairingState';
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
 
 export type OkComponentProps = {
     device: DesktopBluetoothDevice;

--- a/packages/suite/src/components/suite/bluetooth/BluetoothTips.tsx
+++ b/packages/suite/src/components/suite/bluetooth/BluetoothTips.tsx
@@ -3,7 +3,8 @@ import { type ReactNode } from 'react';
 import { Translation } from '@suite/intl';
 import { Box, Button, Card, Column, H3, Row, Text } from '@trezor/components';
 
-import { type DesktopBluetoothDevice } from '../../../actions/bluetooth/DesktopBluetoothDevice';
+import { type DesktopBluetoothDevice } from 'src/actions/bluetooth/DesktopBluetoothDevice';
+
 import { TroubleshootingTipsList } from '../troubleshooting/TroubleshootingTipsList';
 import { TROUBLESHOOTING_ALL_BLUETOOTH_TIPS } from '../troubleshooting/tips';
 

--- a/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
+++ b/packages/suite/src/components/suite/bluetooth/UnpairBluetoothDeviceFromOsModal.tsx
@@ -5,11 +5,10 @@ import { bluetoothActions } from '@suite-common/bluetooth';
 import { Banner, Column, H3, Modal, Paragraph, Spinner } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { selectIsUnpairingDevice } from 'src/actions/bluetooth/desktopBluetoothSelectors';
 import { openSystemSettingsThunk } from 'src/actions/bluetooth/openSystemSettingsThunk';
 import { toggleConnectionModal } from 'src/actions/device/deviceSlice';
-
-import { selectIsUnpairingDevice } from '../../../actions/bluetooth/desktopBluetoothSelectors';
-import { useDispatch, useSelector } from '../../../hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type UnpairBluetoothDeviceFromOsModalProps = {
     onFinish?: () => void;

--- a/packages/suite/src/components/suite/bluetooth/WipedBleDeviceNeedsManualOsRemovalModalManager.tsx
+++ b/packages/suite/src/components/suite/bluetooth/WipedBleDeviceNeedsManualOsRemovalModalManager.tsx
@@ -1,7 +1,8 @@
 import { selectIsDeviceOsUnpairingRequired } from '@suite-common/bluetooth';
 
+import { useSelector } from 'src/hooks/suite';
+
 import { UnpairBluetoothDeviceFromOsModal } from './UnpairBluetoothDeviceFromOsModal';
-import { useSelector } from '../../../hooks/suite';
 
 export const WipedBleDeviceNeedsManualOsRemovalModalManager = () => {
     const wasBluetoothDeviceWiped = useSelector(selectIsDeviceOsUnpairingRequired);

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
@@ -17,12 +17,13 @@ import { type SuiteSyncState, type WithSuiteSyncAndDeviceState } from '@suite-co
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type StaticSessionId, type UnavailableCapabilities } from '@trezor/connect';
 
-import { selectIsLabelActionEnabled } from './selectIsLabelActionEnabled';
 import {
     type DesktopSuiteSyncRootState,
     initialSuiteSyncDesktopState,
-} from '../../../../actions/suiteSync/suiteSyncSlice';
-import { type SuiteRootState, suiteInitialState } from '../../../../reducers/suite/suiteReducer';
+} from 'src/actions/suiteSync/suiteSyncSlice';
+import { type SuiteRootState, suiteInitialState } from 'src/reducers/suite/suiteReducer';
+
+import { selectIsLabelActionEnabled } from './selectIsLabelActionEnabled';
 
 /**
  * It was really hard to mock the state for metadata. So I statically mocked

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
@@ -14,8 +14,8 @@ import { type StaticSessionId } from '@trezor/connect';
 import {
     type DesktopSuiteSyncRootState,
     selectDesktopSuiteSyncInteraction,
-} from '../../../../actions/suiteSync/suiteSyncSlice';
-import { type SuiteRootState } from '../../../../reducers/suite/suiteReducer';
+} from 'src/actions/suiteSync/suiteSyncSlice';
+import { type SuiteRootState } from 'src/reducers/suite/suiteReducer';
 
 export const selectIsLabelActionEnabled = (
     state: WithSuiteSyncAndDeviceState &

--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncFirmwareUpgradeNeededModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncFirmwareUpgradeNeededModal.tsx
@@ -4,7 +4,7 @@ import { selectDeviceByStaticSessionId, selectDeviceLabelOrNameById } from '@sui
 import { Card, Modal, Paragraph } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/connect';
 
-import { useDispatch, useSelector } from '../../../../hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type SuiteSyncFirmwareUpgradeNeededModalProps = {
     onClose: () => void;

--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/SuiteSyncTurnOnModal.tsx
@@ -5,8 +5,9 @@ import { Card, Column, Icon, List, Modal, Paragraph } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
-import { useDispatch, useSelector } from '../../../../hooks/suite';
-import { useSuiteServices } from '../../../../support/SuiteServicesProvider';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
+
 import { suiteSyncErrorTranslationKeyMap } from '../suiteSyncErrorTranslationKeyMap';
 
 type SuiteSyncTurnOnAndFwUpgradeModalProps = {

--- a/packages/suite/src/components/suite/labeling/suiteSyncErrorHandler.ts
+++ b/packages/suite/src/components/suite/labeling/suiteSyncErrorHandler.ts
@@ -5,9 +5,10 @@ import { notificationsActions } from '@suite-common/toast-notifications';
 import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
+import { updateShowEnableSuiteSyncModal } from 'src/actions/suiteSync/suiteSyncSlice';
+import { type Dispatch } from 'src/types/suite';
+
 import { suiteSyncErrorTranslationKeyMap } from './suiteSyncErrorTranslationKeyMap';
-import { updateShowEnableSuiteSyncModal } from '../../../actions/suiteSync/suiteSyncSlice';
-import { type Dispatch } from '../../../types/suite';
 
 type SuiteSyncErrorHandler = {
     error: EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError;

--- a/packages/suite/src/components/suite/layouts/ContentContainer.tsx
+++ b/packages/suite/src/components/suite/layouts/ContentContainer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { variables } from '@trezor/components';
 import { spacingsPx } from '@trezor/theme';
 
-import { HORIZONTAL_LAYOUT_PADDINGS, MAX_CONTENT_WIDTH } from '../../../constants/suite/layout';
+import { HORIZONTAL_LAYOUT_PADDINGS, MAX_CONTENT_WIDTH } from 'src/constants/suite/layout';
 
 export const ContentContainer = styled.div`
     position: relative;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -12,9 +12,9 @@ import { setRecentlyConnectedDevicePath } from 'src/actions/suite/suiteActions';
 import { openSwitchDeviceDialog } from 'src/actions/wallet/addWalletThunk';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectRecentlyConnectedDevice } from 'src/selectors/suite/suiteSelectors';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 import { SidebarDeviceStatus } from './SidebarDeviceStatus';
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
 import { ExpandedSidebarOnly } from '../Sidebar/ExpandedSidebarOnly';
 
 const CaretContainer = styled.div`

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/SidebarDeviceStatus.tsx
@@ -2,11 +2,11 @@ import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import * as deviceUtils from '@suite-common/suite-utils';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 
+import { useSelector } from 'src/hooks/suite';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { type TrezorDevice } from 'src/types/suite';
 
 import { DeviceStatus } from './DeviceStatus';
-import { useSelector } from '../../../../../hooks/suite';
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
 
 const needsRefresh = (device?: TrezorDevice) => {
     if (!device?.connected) return false;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveAnalytics.ts
@@ -6,7 +6,7 @@ import {
     events,
 } from '@suite/analytics';
 
-import { useAnalytics } from '../../../../../../../support/useAnalytics';
+import { useAnalytics } from 'src/support/useAnalytics';
 
 export const useGlobalSendReceiveAnalytics = () => {
     const analytics = useAnalytics();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -7,13 +7,13 @@ import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Dropdown, type DropdownMenuItemProps, type IconName } from '@trezor/components';
 import { breakpoints } from '@trezor/theme';
 
+import { AppNavigationTooltip } from 'src/components/suite/AppNavigation/AppNavigationTooltip';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
+import { useConditionalRender } from 'src/support/suite/ConditionalRender';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { useGoToWithAnalytics } from './useGoToWithAnalytics';
-import { useDispatch, useSelector } from '../../../../../hooks/suite';
-import { selectSelectedAccount } from '../../../../../reducers/wallet/selectedAccountReducer';
-import { useConditionalRender } from '../../../../../support/suite/ConditionalRender';
-import { AppNavigationTooltip } from '../../../AppNavigation/AppNavigationTooltip';
 
 type ActionItem = {
     id: string;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { H2 } from '@trezor/components';
 
-import { useIsContentBelowBreakpoint } from '../../../../../../support/suite/ContentFlex';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 export const NoDragContainer = styled.div`
     -webkit-app-region: no-drag;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics.ts
@@ -2,10 +2,9 @@ import { events } from '@suite/analytics';
 import { goto } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
 
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { useDispatch, useSelector } from '../../../../../hooks/suite';
-import { selectSelectedAccount } from '../../../../../reducers/wallet/selectedAccountReducer';
 
 export const useGoToWithAnalytics = (account?: Account) => {
     const analytics = useAnalytics();

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PassphraseFlow.tsx
@@ -7,11 +7,11 @@ import {
     selectShowEnableSuiteSyncModal,
     updateShowEnableSuiteSyncModal,
 } from 'src/actions/suiteSync/suiteSyncSlice';
+import { ThpGlobalModalManager } from 'src/components/connection/thp/ThpGlobalModalManager';
+import { useDispatch, usePreferredModal, useSelector } from 'src/hooks/suite';
+import type { AppState, ForegroundAppRoute } from 'src/types/suite';
+import { SwitchDevice } from 'src/views/suite/SwitchDevice/SwitchDevice';
 
-import { useDispatch, usePreferredModal, useSelector } from '../../../../hooks/suite';
-import type { AppState, ForegroundAppRoute } from '../../../../types/suite';
-import { SwitchDevice } from '../../../../views/suite/SwitchDevice/SwitchDevice';
-import { ThpGlobalModalManager } from '../../../connection/thp/ThpGlobalModalManager';
 import { TurnOnSuiteSyncModals } from '../../labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals';
 import { ConfirmPassphraseBeforeAction } from '../../modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction';
 import { PassphraseModal } from '../../modals/ReduxModal/DeviceContextModal/PassphraseModal';

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 type Props = {
     children: React.ReactNode;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 type Props = {
     children: React.ReactNode;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -8,11 +8,11 @@ import { selectIsAnyNonBitcoinLikeNetworkEnabled } from '@suite-common/wallet-co
 import { Column } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 import { NavigationItem, type NavigationItemProps } from './NavigationItem';
 import { NotificationDropdown } from './NotificationDropdown';
 import { SettingsWithTooltip } from './SettingsWithTooltip';
-import { useResponsiveContext } from '../../../../../support/suite/ResponsiveContext';
 
 export const SETTINGS_ROUTES: Route['name'][] = [
     'settings-index',

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/updateQuickActionTypes.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/updateQuickActionTypes.ts
@@ -5,8 +5,8 @@ import {
     installUpdate,
     justUpdated,
     setIsUpdateModalVisible,
-} from '../../../../../../../actions/suite/desktopUpdateActions';
-import { type Dispatch } from '../../../../../../../types/suite';
+} from 'src/actions/suite/desktopUpdateActions';
+import { type Dispatch } from 'src/types/suite';
 
 export type UpdateStatusDevice = 'up-to-date' | 'update-available' | 'disconnected';
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/useUpdateStatus.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/Update/useUpdateStatus.ts
@@ -1,17 +1,18 @@
 import { getSuiteVersion } from '@trezor/env-utils';
 import { versionUtils } from '@trezor/utils';
 
+import { useDevice, useSelector } from 'src/hooks/suite';
+import {
+    type DesktopUpdateState,
+    UpdateState,
+    selectDesktopUpdate,
+} from 'src/reducers/suite/desktopUpdateReducer';
+
 import {
     type UpdateStatus,
     type UpdateStatusDevice,
     type UpdateStatusSuite,
 } from './updateQuickActionTypes';
-import { useDevice, useSelector } from '../../../../../../../hooks/suite';
-import {
-    type DesktopUpdateState,
-    UpdateState,
-    selectDesktopUpdate,
-} from '../../../../../../../reducers/suite/desktopUpdateReducer';
 
 type UpdateStatusData = {
     updateStatus: UpdateStatus;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
     zIndices,
 } from '@trezor/theme';
 
+import { TrafficLightOffset } from 'src/components/suite/TrafficLightOffset';
 import { AccountsMenu } from 'src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectShouldDisplayDeviceCompromised } from 'src/selectors/suite/suiteAuthenticityChecksSelectors';
@@ -31,7 +32,6 @@ import {
     SIDEBAR_MAX_WIDTH,
     SIDEBAR_MIN_WIDTH,
 } from './consts';
-import { TrafficLightOffset } from '../../../TrafficLightOffset';
 import { DeviceSelector } from '../DeviceSelector/DeviceSelector';
 
 const Container = styled.nav<{ $elevation: Elevation }>`

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/useResponsiveContextOnChange.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import { useDebounce } from '@trezor/react-utils';
 
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 const THRESHOLD_SIZE = 8;
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -32,6 +32,7 @@ import { copyToClipboard } from '@trezor/dom-utils';
 import { CoinLogo, ConfirmOnDevicePill } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
+import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { Address } from 'src/components/suite/Address';
 import { QrCode } from 'src/components/suite/QrCode';
@@ -41,8 +42,6 @@ import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { type ThunkAction } from 'src/types/suite';
 import { DESTINATION_TAG_GUIDE_PATH } from 'src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag';
-
-import { selectIsLegacyLabelingVisible } from '../../../../../actions/labels/selectIsLegacyLabelingVisible';
 
 export type ConfirmValueModalProps = Pick<ModalProps, 'onCancel' | 'heading'> & {
     account?: Account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ConfirmPassphraseBeforeAction.tsx
@@ -11,10 +11,10 @@ import { Column, H3, Paragraph } from '@trezor/components';
 import TrezorConnect, { UI_RESPONSE } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
+import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
 
 import { PassphraseInputCard } from './PassphraseInputCard';
-import { CardWithDevice } from '../../../../../views/suite/SwitchDevice/CardWithDevice';
-import { SwitchDeviceModal } from '../../../../../views/suite/SwitchDevice/SwitchDeviceModal';
 
 export const ConfirmPassphraseBeforeAction = () => {
     const device = useSelector(selectSelectedDevice);

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/EnterPassphrase.tsx
@@ -9,11 +9,11 @@ import { HELP_CENTER_PASSPHRASE_URL } from '@trezor/urls';
 import { getNonAsciiChars } from '@trezor/utils';
 
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { useSelector } from 'src/hooks/suite';
+import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
 
 import { PassphraseInputCard } from './PassphraseInputCard';
-import { useSelector } from '../../../../../hooks/suite';
-import { CardWithDevice } from '../../../../../views/suite/SwitchDevice/CardWithDevice';
-import { SwitchDeviceModal } from '../../../../../views/suite/SwitchDevice/SwitchDeviceModal';
 
 type EnterPassphraseProps = {
     offerPassphraseOnDevice: boolean;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletBestPractices.tsx
@@ -5,9 +5,8 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_PASSPHRASE_URL } from '@trezor/urls';
 
 import { TrezorLink } from 'src/components/suite/TrezorLink';
-
-import { CardWithDevice } from '../../../../../views/suite/SwitchDevice/CardWithDevice';
-import { SwitchDeviceModal } from '../../../../../views/suite/SwitchDevice/SwitchDeviceModal';
+import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
 
 type PassphraseWalletBestPracticesProps = {
     onCancel: () => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmation.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletConfirmation.tsx
@@ -4,11 +4,11 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { Banner, Column, H3 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { useSelector } from 'src/hooks/suite';
 import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
 import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
 
 import { PassphraseInputCard } from './PassphraseInputCard';
-import { useSelector } from '../../../../../hooks/suite';
 
 type PassphraseWalletConfirmationProps = {
     onSubmit: (value: string, passphraseOnDevice?: boolean) => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseWalletIsEmpty.tsx
@@ -8,10 +8,10 @@ import { CoinLogo } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 import { HELP_CENTER_PASSPHRASE_URL } from '@trezor/urls';
 
-import { useNetworkSupport } from '../../../../../hooks/settings/useNetworkSupport';
-import { useDispatch, useSelector } from '../../../../../hooks/suite';
-import { CardWithDevice } from '../../../../../views/suite/SwitchDevice/CardWithDevice';
-import { SwitchDeviceModal } from '../../../../../views/suite/SwitchDevice/SwitchDeviceModal';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { CardWithDevice } from 'src/views/suite/SwitchDevice/CardWithDevice';
+import { SwitchDeviceModal } from 'src/views/suite/SwitchDevice/SwitchDeviceModal';
 
 type PassphraseWalletIsEmptyProps = {
     onRetry: () => void;

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/ThpPairingPinEntryModal.tsx
@@ -4,7 +4,7 @@ import { Translation, messages } from '@suite/intl';
 import { Box, Modal } from '@trezor/components';
 import TrezorConnect from '@trezor/connect';
 
-import { ThpPairingCodeEntry } from '../../../../connection/thp/ThpPairingCodeEntry';
+import { ThpPairingCodeEntry } from 'src/components/connection/thp/ThpPairingCodeEntry';
 
 export const ThpPairingPinEntryModal = () => {
     const intl = useIntl();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransaction.tsx
@@ -10,9 +10,9 @@ import { spacings } from '@trezor/theme';
 import { HELP_CENTER_CANCEL_TRANSACTION } from '@trezor/urls';
 import { BigNumber } from '@trezor/utils';
 
-import { useCancelTxContext } from '../../../../../../../hooks/wallet/useCancelTxContext';
-import { BaseCurrencyValue } from '../../../../../BaseCurrencyValue';
-import { FormattedCryptoAmount } from '../../../../../FormattedCryptoAmount';
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useCancelTxContext } from 'src/hooks/wallet/useCancelTxContext';
 
 type CancelTransactionProps = {
     tx: WalletAccountTransaction;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionButton.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionButton.tsx
@@ -3,10 +3,9 @@ import { DEFAULT_PAYMENT } from '@suite-common/wallet-constants';
 import { type Account, type FormState } from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
 
+import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-
-import { signAndPushSendFormTransactionThunk } from '../../../../../../../actions/wallet/send/sendFormThunks';
-import { useCancelTxContext } from '../../../../../../../hooks/wallet/useCancelTxContext';
+import { useCancelTxContext } from 'src/hooks/wallet/useCancelTxContext';
 
 type CancelTransactionButtonProps = {
     account: Account;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/CancelTransactionModal.tsx
@@ -16,10 +16,11 @@ import {
 import { Banner, Column, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { useDispatch, useSelector } from 'src/hooks/suite';
+import { CancelTxContext } from 'src/hooks/wallet/useCancelTxContext';
+
 import { CancelTransaction } from './CancelTransaction';
 import { CancelTransactionButton } from './CancelTransactionButton';
-import { useDispatch, useSelector } from '../../../../../../../hooks/suite';
-import { CancelTxContext } from '../../../../../../../hooks/wallet/useCancelTxContext';
 import { AffectedTransactions } from '../AffectedTransactions/AffectedTransactions';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../ReplaceByFeeFailedOriginalTxConfirmed';
 import { TxDetailModalBase } from '../TxDetailModalBase';

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/BumpFeeModal.tsx
@@ -7,10 +7,11 @@ import {
 } from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
 
+import { useSelector } from 'src/hooks/suite';
+import { RbfContext, useRbf } from 'src/hooks/wallet/useRbfForm';
+
 import { ChangeFee } from './ChangeFee';
 import { ReplaceTxButton } from './ReplaceTxButton';
-import { useSelector } from '../../../../../../../hooks/suite';
-import { RbfContext, useRbf } from '../../../../../../../hooks/wallet/useRbfForm';
 import { ReplaceByFeeFailedOriginalTxConfirmed } from '../ReplaceByFeeFailedOriginalTxConfirmed';
 import { TxDetailModalBase } from '../TxDetailModalBase';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -10,9 +10,10 @@ import {
 } from '@suite-common/wallet-types';
 import { Modal } from '@trezor/components';
 
-import { AdvancedTxDetails, type TabID } from './AdvancedTxDetails/AdvancedTxDetails';
-import { useSelector } from '../../../../../../../hooks/suite';
+import { useSelector } from 'src/hooks/suite';
+
 import { TxDetailModalBase } from '../TxDetailModalBase';
+import { AdvancedTxDetails, type TabID } from './AdvancedTxDetails/AdvancedTxDetails';
 
 type DetailModalProps = {
     tx: WalletAccountTransaction;

--- a/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsFooter.tsx
+++ b/packages/suite/src/components/suite/troubleshooting/TroubleshootingTipsFooter.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Text, useMediaQuery, variables } from '@trezor/components
 import { spacings } from '@trezor/theme';
 import { TREZOR_SUPPORT_DEVICE_URL } from '@trezor/urls';
 
-import { useExternalLink } from '../../../hooks/suite';
+import { useExternalLink } from 'src/hooks/suite';
 
 export const TroubleshootingTipsFooter = () => {
     const href = useExternalLink(TREZOR_SUPPORT_DEVICE_URL);

--- a/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
+++ b/packages/suite/src/components/wallet/Fees/DustPreventionNotice.tsx
@@ -6,8 +6,9 @@ import { type FormState } from '@suite-common/wallet-types';
 import { Note } from '@trezor/components';
 import { isApproximatelyEqual } from '@trezor/utils';
 
+import { useSelector } from 'src/hooks/suite';
+
 import { useFeesContext } from './context/FeesContext';
-import { useSelector } from '../../../hooks/suite';
 
 type DustPreventionNoticeProps = {
     chosenFeePerByte: string | undefined;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -7,9 +7,8 @@ import { type ArrayElement } from '@trezor/type-utils';
 
 import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { Address, AddressLabeling } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 import { type WalletAccountTransaction } from 'src/types/wallet';
-
-import { useSelector } from '../../../../hooks/suite';
 
 type TargetAddressLabelProps = {
     symbol: NetworkSymbol;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountItem.tsx
@@ -4,14 +4,14 @@ import { Box, Column, GhostContainer, TOOLTIP_DELAY_NORMAL, Tooltip } from '@tre
 import { exhaustive } from '@trezor/type-utils';
 
 import { useGoToWithAnalytics } from 'src/components/suite/layouts/SuiteLayout/PageHeader/useGoToWithAnalytics';
+import { CollapsedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
+import { ExpandedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 import { useAnalytics } from 'src/support/useAnalytics';
 import { type Account, type AccountItemType } from 'src/types/wallet';
 
 import { AccountItemLogo } from './AccountItemLogo/AccountItemLogo';
 import { AccountItemContent } from './AccountRow/AccountItemContent/AccountItemContent';
 import { AccountRow } from './AccountRow/AccountRow';
-import { CollapsedSidebarOnly } from '../../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
-import { ExpandedSidebarOnly } from '../../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 
 function getRoute(type: AccountItemType) {
     switch (type) {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemSkeleton.tsx
@@ -2,8 +2,7 @@ import { Column, Row, SkeletonCircle, SkeletonRectangle } from '@trezor/componen
 import { spacings } from '@trezor/theme';
 
 import { useLoadingSkeleton } from 'src/hooks/suite';
-
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 export const AccountItemSkeleton = () => {
     const { shouldAnimate } = useLoadingSkeleton();

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -12,10 +12,10 @@ import { Column } from '@trezor/components';
 import { borders, spacings, spacingsPx } from '@trezor/theme';
 
 import { useSelector } from 'src/hooks/suite';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { type Account } from 'src/types/wallet';
 
 import { AccountItem, type AccountItemProps } from './AccountItem/AccountItem';
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
 
 const Section = styled.div<{ $selected?: boolean; $isSidebarCollapsed?: boolean }>`
     display: flex;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -10,17 +10,17 @@ import { accountSearchFn } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { CollapsedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
+import { ExpandedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 import { useAccountSearch, useDefaultAccountLabel, useSelector } from 'src/hooks/suite';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { type AccountItemType } from 'src/types/wallet';
+import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
 
 import { AccountGroup } from './AccountGroup';
 import { AccountItemSkeleton } from './AccountItemSkeleton';
 import { AccountSection } from './AccountSection';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
-import { selectDiscoveryOverallStatus } from '../../../../utils/wallet/selectDiscoveryOverallStatus';
-import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
-import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 
 interface AccountListProps {
     forceOnlyItemClick?: boolean;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenu.tsx
@@ -8,12 +8,12 @@ import { useScrollShadow } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
 import { ReduxAccountSearchProvider } from 'src/hooks/suite/useAccountSearch';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 import { AccountsList } from './AccountsList';
 import { AccountsMenuHeader } from './AccountsMenuHeader';
 import { AccountsMenuNotice } from './AccountsMenuNotice';
 import { RefreshAfterDiscoveryNeeded } from './RefreshAfterDiscoveryNeeded';
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
 
 const ScrollContainer = styled.div`
     height: auto;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -6,13 +6,14 @@ import { selectSelectedDevice } from '@suite-common/device';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { Box, Column, Divider, Icon, Row, SkeletonRectangle, Tooltip } from '@trezor/components';
 
+import { CollapsedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
+import { ExpandedSidebarOnly } from 'src/components/suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
+import { useAccountSearch, useDiscovery, useDispatch, useSelector } from 'src/hooks/suite';
+
 import { AccountSearchBox } from './AccountSearchBox';
 import { AddAccountButton } from './AddAccountButton';
 import { CoinsFilter } from './CoinsFilter';
 import { useAvailableNetworkSymbols } from './useAvailableNetworkSymbols';
-import { useAccountSearch, useDiscovery, useDispatch, useSelector } from '../../../../hooks/suite';
-import { CollapsedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/CollapsedSidebarOnly';
-import { ExpandedSidebarOnly } from '../../../suite/layouts/SuiteLayout/Sidebar/ExpandedSidebarOnly';
 
 const Indicator = styled.div`
     width: 11px;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/RefreshAfterDiscoveryNeeded.tsx
@@ -13,9 +13,9 @@ import { Button, IconButton, Row, Tooltip, motionEasing } from '@trezor/componen
 import { spacings, spacingsPx, typography } from '@trezor/theme';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 import { AccountsMenuNotice } from './AccountsMenuNotice';
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
 
 const DiscoveryButtonContainer = styled(motion.div)`
     display: flex;

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
@@ -1,8 +1,8 @@
 import { getNetwork } from '@suite-common/wallet-config';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 
-import { useNetworkSupport } from '../../../../hooks/settings/useNetworkSupport';
-import { useSelector } from '../../../../hooks/suite';
+import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
+import { useSelector } from 'src/hooks/suite';
 
 export const useAvailableNetworkSymbols = () => {
     const enabledNetworks = useSelector(selectEnabledNetworks);

--- a/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useRbfForm.ts
@@ -9,7 +9,7 @@ import {
 import { type AccountUtxo } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
 
-import { type CoinjoinState } from '../../../reducers/wallet/coinjoinReducer';
+import { type CoinjoinState } from 'src/reducers/wallet/coinjoinReducer';
 
 export { getRootReducer } from './useSendForm';
 

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -28,9 +28,8 @@ import {
 import { PROTO } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
 
+import { type AppState } from 'src/reducers/store';
 import { extraDependencies } from 'src/support/extraDependencies';
-
-import { type AppState } from '../../../reducers/store';
 
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
 

--- a/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useRbfForm.test.tsx
@@ -9,6 +9,7 @@ import TrezorConnect from '@trezor/connect';
 
 import { ChangeFee } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee';
 import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton';
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import {
     actionSequence,
     findByTestId,
@@ -16,7 +17,6 @@ import {
     waitForLoader,
 } from 'src/support/tests/hooksHelper';
 
-import { extraDependenciesDesktopMock } from '../../../support/tests/extraDependenciesDesktop.mock';
 import * as fixtures from '../__fixtures__/useRbfForm';
 import { RbfContext, useRbf, useRbfContext } from '../useRbfForm';
 

--- a/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/__tests__/useSendForm.test.tsx
@@ -15,6 +15,7 @@ import {
 import { type FormState } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
 
+import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import {
     type UserAction,
     actionSequence,
@@ -25,7 +26,6 @@ import {
 import { type SendContextValues } from 'src/types/wallet/sendForm';
 import SendIndex from 'src/views/wallet/send';
 
-import { extraDependenciesDesktopMock } from '../../../support/tests/extraDependenciesDesktop.mock';
 import * as fixtures from '../__fixtures__/useSendForm';
 import { useSendFormContext } from '../useSendForm';
 

--- a/packages/suite/src/hooks/wallet/form/useCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useCompose.ts
@@ -21,8 +21,7 @@ import { useDebounce } from '@trezor/react-utils';
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSelectedAccount } from 'src/reducers/wallet/selectedAccountReducer';
-
-import { type SendContextValues } from '../../../types/wallet/sendForm';
+import { type SendContextValues } from 'src/types/wallet/sendForm';
 
 const DEFAULT_FIELD = 'outputs.0.amount';
 

--- a/packages/suite/src/hooks/wallet/form/useFees.ts
+++ b/packages/suite/src/hooks/wallet/form/useFees.ts
@@ -11,8 +11,7 @@ import { isEip1559 } from '@suite-common/wallet-utils';
 import { type FeeLevel } from '@trezor/connect';
 
 import { useDispatch } from 'src/hooks/suite';
-
-import { type SendContextValues } from '../../../types/wallet/sendForm';
+import { type SendContextValues } from 'src/types/wallet/sendForm';
 
 export type FeesFormValues = Pick<
     FormState,

--- a/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
+++ b/packages/suite/src/hooks/wallet/form/useStakeCompose.ts
@@ -14,9 +14,8 @@ import { type FeeLevel } from '@trezor/connect';
 import { useDebounce } from '@trezor/react-utils';
 
 import { composeTransaction } from 'src/actions/wallet/stakeActions';
+import { type StakeContextValues } from 'src/components/earn/forms/SupplyFormContext';
 import { useDispatch } from 'src/hooks/suite';
-
-import { type StakeContextValues } from '../../../components/earn/forms/SupplyFormContext';
 
 const DEFAULT_FIELD = 'outputs.0.amount';
 

--- a/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
+++ b/packages/suite/src/hooks/wallet/form/useUtxoSelection.ts
@@ -7,14 +7,14 @@ import { getUtxoOutpoint, isSameUtxo } from '@suite-common/wallet-utils';
 import type { AccountUtxo, PROTO } from '@trezor/connect';
 
 import { useSelector } from 'src/hooks/suite';
-import { sortUtxos } from 'src/utils/wallet/utxoSortingUtils';
-
-import { useCoinjoinRegisteredUtxos } from './useCoinjoinRegisteredUtxos';
 import {
     type SendContextValues,
     type UseSendFormState,
     type UtxoSelectionContext,
-} from '../../../types/wallet/sendForm';
+} from 'src/types/wallet/sendForm';
+import { sortUtxos } from 'src/utils/wallet/utxoSortingUtils';
+
+import { useCoinjoinRegisteredUtxos } from './useCoinjoinRegisteredUtxos';
 
 interface UtxoSelectionContextProps
     extends UseFormReturn<FormState>, Pick<UseSendFormState, 'account' | 'composedLevels'> {

--- a/packages/suite/src/reducers/wallet/__tests__/formDraftReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/__tests__/formDraftReducer.test.ts
@@ -1,6 +1,7 @@
 import { formDraftActions } from '@suite-common/wallet-core';
 
-import { STORAGE } from '../../../actions/suite/constants';
+import { STORAGE } from 'src/actions/suite/constants';
+
 import formDraftReducer from '../formDraftReducer';
 
 describe('formDraftReducer', () => {

--- a/packages/suite/src/storage/migrations/versions/__tests__/25.10.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/25.10.0.test.ts
@@ -1,7 +1,8 @@
 import '@suite-common/test-utils/src/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
-import { type SuiteDBSchema } from '../../../definitions';
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
 import migration from '../25.10.0';
 
 const DB_NAME = 'suite-idb-test-25.10.0';

--- a/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/25.11.0.test.ts
@@ -1,7 +1,8 @@
 import '@suite-common/test-utils/src/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
-import { type SuiteDBSchema } from '../../../definitions';
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
 import migration from '../25.11.0';
 
 const DB_NAME = 'suite-idb-test-25.11.0';

--- a/packages/suite/src/storage/migrations/versions/__tests__/26.4.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/__tests__/26.4.0.1.test.ts
@@ -1,7 +1,8 @@
 import '@suite-common/test-utils/src/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
-import { type SuiteDBSchema } from '../../../definitions';
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
 import migration from '../26.4.0.1';
 
 const DB_NAME = 'suite-idb-test-26.4.0.1';

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -10,6 +10,7 @@ import { type MetadataState } from '@suite-common/metadata-types';
 import { quotaManagerInitialState } from '@suite-common/suite-sync-quota-manager/src/quotaManagerReducer';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
+import { initialDesktopBluetoothState } from 'src/actions/bluetooth/desktopBluetoothReducer';
 import { initialState } from 'src/actions/device/deviceSlice';
 import { initialSuiteSyncDesktopState } from 'src/actions/suiteSync/suiteSyncSlice';
 import { type OnboardingState } from 'src/reducers/onboarding/onboardingReducer';
@@ -18,8 +19,6 @@ import { desktopUpdateInitialState } from 'src/reducers/suite/desktopUpdateReduc
 import { type ProtocolState } from 'src/reducers/suite/protocolReducer';
 import { suiteInitialState } from 'src/reducers/suite/suiteReducer';
 import type WalletReducers from 'src/reducers/wallet';
-
-import { initialDesktopBluetoothState } from '../../../actions/bluetooth/desktopBluetoothReducer';
 
 export const initialAppState: AppState = {
     suite: suiteInitialState,

--- a/packages/suite/src/utils/wallet/graph/utilsWorker.ts
+++ b/packages/suite/src/utils/wallet/graph/utilsWorker.ts
@@ -4,6 +4,7 @@ import { BASE_CURRENCY_ZERO, toFiatCurrency } from '@suite-common/wallet-utils';
 import type { FiatRatesBySymbol, StaticSessionId } from '@trezor/connect';
 import { BigNumber, typedObjectFromEntries, typedObjectKeys } from '@trezor/utils';
 
+import type { State as GraphState } from 'src/reducers/wallet/graphReducer';
 import {
     type AggregatedAccountHistory,
     type AggregatedDashboardHistory,
@@ -13,7 +14,6 @@ import {
 import { type FiatValueMap, type GraphDataPoint, type TypeName } from './types';
 import { getGraphDataForInterval } from './utils';
 import { sumFiatValueMapInPlace } from './utilsShared';
-import type { State as GraphState } from '../../../reducers/wallet/graphReducer';
 
 const calcFiatValueMap = (amount: string, rates: FiatRatesBySymbol): FiatValueMap =>
     typedObjectFromEntries(

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/CommonPromoBannerComponents.tsx
@@ -5,7 +5,8 @@ import { type FlagsState, setFlag } from '@suite/flags';
 import { IconButton } from '@trezor/components';
 import { borders, spacingsPx } from '@trezor/theme';
 
-import { useDispatch } from '../../../hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
+
 import { bannerAnimationConfig } from '../banner-animations';
 
 const CloseButtonContainer = styled.div`

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TS7Banner.tsx
@@ -5,9 +5,10 @@ import { Box, Button, Column, Image, Paragraph, Text } from '@trezor/components'
 import { spacings } from '@trezor/theme';
 import { DASHBOARD_BANNER_TS7_URL } from '@trezor/urls';
 
+import { useExternalLink, useLayoutSize } from 'src/hooks/suite';
+import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
+
 import { AnimatedWrapper, CloseButton } from './CommonPromoBannerComponents';
-import { useExternalLink, useLayoutSize } from '../../../hooks/suite';
-import { ContentFlex, useIsContentBelowBreakpoint } from '../../../support/suite/ContentFlex';
 
 type TS7BannerProps = {
     onClose: () => void;

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
@@ -6,8 +6,9 @@ import { resolveStaticPath } from '@trezor/env-utils';
 import { borders, colorVariants, spacings, spacingsPx } from '@trezor/theme';
 import { DASHBOARD_BANNER_TEX_URL } from '@trezor/urls';
 
+import { useExternalLink, useLayoutSize } from 'src/hooks/suite';
+
 import { AnimatedWrapper, CloseButton } from './CommonPromoBannerComponents';
-import { useExternalLink, useLayoutSize } from '../../../hooks/suite';
 
 const underlineImage = resolveStaticPath(
     `${IMAGES_PATH}/${IMAGES.DASHBOARD_PROMO_BANNER_UNDERLINE}`,

--- a/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/DashboardGraph.tsx
@@ -14,11 +14,10 @@ import { typography } from '@trezor/theme';
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { HiddenPlaceholder, TransactionsGraph } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { type Account } from 'src/types/wallet';
 import { type AggregatedDashboardHistory } from 'src/types/wallet/graph';
 import { getMinMaxValueFromData, prepareGraphDataAsync } from 'src/utils/wallet/graph';
-
-import { useIsContentBelowBreakpoint } from '../../../support/suite/ContentFlex';
 
 const Wrapper = styled.div`
     display: flex;

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardHeader.tsx
@@ -7,10 +7,9 @@ import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector } from 'src/components/suite';
 import { FiatHeader } from 'src/components/wallet/FiatHeader';
 import { useSelector } from 'src/hooks/suite';
+import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { type Discovery } from 'src/types/wallet';
 import { type GraphRange } from 'src/types/wallet/graph';
-
-import { ContentFlex, useIsContentBelowBreakpoint } from '../../../support/suite/ContentFlex';
 
 export type PortfolioCardHeaderProps = {
     discovery?: Discovery;

--- a/packages/suite/src/views/firmware/Steps/StepDone.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepDone.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 import { Translation } from '@suite/intl';
 import { Modal } from '@trezor/components';
 
-import { FirmwareInstallation } from '../../../components/firmware';
+import { FirmwareInstallation } from 'src/components/firmware';
 
 type StepDoneProps = {
     onClose: () => void;

--- a/packages/suite/src/views/firmware/Steps/StepInitial.tsx
+++ b/packages/suite/src/views/firmware/Steps/StepInitial.tsx
@@ -5,9 +5,9 @@ import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { type FirmwareStatus } from '@suite-common/suite-types';
 import { Modal, Tooltip } from '@trezor/components';
 
-import { updateAnalytics } from '../../../actions/onboarding/onboardingActions';
-import { PrerequisitesGuide } from '../../../components/suite';
-import { useSelector } from '../../../hooks/suite';
+import { updateAnalytics } from 'src/actions/onboarding/onboardingActions';
+import { PrerequisitesGuide } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
 
 type StepInitialProps = {
     onClose: () => void;

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -42,12 +42,12 @@ import { SecurityCheckLayout } from 'src/components/suite/SecurityCheck/Security
 import { ContactSupport } from 'src/components/suite/SecurityCheck/deviceCompromisedCtas';
 import { useDispatch, useLayoutSize, useOnboarding, useSelector } from 'src/hooks/suite';
 import { selectIsOnboardingActive } from 'src/reducers/onboarding/onboardingReducer';
+import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
+import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { useAnalytics } from 'src/support/useAnalytics';
 
 import { SecurityChecklist } from './SecurityChecklist';
 import { type SecurityChecklistItem } from './types';
-import { ContentFlex, useIsContentBelowBreakpoint } from '../../../../support/suite/ContentFlex';
-import { useResponsiveContext } from '../../../../support/suite/ResponsiveContext';
 
 import { DeviceAuthenticityStep } from './index';
 

--- a/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
+++ b/packages/suite/src/views/onboarding/steps/SelectBackupType/ShamirOptions.tsx
@@ -7,9 +7,10 @@ import { Badge, Tooltip } from '@trezor/components';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import { spacings } from '@trezor/theme';
 
+import { useLayoutSize, useSelector } from 'src/hooks/suite';
+
 import { DefaultTag } from './DefaultTag';
 import { OptionWithContent } from './OptionWithContent';
-import { useLayoutSize, useSelector } from '../../../../hooks/suite';
 
 const UpgradableToMultiTag = () => {
     const { isBelowTablet } = useLayoutSize();

--- a/packages/suite/src/views/settings/SettingsDebug/ResetThpCredentials.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/ResetThpCredentials.tsx
@@ -5,7 +5,7 @@ import { removeThpCredentialsThunk } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { useDispatch, useSelector } from '../../../hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const ResetThpCredentials = () => {
     const [isLoading, setIsLoading] = useState(false);

--- a/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TransportBackends.tsx
@@ -2,9 +2,8 @@ import { Checkbox } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
+import { useBridgeDesktopApi } from 'src/hooks/suite/useBridgeDesktopApi';
 import { selectTransportOfType } from 'src/selectors/suite/suiteSelectors';
-
-import { useBridgeDesktopApi } from '../../../hooks/suite/useBridgeDesktopApi';
 
 export const TransportBackends = () => {
     const bridge = useSelector(selectTransportOfType('BridgeTransport'));

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerHighlight.tsx
@@ -1,7 +1,7 @@
 import { SettingsAnchor, goto } from '@suite/router';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { useDispatch } from '../../../hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 export const TriggerHighlight = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsDebug/TriggerToast.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/TriggerToast.tsx
@@ -1,7 +1,7 @@
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
-import { useDispatch } from '../../../hooks/suite';
+import { useDispatch } from 'src/hooks/suite';
 
 export const TriggerToast = () => {
     const dispatch = useDispatch();

--- a/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Brightness.tsx
@@ -3,9 +3,8 @@ import { Translation } from '@suite/intl';
 import TrezorConnect from '@trezor/connect';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
+import { useDevice } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { useDevice } from '../../../hooks/suite';
 
 interface DeviceLabelProps {
     isDeviceLocked: boolean;

--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -3,10 +3,9 @@ import { SettingsAnchor } from '@suite/router';
 import { LANGUAGES, type Locale } from '@suite-common/suite-types';
 import { ActionColumn, ActionSelect, TextColumn } from '@trezor/product-components';
 
+import { changeLanguage } from 'src/actions/settings/deviceSettingsActions';
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
-
-import { changeLanguage } from '../../../actions/settings/deviceSettingsActions';
-import { useDevice, useDispatch } from '../../../hooks/suite';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 
 const BASE_TRANSLATIONS = [{ value: 'en-US', label: LANGUAGES['en-US'].name as string }];
 

--- a/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/HapticFeedback.tsx
@@ -6,9 +6,8 @@ import { ActionColumn, TextColumn } from '@trezor/product-components';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
+import { useDevice, useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { useDevice, useDispatch } from '../../../hooks/suite';
 
 interface DeviceLabelProps {
     isDeviceLocked: boolean;

--- a/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/Homescreen/ChangeHomescreenButtons.tsx
@@ -3,9 +3,8 @@ import { openModal } from '@suite/modal';
 import { Button, ButtonGroup, Tooltip } from '@trezor/components';
 import { type DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
+import { getHomescreens } from 'src/constants/suite/homescreens';
 import { useDevice, useDispatch } from 'src/hooks/suite';
-
-import { getHomescreens } from '../../../../constants/suite/homescreens';
 
 type ChangeHomescreenButtonsParams = {
     deviceModelInternal: DeviceModelInternal;

--- a/packages/suite/src/views/settings/SettingsGeneral/AutomaticUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/AutomaticUpdate.tsx
@@ -7,9 +7,8 @@ import { ActionColumn, TextColumn } from '@trezor/product-components';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
+import { useSelector } from 'src/hooks/suite';
 import { selectDesktopUpdateEnabled } from 'src/reducers/suite/desktopUpdateReducer';
-
-import { useSelector } from '../../../hooks/suite';
 
 const PositionedSwitch = styled.div`
     align-self: center;

--- a/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/DesktopSuiteBanner.tsx
@@ -11,10 +11,10 @@ import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 import { SUITE_URL } from '@trezor/urls';
 
+import { useExternalLink } from 'src/hooks/suite';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
 import { useAnalytics } from 'src/support/useAnalytics';
 
-import { useExternalLink } from '../../../hooks/suite';
 import { bannerAnimationConfig } from '../../dashboard/banner-animations';
 
 const Container = styled(motion.div)`

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -13,6 +13,7 @@ import {
 import { isDesktop, isLinux, isWeb } from '@trezor/env-utils';
 import { SettingsSection } from '@trezor/product-components';
 
+import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useLayoutSize, useSelector } from 'src/hooks/suite';
@@ -45,7 +46,6 @@ import { Tor } from './Tor';
 import { TorExternal } from './TorExternal';
 import { TorOnionLinks } from './TorOnionLinks';
 import { VersionWithUpdate } from './VersionWithUpdate';
-import { selectIsLegacyLabelingVisible } from '../../../actions/labels/selectIsLegacyLabelingVisible';
 import { Labeling } from '../labeling/Labeling';
 
 export const SettingsGeneral = () => {

--- a/packages/suite/src/views/settings/labeling/Labeling.tsx
+++ b/packages/suite/src/views/settings/labeling/Labeling.tsx
@@ -16,6 +16,8 @@ import { HELP_CENTER_LABELING } from '@trezor/urls';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
+import { LabelingSwitchToLegacyModal } from 'src/components/suite/labeling/LabelingSwitchToLegacyModal';
+import { suiteSyncErrorHandler } from 'src/components/suite/labeling/suiteSyncErrorHandler';
 import {
     LABELING_LEGACY_OPTION_LABEL,
     LABELING_SELECT_OPTIONS,
@@ -27,9 +29,6 @@ import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useLabelingDeviceState } from 'src/hooks/suite/useLabelingDeviceState';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 import { useAnalytics } from 'src/support/useAnalytics';
-
-import { LabelingSwitchToLegacyModal } from '../../../components/suite/labeling/LabelingSwitchToLegacyModal';
-import { suiteSyncErrorHandler } from '../../../components/suite/labeling/suiteSyncErrorHandler';
 
 export const Labeling = () => {
     const { translationString } = useTranslation();

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SmallDeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/SmallDeviceItem.tsx
@@ -4,9 +4,10 @@ import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { Image, Row } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { useSelector } from 'src/hooks/suite';
+
 import { DeviceConnectionText } from './DeviceConnectionText';
 import { DeviceDetail } from './DeviceDetail';
-import { useSelector } from '../../../../hooks/suite';
 
 type SmallDeviceItemProps = {
     forceAlternativeDeviceLabel?: string;

--- a/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/NeedsAttentionBanner.tsx
@@ -8,10 +8,11 @@ import { acquireDevice, selectDeviceThunk } from '@suite-common/wallet-core';
 import { Banner, type BannerIntent } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
+import { redirectAfterWalletSelectedThunk } from 'src/actions/wallet/addWalletThunk';
+import { useDevice, useDispatch } from 'src/hooks/suite';
+import type { ForegroundAppProps, TrezorDevice } from 'src/types/suite';
+
 import { getDeviceResolveStatusCTAMessage } from './getDeviceResolveStatusCTAMessage';
-import { redirectAfterWalletSelectedThunk } from '../../../actions/wallet/addWalletThunk';
-import { useDevice, useDispatch } from '../../../hooks/suite';
-import type { ForegroundAppProps, TrezorDevice } from '../../../types/suite';
 
 const getDeviceNeedsAttentionMessage = (
     deviceStatus: ReturnType<typeof getStatus>,

--- a/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/SwitchDeviceModal.tsx
@@ -7,9 +7,8 @@ import { selectConnectPopupCall } from '@suite-common/connect-popup';
 import { Column, Modal } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { TrafficLightOffset } from 'src/components/suite/TrafficLightOffset';
 import { useSelector } from 'src/hooks/suite/useSelector';
-
-import { TrafficLightOffset } from '../../../components/suite/TrafficLightOffset';
 
 type SwitchDeviceModalProps = {
     children?: React.ReactNode;

--- a/packages/suite/src/views/wallet/details/index.tsx
+++ b/packages/suite/src/views/wallet/details/index.tsx
@@ -16,11 +16,11 @@ import { AccountTypeDescription } from 'src/components/suite/modals/ReduxModal/U
 import { WalletLayout } from 'src/components/wallet';
 import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
 import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
+import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 
 import { CoinjoinLogs } from './CoinjoinLogs';
 import { CoinjoinSetup } from './CoinjoinSetup/CoinjoinSetup';
 import { RescanAccount } from './RescanAccount';
-import { ContentFlex, useIsContentBelowBreakpoint } from '../../../support/suite/ContentFlex';
 import { Bip329Labels } from '../labels/Bip329Labels';
 
 const Heading = styled.h3`

--- a/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
+++ b/packages/suite/src/views/wallet/labels/Bip329Labels.tsx
@@ -21,13 +21,12 @@ import {
 import { HELP_CENTER_BIP329_URL } from '@trezor/urls';
 
 import { exportMetadataToBip329File } from 'src/actions/labels/exportMetadataToBip329File';
+import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { LearnMoreButton } from 'src/components/suite/LearnMoreButton';
 import { suiteSyncErrorHandler } from 'src/components/suite/labeling/suiteSyncErrorHandler';
 import { useDefaultAccountLabel, useDispatch, useSelector } from 'src/hooks/suite';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 import { ContentFlex, useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
-
-import { selectIsLegacyLabelingVisible } from '../../../actions/labels/selectIsLegacyLabelingVisible';
 
 type Bip329LabelsProps = {
     account: Account;

--- a/packages/suite/src/views/wallet/receive/Receive.tsx
+++ b/packages/suite/src/views/wallet/receive/Receive.tsx
@@ -4,13 +4,13 @@ import { selectPendingAccountAddresses } from '@suite-common/wallet-core';
 import { Column } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
+import { ConfirmEvmExplanationModal } from 'src/components/suite/modals/ConfirmEvmExplanationModal';
 import { WalletLayout, WalletSubpageHeading } from 'src/components/wallet';
 import { useDevice, useSelector } from 'src/hooks/suite';
 
 import { CoinjoinReceiveWarning } from './components/CoinjoinReceiveWarning';
 import { FreshAddress } from './components/FreshAddress';
 import { UsedAddresses } from './components/UsedAddresses';
-import { ConfirmEvmExplanationModal } from '../../../components/suite/modals/ConfirmEvmExplanationModal';
 
 export const Receive = () => {
     const isCoinjoinReceiveWarningHidden = useSelector(selectIsCoinjoinReceiveWarningHidden);

--- a/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
+++ b/packages/suite/src/views/wallet/receive/components/ConnectDevicePromo.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_FLAGSHIP_MODEL } from '@suite-common/suite-constants';
 import { Banner } from '@trezor/components';
 import { mapTrezorModelToIcon } from '@trezor/product-components';
 
-import { useSelector } from '../../../../hooks/suite';
+import { useSelector } from 'src/hooks/suite';
 
 type ConnectDevicePromoProps = {
     title: JSX.Element | string;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -24,14 +24,13 @@ import {
 } from '@trezor/components';
 import { type AccountUtxo } from '@trezor/connect';
 
+import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { Address, BaseCurrencyValue, FormattedCryptoAmount, Labeling } from 'src/components/suite';
 import { TransactionTimestamp, UtxoAnonymity } from 'src/components/wallet';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 import { useCoinjoinUnavailableUtxos } from 'src/hooks/wallet/form/useCoinjoinUnavailableUtxos';
 import { type WalletAccountTransaction } from 'src/types/wallet';
-
-import { selectIsLegacyLabelingVisible } from '../../../../../../../../actions/labels/selectIsLegacyLabelingVisible';
 
 type ResolveUtxoSpendableProps = {
     utxo: AccountUtxo;

--- a/packages/suite/src/views/wallet/send/index.tsx
+++ b/packages/suite/src/views/wallet/send/index.tsx
@@ -10,6 +10,7 @@ import { Banner, Column } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacings, spacingsPx } from '@trezor/theme';
 
+import { ConfirmEvmExplanationModal } from 'src/components/suite/modals/ConfirmEvmExplanationModal';
 import { WalletLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';
 import { SendContext, type UseSendFormProps, useSendForm } from 'src/hooks/wallet/useSendForm';
@@ -24,7 +25,6 @@ import { SendFees } from './SendFees';
 import { SendHeader } from './SendHeader';
 import { SendRaw } from './SendRaw';
 import { TotalSent } from './TotalSent/TotalSent';
-import { ConfirmEvmExplanationModal } from '../../../components/suite/modals/ConfirmEvmExplanationModal';
 
 const FormGrid = styled.div`
     gap: ${spacingsPx.md};

--- a/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
@@ -1,7 +1,7 @@
 import { useFormatters } from '@suite-common/formatters';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 
-import { HiddenPlaceholder } from '../../../../components/suite';
+import { HiddenPlaceholder } from 'src/components/suite';
 
 interface TradingFiatAmountProps {
     amount?: BaseCurrencyAmount;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
@@ -11,8 +11,7 @@ import { Row } from '@trezor/components';
 import { useTradingAssetDecimals } from 'src/hooks/wallet/trading/form/common/useTradingAssetDecimals';
 import { useTradingFiatValues } from 'src/hooks/wallet/trading/form/common/useTradingFiatValues';
 import { useTradingFindAccountOrToken } from 'src/hooks/wallet/trading/form/common/useTradingFindAccountOrToken';
-
-import { TradingBalance } from '../../../../TradingBalance';
+import { TradingBalance } from 'src/views/wallet/trading/common/TradingBalance';
 
 export interface AssetPickerInputBalanceProps {
     name: typeof TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -17,6 +17,7 @@ import { buildCurrencyOptions, buildCurrencyShortOption } from '@suite-common/wa
 import { isBaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import {
     type TradingAllFormProps,
     type TradingFormInputCurrencyProps,
@@ -28,8 +29,6 @@ import {
     isTradingExchangeContext,
     isTradingSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
-
-import { useBitcoinAmountUnit } from '../../../../../../hooks/wallet/useBitcoinAmountUnit';
 
 export const TradingFormInputCurrency = ({
     width,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormLayout.tsx
@@ -9,11 +9,11 @@ import { breakpoints, spacings } from '@trezor/theme';
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
 import { useSelector } from 'src/hooks/suite';
 import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/common/useTradingDeviceDisconnected';
+import { ContentFlex } from 'src/support/suite/ContentFlex';
 import { ConnectDeviceGenericPromo } from 'src/views/wallet/receive/components/ConnectDevicePromo';
 import { TradingFeaturedOffers } from 'src/views/wallet/trading/common/TradingFeaturedOffers/TradingFeaturedOffers';
 import { TradingFormOffer } from 'src/views/wallet/trading/common/TradingForm/TradingFormOffer';
 
-import { ContentFlex } from '../../../../../support/suite/ContentFlex';
 import { ReceiveAddressModalControlsProvider } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 
 interface TradingFormLayoutProps {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer.tsx
@@ -24,6 +24,7 @@ import { useTradingDeviceDisconnected } from 'src/hooks/wallet/trading/form/comm
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
 import { useTradingStellarActivateToken } from 'src/hooks/wallet/trading/useTradingStellarActivateToken';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { type TradingFormContextValues } from 'src/types/trading/tradingForm';
 import {
     getCryptoQuoteAmountProps,
@@ -45,7 +46,6 @@ import { TradingFormOfferOTC } from 'src/views/wallet/trading/common/TradingForm
 
 import { TradingApproveModal } from './TradingApproveModal';
 import { TradingRevokeModal } from './TradingRevokeModal';
-import { useIsContentBelowBreakpoint } from '../../../../../support/suite/ContentFlex';
 import { useReceiveAddressModalControls } from '../TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 import { TradingUtilsTorWarning } from '../TradingUtils/TradingUtilsTorWarning';
 

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -11,6 +11,7 @@ import { BigNumber } from '@trezor/utils';
 import { updateGraphData } from 'src/actions/wallet/graphActions';
 import { GraphRangeSelector, HiddenPlaceholder, TransactionsGraph } from 'src/components/suite';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useIsContentBelowBreakpoint } from 'src/support/suite/ContentFlex';
 import { type Account } from 'src/types/wallet';
 import {
     aggregateBalanceHistory,
@@ -21,7 +22,6 @@ import {
 
 import { SummaryCards } from './SummaryCards';
 import { TransactionSummaryDropdown } from './TransactionSummaryDropdown';
-import { useIsContentBelowBreakpoint } from '../../../../support/suite/ContentFlex';
 
 const ErrorMessage = styled.div`
     display: flex;


### PR DESCRIPTION
Only code improvements. 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=better-src-abs-path&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=better-src-abs-path&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:55:51.890Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T13:54:43.895Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->