### PR TITLE
[wip] transport spring cleanup

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -74,3 +74,4 @@
     - [device naming](./misc/device-naming.md)
     - [review](./misc/review.md)
     - [videos](./misc/videos.md)
+    - [transport-refactor](./transport-layer-audit.md)

--- a/docs/transport-layer-audit.md
+++ b/docs/transport-layer-audit.md
@@ -1,0 +1,468 @@
+# Transport Layer Refactor Plan
+
+Actionable checklist for stabilizing transport sessions/concurrency and related bugs.
+
+How to use this plan:
+
+- Check a box only when code, tests, and verification for that item are done.
+- Keep PRs small: 1-2 checklist items per PR.
+- Prefer correctness first, then throughput/performance.
+
+## Workstream A: Sessions Correctness (highest priority)
+
+- [ ] A1: Replace global lock queue semantics in sessions
+    - Description: Fix `waitForUnlocked`/`clearLock` behavior so one requester cannot incorrectly release another requester.
+    - Rationale: Current queue semantics can release the wrong waiter and create ownership races.
+    - Files:
+        1. `packages/transport/src/sessions/background.ts`
+    - Specific implementation instructions:
+        1. Replace array-index based ownership (`locksQueue[0]`) with per-request lock token/handle.
+        2. Ensure `clearLock` accepts and validates owner token.
+        3. Remove `Promise.all(beforeMe)` in `waitForUnlocked`; wait only on immediate predecessor token.
+        4. Guarantee every `acquireIntent`/`releaseIntent` either commits or exits with its own lock released.
+        5. Enforce policy: timeout must never transfer ownership; timeout may only fail/cleanup its own request.
+    - Done when:
+        1. Two simultaneous acquire calls on same path result in exactly one success and one `SESSION_WRONG_PREVIOUS`.
+        2. No code path can resolve a lock it does not own.
+
+- [ ] A2: Make lock release exception-safe in release path
+    - Description: Ensure release path cannot leave queue uncleared after descriptor races/disconnect.
+    - Rationale: `releaseDone` can throw before unlocking, causing lock starvation until timeout.
+    - Files:
+        1. `packages/transport/src/sessions/background.ts`
+    - Specific implementation instructions:
+        1. Add descriptor existence validation before mutation in `releaseDone`.
+        2. Move unlock logic into `finally` so it runs for both success and error.
+        3. Return structured error when path is gone instead of throwing.
+    - Done when:
+        1. Releasing a disconnected device returns structured error and does not block next waiter.
+
+- [ ] A3: Make bridge core acquire/release lock-safe on failure
+    - Description: Release the session lock in `core.acquire` and `core.release` when `openDevice` or `closeDevice` fails after intent.
+    - Rationale: After A1 removed auto-timeout from lock deferreds, a failed `openDevice` leaves the lock held permanently — cascading all subsequent waiters into 4s timeouts. The old code masked this with `setTimeout` auto-resolve; the new code makes the leak permanent.
+    - Files:
+        1. `packages/transport-bridge/src/core.ts`
+    - Specific implementation instructions:
+        1. In `acquire`: if `openDevice` fails after `acquireIntent` succeeded, call `sessionsClient.acquireDone` (to release the lock) and then return the error. Alternatively, add a dedicated `sessionsClient.acquireAbort` or call `releaseDone` on the intent path.
+        2. In `release`: if `closeDevice` fails, still call `sessionsClient.releaseDone` so the lock is released.
+        3. Use try/finally in both functions to guarantee lock release.
+    - Done when:
+        1. `openDevice` failure does not block subsequent acquire attempts.
+        2. `closeDevice` failure does not block subsequent release/acquire attempts.
+
+- [ ] A4: Await commit in abstractApi `acquire`
+    - Description: Remove fire-and-forget `acquireDone` call.
+    - Rationale: Current code can return acquire success before session commit is persisted.
+    - Files:
+        1. `packages/transport/src/transports/abstractApi.ts`
+    - Specific implementation instructions:
+        1. Change `this.sessionsClient.acquireDone(...)` to awaited call.
+        2. If acquireDone fails, close opened device and return structured error.
+        3. Add logging for rollback branch.
+    - Done when:
+        1. `acquire` returns success only after session state commit succeeds.
+
+- [ ] A5: Introduce per-device session queues
+    - Description: Remove cross-device blocking in sessions background.
+    - Rationale: Global queue serializes unrelated devices, causing head-of-line blocking.
+    - Files:
+        1. `packages/transport/src/sessions/background.ts`
+    - Specific implementation instructions:
+        1. Replace single `locksQueue` with `Map<PathInternal, DeviceQueueState>`.
+        2. Route `acquireIntent` and `releaseIntent` to queue keyed by resolved `pathInternal`.
+        3. Cleanup queue entry when device disconnects or queue becomes empty.
+    - Done when:
+        1. Parallel acquire/release on different paths do not wait for each other.
+
+- [ ] A6: Add fencing generation to session state
+    - Description: Add per-device monotonic generation token and validate it on state transitions.
+    - Rationale: Prevent stale completions from overwriting newer ownership.
+    - Files:
+        1. `packages/transport/src/sessions/background.ts`
+        2. `packages/transport/src/sessions/types.ts`
+        3. Call sites in transports that use session lookups
+    - Specific implementation instructions:
+        1. Extend descriptor/session state with `generation: number`.
+        2. Increment generation on successful acquire commit.
+        3. Include generation in acquire result and require it for release/call/send/receive validation where feasible.
+        4. Reject operations where generation does not match current owner.
+    - Done when:
+        1. Stale acquire/release completions are rejected deterministically in tests.
+
+---
+
+## Workstream B: Sessions Runtime Reliability
+
+- [ ] B0: Fix multiple-sessions e2e test
+    - Description: Restore the commented-out `stealBridgeSession()` call in the test, or rewrite the last two steps to match the intended behavior.
+    - Rationale: Commit `41a10e26ab` commented out the second `stealBridgeSession()` call that set up the `TR_USE_HERE` condition for the final assertion. The last step now expects `TR_USE_HERE` (session stolen) but nothing steals the session after the previous step restored `TR_CONNECTED`. The test always times out at 30s.
+    - Files:
+        1. `suite/e2e/tests/suite/multiple-sessions.test.ts`
+    - Specific implementation instructions:
+        1. Uncomment the "Reload inactive suite session" step which calls `stealBridgeSession()`, reloads, and expects Suite auto-reacquires after reload.
+        2. Remove the broken "After reloading inactive suite session does not take Bridge session back" and trailing "Take Bridge session back" steps.
+    - Done when:
+        1. `yarn e2e:suite multiple-sessions` passes reliably.
+
+- [ ] B1: Fix SharedWorker port lifecycle leak
+    - Description: Remove dead ports from shared worker broadcast list.
+    - Rationale: Dead ports accumulate and degrade broadcast loop health.
+    - Files:
+        1. `packages/transport/src/sessions/background-sharedworker.ts`
+    - Specific implementation instructions:
+        1. Track ports in `Set<MessagePort>` instead of array.
+        2. Register per-port cleanup on close/error (or failed postMessage handling).
+        3. During broadcast, catch failures and prune dead ports.
+    - Done when:
+        1. Repeated connect/disconnect cycles keep port count stable.
+
+- [ ] B2: Fix browser background request hang on message error
+    - Description: Ensure `handleMessage()` promise always resolves or rejects.
+    - Rationale: Current `onmessageerror` removes listener without settling promise.
+    - Files:
+        1. `packages/transport/src/sessions/background-browser.ts`
+    - Specific implementation instructions:
+        1. In `onmessageerror`, reject promise with structured error.
+        2. Ensure listener cleanup runs exactly once (success/error/timeout).
+        3. Add optional request timeout guard as fallback.
+    - Done when:
+        1. Forced message error does not leave pending promises.
+
+- [ ] B3: Add explicit session-invariant tests
+    - Description: Add tests for ownership and queue safety.
+    - Rationale: Current tests cover some happy paths but not all race invariants.
+    - Files:
+        1. `packages/transport-test/e2e/bridge/bridge.test.ts`
+        2. Add/extend unit tests around sessions background if available
+    - Specific implementation instructions:
+        1. Add test: same-path concurrent acquire => one success, one wrong previous.
+        2. Add test: different-path concurrent acquire => both proceed without blocking.
+        3. Add test: release path with missing descriptor => lock cleanup still occurs.
+        4. Add test: timeout never grants ownership to another waiter; timed-out request fails explicitly.
+    - Done when:
+        1. All invariants are covered and reproducible.
+
+---
+
+## Workstream C: Transport Isolation and Throughput
+
+- [ ] C1: Path-scoped isolation in AbstractApi
+    - Description: Avoid global serialization in `runInIsolation`.
+    - Rationale: `getSynchronize()` is currently used without lock id, serializing unrelated operations.
+    - Files:
+        1. `packages/transport/src/api/abstract.ts`
+    - Specific implementation instructions:
+        1. Change `this.synchronize(fn)` to `this.synchronize(fn, path)` in `runInIsolation`.
+        2. Keep read/write conflict check (`requestAccess`) intact per path.
+        3. Validate no regressions in `OTHER_CALL_IN_PROGRESS` behavior for same path.
+    - Done when:
+        1. Calls on different paths can run concurrently while same-path conflicts remain guarded.
+
+- [ ] C2: Keep listener ordering safe in AbstractApiTransport
+    - Description: Attach API listeners before starting listen stream.
+    - Rationale: Prevent first emitted descriptor update from being lost.
+    - Files:
+        1. `packages/transport/src/transports/abstractApi.ts`
+    - Specific implementation instructions:
+        1. Move `this.api.on('transport-interface-change', ...)` registration before `this.api.listen()`.
+        2. Preserve existing `this.listening` guard.
+    - Done when:
+        1. No missed first-event race under simulated connect-at-start.
+
+---
+
+## Workstream D: Confirmed Data-Plane Bugs
+
+- [ ] D1: USB reset race fix
+    - Description: Make `resetDevice` deduplicated and awaitable.
+    - Rationale: Boolean flag check/set is non-atomic and can start multiple resets.
+    - Files:
+        1. `packages/transport/src/api/usb.ts`
+    - Specific implementation instructions:
+        1. Replace `deviceResetMap[path]: boolean` with `Map<path, Promise<void>>`.
+        2. If reset in progress, return/await existing promise.
+        3. Clear map entry in `finally`.
+    - Done when:
+        1. Concurrent reset callers await same reset task.
+
+- [ ] D2: USB selectConfiguration failure handling
+    - Description: Stop open flow after configuration failure.
+    - Rationale: Continuing to claim interface after config failure creates misleading downstream errors.
+    - Files:
+        1. `packages/transport/src/api/usb.ts`
+    - Specific implementation instructions:
+        1. Return structured open error immediately on selectConfiguration catch.
+        2. Do not proceed to claimInterface in this branch.
+    - Done when:
+        1. Config failure surfaces as immediate open failure.
+
+- [ ] D3: USB releaseInterface failure recovery
+    - Description: Add deterministic fallback or hard-fail path.
+    - Rationale: Swallowing release failure can leave interface stuck claimed.
+    - Files:
+        1. `packages/transport/src/api/usb.ts`
+    - Specific implementation instructions:
+        1. On releaseInterface failure, attempt `device.reset()` fallback where safe.
+        2. If fallback fails, return structured close error.
+    - Done when:
+        1. Subsequent open attempts do not silently fail due to stale claim.
+
+- [ ] D4: BLE write error propagation
+    - Description: Do not swallow write failures.
+    - Rationale: Silent failure can corrupt protocol flow (especially firmware update).
+    - Files:
+        1. `packages/transport-native-bluetooth/src/api/bluetoothManager.ts`
+    - Specific implementation instructions:
+        1. Re-throw write error after logging, or return typed error result.
+        2. Ensure caller converts it to structured transport error.
+    - Done when:
+        1. Failed BLE write propagates to API caller as failure.
+
+- [ ] D5: BLE connect deduplication and monitor cleanup
+    - Description: Guard concurrent connect attempts and cleanup monitor subscriptions on disconnect.
+    - Rationale: Current behavior can overwrite connected device state and keep ghost callbacks alive.
+    - Files:
+        1. `packages/transport-native-bluetooth/src/api/bluetoothManager.ts`
+    - Specific implementation instructions:
+        1. Add `inFlightConnects: Map<DeviceId, Promise<Device>>` and reuse pending connect.
+        2. Store monitor unsubscribe handles per device.
+        3. On disconnect, cancel reads and unsubscribe all monitors before deleting state.
+    - Done when:
+        1. Concurrent connect on same device converges to one successful connection path.
+        2. No messages are accepted after disconnect cleanup.
+
+---
+
+## Workstream E: Hygiene and Leak Prevention
+
+- [ ] E1: Ensure merged abort listeners are always cleaned up
+    - Description: Verify every merged signal path clears listeners.
+    - Rationale: Missing cleanup accumulates abort listeners and closures.
+    - Files:
+        1. `packages/transport/src/transports/abstract.ts`
+        2. Call sites using `scheduleAction`
+    - Specific implementation instructions:
+        1. Keep cleanup in `.finally(clear)` (already present).
+        2. Audit any direct `mergeAbort` usage outside `scheduleAction` and enforce `finally` cleanup.
+    - Done when:
+        1. No call path leaves merged listeners attached after completion.
+
+- [ ] E2: HTTP handler defensive catch/finally cleanup
+    - Description: Add defensive `.catch` and always-run cleanup for abortable session entries.
+    - Rationale: Low-risk correctness issue, but improves resilience and avoids leaked abort entries.
+    - Files:
+        1. `packages/transport-bridge/src/http.ts`
+    - Specific implementation instructions:
+        1. Add `.catch(...)` for each async route chain.
+        2. Move `removeAbortableSignal(session)` into `.finally(...)` for `call/read` handlers.
+        3. Keep current structured error response format.
+    - Done when:
+        1. Handler-level throws do not leak abortable signals.
+
+- [ ] E3: Immediate `/listen` subscription cleanup
+    - Description: Remove dead subscriptions on response close, not only on descriptor changes.
+    - Rationale: Prevent unbounded list growth under unstable network conditions.
+    - Files:
+        1. `packages/transport-bridge/src/http.ts`
+    - Specific implementation instructions:
+        1. Register `res.on('close', ...)` to remove entry immediately.
+        2. Keep existing descriptor-diff dispatch behavior.
+    - Done when:
+        1. Disconnecting clients do not accumulate stale subscription entries.
+
+---
+
+## Workstream F: Optional Protocol Hardening
+
+- [ ] F1: THP deadline enforcement at I/O level
+    - Description: Ensure deadline cannot be exceeded by a long in-flight attempt.
+    - Rationale: Pre-attempt deadline check is insufficient for long single operations.
+    - Files:
+        1. `packages/transport/src/thp/loop.ts`
+    - Specific implementation instructions:
+        1. Thread merged timeout/abort signal into each read/write attempt.
+        2. Abort in-flight attempt when deadline expires.
+    - Done when:
+        1. No attempt can run past configured deadline without failure.
+
+- [ ] F2: THP nonce/state race audit
+    - Description: Ensure no await-gap race around nonce checks and sync updates.
+    - Rationale: Prevent stale/non-atomic state updates.
+    - Files:
+        1. `packages/transport/src/thp/send.ts`
+        2. `packages/transport/src/thp/call.ts`
+    - Specific implementation instructions:
+        1. Audit check-update sections for await boundaries.
+        2. Refactor to atomic compare-and-update helper where needed.
+    - Done when:
+        1. Concurrent THP operations preserve valid nonce progression.
+
+- [ ] F3: Rust WebSocket concurrency cap
+    - Description: Bound spawned tasks per websocket connection.
+    - Rationale: Unbounded `tokio::spawn` per frame can lead to memory pressure/OOM.
+    - Files:
+        1. `packages/transport-bluetooth/src/server/connection_handler.rs`
+    - Specific implementation instructions:
+        1. Add semaphore or buffered stream processing with fixed concurrency.
+        2. Keep response ordering constraints explicit (document if unordered responses are acceptable).
+    - Done when:
+        1. Burst traffic does not create unbounded in-flight task growth.
+
+---
+
+## Workstream G: Legacy Bridge (trezord-go) Cleanup
+
+The old trezord-go bridge (a standalone Go binary running as a system service) is deprecated and replaced by the NodeJS transport-bridge. Remnants span transport compatibility code, dual-port infrastructure, desktop app switches, deprecation UI, and CI configs. Items are ordered bottom-up: infrastructure first, then transport, then UI.
+
+- [ ] G1: Remove old bridge binary LFS entries
+    - Description: Delete dead `.gitattributes` rules that track trezord binaries in LFS.
+    - Rationale: The directory `packages/suite-data/files/bin/bridge/` no longer exists. These are dead entries.
+    - Files:
+        1. `.gitattributes`
+    - Specific implementation instructions:
+        1. Remove the 3 LFS tracking lines for `packages/suite-data/files/bin/bridge/linux-*/trezord`, `mac-*/trezord`, `win-*/trezord.exe`.
+    - Done when:
+        1. No LFS rules reference bridge binaries.
+
+- [ ] G2: Remove `bridge-legacy` desktop switch
+    - Description: Remove the CLI flag that allows opting in to the old trezord-go bridge in suite-desktop.
+    - Rationale: There is no old bridge to opt in to anymore.
+    - Files:
+        1. `packages/suite-desktop-core/src/libs/process-switches.ts`
+        2. `docs/packages/suite-desktop/runtime-flags.md`
+        3. Any runtime code that reads the `bridge-legacy` switch value
+    - Specific implementation instructions:
+        1. Remove `'bridge-legacy'` from the switch type/definition.
+        2. Remove the `--bridge-legacy` row from runtime-flags docs.
+        3. Search for and remove any conditional code that branches on this switch.
+    - Done when:
+        1. `--bridge-legacy` flag has no effect and is not documented.
+
+- [ ] G4: Remove dual BridgeTransport instantiation
+    - Description: Stop creating two BridgeTransport instances (ports 21328 + 21325) in connect.
+    - Rationale: With the old bridge gone, only one transport instance targeting the primary port is needed. The compatibility port (21325) continues to exist in transport-bridge for now but does not require a second client.
+    - Files:
+        1. `packages/connect/src/device/TransportList.ts`
+        2. `packages/transport/src/transports/bridge.ts`
+    - Specific implementation instructions:
+        1. Remove the second `BridgeTransport` instance for port 21325.
+        2. Change `DEFAULT_PORT` in `bridge.ts` from 21325 to 21328.
+    - Done when:
+        1. Only one BridgeTransport instance is created, targeting port 21328.
+
+- [ ] G5: Remove legacy bridge protocol compatibility code
+    - Description: Remove `isOutdated`, `useProtocolMessages` toggle, and legacy hex-string protocol path.
+    - Rationale: The NodeJS bridge always supports protocol messages. The legacy code path is unreachable once old bridge support is removed.
+    - Files:
+        1. `packages/transport/src/transports/bridge.ts` (remove `isOutdated` flag, `useProtocolMessages` toggle, `getProtocol()` legacy fallback)
+        2. `packages/transport/src/utils/bridgeProtocolMessage.ts` (remove legacy hex-string parsing/creation)
+    - Specific implementation instructions:
+        1. Remove `if (!this.version.startsWith('3'))` outdated check and the `isOutdated` property.
+        2. Remove `useProtocolMessages` property; always assume protocol messages are supported.
+        3. In `getProtocol()`, remove the `if (!this.useProtocolMessages) return protocolBridge` fallback.
+        4. In `bridgeProtocolMessage.ts`, remove the "Legacy bridge results" parsing branch in `validateProtocolMessage()` and the raw-hex path in `createProtocolMessage()`.
+    - Done when:
+        1. No code path falls back to legacy protocol encoding.
+
+- [ ] G6: Remove legacy bridge guards in connect
+    - Description: Remove `isLegacyBridge()` and version-gated workarounds in connect.
+    - Rationale: These guards add delay and block features (THP) for an old bridge that no longer exists.
+    - Files:
+        1. `packages/connect/src/device/workflow/handshake.ts` (remove `isLegacyBridge()` and 501ms delay)
+        2. `packages/connect/src/device/Device.ts` (remove THP incompatibility guard for bridge < 3.0.0)
+    - Specific implementation instructions:
+        1. Remove the `isLegacyBridge()` function and its call site.
+        2. Remove the `resolveAfter(501)` delay that only applies to legacy bridge.
+        3. Remove the `!versionUtils.isNewerOrEqual(this.transport.version, '3.0.0')` THP guard.
+    - Done when:
+        1. No version-gated legacy bridge workarounds in connect.
+
+- [ ] G7: Remove bridge deprecation UI
+    - Description: Remove the deprecation modal, banner, route, translations, and URL constant.
+    - Rationale: Once the old bridge is no longer supported, there is nothing to deprecate or uninstall.
+    - Files:
+        1. `packages/suite/src/views/suite/bridge-deprecated/index.tsx`
+        2. `packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.tsx`
+        3. `suite/router-config/src/routeConfig.ts` (remove `suite-bridge-deprecated` route)
+        4. `suite/intl/src/messages.ts` and locale JSON files (remove `TR_STANDALONE_BRIDGE_DEPRECATED*` keys)
+        5. `packages/urls/src/urls.ts` (remove `UNINSTALL_BRIDGE_URL`)
+    - Specific implementation instructions:
+        1. Delete the bridge-deprecated view component.
+        2. Delete the `BridgeDeprecatedBanner` component and remove references from banner list.
+        3. Remove the `suite-bridge-deprecated` route entry.
+        4. Remove translation keys for standalone bridge deprecation from all locales.
+        5. Remove `UNINSTALL_BRIDGE_URL` constant.
+    - Done when:
+        1. No UI references the old standalone bridge.
+
+- [ ] G8: Update tests and CI to target port 21328 only
+    - Description: Remove references to port 21325 from tests, docker configs, and CI scripts.
+    - Rationale: Once the dual BridgeTransport is removed, tests should target only the primary port.
+    - Files:
+        1. `docker/docker-compose.transport-test-ci.yml`
+        2. `docker/docker-connect-test.sh`
+        3. `packages/transport-test/e2e/bridge/headers.test.ts`
+        4. Any other test files referencing port 21325
+    - Specific implementation instructions:
+        1. Replace port 21325 with 21328 in all test targets.
+        2. Remove any dual-port test assertions.
+    - Done when:
+        1. All tests target port 21328
+
+- [ ] G9: Clean up stale comments and references
+    - Description: Remove or update comments referencing trezord-go source code, old bridge behavior, and stale architectural notes.
+    - Rationale: Stale comments mislead future developers.
+    - Files:
+        1. `packages/transport/src/transports/bridge.ts` (GitHub URLs to trezord-go)
+        2. `packages/transport/src/errors.ts` (trezord-go source links)
+        3. `packages/suite/src/components/suite/PrerequisitesGuide/DeviceUnreadable.tsx` (stale comment about legacy bridge opt-in)
+        4. `packages/suite/src/views/settings/SettingsDebug/Transport.tsx` (description mentioning trezord-go)
+    - Specific implementation instructions:
+        1. Remove or replace GitHub links to `trezor/trezord-go`.
+        2. Update description strings to reference only the NodeJS bridge.
+        3. Remove stale comments about legacy bridge opt-in.
+    - Done when:
+        1. No code comments reference trezord-go as a current/supported option.
+
+- [ ] G10: Replace bridge REST API with WebSocket transport (future)
+    - Description: Replace the HTTP request/response bridge API with a persistent WebSocket connection on both ports.
+    - Rationale: The REST API requires long-polling for `/listen`, creates a new TCP connection per request, and maintains a separate protocol encoding layer. A WebSocket transport eliminates all of these issues. Port 21325 stays but serves WebSocket instead of REST.
+    - Files:
+        1. `packages/transport-bridge/src/http.ts` (replace REST handlers with WebSocket server)
+        2. `packages/transport/src/transports/bridge.ts` (replace HTTP client with WebSocket client)
+        3. Related test and CI infrastructure
+    - Specific implementation instructions:
+        1. Design WebSocket message protocol (multiplex acquire/release/call/listen over a single connection).
+        2. Implement server-side in transport-bridge, serving on both 21328 and 21325.
+        3. Implement client-side transport replacing BridgeTransport.
+        4. Drop REST API and all HTTP-specific code.
+    - Done when:
+        1. Bridge communication uses WebSocket exclusively on both ports.
+        2. Legacy REST API is gone.
+
+---
+
+## Suggested PR Sequence
+
+- [ ] PR1: A1 + A2 + A3 + B0 + tests from B3 (sessions correctness baseline + e2e fix)
+- [ ] PR2: A4 + A5 + C1 + cross-device concurrency tests (B3)
+- [ ] PR3: B1 + B2 + E2 + E3 (runtime hygiene)
+- [ ] PR4: D1 + D2 + D3 (USB stability)
+- [ ] PR5: D4 + D5 (BLE stability)
+- [ ] PR6: F1 + F2 + F3 (optional hardening)
+- [ ] PR7: G1 + G2 + G9 (trivial legacy cleanup — LFS, switch, comments)
+- [ ] PR8: G4 + G5 + G8 (single BridgeTransport + remove legacy protocol)
+- [ ] PR9: G6 + G7 (remove connect guards + deprecation UI)
+- [ ] PR10 (future): G10 (WebSocket transport — replaces REST API on both ports)
+
+---
+
+## Verification Matrix
+
+For each completed item, run and record:
+
+- [ ] Unit tests for touched package(s)
+- [ ] `yarn test packages/transport-test`
+- [ ] Manual check: concurrent acquire same device
+- [ ] Manual check: concurrent operations on two different devices (if available)
+- [ ] Regression check: release/disconnect cleanup paths

