### PR TITLE
fix(suite): Not to show eth after update suite app

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -10,8 +10,13 @@ import {
 import { selectSelectedDevice } from '@suite-common/device';
 import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { type BackupType } from '@suite-common/suite-types';
-import { startDiscoveryThunk } from '@suite-common/wallet-core';
+import {
+    changeNetworks,
+    selectEnabledNetworks,
+    startDiscoveryThunk,
+} from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
+import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 
 import { ONBOARDING } from 'src/actions/onboarding/constants';
 import { stepCategories } from 'src/config/onboarding/steps';
@@ -122,6 +127,14 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
     dispatch(initialRunCompleted());
     dispatch(resetOnboarding());
     dispatch(closeModalApp(true));
+
+    // Enable eth by default for new users unless the device has bitcoin-only firmware.
+    if (!hasBitcoinOnlyFirmware(device)) {
+        const enabledNetworks = selectEnabledNetworks(getState());
+        if (!enabledNetworks.includes('eth')) {
+            dispatch(changeNetworks([...enabledNetworks, 'eth']));
+        }
+    }
 
     dispatch(startDiscoveryThunk({ device }));
 

--- a/packages/suite/src/actions/suite/__tests__/initAction.test.ts
+++ b/packages/suite/src/actions/suite/__tests__/initAction.test.ts
@@ -78,7 +78,6 @@ const EMPTY_ACTION = { type: 'foo' } as any;
 
 const getInitialState = (initialRun?: boolean) => {
     const initialFlagsState = flagsReducer(undefined, EMPTY_ACTION);
-    const walletState = walletReducers(undefined, EMPTY_ACTION);
 
     return {
         suite: suiteReducer(undefined, EMPTY_ACTION),
@@ -92,10 +91,7 @@ const getInitialState = (initialRun?: boolean) => {
         router: routerReducer(undefined, EMPTY_ACTION),
         analytics: analyticsReducer(undefined, EMPTY_ACTION),
         modal: modalReducer(undefined, EMPTY_ACTION),
-        wallet: {
-            ...walletState,
-            settings: { ...walletState.settings, enabledNetworks: ['btc'] },
-        },
+        wallet: walletReducers(undefined, EMPTY_ACTION),
         messageSystem: messageSystemReducer(undefined, EMPTY_ACTION),
         device: deviceReducer(undefined, EMPTY_ACTION),
         metadata: metadataReducer(undefined, EMPTY_ACTION),

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -34,7 +34,7 @@ const initialState: WalletSettingsState = {
     localCurrency: 'usd',
     discreetMode: false,
     // Suite Mobile did not have BTC enabled by default
-    enabledNetworks: isNative() ? [] : ['btc', 'eth'],
+    enabledNetworks: isNative() ? [] : ['btc'],
     hideSuspiciousTransactions: false,
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,

--- a/suite-common/wallet-core/tests/settings/walletSettingsActions.fixtures.ts
+++ b/suite-common/wallet-core/tests/settings/walletSettingsActions.fixtures.ts
@@ -3,11 +3,11 @@ import { changeCoinVisibility } from '../../src/settings/walletSettingsThunks';
 
 export const walletSettingsFixtures = [
     {
-        description: 'Btc and eth should be visible as a default if no initial state provided',
+        description: 'Btc should be visible as a default if no initial state provided',
         initialState: undefined,
         action: () => changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: true }),
         result: {
-            enabledNetworks: ['btc', 'eth', 'ltc'],
+            enabledNetworks: ['btc', 'ltc'],
         },
     },
     {

--- a/suite/e2e/tests/analytics/events.test.ts
+++ b/suite/e2e/tests/analytics/events.test.ts
@@ -38,7 +38,7 @@ test.describe(
                     >(events.suiteReadyEvent.name);
                     expect(suiteReadyEvent).toMatchObject({
                         language: 'en-US',
-                        enabledNetworks: 'btc,eth',
+                        enabledNetworks: 'btc',
                         customBackends: '',
                         localCurrency: 'usd',
                         bitcoinUnit: 'BTC',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

new users -> should have ETH
old users -> should not have ETH

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=not-show-eth-after-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=not-show-eth-after-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=not-show-eth-after-update&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T06:10:19.483Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T13:26:46.469Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->