### PR TITLE
chore: dependency uuid in favor of crypto.randomUUID

### DIFF
--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -18,7 +18,6 @@
         "@trezor/utils": "workspace:*",
         "dotenv": "^16.4.7",
         "express": "^5.2.1",
-        "uuid": "^13.0.0",
         "ws": "^8.18.0"
     },
     "devDependencies": {

--- a/packages/e2e-utils/src/mocks/google.ts
+++ b/packages/e2e-utils/src/mocks/google.ts
@@ -1,8 +1,6 @@
 /* eslint-disable no-console */
 
 import express, { type Express } from 'express';
-import { v4 as uuidv4 } from 'uuid';
-
 const BOUNDARY = '---------314159265358979323846';
 const port = 30001;
 
@@ -112,7 +110,7 @@ export class GoogleMock {
                 if (!file) throw new Error('no such file exists');
                 file.data = data;
             } else {
-                const file = new GoogleFile(uuidv4(), json.name, data);
+                const file = new GoogleFile(crypto.randomUUID(), json.name, data);
                 this.files[file.name] = file;
             }
         };
@@ -251,7 +249,7 @@ export class GoogleMock {
                 content.toString('hex'),
             );
         } else {
-            const file = new GoogleFile(uuidv4(), name, content.toString('hex'));
+            const file = new GoogleFile(crypto.randomUUID(), name, content.toString('hex'));
             this.files[file.name] = file;
         }
     }

--- a/packages/suite/jest.setup.js
+++ b/packages/suite/jest.setup.js
@@ -1,6 +1,12 @@
 require('@testing-library/jest-dom');
 const { TextEncoder, TextDecoder } = require('util');
 
+// Polyfill crypto.randomUUID for jsdom test environment
+if (!globalThis.crypto?.randomUUID) {
+    const { randomUUID } = require('crypto');
+    globalThis.crypto.randomUUID = randomUUID;
+}
+
 Object.assign(global, { TextDecoder, TextEncoder });
 
 // Fixes issues with Buffer instanceof Uint8Array checks relevant for Solana tests.

--- a/suite-common/message-system/package.json
+++ b/suite-common/message-system/package.json
@@ -34,8 +34,7 @@
         "json-schema-to-typescript": "^15.0.4",
         "react": "19.2.4",
         "react-redux": "9.2.0",
-        "semver": "^7.7.1",
-        "uuid": "^13.0.0"
+        "semver": "^7.7.1"
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",

--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -1,5 +1,4 @@
 import * as semver from 'semver';
-import { v4 as uuidv4 } from 'uuid';
 
 import type { CountryCode } from '@suite-common/geolocation';
 import {
@@ -443,7 +442,7 @@ const EXTRA_BY_CATEGORY = {
 
 export const getDefaultActionByCategory = (category: Category): Action => {
     const baseMessage = {
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         priority: 100,
         dismissible: true,
         variant: 'info' as const,
@@ -462,7 +461,7 @@ export const getDefaultActionByCategory = (category: Category): Action => {
 
 export const getDefaultExperiment = (): Experiments => ({
     experiment: {
-        id: uuidv4(),
+        id: crypto.randomUUID(),
         groups: [
             {
                 variant: 'A',

--- a/suite-common/trading/package.json
+++ b/suite-common/trading/package.json
@@ -36,8 +36,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.4",
-        "react-redux": "9.2.0",
-        "uuid": "^13.0.0"
+        "react-redux": "9.2.0"
     },
     "devDependencies": {
         "@suite-common/test-utils": "workspace:*",

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -10,7 +10,6 @@ import {
     type SellProviderInfo,
     type SellTradeFinalStatus,
 } from 'invity-api';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
     type Network,
@@ -272,14 +271,14 @@ export const addIdsToQuotes = <T extends TradingType>(
             : null;
 
         if (sellBuyQuote && !sellBuyQuote.paymentId) {
-            sellBuyQuote.paymentId = uuidv4();
+            sellBuyQuote.paymentId = crypto.randomUUID();
         }
 
         if (type === 'exchange' && !quote.quoteId) {
-            (quote as ExchangeTrade).quoteId = uuidv4();
+            (quote as ExchangeTrade).quoteId = crypto.randomUUID();
         }
 
-        quote.orderId = uuidv4();
+        quote.orderId = crypto.randomUUID();
     });
 
     return quotes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10868,7 +10868,6 @@ __metadata:
     react-redux: "npm:9.2.0"
     semver: "npm:^7.7.1"
     tsx: "npm:^4.21.0"
-    uuid: "npm:^13.0.0"
   languageName: unknown
   linkType: soft
 
@@ -11312,7 +11311,6 @@ __metadata:
     "@types/invity-api": "npm:^1.1.15"
     react: "npm:19.2.4"
     react-redux: "npm:9.2.0"
-    uuid: "npm:^13.0.0"
   languageName: unknown
   linkType: soft
 
@@ -15382,7 +15380,6 @@ __metadata:
     dotenv: "npm:^16.4.7"
     express: "npm:^5.2.1"
     tsx: "npm:^4.21.0"
-    uuid: "npm:^13.0.0"
     ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Get rid of `uuid` library just because we do not need it, we have it available in browser and nodejs https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID

## Notes for QA
Nothing to test, just removing a library we don't need.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/get-rid-of-uuid-in-favor-of-crypto.randomUUID&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/get-rid-of-uuid-in-favor-of-crypto.randomUUID&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/get-rid-of-uuid-in-favor-of-crypto.randomUUID&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T14:03:28.579Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T11:44:35.619Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->