### PR TITLE
refactor(suite): onboarding tooltip update for BTC-only devices

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1964,6 +1964,7 @@
   "TR_SETTINGS_DEVICE_BANNER_TITLE_REMEMBERED": "Connect & unlock your Trezor to change settings",
   "TR_SETTINGS_DEVICE_BANNER_TITLE_UNAVAILABLE": "Your Trezor is in an incorrect state",
   "TR_SETTINGS_SAME_AS_SYSTEM": "System",
+  "TR_SETTINGS_TOOLTIP_DESCRIPTION_BTC_ONLY": "<strong>Power user?</strong> Set up <tor>Tor</tor> in Settings first.",
   "TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP": "<strong>Power user?</strong> Set up <tor>Tor</tor> & <networks>networks</networks> in Settings first.",
   "TR_SETTINGS_TOOLTIP_DESCRIPTION_WEB": "<strong>Power user?</strong> Set up <networks>networks</networks> in Settings first.",
   "TR_SETUP_MY_TREZOR": "Set up my Trezor",

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/SettingsWithTooltip.tsx
@@ -1,8 +1,9 @@
-import { type FC, useState } from 'react';
+import { type FC } from 'react';
 
+import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor, goto, selectRouteName } from '@suite/router';
-import { selectIsDeviceInitialized } from '@suite-common/device';
+import { selectHasBitcoinOnlyFirmware, selectIsDeviceInitialized } from '@suite-common/device';
 import { Button, Column, Link, Paragraph, Text, Tooltip } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 
@@ -10,15 +11,36 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { NavigationItem, type NavigationItemProps } from './NavigationItem';
 
+const getDescriptionTranslationId = (hasBitcoinOnlyFirmware: boolean) => {
+    if (hasBitcoinOnlyFirmware) {
+        return 'TR_SETTINGS_TOOLTIP_DESCRIPTION_BTC_ONLY';
+    }
+
+    if (isDesktop()) {
+        return 'TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP';
+    }
+
+    return 'TR_SETTINGS_TOOLTIP_DESCRIPTION_WEB';
+};
+
 export const SettingsWithTooltip: FC<NavigationItemProps> = props => {
     const dispatch = useDispatch();
-    const [isDismissed, setIsDismissed] = useState(false);
 
+    const { settingsSidebarTooltipClosed } = useSelector(selectFlags);
     const routeName = useSelector(selectRouteName);
+    const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
     const isDeviceInitialized = useSelector(selectIsDeviceInitialized);
 
-    const isTooltipOpen = !isDismissed && routeName === 'suite-start' && !isDeviceInitialized;
-    const handleTooltipClose = () => setIsDismissed(true);
+    const shouldShowTooltip = !hasBitcoinOnlyFirmware || isDesktop();
+    const isTooltipOpen =
+        shouldShowTooltip &&
+        !settingsSidebarTooltipClosed &&
+        routeName === 'suite-start' &&
+        !isDeviceInitialized;
+    const handleTooltipClose = () =>
+        dispatch(setFlag({ key: 'settingsSidebarTooltipClosed', value: true }));
+
+    const descriptionTranslationId = getDescriptionTranslationId(hasBitcoinOnlyFirmware);
 
     return (
         <Tooltip
@@ -27,11 +49,7 @@ export const SettingsWithTooltip: FC<NavigationItemProps> = props => {
                 <Column padding={2} gap={6}>
                     <Paragraph textWrap="pretty">
                         <Translation
-                            id={
-                                isDesktop()
-                                    ? 'TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP'
-                                    : 'TR_SETTINGS_TOOLTIP_DESCRIPTION_WEB'
-                            }
+                            id={descriptionTranslationId}
                             values={{
                                 strong: chunks => (
                                     <Text typographyStyle="body-sm-strong">{chunks}</Text>

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -4,6 +4,7 @@ import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 
 export interface FlagsState {
     initialRun: boolean;
+    settingsSidebarTooltipClosed: boolean;
     taprootBannerClosed: boolean;
     firmwareTypeBannerClosed: boolean;
     discreetModeCompleted: boolean;
@@ -31,6 +32,7 @@ export type FlagsRootState = { flags: FlagsState };
 
 export const flagsInitialState: FlagsState = {
     initialRun: true,
+    settingsSidebarTooltipClosed: false,
     discreetModeCompleted: false,
     taprootBannerClosed: false,
     firmwareTypeBannerClosed: false,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3108,6 +3108,10 @@ export const messages = defineMessages({
         defaultMessage: 'System',
         id: 'TR_SETTINGS_SAME_AS_SYSTEM',
     },
+    TR_SETTINGS_TOOLTIP_DESCRIPTION_BTC_ONLY: {
+        defaultMessage: '<strong>Power user?</strong> Set up <tor>Tor</tor> in Settings first.',
+        id: 'TR_SETTINGS_TOOLTIP_DESCRIPTION_BTC_ONLY',
+    },
     TR_SETTINGS_TOOLTIP_DESCRIPTION_DESKTOP: {
         defaultMessage:
             '<strong>Power user?</strong> Set up <tor>Tor</tor> & <networks>networks</networks> in Settings first.',


### PR DESCRIPTION
## Notes for QA

Tooltip copy is updated for BTC-only devices, only Tor is mentioned on desktop. On web, the tooltip is not shown at all for btc-only devices.

## Screenshots:
<img width="292" height="355" alt="image" src="https://github.com/user-attachments/assets/c8d223d4-b70e-488e-b737-c96aba3899f1" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/power-user-activate-network-for-bitcoin-only-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/power-user-activate-network-for-bitcoin-only-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T09:00:50.386Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 10 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T08:59:36.230Z • 10 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->