### PR TITLE
fix(suite): use SettingsLayout in Connected Apps tab to fix top gap

### DIFF
--- a/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/SettingsConnectedApps.tsx
@@ -6,6 +6,7 @@ import { Column, Icon, Row, SubTabs } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
 import { spacings } from '@trezor/theme';
 
+import { SettingsLayout } from 'src/components/settings/SettingsLayout';
 import { useDispatch } from 'src/hooks/suite';
 
 import { ConnectPermissions } from './ConnectPermissions';
@@ -40,26 +41,28 @@ export const SettingsConnectedApps = () => {
     }, [tabs.length, dispatch]);
 
     return (
-        <Column gap={spacings.md} margin={{ top: spacings.md }} flex="1">
-            <Row justifyContent="space-between" flexWrap="wrap" gap={spacings.sm}>
-                <SubTabs size="large" activeItemId={activeItemdId}>
-                    {tabs.map(tab => (
-                        <SubTabs.Item
-                            key={tab.id}
-                            id={tab.id}
-                            data-testid={`@settings/connect-apps/tabs/${tab.id}`}
-                            onClick={() => setActiveItemId(tab.id)}
-                        >
-                            <Row alignItems="center" gap={spacings.xs}>
-                                <Icon name={tab.icon} />
-                                {tab.title}
-                            </Row>
-                        </SubTabs.Item>
-                    ))}
-                </SubTabs>
-                <WalletConnectButton handleOpened={() => setActiveItemId('walletconnect')} />
-            </Row>
-            {tabs.find(tab => tab.id === activeItemdId)?.component}
-        </Column>
+        <SettingsLayout>
+            <Column gap={spacings.md} flex="1">
+                <Row justifyContent="space-between" flexWrap="wrap" gap={spacings.sm}>
+                    <SubTabs size="large" activeItemId={activeItemdId}>
+                        {tabs.map(tab => (
+                            <SubTabs.Item
+                                key={tab.id}
+                                id={tab.id}
+                                data-testid={`@settings/connect-apps/tabs/${tab.id}`}
+                                onClick={() => setActiveItemId(tab.id)}
+                            >
+                                <Row alignItems="center" gap={spacings.xs}>
+                                    <Icon name={tab.icon} />
+                                    {tab.title}
+                                </Row>
+                            </SubTabs.Item>
+                        ))}
+                    </SubTabs>
+                    <WalletConnectButton handleOpened={() => setActiveItemId('walletconnect')} />
+                </Row>
+                {tabs.find(tab => tab.id === activeItemdId)?.component}
+            </Column>
+        </SettingsLayout>
     );
 };


### PR DESCRIPTION
Closes #26679

<!--- Provide a general summary of your changes in the Title above -->

## Description

The Connected Apps settings tab was not using SettingsLayout like all other settings tabs (General, Device, Coins). Instead it wrapped content in a Column with margin={{ top: spacings.md }}, causing an extra gap at the top. This wraps the content in SettingsLayout and removes the extra margin to align with the other tabs.    

## Notes for QA

  - Navigate to Settings → Connected Apps and compare the top spacing with other tabs (General, Device, Coins)
  - Content should now start at the same vertical position across all tabs   

## Related Issue

 Resolve https://github.com/trezor/trezor-suite/issues/26679

## Screenshots:
<img width="1013" height="354" alt="Screenshot 2026-04-14 at 14 49 31" src="https://github.com/user-attachments/assets/49f41cda-f175-4aa2-8e57-fea76807f4a9" />
