### PR TITLE
fix(suite): Enable ETH after onboarding

### DIFF
--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -78,6 +78,7 @@ const EMPTY_ACTION = { type: 'foo' } as any;
 
 const getInitialState = (initialRun?: boolean) => {
     const initialFlagsState = flagsReducer(undefined, EMPTY_ACTION);
+    const walletState = walletReducers(undefined, EMPTY_ACTION);
 
     return {
         suite: suiteReducer(undefined, EMPTY_ACTION),
@@ -91,7 +92,10 @@ const getInitialState = (initialRun?: boolean) => {
         router: routerReducer(undefined, EMPTY_ACTION),
         analytics: analyticsReducer(undefined, EMPTY_ACTION),
         modal: modalReducer(undefined, EMPTY_ACTION),
-        wallet: walletReducers(undefined, EMPTY_ACTION),
+        wallet: {
+            ...walletState,
+            settings: { ...walletState.settings, enabledNetworks: ['btc'] },
+        },
         messageSystem: messageSystemReducer(undefined, EMPTY_ACTION),
         device: deviceReducer(undefined, EMPTY_ACTION),
         metadata: metadataReducer(undefined, EMPTY_ACTION),

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -34,7 +34,7 @@ const initialState: WalletSettingsState = {
     localCurrency: 'usd',
     discreetMode: false,
     // Suite Mobile did not have BTC enabled by default
-    enabledNetworks: isNative() ? [] : ['btc'],
+    enabledNetworks: isNative() ? [] : ['btc', 'eth'],
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,

--- a/suite-common/wallet-core/tests/settings/walletSettingsActions.fixtures.ts
+++ b/suite-common/wallet-core/tests/settings/walletSettingsActions.fixtures.ts
@@ -3,11 +3,11 @@ import { changeCoinVisibility } from '../../src/settings/walletSettingsThunks';
 
 export const walletSettingsFixtures = [
     {
-        description: 'Btc should be visible as a default if no initial state provided',
+        description: 'Btc and eth should be visible as a default if no initial state provided',
         initialState: undefined,
         action: () => changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: true }),
         result: {
-            enabledNetworks: ['btc', 'ltc'],
+            enabledNetworks: ['btc', 'eth', 'ltc'],
         },
     },
     {

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -41,19 +41,13 @@ export class CoinsTab {
 
     @step()
     async enableNetwork(symbol: NetworkSymbol) {
-        const isActive = await this.networkButton(symbol).getAttribute('data-active');
-        if (isActive !== 'true') {
-            await this.networkButton(symbol).click();
-        }
+        await this.networkButton(symbol).click();
         await expect(this.networkButton(symbol)).toBeEnabledCoin();
     }
 
     @step()
     async disableNetwork(symbol: NetworkSymbol) {
-        const isActive = await this.networkButton(symbol).getAttribute('data-active');
-        if (isActive !== 'false') {
-            await this.networkButton(symbol).click();
-        }
+        await this.networkButton(symbol).click();
         await expect(this.networkButton(symbol)).toBeDisabledCoin();
     }
 

--- a/suite/e2e/support/pageObjects/settings/coinsTab.ts
+++ b/suite/e2e/support/pageObjects/settings/coinsTab.ts
@@ -41,13 +41,19 @@ export class CoinsTab {
 
     @step()
     async enableNetwork(symbol: NetworkSymbol) {
-        await this.networkButton(symbol).click();
+        const isActive = await this.networkButton(symbol).getAttribute('data-active');
+        if (isActive !== 'true') {
+            await this.networkButton(symbol).click();
+        }
         await expect(this.networkButton(symbol)).toBeEnabledCoin();
     }
 
     @step()
     async disableNetwork(symbol: NetworkSymbol) {
-        await this.networkButton(symbol).click();
+        const isActive = await this.networkButton(symbol).getAttribute('data-active');
+        if (isActive !== 'false') {
+            await this.networkButton(symbol).click();
+        }
         await expect(this.networkButton(symbol)).toBeDisabledCoin();
     }
 

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -38,7 +38,7 @@ test.describe(
                     >(events.suiteReadyEvent.name);
                     expect(suiteReadyEvent).toMatchObject({
                         language: 'en-US',
-                        enabledNetworks: 'btc',
+                        enabledNetworks: 'btc,eth',
                         customBackends: '',
                         localCurrency: 'usd',
                         bitcoinUnit: 'BTC',
@@ -147,7 +147,6 @@ test.describe('Analytics Events', { tag: ['@webOnly', '@T3W1', '@T3T1', '@smoke'
             await settingsPage.changeTheme(Theme.Dark);
             await settingsPage.toggleTestnetNetworks();
             await settingsPage.navigateTo('coins');
-            await settingsPage.coinsTab.enableNetwork('eth');
             await settingsPage.coinsTab.enableNetwork('thod');
             await settingsPage.coinsTab.disableNetwork('btc');
             await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');

--- a/suite/e2e/tests/analytics/staking-events.test.ts
+++ b/suite/e2e/tests/analytics/staking-events.test.ts
@@ -8,7 +8,7 @@ test.describe('Analytics Events - Staking Navigate', { tag: ['@T3W1', '@nightlyO
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
-            enableNetworks: ['eth', 'ada'],
+            enableNetworks: ['ada'],
         });
     });
 

--- a/suite/e2e/tests/analytics/wallet-connect-events.test.ts
+++ b/suite/e2e/tests/analytics/wallet-connect-events.test.ts
@@ -17,7 +17,7 @@ test.describe('Analytics Events - WalletConnect', { tag: ['@T3W1', '@nightlyOnly
         await test.step('Onboarding', async () => {
             await onboardingPage.completeOnboarding();
             await settingsPage.changeNetworks({
-                enableNetworks: ['eth', 'ada'],
+                enableNetworks: ['ada'],
             });
         });
     });

--- a/suite/e2e/tests/dashboard/assets.test.ts
+++ b/suite/e2e/tests/dashboard/assets.test.ts
@@ -30,7 +30,7 @@ test.describe('Assets', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
         settingsPage,
     }) => {
         await assetsSection.enableMoreCoins.click();
-        await settingsPage.coinsTab.enableNetwork('eth');
+        await settingsPage.coinsTab.enableNetwork('ltc');
         await dashboardPage.navigateTo();
         await page.discoveryShouldFinish();
         await assetsSection.verifyAssetContents();

--- a/suite/e2e/tests/settings/coins-custom-backend.test.ts
+++ b/suite/e2e/tests/settings/coins-custom-backend.test.ts
@@ -51,9 +51,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 }),
             },
             async ({ page, settingsPage, walletPage }) => {
-                if (coin === 'btc') {
-                    await settingsPage.coinsTab.disableNetwork(coin);
-                }
+                await settingsPage.coinsTab.disableNetwork(coin);
                 await test.step(`Enable ${coin.toUpperCase()} asset`, async () => {
                     await expect(settingsPage.coinsTab.networkButton(coin)).toBeDisabledCoin();
                     await settingsPage.coinsTab.enableNetwork(coin);
@@ -93,9 +91,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 }),
             },
             async ({ page, settingsPage, walletPage }) => {
-                if (coin === 'btc') {
-                    await settingsPage.coinsTab.disableNetwork(coin);
-                }
+                await settingsPage.coinsTab.disableNetwork(coin);
                 await test.step(`Enable ${coin.toUpperCase()} asset`, async () => {
                     await expect(settingsPage.coinsTab.networkButton(coin)).toBeDisabledCoin();
                     await settingsPage.coinsTab.enableNetwork(coin);

--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -24,7 +24,6 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
         async ({ dashboardPage, settingsPage }) => {
             const defaultUnchecked: NetworkSymbol[] = [
                 'ltc',
-                'eth',
                 'etc',
                 'xrp',
                 // 'xlm', add when removed from experimental features
@@ -46,10 +45,12 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await settingsPage.navigateTo('coins');
 
                 await expect(settingsPage.coinsTab.networkButton('btc')).toBeEnabledCoin();
+                await expect(settingsPage.coinsTab.networkButton('eth')).toBeEnabledCoin();
                 for (const network of defaultUnchecked) {
                     await expect(settingsPage.coinsTab.networkButton(network)).toBeDisabledCoin();
                 }
                 await settingsPage.coinsTab.disableNetwork('btc');
+                await settingsPage.coinsTab.disableNetwork('eth');
                 // check dashboard with all coins disabled
                 await dashboardPage.navigateTo();
                 await expect(dashboardPage.discoveryEmptyHeader).toHaveTranslation(
@@ -66,7 +67,7 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
             await test.step('Activate assets', async () => {
                 await dashboardPage.discoveryEmptyPrimaryButton.click();
                 await settingsPage.navigateTo('coins');
-                for (const network of ['btc', ...defaultUnchecked] as NetworkSymbol[]) {
+                for (const network of ['btc', 'eth', ...defaultUnchecked] as NetworkSymbol[]) {
                     await settingsPage.coinsTab.enableNetwork(network);
                     if (network === 'ada') {
                         await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();

--- a/suite/e2e/tests/staking/eth/initial-stake.test.ts
+++ b/suite/e2e/tests/staking/eth/initial-stake.test.ts
@@ -40,7 +40,6 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await settingsPage.coinsTab.disableNetwork('btc');
-            await settingsPage.coinsTab.enableNetwork('eth');
             await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');
             await settingsPage.coinsTab.changeBackend('blockbook', blockbookMock.url);
 

--- a/suite/e2e/tests/staking/eth/stake-more.test.ts
+++ b/suite/e2e/tests/staking/eth/stake-more.test.ts
@@ -58,7 +58,6 @@ test.describe('ETH staking', { tag: ['@T3W1', '@T3T1'] }, () => {
             await blockbookMock.start('eth');
 
             await settingsPage.coinsTab.disableNetwork('btc');
-            await settingsPage.coinsTab.enableNetwork('eth');
             await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');
             await settingsPage.coinsTab.changeBackend('blockbook', blockbookMock.url);
 

--- a/suite/e2e/tests/staking/eth/unstake.test.ts
+++ b/suite/e2e/tests/staking/eth/unstake.test.ts
@@ -22,7 +22,6 @@ test.describe('ETH unstaking and claim', { tag: ['@T3W1', '@T3T1'] }, () => {
             await blockbookMock.start('eth');
 
             await settingsPage.coinsTab.disableNetwork('btc');
-            await settingsPage.coinsTab.enableNetwork('eth');
             await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');
             await settingsPage.coinsTab.changeBackend('blockbook', blockbookMock.url);
 

--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -22,7 +22,6 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
             await blockbookMock.start('eth');
 
             await settingsPage.coinsTab.disableNetwork('btc');
-            await settingsPage.coinsTab.enableNetwork('eth');
             await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');
             await settingsPage.coinsTab.changeBackend('blockbook', blockbookMock.url);
 

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -35,7 +35,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             await tradingPage.fillBuyForm({
                 amount: fiatAmount,
                 selectReceiveAddress: async () => {
-                    await tradingPage.receiveAccount.selectAddSuiteReceiveAccount(0);
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(0);
                 },
             });
             await expect(tradingPage.quotes.bestOfferAmount).toContainText('0.018615 ETH');

--- a/suite/e2e/tests/trading/navigation.test.ts
+++ b/suite/e2e/tests/trading/navigation.test.ts
@@ -6,7 +6,7 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.beforeEach(async ({ onboardingPage, dashboardPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
         await settingsPage.changeNetworks({
-            enableNetworks: ['eth', 'ltc'],
+            enableNetworks: ['ltc'],
         });
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);

--- a/suite/e2e/tests/trading/sell-ethereum-token.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum-token.test.ts
@@ -24,27 +24,24 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
     test.use({
         deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
-    test.beforeEach(
-        async ({ page, tradingMock, onboardingPage, dashboardPage, settingsPage, walletPage }) => {
-            await test.step('Mocking responses', async () => {
-                await page.route(invityEndpoint.sellQuotes, async route => {
-                    await route.fulfill({ json: sellQuotesEthereumToken });
-                });
-                await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeEthereumToken);
-                await page.route(invityEndpoint.sellWatch, async route => {
-                    await route.fulfill({ json: sellWatchEthereum });
-                });
+    test.beforeEach(async ({ page, tradingMock, onboardingPage, dashboardPage, walletPage }) => {
+        await test.step('Mocking responses', async () => {
+            await page.route(invityEndpoint.sellQuotes, async route => {
+                await route.fulfill({ json: sellQuotesEthereumToken });
             });
-            await onboardingPage.completeOnboarding();
+            await tradingMock.routeTrade(invityEndpoint.sellTrade, sellTradeEthereumToken);
+            await page.route(invityEndpoint.sellWatch, async route => {
+                await route.fulfill({ json: sellWatchEthereum });
+            });
+        });
+        await onboardingPage.completeOnboarding();
 
-            await test.step('Enable Ethereum and open its token sell trading', async () => {
-                await settingsPage.changeNetworks({ enableNetworks: ['eth'] });
-                await dashboardPage.deviceSwitchingOpenButton.click();
-                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-                await walletPage.openSellTradingOfToken('eth', 'USD Coin');
-            });
-        },
-    );
+        await test.step('Open Ethereum token sell trading', async () => {
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSellTradingOfToken('eth', 'USD Coin');
+        });
+    });
 
     test('Sell Ethereum token USDC', async ({ tradingPage, devicePrompt }) => {
         await test.step('Fill in a sell request', async () => {

--- a/suite/e2e/tests/trading/sell-ethereum.test.ts
+++ b/suite/e2e/tests/trading/sell-ethereum.test.ts
@@ -37,15 +37,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
         deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
     });
     test.beforeEach(
-        async ({
-            page,
-            tradingMock,
-            tradingPage,
-            onboardingPage,
-            dashboardPage,
-            settingsPage,
-            walletPage,
-        }) => {
+        async ({ page, tradingMock, tradingPage, onboardingPage, dashboardPage, walletPage }) => {
             await test.step('Mocking responses', async () => {
                 await page.route(invityEndpoint.sellQuotes, async route => {
                     await route.fulfill({ json: sellQuotesEthereum });
@@ -57,8 +49,7 @@ test.describe('Trading - Sell Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] }
             });
             await onboardingPage.completeOnboarding();
 
-            await test.step('Enable Ethereum and open its token sell trading', async () => {
-                await settingsPage.changeNetworks({ enableNetworks: ['eth'] });
+            await test.step('Open Ethereum sell trading', async () => {
                 await dashboardPage.deviceSwitchingOpenButton.click();
                 await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
                 await walletPage.openTrading({ symbol: 'eth' });

--- a/suite/e2e/tests/trading/swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading/swap-coin-to-token.test.ts
@@ -35,7 +35,7 @@ test.describe('Trading - Swap coin to token', { tag: ['@webOnly', '@T3W1', '@T3T
             });
             await onboardingPage.completeOnboarding();
             await settingsPage.changeNetworks({
-                enableNetworks: ['sol', 'eth'],
+                enableNetworks: ['sol'],
                 disableNetworks: ['btc'],
             });
             await dashboardPage.deviceSwitchingOpenButton.click();

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -8,21 +8,18 @@ const customFee = '10';
 
 test.describe('Trading - Swap fees Bitcoin', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
-    test.beforeEach(
-        async ({ onboardingPage, dashboardPage, walletPage, settingsPage, page, tradingMock }) => {
-            await test.step('Mocking responses', async () => {
-                await page.route(invityEndpoint.swapQuotes, route => {
-                    route.fulfill({ json: swapQuotesBTCEthereum });
-                });
-                await tradingMock.routeSwapTrade(swapTradeBTCEthereum);
+    test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, page, tradingMock }) => {
+        await test.step('Mocking responses', async () => {
+            await page.route(invityEndpoint.swapQuotes, route => {
+                route.fulfill({ json: swapQuotesBTCEthereum });
             });
-            await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['eth'] });
-            await dashboardPage.deviceSwitchingOpenButton.click();
-            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-            await walletPage.openSwapTrading({ symbol: 'btc' });
-        },
-    );
+            await tradingMock.routeSwapTrade(swapTradeBTCEthereum);
+        });
+        await onboardingPage.completeOnboarding();
+        await dashboardPage.deviceSwitchingOpenButton.click();
+        await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+        await walletPage.openSwapTrading({ symbol: 'btc' });
+    });
 
     test('Swap custom fees for Bitcoin', async ({ page, device, tradingPage, devicePrompt }) => {
         let feeRate: string;

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -18,22 +18,19 @@ const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalP
 
 test.describe('Trading - Swap fees', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
-    test.beforeEach(
-        async ({ page, onboardingPage, dashboardPage, walletPage, settingsPage, tradingMock }) => {
-            await test.step('Mocking responses', async () => {
-                await tradingMock.routeInvityGeneralEndpoints();
-                await page.route(invityEndpoint.swapQuotes, route => {
-                    route.fulfill({ json: swapQuotesEthereumBTC });
-                });
-                await tradingMock.routeSwapTrade(swapTradeEthereumBTC);
+    test.beforeEach(async ({ page, onboardingPage, dashboardPage, walletPage, tradingMock }) => {
+        await test.step('Mocking responses', async () => {
+            await tradingMock.routeInvityGeneralEndpoints();
+            await page.route(invityEndpoint.swapQuotes, route => {
+                route.fulfill({ json: swapQuotesEthereumBTC });
             });
-            await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['eth'] });
-            await dashboardPage.deviceSwitchingOpenButton.click();
-            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-            await walletPage.openSwapTrading({ symbol: 'eth' });
-        },
-    );
+            await tradingMock.routeSwapTrade(swapTradeEthereumBTC);
+        });
+        await onboardingPage.completeOnboarding();
+        await dashboardPage.deviceSwitchingOpenButton.click();
+        await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+        await walletPage.openSwapTrading({ symbol: 'eth' });
+    });
 
     test('Swap custom fees for Ethereum', async ({ page, device, tradingPage, devicePrompt }) => {
         await test.step('Fill in a Swap form', async () => {

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -15,12 +15,6 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
             await expect(devicePrompt.header).toHaveTranslation('TR_NAV_RECEIVE');
         });
 
-        await test.step('Add ETH account', async () => {
-            await tradingPage.assetPicker.globalAddAccountButton.click();
-            await page.getByTestId('@settings/wallet/network/eth').click();
-            await tradingPage.receiveAccount.findAccountButton.click();
-        });
-
         await test.step('Filter and select account', async () => {
             await tradingPage.assetPicker.filterByNetwork('eth');
             await tradingPage.assetPicker

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -48,10 +48,13 @@ test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
                 }),
             },
             async ({ page, devicePrompt, settingsPage, walletPage }) => {
-                if (coin !== 'btc') {
+                if (coin === 'eth') {
+                    await settingsPage.navigateTo('coins');
+                    await settingsPage.coinsTab.disableNetwork('btc');
+                } else if (coin !== 'btc') {
                     await settingsPage.changeNetworks({
                         enableNetworks: [coin],
-                        disableNetworks: ['btc'],
+                        disableNetworks: ['btc', 'eth'],
                     });
                 }
                 await walletPage.accountButton({ symbol: coin }).click();

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -24,10 +24,8 @@ test.describe('Send Eth', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
 
     test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({
-            enableNetworks: ['eth'],
-            disableNetworks: ['btc'],
-        });
+        await settingsPage.navigateTo('coins');
+        await settingsPage.coinsTab.disableNetwork('btc');
         await dashboardPage.deviceSwitchingOpenButton.click();
         await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
         await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });

--- a/suite/e2e/tests/wallet/sign-and-verify-eth.test.ts
+++ b/suite/e2e/tests/wallet/sign-and-verify-eth.test.ts
@@ -4,7 +4,8 @@ test.describe('Sign and verify ETH', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
     test.beforeEach(async ({ onboardingPage, settingsPage }) => {
         await onboardingPage.completeOnboarding();
-        await settingsPage.changeNetworks({ enableNetworks: ['eth'], disableNetworks: ['btc'] });
+        await settingsPage.navigateTo('coins');
+        await settingsPage.coinsTab.disableNetwork('btc');
     });
 
     const MESSAGE_SIGN = 'hello world';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve  https://github.com/trezor/trezor-suite/issues/26551

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=enable-eth-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=enable-eth-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=enable-eth-after-onboarding&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 17 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-12T15:37:11.797Z • 17 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-12T15:35:28.113Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->