### PR TITLE
feat(ci): auto-assign Release iteration on issue close / PR merge

### DIFF
--- a/.github/workflows/bot-set-release-iteration.yml
+++ b/.github/workflows/bot-set-release-iteration.yml
@@ -1,0 +1,202 @@
+name: "[Bot] Set Release iteration on Close/Merge PR & Issue"
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+env:
+  CHERRY_PICK_LABEL: "cherry-pick\U0001F352"
+  PROJECT_ID: PVT_kwDOAD9FD84AAuwj
+  PLATFORM_FIELD_ID: PVTSSF_lADOAD9FD84AAuwjzg5k-KU
+  RELEASE_FIELD_ID: PVTIF_lADOAD9FD84AAuwjzgAYje4
+  PLATFORM_DESKTOP_ID: e9bcca7d
+  PLATFORM_SUITE_ID: a0052515
+  PLATFORM_CONNECT_ID: 3586cc60
+  PLATFORM_MOBILE_ID: 3f0dd7ab
+
+jobs:
+  set-release-iteration:
+    name: Set Release iteration
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Determine event context
+        id: context
+        run: |
+          if [ "${{ github.event_name }}" == "issues" ]; then
+            echo "content_id=${{ github.event.issue.node_id }}" >> $GITHUB_OUTPUT
+            echo "has_cherry_pick=${{ contains(github.event.issue.labels.*.name, env.CHERRY_PICK_LABEL) }}" >> $GITHUB_OUTPUT
+            echo "is_merged=false" >> $GITHUB_OUTPUT
+            echo "event_type=issue" >> $GITHUB_OUTPUT
+          else
+            echo "content_id=${{ github.event.pull_request.node_id }}" >> $GITHUB_OUTPUT
+            echo "has_cherry_pick=${{ contains(github.event.pull_request.labels.*.name, env.CHERRY_PICK_LABEL) }}" >> $GITHUB_OUTPUT
+            echo "is_merged=${{ github.event.pull_request.merged }}" >> $GITHUB_OUTPUT
+            echo "event_type=pull_request" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if should proceed
+        id: guard
+        run: |
+          SHOULD_PROCEED=false
+
+          if [ "${{ steps.context.outputs.event_type }}" == "issue" ]; then
+            SHOULD_PROCEED=true
+          elif [ "${{ steps.context.outputs.is_merged }}" == "true" ]; then
+            SHOULD_PROCEED=true
+          else
+            echo "PR was closed without merging — skipping."
+          fi
+
+          if [ "${{ steps.context.outputs.has_cherry_pick }}" == "true" ]; then
+            echo "Item has 'cherry-pick🍒' label — skipping Release assignment."
+            SHOULD_PROCEED=false
+          fi
+
+          echo "proceed=$SHOULD_PROCEED" >> $GITHUB_OUTPUT
+
+      - name: Generate GitHub App token
+        if: steps.guard.outputs.proceed == 'true'
+        id: trezor-bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TREZOR_BOT_APP_ID }}
+          private-key: ${{ secrets.TREZOR_BOT_PRIVATE_KEY }}
+
+      - name: Resolve and set Release iteration
+        if: steps.guard.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
+        run: |
+          # --- Util for GraphQL errors ---
+          check_graphql_errors() {
+            if echo "$1" | jq -e '.errors' > /dev/null 2>&1; then
+              echo "::error::GraphQL error: $(echo "$1" | jq -r '.errors[0].message')"
+              exit 1
+            fi
+          }
+
+          CONTENT_ID="${{ steps.context.outputs.content_id }}"
+          EVENT_TYPE="${{ steps.context.outputs.event_type }}"
+
+          # --- Get project item and field values ---
+          RESPONSE=$(gh api graphql -f query='
+            fragment ProjectFields on ProjectV2Item {
+              id
+              project { id }
+              fieldValues(first: 20) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    field { ... on ProjectV2SingleSelectField { id } }
+                    optionId
+                  }
+                  ... on ProjectV2ItemFieldIterationValue {
+                    field { ... on ProjectV2IterationField { id } }
+                    iterationId
+                  }
+                }
+              }
+            }
+            query($content_id: ID!) {
+              node(id: $content_id) {
+                ... on Issue { projectItems(first: 10) { nodes { ...ProjectFields } } }
+                ... on PullRequest { projectItems(first: 10) { nodes { ...ProjectFields } } }
+              }
+            }' \
+            -f content_id="$CONTENT_ID")
+          check_graphql_errors "$RESPONSE"
+
+          PROJECT_ITEM=$(echo "$RESPONSE" | jq -r \
+            ".data.node.projectItems.nodes[] | select(.project.id == \"${{ env.PROJECT_ID }}\")")
+
+          ITEM_ID=$(echo "$PROJECT_ITEM" | jq -r '.id')
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "Item not found in project — it may not be tracked. Skipping."
+            exit 0
+          fi
+
+          # --- Check if Release already set ---
+          RELEASE_ITERATION=$(echo "$PROJECT_ITEM" | jq -r \
+            ".fieldValues.nodes[] | select(.field?.id == \"${{ env.RELEASE_FIELD_ID }}\") | .iterationId // empty")
+
+          if [ -n "$RELEASE_ITERATION" ]; then
+            echo "⏭️ Release iteration is already set — skipping."
+            exit 0
+          fi
+
+          # --- Determine version from Platform ---
+          PLATFORM=$(echo "$PROJECT_ITEM" | jq -r \
+            ".fieldValues.nodes[] | select(.field?.id == \"${{ env.PLATFORM_FIELD_ID }}\") | .optionId // empty")
+
+          if [ "$PLATFORM" = "${{ env.PLATFORM_DESKTOP_ID }}" ] || \
+             [ "$PLATFORM" = "${{ env.PLATFORM_SUITE_ID }}" ] || \
+             [ "$PLATFORM" = "${{ env.PLATFORM_CONNECT_ID }}" ]; then
+            FILE_PATH="packages/suite/package.json"
+            VERSION_KEY="suiteVersion"
+          elif [ "$PLATFORM" = "${{ env.PLATFORM_MOBILE_ID }}" ]; then
+            FILE_PATH="suite-native/app/package.json"
+            VERSION_KEY="suiteNativeVersion"
+          else
+            echo "Platform option '$PLATFORM' is not Desktop/Suite/Connect/Mobile — skipping."
+            exit 0
+          fi
+
+          RAW_VERSION=$(gh api "repos/trezor/trezor-suite/contents/$FILE_PATH?ref=develop" \
+            --jq '.content' | base64 -d | jq -r ".$VERSION_KEY")
+
+          if [ -z "$RAW_VERSION" ] || [ "$RAW_VERSION" = "null" ]; then
+            echo "Could not read $VERSION_KEY from $FILE_PATH on develop — skipping."
+            exit 0
+          fi
+
+          RELEASE_VERSION=$(echo "$RAW_VERSION" | sed 's/\.[0-9]*$//')
+          echo "Resolved version: $RAW_VERSION → $RELEASE_VERSION"
+
+          # --- Find matching Release iteration ---
+          ITER_RESPONSE=$(gh api graphql \
+            -f query='query($fieldId: ID!) {
+              node(id: $fieldId) {
+                ... on ProjectV2IterationField {
+                  configuration {
+                    iterations { id title }
+                    completedIterations { id title }
+                  }
+                }
+              }
+            }' \
+            -f fieldId="${{ env.RELEASE_FIELD_ID }}")
+          check_graphql_errors "$ITER_RESPONSE"
+
+          ITERATION_ID=$(echo "$ITER_RESPONSE" | jq -r \
+            ".data.node.configuration | (.iterations + .completedIterations)[] | select(.title == \"$RELEASE_VERSION\") | .id")
+
+          if [ -z "$ITERATION_ID" ]; then
+            echo "No Release iteration found matching '$RELEASE_VERSION' — skipping."
+            exit 0
+          fi
+
+          echo "Found iteration: $RELEASE_VERSION → $ITERATION_ID"
+
+          # --- Set Release iteration ---
+          MUTATION_RESPONSE=$(gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $iterationId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field
+                value: { iterationId: $iterationId }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project="${{ env.PROJECT_ID }}" \
+               -f item="$ITEM_ID" \
+               -f field="${{ env.RELEASE_FIELD_ID }}" \
+               -f iterationId="$ITERATION_ID")
+          check_graphql_errors "$MUTATION_RESPONSE"
+
+          echo "✅ Release set to '$RELEASE_VERSION' for $EVENT_TYPE"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bot-set-release-iteration.yml` — a new bot workflow that automatically sets the **Release** iteration field on GitHub Project 58 when an issue is closed or a PR is merged
- Skips if the Release field is already filled, the item has the `cherry-pick🍒` label, or the Platform is not one of Desktop / Suite / Connect / Mobile
- Reads the current version from `packages/suite/package.json` (`suiteVersion`) or `suite-native/app/package.json` (`suiteNativeVersion`) on the `develop` branch via the GitHub API (no checkout required), strips the patch segment (e.g. `26.5.0` → `26.5`), and assigns the matching iteration

## How it works

1. On issue closed / PR merged, determines event context and checks skip conditions (no-merge, cherry-pick label)
2. Queries the project item for the Platform and Release field values in a single GraphQL call
3. Fetches the relevant `package.json` from `develop` to resolve the target release version
4. Looks up the matching iteration ID from the Release field configuration (active + completed iterations)
5. Sets the Release iteration via `updateProjectV2ItemFieldValue` mutation

Follows the same patterns as `bot-needs-qa.yml` (token generation, GraphQL style, step conditions, skip logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bot-set-release-iteration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bot-set-release-iteration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T11:49:46.690Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-10T20:57:54.771Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/bot-set-release-iteration/web/](https://dev.suite.sldev.cz/suite-web/feat/bot-set-release-iteration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->