--- a/packages/connect/setupJest.ts
+++ b/packages/connect/setupJest.ts
@@ -28,6 +28,7 @@ const createTransportApi = (override = {}) =>
         listen: () => {},
         dispose: () => {},
         type: 'usb',
+        runInIsolation: (_: unknown, fn: () => unknown) => fn(),
         ...override,
     }) as unknown as UsbApi;
 

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -161,24 +161,43 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         logger?.debug(`core: openDevice: result: ${JSON.stringify(openDeviceResult)}`);
 
         if (!openDeviceResult.success) {
+            // Release the lock without committing session (abort acquire).
+            await sessionsClient.acquireDone({ path: acquireInput.path, abort: true });
+
             return openDeviceResult;
         }
-        await sessionsClient.acquireDone({
+        const acquireDoneResult = await sessionsClient.acquireDone({
             path: acquireInput.path,
             sessionOwner: acquireInput.sessionOwner,
         });
+
+        if (!acquireDoneResult.success) {
+            // Device disappeared between openDevice and session commit.
+            // Close the device we just opened to avoid a leaked handle.
+            await api.closeDevice(acquireIntentResult.payload.path);
+
+            return error({ code: acquireDoneResult.error.code });
+        }
 
         return acquireIntentResult;
     };
 
     const release = async ({ session }: Omit<ReleaseInput, 'path'>) => {
-        await sessionsClient.releaseIntent({ session });
+        const releaseIntentResult = await sessionsClient.releaseIntent({ session });
+
+        if (!releaseIntentResult.success) {
+            return releaseIntentResult;
+        }
 
         const sessionsResult = await sessionsClient.getPathBySession({
             session,
         });
 
         if (!sessionsResult.success) {
+            // releaseIntent succeeded (lock held) but path lookup failed.
+            // Release the lock to avoid starvation.
+            await sessionsClient.releaseDone({ path: releaseIntentResult.payload.path });
+
             return sessionsResult;
         }
 
@@ -188,6 +207,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
             logger?.error(`core: release: api.closeDevice error: ${closeRes.error}`);
         }
 
+        // Always call releaseDone to release the lock, even if closeDevice failed.
         return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
     };
 

