### PR TITLE
Hide Add address label button if trezor is not connected and make it never disabled

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -33,6 +33,7 @@ import { CoinLogo, ConfirmOnDevicePill } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
 import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
+import { selectDesktopSuiteSyncInteraction } from 'src/actions/suiteSync/suiteSyncSlice';
 import { AccountLabel } from 'src/components/suite/AccountLabel';
 import { Address } from 'src/components/suite/Address';
 import { QrCode } from 'src/components/suite/QrCode';
@@ -67,8 +68,7 @@ export const ConfirmValueModal = ({
     value,
 }: ConfirmValueModalProps) => {
     const [isCopied, setIsCopied] = useState(false);
-    const { device, isLocked } = useDevice();
-    const isDeviceLocked = isLocked();
+    const { device } = useDevice();
     const modalContext = useSelector(state => state.modal.context);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const { addressLabels } = useSelector(selectLabelingDataForSelectedAccount);
@@ -80,21 +80,18 @@ export const ConfirmValueModal = ({
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
 
-    const legacyMetadataState = useSelector(state => state.metadata);
-
-    // block labeling if metadata needs to be enabled on device until receive address is confirmed (device locked)
-    const isMetadataBlockedByDeviceCall =
-        isDeviceLocked &&
-        !isSuiteSyncEnabled &&
-        (!legacyMetadataState.enabled || legacyMetadataState.providers.length === 0);
-
     const suiteSyncAddressLabels = useSelector(state =>
         account && isSuiteSyncEnabled
             ? selectSuiteSyncAddressLabels(state, account.deviceState)
             : undefined,
     );
+    const suiteSyncInteraction = useSelector(state =>
+        account ? selectDesktopSuiteSyncInteraction(state, account.deviceState) : null,
+    );
 
     const canConfirmOnDevice = !!(device?.connected && device?.available);
+    // Do not show Add address label button if there is device interaction needed and device is not connected.
+    const shouldShowAddressLabelAction = suiteSyncInteraction === null || !!device?.connected;
 
     const copy = () => {
         const result = copyToClipboard(value);
@@ -198,42 +195,37 @@ export const ConfirmValueModal = ({
                                 <QrCode value={value} />
                             </Box>
                             <Column gap={12} alignItems="flex-start">
-                                {isAddress &&
-                                    (account ? (
-                                        <Labeling
-                                            deviceStaticSessionId={account.deviceState}
-                                            isDisabled={isMetadataBlockedByDeviceCall}
-                                            displayValue={
-                                                <Text typographyStyle="body-md-strong">
-                                                    <Translation id="TR_LABELING_ADD_ADDRESS_LABEL" />
-                                                </Text>
-                                            }
-                                            placeholder={translationString(
-                                                'TR_LABELING_ADDRESS_LABEL',
-                                            )}
-                                            leftAddon={
-                                                <Icon
-                                                    name={addressLabel ? 'tagFilled' : 'tag'}
-                                                    size={16}
-                                                    intent="neutral"
-                                                    priority="secondary"
-                                                />
-                                            }
-                                            payload={{
-                                                type: 'addressLabel',
-                                                entityKey: account.key,
-                                                defaultValue: value,
-                                                networkSymbol: account.symbol,
-                                                accountDescriptor: account.descriptor,
-                                                value: addressLabel,
-                                            }}
-                                            maxWidth={290}
-                                        >
-                                            {addressLabel}
-                                        </Labeling>
-                                    ) : (
-                                        label
-                                    ))}
+                                {isAddress && !account && label}
+                                {isAddress && !!account && shouldShowAddressLabelAction && (
+                                    <Labeling
+                                        deviceStaticSessionId={account.deviceState}
+                                        displayValue={
+                                            <Text typographyStyle="body-md-strong">
+                                                <Translation id="TR_LABELING_ADD_ADDRESS_LABEL" />
+                                            </Text>
+                                        }
+                                        placeholder={translationString('TR_LABELING_ADDRESS_LABEL')}
+                                        leftAddon={
+                                            <Icon
+                                                name={addressLabel ? 'tagFilled' : 'tag'}
+                                                size={16}
+                                                intent="neutral"
+                                                priority="secondary"
+                                            />
+                                        }
+                                        payload={{
+                                            type: 'addressLabel',
+                                            entityKey: account.key,
+                                            defaultValue: value,
+                                            networkSymbol: account.symbol,
+                                            accountDescriptor: account.descriptor,
+                                            value: addressLabel,
+                                        }}
+                                        maxWidth={290}
+                                    >
+                                        {addressLabel}
+                                    </Labeling>
+                                )}
                                 <Address
                                     value={value}
                                     data-testid="@modal/output-value"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add address label button should be for now hidden if Trezor is not connected, so there is no way to enable Suite Sync. There is another issue to make that possible https://github.com/trezor/trezor-suite/issues/26653

Disabled button was confusing, it's not clear from the UI that the button is disabled. And it can be enabled and allow to show Turn on Suite Sync modal if needed.

## Notes for QA

- This change is isolated to Confirm value dialog, but that is used not only for address value confirmation, but also for XPUB confirmation and also address value in some Trade scenario (I don't know which exactly).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26649

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/address-label-edit-without-trezor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/address-label-edit-without-trezor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T10:34:33.046Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T12:30:55.118Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->