### PR TITLE
Wire FeeSelector into earn stake, unstake, and claim

### DIFF
--- a/suite-common/delegated-identity-key-types/tsconfig.json
+++ b/suite-common/delegated-identity-key-types/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-types" },
         { "path": "../../packages/type-utils" }

--- a/suite-common/delegated-identity-key/tsconfig.json
+++ b/suite-common/delegated-identity-key/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
             "path": "../delegated-identity-key-types"

--- a/suite-common/platform-encryption/tsconfig.json
+++ b/suite-common/platform-encryption/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../../packages/type-utils" }
     ]

--- a/suite-common/suite-rbf-labels-migrations-types/tsconfig.json
+++ b/suite-common/suite-rbf-labels-migrations-types/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../suite-sync-storage" },
         { "path": "../suite-sync-types" },

--- a/suite-common/suite-rbf-labels-migrations/tsconfig.json
+++ b/suite-common/suite-rbf-labels-migrations/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../dependency-injection" },
         {

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -20,6 +20,8 @@
         "@suite-common/earn-api": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/message-system": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/staking": "workspace:*",
         "@suite-common/validators": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-constants": "workspace:*",

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -20,6 +20,7 @@ import {
 
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { UnstakeOutputItem } from './UnstakeOutputItem';
+import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useHandleOnUnstakeTransactionReview } from '../hooks/useHandleOnUnstakeTransactionReview';
 
 const NUMBER_OF_STEPS = 2;
@@ -43,6 +44,8 @@ export const UnstakeTransactionDataReviewStepList = ({
     const summaryOutput = useSelector((state: TransactionReviewOutputsState) =>
         selectReviewSummaryOutput(state, 'unstake', accountKey),
     );
+
+    const selectedPrecomposed = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
     const accountSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -82,7 +85,7 @@ export const UnstakeTransactionDataReviewStepList = ({
                         <EarnSummaryOutputItem
                             accountKey={accountKey}
                             amount={amountInWei}
-                            fee={summaryOutput?.fee ?? '0'}
+                            fee={summaryOutput?.fee ?? selectedPrecomposed?.fee ?? '0'}
                             outputState={summaryOutput?.state}
                             onLayout={event => handleReadListItemHeight(event, 1)}
                         />

--- a/suite-native/module-earn/src/constants.ts
+++ b/suite-native/module-earn/src/constants.ts
@@ -1,5 +1,7 @@
 import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 
+export const EARN_MODULE_PREFIX = '@suite-native/module-earn';
+
 export const MOBILE_SUPPORTED_STAKING_NETWORKS: readonly NetworkSymbol[] = ['eth', 'thod'] as const;
 
 export const isMobileSupportedStakingNetwork = (symbol: NetworkSymbol): boolean =>

--- a/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
+++ b/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { isFulfilled } from '@reduxjs/toolkit';
+
+import { createThunk } from '@suite-common/redux-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    type FeesRootState,
+    composeSendFormTransactionFeeLevelsThunk,
+    formDraftActions,
+    selectAccountByKey,
+    selectConvertedNetworkFeeInfo,
+    selectDeepCopyOfFormDraft,
+    useFormDraft,
+} from '@suite-common/wallet-core';
+import {
+    type AccountKey,
+    type FormState,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
+import {
+    type UpdateSelectedFeeLevelThunkParams,
+    transactionManagementActions,
+} from '@suite-native/transaction-management';
+import { useDebounce } from '@trezor/react-utils';
+
+import { EARN_MODULE_PREFIX } from '../constants';
+import { type EarnFormDraftPrefix } from '../types';
+
+export const updateEarnSelectedFeeLevelThunk = createThunk(
+    `${EARN_MODULE_PREFIX}/updateSelectedFeeLevelThunk`,
+    (
+        {
+            feeLevelLabel,
+            feePerUnit,
+            feeLimit,
+            formDraftKey,
+            maxFeePerGas,
+            maxPriorityFeePerGas,
+        }: UpdateSelectedFeeLevelThunkParams,
+        { dispatch, getState },
+    ) => {
+        if (!formDraftKey) return;
+        const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey);
+        if (!formDraft) return;
+
+        formDraft.selectedFee = feeLevelLabel;
+        if (feePerUnit) {
+            formDraft.feePerUnit = feePerUnit;
+        }
+        if (feeLimit) {
+            formDraft.feeLimit = feeLimit;
+        }
+        if (maxFeePerGas) {
+            formDraft.maxFeePerGas = maxFeePerGas;
+        }
+        if (maxPriorityFeePerGas) {
+            formDraft.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        }
+
+        dispatch(formDraftActions.storeDraft({ key: formDraftKey, formDraft }));
+    },
+);
+
+type UseComposeEarnFeesParams = {
+    accountKey: AccountKey;
+    formState: FormState | undefined;
+    formDraftPrefix: EarnFormDraftPrefix;
+};
+
+// Triggers fee level composition for earn flows and stores the draft so `<FeeSelector>` can read it.
+export const useComposeEarnFees = ({
+    accountKey,
+    formState,
+    formDraftPrefix,
+}: UseComposeEarnFeesParams) => {
+    const dispatch = useDispatch();
+    const debounce = useDebounce();
+    const {
+        draft: formDraft,
+        formDraftKey,
+        saveDraft,
+    } = useFormDraft<FormState>(formDraftPrefix, accountKey);
+    const formDraftRef = useRef(formDraft);
+    formDraftRef.current = formDraft;
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const feeInfo = useSelector((state: FeesRootState) =>
+        selectConvertedNetworkFeeInfo(state, account?.symbol),
+    );
+
+    const composeFeeLevels = useCallback(async () => {
+        if (!formState || !account || !feeInfo) return;
+
+        const { selectedFee, feePerUnit, feeLimit, maxFeePerGas, maxPriorityFeePerGas } =
+            formDraftRef.current ?? {};
+
+        const mergedFormState = {
+            ...formState,
+            selectedFee: selectedFee ?? formState.selectedFee,
+            feePerUnit: feePerUnit ?? formState.feePerUnit,
+            feeLimit: feeLimit ?? formState.feeLimit,
+            maxFeePerGas: maxFeePerGas ?? formState.maxFeePerGas,
+            maxPriorityFeePerGas: maxPriorityFeePerGas ?? formState.maxPriorityFeePerGas,
+        };
+
+        const response = await dispatch(
+            composeSendFormTransactionFeeLevelsThunk({
+                formState: mergedFormState,
+                composeContext: { account, feeInfo, network: getNetwork(account.symbol) },
+            }),
+        );
+        if (!isFulfilled(response)) return;
+
+        dispatch(transactionManagementActions.storeFeeLevels({ feeLevels: response.payload }));
+
+        const normalLevel = response.payload.normal;
+        if (!mergedFormState.feePerUnit && isFinalPrecomposedTransaction(normalLevel)) {
+            mergedFormState.feePerUnit = normalLevel.feePerByte;
+        }
+
+        saveDraft(mergedFormState);
+    }, [dispatch, formState, account, feeInfo, saveDraft]);
+
+    useEffect(() => {
+        debounce(composeFeeLevels);
+    }, [debounce, composeFeeLevels]);
+
+    return { formDraft, formDraftKey, updateFeeLevelThunk: updateEarnSelectedFeeLevelThunk };
+};

--- a/suite-native/module-earn/src/hooks/useEarnForm.ts
+++ b/suite-native/module-earn/src/hooks/useEarnForm.ts
@@ -1,13 +1,18 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getEthereumStakingAddressByType } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
+import { STAKE_CALLDATA } from '@suite-native/staking';
 
 import { type EarnFormValues, earnFormValidationSchema } from '../earnFormSchema';
+import { buildEarnComposeFormState } from '../utils';
+import { useComposeEarnFees } from './useComposeEarnFees';
 
 export const useEarnForm = (accountKey: AccountKey) => {
     const { translate } = useTranslate();
@@ -32,8 +37,27 @@ export const useEarnForm = (accountKey: AccountKey) => {
     });
 
     const amountValue = useWatch({ control: form.control, name: 'amount' });
+    const {
+        formState: { isValid },
+    } = form;
+
+    const stakeFormState = useMemo(() => {
+        if (!account || !isValid || !amountValue) return undefined;
+
+        return buildEarnComposeFormState(
+            getEthereumStakingAddressByType(account.symbol, 'stake'),
+            amountValue,
+            STAKE_CALLDATA,
+        );
+    }, [account, isValid, amountValue]);
+
+    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+        accountKey,
+        formState: stakeFormState,
+        formDraftPrefix: 'stake',
+    });
 
     if (!account) return null;
 
-    return { form, amountValue, account };
+    return { form, amountValue, account, formDraft, formDraftKey, updateFeeLevelThunk };
 };