--- a/packages/transport-bridge/tests/core.test.ts
+++ b/packages/transport-bridge/tests/core.test.ts
@@ -1,0 +1,150 @@
+import { type AbstractApi } from '@trezor/transport/src/api/abstract';
+import * as ERRORS from '@trezor/transport/src/errors';
+import { PathInternal, PathPublic, Session } from '@trezor/transport/src/types';
+
+import { createCore } from '../src/core';
+
+const createFakeApi = (override: Partial<AbstractApi> = {}): AbstractApi =>
+    ({
+        chunkSize: 64,
+        enumerate: jest.fn(() =>
+            Promise.resolve({
+                success: true,
+                payload: [{ path: PathInternal('1'), type: 1, product: 0, vendor: 0 }],
+            }),
+        ),
+        openDevice: jest.fn(() => Promise.resolve({ success: true, payload: undefined })),
+        closeDevice: jest.fn(() => Promise.resolve({ success: true, payload: undefined })),
+        on: jest.fn(),
+        off: jest.fn(),
+        listen: jest.fn(),
+        dispose: jest.fn(),
+        ...override,
+    }) as unknown as AbstractApi;
+
+const abortSignal = () => new AbortController().signal;
+
+describe('core', () => {
+    describe('acquire failure paths', () => {
+        it('openDevice failure releases session lock via abort', async () => {
+            const api = createFakeApi({
+                openDevice: jest.fn(() =>
+                    Promise.resolve({
+                        success: false,
+                        error: { code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE },
+                    }),
+                ),
+            });
+            const core = createCore(api);
+            await core.enumerate({ signal: abortSignal() });
+
+            const first = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal: abortSignal(),
+                sessionOwner: 'test',
+            });
+            expect(first).toMatchObject({
+                success: false,
+                error: { code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE },
+            });
+
+            // Lock was released: a subsequent acquire proceeds (openDevice is called again).
+            const second = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal: abortSignal(),
+                sessionOwner: 'test',
+            });
+            expect(second.success).toBe(false);
+            expect(api.openDevice).toHaveBeenCalledTimes(2);
+
+            core.dispose();
+        });
+
+        it('acquireDone failure closes opened device', async () => {
+            const api = createFakeApi();
+            const core = createCore(api);
+            await core.enumerate({ signal: abortSignal() });
+
+            jest.spyOn(core.sessionsClient, 'acquireDone').mockResolvedValueOnce({
+                success: false,
+                error: { code: ERRORS.DEVICE_NOT_FOUND },
+                id: 0,
+            });
+
+            const result = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal: abortSignal(),
+                sessionOwner: 'test',
+            });
+            expect(result).toMatchObject({
+                success: false,
+                error: { code: ERRORS.DEVICE_NOT_FOUND },
+            });
+            expect(api.closeDevice).toHaveBeenCalledWith(PathInternal('1'));
+
+            core.dispose();
+        });
+    });
+
+    describe('release failure paths', () => {
+        it('releaseIntent failure returns early without closing device', async () => {
+            const api = createFakeApi();
+            const core = createCore(api);
+            await core.enumerate({ signal: abortSignal() });
+
+            // Unknown session → releaseIntent fails with SESSION_NOT_FOUND.
+            const result = await core.release({ session: Session('999') });
+            expect(result).toMatchObject({
+                success: false,
+                error: { code: ERRORS.SESSION_NOT_FOUND },
+            });
+            expect(api.closeDevice).not.toHaveBeenCalled();
+
+            core.dispose();
+        });
+
+        it('getPathBySession failure after releaseIntent still releases lock', async () => {
+            const api = createFakeApi();
+            const core = createCore(api);
+            await core.enumerate({ signal: abortSignal() });
+
+            const acquired = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal: abortSignal(),
+                sessionOwner: 'test',
+            });
+            expect(acquired.success).toBe(true);
+            if (!acquired.success) return;
+            const { session } = acquired.payload;
+
+            // Force getPathBySession to fail after releaseIntent succeeds.
+            jest.spyOn(core.sessionsClient, 'getPathBySession').mockResolvedValueOnce({
+                success: false,
+                error: { code: ERRORS.SESSION_NOT_FOUND },
+                id: 0,
+            });
+
+            const result = await core.release({ session });
+            expect(result).toMatchObject({
+                success: false,
+                error: { code: ERRORS.SESSION_NOT_FOUND },
+            });
+
+            // Lock was released: a new acquire can proceed. releaseDone cleared the session,
+            // so the previous session is null from the caller's perspective.
+            const reacquired = await core.acquire({
+                path: PathPublic('1'),
+                previous: 'null',
+                signal: abortSignal(),
+                sessionOwner: 'test',
+            });
+            expect(reacquired.success).toBe(true);
+
+            core.dispose();
+        });
+    });
+});

