### PR TITLE
fix(trading): unblock native trade flow for US without subdivision input

### DIFF
--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -3,6 +3,7 @@ import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
+import * as envUtils from '@trezor/env-utils';
 
 import { ALTERNATIVE_QUOTES } from '../../../__fixtures__/buyUtils';
 import { invityAPI } from '../../../invityAPI';
@@ -19,10 +20,19 @@ import { buyThunks } from '../index';
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const createMockQuotes = () =>
     [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES].map(quote => ({ ...quote }));
+const mockedIsNative = jest.spyOn(envUtils, 'isNative');
 
 describe('handleBuyRequestThunk', () => {
+    beforeEach(() => {
+        mockedIsNative.mockReturnValue(false);
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        mockedIsNative.mockRestore();
     });
 
     jest.mock('../../../invityAPI');
@@ -238,6 +248,54 @@ describe('handleBuyRequestThunk', () => {
         expect(state.buy.quotesRequest).toEqual({
             country: 'US',
             subdivision: 'CA',
+            cryptoStringAmount: '0',
+            fiatCurrency: 'USD',
+            fiatStringAmount: '1000',
+            receiveCurrency: 'bitcoin',
+            wantCrypto: false,
+        });
+        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(quotesResponse).toEqual([
+            expect.objectContaining(mockQuotes[1]),
+            expect.objectContaining(mockQuotes[6]),
+        ]);
+    });
+
+    it('should request quotes for US without subdivision on native', async () => {
+        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const mockQuotes = createMockQuotes();
+
+        mockedIsNative.mockReturnValue(true);
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        const quotesResponse = await store
+            .dispatch(
+                buyThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        countrySelect: {
+                            value: 'US' as const,
+                            codeAlpha3: 'USA',
+                            flag: '🇺🇸',
+                            name: 'United States of America',
+                            label: '🇺🇸 United States',
+                            shortLabel: '🇺🇸 USA',
+                        },
+                        countrySubdivisionSelect: undefined,
+                    },
+                }),
+            )
+            .unwrap();
+
+        const state = store.getState().wallet.trading;
+
+        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
+        expect(state.buy.amountLimits).toBeUndefined();
+        expect(state.buy.quotes?.length).toEqual(2);
+        expect(state.buy.quotesRequest).toEqual({
+            country: 'US',
             cryptoStringAmount: '0',
             fiatCurrency: 'USD',
             fiatStringAmount: '1000',

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -3,6 +3,7 @@ import { type BuyTrade, type BuyTradeQuoteRequest } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
+import { isNative } from '@trezor/env-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -70,7 +71,10 @@ const getQuoteRequestData = ({
     }
 
     // do not fetch quotes until subdivision is set when country has subdivisions
-    if (isCountrySubdivisionEmpty(request.country, formValues.countrySubdivisionSelect?.value)) {
+    if (
+        !isNative() && // todo: subdivisions are not yet implemented for mobile, should be removed in #24188
+        isCountrySubdivisionEmpty(request.country, formValues.countrySubdivisionSelect?.value)
+    ) {
         return undefined;
     }
 

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -5,6 +5,7 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
+import * as envUtils from '@trezor/env-utils';
 
 import { sellThunks } from '../';
 import { invityAPI } from '../../../invityAPI';
@@ -19,10 +20,19 @@ import {
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const mockedIsNative = jest.spyOn(envUtils, 'isNative');
 
 describe('handleSellRequestThunk', () => {
+    beforeEach(() => {
+        mockedIsNative.mockReturnValue(false);
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
+    });
+
+    afterAll(() => {
+        mockedIsNative.mockRestore();
     });
 
     jest.mock('../../../invityAPI');
@@ -303,6 +313,55 @@ describe('handleSellRequestThunk', () => {
             fiatCurrency: 'USD',
             country: 'US',
             subdivision: 'CA',
+            cryptoStringAmount: '0.0015',
+            fiatStringAmount: '50',
+            flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+        });
+        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(state.isLoading).toBe(false);
+    });
+
+    it('should request sell quotes for US without subdivision on native', async () => {
+        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
+            ...quote,
+            orderId: undefined,
+        }));
+
+        mockedIsNative.mockReturnValue(true);
+
+        invityAPI.getSellQuotes = () => Promise.resolve(mockQuotes);
+
+        const quotesResponse = await store
+            .dispatch(
+                sellThunks.handleRequestThunk({
+                    ...input,
+                    formValues: {
+                        ...input.formValues,
+                        countrySelect: {
+                            value: 'US' as const,
+                            codeAlpha3: 'USA',
+                            flag: '🇺🇸',
+                            name: 'United States of America',
+                            label: '🇺🇸 United States',
+                            shortLabel: '🇺🇸 USA',
+                        },
+                        countrySubdivisionSelect: undefined,
+                    },
+                }),
+            )
+            .unwrap();
+
+        const state = store.getState().wallet.trading;
+
+        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
+        expect(state.sell.quotes.length).toEqual(1);
+        expect(quotesResponse?.length).toEqual(1);
+        expect(state.sell.quotesRequest).toEqual({
+            amountInCrypto: true,
+            cryptoCurrency: 'bitcoin',
+            fiatCurrency: 'USD',
+            country: 'US',
             cryptoStringAmount: '0.0015',
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -3,6 +3,7 @@ import { type SellFiatTrade, type SellFiatTradeQuoteRequest } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
+import { isNative } from '@trezor/env-utils';
 
 import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -75,6 +76,7 @@ const getQuoteRequestData = ({
 
     // do not fetch quotes until subdivision is set when country has subdivisions
     if (
+        !isNative() && // todo: subdivisions are not yet implemented for mobile, should be removed in #24188
         request.country &&
         isCountryCode(request.country) &&
         hasCountrySubdivisions(request.country) &&


### PR DESCRIPTION
## Description

This is a hotfix for a recent [inclusion of subdivisions (states) in US trading flow](https://github.com/trezor/trezor-suite/issues/21974). As the input [has not yet been implemented on mobile](https://github.com/trezor/trezor-suite/issues/24188), these changes ensure quotes are loaded even if `subdivision` input is missing.

## Notes for QA

Already conducted testing locally, but regardless it should be enough to reproduce the steps as described in the issue for both `ANDROID` and `IOS`, and make sure it no longer gets stuck in the infinite loading.

## Related Issue

Resolve #26601

## Screenshots:

<img width="758" height="1418" alt="image" src="https://github.com/user-attachments/assets/8b86297d-6148-4e92-af11-569d7f3aa0b9" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native-us-trading&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native-us-trading&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-us-trading&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T11:43:07.409Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T11:42:09.465Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->