### PR TITLE
fix(suite-native): land on Earn tab after staking tx

### DIFF
--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -46,7 +46,7 @@ const navigateToClaimedTransactionAction = ({
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
-                params: { screen: AppTabsRoutes.HomeStack },
+                params: { screen: AppTabsRoutes.EarnStack },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -47,7 +47,7 @@ const navigateToStakedTransactionAction = ({
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
-                params: { screen: AppTabsRoutes.HomeStack },
+                params: { screen: AppTabsRoutes.EarnStack },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -46,7 +46,7 @@ const navigateToUnstakedTransactionAction = ({
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
-                params: { screen: AppTabsRoutes.HomeStack },
+                params: { screen: AppTabsRoutes.EarnStack },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,


### PR DESCRIPTION
## Description

Update post-staking navigation so that opening transaction details after staking, unstaking, or claiming to the Earn screen instead of Home.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26576