### PR TITLE
Disable label edit on desktop if Suite Sync is on but missing keys and Trezor disconnected

### DIFF
--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
@@ -125,16 +125,18 @@ describe(selectIsLabelActionEnabled.name, () => {
     });
 
     const testLabelActionEnabled = ({
+        deviceOverrides,
         unavailableCapabilities,
         isSuiteSyncFeatureEnabled,
         isSuiteSyncEnabled = false,
     }: {
+        deviceOverrides?: Parameters<typeof mockSuiteDevice>[0];
         unavailableCapabilities: UnavailableCapabilities;
         isSuiteSyncFeatureEnabled: boolean;
         isSuiteSyncEnabled?: boolean;
     }) => {
         const state = createMockState(
-            { unavailableCapabilities },
+            { unavailableCapabilities, ...deviceOverrides },
             {
                 settings: {
                     ...initialSuiteSyncDesktopState.settings,
@@ -155,6 +157,36 @@ describe(selectIsLabelActionEnabled.name, () => {
         });
 
         expect(result).toBe(true);
+    });
+
+    it('allows labeling when Suite Sync is enabled and device is connected but keys are needed', () => {
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: true,
+            isSuiteSyncEnabled: true,
+            deviceOverrides: {
+                connected: true,
+                available: true,
+                remember: true,
+            },
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('disables labeling when Suite Sync is enabled and remembered device is disconnected', () => {
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: true,
+            isSuiteSyncEnabled: true,
+            deviceOverrides: {
+                connected: false,
+                available: false,
+                remember: true,
+            },
+        });
+
+        expect(result).toBe(false);
     });
 
     it('disables labeling for unsupported device', () => {

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
@@ -3,6 +3,7 @@ import {
     selectIsLabelingAvailableForEntity,
     selectIsLabelingInitPossible,
 } from '@suite/metadata';
+import { selectDeviceByStaticSessionId } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type WithSuiteSyncAndDeviceState,
@@ -29,10 +30,15 @@ export const selectIsLabelActionEnabled = (
     const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
 
     if (isSuiteSyncEnabled) {
+        const device = selectDeviceByStaticSessionId(state, deviceStaticSessionId);
         const suiteSyncInteraction = selectDesktopSuiteSyncInteraction(
             state,
             deviceStaticSessionId,
         );
+
+        if (suiteSyncInteraction === 'keys-needed' && device?.connected === false) {
+            return false;
+        }
 
         return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
     }

--- a/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
@@ -1,15 +1,24 @@
 import type { Dispatch } from '@reduxjs/toolkit';
 
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
 import { createSuiteSyncStorageMock } from '../../tests/createSuiteSyncStorageMock.mock';
 import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
 import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from '../createTurnOnSuiteSync';
+import type { GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
 import { updateSuiteSyncEnabled } from '../suiteSyncSlice';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
+
+const createConnectedDevice = () =>
+    mockSuiteDevice({
+        connected: true,
+        available: true,
+        state: { staticSessionId: deviceStaticSessionId },
+    });
 
 describe(createTurnOnSuiteSync.name, () => {
     it('returns ok early when suite sync is already enabled', async () => {
@@ -17,6 +26,7 @@ describe(createTurnOnSuiteSync.name, () => {
             getIsSuiteSyncEnabled: () => true,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
+            getDeviceForStaticSessionId: () => createConnectedDevice(),
         });
 
         const turnOnSuiteSync = createTurnOnSuiteSync(deps);
@@ -34,6 +44,7 @@ describe(createTurnOnSuiteSync.name, () => {
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(storage)),
+            getDeviceForStaticSessionId: () => createConnectedDevice(),
         });
 
         const turnOnSuiteSync = createTurnOnSuiteSync(deps);
@@ -52,10 +63,31 @@ describe(createTurnOnSuiteSync.name, () => {
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
+            getDeviceForStaticSessionId: () => createConnectedDevice(),
         });
 
         const turnOnSuiteSync = createTurnOnSuiteSync(deps);
         const result = await turnOnSuiteSync({ deviceStaticSessionId: undefined });
+
+        expect(deps.dispatch).toHaveBeenCalledWith(updateSuiteSyncEnabled({ isEnabled: true }));
+        expect(deps.ensureWalletSuiteSyncOn).not.toHaveBeenCalled();
+        expect(result).toEqual(ok());
+    });
+
+    it('enables suite sync without calling ensureWalletSuiteSyncOn when remembered device is disconnected', async () => {
+        const deps = createMockDeps<CreateTurnOnSuiteSyncDeps & GetDeviceForStaticSessionIdDep>({
+            getIsSuiteSyncEnabled: () => false,
+            dispatch: mock<Dispatch>(() => {}),
+            ensureWalletSuiteSyncOn: () => Promise.resolve(ok(createSuiteSyncStorageMock())),
+            getDeviceForStaticSessionId: () =>
+                mockSuiteDevice({
+                    connected: false,
+                    state: { staticSessionId: deviceStaticSessionId },
+                }),
+        });
+
+        const turnOnSuiteSync = createTurnOnSuiteSync(deps);
+        const result = await turnOnSuiteSync({ deviceStaticSessionId });
 
         expect(deps.dispatch).toHaveBeenCalledWith(updateSuiteSyncEnabled({ isEnabled: true }));
         expect(deps.ensureWalletSuiteSyncOn).not.toHaveBeenCalled();
@@ -69,6 +101,7 @@ describe(createTurnOnSuiteSync.name, () => {
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
             ensureWalletSuiteSyncOn: () => Promise.resolve(ensureWalletSuiteSyncOnResult),
+            getDeviceForStaticSessionId: () => createConnectedDevice(),
         });
 
         const turnOnSuiteSync = createTurnOnSuiteSync(deps);

--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -171,6 +171,7 @@ export const createSuiteSyncCompositionRoot = (
             getIsSuiteSyncEnabled,
             dispatch: deps.dispatch,
             ensureWalletSuiteSyncOn,
+            getDeviceForStaticSessionId,
         }),
         labeling: {
             updateWalletLabel: createUpdateWalletLabel(labelingDeps),

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -7,17 +7,22 @@ import {
 } from '@suite-common/suite-sync-types';
 import { ok } from '@trezor/type-utils';
 
+import { type GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
 import { updateSuiteSyncEnabled } from './suiteSyncSlice';
 
 export type CreateTurnOnSuiteSyncDeps = {
     getIsSuiteSyncEnabled: () => boolean;
     dispatch: Dispatch;
-} & EnsureWalletSuiteSyncOnDep;
+} & EnsureWalletSuiteSyncOnDep &
+    GetDeviceForStaticSessionIdDep;
 
 export const createTurnOnSuiteSync =
     (deps: CreateTurnOnSuiteSyncDeps): TurnOnSuiteSync =>
     async ({ deviceStaticSessionId }) => {
         const isSuiteSyncEnabled = deps.getIsSuiteSyncEnabled();
+        const isDeviceConnected = deviceStaticSessionId
+            ? deps.getDeviceForStaticSessionId(deviceStaticSessionId)?.connected === true
+            : false;
 
         if (isSuiteSyncEnabled) {
             return ok();
@@ -27,7 +32,8 @@ export const createTurnOnSuiteSync =
 
         if (
             deviceStaticSessionId !== undefined &&
-            deviceStaticSessionId !== PORTFOLIO_TRACKER_DEVICE_STATE
+            deviceStaticSessionId !== PORTFOLIO_TRACKER_DEVICE_STATE &&
+            isDeviceConnected
         ) {
             const result = await deps.ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- We would like to make Edit label visible always and guide user to connect the Trezor if click on it to unify that with mobile flow, but as a followup. Handling device authorization during device action is not trivial. So this is most probably only temporary solution until we unify it with the mobile flow.

- There is one more fix in this PR as second commit: Do not initiate Suite Sync if Trezor is not connected. Originally we try to initialize Suite Sync even with Trezor disconnected, and it leads to DeviceError. On mobile that error is simply [ignored (not showned to user) ](https://github.com/trezor/trezor-suite/blob/2e6b8257a1ab95a9023623a63595d560e92b4584/suite-native/labeling/src/hooks/useSuiteSyncLabelErrorHandler.ts#L34). But it will not be possible to successfully initialize Suite Sync without Trezor connected. We will delete the keys on turning Suite Sync off, see https://github.com/trezor/trezor-suite/issues/26466


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26651



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync-disconnected-trezor-without-keys&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync-disconnected-trezor-without-keys&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T07:28:33.193Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->