--- a/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
@@ -1,22 +1,21 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
+import { cancelSignSendFormTransactionThunk, formDraftActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
-import { useOverrideBackNavigation } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
     selectIsTransactionReviewInProgress,
     useShowReviewCancellationAlert,
 } from '@suite-native/transaction-management';
 
-type EarnReviewFormType = 'stake' | 'claim';
+import { type EarnFormDraftPrefix } from '../types';
 
 export const useEarnReviewBackNavigation = (
-    formType: EarnReviewFormType,
+    formType: EarnFormDraftPrefix,
     accountKey: AccountKey,
 ) => {
     const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
@@ -27,21 +26,42 @@ export const useEarnReviewBackNavigation = (
     const navigation = useNavigation();
     const showReviewCancellationAlert = useShowReviewCancellationAlert();
 
-    const onNavigateBack = useCallback(async () => {
-        if (isTransactionReviewInProgress) {
-            const { wasReviewCanceled } = await showReviewCancellationAlert();
-            if (!wasReviewCanceled) return;
-        }
-        dispatch(sendFormActions.discardTransaction());
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey(formType, '') }));
-        navigation.goBack();
+    useEffect(() => {
+        const cleanup = () => {
+            dispatch(cancelSignSendFormTransactionThunk());
+            dispatch(formDraftActions.removeDraft({ key: getFormDraftKey(formType, accountKey) }));
+        };
+
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK' && isTransactionReviewInProgress) {
+                e.preventDefault();
+                showReviewCancellationAlert().then(({ wasReviewCanceled }) => {
+                    if (wasReviewCanceled) {
+                        cleanup();
+                        unsubscribe();
+                        navigation.dispatch(e.data.action);
+                    }
+                });
+
+                return;
+            }
+
+            cleanup();
+        });
+
+        return unsubscribe;
     }, [
+        accountKey,
+        navigation,
         isTransactionReviewInProgress,
         showReviewCancellationAlert,
         dispatch,
-        navigation,
         formType,
     ]);
 
-    useOverrideBackNavigation({ onNavigateBack });
+    const navigateBack = useCallback(() => {
+        navigation.goBack();
+    }, [navigation]);
+
+    return { navigateBack };
 };

--- a/suite-native/module-earn/src/hooks/useEarnSelectedPrecomposedTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useEarnSelectedPrecomposedTransaction.ts
@@ -1,0 +1,29 @@
+import { useSelector } from 'react-redux';
+
+import { type FormDraftRootState, selectFormDraft } from '@suite-common/wallet-core';
+import {
+    type AccountKey,
+    type FormState,
+    type PrecomposedTransactionFinal,
+    isFinalPrecomposedTransaction,
+} from '@suite-common/wallet-types';
+import { getFormDraftKey } from '@suite-common/wallet-utils';
+import { type NativeSendRootState, selectFeeLevels } from '@suite-native/transaction-management';
+
+import { type EarnFormDraftPrefix } from '../types';
+
+export const useEarnSelectedPrecomposedTransaction = (
+    prefix: EarnFormDraftPrefix,
+    accountKey: AccountKey,
+): PrecomposedTransactionFinal | undefined => {
+    const formDraftKey = getFormDraftKey(prefix, accountKey);
+    const formDraft = useSelector((state: FormDraftRootState) =>
+        selectFormDraft<FormState>(state, formDraftKey),
+    );
+    const feeLevels = useSelector((state: NativeSendRootState) => selectFeeLevels(state));
+
+    const selectedLabel = formDraft?.selectedFee ?? 'normal';
+    const precomposed = feeLevels[selectedLabel];
+
+    return isFinalPrecomposedTransaction(precomposed) ? precomposed : undefined;
+};

--- a/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
@@ -1,25 +1,20 @@
-import { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
-import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import { signEthClaimTransactionNativeThunk } from '@suite-native/staking';
-import {
-    type TransactionReviewOutputsState,
-    selectIsTransactionReviewInProgress,
-    useShowReviewCancellationAlert,
-} from '@suite-native/transaction-management';
 
 import { handleEarnReviewError } from '../utils';
+import { useEarnReviewBackNavigation } from './useEarnReviewBackNavigation';
+import { useEarnSelectedPrecomposedTransaction } from './useEarnSelectedPrecomposedTransaction';
 import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
 import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
 
@@ -37,35 +32,21 @@ export const useHandleOnClaimTransactionReview = ({
     accountKey,
     onTransactionSubmitted,
 }: HandleOnClaimTransactionReviewProps) => {
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'claim', accountKey),
-    );
+    useEarnReviewBackNavigation('claim', accountKey);
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const showReviewCancellationAlert = useShowReviewCancellationAlert();
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
         useShowPushTransactionFailedDuringReviewAlert('claim');
