### PR TITLE
test(e2e-suite): fix t1b1 create wallet test

### DIFF
--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -59,12 +59,18 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 
+            // Issue: Clicking setPinButton causes toast error: 'Error: Initialize failed: messages.c:257:Unknown message, code: Failure_UnexpectedMessage'
+            // Second click on setPinButton does continue the flow correctly
             await test.step('Lets set PIN', async () => {
                 await page.waitForTimeout(2_000);
                 const pin = '12345';
 
-                await onboardingPage.pin.setPinButton.click();
-                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(async () => {
+                    await onboardingPage.pin.setPinButton.click();
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                }).toPass({
+                    timeout: 15_000,
+                });
                 await device.pressYes();
                 // enter the PIN
                 await trezorInput.enterPinOnBlindMatrix(pin);
@@ -74,7 +80,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
 
             await test.step('Finish wallet creation', async () => {
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
-                await expect(dashboardPage.walletReady).toBeVisible();
+                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
             });
         },
     );


### PR DESCRIPTION


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fixes-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fixes-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:43:45.645Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T09:42:38.057Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->