### PR TITLE
fix(e2e): restore session-steal step in multiple-sessions test

### DIFF
--- a/suite/e2e/tests/suite/multiple-sessions.test.ts
+++ b/suite/e2e/tests/suite/multiple-sessions.test.ts
@@ -53,27 +53,13 @@ test.describe('Multiple sessions', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_CONNECTED');
             });
 
-            // Possible change of behaviour to this instead of rest of the test.
-            // ATM discussed with Varmuza
-            // await test.step('Reload inactive suite session to take Bridge session back', async () => {
-            //     await stealBridgeSession();
-            //     await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
-            //     await page.reload();
-            //     await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
-            //         timeout: 30_000,
-            //     });
-            // });
-
-            await test.step('After reloading inactive suite session does not take Bridge session back', async () => {
-                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE', {
+            await test.step('Reload inactive suite session to take Bridge session back', async () => {
+                await stealBridgeSession();
+                await expect(dashboardPage.deviceStatus).toHaveTranslation('TR_USE_HERE');
+                await page.reload();
+                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible({
                     timeout: 30_000,
                 });
-            });
-
-            await test.step('Take Bridge session back', async () => {
-                await dashboardPage.deviceSwitchingOpenButton.click();
-                await dashboardPage.solveIssuesButton.click();
-                await expect(page.getByTestId('@deviceStatus-connected').first()).toBeVisible();
             });
         },
     );


### PR DESCRIPTION
Uncomment the 'Reload inactive suite session' step that steals the
bridge session, reloads the page, and verifies Suite auto-reacquires.
Remove the two broken trailing steps that expected TR_USE_HERE without
anything stealing the session first (always timed out at 30s).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>