### PR TITLE
Use total stake pending and remaining entry period in staking

### DIFF
--- a/suite-common/earn-staking-api/src/index.ts
+++ b/suite-common/earn-staking-api/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api/schemas';
 export type * from './api/types';
+export * from './staking/hooks';
 export * from './staking/services';
 export type * from './staking/types';
 export * from './constants';

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -18,6 +18,7 @@
         "@shopify/flash-list": "2.3.0",
         "@suite-common/device": "workspace:*",
         "@suite-common/earn-api": "workspace:*",
+        "@suite-common/earn-staking-api": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",

--- a/suite-native/module-earn/src/components/StakingManagementPendingSection.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementPendingSection.tsx
@@ -6,7 +6,7 @@ import {
     type NativeStakingRootState,
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
-    selectPendingDepositedBalanceByAccountKey,
+    selectTotalStakePendingByAccountKey,
     selectUnstakingBalanceByAccountKey,
     selectUnstakingPeriodInDaysByAccountKey,
     useSelector,
@@ -31,9 +31,10 @@ export const StakingManagementPendingSection = ({
     const unstakingBalance = useSelector((state: NativeStakingRootState) =>
         selectUnstakingBalanceByAccountKey(state, accountKey),
     );
-    const pendingDepositedBalance = useSelector((state: NativeStakingRootState) =>
-        selectPendingDepositedBalanceByAccountKey(state, accountKey),
-    );
+    const totalStakePending =
+        useSelector((state: NativeStakingRootState) =>
+            selectTotalStakePendingByAccountKey(state, accountKey),
+        ) ?? '0';
     const unstakingPeriodInDays = useSelector((state: NativeStakingRootState) =>
         selectUnstakingPeriodInDaysByAccountKey(state, accountKey),
     );
@@ -55,7 +56,7 @@ export const StakingManagementPendingSection = ({
     const isClaim = isPositiveBalance(claimableAmount) && canClaim;
     const hasPendingUnstaking =
         isPositiveBalance(unstakingBalance) && !new BigNumber(unstakingBalance).eq(claimableAmount);
-    const hasPendingDeposit = isPositiveBalance(pendingDepositedBalance);
+    const hasPendingDeposit = isPositiveBalance(totalStakePending);
 
     const hasPendingActions = isClaim || hasPendingUnstaking || hasPendingDeposit;
 
@@ -87,7 +88,7 @@ export const StakingManagementPendingSection = ({
                         label={
                             <Translation id="earn.stakingManagementScreen.pendingStakesItem.label" />
                         }
-                        amount={pendingDepositedBalance}
+                        amount={totalStakePending}
                         onPress={openPendingStakeModal}
                     />
                 )}

--- a/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
@@ -1,6 +1,15 @@
+import { useEthereumValidatorsQueue } from '@suite-common/earn-staking-api';
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
-import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
+import { getDaysToAddToPool } from '@suite-common/staking';
+import { DAYS_TO_ADD_TO_POOL_DEFAULT } from '@suite-common/wallet-constants';
+import {
+    selectAccountByKey,
+    selectAccountNetworkSymbol,
+    selectAccountStakeTransactions,
+    useAccountsSelector,
+} from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { hasStakeInPendingDepositedState } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -15,8 +24,7 @@ import {
     type NativeStakingRootState,
     selectIsStakeConfirmingByAccountKey,
     selectIsStakePendingByAccountKey,
-    selectPendingDepositedBalanceByAccountKey,
-    selectUnstakingPeriodInDaysByAccountKey,
+    selectTotalStakePendingByAccountKey,
     useSelector,
 } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -57,12 +65,25 @@ export const StakingManagementPendingStakeModal = ({
     const isStakePending = useSelector((state: NativeStakingRootState) =>
         selectIsStakePendingByAccountKey(state, accountKey),
     );
-    const pendingDepositedBalance = useSelector((state: NativeStakingRootState) =>
-        selectPendingDepositedBalanceByAccountKey(state, accountKey),
+    const totalStakePending =
+        useSelector((state: NativeStakingRootState) =>
+            selectTotalStakePendingByAccountKey(state, accountKey),
+        ) ?? '0';
+    const account = useSelector((state: NativeStakingRootState) =>
+        selectAccountByKey(state, accountKey),
     );
-    const unstakingPeriodInDays = useSelector((state: NativeStakingRootState) =>
-        selectUnstakingPeriodInDaysByAccountKey(state, accountKey),
+    const stakeTxs = useSelector((state: NativeStakingRootState) =>
+        selectAccountStakeTransactions(state, accountKey),
     );
+    const lastTxBlockTime = stakeTxs[0]?.blockTime;
+    const timestamp =
+        account && hasStakeInPendingDepositedState(account) ? lastTxBlockTime : undefined;
+    const { data: validatorQueueData } = useEthereumValidatorsQueue({
+        account: account!,
+        timestamp,
+    });
+    const entryPeriodRemainingInDays =
+        getDaysToAddToPool(stakeTxs, validatorQueueData) ?? DAYS_TO_ADD_TO_POOL_DEFAULT;
 
     const currentStep: StakingDetailModalStep = (() => {
         if (isStakeConfirming) return StakingDetailModalStep.TransactionConfirmed;
@@ -74,7 +95,7 @@ export const StakingManagementPendingStakeModal = ({
     const inProgressLabel = (
         <Translation
             id="earn.stakingManagementScreen.pendingItemModal.stepEntryPeriod"
-            values={{ days: unstakingPeriodInDays }}
+            values={{ days: entryPeriodRemainingInDays }}
         />
     );
 
@@ -94,7 +115,7 @@ export const StakingManagementPendingStakeModal = ({
                 {!!symbol && (
                     <VStack style={applyStyle(amountsStyle)} spacing="sp2">
                         <CryptoAmountFormatter
-                            value={pendingDepositedBalance}
+                            value={totalStakePending}
                             symbol={symbol}
                             decimals={BASE_CRYPTO_MAX_DISPLAYED_DECIMALS}
                             color="textDefault"
@@ -105,7 +126,7 @@ export const StakingManagementPendingStakeModal = ({
                                 ≈
                             </Text>
                             <CryptoToFiatAmountFormatter
-                                value={pendingDepositedBalance}
+                                value={totalStakePending}
                                 symbol={symbol}
                                 color="textSubdued"
                                 variant="body-sm"

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -6,6 +6,9 @@
         { "path": "../../suite-common/device" },
         { "path": "../../suite-common/earn-api" },
         {
+            "path": "../../suite-common/earn-staking-api"
+        },
+        {
             "path": "../../suite-common/formatters"
         },
         {

--- a/suite-native/staking/src/ethereumStakingSelectors.ts
+++ b/suite-native/staking/src/ethereumStakingSelectors.ts
@@ -1,4 +1,4 @@
-import { getDaysToAddToPoolInitial } from '@suite-common/staking';
+import { getDaysToAddToPool, getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -119,15 +119,6 @@ export const selectEthereumUnstakingBalanceByAccountKey = (
     return stakingPool?.withdrawTotalAmount ?? '0';
 };
 
-export const selectEthereumPendingDepositedBalanceByAccountKey = (
-    state: AccountsRootState,
-    accountKey: AccountKey,
-) => {
-    const stakingPool = selectEthereumStakingPoolByAccountKey(state, accountKey);
-
-    return stakingPool?.pendingDepositedBalance ?? '0';
-};
-
 export const selectUnstakingPeriodInDaysBySymbol = (
     state: NativeStakingRootState,
     symbol: NetworkSymbol | undefined,
@@ -148,4 +139,14 @@ export const selectEntryPeriodInDaysBySymbol = (state: NativeStakingRootState) =
     }
 
     return getDaysToAddToPoolInitial(validatorsQueue);
+};
+
+export const selectEntryPeriodRemainingInDaysByAccountKey = (
+    state: NativeStakingRootState,
+    accountKey: AccountKey,
+) => {
+    const validatorsQueue = selectEthValidatorsQueue(state);
+    const stakeTxs = selectAccountStakeTransactions(state, accountKey);
+
+    return getDaysToAddToPool(stakeTxs, validatorsQueue);
 };

--- a/suite-native/staking/src/selectors.ts
+++ b/suite-native/staking/src/selectors.ts
@@ -22,12 +22,12 @@ import {
 } from './cardanoStakingSelectors';
 import {
     selectEntryPeriodInDaysBySymbol,
+    selectEntryPeriodRemainingInDaysByAccountKey,
     selectEthereumAccountHasStaking,
     selectEthereumCanClaimByAccountKey,
     selectEthereumClaimableAmountByAccountKey,
     selectEthereumIsStakeConfirmingByAccountKey,
     selectEthereumIsStakePendingByAccountKey,
-    selectEthereumPendingDepositedBalanceByAccountKey,
     selectEthereumRewardsBalanceByAccountKey,
     selectEthereumStakedBalanceByAccountKey,
     selectEthereumTotalStakePendingByAccountKey,
@@ -355,28 +355,8 @@ export const selectUnstakingPeriodInDaysByAccountKey = (
     return getUnstakingPeriodInDays(account.networkType, validatorsQueueData);
 };
 
-export const selectPendingDepositedBalanceByAccountKey = (
-    state: NativeStakingRootState,
-    accountKey: AccountKey,
-) => {
-    const account = selectAccountByKey(state, accountKey);
-    const symbol = account?.symbol;
-    if (!symbol || !doesCoinSupportStaking(symbol)) {
-        return '0';
-    }
-
-    switch (symbol) {
-        case 'eth':
-        case 'thod':
-        case 'tsep':
-            return selectEthereumPendingDepositedBalanceByAccountKey(state, accountKey);
-        case 'dsol':
-        case 'sol':
-            return selectSolanaTotalStakePendingByAccountKey(state, accountKey);
-        case 'ada':
-            return '0';
-        default:
-            return exhaustive(symbol);
-    }
+export {
+    selectEntryPeriodInDaysBySymbol,
+    selectEntryPeriodRemainingInDaysByAccountKey,
+    selectUnstakingPeriodInDaysBySymbol,
 };
-export { selectEntryPeriodInDaysBySymbol, selectUnstakingPeriodInDaysBySymbol };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13366,6 +13366,7 @@ __metadata:
     "@shopify/flash-list": "npm:2.3.0"
     "@suite-common/device": "workspace:*"
     "@suite-common/earn-api": "workspace:*"
+    "@suite-common/earn-staking-api": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"


### PR DESCRIPTION
## Description

Fixes pending-stake UI on native Earn: use total stake pending for amounts and remaining entry-period days (from stake txs + validator queue) instead of pool pending deposit and unstaking-period days. 

## Related Issue

Resolve #26548

## Screenshots:
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-13 at 11 54 26" src="https://github.com/user-attachments/assets/3cd735aa-d23c-4ac7-aae3-359403e47720" />