--- a/packages/transport/src/api/abstract.ts
+++ b/packages/transport/src/api/abstract.ts
@@ -189,7 +189,7 @@ export abstract class AbstractApi extends TypedEmitter<{
 
         try {
             // note: await is needed here
-            return await this.synchronize(fn);
+            return await this.synchronize(fn, path);
         } catch (err) {
             // this should never happen, incorrectly handled error on api level. fn should not throw.
             this.logger?.error('transport: abstract api: runInIsolation error', err);

--- a/packages/transport/src/sessions/background-browser.ts
+++ b/packages/transport/src/sessions/background-browser.ts
@@ -1,3 +1,4 @@
+import * as ERRORS from '../errors';
 import type { Descriptor } from '../types';
 import { type SessionsBackground } from './background';
 import {
@@ -5,6 +6,8 @@ import {
     type HandleMessageResponse,
     type SessionsBackgroundInterface,
 } from './types';
+
+const REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * creating BrowserSessionsBackground initiates sessions-background for browser based environments and provides:
@@ -26,22 +29,42 @@ export class BrowserSessionsBackground implements SessionsBackgroundInterface {
     handleMessage<M extends HandleMessageParams>(params: M): Promise<HandleMessageResponse<M>> {
         const { background } = this;
 
-        return new Promise(resolve => {
+        return new Promise<HandleMessageResponse<M>>(resolve => {
+            let settled = false;
+            const cleanup: Array<() => void> = [];
+
+            const timeoutResponse = {
+                success: false,
+                error: { code: ERRORS.SESSION_BACKGROUND_TIMEOUT },
+                id: params.id ?? -1,
+            } as HandleMessageResponse<M>;
+
+            const settle = (value: HandleMessageResponse<M>) => {
+                if (settled) return;
+                settled = true;
+                cleanup.forEach(fn => fn());
+                resolve(value);
+            };
+
             const onmessage = (message: MessageEvent<any>) => {
                 if (params.id === message.data.id) {
-                    resolve(message.data);
-                    background.port.removeEventListener('message', onmessage);
+                    settle(message.data);
                 }
             };
 
-            background.port.addEventListener('message', onmessage);
-
-            background.port.onmessageerror = message => {
-                // not sure under what circumstances this error occurs. let's observe it during testing
+            const onmessageerror = (message: MessageEvent<any>) => {
                 console.error('background-browser onmessageerror,', message);
-
-                background.port.removeEventListener('message', onmessage);
+                settle(timeoutResponse);
             };
+
+            background.port.addEventListener('message', onmessage);
+            background.port.addEventListener('messageerror', onmessageerror);
+            cleanup.push(() => background.port.removeEventListener('message', onmessage));
+            cleanup.push(() => background.port.removeEventListener('messageerror', onmessageerror));
+
+            const timeoutHandle = setTimeout(() => settle(timeoutResponse), REQUEST_TIMEOUT_MS);
+            cleanup.push(() => clearTimeout(timeoutHandle));
+
             background.port.postMessage(params);
         });
     }

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -236,10 +236,13 @@ export class SessionsBackground
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
-        // Commit session state before releasing lock so the next waiter sees the update.
-        const session = Session(`${this.lastSessionId}`);
-        this.descriptors[pathInternal].session = session;
-        this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        // When abort is set, just release the lock without modifying session.
+        let { session } = this.descriptors[pathInternal];
+        if (!payload.abort) {
+            session = Session(`${this.lastSessionId}`);
+            this.descriptors[pathInternal].session = session;
+            this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        }
 
         this.releaseActiveLock(pathInternal);
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -50,9 +50,11 @@ export class SessionsBackground
     private descriptors: DescriptorsDict = {};
     private pathInternalPathPublicMap: Record<PathInternal, PathPublic> = {};
 
-    // if lock is set, somebody is doing something with device. we have to wait
-    private locksQueue: { id: TimerId; dfd: Deferred<void> }[] = [];
-    private locksTimeoutQueue: TimerId[] = [];
+    // Lock queue for exclusive device access. Each entry has a unique token for ownership tracking.
+    private locksQueue: { token: number; dfd: Deferred<void> }[] = [];
+    private lockIdCounter = 0;
+    // Active lock token per device path, persisted between Intent and Done calls.
+    private activeLocks = new Map<PathInternal, number>();
     private lastSessionId = 0;
     private lastPathId = 0;
 
@@ -140,6 +142,8 @@ export class SessionsBackground
         );
 
         disconnectedDevices.forEach(d => {
+            // Release any active lock held for this device to avoid starvation.
+            this.releaseActiveLock(d);
             delete this.descriptors[d];
             delete this.pathInternalPathPublicMap[d];
         });
@@ -181,14 +185,32 @@ export class SessionsBackground
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
-        await this.waitInQueue();
+        // Snapshot session before waiting so the post-wait check compares against
+        // the value at intent time, not the (possibly mutated) current value.
+        const previousSession = previous.session;
 
-        // in case there are 2 simultaneous acquireIntents, one goes through, the other one waits and gets error here
-        if (previous.session !== this.descriptors[pathInternal]?.session) {
-            this.clearLock();
+        const lock = await this.waitInQueue();
+        if (!lock) {
+            return error({ code: ERRORS.ABORTED_BY_TIMEOUT });
+        }
+
+        // Device may have disconnected while we were waiting. Report that accurately
+        // instead of masking it as a wrong-previous error.
+        if (!this.descriptors[pathInternal]) {
+            this.clearLock(lock.token);
+
+            return error({ code: ERRORS.DEVICE_NOT_FOUND });
+        }
+
+        // In case there are 2 simultaneous acquireIntents, one goes through, the other waits and gets error here.
+        if (previousSession !== this.descriptors[pathInternal].session) {
+            this.clearLock(lock.token);
 
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
+
+        // Store lock token for this path until acquireDone.
+        this.activeLocks.set(pathInternal, lock.token);
 
         this.lastSessionId++;
         const session = Session(`${this.lastSessionId}`);
@@ -203,16 +225,25 @@ export class SessionsBackground
      * - assign client a new "session". this session will be used in all subsequent communication
      */
     private acquireDone(payload: AcquireDoneRequest) {
-        this.clearLock();
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal || !this.descriptors[pathInternal]) {
+            // Release lock on error to avoid starvation.
+            if (pathInternal) {
+                this.releaseActiveLock(pathInternal);
+            }
+
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
-        this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+
+        // Commit session state before releasing lock so the next waiter sees the update.
+        const session = Session(`${this.lastSessionId}`);
+        this.descriptors[pathInternal].session = session;
         this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
 
-        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+        this.releaseActiveLock(pathInternal);
+
+        return Promise.resolve(success({ session, descriptors: Object.values(this.descriptors) }));
     }
 
     private async releaseIntent(payload: ReleaseIntentRequest) {
@@ -223,18 +254,31 @@ export class SessionsBackground
         }
         const { path } = pathResult.payload;
 
-        await this.waitInQueue();
+        const lock = await this.waitInQueue();
+        if (!lock) {
+            return error({ code: ERRORS.ABORTED_BY_TIMEOUT });
+        }
+
+        // Store lock token for this path until releaseDone.
+        this.activeLocks.set(path, lock.token);
 
         return success({ path });
     }
 
     private releaseDone(payload: ReleaseDoneRequest) {
-        this.descriptors[payload.path].session = null;
-        this.descriptors[payload.path].sessionOwner = undefined;
+        try {
+            if (!this.descriptors[payload.path]) {
+                return error({ code: ERRORS.DEVICE_NOT_FOUND });
+            }
 
-        this.clearLock();
+            this.descriptors[payload.path].session = null;
+            this.descriptors[payload.path].sessionOwner = undefined;
 
-        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+            return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+        } finally {
+            // Release lock in finally to avoid starvation on error or disconnect.
+            this.releaseActiveLock(payload.path);
+        }
     }
 
     private getSessions() {
@@ -253,46 +297,71 @@ export class SessionsBackground
         return success({ path });
     }
 
-    private startLock() {
-        // todo: create a deferred with built-in timeout functionality (util)
-        const dfd = createDeferred();
+    private startLock(): number {
+        this.lockIdCounter++;
+        const dfd = createDeferred<void>();
+        this.locksQueue.push({ token: this.lockIdCounter, dfd });
 
-        // to ensure that communication with device will not get stuck forever,
-        // lock times out:
-        // - if cleared by client (enumerateDone)
-        // - after n second automatically
-        const timeout = setTimeout(() => {
-            dfd.resolve(undefined);
-        }, lockDuration);
-
-        this.locksQueue.push({ id: timeout, dfd });
-        this.locksTimeoutQueue.push(timeout);
-
-        return this.locksQueue.length - 1;
+        return this.lockIdCounter;
     }
 
-    private clearLock() {
-        const lock = this.locksQueue[0];
-        if (lock) {
-            this.locksQueue[0].dfd.resolve(undefined);
-            this.locksQueue.shift();
-            clearTimeout(this.locksTimeoutQueue[0]);
-            this.locksTimeoutQueue.shift();
+    private clearLock(token: number) {
+        const index = this.locksQueue.findIndex(l => l.token === token);
+        if (index !== -1) {
+            this.locksQueue[index].dfd.resolve(undefined);
+            this.locksQueue.splice(index, 1);
         }
     }
 
-    private async waitForUnlocked(myIndex: number) {
-        if (myIndex > 0) {
-            const beforeMe = this.locksQueue.slice(0, myIndex);
-            if (beforeMe.length) {
-                await Promise.all(beforeMe.map(lock => lock.dfd.promise));
+    private releaseActiveLock(pathInternal: PathInternal) {
+        const token = this.activeLocks.get(pathInternal);
+        if (token !== undefined) {
+            this.clearLock(token);
+            this.activeLocks.delete(pathInternal);
+        }
+    }
+
+    /**
+     * Wait in the lock queue. Returns a lock handle on success, or null if the wait timed out.
+     * Timeout is a safety net only; it never transfers ownership to another waiter.
+     */
+    private async waitInQueue(): Promise<{ token: number } | null> {
+        const token = this.startLock();
+        const deadline = Date.now() + lockDuration;
+
+        // Wait for predecessors before proceeding. Re-check position after each
+        // predecessor resolves in case an earlier waiter timed out and was removed.
+        while (true) {
+            const myIndex = this.locksQueue.findIndex(l => l.token === token);
+            if (myIndex <= 0) {
+                break;
+            }
+
+            const predecessor = this.locksQueue[myIndex - 1];
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+                this.clearLock(token);
+
+                return null;
+            }
+
+            let timeoutId: TimerId;
+            const timedOut = await Promise.race([
+                predecessor.dfd.promise.then(() => false),
+                new Promise<true>(resolve => {
+                    timeoutId = setTimeout(() => resolve(true), remaining);
+                }),
+            ]);
+            clearTimeout(timeoutId!);
+
+            if (timedOut) {
+                this.clearLock(token);
+
+                return null;
             }
         }
-    }
 
-    private async waitInQueue() {
-        const myIndex = this.startLock();
-        await this.waitForUnlocked(myIndex);
+        return { token };
     }
 
     private getInternal(pathPublic: PathPublic): PathInternal | undefined {
@@ -302,8 +371,10 @@ export class SessionsBackground
     }
 
     dispose() {
-        this.locksQueue.forEach(lock => clearTimeout(lock.id));
-        this.locksTimeoutQueue.forEach(timeout => clearTimeout(timeout));
+        // Resolve all pending lock deferreds to unblock waiters.
+        this.locksQueue.forEach(lock => lock.dfd.resolve(undefined));
+        this.locksQueue = [];
+        this.activeLocks.clear();
         this.descriptors = {};
         this.lastSessionId = 0;
         this.removeAllListeners();

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -31,7 +31,9 @@ export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
     { session: Session; path: PathInternal; releaseRequest?: Descriptor },
-    typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.SESSION_WRONG_PREVIOUS
+    | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.ABORTED_BY_TIMEOUT
 >;
 
 export type AcquireDoneRequest = {
@@ -52,16 +54,19 @@ export interface ReleaseIntentRequest {
 
 export type ReleaseIntentResponse = BackgroundResponseWithError<
     { path: PathInternal },
-    typeof ERRORS.SESSION_NOT_FOUND
+    typeof ERRORS.SESSION_NOT_FOUND | typeof ERRORS.ABORTED_BY_TIMEOUT
 >;
 
 export interface ReleaseDoneRequest {
     path: PathInternal;
 }
 
-export type ReleaseDoneResponse = BackgroundResponse<{
-    descriptors: Descriptor[];
-}>;
+export type ReleaseDoneResponse = BackgroundResponseWithError<
+    {
+        descriptors: Descriptor[];
+    },
+    typeof ERRORS.DEVICE_NOT_FOUND
+>;
 
 export type GetSessionsRequest = Record<string, never>;
 export type GetSessionsResponse = BackgroundResponse<{

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -39,11 +39,13 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 export type AcquireDoneRequest = {
     path: PathPublic;
     sessionOwner?: string;
+    abort?: boolean;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<
     {
-        session: Session;
+        // Null when acquireDone is invoked with abort: true and descriptor had no active session.
+        session: Session | null;
         descriptors: Descriptor[];
     },
     typeof ERRORS.DEVICE_NOT_FOUND

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -132,6 +132,9 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 );
 
                 if (!openDeviceResult.success) {
+                    // Release the lock without committing session (abort acquire).
+                    this.sessionsClient.acquireDone({ path, abort: true });
+
                     return openDeviceResult;
                 }
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -255,79 +255,87 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
                 const { path } = getPathBySessionResponse.payload;
 
-                const protocol = customProtocol || v1Protocol;
-                const bytes = buildMessage({
-                    messages: this.messages,
-                    name,
-                    data,
-                    protocol,
-                    thpState,
-                });
-                const [, chunkHeader] = protocol.getHeaders(bytes);
-                const chunks = createChunks(
-                    bytes,
-                    chunkHeader,
-                    this.api.nativeWriteChunking ? 0 : this.api.chunkSize,
+                return this.api.runInIsolation(
+                    { lock: { read: true, write: true }, path },
+                    async () => {
+                        const protocol = customProtocol || v1Protocol;
+                        const bytes = buildMessage({
+                            messages: this.messages,
+                            name,
+                            data,
+                            protocol,
+                            thpState,
+                        });
+                        const [, chunkHeader] = protocol.getHeaders(bytes);
+                        const chunks = createChunks(
+                            bytes,
+                            chunkHeader,
+                            this.api.nativeWriteChunking ? 0 : this.api.chunkSize,
+                        );
+                        let progress = 0;
+                        const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) => {
+                            if (chunks.length > 1) {
+                                progress++;
+                                this.emit(
+                                    TRANSPORT.SEND_MESSAGE_PROGRESS,
+                                    progress / chunks.length,
+                                );
+                            }
+
+                            return this.api.write(path, chunk, attemptSignal || signal);
+                        };
+
+                        const apiRead = (attemptSignal?: AbortSignal) =>
+                            this.api.read(path, attemptSignal || signal);
+
+                        if (protocol.name === 'v2') {
+                            const prevNonce = thpState?.sendNonce;
+                            const callResult = await callThpMessage({
+                                thpState,
+                                chunks,
+                                apiWrite,
+                                apiRead,
+                                signal,
+                                logger: this.logger,
+                            });
+                            if (!callResult.success) {
+                                handleError(callResult.error.code);
+
+                                return callResult;
+                            }
+
+                            // sync bit and nonce updated by Cancel
+                            if (prevNonce === thpState?.sendNonce) {
+                                thpState?.sync('send', name);
+                            }
+                            const message = parseThpMessage({
+                                messages: this.messages,
+                                decoded: callResult.payload,
+                                thpState,
+                            });
+                            thpState?.sync('recv', message.type);
+
+                            return success(message);
+                        }
+                        const sendResult = await sendChunks(chunks, apiWrite);
+
+                        if (!sendResult.success) {
+                            handleError(sendResult.error.code);
+
+                            return sendResult;
+                        }
+
+                        const readResult = await receiveAndParse(this.messages, apiRead, protocol);
+
+                        if (!readResult.success) {
+                            handleError(readResult.error.code);
+
+                            return readResult;
+                        }
+
+                        return readResult;
+                    },
                 );
-                let progress = 0;
-                const apiWrite = (chunk: Buffer, attemptSignal?: AbortSignal) => {
-                    if (chunks.length > 1) {
-                        progress++;
-                        this.emit(TRANSPORT.SEND_MESSAGE_PROGRESS, progress / chunks.length);
-                    }
-
-                    return this.api.write(path, chunk, attemptSignal || signal);
-                };
-
-                const apiRead = (attemptSignal?: AbortSignal) =>
-                    this.api.read(path, attemptSignal || signal);
-
-                if (protocol.name === 'v2') {
-                    const prevNonce = thpState?.sendNonce;
-                    const callResult = await callThpMessage({
-                        thpState,
-                        chunks,
-                        apiWrite,
-                        apiRead,
-                        signal,
-                        logger: this.logger,
-                    });
-                    if (!callResult.success) {
-                        handleError(callResult.error.code);
-
-                        return callResult;
-                    }
-
-                    // sync bit and nonce updated by Cancel
-                    if (prevNonce === thpState?.sendNonce) {
-                        thpState?.sync('send', name);
-                    }
-                    const message = parseThpMessage({
-                        messages: this.messages,
-                        decoded: callResult.payload,
-                        thpState,
-                    });
-                    thpState?.sync('recv', message.type);
-
-                    return success(message);
-                }
-                const sendResult = await sendChunks(chunks, apiWrite);
-
-                if (!sendResult.success) {
-                    handleError(sendResult.error.code);
-
-                    return sendResult;
-                }
-
-                const readResult = await receiveAndParse(this.messages, apiRead, protocol);
-
-                if (!readResult.success) {
-                    handleError(readResult.error.code);
-
-                    return readResult;
-                }
-
-                return readResult;
             },
             { signal, graceful: true, timeout },
         );
@@ -426,43 +434,48 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 }
                 const { path } = getPathBySessionResponse.payload;
 
-                const apiRead = (attemptSignal?: AbortSignal) =>
-                    this.api.read(path, attemptSignal || signal);
+                return this.api.runInIsolation(
+                    { lock: { read: true, write: false }, path },
+                    async () => {
+                        const apiRead = (attemptSignal?: AbortSignal) =>
+                            this.api.read(path, attemptSignal || signal);
 
-                const protocol = customProtocol || v1Protocol;
-                if (protocol.name === 'v2') {
-                    const decoded = await receiveThpMessage({
-                        thpState,
-                        skipAck: true,
-                        apiWrite: (chunk, attemptSignal) =>
-                            this.api.write(path, chunk, attemptSignal || signal),
-                        apiRead,
-                        signal,
-                        logger: this.logger,
-                    });
+                        const protocol = customProtocol || v1Protocol;
+                        if (protocol.name === 'v2') {
+                            const decoded = await receiveThpMessage({
+                                thpState,
+                                skipAck: true,
+                                apiWrite: (chunk, attemptSignal) =>
+                                    this.api.write(path, chunk, attemptSignal || signal),
+                                apiRead,
+                                signal,
+                                logger: this.logger,
+                            });
 
-                    if (!decoded.success) {
-                        return decoded;
-                    }
+                            if (!decoded.success) {
+                                return decoded;
+                            }
 
-                    const message = parseThpMessage({
-                        messages: this.messages,
-                        decoded: decoded.payload,
-                        thpState,
-                    });
+                            const message = parseThpMessage({
+                                messages: this.messages,
+                                decoded: decoded.payload,
+                                thpState,
+                            });
 
-                    return success(message);
-                }
+                            return success(message);
+                        }
 
-                const message = await receiveAndParse(this.messages, apiRead, protocol);
+                        const message = await receiveAndParse(this.messages, apiRead, protocol);
 
-                if (!message.success) {
-                    if (message.error.code === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
-                        this.enumerate();
-                    }
-                }
+                        if (!message.success) {
+                            if (message.error.code === ERRORS.DEVICE_DISCONNECTED_DURING_ACTION) {
+                                this.enumerate();
+                            }
+                        }
 
-                return message;
+                        return message;
+                    },
+                );
             },
             { signal, graceful: true, timeout },
         );

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -133,12 +133,25 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 if (!openDeviceResult.success) {
                     // Release the lock without committing session (abort acquire).
-                    this.sessionsClient.acquireDone({ path, abort: true });
+                    await this.sessionsClient.acquireDone({ path, abort: true });
 
                     return openDeviceResult;
                 }
 
-                this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
+                const acquireDoneResponse = await this.sessionsClient.acquireDone({
+                    path,
+                    sessionOwner: this.id,
+                });
+
+                if (!acquireDoneResponse.success) {
+                    // Device disappeared between openDevice and session commit.
+                    // Close the device we just opened to avoid a leaked handle.
+                    await this.api.closeDevice(acquireIntentResponse.payload.path, {
+                        channel: 'read',
+                    });
+
+                    return error({ code: acquireDoneResponse.error.code });
+                }
 
                 return success(acquireIntentResponse.payload.session);
             },

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -2,6 +2,7 @@ import * as messages from '@trezor/protobuf/messages.json';
 import { v1 as v1Protocol } from '@trezor/protocol';
 
 import { UsbApi } from '../src/api/usb';
+import * as ERRORS from '../src/errors';
 import { AbstractApiTransport } from '../src/transports/abstractApi';
 import { PathPublic, Session } from '../src/types';
 
@@ -330,6 +331,51 @@ describe('Usb', () => {
                 success: true,
                 payload: null,
             });
+        });
+
+        it('acquire - openDevice failure releases session lock', async () => {
+            const { transport, testUsbApi } = await initTest();
+            await transport.enumerate();
+
+            jest.spyOn(testUsbApi, 'openDevice').mockResolvedValueOnce({
+                success: false,
+                error: { code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE },
+            });
+
+            const failedAcquire = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(failedAcquire).toMatchObject({
+                success: false,
+                error: { code: ERRORS.INTERFACE_UNABLE_TO_OPEN_DEVICE },
+            });
+
+            // Lock was released via abort: a subsequent acquire on the same path succeeds.
+            const retryAcquire = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(retryAcquire).toMatchObject({ success: true });
+        });
+
+        it('acquire - acquireDone failure closes opened device', async () => {
+            const { transport, testUsbApi } = await initTest();
+            await transport.enumerate();
+
+            const closeDeviceSpy = jest.spyOn(testUsbApi, 'closeDevice');
+            jest.spyOn(transport['sessionsClient'], 'acquireDone').mockResolvedValueOnce({
+                success: false,
+                error: { code: ERRORS.DEVICE_NOT_FOUND },
+                id: 0,
+            });
+
+            const result = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(result).toMatchObject({
+                success: false,
+                error: { code: ERRORS.DEVICE_NOT_FOUND },
+            });
+            expect(closeDeviceSpy).toHaveBeenCalled();
         });
 
         it('call - with use abort', async () => {

--- a/packages/transport/tests/abstractUsb.test.ts
+++ b/packages/transport/tests/abstractUsb.test.ts
@@ -378,6 +378,148 @@ describe('Usb', () => {
             expect(closeDeviceSpy).toHaveBeenCalled();
         });
 
+        it('concurrent call on same session - second fails with OTHER_CALL_IN_PROGRESS', async () => {
+            let resolveTransferIn: (value: { data: Buffer }) => void = () => {};
+            const deferredTransferIn = new Promise<{ data: Buffer }>(resolve => {
+                resolveTransferIn = resolve;
+            });
+            const testUsbApi = new UsbApi({
+                usbInterface: {
+                    getDevices: () =>
+                        Promise.resolve([
+                            createMockedDevice({
+                                transferIn: () => deferredTransferIn,
+                            }),
+                        ]),
+                } as unknown as UsbApi['usbInterface'],
+            });
+            const transport = new TestUsbTransport({ api: testUsbApi, messages, id: 'test' });
+            await transport.init();
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(acquireRes.success).toEqual(true);
+            if (!acquireRes.success) return;
+
+            const [r1, r2] = await Promise.all([
+                transport.call({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquireRes.payload,
+                    protocol: v1Protocol,
+                }),
+                transport.call({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquireRes.payload,
+                    protocol: v1Protocol,
+                }),
+                // release the blocking read once both calls raced for the lock
+                Promise.resolve().then(() => {
+                    const buffer = Buffer.alloc(64);
+                    buffer.write(
+                        '3f23230002000000060a046d656f7700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+                        'hex',
+                    );
+                    resolveTransferIn({ data: buffer });
+                }),
+            ]);
+
+            expect([r1, r2]).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ success: true }),
+                    expect.objectContaining({
+                        success: false,
+                        error: { code: ERRORS.OTHER_CALL_IN_PROGRESS },
+                    }),
+                ]),
+            );
+        });
+
+        it('concurrent call on different paths - both succeed (per-path synchronize)', async () => {
+            const { transport } = await initTest();
+            await transport.enumerate();
+            const acquire1 = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            const acquire2 = await transport.acquire({
+                input: { path: PathPublic('2'), previous: null },
+            });
+            expect(acquire1.success).toEqual(true);
+            expect(acquire2.success).toEqual(true);
+            if (!acquire1.success || !acquire2.success) return;
+
+            const [r1, r2] = await Promise.all([
+                transport.call({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquire1.payload,
+                    protocol: v1Protocol,
+                }),
+                transport.call({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquire2.payload,
+                    protocol: v1Protocol,
+                }),
+            ]);
+
+            expect(r1).toMatchObject({ success: true });
+            expect(r2).toMatchObject({ success: true });
+        });
+
+        it('concurrent call and send on same session - both succeed (send skips lock)', async () => {
+            let resolveTransferIn: (value: { data: Buffer }) => void = () => {};
+            const deferredTransferIn = new Promise<{ data: Buffer }>(resolve => {
+                resolveTransferIn = resolve;
+            });
+            const testUsbApi = new UsbApi({
+                usbInterface: {
+                    getDevices: () =>
+                        Promise.resolve([
+                            createMockedDevice({
+                                transferIn: () => deferredTransferIn,
+                            }),
+                        ]),
+                } as unknown as UsbApi['usbInterface'],
+            });
+            const transport = new TestUsbTransport({ api: testUsbApi, messages, id: 'test' });
+            await transport.init();
+            await transport.enumerate();
+            const acquireRes = await transport.acquire({
+                input: { path: PathPublic('1'), previous: null },
+            });
+            expect(acquireRes.success).toEqual(true);
+            if (!acquireRes.success) return;
+
+            const [callRes, sendRes] = await Promise.all([
+                transport.call({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquireRes.payload,
+                    protocol: v1Protocol,
+                }),
+                transport.send({
+                    name: 'GetAddress',
+                    data: {},
+                    session: acquireRes.payload,
+                    protocol: v1Protocol,
+                }),
+                Promise.resolve().then(() => {
+                    const buffer = Buffer.alloc(64);
+                    buffer.write(
+                        '3f23230002000000060a046d656f7700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+                        'hex',
+                    );
+                    resolveTransferIn({ data: buffer });
+                }),
+            ]);
+
+            expect(callRes).toMatchObject({ success: true });
+            expect(sendRes).toMatchObject({ success: true });
+        });
+
         it('call - with use abort', async () => {
             const { transport } = await initTest();
             await transport.enumerate();

--- a/packages/transport/tests/background-browser.test.ts
+++ b/packages/transport/tests/background-browser.test.ts
@@ -1,0 +1,132 @@
+import * as ERRORS from '../src/errors';
+import { BrowserSessionsBackground } from '../src/sessions/background-browser';
+
+type Listener = (event: { data: unknown }) => void;
+
+class FakePort {
+    listeners: Map<string, Set<Listener>> = new Map();
+    postedMessages: unknown[] = [];
+
+    addEventListener(type: string, cb: Listener) {
+        if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+        this.listeners.get(type)!.add(cb);
+    }
+
+    removeEventListener(type: string, cb: Listener) {
+        this.listeners.get(type)?.delete(cb);
+    }
+
+    postMessage(msg: unknown) {
+        this.postedMessages.push(msg);
+    }
+
+    dispatch(type: string, data: unknown) {
+        this.listeners.get(type)?.forEach(cb => cb({ data }));
+    }
+
+    listenerCount(type: string) {
+        return this.listeners.get(type)?.size ?? 0;
+    }
+}
+
+class FakeSharedWorker {
+    port = new FakePort();
+}
+
+describe('BrowserSessionsBackground.handleMessage', () => {
+    let originalSharedWorker: unknown;
+
+    beforeAll(() => {
+        originalSharedWorker = (global as any).SharedWorker;
+        (global as any).SharedWorker = FakeSharedWorker;
+    });
+
+    afterAll(() => {
+        (global as any).SharedWorker = originalSharedWorker;
+    });
+
+    const makeBackground = () => {
+        const bg = new BrowserSessionsBackground('fake-url');
+        const { port } = (bg as any).background as { port: FakePort };
+
+        return { bg, port };
+    };
+
+    it('resolves with the matching response', async () => {
+        const { bg, port } = makeBackground();
+
+        const promise = bg.handleMessage({ type: 'handshake', id: 7 } as any);
+        port.dispatch('message', { id: 7, success: true, payload: undefined });
+
+        await expect(promise).resolves.toEqual({
+            id: 7,
+            success: true,
+            payload: undefined,
+        });
+    });
+
+    it('cleans up listeners once response is settled', async () => {
+        const { bg, port } = makeBackground();
+
+        const promise = bg.handleMessage({ type: 'handshake', id: 1 } as any);
+        expect(port.listenerCount('message')).toBe(1);
+        expect(port.listenerCount('messageerror')).toBe(1);
+
+        port.dispatch('message', { id: 1, success: true, payload: undefined });
+        await promise;
+
+        expect(port.listenerCount('message')).toBe(0);
+        expect(port.listenerCount('messageerror')).toBe(0);
+    });
+
+    it('settles with SESSION_BACKGROUND_TIMEOUT on messageerror', async () => {
+        const { bg, port } = makeBackground();
+
+        const promise = bg.handleMessage({ type: 'handshake', id: 2 } as any);
+        port.dispatch('messageerror', { broken: true });
+
+        await expect(promise).resolves.toEqual({
+            success: false,
+            error: { code: ERRORS.SESSION_BACKGROUND_TIMEOUT },
+            id: 2,
+        });
+    });
+
+    it('settles with SESSION_BACKGROUND_TIMEOUT when timeout elapses', async () => {
+        jest.useFakeTimers();
+        try {
+            const { bg } = makeBackground();
+
+            const promise = bg.handleMessage({ type: 'handshake', id: 3 } as any);
+            jest.advanceTimersByTime(10_000);
+
+            await expect(promise).resolves.toEqual({
+                success: false,
+                error: { code: ERRORS.SESSION_BACKGROUND_TIMEOUT },
+                id: 3,
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('isolates concurrent requests - each receives its own response', async () => {
+        const { bg, port } = makeBackground();
+
+        const p1 = bg.handleMessage({ type: 'handshake', id: 1 } as any);
+        const p2 = bg.handleMessage({ type: 'handshake', id: 2 } as any);
+
+        expect(port.listenerCount('message')).toBe(2);
+        expect(port.listenerCount('messageerror')).toBe(2);
+
+        port.dispatch('message', { id: 2, success: true, payload: 'second' });
+        port.dispatch('message', { id: 1, success: true, payload: 'first' });
+
+        const [r1, r2] = await Promise.all([p1, p2]);
+        expect(r1).toMatchObject({ id: 1, payload: 'first' });
+        expect(r2).toMatchObject({ id: 2, payload: 'second' });
+
+        expect(port.listenerCount('message')).toBe(0);
+        expect(port.listenerCount('messageerror')).toBe(0);
+    });
+});

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -51,6 +51,7 @@ describe('sessions', () => {
             success: true,
             id: 3,
             payload: {
+                session: '1',
                 descriptors: [
                     {
                         path: '1',
@@ -196,5 +197,148 @@ describe('sessions', () => {
                 ],
             },
         });
+    });
+
+    test('concurrent acquire on same path - one succeeds, one fails', async () => {
+        const client1 = new SessionsClient(background);
+        const client2 = new SessionsClient(background);
+        await client1.handshake();
+        await client2.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Both clients issue acquireIntent concurrently with the same previous session.
+        // client1 enters the queue first (synchronous execution order) and proceeds immediately.
+        // client2 enters second and waits for client1's lock.
+        const promise1 = client1.acquireIntent({ path: PathPublic('1'), previous: null });
+        const promise2 = client2.acquireIntent({ path: PathPublic('1'), previous: null });
+
+        // client1 succeeds immediately (first in queue).
+        const acquire1 = await promise1;
+        expect(acquire1).toMatchObject({ success: true, payload: { session: '1' } });
+
+        // Complete client1's acquire, which releases the lock and commits session.
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        // client2 wakes up and detects the session has changed.
+        const acquire2 = await promise2;
+        expect(acquire2).toMatchObject({
+            success: false,
+            error: { code: 'wrong previous session' },
+        });
+    });
+
+    test('release with missing descriptor returns error and releases lock', async () => {
+        const client1 = new SessionsClient(background);
+        await client1.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Acquire and release setup.
+        await client1.acquireIntent({ path: PathPublic('1'), previous: null });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        const release = await client1.releaseIntent({ session: Session('1') });
+        expect(release).toMatchObject({ success: true });
+
+        // Simulate device disconnect by re-enumerating without the device.
+        await client1.enumerateDone({ descriptors: [] });
+
+        // ReleaseDone on a path that no longer exists should return error.
+        const releaseDone = await client1.releaseDone({ path: PathInternal('1') });
+        expect(releaseDone).toMatchObject({
+            success: false,
+            error: { code: 'device not found' },
+        });
+
+        // The lock should still be released - a subsequent acquire on a re-enumerated device should work.
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('2'), type: 1, apiType: 'usb' }],
+        });
+
+        const acquire2 = await client1.acquireIntent({
+            path: PathPublic('2'),
+            previous: null,
+        });
+        expect(acquire2).toMatchObject({ success: true });
+        await client1.acquireDone({ path: PathPublic('2') });
+    });
+
+    test('device disconnect during acquire wait - returns device not found', async () => {
+        const client1 = new SessionsClient(background);
+        const client2 = new SessionsClient(background);
+        await client1.handshake();
+        await client2.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('abc'), type: 1, apiType: 'usb' }],
+        });
+
+        // Client 1 acquires and holds the lock (no acquireDone yet).
+        const acquire1 = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquire1).toMatchObject({ success: true });
+
+        // Client 2 enqueues behind client 1.
+        const promise2 = client2.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+
+        // Device disconnects: descriptor is removed and client 1's active lock is released,
+        // which wakes client 2. Client 2 must observe the missing descriptor.
+        await client1.enumerateDone({ descriptors: [] });
+
+        const acquire2 = await promise2;
+        expect(acquire2).toMatchObject({
+            success: false,
+            error: { code: 'device not found' },
+        });
+    });
+
+    test('clearLock only releases own lock, not another requester lock', async () => {
+        const client1 = new SessionsClient(background);
+        const client2 = new SessionsClient(background);
+        await client1.handshake();
+        await client2.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Client 1 acquires successfully.
+        const acquire1 = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquire1).toMatchObject({ success: true });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        // Client 2 tries to acquire with wrong previous - fails before queue.
+        const acquire2 = await client2.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquire2).toMatchObject({
+            success: false,
+            error: { code: 'wrong previous session' },
+        });
+
+        // Client 2 can still acquire with correct previous.
+        const acquire3 = await client2.acquireIntent({
+            path: PathPublic('1'),
+            previous: Session('1'),
+        });
+        expect(acquire3).toMatchObject({
+            success: true,
+            payload: { session: '2' },
+        });
+        await client2.acquireDone({ path: PathPublic('1') });
     });
 });

