### PR TITLE
fix: Clear Suite Sync keys when Suite Sync is disabled

### DIFF
--- a/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncCompositionRoot.ts
@@ -139,6 +139,7 @@ export const createSuiteSyncCompositionRoot = (
     const turnOffSuiteSyncForWallet = createTurnOffSuiteSyncForWallet({
         suiteSyncStorageRepository,
         subscriptionStorage,
+        dispatch: deps.dispatch,
     });
 
     const getIsSuiteSyncEnabled = toGetter(deps.getState, selectIsSuiteSyncEnabled);

--- a/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
+++ b/suite-common/suite-sync/src/storage/createTurnOffSuiteSyncForWallet.ts
@@ -1,3 +1,5 @@
+import { type Dispatch } from '@reduxjs/toolkit';
+
 import {
     type SubscriptionStorageDep,
     type SuiteSyncStorageRepositoryDep,
@@ -5,15 +7,23 @@ import {
 } from '@suite-common/suite-sync-types';
 
 import { createStorageIdFromDeviceStaticSessionId } from './createStorageIdFromDeviceStaticSessionId';
+import { setSuiteSyncOwner } from '../suiteSyncSlice';
 
-export type CreateTurnOnSuiteSyncForWalletDeps = SuiteSyncStorageRepositoryDep &
-    SubscriptionStorageDep;
+export type CreateTurnOffSuiteSyncForWalletDeps = SuiteSyncStorageRepositoryDep &
+    SubscriptionStorageDep & { dispatch: Dispatch };
 
 export const createTurnOffSuiteSyncForWallet =
-    (deps: CreateTurnOnSuiteSyncForWalletDeps): TurnOffSuiteSyncForWallet =>
+    (deps: CreateTurnOffSuiteSyncForWalletDeps): TurnOffSuiteSyncForWallet =>
     async ({ deviceStaticSessionId }) => {
         const storageId = createStorageIdFromDeviceStaticSessionId(deviceStaticSessionId);
 
-        deps.subscriptionStorage.dispose(storageId);
-        await deps.suiteSyncStorageRepository.delete(storageId);
+        try {
+            deps.subscriptionStorage.dispose(storageId);
+            await deps.suiteSyncStorageRepository.delete(storageId);
+        } finally {
+            // Defensively always delete keys
+            deps.dispatch(
+                setSuiteSyncOwner({ deviceStaticId: deviceStaticSessionId, owner: null }),
+            );
+        }
     };

--- a/suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createTurnOffSuiteSyncForWallet.test.ts
@@ -1,0 +1,43 @@
+import { type Dispatch } from '@reduxjs/toolkit';
+
+import { createMockDeps, mock } from '@suite-common/dependency-injection';
+import { type StaticSessionId } from '@trezor/connect';
+
+import { setSuiteSyncOwner } from '../../suiteSyncSlice';
+import { createStorageIdFromDeviceStaticSessionId } from '../createStorageIdFromDeviceStaticSessionId';
+import { createSubscriptionStorageMock } from '../createSubscriptionStorage.mock';
+import {
+    type CreateTurnOffSuiteSyncForWalletDeps,
+    createTurnOffSuiteSyncForWallet,
+} from '../createTurnOffSuiteSyncForWallet';
+
+const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
+
+describe(createTurnOffSuiteSyncForWallet.name, () => {
+    it('disposes wallet storage, deletes repository entry, and clears owner from state', async () => {
+        const deps = createMockDeps<CreateTurnOffSuiteSyncForWalletDeps>({
+            dispatch: mock<Dispatch>(() => {}),
+            subscriptionStorage: createSubscriptionStorageMock(),
+            suiteSyncStorageRepository: {
+                get: null,
+                delete: () => Promise.resolve(),
+                set: null,
+            },
+        });
+
+        await createTurnOffSuiteSyncForWallet(deps)({
+            deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+        });
+
+        const storageId = createStorageIdFromDeviceStaticSessionId(DEVICE_STATIC_SESSION_ID_123);
+
+        expect(deps.subscriptionStorage.dispose).toHaveBeenCalledWith(storageId);
+        expect(deps.suiteSyncStorageRepository.delete).toHaveBeenCalledWith(storageId);
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            setSuiteSyncOwner({
+                deviceStaticId: DEVICE_STATIC_SESSION_ID_123,
+                owner: null,
+            }),
+        );
+    });
+});


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/26466

### Testing

After turning off suite sync, the encrypted owner data are not present in the app state

After turning suite sync off => 
<img width="327" height="143" alt="image" src="https://github.com/user-attachments/assets/85f981de-03e1-4db9-af99-661bf18a6506" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=clear-suite-sync-keys&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=clear-suite-sync-keys&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=clear-suite-sync-keys&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:22:45.637Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:20:55.615Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->