### PR TITLE
fix(ci): skip project status update if already approved

### DIFF
--- a/.github/workflows/bot-needs-qa.yml
+++ b/.github/workflows/bot-needs-qa.yml
@@ -66,20 +66,44 @@ jobs:
               node(id: $content_id) {
                 ... on Issue {
                   projectItems(first: 10) {
-                    nodes { id project { id } }
+                    nodes {
+                      id
+                      project { id }
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { id } }
+                            optionId
+                          }
+                        }
+                      }
+                    }
                   }
                 }
                 ... on PullRequest {
                   projectItems(first: 10) {
-                    nodes { id project { id } }
+                    nodes {
+                      id
+                      project { id }
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { id } }
+                            optionId
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
             }' \
             -f content_id="$CONTENT_ID")
 
-          ITEM_ID=$(echo "$RESPONSE" | jq -r \
-            ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\") | .id")
+          PROJECT_ITEM=$(echo "$RESPONSE" | jq -r \
+            ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\")")
+
+          ITEM_ID=$(echo "$PROJECT_ITEM" | jq -r '.id')
 
           if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
             echo "Item not found in project — it may not be tracked. Skipping."
@@ -87,13 +111,27 @@ jobs:
             exit 0
           fi
 
+          CURRENT_STATUS=$(echo "$PROJECT_ITEM" | jq -r \
+            ".fieldValues.nodes[] | select(.field?.id == \"${{ env.STATUS_FIELD_ID }}\") | .optionId // empty")
+
           echo "ITEM_ID=$ITEM_ID" >> $GITHUB_ENV
           echo "item_found=true" >> $GITHUB_OUTPUT
+          echo "current_status=$CURRENT_STATUS" >> $GITHUB_OUTPUT
+          echo "Current status option ID: $CURRENT_STATUS"
+
+      - name: Skip if already approved
+        if: |
+          (steps.context.outputs.event_type == 'issue' || steps.context.outputs.is_merged == 'true') &&
+          steps.get-item.outputs.item_found == 'true' &&
+          steps.get-item.outputs.current_status == env.APPROVED_OPTION_ID
+        run: |
+          echo "⏭️ Status is already 'Approved' — skipping update."
 
       - name: Determine target status
         if: |
           (steps.context.outputs.event_type == 'issue' || steps.context.outputs.is_merged == 'true') &&
-          steps.get-item.outputs.item_found == 'true'
+          steps.get-item.outputs.item_found == 'true' &&
+          steps.get-item.outputs.current_status != env.APPROVED_OPTION_ID
         id: target-status
         run: |
           if [ "${{ steps.context.outputs.has_noqa_label }}" == "true" ]; then
@@ -107,7 +145,8 @@ jobs:
       - name: Set project status
         if: |
           (steps.context.outputs.event_type == 'issue' || steps.context.outputs.is_merged == 'true') &&
-          steps.get-item.outputs.item_found == 'true'
+          steps.get-item.outputs.item_found == 'true' &&
+          steps.get-item.outputs.current_status != env.APPROVED_OPTION_ID
         env:
           GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary
- Prevents the `bot-needs-qa` workflow from overwriting a manually set "Approved" project status when a PR is merged or an issue is closed
- Extends the GraphQL query to fetch the current status field value, then skips the update if it already matches the "Approved" option ID
- Adds a "Skip if already approved" log step for visibility in workflow runs

## Test plan
- [ ] Merge a PR whose project item is already set to "Approved" — verify the workflow skips the status update
- [ ] Merge a PR whose project item is set to another status — verify the workflow still updates correctly
- [ ] Close an issue with "Approved" status — verify no change is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bot-needs-qa-skip-approved&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bot-needs-qa-skip-approved&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T20:06:09.504Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T20:05:45.231Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->