### PR TITLE
fix(ci): reduce parallelism for suite native tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "type-check:all": "yarn nx run-many --target=type-check",
         "test:unit": "yarn nx affected --target=test:unit",
         "test:unit:suite": "yarn nx affected --target=test:unit --exclude='@suite-native/*'",
-        "test:unit:native": "yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading'",
+        "test:unit:native": "yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading' --parallel=2",
         "test:unit:all": "yarn nx run-many --target=test:unit",
         "lint:js": "yarn nx affected --target=lint:js",
         "lint:js:fix": "yarn lint:js --fix",


### PR DESCRIPTION
## Description

Reduce Suite native unit test parallelism from 4 to 2. 
It seems the GitHub Actions runners are hitting CPU/memory limits, leading to degraded performance and timeouts.

<img width="1019" height="99" alt="Screenshot 2026-04-10 at 23 24 12" src="https://github.com/user-attachments/assets/012810f5-7423-4354-bda0-ef519730b24b" />

I ended up with this solution while trying to merge PR #26549, where the native unit tests were always getting stuck after several reruns, this change finally solved the problem ([run here](https://github.com/trezor/trezor-suite/actions/runs/24254840019/job/70824643628)), so I pulled it into a separate PR

## Notes for QA

Nothing to test, CI only change

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-native-parallelism&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Account metadata,google - watches files over time" | 🙋 manual |
| Quarantine test: "Account metadata,dropbox - watches files over time" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-10T20:34:52.588Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->