### PR TITLE
fix(connect): fix maxFeePerGas, misuse of gwei in wei calculation

### DIFF
--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -24,8 +24,10 @@ export class EthereumFeeLevels extends MiscFeeLevels {
             const minFeeInWei = new BigNumber(this.coinInfo.minFee).multipliedBy('1e+9').toNumber();
             const feeInWei = new BigNumber(response.feePerUnit).toNumber();
 
-            // validate gas price from backend
-            const feePerUnit = Math.min(maxFeeInWei, Math.max(minFeeInWei, feeInWei)).toString();
+            // validate gas price from backend; clamp and round to integer wei (backend may return decimal)
+            const feePerUnit = new BigNumber(
+                Math.min(maxFeeInWei, Math.max(minFeeInWei, feeInWei)),
+            ).toFixed(0);
 
             if (eip1559?.baseFeePerGas) {
                 const minMaxPriorityFeePerGas = new BigNumber(this.coinInfo.minPriorityFee)
@@ -42,15 +44,15 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                     }
 
                     const maxFeePerGas = BigNumber.max(
-                        this.coinInfo.minFee,
+                        minFeeInWei,
                         level.maxFeePerGas,
                         minMaxPriorityFeePerGas,
-                    ).toString();
+                    ).toFixed(0);
 
                     const maxPriorityFeePerGas = BigNumber.max(
                         minMaxPriorityFeePerGas,
                         BigNumber.min(maxFeePerGas, level.maxPriorityFeePerGas),
-                    ).toString();
+                    ).toFixed(0);
 
                     return {
                         label,

--- a/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
@@ -91,6 +91,55 @@ describe('api/ethereum/Fees', () => {
             spy.mockRestore();
         });
 
+        it('rounds feePerUnit to integer when backend returns decimal wei value', async () => {
+            const coinInfo = getEthereumNetwork('eth')!;
+            const spy = jest
+                .spyOn(BlockchainLink.prototype, 'estimateFee')
+                .mockResolvedValue([{ feePerUnit: '1500000000.7' }]); // fractional wei
+
+            const backend = await initBlockchain(coinInfo, () => {});
+            const feeLevels = new EthereumFeeLevels(coinInfo);
+
+            const [level] = await feeLevels.load(backend, ETH_REQUEST);
+
+            // must be an integer wei string — fromWei("1500000000.7", 'gwei') would crash
+            expect(level.feePerUnit).toMatch(/^\d+$/);
+
+            backend.disconnect();
+            spy.mockRestore();
+        });
+
+        it('EIP-1559: clamps maxFeePerGas to minFee (in wei) when backend returns zero', async () => {
+            const coinInfo = getEthereumNetwork('eth')!;
+            const spy = jest.spyOn(BlockchainLink.prototype, 'estimateFee').mockResolvedValue([
+                {
+                    feePerUnit: '2000000000',
+                    feeLimit: '21000',
+                    eip1559: {
+                        baseFeePerGas: '1000000000',
+                        low: { maxFeePerGas: '0', maxPriorityFeePerGas: '0' },
+                        medium: { maxFeePerGas: '0', maxPriorityFeePerGas: '0' },
+                        high: { maxFeePerGas: '0', maxPriorityFeePerGas: '0' },
+                    },
+                },
+            ]);
+
+            const backend = await initBlockchain(coinInfo, () => {});
+            const feeLevels = new EthereumFeeLevels(coinInfo);
+
+            const levels = await feeLevels.load(backend, ETH_REQUEST);
+
+            // minFee for eth = 0.1 Gwei → 0.1 × 1e9 = 100 000 000 wei
+            // maxFeePerGas must be an integer wei string, never a decimal gwei string like "0.1"
+            levels.forEach(level => {
+                expect(Number(level.maxFeePerGas)).toBeGreaterThanOrEqual(100000000);
+                expect(level.maxFeePerGas).toMatch(/^\d+$/);
+            });
+
+            backend.disconnect();
+            spy.mockRestore();
+        });
+
         it('clamps to maxFee when backend returns over-limit value', async () => {
             const coinInfo = getEthereumNetwork('eth')!;
             const overLimit = (coinInfo.maxFee * 1e9 * 10).toFixed(0); // 10× max


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- when fees from blockbook were 0, it used default value in gwei instead of in wei

## Notes for QA

It is really hard to test as it depends on data from third party. Just test that fees are not completely wrong now on evms

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26516

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evm-fees-l2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/evm-fees-l2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 17 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect popup web > call cancellation | 🤖 auto |
| TrezorConnect popup web > closing popup window returns Method_Interrupted error | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-12T16:45:24.565Z • 17 test(s) total_
<!-- QUARANTINE-LIST:web:END -->