### PR TITLE
Fix/25623 earn worker

### DIFF
--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -1,6 +1,6 @@
 import { getStakingBatch } from '@suite-common/earn-staking-api';
 import { createThunk } from '@suite-common/redux-utils';
-import { isSupportedStakingNetworkSymbol, isTestnet } from '@suite-common/wallet-utils';
+import { PROD_STAKING_SYMBOLS } from '@suite-common/wallet-config';
 import { type TimerId } from '@trezor/type-utils';
 
 import { stakeDataSlice } from './stakeDataSlice';
@@ -25,13 +25,9 @@ export const initStakeDataThunk = createThunk(
     `${STAKE_MODULE}/initStakeDataThunk`,
     async (_, { getState, dispatch }) => {
         const enabledNetworks = selectEnabledNetworks(getState());
-        const enabledStakingNetworks = new Set(
-            enabledNetworks.filter(
-                symbol => isSupportedStakingNetworkSymbol(symbol) && !isTestnet(symbol),
-            ),
-        );
+        const isBtcOnly = enabledNetworks.length === 1 && enabledNetworks.includes('btc');
 
-        if (enabledStakingNetworks.size === 0) return;
+        if (isBtcOnly) return;
 
         // because fetch only happens every 5 minutes we fetch according all devices in case a device is changed within those 5 minutes
         const needsRefetch = stakingDataNeedsRefetch(getState());
@@ -43,7 +39,7 @@ export const initStakeDataThunk = createThunk(
             dispatch(stakeDataSlice.actions.fetchStakeDataRequest(undefined));
 
             const stakingData = await getStakingBatch({
-                params: { networks: Array.from(enabledStakingNetworks) },
+                params: { networks: PROD_STAKING_SYMBOLS },
             });
 
             // A part of the batch requests failed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Until we will get rid off the thunk itself and use Tanstack hooks instead so the data fetching is executed once is needed, not arbitrary during app load, we have to fetch staking data of all staking networks (not only the enabled ones).

## Related Issue

Resolve #25623

<img width="1254" height="694" alt="Snímek obrazovky 2026-04-13 v 15 41 13" src="https://github.com/user-attachments/assets/61ac8859-4ea3-4a30-89e8-4c4f492d6517" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/25623-earn-worker&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-13T13:51:51.996Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-13T13:50:33.885Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->