### PR TITLE
Fix/25623 earn worker

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
@@ -38,7 +38,7 @@ interface EthStakingDashboardProps {
 export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProps) => {
     const { account } = selectedAccount;
 
-    const accountKey = account?.key ?? '';
+    const accountKey = account.key;
     const { isBelowLaptop } = useLayoutSize();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
 import { BACKUP_REWARD_PAYOUT_DAYS } from '@suite-common/wallet-constants';
-import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
+import { getStakingDataForNetwork, secondsToDays } from '@suite-common/wallet-utils';
 import { Paragraph } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -35,7 +35,7 @@ export const PayoutCardNextRewards = ({
 
         if (!validatorWithdrawTime) return undefined;
 
-        return Math.round(validatorWithdrawTime / 60 / 60 / 24) + nextRewardPayout;
+        return secondsToDays(validatorWithdrawTime) + nextRewardPayout;
     }, [autocompoundBalance, daysToAddToPool, nextRewardPayout, validatorWithdrawTime]);
 
     return (

--- a/suite-common/earn-staking-api/README.md
+++ b/suite-common/earn-staking-api/README.md
@@ -1,9 +1,0 @@
-# `@trezor-suite/earn-staking-api`
-
-## Base URL by environment
-
-- `dev`: `http://dev-earn.suite.sldev.cz/staking/*` (used with [Suite dev web](https://dev.suite.sldev.cz/suite-web/develop/web))
-- `staging`: `TODO`
-- `prod`: `TODO` (Suite production web: [suite.trezor.io/web](https://suite.trezor.io/web/))
-
-Update the `EARN_API_BASE_URL` in `./src/constants/index.ts`.

--- a/suite-common/earn-staking-api/package.json
+++ b/suite-common/earn-staking-api/package.json
@@ -18,6 +18,7 @@
         "@suite-common/http-client": "workspace:*",
         "@suite-common/react-query": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
         "zod": "4.3.6"
     },
     "devDependencies": {

--- a/suite-common/earn-staking-api/src/api/schemas/index.ts
+++ b/suite-common/earn-staking-api/src/api/schemas/index.ts
@@ -18,48 +18,30 @@ export const stakingBatchResponse = zod.object({
         zod.union([
             zod.object({
                 stats: zod.object({
-                    apy: zod
-                        .number()
-                        .describe(
-                            'Pool APY as a percentage number (e.g. 3.08). Derived from Everstake pool APR decimal × 100, rounded down to 3 decimal places.',
-                        ),
-                    nextRewardPayout: zod
-                        .number()
-                        .describe(
-                            'Whole days until next reward payout; ceil from upstream seconds (86400).',
-                        ),
+                    apy: zod.number().describe('Pool APY as a percentage number (e.g. 3.08).'),
+                    nextRewardPayout: zod.number().describe('Seconds until next reward payout.'),
                 }),
                 validators: zod.object({
                     activationTime: zod
                         .number()
                         .optional()
-                        .describe(
-                            'Seconds — estimated delay before a validator becomes active (Everstake `validator_activation_time`).',
-                        ),
+                        .describe('Seconds — estimated delay before a validator becomes active.'),
                     exitTime: zod
                         .number()
                         .optional()
-                        .describe(
-                            'Seconds — estimated delay before a validator is exited (`validator_exit_time`).',
-                        ),
+                        .describe('Seconds — estimated delay before a validator is exited.'),
                     withdrawTime: zod
                         .number()
                         .optional()
-                        .describe(
-                            'Seconds — withdraw period from beacon chain (`validator_withdraw_time`).',
-                        ),
+                        .describe('Seconds — withdraw period from beacon chain.'),
                     addingDelay: zod
                         .number()
                         .optional()
-                        .describe(
-                            'Seconds — delay before validator is known at beacon chain (`validator_adding_delay`).',
-                        ),
+                        .describe('Seconds — delay before validator is known at beacon chain.'),
                     updatedAt: zod
                         .number()
                         .optional()
-                        .describe(
-                            'Unix timestamp (seconds) of last upstream refresh (`updated_at`).',
-                        ),
+                        .describe('Unix timestamp (seconds) of last upstream refresh.'),
                 }),
                 symbol: zod.enum(['eth']),
             }),
@@ -77,9 +59,7 @@ export const stakingBatchResponse = zod.object({
                         apy: zod
                             .number()
                             .describe('Validator APY percentage value from Everstake stats.'),
-                        saturation: zod
-                            .number()
-                            .describe('Saturation as percentage 0–100 (upstream decimal × 100).'),
+                        saturation: zod.number().describe('Saturation as percentage 0–100'),
                         id: zod.string().describe('Cardano validator address (pool id).'),
                     }),
                 ),
@@ -109,22 +89,12 @@ export const stakingStatsParams = zod.object({
 
 export const stakingStatsResponse = zod.union([
     zod.object({
-        apy: zod
-            .number()
-            .describe(
-                'Pool APY as a percentage number (e.g. 3.08). Derived from Everstake pool APR decimal × 100, rounded down to 3 decimal places.',
-            ),
-        nextRewardPayout: zod
-            .number()
-            .describe('Whole days until next reward payout; ceil from upstream seconds (86400).'),
+        apy: zod.number().describe('Pool APY as a percentage number (e.g. 3.08).'),
+        nextRewardPayout: zod.number().describe('Seconds until next reward payout.'),
         symbol: zod.enum(['eth']),
     }),
     zod.object({
-        apy: zod
-            .number()
-            .describe(
-                'Chain staking APR from Everstake dashboard as decimal fraction (same as Suite `blockchain.apr`).',
-            ),
+        apy: zod.number().describe('Chain staking APY from Everstake dashboard (e.g. 2.45).'),
         symbol: zod.enum(['sol']),
     }),
 ]);
@@ -140,29 +110,20 @@ export const stakingEthereumValidatorsQueueResponse = zod.object({
     activationTime: zod
         .number()
         .optional()
-        .describe(
-            'Seconds — estimated delay before a validator becomes active (Everstake `validator_activation_time`).',
-        ),
+        .describe('Seconds — estimated delay before a validator becomes active.'),
     exitTime: zod
         .number()
         .optional()
-        .describe(
-            'Seconds — estimated delay before a validator is exited (`validator_exit_time`).',
-        ),
-    withdrawTime: zod
-        .number()
-        .optional()
-        .describe('Seconds — withdraw period from beacon chain (`validator_withdraw_time`).'),
+        .describe('Seconds — estimated delay before a validator is exited.'),
+    withdrawTime: zod.number().optional().describe('Seconds — withdraw period from beacon chain.'),
     addingDelay: zod
         .number()
         .optional()
-        .describe(
-            'Seconds — delay before validator is known at beacon chain (`validator_adding_delay`).',
-        ),
+        .describe('Seconds — delay before validator is known at beacon chain.'),
     updatedAt: zod
         .number()
         .optional()
-        .describe('Unix timestamp (seconds) of last upstream refresh (`updated_at`).'),
+        .describe('Unix timestamp (seconds) of last upstream refresh.'),
 });
 
 /**
@@ -196,9 +157,7 @@ export const stakingCardanoPoolsResponse = zod.object({
     pools: zod.array(
         zod.object({
             apy: zod.number().describe('Validator APY percentage value from Everstake stats.'),
-            saturation: zod
-                .number()
-                .describe('Saturation as percentage 0–100 (upstream decimal × 100).'),
+            saturation: zod.number().describe('Saturation as percentage 0–100'),
             id: zod.string().describe('Cardano validator address (pool id).'),
         }),
     ),

--- a/suite-common/earn-staking-api/src/api/types/adaPoolsPoolsItem.ts
+++ b/suite-common/earn-staking-api/src/api/types/adaPoolsPoolsItem.ts
@@ -8,7 +8,7 @@
 export type AdaPoolsPoolsItem = {
     /** Validator APY percentage value from Everstake stats. */
     apy: number;
-    /** Saturation as percentage 0–100 (upstream decimal × 100). */
+    /** Saturation as percentage 0–100 */
     saturation: number;
     /** Cardano validator address (pool id). */
     id: string;

--- a/suite-common/earn-staking-api/src/api/types/ethOrSolStats.ts
+++ b/suite-common/earn-staking-api/src/api/types/ethOrSolStats.ts
@@ -7,14 +7,14 @@
 
 export type EthOrSolStats =
     | {
-          /** Pool APY as a percentage number (e.g. 3.08). Derived from Everstake pool APR decimal × 100, rounded down to 3 decimal places. */
+          /** Pool APY as a percentage number (e.g. 3.08). */
           apy: number;
-          /** Whole days until next reward payout; ceil from upstream seconds (86400). */
+          /** Seconds until next reward payout. */
           nextRewardPayout: number;
           symbol: 'eth';
       }
     | {
-          /** Chain staking APR from Everstake dashboard as decimal fraction (same as Suite `blockchain.apr`). */
+          /** Chain staking APY from Everstake dashboard (e.g. 2.45). */
           apy: number;
           symbol: 'sol';
       };

--- a/suite-common/earn-staking-api/src/api/types/ethValidatorsQueue.ts
+++ b/suite-common/earn-staking-api/src/api/types/ethValidatorsQueue.ts
@@ -6,14 +6,14 @@
  */
 
 export type EthValidatorsQueue = {
-    /** Seconds — estimated delay before a validator becomes active (Everstake `validator_activation_time`). */
+    /** Seconds — estimated delay before a validator becomes active. */
     activationTime?: number;
-    /** Seconds — estimated delay before a validator is exited (`validator_exit_time`). */
+    /** Seconds — estimated delay before a validator is exited. */
     exitTime?: number;
-    /** Seconds — withdraw period from beacon chain (`validator_withdraw_time`). */
+    /** Seconds — withdraw period from beacon chain. */
     withdrawTime?: number;
-    /** Seconds — delay before validator is known at beacon chain (`validator_adding_delay`). */
+    /** Seconds — delay before validator is known at beacon chain. */
     addingDelay?: number;
-    /** Unix timestamp (seconds) of last upstream refresh (`updated_at`). */
+    /** Unix timestamp (seconds) of last upstream refresh. */
     updatedAt?: number;
 };

--- a/suite-common/earn-staking-api/src/api/types/stakingBatchDataItem.ts
+++ b/suite-common/earn-staking-api/src/api/types/stakingBatchDataItem.ts
@@ -8,21 +8,21 @@
 export type StakingBatchDataItem =
     | {
           stats: {
-              /** Pool APY as a percentage number (e.g. 3.08). Derived from Everstake pool APR decimal × 100, rounded down to 3 decimal places. */
+              /** Pool APY as a percentage number (e.g. 3.08). */
               apy: number;
-              /** Whole days until next reward payout; ceil from upstream seconds (86400). */
+              /** Seconds until next reward payout. */
               nextRewardPayout: number;
           };
           validators: {
-              /** Seconds — estimated delay before a validator becomes active (Everstake `validator_activation_time`). */
+              /** Seconds — estimated delay before a validator becomes active. */
               activationTime?: number;
-              /** Seconds — estimated delay before a validator is exited (`validator_exit_time`). */
+              /** Seconds — estimated delay before a validator is exited. */
               exitTime?: number;
-              /** Seconds — withdraw period from beacon chain (`validator_withdraw_time`). */
+              /** Seconds — withdraw period from beacon chain. */
               withdrawTime?: number;
-              /** Seconds — delay before validator is known at beacon chain (`validator_adding_delay`). */
+              /** Seconds — delay before validator is known at beacon chain. */
               addingDelay?: number;
-              /** Unix timestamp (seconds) of last upstream refresh (`updated_at`). */
+              /** Unix timestamp (seconds) of last upstream refresh. */
               updatedAt?: number;
           };
           symbol: 'eth';
@@ -39,7 +39,7 @@ export type StakingBatchDataItem =
           pools: {
               /** Validator APY percentage value from Everstake stats. */
               apy: number;
-              /** Saturation as percentage 0–100 (upstream decimal × 100). */
+              /** Saturation as percentage 0–100 */
               saturation: number;
               /** Cardano validator address (pool id). */
               id: string;

--- a/suite-common/earn-staking-api/src/constants/index.ts
+++ b/suite-common/earn-staking-api/src/constants/index.ts
@@ -1,1 +1,5 @@
-export const EARN_API_BASE_URL = 'https://dev-earn.suite.sldev.cz/staking/v1';
+import { isCodesignBuild } from '@trezor/env-utils';
+
+export const EARN_API_BASE_URL = isCodesignBuild()
+    ? 'https://earn.trezor.io/staking/v1'
+    : 'https://dev-earn.suite.sldev.cz/staking/v1';

--- a/suite-common/earn-staking-api/tsconfig.json
+++ b/suite-common/earn-staking-api/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "../http-client" },
         { "path": "../react-query" },
-        { "path": "../wallet-types" }
+        { "path": "../wallet-types" },
+        { "path": "../../packages/env-utils" }
     ]
 }

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { selectBestCardanoPool } from '@suite-common/wallet-utils';
+import { secondsToDays, selectBestCardanoPool } from '@suite-common/wallet-utils';
 
 import type { VotingDelegationOption } from './stakeActions';
 import type { StakeRootState } from './stakeReducerTypes';
@@ -12,8 +12,11 @@ export const selectStakeData = (state: StakeRootState) => selectStake(state).dat
 export const selectCardanoPoolsInfo = (state: StakeRootState) =>
     selectStakeData(state).ada?.pools ?? [];
 
-export const selectEthNextRewardPayout = (state: StakeRootState) =>
-    selectStakeData(state).eth?.stats?.nextRewardPayout;
+export const selectEthNextRewardPayout = (state: StakeRootState) => {
+    const nextRewardPayout = selectStakeData(state).eth?.stats?.nextRewardPayout;
+
+    return nextRewardPayout ? secondsToDays(nextRewardPayout) : null;
+};
 
 export const selectEthValidatorsQueue = (state: StakeRootState) =>
     selectStakeData(state).eth?.validators;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10661,6 +10661,7 @@ __metadata:
     "@suite-common/http-client": "workspace:*"
     "@suite-common/react-query": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
     orval: "npm:8.5.0"
     prettier: "npm:^3.8.1"
     zod: "npm:4.3.6"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- The incorrect ETH APY value has been fixed in the Earn staking worker. (https://github.com/trezor/cloudflare-workers/pull/20/changes/14f503d24e7d9df224ce42dc36d6ecb27701eb23)
- In this PR, only the API types / schemas have been updated and some minor refactoring regarding the `nextRewardPayout` field.

## Related Issue

Resolve #25623

## Screenshots:
<img width="1222" height="440" alt="Snímek obrazovky 2026-04-13 v 9 59 18" src="https://github.com/user-attachments/assets/f1d8407a-d0da-47e2-a64b-b2e66f33c359" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T08:11:01.482Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T11:19:42.436Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->