### PR TITLE
Disable press on account details card list item

### DIFF
--- a/suite-native/accounts/src/components/AccountDetailsCard.tsx
+++ b/suite-native/accounts/src/components/AccountDetailsCard.tsx
@@ -28,6 +28,7 @@ const stakeCardStyle = prepareNativeStyle<{ isStakeVariant: boolean }>(
                 backgroundColor: utils.colors.backgroundTertiaryDefaultOnElevation1,
                 borderColor: utils.colors.backgroundTertiaryDefaultOnElevation0,
                 borderWidth: utils.borders.widths.small,
+                pointerEvents: 'none',
             },
         },
     }),


### PR DESCRIPTION
## Description

Remove tap interaction from the account row on the account details card, so it behaves as read-only information.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26582
