### PR TITLE
Add isCryptoPrimary to review output values for earn summaries

### DIFF
--- a/suite-native/module-earn/src/components/ClaimSummaryOutputItem.tsx
+++ b/suite-native/module-earn/src/components/ClaimSummaryOutputItem.tsx
@@ -33,11 +33,13 @@ export const ClaimSummaryOutputItem = ({
                         accountKey={accountKey}
                         value={claimableAmountInWei}
                         translationKey="transactionManagement.review.outputs.summary.amount"
+                        isCryptoPrimary
                     />
                     <ReviewOutputItemValues
                         accountKey={accountKey}
                         value={fee}
                         translationKey="transactionManagement.review.outputs.summary.maxFee"
+                        isCryptoPrimary
                     />
                 </VStack>
             </ReviewOutputCard>

--- a/suite-native/module-earn/src/components/EarnSummaryOutputItem.tsx
+++ b/suite-native/module-earn/src/components/EarnSummaryOutputItem.tsx
@@ -33,11 +33,13 @@ export const EarnSummaryOutputItem = ({
                         accountKey={accountKey}
                         value={amount}
                         translationKey="transactionManagement.review.outputs.summary.amount"
+                        isCryptoPrimary
                     />
                     <ReviewOutputItemValues
                         accountKey={accountKey}
                         value={fee}
                         translationKey="transactionManagement.review.outputs.summary.maxFee"
+                        isCryptoPrimary
                     />
                 </VStack>
             </ReviewOutputCard>

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.tsx
@@ -8,6 +8,7 @@ export type ReviewOutputItemValuesProps = {
     value: string;
     translationKey: TxKeyPath;
     tokenContract?: TokenAddress;
+    isCryptoPrimary?: boolean;
 };
 
 export const ReviewOutputItemValues = ({
@@ -15,35 +16,46 @@ export const ReviewOutputItemValues = ({
     value,
     translationKey,
     tokenContract,
-}: ReviewOutputItemValuesProps) => (
-    <HStack>
-        <Box flex={0.4} justifyContent="center">
-            <Text variant="body-sm">
-                <Translation id={translationKey} />
-            </Text>
-        </Box>
-        <VStack flex={0.6} alignItems="flex-end" spacing="sp4">
-            <CoinToFiatAmountFormatter
-                variant="body-sm"
-                color="textDefault"
-                value={value}
-                accountKey={accountKey}
-                tokenContract={tokenContract}
-                adjustsFontSizeToFit
-                numberOfLines={1}
-                isDiscreetText={false}
-            />
-            <CoinAmountFormatter
-                variant="body-sm"
-                color="textSubdued"
-                value={value}
-                accountKey={accountKey}
-                tokenContract={tokenContract}
-                isBalance={false}
-                adjustsFontSizeToFit
-                numberOfLines={1}
-                isDiscreetText={false}
-            />
-        </VStack>
-    </HStack>
-);
+    isCryptoPrimary = false,
+}: ReviewOutputItemValuesProps) => {
+    const fiatFormatter = (
+        <CoinToFiatAmountFormatter
+            variant="body-sm"
+            color={isCryptoPrimary ? 'textSubdued' : 'textDefault'}
+            value={value}
+            accountKey={accountKey}
+            tokenContract={tokenContract}
+            adjustsFontSizeToFit
+            numberOfLines={1}
+            isDiscreetText={false}
+        />
+    );
+
+    const cryptoFormatter = (
+        <CoinAmountFormatter
+            variant="body-sm"
+            color={isCryptoPrimary ? 'textDefault' : 'textSubdued'}
+            value={value}
+            accountKey={accountKey}
+            tokenContract={tokenContract}
+            isBalance={false}
+            adjustsFontSizeToFit
+            numberOfLines={1}
+            isDiscreetText={false}
+        />
+    );
+
+    return (
+        <HStack>
+            <Box flex={0.4} justifyContent="center">
+                <Text variant="body-sm">
+                    <Translation id={translationKey} />
+                </Text>
+            </Box>
+            <VStack flex={0.6} alignItems="flex-end" spacing="sp4">
+                {isCryptoPrimary ? cryptoFormatter : fiatFormatter}
+                {isCryptoPrimary ? fiatFormatter : cryptoFormatter}
+            </VStack>
+        </HStack>
+    );
+};


### PR DESCRIPTION
## Description

Add ability to show crypto first (primary styling) and fiat second via a new isCryptoPrimary flag on ReviewOutputItemValues

## Related Issue

Related to https://github.com/trezor/trezor-suite/issues/26707

## Screenshots:
<img width="1284" height="1367" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-12 at 23 13 28" src="https://github.com/user-attachments/assets/ce6a6c46-e28b-49bb-9aa9-7aed15945bd0" />
<img width="1290" height="1173" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-12 at 23 18 27" src="https://github.com/user-attachments/assets/b22dc103-88ee-4ed9-8f48-b5a77c3df577" />
<img width="1276" height="1285" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-12 at 23 28 15" src="https://github.com/user-attachments/assets/2cb8d050-0eef-4376-be35-2e097514c64c" />
