### PR TITLE
refactor(suite-native): Mobile Trade: update button styles and sizes

### DIFF
--- a/suite-native/atoms/src/index.ts
+++ b/suite-native/atoms/src/index.ts
@@ -31,6 +31,7 @@ export * from './Button/Button';
 export * from './Button/AsyncButton';
 export * from './Button/IconButton';
 export * from './Button/TextButton';
+export { buttonSizeToDimensionsMap } from './Button/utils';
 export * from './Select/Select';
 export * from './Select/SelectItem';
 export * from './Spinner/Spinner';

--- a/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyButton.tsx
@@ -2,7 +2,7 @@ import { Pressable } from 'react-native';
 
 import type { FiatCurrencyCode } from 'invity-api';
 
-import { Text } from '@suite-native/atoms';
+import { Text, buttonSizeToDimensionsMap } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -16,15 +16,13 @@ export type FiatCurrencyButtonProps = {
 };
 
 const buttonStyle = prepareNativeStyle(({ borders, colors, spacings }) => ({
-    height: spacings.sp40,
-    paddingHorizontal: spacings.sp8,
+    ...buttonSizeToDimensionsMap.medium,
     gap: spacings.sp8,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: colors.backgroundNeutralSubtleOnElevation1,
     borderColor: colors.borderElevation0,
-    borderRadius: borders.radii.round,
     borderWidth: borders.widths.small,
 }));
 
