### PR TITLE
feat(suite-native): change border radius of the device switcher

### DIFF
--- a/suite-native/device-manager/src/components/DeviceSwitch.tsx
+++ b/suite-native/device-manager/src/components/DeviceSwitch.tsx
@@ -23,7 +23,7 @@ const switchStyle = prepareNativeStyle<SwitchStyleProps>((utils, { isDeviceManag
     paddingHorizontal: utils.spacings.sp16,
     borderColor: utils.colors.borderElevation2,
     borderWidth: utils.borders.widths.small,
-    borderRadius: utils.borders.radii.round,
+    borderRadius: utils.borders.radii.r16,
     backgroundColor: utils.colors.backgroundSurfaceElevation1,
     extends: {
         condition: isDeviceManagerVisible,


### PR DESCRIPTION
Border radius of device switcher aligned with border radii of the new buttons.

## Related Issue

Resolve #26598

## Screenshots:
<img width="1179" height="609" alt="image" src="https://github.com/user-attachments/assets/ea5622bd-e9c3-48b9-a475-7ac4dfc91936" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/device-switcher-border-radius&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->