### PR TITLE
chore: make all blockchain-link-types import direct, no  imports

### DIFF
--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -1,14 +1,52 @@
 export type * from './common';
 export type * from './params';
 
+export { MESSAGES, RESPONSES } from './constants';
+export { CustomError } from './constants/errors';
 export type { Response } from './responses';
+export type { BlockEvent, FiatRatesEvent, NotificationEvent } from './responses';
+export type { Message } from './messages';
+export type { Events } from './events';
 export * from './baseCurrency';
+export { StakeState } from './solana';
 
-export type { Transaction as BlockbookTransaction } from './blockbook';
-export type { TronAccountExtraData } from './blockbook-api';
+export type * as MessageTypes from './messages';
+export type * as ResponseTypes from './responses';
+export type * as ElectrumTypes from './electrum';
+
+export type {
+    AccountInfo as BlockbookAccountInfo,
+    AccountUtxo as BlockbookAccountUtxo,
+    AddressNotification as BlockbookAddressNotification,
+    BlockNotification as BlockbookBlockNotification,
+    Fee as BlockbookFee,
+    FiatRatesNotification as BlockbookFiatRatesNotification,
+    FilterRequestParams as BlockbookFilterRequestParams,
+    FilterResponse as BlockbookFilterResponse,
+    MempoolTransactionNotification as BlockbookMempoolTransactionNotification,
+    Send as BlockbookSend,
+    ServerInfo as BlockbookServerInfo,
+    Transaction as BlockbookTransaction,
+} from './blockbook';
+
+export type { TronAccountExtraData, Eip1559Fees } from './blockbook-api';
+
+export type {
+    BlockHeader as ElectrumBlockHeader,
+    ElectrumAPI,
+    HistoryTx as ElectrumHistoryTx,
+    Status as ElectrumStatus,
+    Utxo as ElectrumUtxo,
+    StatusChange as ElectrumStatusChange,
+} from './electrum';
+
+export type { SolanaTokenAccountInfo } from './solana';
+
 export type {
     AssetBalance,
     BlockfrostAccountInfo,
+    BlockContent as BlockfrostBlockContent,
+    Send as BlockfrostSend,
     BlockfrostTransaction,
     BlockfrostUtxos,
     ParseAssetResult,

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -2,19 +2,17 @@ import type {
     AccountAddresses,
     AccountInfo,
     Address,
+    BlockbookAccountInfo,
+    BlockbookAccountUtxo,
+    BlockbookTransaction,
     InternalTransfer,
+    BlockbookServerInfo as ServerInfo,
     TokenInfo,
     TokenTransfer,
     Transaction,
     Utxo,
     VinVout,
 } from '@trezor/blockchain-link-types';
-import type {
-    AccountInfo as BlockbookAccountInfo,
-    AccountUtxo as BlockbookAccountUtxo,
-    Transaction as BlockbookTransaction,
-    ServerInfo,
-} from '@trezor/blockchain-link-types/src/blockbook';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 
 import {

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -1,3 +1,4 @@
+import { type SolanaTokenAccountInfo } from '@trezor/blockchain-link-types';
 import {
     type StakeType,
     type Target,
@@ -7,7 +8,6 @@ import {
     type TokenTransfer,
     type Transaction,
 } from '@trezor/blockchain-link-types/src';
-import { type SolanaTokenAccountInfo } from '@trezor/blockchain-link-types/src/solana';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { arrayPartition } from '@trezor/utils';
 import { BigNumber } from '@trezor/utils/src/bigNumber';

--- a/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
+++ b/packages/blockchain-link-utils/src/tests/fixtures/blockbook.ts
@@ -1,5 +1,8 @@
-import type { AccountAddresses, Transaction } from '@trezor/blockchain-link-types';
-import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/src/blockbook';
+import type {
+    AccountAddresses,
+    BlockbookTransaction,
+    Transaction,
+} from '@trezor/blockchain-link-types';
 import type { DeepPartial } from '@trezor/type-utils';
 
 const token = {

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -1,9 +1,10 @@
-import type { BlockchainSettings } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type { Events } from '@trezor/blockchain-link-types/src/events';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as ResponseTypes from '@trezor/blockchain-link-types/src/responses';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
+import type {
+    BlockchainSettings,
+    Events,
+    MessageTypes,
+    ResponseTypes,
+} from '@trezor/blockchain-link-types';
 import {
     Throttler,
     TypedEmitter,
@@ -358,13 +359,13 @@ export type BlockchainLinkResponse<T extends keyof BlockchainLinkInterface> =
 export { sumAddressValues } from './workers/electrum/methods/getAccountInfo';
 
 // reexport types
-export type { Message } from '@trezor/blockchain-link-types/src/messages';
+export type { Message } from '@trezor/blockchain-link-types';
 export type {
     Response,
     BlockEvent,
     NotificationEvent,
     FiatRatesEvent,
-} from '@trezor/blockchain-link-types/src/responses';
+} from '@trezor/blockchain-link-types';
 export type {
     Address,
     AccountAddresses,
@@ -382,4 +383,4 @@ export type {
     Transaction,
     TransactionDetail,
     Utxo,
-} from '@trezor/blockchain-link-types/src/common';
+} from '@trezor/blockchain-link-types';

--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -1,4 +1,4 @@
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
+import { CustomError } from '@trezor/blockchain-link-types';
 import {
     WebsocketClient,
     type WebsocketRequest,

--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -7,10 +7,8 @@
 
 import { SocksProxyAgent } from 'socks-proxy-agent';
 
-import type { BlockchainSettings, Response } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type { Message } from '@trezor/blockchain-link-types/src/messages';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
+import type { BlockchainSettings, Message, Response } from '@trezor/blockchain-link-types';
 
 import { WorkerState } from './state';
 import { prioritizeEndpoints } from './utils';

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -1,13 +1,15 @@
-import type { Response, SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
-import type {
-    AddressNotification,
-    BlockNotification,
-    FiatRatesNotification,
-    MempoolTransactionNotification,
-} from '@trezor/blockchain-link-types/src/blockbook';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
+import {
+    type BlockbookAddressNotification as AddressNotification,
+    type BlockbookBlockNotification as BlockNotification,
+    CustomError,
+    type BlockbookFiatRatesNotification as FiatRatesNotification,
+    MESSAGES,
+    type BlockbookMempoolTransactionNotification as MempoolTransactionNotification,
+    type MessageTypes,
+    RESPONSES,
+    type Response,
+    type SubscriptionAccountInfo,
+} from '@trezor/blockchain-link-types';
 import * as utils from '@trezor/blockchain-link-utils/src/blockbook';
 
 import { BaseWorker, CONTEXT, type ContextType } from '../baseWorker';

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -1,26 +1,24 @@
-import type {
-    AddressNotification,
-    BlockNotification,
-    FiatRatesNotification,
-    FilterRequestParams,
-    MempoolTransactionNotification,
-    Send,
-} from '@trezor/blockchain-link-types/src/blockbook';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type {
-    GetCurrentFiatRates,
-    GetFiatRatesForTimestamps,
-    GetFiatRatesTickersList,
-} from '@trezor/blockchain-link-types/src/messages';
+import { CustomError } from '@trezor/blockchain-link-types';
 import type {
     AccountBalanceHistoryParams,
     AccountInfoParams,
+    BlockbookAddressNotification as AddressNotification,
+    BlockbookBlockNotification as BlockNotification,
     EstimateFeeParams,
+    BlockbookFiatRatesNotification as FiatRatesNotification,
+    BlockbookFilterRequestParams as FilterRequestParams,
+    BlockbookMempoolTransactionNotification as MempoolTransactionNotification,
+    MessageTypes,
     RpcCallParams,
-} from '@trezor/blockchain-link-types/src/params';
+    BlockbookSend as Send,
+} from '@trezor/blockchain-link-types';
 import { getSuiteVersion } from '@trezor/env-utils';
 
 import { BaseWebsocket } from '../baseWebsocket';
+
+type GetCurrentFiatRates = MessageTypes.GetCurrentFiatRates;
+type GetFiatRatesForTimestamps = MessageTypes.GetFiatRatesForTimestamps;
+type GetFiatRatesTickersList = MessageTypes.GetFiatRatesTickersList;
 
 interface BlockbookEvents {
     block: BlockNotification;

--- a/packages/blockchain-link/src/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/index.ts
@@ -1,12 +1,11 @@
-import type { Response } from '@trezor/blockchain-link-types';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
 import type {
-    BlockContent,
+    BlockfrostBlockContent as BlockContent,
     BlockfrostTransaction,
-} from '@trezor/blockchain-link-types/src/blockfrost';
-import type { SubscriptionAccountInfo } from '@trezor/blockchain-link-types/src/common';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
+    MessageTypes,
+    Response,
+    SubscriptionAccountInfo,
+} from '@trezor/blockchain-link-types';
 import {
     transformAccountInfo,
     transformTransaction,

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -1,13 +1,11 @@
 import type {
-    BlockContent,
-    BlockfrostTransaction,
-    Send,
-} from '@trezor/blockchain-link-types/src/blockfrost';
-import type {
     AccountBalanceHistoryParams,
     AccountInfoParams,
+    BlockfrostBlockContent as BlockContent,
+    BlockfrostTransaction,
     EstimateFeeParams,
-} from '@trezor/blockchain-link-types/src/params';
+    BlockfrostSend as Send,
+} from '@trezor/blockchain-link-types';
 import { getSuiteVersion } from '@trezor/env-utils';
 
 import { BaseWebsocket } from '../baseWebsocket';

--- a/packages/blockchain-link/src/workers/electrum/client/caching.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/caching.ts
@@ -1,4 +1,4 @@
-import { type Status } from '@trezor/blockchain-link-types/src/electrum';
+import { type ElectrumStatus as Status } from '@trezor/blockchain-link-types';
 import { type IntervalId } from '@trezor/type-utils';
 
 import { ElectrumClient } from './electrum';

--- a/packages/blockchain-link/src/workers/electrum/client/electrum.ts
+++ b/packages/blockchain-link/src/workers/electrum/client/electrum.ts
@@ -1,8 +1,8 @@
 import {
-    type BlockHeader,
+    type ElectrumBlockHeader as BlockHeader,
     type ElectrumAPI,
-    type Version,
-} from '@trezor/blockchain-link-types/src/electrum';
+    type ElectrumTypes,
+} from '@trezor/blockchain-link-types';
 import { type IntervalId } from '@trezor/type-utils';
 import { type Network, networks } from '@trezor/utxo-lib';
 
@@ -11,6 +11,8 @@ import { type JsonRpcClientOptions } from './json-rpc';
 import type { ISocket } from '../sockets/interface';
 
 const KEEP_ALIVE_INTERVAL = 120 * 1000; // 2 minutes
+
+type Version = ElectrumTypes.Version;
 
 type ElectrumClientOptions = JsonRpcClientOptions & {
     client: {

--- a/packages/blockchain-link/src/workers/electrum/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/index.ts
@@ -1,7 +1,5 @@
-import type { Response } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import { type Message } from '@trezor/blockchain-link-types/src/messages';
+import type { Message, Response } from '@trezor/blockchain-link-types';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
 import { type Without } from '@trezor/type-utils';
 import { type AddressCache, createAddressCache } from '@trezor/utxo-lib';
 

--- a/packages/blockchain-link/src/workers/electrum/listeners/blockListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/blockListener.ts
@@ -1,5 +1,8 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type { BlockHeader, ElectrumAPI } from '@trezor/blockchain-link-types/src/electrum';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type {
+    ElectrumBlockHeader as BlockHeader,
+    ElectrumAPI,
+} from '@trezor/blockchain-link-types';
 import { throwError } from '@trezor/utils';
 
 import type { BaseWorker } from '../../baseWorker';

--- a/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
+++ b/packages/blockchain-link/src/workers/electrum/listeners/txListener.ts
@@ -1,23 +1,26 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
+import { RESPONSES } from '@trezor/blockchain-link-types';
 import type {
     ElectrumAPI,
-    HistoryTx,
-    StatusChange,
-} from '@trezor/blockchain-link-types/src/electrum';
-import type { Subscribe, Unsubscribe } from '@trezor/blockchain-link-types/src/messages';
+    ElectrumHistoryTx,
+    ElectrumStatusChange,
+    MessageTypes,
+} from '@trezor/blockchain-link-types';
 import { transformTransaction } from '@trezor/blockchain-link-utils/src/blockbook';
 import { throwError } from '@trezor/utils';
 
 import type { BaseWorker } from '../../baseWorker';
 import { createAddressManager, getTransactions } from '../utils';
 
+type Subscribe = MessageTypes.Subscribe;
+type Unsubscribe = MessageTypes.Unsubscribe;
+
 type Payload<T extends { type: string; payload: any }> = Extract<
     T['payload'],
     { type: 'addresses' | 'accounts' }
 >;
 
-// TODO optimize if neccessary
-const mostRecent = (previous: HistoryTx | undefined, current: HistoryTx) => {
+// TODO optimize if necessary
+const mostRecent = (previous: ElectrumHistoryTx | undefined, current: ElectrumHistoryTx) => {
     if (previous === undefined) return current;
     if (previous.height === -1) return previous;
     if (current.height === -1) return current;
@@ -33,14 +36,14 @@ export const txListener = (worker: BaseWorker<ElectrumAPI>) => {
 
     const addressManager = createAddressManager(() => api().getInfo()?.network);
 
-    const onTransaction = async ([scripthash, _status]: StatusChange) => {
+    const onTransaction = async ([scripthash, _status]: ElectrumStatusChange) => {
         const { descriptor, addresses } = addressManager.getInfo(scripthash);
         if (descriptor === scripthash) {
             // scripthash was subscribed to only internally, not explicitly from Suite
             return;
         }
         const history = await api().request('blockchain.scripthash.get_history', scripthash);
-        const recent = history.reduce<HistoryTx | undefined>(mostRecent, undefined);
+        const recent = history.reduce<ElectrumHistoryTx | undefined>(mostRecent, undefined);
         if (!recent) return;
         const [tx] = await getTransactions(api(), [recent]);
         worker.post({

--- a/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/estimateFee.ts
@@ -1,7 +1,9 @@
-import type { EstimateFee as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { EstimateFee as Res } from '@trezor/blockchain-link-types/src/responses';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 
 import { type Api, btcToSat } from '../utils';
+
+type Req = MessageTypes.EstimateFee;
+type Res = ResponseTypes.EstimateFee;
 
 const estimateFee: Api<Req, Res> = ({ client }, payload) =>
     Promise.all(

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountBalanceHistory.ts
@@ -1,11 +1,11 @@
 import {
     type AccountAddresses,
     type Address,
+    type ElectrumHistoryTx as HistoryTx,
+    type MessageTypes,
+    type ResponseTypes,
     type Transaction,
-} from '@trezor/blockchain-link-types/src/common';
-import type { HistoryTx } from '@trezor/blockchain-link-types/src/electrum';
-import type { GetAccountBalanceHistory as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetAccountBalanceHistory as Res } from '@trezor/blockchain-link-types/src/responses';
+} from '@trezor/blockchain-link-types';
 import { sumVinVout } from '@trezor/blockchain-link-utils';
 import { transformTransaction } from '@trezor/blockchain-link-utils/src/blockbook';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -18,6 +18,9 @@ import {
     getTransactions,
     tryGetScripthash,
 } from '../utils';
+
+type Req = MessageTypes.GetAccountBalanceHistory;
+type Res = ResponseTypes.GetAccountBalanceHistory;
 
 const transformAddress = (addr: AddressHistory): Address => ({
     address: addr.address,

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -1,7 +1,11 @@
-import type { Address, Transaction, VinVout } from '@trezor/blockchain-link-types';
-import type { ElectrumAPI } from '@trezor/blockchain-link-types/src/electrum';
-import type { GetAccountInfo as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetAccountInfo as Res } from '@trezor/blockchain-link-types/src/responses';
+import type {
+    Address,
+    ElectrumAPI,
+    MessageTypes,
+    ResponseTypes,
+    Transaction,
+    VinVout,
+} from '@trezor/blockchain-link-types';
 import { sortTxsFromLatest } from '@trezor/blockchain-link-utils';
 import { transformTransaction } from '@trezor/blockchain-link-utils/src/blockbook';
 import { discovery } from '@trezor/utxo-lib';
@@ -15,6 +19,9 @@ import {
 } from '../utils';
 
 const PAGE_SIZE_DEFAULT = 25;
+
+type Req = MessageTypes.GetAccountInfo;
+type Res = ResponseTypes.GetAccountInfo;
 
 type AddressInfo = Omit<AddressHistory, 'scripthash'> & {
     confirmed: number;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountUtxo.ts
@@ -1,10 +1,15 @@
-import type { Utxo } from '@trezor/blockchain-link-types/src/electrum';
-import type { GetAccountUtxo as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetAccountUtxo as Res } from '@trezor/blockchain-link-types/src/responses';
+import type {
+    MessageTypes,
+    ResponseTypes,
+    ElectrumUtxo as Utxo,
+} from '@trezor/blockchain-link-types';
 import { throwError } from '@trezor/utils';
 import { discovery } from '@trezor/utxo-lib';
 
 import { type Api, discoverAddress, tryGetScripthash } from '../utils';
+
+type Req = MessageTypes.GetAccountUtxo;
+type Res = ResponseTypes.GetAccountUtxo;
 
 const transformUtxo =
     (currentHeight: number, addressInfo: { address?: string; path?: string } = {}) =>

--- a/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getBlockHash.ts
@@ -1,7 +1,9 @@
-import type { GetBlockHash as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetBlockHash as Res } from '@trezor/blockchain-link-types/src/responses';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 
 import { type Api, blockheaderToBlockhash } from '../utils';
+
+type Req = MessageTypes.GetBlockHash;
+type Res = ResponseTypes.GetBlockHash;
 
 const getBlockHash: Api<Req, Res> = async ({ client }, payload) => {
     const blockheader = await client.request('blockchain.block.header', payload);

--- a/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getInfo.ts
@@ -1,8 +1,10 @@
-import type { GetInfo as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetInfo as Res } from '@trezor/blockchain-link-types/src/responses';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 import { throwError } from '@trezor/utils';
 
 import { type Api, blockheaderToBlockhash } from '../utils';
+
+type Req = MessageTypes.GetInfo;
+type Res = ResponseTypes.GetInfo;
 
 const getInfo: Api<Req, Res> = client => {
     const {

--- a/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getTransaction.ts
@@ -1,8 +1,10 @@
-import type { GetTransaction as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { GetTransaction as Res } from '@trezor/blockchain-link-types/src/responses';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 import { transformTransaction } from '@trezor/blockchain-link-utils/src/blockbook';
 
 import { type Api, getTransactions } from '../utils';
+
+type Req = MessageTypes.GetTransaction;
+type Res = ResponseTypes.GetTransaction;
 
 const getTransaction: Api<Req, Res> = async ({ client }, payload) => {
     const [tx] = await getTransactions(client, [{ tx_hash: payload, height: -1 }]);

--- a/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/pushTransaction.ts
@@ -1,7 +1,9 @@
-import type { PushTransaction as Req } from '@trezor/blockchain-link-types/src/messages';
-import type { PushTransaction as Res } from '@trezor/blockchain-link-types/src/responses';
+import type { MessageTypes, ResponseTypes } from '@trezor/blockchain-link-types';
 
 import { type Api } from '../utils';
+
+type Req = MessageTypes.PushTransaction;
+type Res = ResponseTypes.PushTransaction;
 
 const pushTransaction: Api<Req, Res> = async ({ client }, payload) => {
     const res = await client.request('blockchain.transaction.broadcast', payload.hex);

--- a/packages/blockchain-link/src/workers/electrum/sockets/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/sockets/index.ts
@@ -1,4 +1,4 @@
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
+import { CustomError } from '@trezor/blockchain-link-types';
 import { parseElectrumUrl } from '@trezor/utils';
 
 import type { SocketBase, SocketOptions } from './base';

--- a/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/discovery.ts
@@ -1,4 +1,4 @@
-import type { ElectrumAPI, HistoryTx } from '@trezor/blockchain-link-types/src/electrum';
+import type { ElectrumAPI, ElectrumHistoryTx as HistoryTx } from '@trezor/blockchain-link-types';
 
 import { addressToScripthash } from './transform';
 

--- a/packages/blockchain-link/src/workers/electrum/utils/index.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/index.ts
@@ -1,5 +1,4 @@
-import type { Response } from '@trezor/blockchain-link-types/src';
-import type { ElectrumAPI } from '@trezor/blockchain-link-types/src/electrum';
+import type { ElectrumAPI, Response } from '@trezor/blockchain-link-types';
 import type { AddressCache } from '@trezor/utxo-lib';
 
 export * from './addressManager';

--- a/packages/blockchain-link/src/workers/electrum/utils/transaction.ts
+++ b/packages/blockchain-link/src/workers/electrum/utils/transaction.ts
@@ -1,15 +1,17 @@
-import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/src/blockbook';
 import type {
+    BlockbookTransaction,
     ElectrumAPI,
-    HistoryTx,
-    TransactionVerbose,
-    TxCoinbase,
-    TxIn,
-    TxOut,
-} from '@trezor/blockchain-link-types/src/electrum';
+    ElectrumTypes,
+    ElectrumHistoryTx as HistoryTx,
+} from '@trezor/blockchain-link-types';
 import { arrayDistinct, arrayToDictionary } from '@trezor/utils';
 
 import { btcToSat } from './transform';
+
+type TransactionVerbose = ElectrumTypes.TransactionVerbose;
+type TxCoinbase = ElectrumTypes.TxCoinbase;
+type TxIn = ElectrumTypes.TxIn;
+type TxOut = ElectrumTypes.TxOut;
 
 const transformOpReturn = (hex: string) => {
     const [, _len, data] = hex.match(/^6a(?:4c)?([0-9a-f]{2})([0-9a-f]*)$/i) ?? [];

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/estimateFee.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/estimateFee.ts
@@ -1,6 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 import { calculateEip1559Fees, estimateGasLimit } from '../utils/fees';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getAccountInfo.ts
@@ -1,6 +1,8 @@
-import type { TokenInfo } from '@trezor/blockchain-link-types';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import type {
+    MessageTypes,
+    ResponseTypes as Responses,
+    TokenInfo,
+} from '@trezor/blockchain-link-types';
 
 import { mapGetAccountInfoResponse } from '../mappers/accountInfo';
 import { getStakingPoolData } from '../staking/poolData';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlock.ts
@@ -1,8 +1,7 @@
 import { isHex } from 'viem';
 
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import { mapGetBlockResponse } from '../mappers/block';
 import type { Request } from '../types';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlockHash.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getBlockHash.ts
@@ -1,7 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError, RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getInfo.ts
@@ -1,6 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/getTransaction.ts
@@ -1,6 +1,5 @@
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import { mapGetTransactionResponse } from '../mappers/transaction';
 import type { Request } from '../types';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/pushTransaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/pushTransaction.ts
@@ -1,6 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 import { toHex } from '../utils/hex';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/rpcCall.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/rpcCall.ts
@@ -1,7 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError, RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 import { toHex } from '../utils/hex';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/subscribe.ts
@@ -1,7 +1,5 @@
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError, RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import { BLOCK_SUBSCRIPTION } from '../constants';
 import type { Request } from '../types';

--- a/packages/blockchain-link/src/workers/evm-rpc/handlers/validateRpcUrl.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/handlers/validateRpcUrl.ts
@@ -1,9 +1,7 @@
 import { createPublicClient } from 'viem';
 
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { CustomError, RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 import type { Request } from '../types';
 import { getTransportType } from '../utils/transportType';

--- a/packages/blockchain-link/src/workers/evm-rpc/index.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/index.ts
@@ -1,9 +1,7 @@
 import { type PublicClient, createPublicClient } from 'viem';
 
-import type { Response } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
+import type { MessageTypes, Response } from '@trezor/blockchain-link-types';
 
 import { BaseWorker, CONTEXT } from '../baseWorker';
 import { estimateFee } from './handlers/estimateFee';

--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/accountInfo.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/accountInfo.ts
@@ -1,7 +1,9 @@
-import type { TokenInfo } from '@trezor/blockchain-link-types';
-import type { StakingPool } from '@trezor/blockchain-link-types/src/blockbook-api';
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type {
+    ResponseTypes as Responses,
+    StakingPool,
+    TokenInfo,
+} from '@trezor/blockchain-link-types';
 
 interface MapGetAccountInfoResponseParams {
     descriptor: string;

--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/block.ts
@@ -1,7 +1,7 @@
 import type { Block, Transaction } from 'viem';
 
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
+import { RESPONSES } from '@trezor/blockchain-link-types';
+import type { ResponseTypes as Responses } from '@trezor/blockchain-link-types';
 
 const mapBlockTransaction = (
     tx: Transaction,

--- a/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/mappers/transaction.ts
@@ -1,12 +1,12 @@
 import type { Block, Transaction, TransactionReceipt } from 'viem';
 
+import { RESPONSES } from '@trezor/blockchain-link-types';
 import type {
     EnhancedVinVout,
     InternalTransfer,
+    ResponseTypes as Responses,
     TokenTransfer,
 } from '@trezor/blockchain-link-types';
-import { RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import type * as Responses from '@trezor/blockchain-link-types/src/responses';
 
 import { getTransactionType } from '../utils/transactionType';
 

--- a/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/staking/poolData.ts
@@ -1,6 +1,6 @@
 import type { PublicClient } from 'viem';
 
-import type { StakingPool } from '@trezor/blockchain-link-types/src/blockbook-api';
+import type { StakingPool } from '@trezor/blockchain-link-types';
 
 import { EVERSTAKE_ACCOUNTING_ABI } from './abi';
 import { STAKING_POOL_CONTRACTS } from './constants';

--- a/packages/blockchain-link/src/workers/evm-rpc/utils/fees.ts
+++ b/packages/blockchain-link/src/workers/evm-rpc/utils/fees.ts
@@ -1,7 +1,6 @@
 import { type PublicClient } from 'viem';
 
-import { type Eip1559Fees } from '@trezor/blockchain-link-types/src/blockbook-api';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
+import { type Eip1559Fees, type MessageTypes } from '@trezor/blockchain-link-types';
 
 import { averageRewards, calculateBlockTime } from './block';
 import { toHex } from './hex';

--- a/packages/blockchain-link/src/workers/ripple/index.ts
+++ b/packages/blockchain-link/src/workers/ripple/index.ts
@@ -8,15 +8,14 @@ import {
     xrpToDrops,
 } from 'xrpl';
 
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
 import type {
     AccountInfo,
     AccountInfoParams,
+    MessageTypes,
     Response,
     SubscriptionAccountInfo,
 } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
 import * as utils from '@trezor/blockchain-link-utils/src/ripple';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { type TimerId } from '@trezor/type-utils';

--- a/packages/blockchain-link/src/workers/solana/index.ts
+++ b/packages/blockchain-link/src/workers/solana/index.ts
@@ -37,18 +37,17 @@ import {
 import { getTokenSize as _getTokenSize } from '@solana-program/token';
 import { getTokenSize as _getToken2022Size } from '@solana-program/token-2022';
 
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
 import type {
     AccountInfo,
+    MessageTypes,
     Response,
+    SolanaTokenAccountInfo,
     SubscriptionAccountInfo,
     TokenDetailByMint,
     TokenInfo,
     Transaction,
 } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
-import type { SolanaTokenAccountInfo } from '@trezor/blockchain-link-types/src/solana';
 import { solanaUtils } from '@trezor/blockchain-link-utils';
 import {
     type TokenProgramName,

--- a/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
+++ b/packages/blockchain-link/src/workers/solana/utils/stakingAccounts.ts
@@ -13,7 +13,7 @@ import {
 } from '@solana-program/stake';
 
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
-import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { StakeState } from '@trezor/blockchain-link-types';
 
 export const STAKE_ACCOUNT_V2_SIZE = 200;
 export const FILTER_DATA_SIZE = 200n;

--- a/packages/blockchain-link/src/workers/state.ts
+++ b/packages/blockchain-link/src/workers/state.ts
@@ -1,5 +1,5 @@
 import type { SubscriptionAccountInfo } from '@trezor/blockchain-link-types';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
+import { CustomError } from '@trezor/blockchain-link-types';
 import { Cache } from '@trezor/utils';
 
 export class WorkerState {

--- a/packages/blockchain-link/src/workers/stellar/index.ts
+++ b/packages/blockchain-link/src/workers/stellar/index.ts
@@ -1,9 +1,12 @@
 import { Horizon, Networks, Transaction as StellarTransaction } from '@stellar/stellar-sdk';
 
-import type { AccountInfo, Response, TokenDetailByMint } from '@trezor/blockchain-link-types';
-import { MESSAGES, RESPONSES } from '@trezor/blockchain-link-types/src/constants';
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
-import type * as MessageTypes from '@trezor/blockchain-link-types/src/messages';
+import { CustomError, MESSAGES, RESPONSES } from '@trezor/blockchain-link-types';
+import type {
+    AccountInfo,
+    MessageTypes,
+    Response,
+    TokenDetailByMint,
+} from '@trezor/blockchain-link-types';
 import * as utils from '@trezor/blockchain-link-utils/src/stellar';
 import { getSuiteVersion, isDesktop, isNative } from '@trezor/env-utils';
 import { type IntervalId } from '@trezor/type-utils';

--- a/packages/blockchain-link/tests/integration/electrum.test.ts
+++ b/packages/blockchain-link/tests/integration/electrum.test.ts
@@ -1,6 +1,4 @@
-import { GET_ACCOUNT_INFO, HANDSHAKE } from '@trezor/blockchain-link-types/src/constants/messages';
-import type { Message } from '@trezor/blockchain-link-types/src/messages';
-import type { Response } from '@trezor/blockchain-link-types/src/responses';
+import { MESSAGES, type Message, type Response } from '@trezor/blockchain-link-types';
 
 import ElectrumWorker from '../../src/workers/electrum';
 
@@ -25,7 +23,7 @@ describe('Electrum', () => {
     };
 
     worker.postMessage({
-        type: HANDSHAKE,
+        type: MESSAGES.HANDSHAKE,
         id,
         settings: {
             name: NETWORK,
@@ -50,7 +48,7 @@ describe('Electrum', () => {
         const testId = ++id;
         const waited = await sendAndWait({
             id: testId,
-            type: GET_ACCOUNT_INFO,
+            type: MESSAGES.GET_ACCOUNT_INFO,
             payload: { descriptor: address, details: 'txs' },
         });
         expect(waited).toEqual({

--- a/packages/blockchain-link/tests/unit/errors.test.ts
+++ b/packages/blockchain-link/tests/unit/errors.test.ts
@@ -1,4 +1,4 @@
-import { CustomError } from '@trezor/blockchain-link-types/src/constants/errors';
+import { CustomError } from '@trezor/blockchain-link-types';
 
 describe('Custom errors', () => {
     it('Error with predefined code and predefined message', () => {

--- a/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
+++ b/packages/blockchain-link/tests/unit/fixtures/getAccountInfo-blockbook.ts
@@ -1,5 +1,8 @@
-import type { AccountInfo, AccountInfoParams } from '@trezor/blockchain-link-types';
-import type { AccountInfo as BlockbookAccountInfo } from '@trezor/blockchain-link-types/src/blockbook';
+import type {
+    AccountInfo,
+    AccountInfoParams,
+    BlockbookAccountInfo,
+} from '@trezor/blockchain-link-types';
 import type { DeepPartial } from '@trezor/type-utils';
 
 const fixtures: {

--- a/packages/coinjoin/src/types/backend.ts
+++ b/packages/coinjoin/src/types/backend.ts
@@ -2,16 +2,14 @@ import type {
     AccountAddresses,
     AccountInfo as AccountInfoBase,
     Address,
+    BlockbookTransaction,
     EnhancedVinVout,
+    BlockbookFilterResponse as FilterResponse,
+    BlockbookServerInfo as ServerInfo,
     Transaction,
     Utxo,
     VinVout,
 } from '@trezor/blockchain-link-types';
-import type {
-    Transaction as BlockbookTransaction,
-    FilterResponse,
-    ServerInfo,
-} from '@trezor/blockchain-link-types/src/blockbook';
 import type { Network } from '@trezor/utxo-lib';
 
 import type { RequestOptions } from '../utils/http';

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -1,5 +1,5 @@
 import type { AccountAddresses } from '@trezor/blockchain-link';
-import type { Transaction as BlockbookTransaction } from '@trezor/blockchain-link-types/src/blockbook';
+import type { BlockbookTransaction } from '@trezor/blockchain-link-types';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';

--- a/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
+++ b/packages/connect/src/api/blockchainValidateEvmRpcUrl.ts
@@ -1,6 +1,5 @@
 import { BlockchainLink } from '@trezor/blockchain-link';
-import { MESSAGES } from '@trezor/blockchain-link-types/src/constants';
-import type { ValidateEvmRpc } from '@trezor/blockchain-link-types/src/responses';
+import { MESSAGES, type ResponseTypes } from '@trezor/blockchain-link-types';
 
 import type { MethodMessage, MethodPermission } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
@@ -11,6 +10,8 @@ type Params = {
     url: string;
     chainId: number;
 };
+
+type ValidateEvmRpc = ResponseTypes.ValidateEvmRpc;
 
 export default class BlockchainValidateEvmRpcUrl extends AbstractMethod<
     'blockchainValidateEvmRpcUrl',

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -39,7 +39,7 @@ import {
     type StakeFormState,
 } from '@suite-common/wallet-types';
 import { networkAmountToSmallestUnit } from '@suite-common/wallet-utils';
-import { type Fee } from '@trezor/blockchain-link-types/src/blockbook';
+import { type BlockbookFee as Fee } from '@trezor/blockchain-link-types';
 import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -12,7 +12,7 @@ import {
     getOutputTxAmount,
     getSolanaStakingAccountsByStatus,
 } from '@suite-common/wallet-utils';
-import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { StakeState } from '@trezor/blockchain-link-types';
 import { Banner } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 

--- a/suite-common/staking-solana-types/src/solanaStaking.ts
+++ b/suite-common/staking-solana-types/src/solanaStaking.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Blockchain } from '@suite-common/wallet-types';
-import { type Fee } from '@trezor/blockchain-link-types/src/blockbook';
+import { type BlockbookFee as Fee } from '@trezor/blockchain-link-types';
 import type { SolanaSignTransaction } from '@trezor/connect';
 
 export const supportedSolanaNetworkSymbols = ['sol', 'dsol'] as const;

--- a/suite-common/staking-solana/src/utils/stakingUtils.ts
+++ b/suite-common/staking-solana/src/utils/stakingUtils.ts
@@ -17,7 +17,7 @@ import {
     WALLET_SDK_SOURCE,
 } from '@suite-common/wallet-constants';
 import { networkAmountToSmallestUnit } from '@suite-common/wallet-utils';
-import { type Fee } from '@trezor/blockchain-link-types/src/blockbook';
+import { type BlockbookFee as Fee } from '@trezor/blockchain-link-types';
 
 import { claim, createTransactionShimCommon, stake, unstake } from './transactionUtils';
 

--- a/suite-common/staking-solana/src/utils/transactionUtils.ts
+++ b/suite-common/staking-solana/src/utils/transactionUtils.ts
@@ -56,7 +56,7 @@ import {
     isStake,
     stakeAccountState,
 } from '@trezor/blockchain-link/src/workers/solana/utils/stakingAccounts';
-import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { StakeState } from '@trezor/blockchain-link-types';
 import { COMPUTE_BUDGET_PROGRAM_ID } from '@trezor/blockchain-link-utils/src/solana';
 import { serializeError } from '@trezor/utils';
 

--- a/suite-common/wallet-utils/src/solanaStakingUtils.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.ts
@@ -6,7 +6,7 @@ import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-con
 import { SOLANA_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { type Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
-import { StakeState } from '@trezor/blockchain-link-types/src/solana';
+import { StakeState } from '@trezor/blockchain-link-types';
 import { BigNumber, isArrayMember } from '@trezor/utils';
 
 import { formatNetworkAmount } from './amountUtils';


### PR DESCRIPTION
Part of: https://github.com/trezor/trezor-suite/pull/26077

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=remove-blockchain-links-types-src-import&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=remove-blockchain-links-types-src-import&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=remove-blockchain-links-types-src-import&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T10:20:01.821Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T10:21:08.123Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->