-
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK' && isTransactionReviewInProgress) {
-                e.preventDefault();
-                showReviewCancellationAlert();
-
-                return;
-            }
-
-            dispatch(sendFormActions.discardTransaction());
-            dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('claim', '') }));
-        });
-
-        return unsubscribe;
-    }, [navigation, isTransactionReviewInProgress, showReviewCancellationAlert, dispatch]);
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
 
     const handleOnClaimTransactionReview = useCallback(async () => {
-        const response = await dispatch(signEthClaimTransactionNativeThunk({ accountKey }));
+        if (!precomposedTransaction) return;
+
+        const response = await dispatch(
+            signEthClaimTransactionNativeThunk({ accountKey, precomposedTransaction }),
+        );
 
         if (isFulfilled(response)) {
             onTransactionSubmitted(response.payload.txid);
@@ -89,6 +70,7 @@ export const useHandleOnClaimTransactionReview = ({
         dispatch,
         navigation,
         onTransactionSubmitted,
+        precomposedTransaction,
         showDeviceDisconnectedAlert,
         showPendingTransactionConflictAlert,
         showPushTransactionFailedAlert,

--- a/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnEarnTransactionReview.ts
@@ -14,6 +14,7 @@ import { signEthStakeTransactionNativeThunk } from '@suite-native/staking';
 
 import { handleEarnReviewError } from '../utils';
 import { useEarnReviewBackNavigation } from './useEarnReviewBackNavigation';
+import { useEarnSelectedPrecomposedTransaction } from './useEarnSelectedPrecomposedTransaction';
 import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
 import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
 
@@ -40,9 +41,14 @@ export const useHandleOnEarnTransactionReview = ({
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
         useShowPushTransactionFailedDuringReviewAlert('stake');
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
     const handleOnEarnTransactionReview = useCallback(async () => {
-        const response = await dispatch(signEthStakeTransactionNativeThunk({ accountKey, amount }));
+        if (!precomposedTransaction) return;
+
+        const response = await dispatch(
+            signEthStakeTransactionNativeThunk({ accountKey, amount, precomposedTransaction }),
+        );
 
         if (isFulfilled(response)) {
             onTransactionSubmitted(response.payload.txid);
@@ -67,6 +73,7 @@ export const useHandleOnEarnTransactionReview = ({
         dispatch,
         navigation,
         onTransactionSubmitted,
+        precomposedTransaction,
         showDeviceDisconnectedAlert,
         showPendingTransactionConflictAlert,
         showPushTransactionFailedAlert,

--- a/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
@@ -1,25 +1,20 @@
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
-import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     type StackNavigationProps,
-    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { signEthUnstakeTransactionNativeThunk } from '@suite-native/staking';
-import {
-    type TransactionReviewOutputsState,
-    selectIsTransactionReviewInProgress,
-    useShowReviewCancellationAlert,
-} from '@suite-native/transaction-management';
 
+import { handleEarnReviewError } from '../utils';
+import { useEarnReviewBackNavigation } from './useEarnReviewBackNavigation';
+import { useEarnSelectedPrecomposedTransaction } from './useEarnSelectedPrecomposedTransaction';
 import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
 import { useShowPushTransactionFailedDuringUnstakeReviewAlert } from './useShowPushTransactionFailedDuringUnstakeReviewAlert';
 
@@ -34,43 +29,29 @@ type HandleOnUnstakeTransactionReviewProps = {
     onTransactionSubmitted: (txid: string) => void;
 };
 
-const USER_CANCELLED_ERROR_CODES = [
-    'Failure_PinCancelled',
-    'Method_Cancel',
-    'Failure_ActionCancelled',
-] as const;
-
 export const useHandleOnUnstakeTransactionReview = ({
     accountKey,
     amount,
     onTransactionSubmitted,
 }: HandleOnUnstakeTransactionReviewProps) => {
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
-    );
+    useEarnReviewBackNavigation('unstake', accountKey);
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const showReviewCancellationAlert = useShowReviewCancellationAlert();
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
         useShowPushTransactionFailedDuringUnstakeReviewAlert();
-
-    const onNavigateBack = useCallback(async () => {
-        if (isTransactionReviewInProgress) {
-            const { wasReviewCanceled } = await showReviewCancellationAlert();
-            if (!wasReviewCanceled) return;
-        }
-        dispatch(sendFormActions.discardTransaction());
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('unstake', '') }));
-        navigation.goBack();
-    }, [isTransactionReviewInProgress, showReviewCancellationAlert, dispatch, navigation]);
-
-    useOverrideBackNavigation({ onNavigateBack });
+    const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
     const handleOnUnstakeTransactionReview = useCallback(async () => {
+        if (!precomposedTransaction) return;
+
         const response = await dispatch(
-            signEthUnstakeTransactionNativeThunk({ accountKey, amount }),
+            signEthUnstakeTransactionNativeThunk({
+                accountKey,
+                amount,
+                precomposedTransaction,
+            }),
         );
 
         if (isFulfilled(response)) {
@@ -83,33 +64,20 @@ export const useHandleOnUnstakeTransactionReview = ({
             return;
         }
 
-        if (response.payload?.error === 'push-transaction-pending-conflict') {
-            showPendingTransactionConflictAlert();
-
-            return;
-        }
-
-        if (response.payload?.error === 'push-transaction-failed') {
-            showPushTransactionFailedAlert();
-
-            return;
-        }
-
-        const errorCode = response.payload?.errorCode;
-
-        if (USER_CANCELLED_ERROR_CODES.some(code => code === errorCode)) {
-            navigation.pop();
-
-            return;
-        }
-
-        showDeviceDisconnectedAlert();
+        handleEarnReviewError({
+            payload: response.payload,
+            navigation,
+            showPushTransactionFailedAlert,
+            showPendingTransactionConflictAlert,
+            showDeviceDisconnectedAlert,
+        });
     }, [
         accountKey,
         amount,
         dispatch,
         navigation,
         onTransactionSubmitted,
+        precomposedTransaction,
         showDeviceDisconnectedAlert,
         showPendingTransactionConflictAlert,
         showPushTransactionFailedAlert,

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getEthereumStakingAddressByType } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -8,6 +10,8 @@ import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
     type NativeStakingRootState,
+    buildUnstakeCalldata,
+    ethToWei,
     selectStakedBalanceByAccountKey,
 } from '@suite-native/staking';
 import { BigNumber } from '@trezor/utils';
@@ -15,6 +19,8 @@ import { BigNumber } from '@trezor/utils';
 import { NETWORK_FEE_WARNING_MULTIPLIER } from '../constants';
 import { type EarnFormValues } from '../earnFormSchema';
 import { unstakeFormValidationSchema } from '../unstakeFormSchema';
+import { buildEarnComposeFormState } from '../utils';
+import { useComposeEarnFees } from './useComposeEarnFees';
 
 export const useUnstakeForm = (accountKey: AccountKey) => {
     const { translate } = useTranslate();
@@ -39,6 +45,25 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
     });
 
     const amountValue = useWatch({ control: form.control, name: 'amount' });
+    const {
+        formState: { isValid },
+    } = form;
+
+    const unstakeFormState = useMemo(() => {
+        if (!account || !isValid || !amountValue) return undefined;
+
+        return buildEarnComposeFormState(
+            getEthereumStakingAddressByType(account.symbol, 'unstake'),
+            '0',
+            buildUnstakeCalldata(ethToWei(amountValue)),
+        );
+    }, [account, isValid, amountValue]);
+
+    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+        accountKey,
+        formState: unstakeFormState,
+        formDraftPrefix: 'unstake',
+    });
 
     if (!account) return null;
 
@@ -52,5 +77,12 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
         new BigNumber(amountValue).gt(0) &&
         new BigNumber(amountValue).lt(networkFeeWarningThreshold);
 
-    return { form, amountValue, showNetworkFeeWarning };
+    return {
+        form,
+        amountValue,
+        showNetworkFeeWarning,
+        formDraft,
+        formDraftKey,
+        updateFeeLevelThunk,
+    };
 };

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
+import { getEthereumStakingAddressByType } from '@suite-common/staking';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import {
@@ -20,11 +22,16 @@ import {
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import {
+    CLAIM_CALLDATA,
     type NativeStakingRootState,
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
 } from '@suite-native/staking';
+import { FeeSelector } from '@suite-native/transaction-management';
 import { BigNumber } from '@trezor/utils';
+
+import { useComposeEarnFees } from '../hooks/useComposeEarnFees';
+import { buildEarnComposeFormState } from '../utils';
 
 export const ClaimReviewScreen = () => {
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.ClaimReview>>();
@@ -51,6 +58,22 @@ export const ClaimReviewScreen = () => {
             value: asAmountSubunit(new BigNumber(availableBalance)),
             symbol,
         }).lt(feeBuffer);
+
+    const claimFormState = useMemo(
+        () =>
+            buildEarnComposeFormState(
+                getEthereumStakingAddressByType(symbol, 'claim'),
+                '0',
+                CLAIM_CALLDATA,
+            ),
+        [symbol],
+    );
+
+    const { formDraft, formDraftKey, updateFeeLevelThunk } = useComposeEarnFees({
+        accountKey,
+        formState: claimFormState,
+        formDraftPrefix: 'claim',
+    });
 
     const handleReviewAndSign = () => {
         navigation.navigate(RootStackRoutes.ClaimTransactionDataReview, { accountKey });
@@ -109,6 +132,14 @@ export const ClaimReviewScreen = () => {
                         }
                     />
                 )}
+                <FeeSelector
+                    accountKey={accountKey}
+                    updateThunk={updateFeeLevelThunk}
+                    selectedFee={formDraft?.selectedFee ?? 'normal'}
+                    selectedFeePerUnit={formDraft?.feePerUnit}
+                    formDraft={formDraft}
+                    formDraftKey={formDraftKey}
+                />
             </VStack>
         </Screen>
     );

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -9,6 +9,7 @@ import {
     Screen,
     type StackNavigationProps,
 } from '@suite-native/navigation';
+import { FeeSelector } from '@suite-native/transaction-management';
 
 import { EarnFormScreenFooter } from '../components/EarnFormScreenFooter';
 import { EarnFormScreenHeader } from '../components/EarnFormScreenHeader';
@@ -27,7 +28,7 @@ export const EarnFormScreen = () => {
         return null;
     }
 
-    const { form, amountValue, account } = earnForm;
+    const { form, amountValue, account, formDraft, formDraftKey, updateFeeLevelThunk } = earnForm;
     const {
         formState: { isValid },
     } = form;
@@ -59,6 +60,18 @@ export const EarnFormScreen = () => {
                     <EarnOutputFields accountKey={accountKey} />
                 </Form>
             </Box>
+            {isValid && (
+                <Box marginTop="sp24">
+                    <FeeSelector
+                        accountKey={accountKey}
+                        updateThunk={updateFeeLevelThunk}
+                        selectedFee={formDraft?.selectedFee ?? 'normal'}
+                        selectedFeePerUnit={formDraft?.feePerUnit}
+                        formDraft={formDraft}
+                        formDraftKey={formDraftKey}
+                    />
+                </Box>
+            )}
         </Screen>
     );
 };

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -10,6 +10,7 @@ import {
     Screen,
     type StackNavigationProps,
 } from '@suite-native/navigation';
+import { FeeSelector } from '@suite-native/transaction-management';
 
 import { EarnOutputFields } from '../components/EarnOutputFields';
 import { UnstakeFlowScreenHeader } from '../components/UnstakeFlowScreenHeader';
@@ -26,7 +27,14 @@ export const UnstakeFlowScreen = () => {
 
     if (!unstakeForm) return null;
 
-    const { form, amountValue, showNetworkFeeWarning } = unstakeForm;
+    const {
+        form,
+        amountValue,
+        showNetworkFeeWarning,
+        formDraft,
+        formDraftKey,
+        updateFeeLevelThunk,
+    } = unstakeForm;
     const {
         formState: { isValid },
     } = form;
@@ -76,6 +84,18 @@ export const UnstakeFlowScreen = () => {
                     <InlineAlertBox
                         variant="warning"
                         title={<Translation id="earn.earnFormScreen.networkFeeWarning" />}
+                    />
+                </Box>
+            )}
+            {isValid && (
+                <Box marginTop="sp24">
+                    <FeeSelector
+                        accountKey={accountKey}
+                        updateThunk={updateFeeLevelThunk}
+                        selectedFee={formDraft?.selectedFee ?? 'normal'}
+                        selectedFeePerUnit={formDraft?.feePerUnit}
+                        formDraft={formDraft}
+                        formDraftKey={formDraftKey}
                     />
                 </Box>
             )}

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -22,6 +22,7 @@ import {
     ScreenHeader,
     type StackProps,
     TransactionDetailStackRoutes,
+    useNavigateToInitialScreen,
 } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
@@ -70,6 +71,7 @@ export const UnstakeTransactionDataReviewScreen = ({
         useConfirmOnTrezorController();
     const { accountKey } = route.params;
     const { navigateToStakingDetail } = useStakingDetailNavigation();
+    const navigateToInitialScreen = useNavigateToInitialScreen();
     const [txid, setTxid] = useState<string>('');
 
     const isAddressConfirmed = useSelector((state: TransactionReviewOutputsState) =>
@@ -112,17 +114,6 @@ export const UnstakeTransactionDataReviewScreen = ({
         }
     }, [closeSheet, showSignSuccessMessage]);
 
-    const handleClose = useCallback(() => {
-        navigation.dispatch(
-            CommonActions.reset({
-                index: 0,
-                routes: [
-                    { name: RootStackRoutes.AppTabs, params: { screen: AppTabsRoutes.EarnStack } },
-                ],
-            }),
-        );
-    }, [navigation]);
-
     const handleViewTransaction = useCallback(() => {
         navigation.dispatch(navigateToUnstakedTransactionAction({ accountKey, txid }));
     }, [accountKey, navigation, txid]);
@@ -140,7 +131,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                         </Text>
                     }
                     closeActionType="close"
-                    closeAction={handleClose}
+                    closeAction={navigateToInitialScreen}
                 />
             }
         >

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -7,6 +7,8 @@ import {
     type TokenSymbol,
 } from '@suite-common/wallet-types';
 
+export type EarnFormDraftPrefix = 'stake' | 'unstake' | 'claim';
+
 export type StakingEarnItem = {
     id: string;
     type: 'staking';

--- a/suite-native/module-earn/src/utils.ts
+++ b/suite-native/module-earn/src/utils.ts
@@ -1,7 +1,34 @@
+import { type FormState } from '@suite-common/wallet-types';
+
 import { USER_CANCELLED_ERROR_CODES } from './constants';
 
+export const buildEarnComposeFormState = (
+    contractAddress: string,
+    amount: string,
+    calldata: string,
+): FormState => ({
+    outputs: [
+        {
+            address: contractAddress,
+            amount,
+            type: 'payment',
+            token: null,
+            fiat: '',
+            currency: { label: '', value: '' },
+        },
+    ],
+    options: ['transactionData'],
+    transactionData: calldata,
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    selectedUtxos: [],
+    selectedFee: 'normal',
+    feePerUnit: '',
+    feeLimit: '',
+});
+
 type HandleEarnReviewErrorProps = {
-    payload: { error?: string; errorCode?: string } | undefined;
+    payload: { error?: string; errorCode?: string; message?: string } | undefined;
     navigation: { pop: () => void };
     showPushTransactionFailedAlert: () => void;
     showPendingTransactionConflictAlert: () => void;
@@ -15,6 +42,10 @@ export const handleEarnReviewError = ({
     showPendingTransactionConflictAlert,
     showDeviceDisconnectedAlert,
 }: HandleEarnReviewErrorProps) => {
+    if (payload?.message === 'tx-cancelled') {
+        return;
+    }
+
     if (payload?.error === 'push-transaction-pending-conflict') {
         showPendingTransactionConflictAlert();
 

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -12,6 +12,10 @@
             "path": "../../suite-common/message-system"
         },
         {
+            "path": "../../suite-common/redux-utils"
+        },
+        { "path": "../../suite-common/staking" },
+        {
             "path": "../../suite-common/validators"
         },
         {

--- a/suite-native/platform-encryption-native/tsconfig.json
+++ b/suite-native/platform-encryption-native/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
             "path": "../../suite-common/platform-encryption"

--- a/suite-native/staking/src/claimEthFormNativeThunks.ts
+++ b/suite-native/staking/src/claimEthFormNativeThunks.ts
@@ -4,39 +4,31 @@ import { getEthNetworkAddresses } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
-    type FeesRootState,
     type SignTransactionError,
     type SignTransactionTimeoutError,
     addFakePendingEvmTxThunk,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
     selectAccountByKey,
-    selectConvertedNetworkFeeInfo,
     sendFormActions,
-    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
-import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
-    getAccountIdentity,
-    getEthereumEstimateFeeParams,
-    getFormDraftKey,
-} from '@suite-common/wallet-utils';
+    type Account,
+    type AccountKey,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { getAccountIdentity, getFormDraftKey } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 
-import {
-    CLAIM_CALLDATA,
-    buildClaimFormState,
-    buildClaimPrecomposedTx,
-    buildEthClaimTx,
-} from './claimFormNativeUtils';
-import { type StakePushTransactionError, selectPreferredFeeLevel } from './stakeFormNativeUtils';
+import { buildClaimFormState, buildEthClaimTx } from './claimFormNativeUtils';
+import { type StakePushTransactionError } from './stakeFormNativeUtils';
 
 const CLAIM_NATIVE_MODULE_PREFIX = '@suite-native/stakingClaim';
 
 export const signEthClaimTransactionNativeThunk = createThunk<
     { txid: string },
-    { accountKey: AccountKey },
+    { accountKey: AccountKey; precomposedTransaction: PrecomposedTransactionFinal },
     {
         rejectValue:
             | SignTransactionError
@@ -46,7 +38,7 @@ export const signEthClaimTransactionNativeThunk = createThunk<
     }
 >(
     `${CLAIM_NATIVE_MODULE_PREFIX}/signEthClaimTransactionNativeThunk`,
-    async ({ accountKey }, { dispatch, rejectWithValue, getState }) => {
+    async ({ accountKey, precomposedTransaction }, { dispatch, rejectWithValue, getState }) => {
         const account = selectAccountByKey(getState() as AccountsRootState, accountKey);
 
         if (!account || account.networkType !== 'ethereum') {
@@ -65,65 +57,33 @@ export const signEthClaimTransactionNativeThunk = createThunk<
             });
         }
 
-        await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+        const gasLimit = precomposedTransaction.feeLimit;
 
-        const feeInfo = selectConvertedNetworkFeeInfo(getState() as FeesRootState, account.symbol);
-        const feeLevel = selectPreferredFeeLevel(feeInfo?.levels);
-
-        if (!feeLevel) {
+        if (!gasLimit) {
             return rejectWithValue({
                 error: 'sign-transaction-failed',
-                message: 'Fee info not available.',
+                message: 'Selected fee level is missing gas limit.',
             });
         }
+
+        const feeLevel: FeeLevel = {
+            label: 'normal',
+            blocks: -1,
+            feePerUnit: precomposedTransaction.feePerByte,
+            feeLimit: gasLimit,
+            maxFeePerGas: precomposedTransaction.maxFeePerGas,
+            maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
+        };
 
         const identity = getAccountIdentity(account);
         const { addressContractAccounting } = getEthNetworkAddresses(account.symbol);
 
-        const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-            coin: account.symbol,
-            identity,
-            request: {
-                blocks: [2],
-                specific: {
-                    from: account.descriptor,
-                    ...getEthereumEstimateFeeParams(
-                        addressContractAccounting,
-                        '0',
-                        undefined,
-                        CLAIM_CALLDATA,
-                    ),
-                },
-            },
-        });
-
-        if (!estimatedFee.success) {
-            return rejectWithValue({
-                error: 'sign-transaction-failed',
-                message: `Gas limit estimation failed: ${estimatedFee.error.message}`,
-            });
-        }
-
-        const rawGasLimit = estimatedFee.payload.levels[0]?.feeLimit;
-
-        if (!rawGasLimit) {
-            return rejectWithValue({
-                error: 'sign-transaction-failed',
-                message: 'Gas limit estimation returned empty value.',
-            });
-        }
-
-        const claimFormState = buildClaimFormState(feeLevel, rawGasLimit);
-        const precomposedTx = buildClaimPrecomposedTx(
-            feeLevel,
-            rawGasLimit,
-            addressContractAccounting,
-        );
+        const claimFormState = buildClaimFormState(feeLevel, gasLimit);
 
         dispatch(
             sendFormActions.storePrecomposedTransaction({
                 formState: claimFormState,
-                precomposedTransaction: precomposedTx,
+                precomposedTransaction,
                 accountKey,
             }),
         );
@@ -147,7 +107,7 @@ export const signEthClaimTransactionNativeThunk = createThunk<
                 contractAddress: addressContractAccounting,
                 chainId: network.chainId!,
                 nonce,
-                rawGasLimit,
+                gasLimit,
                 feeLevel,
             });
 
@@ -216,7 +176,7 @@ export const signEthClaimTransactionNativeThunk = createThunk<
 
         dispatch(
             addFakePendingEvmTxThunk({
-                precomposedTransaction: precomposedTx,
+                precomposedTransaction,
                 precomposedForm: claimFormState,
                 txid,
                 account,

--- a/suite-native/staking/src/claimFormNativeUtils.ts
+++ b/suite-native/staking/src/claimFormNativeUtils.ts
@@ -1,7 +1,6 @@
 import { numberToHex, toWei } from 'web3-utils';
 
-import { STAKE_GAS_LIMIT_RESERVE } from '@suite-common/wallet-constants';
-import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import { type StakeFormState } from '@suite-common/wallet-types';
 import {
     type EthereumTransaction,
     type EthereumTransactionEIP1559,
@@ -14,10 +13,10 @@ export const CLAIM_CALLDATA = '0x33986ffa';
 
 const toHex = (value: string | number): string => `0x${BigInt(value).toString(16)}`;
 
-export const buildClaimFormState = (feeLevel: FeeLevel, rawGasLimit: string): StakeFormState => ({
+export const buildClaimFormState = (feeLevel: FeeLevel, gasLimit: string): StakeFormState => ({
     outputs: [],
     feePerUnit: feeLevel.feePerUnit,
-    feeLimit: rawGasLimit,
+    feeLimit: gasLimit,
     transactionData: CLAIM_CALLDATA,
     stakeType: 'claim',
     options: [],
@@ -33,61 +32,21 @@ export const buildClaimFormState = (feeLevel: FeeLevel, rawGasLimit: string): St
         : {}),
 });
 
-export const buildClaimPrecomposedTx = (
-    feeLevel: FeeLevel,
-    rawGasLimit: string,
-    contractAddress: string,
-): PrecomposedTransactionFinal => {
-    const gasLimitWithReserve = new BigNumber(rawGasLimit).plus(STAKE_GAS_LIMIT_RESERVE);
-    const gasPriceGwei = feeLevel.maxFeePerGas ?? feeLevel.feePerUnit;
-    const fee = new BigNumber(gasPriceGwei)
-        .times(gasLimitWithReserve)
-        .times(new BigNumber(10).pow(9))
-        .toFixed(0);
-
-    return {
-        type: 'final',
-        inputs: [],
-        outputs: [
-            {
-                address: contractAddress,
-                script_type: 'PAYTOADDRESS',
-                amount: '0',
-            },
-        ],
-        outputsPermutation: [0],
-        fee,
-        feePerByte: feeLevel.feePerUnit,
-        feeLimit: rawGasLimit,
-        bytes: 0,
-        totalSpent: fee,
-        ...(feeLevel.maxFeePerGas
-            ? {
-                  maxFeePerGas: feeLevel.maxFeePerGas,
-                  maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas ?? '0',
-              }
-            : {}),
-    };
-};
-
 export const buildEthClaimTx = ({
     contractAddress,
     chainId,
     nonce,
-    rawGasLimit,
+    gasLimit,
     feeLevel,
 }: {
     contractAddress: string;
     chainId: number;
     nonce: number | string;
-    rawGasLimit: string;
+    gasLimit: string;
     feeLevel: FeeLevel;
 }): EthereumTransaction | EthereumTransactionEIP1559 => {
-    const gasLimit = toHex(
-        new BigNumber(rawGasLimit)
-            .plus(STAKE_GAS_LIMIT_RESERVE)
-            .integerValue(BigNumber.ROUND_DOWN)
-            .toNumber(),
+    const gasLimitHex = toHex(
+        new BigNumber(gasLimit).integerValue(BigNumber.ROUND_DOWN).toFixed(0),
     );
 
     const commonTxData = {
@@ -95,7 +54,7 @@ export const buildEthClaimTx = ({
         value: '0x0',
         chainId,
         nonce: toHex(nonce),
-        gasLimit,
+        gasLimit: gasLimitHex,
         data: CLAIM_CALLDATA,
     };
 

--- a/suite-native/staking/src/index.ts
+++ b/suite-native/staking/src/index.ts
@@ -6,6 +6,9 @@
 export * from './utils';
 export * from './selectors';
 export { signEthStakeTransactionNativeThunk } from './stakeEthFormNativeThunks';
+export { STAKE_CALLDATA } from './stakeFormNativeUtils';
+export { buildUnstakeCalldata } from './unstakeFormNativeUtils';
+export { CLAIM_CALLDATA } from './claimFormNativeUtils';
 export { signEthUnstakeTransactionNativeThunk } from './unstakeEthFormNativeThunk';
 export { signEthClaimTransactionNativeThunk } from './claimEthFormNativeThunks';
 export type * from './types';

--- a/suite-native/staking/src/stakeEthFormNativeThunks.ts
+++ b/suite-native/staking/src/stakeEthFormNativeThunks.ts
@@ -3,40 +3,38 @@ import { createThunk } from '@suite-common/redux-utils';
 import { getEthNetworkAddresses } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
-    type FeesRootState,
     type SignTransactionError,
     type SignTransactionTimeoutError,
     addFakePendingEvmTxThunk,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
     selectAccountByKey,
-    selectConvertedNetworkFeeInfo,
     sendFormActions,
-    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
-import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
-    getAccountIdentity,
-    getEthereumEstimateFeeParams,
-    getFormDraftKey,
-} from '@suite-common/wallet-utils';
+    type Account,
+    type AccountKey,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
+import { getAccountIdentity, getFormDraftKey } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 
 import {
-    STAKE_CALLDATA,
     type StakePushTransactionError,
     buildEthStakeTx,
     buildStakeFormState,
-    buildStakePrecomposedTx,
-    selectPreferredFeeLevel,
 } from './stakeFormNativeUtils';
 
 const STAKE_NATIVE_MODULE_PREFIX = '@suite-native/staking';
 
 export const signEthStakeTransactionNativeThunk = createThunk<
     { txid: string },
-    { accountKey: AccountKey; amount: string },
+    {
+        accountKey: AccountKey;
+        amount: string;
+        precomposedTransaction: PrecomposedTransactionFinal;
+    },
     {
         rejectValue:
             | SignTransactionError
@@ -46,7 +44,10 @@ export const signEthStakeTransactionNativeThunk = createThunk<
     }
 >(
     `${STAKE_NATIVE_MODULE_PREFIX}/signEthStakeTransactionNativeThunk`,
-    async ({ accountKey, amount }, { dispatch, rejectWithValue, getState }) => {
+    async (
+        { accountKey, amount, precomposedTransaction },
+        { dispatch, rejectWithValue, getState },
+    ) => {
         try {
             const account = selectAccountByKey(getState(), accountKey);
 
@@ -74,81 +75,37 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                 });
             }
 
-            await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+            const gasLimit = precomposedTransaction.feeLimit;
 
-            const feeInfo = selectConvertedNetworkFeeInfo(
-                getState() as FeesRootState,
-                account.symbol,
-            );
-            const feeLevel = selectPreferredFeeLevel(feeInfo?.levels);
-
-            if (!feeLevel) {
+            if (!gasLimit) {
                 console.error(
-                    `signEthStakeTransactionNativeThunk: Fee info not available for ${account.symbol}`,
+                    'signEthStakeTransactionNativeThunk: Selected fee level is missing gas limit.',
                 );
 
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
-                    message: 'Fee info not available.',
+                    message: 'Selected fee level is missing gas limit.',
                 });
             }
+
+            const feeLevel: FeeLevel = {
+                label: 'normal',
+                blocks: -1,
+                feePerUnit: precomposedTransaction.feePerByte,
+                feeLimit: gasLimit,
+                maxFeePerGas: precomposedTransaction.maxFeePerGas,
+                maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
+            };
 
             const identity = getAccountIdentity(account);
             const { addressContractPool } = getEthNetworkAddresses(account.symbol);
 
-            const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-                coin: account.symbol,
-                identity,
-                request: {
-                    blocks: [2],
-                    specific: {
-                        from: account.descriptor,
-                        ...getEthereumEstimateFeeParams(
-                            addressContractPool,
-                            amount,
-                            undefined,
-                            STAKE_CALLDATA,
-                        ),
-                    },
-                },
-            });
-
-            if (!estimatedFee.success) {
-                console.error(
-                    `signEthStakeTransactionNativeThunk: Gas limit estimation failed: ${estimatedFee.error.message}`,
-                );
-
-                return rejectWithValue({
-                    error: 'sign-transaction-failed',
-                    message: `Gas limit estimation failed: ${estimatedFee.error.message}`,
-                });
-            }
-
-            const rawGasLimit = estimatedFee.payload.levels[0]?.feeLimit;
-
-            if (!rawGasLimit) {
-                console.error(
-                    'signEthStakeTransactionNativeThunk: Gas limit estimation returned empty value.',
-                );
-
-                return rejectWithValue({
-                    error: 'sign-transaction-failed',
-                    message: 'Gas limit estimation returned empty value.',
-                });
-            }
-
-            const stakeFormState = buildStakeFormState(feeLevel, rawGasLimit);
-            const precomposedTx = buildStakePrecomposedTx(
-                feeLevel,
-                rawGasLimit,
-                addressContractPool,
-                amount,
-            );
+            const stakeFormState = buildStakeFormState(feeLevel, gasLimit);
 
             dispatch(
                 sendFormActions.storePrecomposedTransaction({
                     formState: stakeFormState,
-                    precomposedTransaction: precomposedTx,
+                    precomposedTransaction,
                     accountKey,
                 }),
             );
@@ -173,7 +130,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
                     amount,
                     chainId: network.chainId!,
                     nonce,
-                    rawGasLimit,
+                    gasLimit,
                     feeLevel,
                 });
 
@@ -205,9 +162,11 @@ export const signEthStakeTransactionNativeThunk = createThunk<
             const signResponse = deviceAccessResponse.payload;
 
             if (!signResponse.success) {
-                console.error(
-                    `signEthStakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
-                );
+                if (signResponse.error.message !== 'tx-cancelled') {
+                    console.error(
+                        `signEthStakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
+                    );
+                }
 
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
@@ -254,7 +213,7 @@ export const signEthStakeTransactionNativeThunk = createThunk<
 
             dispatch(
                 addFakePendingEvmTxThunk({
-                    precomposedTransaction: precomposedTx,
+                    precomposedTransaction,
                     precomposedForm: stakeFormState,
                     txid,
                     account,

--- a/suite-native/staking/src/stakeFormNativeUtils.ts
+++ b/suite-native/staking/src/stakeFormNativeUtils.ts
@@ -1,6 +1,5 @@
 import { transformTx } from '@suite-common/staking';
-import { STAKE_GAS_LIMIT_RESERVE } from '@suite-common/wallet-constants';
-import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import { type StakeFormState } from '@suite-common/wallet-types';
 import {
     type EthereumTransaction,
     type EthereumTransactionEIP1559,
@@ -16,13 +15,10 @@ export type StakePushTransactionError =
     | { error: 'push-transaction-failed'; message?: string }
     | { error: 'push-transaction-pending-conflict'; message?: string };
 
-export const selectPreferredFeeLevel = (levels: FeeLevel[] | undefined): FeeLevel | undefined =>
-    levels?.find(l => l.label === 'high') ?? levels?.find(l => l.label === 'normal') ?? levels?.[0];
-
-export const buildStakeFormState = (feeLevel: FeeLevel, rawGasLimit: string): StakeFormState => ({
+export const buildStakeFormState = (feeLevel: FeeLevel, gasLimit: string): StakeFormState => ({
     outputs: [],
     feePerUnit: feeLevel.feePerUnit,
-    feeLimit: rawGasLimit,
+    feeLimit: gasLimit,
     transactionData: STAKE_CALLDATA,
     stakeType: 'stake',
     options: [],
@@ -38,67 +34,21 @@ export const buildStakeFormState = (feeLevel: FeeLevel, rawGasLimit: string): St
         : {}),
 });
 
-export const buildStakePrecomposedTx = (
-    feeLevel: FeeLevel,
-    rawGasLimit: string,
-    contractAddress: string,
-    amount: string,
-): PrecomposedTransactionFinal => {
-    const amountInWei = new BigNumber(amount)
-        .times(new BigNumber(10).pow(18))
-        .integerValue()
-        .toFixed(0);
-    const gasLimitWithReserve = new BigNumber(rawGasLimit).plus(STAKE_GAS_LIMIT_RESERVE);
-    const gasPriceGwei = feeLevel.maxFeePerGas ?? feeLevel.feePerUnit;
-    const fee = new BigNumber(gasPriceGwei)
-        .times(gasLimitWithReserve)
-        .times(new BigNumber(10).pow(9))
-        .toFixed(0);
-
-    return {
-        type: 'final',
-        inputs: [],
-        outputs: [
-            {
-                address: contractAddress,
-                script_type: 'PAYTOADDRESS',
-                amount: amountInWei,
-            },
-        ],
-        outputsPermutation: [0],
-        fee,
-        feePerByte: feeLevel.feePerUnit,
-        feeLimit: rawGasLimit,
-        bytes: 0,
-        totalSpent: amountInWei,
-        ...(feeLevel.maxFeePerGas
-            ? {
-                  maxFeePerGas: feeLevel.maxFeePerGas,
-                  maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas ?? '0',
-              }
-            : {}),
-    };
-};
-
 export const buildEthStakeTx = ({
     contractAddress,
     amount,
     chainId,
     nonce,
-    rawGasLimit,
+    gasLimit,
     feeLevel,
 }: {
     contractAddress: string;
     amount: string;
     chainId: number;
     nonce: number | string;
-    rawGasLimit: string;
+    gasLimit: string;
     feeLevel: FeeLevel;
 }): EthereumTransaction | EthereumTransactionEIP1559 => {
-    const adjustedGasLimit = new BigNumber(rawGasLimit)
-        .plus(STAKE_GAS_LIMIT_RESERVE)
-        .integerValue(BigNumber.ROUND_DOWN)
-        .toNumber();
     const amountWei = new BigNumber(amount)
         .times(new BigNumber(10).pow(18))
         .integerValue()
@@ -106,7 +56,7 @@ export const buildEthStakeTx = ({
     const tx = {
         to: contractAddress,
         value: amountWei,
-        gasLimit: adjustedGasLimit,
+        gasLimit: new BigNumber(gasLimit).integerValue(BigNumber.ROUND_DOWN).toNumber(),
         data: STAKE_CALLDATA,
     };
 

--- a/suite-native/staking/src/unstakeEthFormNativeThunk.ts
+++ b/suite-native/staking/src/unstakeEthFormNativeThunk.ts
@@ -4,28 +4,28 @@ import { getEthNetworkAddresses } from '@suite-common/staking';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
-    type FeesRootState,
     type SignTransactionError,
     type SignTransactionTimeoutError,
     addFakePendingEvmTxThunk,
     ethereumGetCurrentNonceThunk,
     formDraftActions,
     selectAccountByKey,
-    selectConvertedNetworkFeeInfo,
     sendFormActions,
-    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
-import { type Account, type AccountKey } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type AccountKey,
+    type PrecomposedTransactionFinal,
+} from '@suite-common/wallet-types';
 import { getAccountIdentity, getFormDraftKey } from '@suite-common/wallet-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 
-import { type StakePushTransactionError, selectPreferredFeeLevel } from './stakeFormNativeUtils';
+import { type StakePushTransactionError } from './stakeFormNativeUtils';
 import {
     buildEthUnstakeTx,
     buildUnstakeCalldata,
     buildUnstakeFormState,
-    buildUnstakePrecomposedTx,
 } from './unstakeFormNativeUtils';
 import { ethToWei } from './utils';
 
@@ -33,7 +33,11 @@ const STAKE_NATIVE_MODULE_PREFIX = '@suite-native/unstaking';
 
 export const signEthUnstakeTransactionNativeThunk = createThunk<
     { txid: string },
-    { accountKey: AccountKey; amount: string },
+    {
+        accountKey: AccountKey;
+        amount: string;
+        precomposedTransaction: PrecomposedTransactionFinal;
+    },
     {
         rejectValue:
             | SignTransactionError
@@ -43,9 +47,12 @@ export const signEthUnstakeTransactionNativeThunk = createThunk<
     }
 >(
     `${STAKE_NATIVE_MODULE_PREFIX}/signEthUnstakeTransactionNativeThunk`,
-    async ({ accountKey, amount }, { dispatch, rejectWithValue, getState }) => {
+    async (
+        { accountKey, amount, precomposedTransaction },
+        { dispatch, rejectWithValue, getState },
+    ) => {
         try {
-            const state = getState() as AccountsRootState & FeesRootState & DeviceRootState;
+            const state = getState() as AccountsRootState & DeviceRootState;
             const account = selectAccountByKey(state, accountKey);
 
             if (!account || account.networkType !== 'ethereum') {
@@ -72,81 +79,38 @@ export const signEthUnstakeTransactionNativeThunk = createThunk<
                 });
             }
 
-            await dispatch(updateFeeInfoThunk({ networkSymbol: account.symbol }));
+            const gasLimit = precomposedTransaction.feeLimit;
 
-            const feeInfo = selectConvertedNetworkFeeInfo(
-                getState() as FeesRootState,
-                account.symbol,
-            );
-            const feeLevel = selectPreferredFeeLevel(feeInfo?.levels);
-
-            if (!feeLevel) {
+            if (!gasLimit) {
                 console.error(
-                    `signEthUnstakeTransactionNativeThunk: Fee info not available for ${account.symbol}`,
+                    'signEthUnstakeTransactionNativeThunk: Selected fee level is missing gas limit.',
                 );
 
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
-                    message: 'Fee info not available.',
+                    message: 'Selected fee level is missing gas limit.',
                 });
             }
+
+            const feeLevel: FeeLevel = {
+                label: 'normal',
+                blocks: -1,
+                feePerUnit: precomposedTransaction.feePerByte,
+                feeLimit: gasLimit,
+                maxFeePerGas: precomposedTransaction.maxFeePerGas,
+                maxPriorityFeePerGas: precomposedTransaction.maxPriorityFeePerGas,
+            };
 
             const identity = getAccountIdentity(account);
             const { addressContractPool } = getEthNetworkAddresses(account.symbol);
 
-            const amountInWei = ethToWei(amount);
-            const calldata = buildUnstakeCalldata(amountInWei);
-
-            const estimatedFee = await TrezorConnect.blockchainEstimateFee({
-                coin: account.symbol,
-                identity,
-                request: {
-                    blocks: [2],
-                    specific: {
-                        from: account.descriptor,
-                        to: addressContractPool,
-                        value: '0x0',
-                        data: calldata,
-                    },
-                },
-            });
-
-            if (!estimatedFee.success) {
-                console.error(
-                    `signEthUnstakeTransactionNativeThunk: Gas limit estimation failed: ${estimatedFee.error.message}`,
-                );
-
-                return rejectWithValue({
-                    error: 'sign-transaction-failed',
-                    message: `Gas limit estimation failed: ${estimatedFee.error.message}`,
-                });
-            }
-
-            const rawGasLimit = estimatedFee.payload.levels[0]?.feeLimit;
-
-            if (!rawGasLimit) {
-                console.error(
-                    'signEthUnstakeTransactionNativeThunk: Gas limit estimation returned empty value.',
-                );
-
-                return rejectWithValue({
-                    error: 'sign-transaction-failed',
-                    message: 'Gas limit estimation returned empty value.',
-                });
-            }
-
-            const unstakeFormState = buildUnstakeFormState(feeLevel, rawGasLimit, calldata);
-            const precomposedTx = buildUnstakePrecomposedTx(
-                feeLevel,
-                rawGasLimit,
-                addressContractPool,
-                amount,
-            );
+            const calldata = buildUnstakeCalldata(ethToWei(amount));
+            const unstakeFormState = buildUnstakeFormState(feeLevel, gasLimit, calldata);
 
             dispatch(
                 sendFormActions.storePrecomposedTransaction({
                     formState: unstakeFormState,
-                    precomposedTransaction: precomposedTx,
+                    precomposedTransaction,
                     accountKey,
                 }),
             );
@@ -171,7 +135,7 @@ export const signEthUnstakeTransactionNativeThunk = createThunk<
                     amount,
                     chainId: network.chainId!,
                     nonce,
-                    rawGasLimit,
+                    gasLimit,
                     feeLevel,
                 });
 
@@ -203,9 +167,11 @@ export const signEthUnstakeTransactionNativeThunk = createThunk<
             const signResponse = deviceAccessResponse.payload;
 
             if (!signResponse.success) {
-                console.error(
-                    `signEthUnstakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
-                );
+                if (signResponse.error.message !== 'tx-cancelled') {
+                    console.error(
+                        `signEthUnstakeTransactionNativeThunk: Sign transaction failed: ${signResponse.error.message}`,
+                    );
+                }
 
                 return rejectWithValue({
                     error: 'sign-transaction-failed',
@@ -252,7 +218,7 @@ export const signEthUnstakeTransactionNativeThunk = createThunk<
 
             dispatch(
                 addFakePendingEvmTxThunk({
-                    precomposedTransaction: precomposedTx,
+                    precomposedTransaction,
                     precomposedForm: unstakeFormState,
                     txid,
                     account,

--- a/suite-native/staking/src/unstakeFormNativeUtils.ts
+++ b/suite-native/staking/src/unstakeFormNativeUtils.ts
@@ -1,10 +1,6 @@
 import { transformTx } from '@suite-common/staking';
-import {
-    STAKE_GAS_LIMIT_RESERVE,
-    UNSTAKE_INTERCHANGES,
-    WALLET_SDK_SOURCE,
-} from '@suite-common/wallet-constants';
-import { type PrecomposedTransactionFinal, type StakeFormState } from '@suite-common/wallet-types';
+import { UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE } from '@suite-common/wallet-constants';
+import { type StakeFormState } from '@suite-common/wallet-types';
 import {
     type EthereumTransaction,
     type EthereumTransactionEIP1559,
@@ -32,12 +28,12 @@ export const buildUnstakeCalldata = (amountWei: string): string => {
 
 export const buildUnstakeFormState = (
     feeLevel: FeeLevel,
-    rawGasLimit: string,
+    gasLimit: string,
     calldata: string,
 ): StakeFormState => ({
     outputs: [],
     feePerUnit: feeLevel.feePerUnit,
-    feeLimit: rawGasLimit,
+    feeLimit: gasLimit,
     transactionData: calldata,
     stakeType: 'unstake',
     options: [],
@@ -53,70 +49,27 @@ export const buildUnstakeFormState = (
         : {}),
 });
 
-export const buildUnstakePrecomposedTx = (
-    feeLevel: FeeLevel,
-    rawGasLimit: string,
-    contractAddress: string,
-    amount: string,
-): PrecomposedTransactionFinal => {
-    const amountInWei = ethToWei(amount);
-    const gasLimitWithReserve = new BigNumber(rawGasLimit).plus(STAKE_GAS_LIMIT_RESERVE);
-    const gasPriceGwei = feeLevel.maxFeePerGas ?? feeLevel.feePerUnit;
-    const fee = new BigNumber(gasPriceGwei)
-        .times(gasLimitWithReserve)
-        .times(new BigNumber(10).pow(9))
-        .toFixed(0);
-
-    return {
-        type: 'final',
-        inputs: [],
-        outputs: [
-            {
-                address: contractAddress,
-                script_type: 'PAYTOADDRESS',
-                amount: amountInWei,
-            },
-        ],
-        outputsPermutation: [0],
-        fee,
-        feePerByte: feeLevel.feePerUnit,
-        feeLimit: rawGasLimit,
-        bytes: 0,
-        totalSpent: fee, // No ETH value is sent for unstake; total spent = fee only
-        ...(feeLevel.maxFeePerGas
-            ? {
-                  maxFeePerGas: feeLevel.maxFeePerGas,
-                  maxPriorityFeePerGas: feeLevel.maxPriorityFeePerGas ?? '0',
-              }
-            : {}),
-    };
-};
-
 export const buildEthUnstakeTx = ({
     contractAddress,
     amount,
     chainId,
     nonce,
-    rawGasLimit,
+    gasLimit,
     feeLevel,
 }: {
     contractAddress: string;
     amount: string;
     chainId: number;
     nonce: number | string;
-    rawGasLimit: string;
+    gasLimit: string;
     feeLevel: FeeLevel;
 }): EthereumTransaction | EthereumTransactionEIP1559 => {
-    const adjustedGasLimit = new BigNumber(rawGasLimit)
-        .plus(STAKE_GAS_LIMIT_RESERVE)
-        .integerValue(BigNumber.ROUND_DOWN)
-        .toNumber();
     const amountInWei = ethToWei(amount);
     const data = buildUnstakeCalldata(amountInWei);
     const tx = {
         to: contractAddress,
         value: '0', // No ETH value for unstake
-        gasLimit: adjustedGasLimit,
+        gasLimit: new BigNumber(gasLimit).integerValue(BigNumber.ROUND_DOWN).toNumber(),
         data,
     };
 

--- a/suite/platform-encryption-electron/tsconfig.json
+++ b/suite/platform-encryption-electron/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
             "path": "../../suite-common/platform-encryption"

--- a/suite/platform-encryption-webauthn/tsconfig.json
+++ b/suite/platform-encryption-webauthn/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "libDev"
-    },
+    "compilerOptions": { "outDir": "libDev" },
     "references": [
         {
             "path": "../../suite-common/platform-encryption"

--- a/suite/suite-sync/tsconfig.json
+++ b/suite/suite-sync/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "outDir": "./libDev"
-    },
+    "compilerOptions": { "outDir": "./libDev" },
     "include": [".", "**/*.json"],
     "references": [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13368,6 +13368,8 @@ __metadata:
     "@suite-common/earn-api": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/message-system": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/staking": "workspace:*"
     "@suite-common/validators": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"


### PR DESCRIPTION
## Description

Added fee composition and FeeSelector to native Earn stake, unstake, and claim, using a shared hook and contract FormState from staking calldata.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26594
Resolve https://github.com/trezor/trezor-suite/issues/26576
Resolve https://github.com/trezor/trezor-suite/issues/26575

## Screenshots:
<img width="1287" height="2023" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-13 at 17 22 51" src="https://github.com/user-attachments/assets/aef1e629-98fd-4664-abee-30bae0ab7d20" />
<img width="1290" height="2540" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-13 at 17 23 03" src="https://github.com/user-attachments/assets/17b1a69e-b20a-4ae2-94f7-52e606298270" />
