### PR TITLE
stack/transport locking cleanup

### DIFF
--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -166,10 +166,18 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
 
             return openDeviceResult;
         }
-        await sessionsClient.acquireDone({
+        const acquireDoneResult = await sessionsClient.acquireDone({
             path: acquireInput.path,
             sessionOwner: acquireInput.sessionOwner,
         });
+
+        if (!acquireDoneResult.success) {
+            // Device disappeared between openDevice and session commit.
+            // Close the device we just opened to avoid a leaked handle.
+            await api.closeDevice(acquireIntentResult.payload.path);
+
+            return error({ code: acquireDoneResult.error.code });
+        }
 
         return acquireIntentResult;
     };

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -161,6 +161,9 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
         logger?.debug(`core: openDevice: result: ${JSON.stringify(openDeviceResult)}`);
 
         if (!openDeviceResult.success) {
+            // Release the lock without committing session (abort acquire).
+            await sessionsClient.acquireDone({ path: acquireInput.path, abort: true });
+
             return openDeviceResult;
         }
         await sessionsClient.acquireDone({
@@ -172,13 +175,21 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
     };
 
     const release = async ({ session }: Omit<ReleaseInput, 'path'>) => {
-        await sessionsClient.releaseIntent({ session });
+        const releaseIntentResult = await sessionsClient.releaseIntent({ session });
+
+        if (!releaseIntentResult.success) {
+            return releaseIntentResult;
+        }
 
         const sessionsResult = await sessionsClient.getPathBySession({
             session,
         });
 
         if (!sessionsResult.success) {
+            // releaseIntent succeeded (lock held) but path lookup failed.
+            // Release the lock to avoid starvation.
+            await sessionsClient.releaseDone({ path: releaseIntentResult.payload.path });
+
             return sessionsResult;
         }
 
@@ -188,6 +199,7 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
             logger?.error(`core: release: api.closeDevice error: ${closeRes.error}`);
         }
 
+        // Always call releaseDone to release the lock, even if closeDevice failed.
         return sessionsClient.releaseDone({ path: sessionsResult.payload.path });
     };
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -142,6 +142,8 @@ export class SessionsBackground
         );
 
         disconnectedDevices.forEach(d => {
+            // Release any active lock held for this device to avoid starvation.
+            this.releaseActiveLock(d);
             delete this.descriptors[d];
             delete this.pathInternalPathPublicMap[d];
         });
@@ -227,14 +229,16 @@ export class SessionsBackground
         }
 
         // When abort is set, just release the lock without modifying session.
+        let { session } = this.descriptors[pathInternal];
         if (!payload.abort) {
-            this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+            session = Session(`${this.lastSessionId}`);
+            this.descriptors[pathInternal].session = session;
             this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
         }
 
         this.releaseActiveLock(pathInternal);
 
