### PR TITLE
chore: unify dotenv dependency version

### DIFF
--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -16,7 +16,7 @@
         "@octokit/rest": "^21.1.1",
         "@trezor/trezor-user-env-link": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "dotenv": "^16.4.7",
+        "dotenv": "17.2.3",
         "express": "^5.2.1",
         "uuid": "^13.0.0",
         "ws": "^8.18.0"

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -13,7 +13,6 @@ import type { Requirement } from '../Requirement';
  * Entries SHOULD be removed once the migration or constraint is resolved.
  */
 export const ALLOWED_DRIFTS = new Set([
-    'dotenv', // migration from v16 to v17 in progress
     '@solana-program/stake', // 0.2.x vs 0.5.x used in different contexts (semver 0.x = breaking)
     '@hookform/resolvers', // migration from v3 to v5 in progress
     'jest-diff', // v29 and v30 coexist during migration

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -199,7 +199,7 @@
         "babel-plugin-transform-remove-console": "^6.9.4",
         "babel-preset-expo": "~55.0.8",
         "detox": "20.45.1",
-        "dotenv": "^17.2.1",
+        "dotenv": "17.2.3",
         "expo-atlas": "0.4.3",
         "expo-mcp": "^0.2.4",
         "jest": "29.7.0",

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -66,7 +66,7 @@
         "@types/lodash": "^4.17.16",
         "@walletconnect/sign-client": "2.21.4",
         "@walletconnect/types": "2.21.4",
-        "dotenv": "^16.4.7",
+        "dotenv": "17.2.3",
         "fs-extra": "^11.3.1",
         "jest-diff": "^29.7.0",
         "lodash": "^4.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12045,7 +12045,7 @@ __metadata:
     browserify-zlib: "npm:^0.2.0"
     crypto-browserify: "npm:3.12.0"
     detox: "npm:20.45.1"
-    dotenv: "npm:^17.2.1"
+    dotenv: "npm:17.2.3"
     event-target-shim: "npm:6.0.2"
     expo: "npm:~55.0.3"
     expo-atlas: "npm:0.4.3"
@@ -15704,7 +15704,7 @@ __metadata:
     "@trezor/node-utils": "workspace:*"
     "@trezor/trezor-user-env-link": "workspace:*"
     "@trezor/utils": "workspace:*"
-    dotenv: "npm:^16.4.7"
+    dotenv: "npm:17.2.3"
     express: "npm:^5.2.1"
     tsx: "npm:^4.21.0"
     uuid: "npm:^13.0.0"
@@ -16178,7 +16178,7 @@ __metadata:
     "@types/lodash": "npm:^4.17.16"
     "@walletconnect/sign-client": "npm:2.21.4"
     "@walletconnect/types": "npm:2.21.4"
-    dotenv: "npm:^16.4.7"
+    dotenv: "npm:17.2.3"
     fs-extra: "npm:^11.3.1"
     jest-diff: "npm:^29.7.0"
     lodash: "npm:^4.18.1"
@@ -24431,14 +24431,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:17.2.3, dotenv@npm:^17.2.1, dotenv@npm:^17.2.3":
+"dotenv@npm:17.2.3, dotenv@npm:^17.2.3":
   version: 17.2.3
   resolution: "dotenv@npm:17.2.3"
   checksum: 10/f8b78626ebfff6e44420f634773375c9651808b3e1a33df6d4cc19120968eea53e100f59f04ec35f2a20b2beb334b6aba4f24040b2f8ad61773f158ac042a636
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.3.1, dotenv@npm:^16.4.4, dotenv@npm:^16.4.5, dotenv@npm:^16.4.7":
+"dotenv@npm:^16.3.1, dotenv@npm:^16.4.4, dotenv@npm:^16.4.5":
   version: 16.6.1
   resolution: "dotenv@npm:16.6.1"
   checksum: 10/1d1897144344447ffe62aa1a6d664f4cd2e0784e0aff787eeeec1940ded32f8e4b5b506d665134fc87157baa086fce07ec6383970a2b6d2e7985beaed6a4cc14


### PR DESCRIPTION
part of #26412 effort

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=unify-dotenv-version&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=unify-dotenv-version&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=unify-dotenv-version&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T10:02:55.252Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T10:01:43.408Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->