### PR TITLE
chore: narrow imports, do not use direct  paths for utxo-lib

### DIFF
--- a/packages/connect/e2e/__txcache__/gen-reftx.ts
+++ b/packages/connect/e2e/__txcache__/gen-reftx.ts
@@ -1,6 +1,6 @@
 import { bufferUtils } from '@trezor/utils';
 import * as BitcoinJs from '@trezor/utxo-lib';
-import type { TxInput, TxOutput } from '@trezor/utxo-lib/src/transaction/base';
+import type { TxInput, TxOutput } from '@trezor/utxo-lib';
 
 import type { RefTransaction } from '../../src';
 

--- a/packages/connect/src/api/bitcoin/refTx.ts
+++ b/packages/connect/src/api/bitcoin/refTx.ts
@@ -12,16 +12,14 @@ import { TypedError } from '@trezor/connect-common/src/constants/errors';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 import { bufferUtils } from '@trezor/utils';
-import type { Network } from '@trezor/utxo-lib';
 import {
     address as BitcoinJsAddress,
+    type TxInput as BitcoinJsInput,
+    type TxOutput as BitcoinJsOutput,
     payments as BitcoinJsPayments,
     Transaction as BitcoinJsTransaction,
+    type Network,
 } from '@trezor/utxo-lib';
-import type {
-    TxInput as BitcoinJsInput,
-    TxOutput as BitcoinJsOutput,
-} from '@trezor/utxo-lib/src/transaction/base';
 
 import { getHDPath, getOutputScriptType, getScriptType } from '../../utils/pathUtils';
 

--- a/packages/connect/src/api/bitcoin/transactionBytes.ts
+++ b/packages/connect/src/api/bitcoin/transactionBytes.ts
@@ -1,6 +1,5 @@
 import type { BitcoinNetworkInfo, PROTO } from '@trezor/connect-common';
-import * as baddress from '@trezor/utxo-lib/src/address';
-import { TxWeightCalculator } from '@trezor/utxo-lib/src/txWeightCalculator';
+import { TxWeightCalculator, address as baddress } from '@trezor/utxo-lib';
 
 import { getOutputScriptType, getScriptType } from '../../utils/pathUtils';
 

--- a/packages/utxo-lib/src/index.ts
+++ b/packages/utxo-lib/src/index.ts
@@ -8,6 +8,7 @@ import { createAddressCache, discovery } from './discovery';
 import * as networks from './networks';
 import * as payments from './payments';
 import * as script from './script';
+import { TxWeightCalculator } from './txWeightCalculator';
 
 export { Transaction } from './transaction';
 
@@ -24,10 +25,12 @@ export {
     getXpubOrDescriptorInfo,
     discovery,
     createAddressCache,
+    TxWeightCalculator,
 };
 
 export type { PaymentType } from './derivation';
 export type { AddressCache, AddressProvider } from './discovery';
+export type { TransactionOptions, TxInput, TxOutput } from './transaction';
 export type {
     ComposeInput,
     ComposeOutput,

--- a/packages/utxo-lib/src/transaction/index.ts
+++ b/packages/utxo-lib/src/transaction/index.ts
@@ -48,5 +48,5 @@ class Transaction extends TransactionBase<dash.DashSpecific | zcash.ZcashSpecifi
     }
 }
 
-export type { TransactionOptions } from './base';
+export type { TransactionOptions, TxInput, TxOutput } from './base';
 export { Transaction };


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/pull/26077

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-utxo-lib-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-utxo-lib-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-utxo-lib-export&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T15:37:16.686Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T15:36:10.835Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->