### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -13,10 +13,6 @@ export const messages = defineMessages({
         defaultMessage: 'Error 404: Link not found',
         id: 'TR_404_TITLE',
     },
-    TR_NEW: {
-        defaultMessage: 'New',
-        id: 'TR_NEW',
-    },
     TR_NEW_PASSPHRASE_WALLET: {
         defaultMessage: 'New passphrase',
         id: 'TR_NEW_PASSPHRASE_WALLET',
@@ -2426,10 +2422,6 @@ export const messages = defineMessages({
         description: 'Category in Settings',
         id: 'TR_GENERAL',
     },
-    TR_CONTINUE_TO_BACKUP: {
-        defaultMessage: 'Continue to wallet backup',
-        id: 'TR_CONTINUE_TO_BACKUP',
-    },
     TR_SKIP_PIN: {
         defaultMessage: 'Skip PIN',
         id: 'TR_SKIP_PIN',
@@ -3065,15 +3057,6 @@ export const messages = defineMessages({
         defaultMessage: 'No QR code found in the image',
         description: 'Error when QR code cannot be decoded from image',
         id: 'TR_QR_NOT_FOUND',
-    },
-    TR_YOUR_WALLET_SUCCESSFULLY_CREATED: {
-        defaultMessage: 'Wallet created successfully',
-        id: 'TR_YOUR_WALLET_SUCCESSFULLY_CREATED',
-    },
-    TR_YOUR_WALLET_IS_ALMOST_READY_DESCRIPTION: {
-        defaultMessage:
-            "Now let's create a wallet backup. Your wallet backup is the only way to recover access to your wallet.",
-        id: 'TR_YOUR_WALLET_IS_ALMOST_READY_DESCRIPTION',
     },
     TR_SELECT_DEVICE: {
         defaultMessage: 'Select device',
@@ -4286,10 +4269,6 @@ export const messages = defineMessages({
         id: 'TR_SAVE',
         defaultMessage: 'Save',
     },
-    TR_TURN_OFF: {
-        id: 'TR_TURN_OFF',
-        defaultMessage: 'Turn off',
-    },
     TR_CANCEL: {
         id: 'TR_CANCEL',
         defaultMessage: 'Cancel',
@@ -5119,10 +5098,6 @@ export const messages = defineMessages({
     ONBOARDING_UNEXPECTED_DEVICE_DIFFERENT_P2: {
         id: 'ONBOARDING_UNEXPECTED_DEVICE_DIFFERENT_P2',
         defaultMessage: 'If you want to use this device instead, start again.',
-    },
-    TR_ONBOARDING_CREATE_NEW_WALLET: {
-        id: 'TR_ONBOARDING_CREATE_NEW_WALLET',
-        defaultMessage: 'Create a new wallet',
     },
     TR_ONBOARDING_SELECTED_OPTIMAL_BACKUP_TYPE: {
         id: 'TR_ONBOARDING_SELECTED_OPTIMAL_BACKUP_TYPE',


### PR DESCRIPTION
## Summary

Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (6):**
- `TR_NEW`
- `TR_CONTINUE_TO_BACKUP`
- `TR_YOUR_WALLET_SUCCESSFULLY_CREATED`
- `TR_YOUR_WALLET_IS_ALMOST_READY_DESCRIPTION`
- `TR_TURN_OFF`
- `TR_ONBOARDING_CREATE_NEW_WALLET`

Identified by the `translations:list-unused` CI check.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260414&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260414&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:43:18.978Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:41:16.940Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->