### PR TITLE
test(connect-explorer): add test for console.errors

### DIFF
--- a/suite/e2e/tests/trezor-connect/connectExplorerConsoleErrors.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectExplorerConsoleErrors.test.ts
@@ -1,0 +1,80 @@
+import { type ConsoleMessage, expect, type Page, test } from '@playwright/test';
+
+/**
+ * Navigates key connect-explorer pages and asserts no console.error messages appear.
+ * Catches hydration mismatches, runtime errors, and other client-side issues.
+ */
+
+function getConnectExplorerUrl() {
+    const connectExplorerUrl = process.env.CONNECT_EXPLORER_URL;
+    if (connectExplorerUrl) {
+        return connectExplorerUrl;
+    }
+
+    const baseUrl = process.env.BASE_URL;
+    if (!baseUrl) {
+        return 'http://localhost:8088/';
+    }
+
+    const branchMatch = baseUrl.match(/suite-web\/(.*?)\/web\/$/);
+    if (!branchMatch) {
+        throw new Error('Could not extract branch from BASE_URL');
+    }
+
+    return getConnectExplorerUrlSldev(branchMatch[1]);
+}
+
+function getConnectExplorerUrlSldev(branch: string = 'develop') {
+    return `https://dev.suite.sldev.cz/connect/${branch}/`;
+}
+
+async function gotoConnectExplorerPage(page: Page, path: string) {
+    try {
+        await page.goto(`${getConnectExplorerUrl()}${path}`, {
+            waitUntil: 'load',
+        });
+    } catch {
+        await page.goto(`${getConnectExplorerUrlSldev()}${path}`, {
+            waitUntil: 'load',
+        });
+    }
+}
+
+const pagesToCheck = [
+    '',
+    'methods/bitcoin/getAddress/',
+    'readme/connect/',
+    'guides/webextension-implementation-tutorial/',
+    'details/deeplinking/',
+];
+
+// Known non-critical warnings that shouldn't fail the test.
+const ignoredErrors: string[] = [
+    // Next.js dev mode deprecation warnings for legacyBehavior (tracked separately).
+    'legacyBehavior',
+];
+
+function isIgnoredError(text: string): boolean {
+    return ignoredErrors.some(ignored => text.includes(ignored));
+}
+
+test.describe('Connect Explorer - no console errors', { tag: ['@webOnly', '@T3T1'] }, () => {
+    for (const path of pagesToCheck) {
+        test(`no console.error on /${path}`, async ({ page }) => {
+            const errors: string[] = [];
+
+            page.on('console', (msg: ConsoleMessage) => {
+                if (msg.type() === 'error' && !isIgnoredError(msg.text())) {
+                    errors.push(msg.text());
+                }
+            });
+
+            await gotoConnectExplorerPage(page, path);
+
+            // Give time for hydration and any deferred rendering.
+            await page.waitForTimeout(2000);
+
+            expect(errors, `Console errors on /${path}:\n${errors.join('\n')}`).toHaveLength(0);
+        });
+    }
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-explorer-hydratation-and-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-explorer-hydratation-and-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-16T11:16:45.233Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T13:28:43.242Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->