### PR TITLE
fix(suite): accept more bitcoin recipient formats

### DIFF
--- a/packages/suite/src/utils/suite/__fixtures__/protocol.ts
+++ b/packages/suite/src/utils/suite/__fixtures__/protocol.ts
@@ -83,6 +83,24 @@ export const getProtocolInfo: getProtocolInfoFixture[] = [
         },
     },
     {
+        description: 'should normalize uppercase Bitcoin bech32 address to lowercase',
+        uri: 'bitcoin:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4?amount=0.1',
+        result: {
+            scheme: 'bitcoin',
+            address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+            amount: 0.1,
+        },
+    },
+    {
+        description: 'should normalize uppercase Bitcoin address when scheme is uppercase too',
+        uri: 'BITCOIN:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4?amount=0.1&message=hello',
+        result: {
+            scheme: 'bitcoin',
+            address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+            amount: 0.1,
+        },
+    },
+    {
         description:
             'should parse Bitcoin URI and ignore amount when it consists of address, and amount is not a number',
         uri: 'bitcoin:3QmuBaZrJNCxc5Xs7aGzZUK8RirUT8jRKf?amount=thousand',

--- a/packages/suite/src/utils/suite/protocol.ts
+++ b/packages/suite/src/utils/suite/protocol.ts
@@ -1,3 +1,4 @@
+import { isBech32AddressUppercase } from '@suite-common/wallet-utils';
 import { type Protocol } from '@suite-common/suite-constants';
 import { getNetworkSymbolForProtocol } from '@suite-common/suite-utils';
 
@@ -10,6 +11,14 @@ export type CoinProtocolInfo = {
 };
 
 const removeLeadingTrailingSlashes = (text: string) => text.replace(/^\/{0,2}|\/$/g, '');
+
+const normalizeAddress = (scheme: Protocol, address: string): string => {
+    if (scheme === 'bitcoin' && isBech32AddressUppercase(address)) {
+        return address.toLowerCase();
+    }
+
+    return address;
+};
 
 export const getProtocolInfo = (
     uri: string,
@@ -30,8 +39,10 @@ export const getProtocolInfo = (
         const floatAmount = Number.parseFloat(params.amount ?? '');
         const amount = !Number.isNaN(floatAmount) && floatAmount > 0 ? floatAmount : undefined;
 
-        const address =
-            removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host);
+        const address = normalizeAddress(
+            scheme,
+            removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host),
+        );
 
         return {
             scheme,


### PR DESCRIPTION
## Summary
- add protocol fixtures that cover uppercase Bitcoin Bech32 recipient inputs
- normalize uppercase Bitcoin Bech32 addresses in the shared protocol parser so QR/protocol imports match manual entry behavior
- keep extra query parameters working while preserving existing parsing behavior

## Testing
- `node .yarn/releases/yarn-4.12.0.cjs workspace @trezor/suite test:unit --coverage=0 parseUri.test.ts protocol.test.ts`

## Notes
- `node .yarn/releases/yarn-4.12.0.cjs workspace @trezor/suite type-check` is currently red in the local checkout because of broader repo build/type state outside this patch (`TS6305` and unrelated package issues).