--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -53,27 +53,13 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
-            // Possible change of behaviour to this instead of rest of the test.
-            // ATM discussed with Varmuza
-            // await test.step('Reload inactive suite session to take Bridge session back', async () => {
-            //     await stealBridgeSession();
-            //     await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
-            //     await page.reload();
-            //     await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
-            //         timeout: 30_000,
-            //     });
-            // });
-
-            await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
+            await test.step('Reload inactive suite session to take Bridge session back', async () => {
+                await stealBridgeSession();
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
+                await page.reload();
+                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
                     timeout: 30_000,
                 });
-            });
-
-            await test.step('Take Bridge session back', async () => {
-                await dashboardPage.deviceSwitchingOpenButton.click();
-                await dashboardPage.solveIssuesButton.click();
-                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );


### PR DESCRIPTION
## Summary

Transport-layer cleanup: safer SessionsBackground lock system, no more permanent lock leaks when `openDevice`/`closeDevice` fails, per-path serialization, parity of the `call`/`receive` guard between bridge and local transport, and a fix for a stuck `handleMessage` in the browser sessions background.

## Commits

### `1840c5b5` refactor(transport): replace lock queue with token-based ownership tracking
**Problem:** the old system identified lock holders by index into `locksQueue` + timer ID. Concurrent `acquireIntent`/`releaseIntent` could race on ownership (a caller's `clearLock` could release someone else's lock), and `Promise.all` over all predecessors picked no deterministic winner.
**Fix:** each entry now carries a monotonic token, and `activeLocks` maps `path → token` to persist ownership between Intent and Done. `clearLock` requires the owner token — no one can release a foreign lock. `waitInQueue` waits on the immediate predecessor only and re-checks its position after every `resolve` (in case earlier waiters timed out and were removed). Timeout becomes a per-waiter safety net via `Promise.race`, never transferring ownership. Reports `DEVICE_NOT_FOUND` instead of `SESSION_WRONG_PREVIOUS` when the descriptor disappears; `releaseDone` holds the release in `try/finally`; `enumerateDone` clears locks for disconnected devices; `dispose()` resolves pending deferreds. Four new unit tests cover concurrent same-path acquire, missing descriptor on release, device disconnect during acquire wait, and lock-ownership isolation.

### `7e109fbf5` fix(transport): release session lock when openDevice fails in acquire
**Problem:** if `acquireIntent` succeeded but the subsequent `openDevice` failed, `acquireDone` was never called and the lock was held forever. The old timeout-based system auto-recovered; the new token-based one does not, causing deadlocks on future connects.
**Fix:** add an `abort: true` flag to `AcquireDoneRequest`. When `openDevice` fails, call `acquireDone({ path, abort: true })`, which releases the lock via `releaseActiveLock` without mutating session state. `AcquireDoneResponse.session` widened to `Session | null` so the abort path is type-safe.

### `37614f7db5` fix(transport-bridge): make acquire and release lock-safe on failure
**Problem:** same leak in bridge core — `openDevice`/`closeDevice` could fail between Intent and Done, leaving the lock permanently held.
**Fix:** `acquire` calls `acquireDone({ abort: true })` when `openDevice` fails, and on `acquireDone` failure closes the already-opened device and returns a structured error. `release` checks the `releaseIntent` result and returns early on failure; when `getPathBySession` fails after a successful `releaseIntent`, it calls `releaseDone` on the intent path so the lock is freed.

### `4f10f196a9` fix(transport): await acquireDone in abstractApi acquire
**Problem:** fire-and-forget `acquireDone` in `abstractApi.acquire` hid commit-path failures (e.g. device disconnected between `openDevice` and session commit).
**Fix:** both `acquireDone` calls (abort and commit paths) are now awaited. On commit failure the opened descriptor is closed and a structured error is returned.

### `6734aa259e` fix(e2e): restore session-steal step in multiple-sessions test
**Problem:** two trailing steps in the `multiple-sessions` e2e expected `TR_USE_HERE` without anything provoking it — they always timed out at 30s. Because of them the whole "Reload inactive suite session" block was commented out, so the session-steal scenario never ran.
**Fix:** uncomment the relevant step and drop the two broken trailing steps. Stealing the bridge session and reloading verifies Suite re-acquires automatically.

### `11e6350f0b` test(transport): add acquire/release failure-path coverage
**Problem:** the lock-safety fixes above were only covered at the `SessionsBackground` level; there were no tests at the transport / bridge-core layer.
**Fix:** in `abstractUsb.test.ts`, tests for `acquire`: `openDevice` failure frees the lock (a follow-up acquire succeeds), `acquireDone` failure closes the descriptor. In the new `transport-bridge/tests/core.test.ts`, the same for bridge core plus tests for `releaseIntent` failure (returns early without touching the api) and `getPathBySession` failure (still calls `releaseDone` on the intent path).

### `6df147ec1b` refactor(transport): per-path synchronize in runInIsolation
**Problem:** `runInIsolation` used the global `synchronize` queue, so calls on unrelated paths (different devices) serialized against each other unnecessarily.
**Fix:** `this.synchronize(fn, path)` instead of `this.synchronize(fn)` — per-path serialization, parallel devices no longer block each other.

### `3734c39f83` fix(transport): guard call/receive with runInIsolation in local transport
**Problem:** `AbstractApiTransport` let concurrent `call`/`receive` on the same session race into the USB layer. Bridge-server already applied this guard; the local (nodeusb/webusb) path did not — asymmetric behavior.
**Fix:** `call` wrapped in `runInIsolation({ lock: { read: true, write: true }, path }, …)`, `receive` in `runInIsolation({ lock: { read: true, write: false }, path }, …)`. A second concurrent call returns `OTHER_CALL_IN_PROGRESS`. `send` is intentionally left outside the lock so cancel messages can still reach a busy session — matching trezord-go `CallModeWrite`. The commit also adds a `runInIsolation` stub to `createTransportApi` in `connect/setupJest.ts` so `@trezor/connect` unit tests don't throw `this.api.runInIsolation is not a function`.

### `195e73ff56` test(transport): add concurrency coverage for call/receive/send
**Problem:** no regression coverage for the new guard.
**Fix:** three tests — a second concurrent `call` on the same session gets `OTHER_CALL_IN_PROGRESS`, `call` on different paths runs in parallel (verifies per-path synchronize), and `send` goes through while a `call` is in flight (cancel path).

### `f0db05902b` fix(transport): settle background-browser handleMessage on error and timeout
**Problem:** `onmessageerror` was set by direct assignment, so each new request overwrote the handler of any earlier in-flight call; on messageerror the listener was only removed and the Promise was left hanging. A dead worker = a permanently stuck transport.
**Fix:** switch to `addEventListener` per request, add a `settle` helper (guarded by a `settled` flag, cleanup runs exactly once), and a `REQUEST_TIMEOUT_MS = 10_000` safety net. Both messageerror and timeout resolve the Promise with `SESSION_BACKGROUND_TIMEOUT`, so callers never hang.

### `6bf5c6ebb1` test(transport): cover background-browser handleMessage settlement paths
**Problem:** regression coverage for the previous fix — using a `FakePort`/`FakeSharedWorker` mock.
**Fix:** five tests — happy-path round trip, messageerror settles with `SESSION_BACKGROUND_TIMEOUT`, timeout does the same, listener cleanup on every outcome, and isolation of two concurrent requests.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=transport-spring-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=transport-spring-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=transport-spring-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T11:45:49.035Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T07:45:27.382Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