@@ -44,7 +42,7 @@ export const FiatCurrencyButton = ({ currency, onPress, testID }: FiatCurrencyBu
             accessibilityLabel={translate('moduleTrading.selectFiat.buttonTitle')}
             testID={testID}
         >
-            <FiatCurrencyIcon size="small" />
+            <FiatCurrencyIcon size="extraSmall" />
             <Text variant="body-sm-strong" color="textDefault" testID={tickerTestID}>
                 {displayCurrency}
             </Text>

--- a/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
@@ -1,11 +1,17 @@
 import { RoundedIcon } from '@suite-native/atoms';
 
 export type FiatCurrencyIconProps = {
-    size: 'small' | 'medium';
+    size: 'extraSmall' | 'small' | 'medium';
 };
 
+const fiatIconSizes = {
+    extraSmall: 16,
+    small: 32,
+    medium: 48,
+} as const;
+
 export const FiatCurrencyIcon = ({ size }: FiatCurrencyIconProps) => {
-    const containerSize = size === 'small' ? 24 : 32;
+    const containerSize = fiatIconSizes[size];
 
     return (
         <RoundedIcon

--- a/suite-native/module-trading/src/components/general/HistoryButton.tsx
+++ b/suite-native/module-trading/src/components/general/HistoryButton.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { AnimatedBox, HStack, Text } from '@suite-native/atoms';
+import { AnimatedBox, HStack, Text, buttonSizeToDimensionsMap } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
@@ -32,13 +32,10 @@ export type NavigationProps = StackToStackCompositeNavigationProps<
 const TRADE_HISTORY_BUTTON_TEST_ID = '@trading/history/button';
 
 const buttonStyle = prepareNativeStyle(utils => ({
+    ...buttonSizeToDimensionsMap.large,
     backgroundColor: utils.colors.backgroundSurfaceElevationNegative,
     borderColor: utils.colors.borderOnElevationNegative,
     borderWidth: utils.borders.widths.small,
-    borderRadius: utils.borders.radii.round,
-    paddingHorizontal: utils.spacings.sp16,
-    paddingVertical: utils.spacings.sp8,
-    minHeight: 56,
     justifyContent: 'space-between',
     alignItems: 'center',
 }));

--- a/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetButton.tsx
@@ -6,7 +6,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { invariant } from '@suite-common/suite-utils';
 import { cryptoIdToSymbol } from '@suite-common/trading';
 import { type NetworkDisplaySymbol, getDisplaySymbol } from '@suite-common/wallet-config';
-import { Box } from '@suite-native/atoms';
+import { Box, buttonSizeToDimensionsMap } from '@suite-native/atoms';
 import { CryptoIcon, Icon } from '@suite-native/icons';
 import { type TradeableAsset } from '@suite-native/trading-types';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -27,8 +27,7 @@ const GRADIENT_START = { x: 0, y: 0.5 } as const;
 const GRADIENT_END = { x: 1, y: 0.5 } as const;
 
 const buttonStyle = prepareNativeStyle(({ spacings }) => ({
-    height: spacings.sp40,
-    paddingHorizontal: spacings.sp8,
+    ...buttonSizeToDimensionsMap.medium,
     gap: spacings.sp8,
     flexDirection: 'row',
     justifyContent: 'center',
@@ -37,7 +36,7 @@ const buttonStyle = prepareNativeStyle(({ spacings }) => ({
 
 const gradientBackgroundStyle = prepareNativeStyle<{ borderColor: ReturnType<typeof hexToRgba> }>(
     ({ borders }, { borderColor }) => ({
-        borderRadius: borders.radii.round,
+        borderRadius: buttonSizeToDimensionsMap.medium.borderRadius,
         borderWidth: borders.widths.small,
         borderColor,
     }),
@@ -85,11 +84,7 @@ export const TradeableAssetButton = ({
                 accessibilityLabel={accessibilityLabel}
                 testID={testID}
             >
-                <CryptoIcon
-                    symbol={adjustedSymbol}
-                    contractAddress={contractAddress}
-                    size="extraSmall"
-                />
+                <CryptoIcon symbol={adjustedSymbol} contractAddress={contractAddress} size="tiny" />
                 <NetworkSymbolExtendedFormatter
                     symbol={symbol}
                     variant="body-sm-strong"

--- a/suite-native/trading-atoms/src/components/FilterTabs.tsx
+++ b/suite-native/trading-atoms/src/components/FilterTabs.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { FlatList } from 'react-native-gesture-handler';
 
 import { Button } from '@suite-native/atoms';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 export type FilterItem<T = any> = {
     label: string;
@@ -20,6 +21,10 @@ export type FilterTabsProps<T = any> = {
     value?: T;
     keyExtractor?: (item: FilterItem<T>) => string;
 };
+
+const tabsStyle = prepareNativeStyle(({ spacings }) => ({
+    gap: spacings.sp12,
+}));
 
 const FilterTab = ({ active, onPress, children }: FilterTabProps) => (
     <Button
@@ -40,6 +45,8 @@ export const FilterTabs = <T,>({
     value,
     keyExtractor = (item: FilterItem<T>) => String(item.value),
 }: FilterTabsProps<T>) => {
+    const { applyStyle } = useNativeStyles();
+
     const defaultKeyExtractor = useMemo(
         () => (item: FilterItem<T>) => keyExtractor(item),
         [keyExtractor],
@@ -55,9 +62,10 @@ export const FilterTabs = <T,>({
         <FlatList
             horizontal
             showsHorizontalScrollIndicator={false}
+            accessible={true}
+            contentContainerStyle={applyStyle(tabsStyle)}
             data={items}
             keyExtractor={defaultKeyExtractor}
-            accessible={true}
             accessibilityRole="tablist"
             renderItem={renderFilterTab}
             keyboardShouldPersistTaps="always"

--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.tsx
@@ -22,7 +22,7 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="critical"
                     priority="secondary"
-                    size="medium"
+                    size="small"
                     onPress={() => {
                         dispatchHelper('window_closed_incomplete');
                     }}
@@ -32,17 +32,19 @@ const ProviderStatusDevButtonsContent = () => {
                 <Button
                     intent="info"
                     priority="secondary"
-                    size="medium"
+                    size="small"
                     onPress={() => {
                         dispatchHelper('window_closed_with_success');
                     }}
                 >
                     with_success
                 </Button>
+            </HStack>
+            <HStack justifyContent="center">
                 <Button
                     intent="critical"
                     priority="primary"
-                    size="medium"
+                    size="small"
                     onPress={() => {
                         dispatchHelper('confirmation_failed');
                     }}
@@ -50,19 +52,17 @@ const ProviderStatusDevButtonsContent = () => {
                     failed
                 </Button>
                 <Button
-                    size="medium"
+                    size="small"
                     onPress={() => {
                         dispatchHelper('confirmation_success');
                     }}
                 >
                     success
                 </Button>
-            </HStack>
-            <HStack justifyContent="center">
                 <Button
                     intent="warning"
                     priority="secondary"
-                    size="medium"
+                    size="small"
                     onPress={() => {
                         dispatchHelper('inactive');
                         dispatchHelper('window_opened');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Styling hot-fix for mobile trading after new buttons were merged.

Note that default button size should be fixed by https://github.com/trezor/trezor-suite/pull/26552.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26557


## Screenshots:

### Before
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 17 05 12" src="https://github.com/user-attachments/assets/6a9529b8-86f6-4c2a-beb0-9d5e9fe3d914" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 35 48" src="https://github.com/user-attachments/assets/5ea5340e-4242-4a5e-9946-bda2a72f0212" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 37 10" src="https://github.com/user-attachments/assets/fe54a85f-3d31-4e3c-a59e-8215b8d8882c" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 17 20 15" src="https://github.com/user-attachments/assets/d7b20d39-acca-41d3-9e96-1c86879398cc" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 22 08 29" src="https://github.com/user-attachments/assets/aa8bb3b4-7754-4e54-b3de-1163e9b0e1a9" />


### After
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 15 03" src="https://github.com/user-attachments/assets/121748ab-c29c-4524-9515-d6f7d34e325b" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 15 17" src="https://github.com/user-attachments/assets/1ecd12f7-df73-4db4-9f09-e0147f3a2e13" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 16 22" src="https://github.com/user-attachments/assets/6b2c94a2-9f2d-42c8-95f3-7aea01930f6d" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 17 16" src="https://github.com/user-attachments/assets/9cb54795-29a4-4b56-ab11-10c89f78e97f" />
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 22 26 32" src="https://github.com/user-attachments/assets/d5621c74-bf58-479c-bc02-2aaf71bcedbc" />



### Before (dev only)
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 35 39" src="https://github.com/user-attachments/assets/ff35c850-766a-41e4-90c0-6ca89f38aa81" />

### After (dev only)
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-10 at 21 28 23" src="https://github.com/user-attachments/assets/f07d961f-cedf-401f-b337-38fc2c242c87" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=trading-visual-fixes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->