### PR TITLE
feat(token-definitions): add Stellar Soroban contract resolution

### DIFF
--- a/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
+++ b/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
@@ -3,8 +3,12 @@ import { blockfrostUtils } from '@trezor/blockchain-link-utils';
 import { getContractAddress } from '../fetchCoins';
 
 describe('getContractAddress', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     describe('Cardano platform', () => {
-        it('should return policy ID for valid Cardano asset', () => {
+        it('should return policy ID for valid Cardano asset', async () => {
             const platforms = {
                 cardano: 'valid_cardano_asset_string',
             };
@@ -12,129 +16,163 @@ describe('getContractAddress', () => {
             const mockParseAsset = jest.spyOn(blockfrostUtils, 'parseAsset');
             mockParseAsset.mockReturnValue({ policyId: 'mock_policy_id' } as any);
 
-            const result = getContractAddress('cardano', platforms);
+            const result = await getContractAddress('cardano', platforms);
 
             expect(result).toBe('mock_policy_id');
             expect(mockParseAsset).toHaveBeenCalledWith('valid_cardano_asset_string');
-
-            mockParseAsset.mockRestore();
         });
     });
 
     describe('Stellar platform', () => {
-        it('should handle uppercase code with hyphen separator', () => {
+        it('should handle uppercase code with hyphen separator', async () => {
             const platforms = {
                 stellar: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             };
-            expect(getContractAddress('stellar', platforms)).toBe(
+            expect(await getContractAddress('stellar', platforms)).toBe(
                 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             );
         });
 
-        it('should handle lowercase code with hyphen separator', () => {
+        it('should handle lowercase code with hyphen separator', async () => {
             const platforms = {
                 stellar: 'usdc-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             };
-            expect(getContractAddress('stellar', platforms)).toBe(
+            expect(await getContractAddress('stellar', platforms)).toBe(
                 'usdc-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             );
         });
 
-        it('should handle code with colon separator', () => {
+        it('should handle code with colon separator', async () => {
             const platforms = {
                 stellar: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             };
-            expect(getContractAddress('stellar', platforms)).toBe(
+            expect(await getContractAddress('stellar', platforms)).toBe(
                 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             );
         });
 
-        it('should return undefined for invalid format', () => {
+        it('should return undefined for invalid format', async () => {
             const platforms = {
                 stellar: 'INVALID_FORMAT',
             };
-            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+            expect(await getContractAddress('stellar', platforms)).toBeUndefined();
         });
 
-        it('should return undefined for code too long', () => {
+        it('should return undefined for code too long', async () => {
             const platforms = {
                 stellar:
                     'VERYLONGCODENAME-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             };
-            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+            expect(await getContractAddress('stellar', platforms)).toBeUndefined();
         });
 
-        it('should return undefined for invalid issuer format', () => {
+        it('should return undefined for invalid issuer format', async () => {
             const platforms = {
                 stellar: 'USDC-AA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             };
-            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+            expect(await getContractAddress('stellar', platforms)).toBeUndefined();
         });
 
-        it('should handle format with numeric suffix', () => {
+        it('should handle format with numeric suffix', async () => {
             const platforms = {
                 stellar: 'BLND-GDJEHTBE6ZHUXSWFI642DCGLUOECLHPF3KSXHPXTSTJ7E3JF6MQ5EZYY-1',
             };
-            expect(getContractAddress('stellar', platforms)).toBe(
+            expect(await getContractAddress('stellar', platforms)).toBe(
                 'BLND-GDJEHTBE6ZHUXSWFI642DCGLUOECLHPF3KSXHPXTSTJ7E3JF6MQ5EZYY',
             );
         });
 
-        it('should handle format with multi-digit numeric suffix', () => {
+        it('should handle format with multi-digit numeric suffix', async () => {
             const platforms = {
                 stellar: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN-123',
             };
-            expect(getContractAddress('stellar', platforms)).toBe(
+            expect(await getContractAddress('stellar', platforms)).toBe(
                 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
             );
         });
 
-        it('should return undefined for format with non-numeric suffix', () => {
+        it('should return undefined for format with non-numeric suffix', async () => {
             const platforms = {
                 stellar: 'TOKEN-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN-abc',
             };
-            expect(getContractAddress('stellar', platforms)).toBeUndefined();
+            expect(await getContractAddress('stellar', platforms)).toBeUndefined();
+        });
+
+        it('should resolve Soroban contract address via StellarExpert API', async () => {
+            const sorobanAddress = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
+            const platforms = { stellar: sorobanAddress };
+
+            const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        asset: 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN-1',
+                    }),
+                    { status: 200, headers: { 'Content-Type': 'application/json' } },
+                ),
+            );
+
+            expect(await getContractAddress('stellar', platforms)).toBe(
+                'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+            );
+            expect(fetchSpy).toHaveBeenCalledWith(
+                `https://api.stellar.expert/explorer/public/contract/${sorobanAddress}`,
+            );
+        });
+
+        it('should return undefined for Soroban contract with invalid asset from API', async () => {
+            const sorobanAddress = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
+            const platforms = { stellar: sorobanAddress };
+
+            jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+            jest.spyOn(global, 'fetch').mockResolvedValue(
+                new Response(JSON.stringify({ asset: 'INVALID_FORMAT' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            );
+
+            expect(await getContractAddress('stellar', platforms)).toBeUndefined();
         });
     });
 
     describe('Other platforms', () => {
-        it('should return address as-is for other platforms', () => {
+        it('should return address as-is for other platforms', async () => {
             const platforms = {
                 ethereum: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             };
-            expect(getContractAddress('ethereum', platforms)).toBe(
+            expect(await getContractAddress('ethereum', platforms)).toBe(
                 '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
             );
         });
 
-        it('should return address as-is for binance-smart-chain', () => {
+        it('should return address as-is for binance-smart-chain', async () => {
             const platforms = {
                 'binance-smart-chain': '0x55d398326f99059ff775485246999027b3197955',
             };
-            expect(getContractAddress('binance-smart-chain', platforms)).toBe(
+            expect(await getContractAddress('binance-smart-chain', platforms)).toBe(
                 '0x55d398326f99059ff775485246999027b3197955',
             );
         });
     });
 
     describe('Edge cases', () => {
-        it('should return undefined when platform not found in platforms object', () => {
+        it('should return undefined when platform not found in platforms object', async () => {
             const platforms = {
                 ethereum: '0x1234567890abcdef',
             };
-            expect(getContractAddress('polygon', platforms)).toBeUndefined();
+            expect(await getContractAddress('polygon', platforms)).toBeUndefined();
         });
 
-        it('should return undefined when platforms object is empty', () => {
+        it('should return undefined when platforms object is empty', async () => {
             const platforms = {};
-            expect(getContractAddress('ethereum', platforms)).toBeUndefined();
+            expect(await getContractAddress('ethereum', platforms)).toBeUndefined();
         });
 
-        it('should return undefined when address is empty string', () => {
+        it('should return undefined when address is empty string', async () => {
             const platforms = {
                 ethereum: '',
             };
-            expect(getContractAddress('ethereum', platforms)).toBeUndefined();
+            expect(await getContractAddress('ethereum', platforms)).toBeUndefined();
         });
     });
 });

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -11,35 +11,101 @@ import {
 import { COIN_LIST_URL, STELLAR_EXPERT_URL, STELLAR_HORIZON_URL } from '../constants';
 import { CoinData } from '../types';
 
-export const getContractAddress = (assetPlatformId: string, platforms: CoinData['platforms']) => {
-    const address = platforms[assetPlatformId];
-    if (address) {
-        if (assetPlatformId === 'cardano') {
-            return blockfrostUtils.parseAsset(address).policyId;
-        }
+const normalizeStellarAssetAddress = (address: string): string | undefined => {
+    // Stellar address format: CODE-ISSUER, CODE:ISSUER, or CODE-ISSUER-NUMBER
+    // CODE: 1-12 alphanumeric characters
+    // ISSUER: 56 characters starting with 'G'
+    // NUMBER: optional numeric suffix
+    const stellarMatch = address.match(/^([A-Za-z0-9]{1,12})[-:]([G][A-Z0-9]{55})(?:-\d+)?$/);
 
-        if (assetPlatformId === 'stellar') {
-            // Stellar address format: CODE-ISSUER, CODE:ISSUER, or CODE-ISSUER-NUMBER
-            // CODE: 1-12 alphanumeric characters
-            // ISSUER: 56 characters starting with 'G'
-            // NUMBER: optional numeric suffix
-            const stellarMatch = address.match(
-                /^([A-Za-z0-9]{1,12})[-:]([G][A-Z0-9]{55})(?:-\d+)?$/,
-            );
-            if (stellarMatch) {
-                const code = stellarMatch[1];
-                const issuer = stellarMatch[2];
-
-                return `${code}-${issuer}`; // Return as CODE-ISSUER format
-            } else {
-                return undefined; // Invalid Stellar address format
-            }
-        }
-
-        return address;
+    if (!stellarMatch) {
+        return undefined;
     }
 
-    return undefined;
+    const code = stellarMatch[1];
+    const issuer = stellarMatch[2];
+
+    return `${code}-${issuer}`;
+};
+
+const isSorobanContractAddress = (address: string) => /^C[A-Z0-9]{55}$/.test(address);
+
+type StellarExpertContractData = {
+    asset?: string;
+};
+
+const fetchSorobanContractAsset = async (contractAddress: string): Promise<string | undefined> => {
+    try {
+        const response = await fetch(`${STELLAR_EXPERT_URL}/contract/${contractAddress}`);
+        if (!response.ok) {
+            console.warn(
+                `StellarExpert API returned ${response.status} for contract ${contractAddress}`,
+            );
+
+            return undefined;
+        }
+
+        const data = (await response.json()) as StellarExpertContractData;
+        if (typeof data.asset !== 'string') {
+            console.warn(`StellarExpert contract ${contractAddress} does not contain an asset.`);
+
+            return undefined;
+        }
+
+        const normalizedAssetAddress = normalizeStellarAssetAddress(data.asset);
+        if (!normalizedAssetAddress) {
+            console.warn(
+                `StellarExpert contract ${contractAddress} returned invalid asset ${data.asset}`,
+            );
+
+            return undefined;
+        }
+
+        return normalizedAssetAddress;
+    } catch (error) {
+        console.warn(`Error fetching Stellar contract asset for ${contractAddress}:`, error);
+
+        return undefined;
+    }
+};
+
+/**
+ * Resolve a Stellar address to the normalized CODE-ISSUER format.
+ * Handles both classic Stellar asset addresses (CODE-ISSUER, CODE:ISSUER)
+ * and Soroban contract addresses (C...) by looking up the underlying asset
+ * via the StellarExpert API.
+ */
+const resolveStellarAddress = async (address: string): Promise<string | undefined> => {
+    const normalizedAssetAddress = normalizeStellarAssetAddress(address);
+    if (normalizedAssetAddress) {
+        return normalizedAssetAddress;
+    }
+
+    if (!isSorobanContractAddress(address)) {
+        return undefined;
+    }
+
+    return await fetchSorobanContractAsset(address);
+};
+
+export const getContractAddress = async (
+    assetPlatformId: string,
+    platforms: CoinData['platforms'],
+): Promise<string | undefined> => {
+    const address = platforms[assetPlatformId];
+    if (!address) {
+        return undefined;
+    }
+
+    if (assetPlatformId === 'cardano') {
+        return blockfrostUtils.parseAsset(address).policyId;
+    }
+
+    if (assetPlatformId === 'stellar') {
+        return await resolveStellarAddress(address);
+    }
+
+    return address;
 };
 
 interface StellarCurrency {
@@ -195,7 +261,7 @@ export const buildCoinDataForPlatform = async (
         const result: AdvancedTokenStructure = {};
 
         for (const { platforms, symbol, name } of allCoins) {
-            const contractAddress = getContractAddress(assetPlatformId, platforms);
+            const contractAddress = await getContractAddress(assetPlatformId, platforms);
             if (!contractAddress) continue;
 
             result[contractAddress] = { symbol, name };
@@ -212,11 +278,16 @@ export const buildCoinDataForPlatform = async (
         return result;
     }
 
-    return [
-        ...new Set(
-            allCoins
-                .map(item => getContractAddress(assetPlatformId, item.platforms))
-                .filter(Boolean),
-        ),
-    ] as SimpleTokenStructure;
+    const contractAddresses = new Set<string>();
+
+    for (const { platforms } of allCoins) {
+        const contractAddress = await getContractAddress(assetPlatformId, platforms);
+        if (!contractAddress) {
+            continue;
+        }
+
+        contractAddresses.add(contractAddress);
+    }
+
+    return [...contractAddresses];
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds Soroban contract support to the Stellar token definitions fetcher.

Previously, the Stellar path only handled classic asset identifiers in `CODE-ISSUER` / `CODE:ISSUER` form. This change adds support for Soroban contract addresses (`C...`) by querying the StellarExpert contract endpoint and resolving the returned `asset` field into the normalized `CODE-ISSUER` format already used by token definitions.
<!--- Describe your changes in detail -->

## Notes for QA
N/A
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26525

## Screenshots:
N/A