### PR TITLE
fix(transport): release session lock when openDevice fails in acquire

### DIFF
--- a/packages/transport/src/sessions/background.ts
+++ b/packages/transport/src/sessions/background.ts
@@ -226,9 +226,11 @@ export class SessionsBackground
             return error({ code: ERRORS.DEVICE_NOT_FOUND });
         }
 
-        // Commit session state before releasing lock so the next waiter sees the update.
-        this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
-        this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        // When abort is set, just release the lock without modifying session.
+        if (!payload.abort) {
+            this.descriptors[pathInternal].session = Session(`${this.lastSessionId}`);
+            this.descriptors[pathInternal].sessionOwner = payload.sessionOwner;
+        }
 
         this.releaseActiveLock(pathInternal);
 

--- a/packages/transport/src/sessions/types.ts
+++ b/packages/transport/src/sessions/types.ts
@@ -39,6 +39,7 @@ export type AcquireIntentResponse = BackgroundResponseWithError<
 export type AcquireDoneRequest = {
     path: PathPublic;
     sessionOwner?: string;
+    abort?: boolean;
 };
 
 export type AcquireDoneResponse = BackgroundResponseWithError<

--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -132,6 +132,9 @@ export abstract class AbstractApiTransport extends AbstractTransport {
                 );
 
                 if (!openDeviceResult.success) {
+                    // Release the lock without committing session (abort acquire).
+                    this.sessionsClient.acquireDone({ path, abort: true });
+
                     return openDeviceResult;
                 }
 


### PR DESCRIPTION
When acquireIntent succeeds but the subsequent openDevice call fails,
acquireDone was never called, leaving the lock permanently held. The
old timeout-based lock system recovered from this silently; the new
token-based lock system (step 1) does not auto-expire, so the leaked
lock blocks all future acquire/release operations on the transport.

Add an `abort` flag to AcquireDoneRequest. When openDevice fails,
call acquireDone({ path, abort: true }) to release the lock without
committing a phantom session. In SessionsBackground.acquireDone, skip
session state mutation when abort is set but still release the active
lock via releaseActiveLock.

Fixes DeviceList unit test failure where a transport with a failing
openDevice would deadlock subsequent device connections.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>