### PR TITLE
fix(transport): await acquireDone in abstractApi acquire

### DIFF
--- a/packages/transport/src/transports/abstractApi.ts
+++ b/packages/transport/src/transports/abstractApi.ts
@@ -133,12 +133,25 @@ export abstract class AbstractApiTransport extends AbstractTransport {
 
                 if (!openDeviceResult.success) {
                     // Release the lock without committing session (abort acquire).
-                    this.sessionsClient.acquireDone({ path, abort: true });
+                    await this.sessionsClient.acquireDone({ path, abort: true });
 
                     return openDeviceResult;
                 }
 
-                this.sessionsClient.acquireDone({ path, sessionOwner: this.id });
+                const acquireDoneResponse = await this.sessionsClient.acquireDone({
+                    path,
+                    sessionOwner: this.id,
+                });
+
+                if (!acquireDoneResponse.success) {
+                    // Device disappeared between openDevice and session commit.
+                    // Close the device we just opened to avoid a leaked handle.
+                    await this.api.closeDevice(acquireIntentResponse.payload.path, {
+                        channel: 'read',
+                    });
+
+                    return error({ code: acquireDoneResponse.error.code });
+                }
 
                 return success(acquireIntentResponse.payload.session);
             },


### PR DESCRIPTION
Await both acquireDone calls (abort and commit paths) instead of
fire-and-forget. If the commit path fails (device disconnected between
openDevice and session commit), close the opened device handle to avoid
a leaked descriptor and return a structured error.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>