### PR TITLE
Сlaim fee insufficient balance banner

### DIFF
--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -3,6 +3,12 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import {
+    asAmountSubunit,
+    getStakingLimitsByNetworkSymbol,
+    subunitsToUnits,
+} from '@suite-common/wallet-utils';
 import { AccountDetailsCard } from '@suite-native/accounts';
 import { Box, Button, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -18,6 +24,7 @@ import {
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
 } from '@suite-native/staking';
+import { BigNumber } from '@trezor/utils';
 
 export const ClaimReviewScreen = () => {
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.ClaimReview>>();
@@ -32,6 +39,18 @@ export const ClaimReviewScreen = () => {
     const claimableAmount = useSelector((state: NativeStakingRootState) =>
         selectClaimableAmountByAccountKey(state, accountKey),
     );
+    const availableBalance = useSelector(
+        (state: AccountsRootState) =>
+            selectAccountByKey(state, accountKey)?.availableBalance ?? '0',
+    );
+
+    const feeBuffer = getStakingLimitsByNetworkSymbol(symbol)?.MIN_BALANCE_FOR_FEE_BUFFER;
+    const isInsufficientFeeBalance =
+        !!feeBuffer &&
+        subunitsToUnits({
+            value: asAmountSubunit(new BigNumber(availableBalance)),
+            symbol,
+        }).lt(feeBuffer);
 
     const handleReviewAndSign = () => {
         navigation.navigate(RootStackRoutes.ClaimTransactionDataReview, { accountKey });
@@ -54,7 +73,7 @@ export const ClaimReviewScreen = () => {
             }
             footer={
                 <Box paddingHorizontal="sp16" paddingBottom="sp16">
-                    <Button onPress={handleReviewAndSign}>
+                    <Button onPress={handleReviewAndSign} isDisabled={isInsufficientFeeBalance}>
                         <Translation id="earn.claimReviewScreen.reviewAndSignButton" />
                     </Button>
                 </Box>
@@ -67,7 +86,19 @@ export const ClaimReviewScreen = () => {
                     titleLabel={<Translation id="earn.claimReviewScreen.amountLabel" />}
                     cryptoAmount={claimableAmount}
                 />
-                {canClaimInstantly && (
+                {isInsufficientFeeBalance && (
+                    <InlineAlertBox
+                        variant="critical"
+                        iconName="warningCircle"
+                        title={
+                            <Translation
+                                id="transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee"
+                                values={{ networkDisplaySymbol: displaySymbol }}
+                            />
+                        }
+                    />
+                )}
+                {canClaimInstantly && !isInsufficientFeeBalance && (
                     <InlineAlertBox
                         variant="success"
                         title={


### PR DESCRIPTION
## Description

Add a handler for insufficient balance for the claim transaction fee.

## Notes for QA

To verify this scenario, you need to have insufficient funds in your wallet to make an ETH claim 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26605

## Screenshots:
<img width="1288" height="2529" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-13 at 09 12 13" src="https://github.com/user-attachments/assets/66988d25-da89-4583-80db-c2debce3a545" />