-        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+        return Promise.resolve(success({ session, descriptors: Object.values(this.descriptors) }));
     }
 
     private async releaseIntent(payload: ReleaseIntentRequest) {

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -226,9 +226,11 @@ export class SessionsBackground
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
-        // Commit session state before releasing lock so the next waiter sees the update.
-        this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
-        this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        // When abort is set, just release the lock without modifying session.
+        if (!payload.abort) {
+            this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+            this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        }
 
         this.releaseActiveLock(pathInternal);
 

--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -50,9 +50,11 @@ export class SessionsBackground
     private descriptors: DescriptorsDict = {};
     private pathInternalPathPublicMap: Record<PathInternal, PathPublic> = {};
 
-    // if lock is set, somebody is doing something with device. we have to wait
-    private locksQueue: { id: TimerId; dfd: Deferred<void> }[] = [];
-    private locksTimeoutQueue: TimerId[] = [];
+    // Lock queue for exclusive device access. Each entry has a unique token for ownership tracking.
+    private locksQueue: { token: number; dfd: Deferred<void> }[] = [];
+    private lockIdCounter = 0;
+    // Active lock token per device path, persisted between Intent and Done calls.
+    private activeLocks = new Map<PathInternal, number>();
     private lastSessionId = 0;
     private lastPathId = 0;
 
@@ -181,14 +183,24 @@ export class SessionsBackground
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
 
-        await this.waitInQueue();
+        // Snapshot session before waiting so the post-wait check compares against
+        // the value at intent time, not the (possibly mutated) current value.
+        const previousSession = previous.session;
 
-        // in case there are 2 simultaneous acquireIntents, one goes through, the other one waits and gets error here
-        if (previous.session !== this.descriptors[pathInternal]?.session) {
-            this.clearLock();
+        const lock = await this.waitInQueue();
+        if (!lock) {
+            return error({ code: ERRORS.ABORTED_BY_TIMEOUT });
+        }
+
+        // In case there are 2 simultaneous acquireIntents, one goes through, the other waits and gets error here.
+        if (previousSession !== this.descriptors[pathInternal]?.session) {
+            this.clearLock(lock.token);
 
             return error({ code: ERRORS.SESSION_WRONG_PREVIOUS });
         }
+
+        // Store lock token for this path until acquireDone.
+        this.activeLocks.set(pathInternal, lock.token);
 
         this.lastSessionId++;
         const session = Session(`${this.lastSessionId}`);
@@ -203,14 +215,22 @@ export class SessionsBackground
      * - assign client a new "session". this session will be used in all subsequent communication
      */
     private acquireDone(payload: AcquireDoneRequest) {
-        this.clearLock();
         const pathInternal = this.getInternal(payload.path);
 
         if (!pathInternal || !this.descriptors[pathInternal]) {
+            // Release lock on error to avoid starvation.
+            if (pathInternal) {
+                this.releaseActiveLock(pathInternal);
+            }
+
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
+
+        // Commit session state before releasing lock so the next waiter sees the update.
         this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
         this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+
+        this.releaseActiveLock(pathInternal);
 
         return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
     }
@@ -223,18 +243,31 @@ export class SessionsBackground
         }
         const { path } = pathResult.payload;
 
-        await this.waitInQueue();
+        const lock = await this.waitInQueue();
+        if (!lock) {
+            return error({ code: ERRORS.ABORTED_BY_TIMEOUT });
+        }
+
+        // Store lock token for this path until releaseDone.
+        this.activeLocks.set(path, lock.token);
 
         return success({ path });
     }
 
     private releaseDone(payload: ReleaseDoneRequest) {
-        this.descriptors[payload.path].session = null;
-        this.descriptors[payload.path].sessionOwner = undefined;
+        try {
+            if (!this.descriptors[payload.path]) {
+                return error({ code: ERRORS.DEVICE_NOT_FOUND });
+            }
 
-        this.clearLock();
+            this.descriptors[payload.path].session = null;
+            this.descriptors[payload.path].sessionOwner = undefined;
 
-        return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+            return Promise.resolve(success({ descriptors: Object.values(this.descriptors) }));
+        } finally {
+            // Release lock in finally to avoid starvation on error or disconnect.
+            this.releaseActiveLock(payload.path);
+        }
     }
 
     private getSessions() {
@@ -253,46 +286,71 @@ export class SessionsBackground
         return success({ path });
     }
 
-    private startLock() {
-        // todo: create a deferred with built-in timeout functionality (util)
-        const dfd = createDeferred();
+    private startLock(): number {
+        this.lockIdCounter++;
+        const dfd = createDeferred<void>();
+        this.locksQueue.push({ token: this.lockIdCounter, dfd });
 
-        // to ensure that communication with device will not get stuck forever,
-        // lock times out:
-        // - if cleared by client (enumerateDone)
-        // - after n second automatically
-        const timeout = setTimeout(() => {
-            dfd.resolve(undefined);
-        }, lockDuration);
-
-        this.locksQueue.push({ id: timeout, dfd });
-        this.locksTimeoutQueue.push(timeout);
-
-        return this.locksQueue.length - 1;
+        return this.lockIdCounter;
     }
 
-    private clearLock() {
-        const lock = this.locksQueue[0];
-        if (lock) {
-            this.locksQueue[0].dfd.resolve(undefined);
-            this.locksQueue.shift();
-            clearTimeout(this.locksTimeoutQueue[0]);
-            this.locksTimeoutQueue.shift();
+    private clearLock(token: number) {
+        const index = this.locksQueue.findIndex(l => l.token === token);
+        if (index !== -1) {
+            this.locksQueue[index].dfd.resolve(undefined);
+            this.locksQueue.splice(index, 1);
         }
     }
 
-    private async waitForUnlocked(myIndex: number) {
-        if (myIndex > 0) {
-            const beforeMe = this.locksQueue.slice(0, myIndex);
-            if (beforeMe.length) {
-                await Promise.all(beforeMe.map(lock => lock.dfd.promise));
+    private releaseActiveLock(pathInternal: PathInternal) {
+        const token = this.activeLocks.get(pathInternal);
+        if (token !== undefined) {
+            this.clearLock(token);
+            this.activeLocks.delete(pathInternal);
+        }
+    }
+
+    /**
+     * Wait in the lock queue. Returns a lock handle on success, or null if the wait timed out.
+     * Timeout is a safety net only; it never transfers ownership to another waiter.
+     */
+    private async waitInQueue(): Promise<{ token: number } | null> {
+        const token = this.startLock();
+        const deadline = Date.now() + lockDuration;
+
+        // Wait for predecessors before proceeding. Re-check position after each
+        // predecessor resolves in case an earlier waiter timed out and was removed.
+        while (true) {
+            const myIndex = this.locksQueue.findIndex(l => l.token === token);
+            if (myIndex <= 0) {
+                break;
+            }
+
+            const predecessor = this.locksQueue[myIndex - 1];
+            const remaining = deadline - Date.now();
+            if (remaining <= 0) {
+                this.clearLock(token);
+
+                return null;
+            }
+
+            let timeoutId: TimerId;
+            const timedOut = await Promise.race([
+                predecessor.dfd.promise.then(() => false),
+                new Promise<true>(resolve => {
+                    timeoutId = setTimeout(() => resolve(true), remaining);
+                }),
+            ]);
+            clearTimeout(timeoutId!);
+
+            if (timedOut) {
+                this.clearLock(token);
+
+                return null;
             }
         }
-    }
 
-    private async waitInQueue() {
-        const myIndex = this.startLock();
-        await this.waitForUnlocked(myIndex);
+        return { token };
     }
 
     private getInternal(pathPublic: PathPublic): PathInternal | undefined {
@@ -302,8 +360,10 @@ export class SessionsBackground
     }
 
     dispose() {
-        this.locksQueue.forEach(lock => clearTimeout(lock.id));
-        this.locksTimeoutQueue.forEach(timeout => clearTimeout(timeout));
+        // Resolve all pending lock deferreds to unblock waiters.
+        this.locksQueue.forEach(lock => lock.dfd.resolve(undefined));
+        this.locksQueue = [];
+        this.activeLocks.clear();
         this.descriptors = {};
         this.lastSessionId = 0;
         this.removeAllListeners();

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -31,7 +31,9 @@ export type AcquireIntentRequest = AcquireInput;
 
 export type AcquireIntentResponse = BackgroundResponseWithError<
     { session: Session; path: PathInternal; releaseRequest?: Descriptor },
-    typeof ERRORS.SESSION_WRONG_PREVIOUS | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.SESSION_WRONG_PREVIOUS
+    | typeof ERRORS.DEVICE_NOT_FOUND
+    | typeof ERRORS.ABORTED_BY_TIMEOUT
 >;
 
 export type AcquireDoneRequest = {
@@ -52,16 +54,19 @@ export interface ReleaseIntentRequest {
 
 export type ReleaseIntentResponse = BackgroundResponseWithError<
     { path: PathInternal },
-    typeof ERRORS.SESSION_NOT_FOUND
+    typeof ERRORS.SESSION_NOT_FOUND | typeof ERRORS.ABORTED_BY_TIMEOUT
 >;
 
 export interface ReleaseDoneRequest {
     path: PathInternal;
 }
 
-export type ReleaseDoneResponse = BackgroundResponse<{
-    descriptors: Descriptor[];
-}>;
+export type ReleaseDoneResponse = BackgroundResponseWithError<
+    {
+        descriptors: Descriptor[];
+    },
+    typeof ERRORS.DEVICE_NOT_FOUND
+>;
 
 export type GetSessionsRequest = Record<string, never>;
 export type GetSessionsResponse = BackgroundResponse<{

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -39,6 +39,7 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 export type AcquireDoneRequest = {
     path: PathPublic;
     sessionOwner?: string;
+    abort?: boolean;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -132,6 +132,9 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 );
 
                 if (!openDeviceResult.success) {
+                    // Release the lock without committing session (abort acquire).
+                    this.sessionsClient.acquireDone({ path, abort: true });
+
                     return openDeviceResult;
                 }
 

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -133,12 +133,25 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 if (!openDeviceResult.success) {
                     // Release the lock without committing session (abort acquire).
-                    this.sessionsClient.acquireDone({ path, abort: true });
+                    await this.sessionsClient.acquireDone({ path, abort: true });
 
                     return openDeviceResult;
                 }
 
-                this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
+                const acquireDoneResponse = await this.sessionsClient.acquireDone({
+                    path,
+                    sessionOwner: this.id,
+                });
+
+                if (!acquireDoneResponse.success) {
+                    // Device disappeared between openDevice and session commit.
+                    // Close the device we just opened to avoid a leaked handle.
+                    await this.api.closeDevice(acquireIntentResponse.payload.path, {
+                        channel: 'read',
+                    });
+
+                    return error({ code: acquireDoneResponse.error.code });
+                }
 
                 return success(acquireIntentResponse.payload.session);
             },

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -197,4 +197,113 @@ describe('sessions', () => {
             },
         });
     });
+
+    test('concurrent acquire on same path - one succeeds, one fails', async () => {
+        const client1 = new SessionsClient(background);
+        const client2 = new SessionsClient(background);
+        await client1.handshake();
+        await client2.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Both clients issue acquireIntent concurrently with the same previous session.
+        // client1 enters the queue first (synchronous execution order) and proceeds immediately.
+        // client2 enters second and waits for client1's lock.
+        const promise1 = client1.acquireIntent({ path: PathPublic('1'), previous: null });
+        const promise2 = client2.acquireIntent({ path: PathPublic('1'), previous: null });
+
+        // client1 succeeds immediately (first in queue).
+        const acquire1 = await promise1;
+        expect(acquire1).toMatchObject({ success: true, payload: { session: '1' } });
+
+        // Complete client1's acquire, which releases the lock and commits session.
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        // client2 wakes up and detects the session has changed.
+        const acquire2 = await promise2;
+        expect(acquire2).toMatchObject({
+            success: false,
+            error: { code: 'wrong previous session' },
+        });
+    });
+
+    test('release with missing descriptor returns error and releases lock', async () => {
+        const client1 = new SessionsClient(background);
+        await client1.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Acquire and release setup.
+        await client1.acquireIntent({ path: PathPublic('1'), previous: null });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        const release = await client1.releaseIntent({ session: Session('1') });
+        expect(release).toMatchObject({ success: true });
+
+        // Simulate device disconnect by re-enumerating without the device.
+        await client1.enumerateDone({ descriptors: [] });
+
+        // ReleaseDone on a path that no longer exists should return error.
+        const releaseDone = await client1.releaseDone({ path: PathInternal('1') });
+        expect(releaseDone).toMatchObject({
+            success: false,
+            error: { code: 'device not found' },
+        });
+
+        // The lock should still be released - a subsequent acquire on a re-enumerated device should work.
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('2'), type: 1, apiType: 'usb' }],
+        });
+
+        const acquire2 = await client1.acquireIntent({
+            path: PathPublic('2'),
+            previous: null,
+        });
+        expect(acquire2).toMatchObject({ success: true });
+        await client1.acquireDone({ path: PathPublic('2') });
+    });
+
+    test('clearLock only releases own lock, not another requester lock', async () => {
+        const client1 = new SessionsClient(background);
+        const client2 = new SessionsClient(background);
+        await client1.handshake();
+        await client2.handshake();
+
+        await client1.enumerateDone({
+            descriptors: [{ path: PathInternal('1'), type: 1, apiType: 'usb' }],
+        });
+
+        // Client 1 acquires successfully.
+        const acquire1 = await client1.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquire1).toMatchObject({ success: true });
+        await client1.acquireDone({ path: PathPublic('1') });
+
+        // Client 2 tries to acquire with wrong previous - fails before queue.
+        const acquire2 = await client2.acquireIntent({
+            path: PathPublic('1'),
+            previous: null,
+        });
+        expect(acquire2).toMatchObject({
+            success: false,
+            error: { code: 'wrong previous session' },
+        });
+
+        // Client 2 can still acquire with correct previous.
+        const acquire3 = await client2.acquireIntent({
+            path: PathPublic('1'),
+            previous: Session('1'),
+        });
+        expect(acquire3).toMatchObject({
+            success: true,
+            payload: { session: '2' },
+        });
+        await client2.acquireDone({ path: PathPublic('1') });
+    });
 });

--- a/packages/transport/tests/sessions.test.ts
+++ b/packages/transport/tests/sessions.test.ts
@@ -51,6 +51,7 @@ describe('sessions', () => {
             success: true,
             id: 3,
             payload: {
+                session: '1',
                 descriptors: [
                     {
                         path: '1',


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=stack/transport-locking-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=stack/transport-locking-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T11:10:48.160Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T11:08:21.636Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->