### PR TITLE
feat(trading): move refetch timer logic to redux

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingBuyHandleChange.ts
@@ -8,9 +8,10 @@ import {
     buyThunks,
     getTradingPaymentMethods,
     isCountrySubdivisionEmpty,
+    tradingActions,
+    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -18,7 +19,6 @@ import { useAnalytics } from 'src/support/useAnalytics';
 type TradingBuyUseHandleChangeProps = {
     formValues: TradingBuyFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
 
     setValue: UseFormSetValue<TradingBuyFormProps>;
@@ -35,7 +35,6 @@ type PromiseType = {
 export const useTradingBuyHandleChange = ({
     formValues,
     network,
-    timer,
     shouldSendInSats,
     setValue,
 }: TradingBuyUseHandleChangeProps) => {
@@ -60,7 +59,6 @@ export const useTradingBuyHandleChange = ({
             buyThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
                 shouldSendInSats,
             }),
         );
@@ -96,9 +94,11 @@ export const useTradingBuyHandleChange = ({
                 }
             }
         } catch (error) {
-            console.warn('Request was aborted:', error.message);
+            console.warn('Request was aborted:', error instanceof Error ? error.message : error);
         }
-    }, [dispatch, formValues, network, timer, shouldSendInSats, analytics, setValue]);
+    }, [dispatch, formValues, network, shouldSendInSats, analytics, setValue]);
+
+    useTradingRefetchScheduler({ onRefetch: handleChange });
 
     // cleanup signal
     useEffect(
@@ -106,8 +106,9 @@ export const useTradingBuyHandleChange = ({
             if (previousPromise.current) {
                 previousPromise.current.abort('Request is canceled - page is unmounted.');
             }
+            dispatch(tradingActions.stopRefetchQuotes());
         },
-        [],
+        [dispatch],
     );
 
     return { handleChange };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingExchangeHandleChange.ts
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef } from 'react';
 
 import { events } from '@suite/analytics';
-import { type TradingExchangeFormProps, exchangeThunks } from '@suite-common/trading';
+import {
+    type TradingExchangeFormProps,
+    exchangeThunks,
+    tradingActions,
+    useTradingRefetchScheduler,
+} from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -11,17 +15,17 @@ import { useAnalytics } from 'src/support/useAnalytics';
 type TradingExchangeUseHandleChangeProps = {
     formValues: TradingExchangeFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
 
     composeRequestCallback: () => void;
-    setApprovalInitiated?: (value: boolean) => void;
     setIsScheduledQuotesRefresh?: (value: boolean) => void;
 };
 
 type PromiseType = {
     abort: (message?: string) => void;
 } | null;
+
+const noop = () => {};
 
 /**
  * Wrapping the handleRequestThunk to have a better control
@@ -30,11 +34,9 @@ type PromiseType = {
 export const useTradingExchangeHandleChange = ({
     formValues,
     network,
-    timer,
     shouldSendInSats,
     composeRequestCallback,
-    setApprovalInitiated,
-    setIsScheduledQuotesRefresh,
+    setIsScheduledQuotesRefresh = noop,
 }: TradingExchangeUseHandleChangeProps) => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
@@ -45,13 +47,10 @@ export const useTradingExchangeHandleChange = ({
             previousPromise.current.abort('Request was replaced by another one.');
         }
 
-        setApprovalInitiated?.(false);
-
         const promise = dispatch(
             exchangeThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
                 shouldSendInSats,
                 composeRequestCallback,
             }),
@@ -73,18 +72,22 @@ export const useTradingExchangeHandleChange = ({
             console.warn('Request was aborted:', error.message);
         }
 
-        setIsScheduledQuotesRefresh?.(false);
+        setIsScheduledQuotesRefresh(false);
     }, [
-        setApprovalInitiated,
         dispatch,
         formValues,
         network,
-        timer,
         shouldSendInSats,
         composeRequestCallback,
         setIsScheduledQuotesRefresh,
         analytics,
     ]);
+
+    const onBeforeRefetch = useCallback(() => {
+        setIsScheduledQuotesRefresh(true);
+    }, [setIsScheduledQuotesRefresh]);
+
+    useTradingRefetchScheduler({ onRefetch: handleChange, onBeforeRefetch });
 
     // cleanup signal
     useEffect(
@@ -92,8 +95,9 @@ export const useTradingExchangeHandleChange = ({
             if (previousPromise.current) {
                 previousPromise.current.abort('Request is canceled - page is unmounted.');
             }
+            dispatch(tradingActions.stopRefetchQuotes());
         },
-        [],
+        [dispatch],
     );
 
     return { handleChange };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingInitializer.ts
@@ -1,15 +1,7 @@
-import { useCallback } from 'react';
-
 import { type TrezorDevice } from '@suite-common/suite-types';
-import {
-    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
-    tradingExchangeActions,
-} from '@suite-common/trading';
-import { type Timer, useTimer } from '@trezor/react-utils';
 
-import { useDevice, useDispatch, useSelector } from 'src/hooks/suite';
+import { useDevice } from 'src/hooks/suite';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
-import { selectIsWindowVisible } from 'src/reducers/suite/windowReducer';
 import { type TradingPageType } from 'src/types/trading/trading';
 
 export type UseTradingCommonProps = {
@@ -17,71 +9,18 @@ export type UseTradingCommonProps = {
     isLoading: boolean;
 };
 export interface UseTradingCommonReturnProps {
-    timer: Timer;
     device: TrezorDevice | undefined;
-    checkQuotesTimer: (callback: () => Promise<void>) => void;
 }
 
 export const useTradingInitializer = ({
-    pageType,
-    isLoading,
+    pageType: _pageType,
+    isLoading: _isLoading,
 }: UseTradingCommonProps): UseTradingCommonReturnProps => {
-    const dispatch = useDispatch();
-    const timer = useTimer();
     const { device } = useDevice();
-
-    const isWindowVisible = useSelector(selectIsWindowVisible);
-
-    const checkQuotesTimer = useCallback(
-        (callback: () => Promise<void>) => {
-            if (isLoading) return;
-
-            if (timer.isLoading) {
-                return;
-            }
-
-            if (timer.resetCount >= 40) {
-                timer.stop();
-
-                return;
-            }
-
-            if (pageType === 'confirm' || pageType === 'retry') {
-                timer.stop();
-
-                return;
-            }
-
-            const hasRefreshIntervalElapsed =
-                timer.timeSpent.seconds >= INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-
-            if (!hasRefreshIntervalElapsed) {
-                return;
-            }
-
-            if (!isWindowVisible) {
-                if (!timer.isStopped) {
-                    timer.stop();
-                }
-
-                return;
-            }
-
-            if (timer.isStopped) {
-                timer.reset();
-            }
-
-            dispatch(tradingExchangeActions.savePreselectedQuote(undefined));
-            callback();
-        },
-        [timer, isWindowVisible, pageType, isLoading, dispatch],
-    );
 
     useServerEnvironment();
 
     return {
-        timer,
         device,
-        checkQuotesTimer,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSellHandleChange.ts
@@ -8,9 +8,10 @@ import {
     getTradingPaymentMethods,
     isCountrySubdivisionEmpty,
     sellThunks,
+    tradingActions,
+    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
-import { type Timer } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
 import { useAnalytics } from 'src/support/useAnalytics';
@@ -18,7 +19,6 @@ import { useAnalytics } from 'src/support/useAnalytics';
 type TradingSellUseHandleChangeProps = {
     formValues: TradingSellFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
 
     setValue: UseFormSetValue<TradingSellFormProps>;
@@ -36,7 +36,6 @@ type PromiseType = {
 export const useTradingSellHandleChange = ({
     formValues,
     network,
-    timer,
     shouldSendInSats,
     setValue,
     composeRequestCallback,
@@ -62,7 +61,6 @@ export const useTradingSellHandleChange = ({
             sellThunks.handleRequestThunk({
                 formValues,
                 network,
-                timer,
                 shouldSendInSats,
                 composeRequestCallback,
             }),
@@ -105,12 +103,13 @@ export const useTradingSellHandleChange = ({
         dispatch,
         formValues,
         network,
-        timer,
         shouldSendInSats,
         composeRequestCallback,
         analytics,
         setValue,
     ]);
+
+    useTradingRefetchScheduler({ onRefetch: handleChange });
 
     // cleanup signal
     useEffect(
@@ -118,8 +117,9 @@ export const useTradingSellHandleChange = ({
             if (previousPromise.current) {
                 previousPromise.current.abort('Request is canceled - page is unmounted.');
             }
+            dispatch(tradingActions.stopRefetchQuotes());
         },
-        [],
+        [dispatch],
     );
 
     return { handleChange };

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingBuyForm.ts
@@ -82,7 +82,7 @@ export const useTradingBuyForm = ({
     const verifiedAddress = useSelector(selectTradingVerifiedAddress);
     const paymentMethods = useSelector(selectTradingPaymentMethods);
 
-    const { timer, device, checkQuotesTimer } = useTradingInitializer({
+    const { device } = useTradingInitializer({
         pageType,
         isLoading,
     });
@@ -189,7 +189,6 @@ export const useTradingBuyForm = ({
     const { handleChange } = useTradingBuyHandleChange({
         formValues: values,
         network,
-        timer,
         shouldSendInSats,
         setValue,
     });
@@ -296,7 +295,6 @@ export const useTradingBuyForm = ({
         await dispatch(
             buyThunks.selectQuoteThunk({
                 quote,
-                timer,
                 returnUrl,
                 loginRequest: form => {
                     dispatch(submitRequestForm(form));
@@ -467,10 +465,6 @@ export const useTradingBuyForm = ({
         }
     }, [isFromRedirect, quotesRequest, dispatch]);
 
-    useEffect(() => {
-        checkQuotesTimer(handleChange);
-    }, [checkQuotesTimer, handleChange]);
-
     useDebounce(
         () => {
             // saving draft after validation & buyInfo is available
@@ -510,7 +504,6 @@ export const useTradingBuyForm = ({
         cryptoInputValue: values.cryptoInput,
         device,
         verifiedAddress,
-        timer,
         quotes: quotesByPaymentMethod,
         quotesRequest,
         preselectedQuote,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingExchangeForm.ts
@@ -110,13 +110,12 @@ export const useTradingExchangeForm = ({
     const [isScheduledQuotesRefresh, setIsScheduledQuotesRefresh] = useState(false);
     const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
 
-    const { timer, device, checkQuotesTimer } = useTradingInitializer({
+    const { device } = useTradingInitializer({
         pageType,
         isLoading,
     });
 
     const [isApproval, setIsApproval] = useState<boolean>(false);
-    const [approvalInitiated, setApprovalInitiated] = useState<boolean>(false);
     const [isLoadingQuote, setIsLoadingQuote] = useState<boolean>(false);
 
     const [receiveAccount, setReceiveAccount] = useState<Account | undefined>();
@@ -258,12 +257,10 @@ export const useTradingExchangeForm = ({
     const { handleChange } = useTradingExchangeHandleChange({
         formValues: values,
         network,
-        timer,
         shouldSendInSats,
         composeRequestCallback: () => {
             composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
         },
-        setApprovalInitiated,
         setIsScheduledQuotesRefresh,
     });
 
@@ -332,7 +329,6 @@ export const useTradingExchangeForm = ({
         await dispatch(
             exchangeThunks.selectQuoteThunk({
                 quote,
-                timer,
                 nextStep: () => {
                     dispatch(goto({ routeName: 'wallet-trading-exchange-confirm' }));
                 },
@@ -577,8 +573,6 @@ export const useTradingExchangeForm = ({
     const approveTransaction = async (trade: ExchangeTrade) => {
         if (!receiveAddress) return false;
 
-        setApprovalInitiated(true);
-
         const newTrade = await confirmApproval({
             trade: { ...trade, status: 'CONFIRM' },
             receiveAddress,
@@ -589,8 +583,6 @@ export const useTradingExchangeForm = ({
 
     const revokeApproval = async (trade: ExchangeTrade) => {
         if (!receiveAddress) return false;
-
-        setApprovalInitiated(true);
 
         const approvalType: DexApprovalType = 'ZERO';
         const updatedTrade: ExchangeTrade = {
@@ -775,12 +767,6 @@ export const useTradingExchangeForm = ({
     }, [isFormPage, quotesRequest, dispatch]);
 
     useEffect(() => {
-        if (preselectedQuote || approvalInitiated) return;
-
-        checkQuotesTimer(handleChange);
-    }, [checkQuotesTimer, handleChange, preselectedQuote, approvalInitiated]);
-
-    useEffect(() => {
         if (isFromRedirect) {
             if (transactionId && trade) {
                 dispatch(tradingExchangeActions.saveSelectedQuote(trade.data));
@@ -808,7 +794,6 @@ export const useTradingExchangeForm = ({
         },
         methods,
         device,
-        timer,
         exchangeInfo,
         quotes,
         dexQuotes,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingSellForm.ts
@@ -93,7 +93,7 @@ export const useTradingSellForm = ({
 
     const { account, tradingAccountKey: accountKey, cryptoId } = useTradingFormAccount(type);
 
-    const { timer, device, checkQuotesTimer } = useTradingInitializer({
+    const { device } = useTradingInitializer({
         pageType,
         isLoading,
     });
@@ -230,7 +230,6 @@ export const useTradingSellForm = ({
     const { handleChange } = useTradingSellHandleChange({
         formValues: values as TradingSellFormProps,
         network,
-        timer,
         shouldSendInSats,
         composeRequestCallback: () => {
             composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
@@ -379,7 +378,6 @@ export const useTradingSellForm = ({
         await dispatch(
             sellThunks.selectQuoteThunk({
                 quote,
-                timer,
                 nextStep,
             }),
         );
@@ -580,10 +578,6 @@ export const useTradingSellForm = ({
         }
     }, [isFromRedirect, trade, transactionId, pageType, dispatch]);
 
-    useEffect(() => {
-        checkQuotesTimer(handleChange);
-    }, [checkQuotesTimer, handleChange]);
-
     // Subscribe to blocks for Solana, since they are not fetched globally
     useSolanaSubscribeBlocks(account);
 
@@ -618,7 +612,6 @@ export const useTradingSellForm = ({
         amountLimits,
         network,
         device,
-        timer,
         preselectedQuote,
         selectedQuote,
         shouldSendInSats,

--- a/packages/suite/src/hooks/wallet/trading/useTradingRefetchCountdown.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingRefetchCountdown.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+import {
+    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
+    clamp,
+    selectTradingQuoteRefetchingState,
+} from '@suite-common/trading';
+
+import { useSelector } from 'src/hooks/suite';
+
+export const useTradingRefetchCountdown = () => {
+    const { lastFetchTimestamp, status } = useSelector(selectTradingQuoteRefetchingState);
+    const [remaining, setRemaining] = useState(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS);
+
+    useEffect(() => {
+        if (status !== 'running' || !lastFetchTimestamp) {
+            setRemaining(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS);
+
+            return;
+        }
+
+        const tick = () => {
+            const elapsed = Math.floor((Date.now() - lastFetchTimestamp) / 1000);
+            setRemaining(
+                clamp(
+                    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS - elapsed,
+                    0,
+                    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
+                ),
+            );
+        };
+
+        tick();
+        const id = setInterval(tick, 1000);
+
+        return () => clearInterval(id);
+    }, [lastFetchTimestamp, status]);
+
+    return remaining;
+};

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -52,7 +52,6 @@ import {
     type PrecomposedLevelsCardano,
 } from '@suite-common/wallet-types';
 import { type FeeLevel } from '@trezor/connect';
-import { type Timer } from '@trezor/react-utils';
 
 import { type useTradingReceiveAddress } from 'src/hooks/wallet/trading/form/useTradingReceiveAddress';
 import { type AppState } from 'src/reducers/store';
@@ -106,7 +105,6 @@ interface TradingFormStateProps {
 
 interface TradingCommonFormProps {
     device: TrezorDevice | undefined;
-    timer: Timer;
     account: Account;
     network: Network;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingHeader/TradingHeader.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
-import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
 import { H2 } from '@trezor/components';
 import { SCREEN_QUERY } from '@trezor/components/src/config/variables';
 import { spacingsPx } from '@trezor/theme';
@@ -60,8 +59,9 @@ interface TradingHeaderProps {
 
 export const TradingHeader = ({ title, titleTimer }: TradingHeaderProps) => {
     const context = useTradingFormContext();
-    const { timer, quotes } = context;
+    const { quotes } = context;
     const headerProps = getCryptoQuoteAmountProps(quotes?.[0], context);
+    const isLoading = context.form.state.isFormLoading;
 
     return (
         <Header>
@@ -77,9 +77,7 @@ export const TradingHeader = ({ title, titleTimer }: TradingHeaderProps) => {
                 <TradingHeaderFilter />
                 <HeaderTradingRefreshTime>
                     <TradingRefreshTime
-                        isLoading={timer.isLoading}
-                        refetchInterval={INVITY_API_RELOAD_QUOTES_AFTER_SECONDS}
-                        seconds={timer.timeSpent.seconds}
+                        isLoading={isLoading}
                         label={<Translation id={titleTimer} />}
                     />
                 </HeaderTradingRefreshTime>

--- a/packages/suite/src/views/wallet/trading/common/TradingRefreshTime.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingRefreshTime.tsx
@@ -2,9 +2,11 @@ import { type ReactElement } from 'react';
 
 import styled from 'styled-components';
 
-import { clamp } from '@suite-common/trading';
+import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS, clamp } from '@suite-common/trading';
 import { Paragraph, ProgressPie, Spinner } from '@trezor/components';
 import { spacingsPx, typography } from '@trezor/theme';
+
+import { useTradingRefetchCountdown } from 'src/hooks/wallet/trading/useTradingRefetchCountdown';
 
 const Wrapper = styled.div`
     display: flex;
@@ -34,19 +36,12 @@ const RefreshTime = styled.div`
 
 interface TradingRefreshTimeProps {
     isLoading: boolean;
-    seconds: number;
-    refetchInterval: number;
     label: ReactElement;
 }
 
-export const TradingRefreshTime = ({
-    isLoading,
-    seconds,
-    refetchInterval,
-    label,
-}: TradingRefreshTimeProps) => {
-    const remaining = Math.max(refetchInterval - seconds, 0);
-    const progress = refetchInterval > 0 ? clamp((remaining / refetchInterval) * 100, 0, 100) : 0;
+export const TradingRefreshTime = ({ isLoading, label }: TradingRefreshTimeProps) => {
+    const remaining = useTradingRefetchCountdown();
+    const progress = clamp((remaining / INVITY_API_RELOAD_QUOTES_AFTER_SECONDS) * 100, 0, 100);
 
     return (
         <>
@@ -61,7 +56,7 @@ export const TradingRefreshTime = ({
                         <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
                             {label}
                         </Paragraph>
-                        <RefreshTime>{`0:${remaining < 10 ? '0' : ''}${remaining}`}</RefreshTime>
+                        <RefreshTime>{`0:${String(remaining).padStart(2, '0')}`}</RefreshTime>
                     </TimerText>
                 </Wrapper>
             )}

--- a/suite-common/trading/src/hooks/__tests__/useTradingRefetchScheduler.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/useTradingRefetchScheduler.test.ts
@@ -1,0 +1,58 @@
+import { act } from 'react';
+
+import { renderHookWithTradingStore } from '../../__tests__/testUtils';
+import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { useTradingRefetchScheduler } from '../useTradingRefetchScheduler';
+
+describe('useTradingRefetchScheduler', () => {
+    it('should verify that timestapp is set and cleared on unmount', () => {
+        const { result, unmount, store } = renderHookWithTradingStore(() =>
+            useTradingRefetchScheduler({
+                onRefetch: jest.fn(),
+            }),
+        );
+        expect(
+            store.getState().wallet.trading.quoteRefetchingState.lastFetchTimestamp,
+        ).toBeUndefined();
+
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
+        expect(
+            store.getState().wallet.trading.quoteRefetchingState.lastFetchTimestamp,
+        ).toBeDefined();
+        expect(result.current).toBeUndefined();
+
+        unmount();
+
+        expect(
+            store.getState().wallet.trading.quoteRefetchingState.lastFetchTimestamp,
+        ).toBeUndefined();
+    });
+
+    it('should call onRefetch after specified time', () => {
+        jest.useFakeTimers();
+        const mockOnRefetch = jest.fn();
+        const { store } = renderHookWithTradingStore(() =>
+            useTradingRefetchScheduler({
+                onRefetch: mockOnRefetch,
+            }),
+        );
+
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(1000);
+        });
+
+        expect(mockOnRefetch).toHaveBeenCalledTimes(0);
+
+        act(() => {
+            jest.advanceTimersByTime(30000);
+        });
+
+        expect(mockOnRefetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
+++ b/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '../constants';
+import { useSelector } from './useSelector';
+import { tradingActions } from '../reducers/tradingCommonReducer';
+import { selectTradingQuoteRefetchingState } from '../selectors/tradingSelectors';
+import { clamp } from '../utils/numberUtils';
+
+type UseTradingRefetchSchedulerProps = {
+    onRefetch: () => void;
+    onBeforeRefetch?: () => void;
+};
+
+export const useTradingRefetchScheduler = ({
+    onRefetch,
+    onBeforeRefetch,
+}: UseTradingRefetchSchedulerProps) => {
+    const dispatch = useDispatch();
+    const { lastFetchTimestamp, status } = useSelector(selectTradingQuoteRefetchingState);
+    const onRefetchRef = useRef(onRefetch);
+    onRefetchRef.current = onRefetch;
+    const onBeforeRefetchRef = useRef(onBeforeRefetch);
+    onBeforeRefetchRef.current = onBeforeRefetch;
+
+    useEffect(() => {
+        if (status !== 'running' || !lastFetchTimestamp) return;
+        const elapsed = Date.now() - lastFetchTimestamp;
+        const delay = clamp(Math.max(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000 - elapsed, 0));
+        const id = setTimeout(() => {
+            onBeforeRefetchRef.current?.();
+            onRefetchRef.current();
+        }, delay);
+
+        return () => clearTimeout(id);
+    }, [lastFetchTimestamp, status]);
+
+    useEffect(
+        () => () => {
+            dispatch(tradingActions.stopRefetchQuotes());
+        },
+        [dispatch],
+    );
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -11,6 +11,7 @@ export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
 export * from './hooks/useExchangeFiatDeviation';
 export * from './hooks/useApprovalStep';
+export * from './hooks/useTradingRefetchScheduler';
 export * from './invityAPI';
 export * from './reducers/buyReducer';
 export * from './reducers/exchangeReducer';

--- a/suite-common/trading/src/reducers/tradingCommonReducer.ts
+++ b/suite-common/trading/src/reducers/tradingCommonReducer.ts
@@ -52,6 +52,15 @@ export interface TradingPrefilledFromAccount {
     key: AccountKey | undefined;
 }
 
+// Maximum number of refetch attempts before the interval automatically stops
+export const REFETCH_QUOTES_MAX_COUNT = 40;
+
+export interface QuoteRefetchingState {
+    remainingRefetches: number;
+    lastFetchTimestamp: number | undefined;
+    status: 'running' | 'stopped';
+}
+
 export interface TradingState {
     info: TradingInfo;
     buy: TradingBuyState;
@@ -69,6 +78,7 @@ export interface TradingState {
     settings: TradingSettingsState;
     currentProviderMetadata?: ProviderMetadata;
     favouriteAssets: Record<CryptoId, true>;
+    quoteRefetchingState: QuoteRefetchingState;
 }
 
 export type TradingRootState = {
@@ -100,6 +110,11 @@ export const initialState: TradingState = {
     verifiedAddress: undefined,
     settings: settingsInitialState,
     favouriteAssets: {},
+    quoteRefetchingState: {
+        remainingRefetches: REFETCH_QUOTES_MAX_COUNT,
+        lastFetchTimestamp: undefined,
+        status: 'stopped',
+    },
 };
 
 const tradingCommonSlice = createSlice({
@@ -170,6 +185,20 @@ const tradingCommonSlice = createSlice({
             { payload }: PayloadAction<ProviderMetadata | undefined>,
         ) => {
             state.currentProviderMetadata = payload;
+        },
+        stopRefetchQuotes: state => {
+            state.quoteRefetchingState.status = 'stopped';
+            state.quoteRefetchingState.remainingRefetches = REFETCH_QUOTES_MAX_COUNT;
+            state.quoteRefetchingState.lastFetchTimestamp = undefined;
+        },
+        setRefetchQuotesTimestamp: (
+            state,
+            { payload }: PayloadAction<QuoteRefetchingState['lastFetchTimestamp']>,
+        ) => {
+            state.quoteRefetchingState.remainingRefetches -= 1;
+            state.quoteRefetchingState.status =
+                state.quoteRefetchingState.remainingRefetches <= 0 ? 'stopped' : 'running';
+            state.quoteRefetchingState.lastFetchTimestamp = payload;
         },
     },
 });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -867,3 +867,6 @@ export const selectTradingLastErrorMessageByTradeType = (
 
 export const selectTradingProviderMetadata = (state: TradingRootState) =>
     state.wallet.trading.currentProviderMetadata;
+
+export const selectTradingQuoteRefetchingState = (state: TradingRootState) =>
+    state.wallet.trading.quoteRefetchingState;

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -7,7 +7,11 @@ import * as envUtils from '@trezor/env-utils';
 
 import { ALTERNATIVE_QUOTES } from '../../../__fixtures__/buyUtils';
 import { invityAPI } from '../../../invityAPI';
-import { initialState } from '../../../reducers/tradingCommonReducer';
+import {
+    type QuoteRefetchingState,
+    REFETCH_QUOTES_MAX_COUNT,
+    initialState,
+} from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import {
     type HandleBuyRequestThunkProps,
@@ -40,7 +44,7 @@ describe('handleBuyRequestThunk', () => {
     invityAPI.setInvityServersEnvironment = () => {};
     invityAPI.createInvityAPIKey = () => {};
 
-    const getMocks = () => {
+    const getMocks = (refetchQuotesOverride?: Partial<QuoteRefetchingState>) => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -67,19 +71,14 @@ describe('handleBuyRequestThunk', () => {
                                 },
                             },
                         },
+                        quoteRefetchingState: {
+                            ...initialState.quoteRefetchingState,
+                            ...refetchQuotesOverride,
+                        },
                     },
                 },
             },
         });
-
-        const mockTimerLoading = jest.fn();
-        const mockTimerStop = jest.fn();
-        const mockTimerReset = jest.fn();
-        const mockTimer = {
-            loading: mockTimerLoading,
-            stop: mockTimerStop,
-            reset: mockTimerReset,
-        } as unknown as HandleBuyRequestThunkProps['timer'];
 
         const formValues: TradingBuyFormProps = {
             fiatInput: '1000',
@@ -116,21 +115,17 @@ describe('handleBuyRequestThunk', () => {
         const input: HandleBuyRequestThunkProps = {
             formValues,
             network: getNetwork('btc'),
-            timer: mockTimer,
             shouldSendInSats: false,
         };
 
         return {
             input,
-            mockTimerLoading,
-            mockTimerStop,
-            mockTimerReset,
             store,
         };
     };
 
     it('should successfully request quotes and save them', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = createMockQuotes();
 
         invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
@@ -139,7 +134,6 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.buy.amountLimits).toBeUndefined();
         expect(state.buy.quotes?.length).toEqual(2);
         expect(state.buy.quotesRequest).toEqual({
@@ -152,7 +146,8 @@ describe('handleBuyRequestThunk', () => {
         });
         expect(state.info.paymentMethods.length).toEqual(1);
         expect(state.isLoading).toBe(false);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(state.quoteRefetchingState.status).toBe('running');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeGreaterThan(0);
         expect(quotesResponse).toEqual([
             expect.objectContaining(mockQuotes[1]),
             expect.objectContaining(mockQuotes[6]),
@@ -188,7 +183,7 @@ describe('handleBuyRequestThunk', () => {
             },
         ],
     ])('should not save quotes when %s', async (_, incorrectFormValues) => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
         const inputWithIncorrectData = {
             ...input,
             formValues: {
@@ -202,8 +197,6 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.buy.quotesRequest).toBeUndefined();
         expect(state.buy.quotes?.length).toEqual(0);
         expect(state.isLoading).toBe(false);
@@ -211,7 +204,7 @@ describe('handleBuyRequestThunk', () => {
     });
 
     it('should request quotes and include subdivision when country has subdivisions and subdivision is selected', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = createMockQuotes();
 
         invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
@@ -242,7 +235,6 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.buy.amountLimits).toBeUndefined();
         expect(state.buy.quotes?.length).toEqual(2);
         expect(state.buy.quotesRequest).toEqual({
@@ -254,7 +246,6 @@ describe('handleBuyRequestThunk', () => {
             receiveCurrency: 'bitcoin',
             wantCrypto: false,
         });
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(quotesResponse).toEqual([
             expect.objectContaining(mockQuotes[1]),
             expect.objectContaining(mockQuotes[6]),
@@ -262,7 +253,7 @@ describe('handleBuyRequestThunk', () => {
     });
 
     it('should request quotes for US without subdivision on native', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = createMockQuotes();
 
         mockedIsNative.mockReturnValue(true);
@@ -291,7 +282,6 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.buy.amountLimits).toBeUndefined();
         expect(state.buy.quotes?.length).toEqual(2);
         expect(state.buy.quotesRequest).toEqual({
@@ -302,7 +292,6 @@ describe('handleBuyRequestThunk', () => {
             receiveCurrency: 'bitcoin',
             wantCrypto: false,
         });
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(quotesResponse).toEqual([
             expect.objectContaining(mockQuotes[1]),
             expect.objectContaining(mockQuotes[6]),
@@ -310,7 +299,7 @@ describe('handleBuyRequestThunk', () => {
     });
 
     it('should save empty quotes when empty array is returned from in the response', async () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getBuyQuotes = () => Promise.resolve([]);
 
@@ -318,8 +307,6 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.buy.quotes?.length).toEqual(0);
         expect(state.buy.quotesRequest).toEqual({
             country: 'CZ',
@@ -330,11 +317,13 @@ describe('handleBuyRequestThunk', () => {
             wantCrypto: false,
         });
         expect(state.isLoading).toBe(false);
+        expect(state.quoteRefetchingState.status).toBe('stopped');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeUndefined();
         expect(quotesResponse).toEqual([]);
     });
 
     it('should not save quotes, when request is aborted', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getBuyQuotes = () => Promise.resolve([]);
 
@@ -345,14 +334,67 @@ describe('handleBuyRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.buy.quotes?.length).toEqual(0);
         expect(state.buy.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);
+        expect(state.quoteRefetchingState.status).toBe('stopped');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeUndefined();
         await expect(() => promise.unwrap()).rejects.toEqual({
             message: 'Aborted',
             name: 'AbortError',
         });
+    });
+
+    it('should set refetch timestamp and decrement remaining refetches on success when refetch is running', async () => {
+        const { input, store } = getMocks({ status: 'running' });
+        const mockQuotes = createMockQuotes();
+        const beforeTimestamp = Date.now();
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('running');
+        expect(refetchQuotes.lastFetchTimestamp).toBeGreaterThanOrEqual(beforeTimestamp);
+        expect(refetchQuotes.remainingRefetches).toBe(REFETCH_QUOTES_MAX_COUNT - 1);
+    });
+
+    it('should stop refetch when last remaining refetch is consumed on success', async () => {
+        const { input, store } = getMocks({ status: 'running', remainingRefetches: 1 });
+        const mockQuotes = createMockQuotes();
+
+        invityAPI.getBuyQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(buyThunks.handleRequestThunk(input)).unwrap();
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('stopped');
+        expect(refetchQuotes.remainingRefetches).toBe(0);
+        expect(refetchQuotes.lastFetchTimestamp).toBeDefined();
+    });
+
+    it('should reset refetch state when request data is invalid while refetch is running', async () => {
+        const { input, store } = getMocks({
+            status: 'running',
+            remainingRefetches: 10,
+            lastFetchTimestamp: Date.now(),
+        });
+
+        const promise = store.dispatch(
+            buyThunks.handleRequestThunk({
+                ...input,
+                formValues: { ...input.formValues, fiatInput: undefined, cryptoInput: undefined },
+            }),
+        );
+        await promise;
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('stopped');
+        expect(refetchQuotes.remainingRefetches).toBe(REFETCH_QUOTES_MAX_COUNT);
+        expect(refetchQuotes.lastFetchTimestamp).toBeUndefined();
     });
 });

--- a/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/selectBuyQuoteThunk.test.ts
@@ -18,7 +18,6 @@ import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { type TradingCountryCode } from '../../../types';
 import type { LogErrorThunkProps } from '../../common/logErrorThunk';
 import { buyThunks } from '../index';
-import { type SelectBuyQuoteThunkProps } from '../selectBuyQuoteThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -125,18 +124,11 @@ describe('selectBuyQuoteThunk', () => {
             },
         });
 
-        const mockTimerStop = jest.fn();
-        const mockTimer = {
-            stop: mockTimerStop,
-        } as unknown as SelectBuyQuoteThunkProps['timer'];
-
         const mockNextStep = jest.fn();
         const mockLoginRequest = jest.fn();
 
         return {
             store,
-            mockTimer,
-            mockTimerStop,
             mockNextStep,
             mockLoginRequest,
         };
@@ -144,14 +136,13 @@ describe('selectBuyQuoteThunk', () => {
 
     it('should successful select without need of login', async () => {
         const { quote, state } = getDataMocks();
-        const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } = getMocks(state);
+        const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
         await store
             .dispatch(
                 buyThunks.selectQuoteThunk({
                     quote,
                     returnUrl: 'returnUrl',
-                    timer: mockTimer,
                     loginRequest: mockLoginRequest,
                     nextStep: mockNextStep,
                 }),
@@ -159,14 +150,13 @@ describe('selectBuyQuoteThunk', () => {
             .unwrap();
 
         expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
         it('when buyInfo is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } = getMocks({
+            const { store, mockNextStep, mockLoginRequest } = getMocks({
                 ...state,
                 buyInfo: undefined,
             });
@@ -176,7 +166,6 @@ describe('selectBuyQuoteThunk', () => {
                     buyThunks.selectQuoteThunk({
                         quote,
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -184,13 +173,12 @@ describe('selectBuyQuoteThunk', () => {
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when quotesRequest is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } = getMocks({
+            const { store, mockNextStep, mockLoginRequest } = getMocks({
                 ...state,
                 quotesRequest: undefined,
             });
@@ -200,7 +188,6 @@ describe('selectBuyQuoteThunk', () => {
                     buyThunks.selectQuoteThunk({
                         quote,
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -208,14 +195,12 @@ describe('selectBuyQuoteThunk', () => {
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when exchange is not found in providerInfos', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } =
-                getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             await store
                 .dispatch(
@@ -225,7 +210,6 @@ describe('selectBuyQuoteThunk', () => {
                             exchange: 'random',
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -233,14 +217,12 @@ describe('selectBuyQuoteThunk', () => {
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when quote receiveCurrency is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } =
-                getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             await store
                 .dispatch(
@@ -250,7 +232,6 @@ describe('selectBuyQuoteThunk', () => {
                             receiveCurrency: undefined,
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -258,7 +239,6 @@ describe('selectBuyQuoteThunk', () => {
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
     });
@@ -266,8 +246,7 @@ describe('selectBuyQuoteThunk', () => {
     describe('should not successfully select quote in login flow', () => {
         it('when there is a need of login request before continue', async () => {
             const { quote, tradeForm, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop, mockLoginRequest } =
-                getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             const buyTradeResponse: BuyTradeResponse = {
                 trade: {
@@ -287,7 +266,6 @@ describe('selectBuyQuoteThunk', () => {
                             quoteId: undefined,
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -296,13 +274,12 @@ describe('selectBuyQuoteThunk', () => {
 
             expect(mockLoginRequest).toHaveBeenCalledTimes(1);
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.buy.selectedQuote).toEqual(undefined);
         });
 
         it('when login response has not tradeForm', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockLoginRequest } = getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             const buyTradeResponse = {
                 trade: {
@@ -321,7 +298,6 @@ describe('selectBuyQuoteThunk', () => {
                             quoteId: undefined,
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -334,7 +310,7 @@ describe('selectBuyQuoteThunk', () => {
 
         it('when login response has incorrect status', async () => {
             const { quote, state, tradeForm } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockLoginRequest } = getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             const buyTradeResponse = {
                 trade: {
@@ -354,7 +330,6 @@ describe('selectBuyQuoteThunk', () => {
                             quoteId: undefined,
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),
@@ -367,7 +342,7 @@ describe('selectBuyQuoteThunk', () => {
 
         it('when login response is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockLoginRequest } = getMocks(state);
+            const { store, mockNextStep, mockLoginRequest } = getMocks(state);
 
             invityAPI.doBuyTrade = () => Promise.resolve(undefined as unknown as BuyTradeResponse);
 
@@ -379,7 +354,6 @@ describe('selectBuyQuoteThunk', () => {
                             quoteId: undefined,
                         },
                         returnUrl: 'returnUrl',
-                        timer: mockTimer,
                         loginRequest: mockLoginRequest,
                         nextStep: mockNextStep,
                     }),

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -93,11 +93,9 @@ export const handleBuyRequestThunk = createThunk<
 >(
     `${TRADING_BUY_THUNK_PREFIX}/handleRequest`,
     async (
-        { formValues, network, timer, shouldSendInSats }: HandleBuyRequestThunkProps,
+        { formValues, network, shouldSendInSats }: HandleBuyRequestThunkProps,
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal },
     ) => {
-        timer.loading();
-
         const quotesRequest = selectTradingBuyQuotesRequest(getState());
 
         const requestData = getQuoteRequestData({
@@ -108,24 +106,21 @@ export const handleBuyRequestThunk = createThunk<
         });
 
         if (!requestData) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Invalid request data');
         }
 
-        const allQuotes = await getQuotesRequest({
-            requestData,
-            signal,
-        });
+        const allQuotes = (await getQuotesRequest({ requestData, signal })) ?? [];
 
         if (signal.aborted) {
-            timer.reset();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Request was aborted');
         }
 
         if (!Array.isArray(allQuotes) || allQuotes.length === 0) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             const quotesSuccess: BuyTrade[] = [];
             dispatch(tradingBuyActions.setAmountLimits(undefined));
@@ -157,8 +152,7 @@ export const handleBuyRequestThunk = createThunk<
         dispatch(tradingBuyActions.saveQuotes(quotesSuccess));
         dispatch(tradingBuyActions.saveQuoteRequest(requestData));
         dispatch(tradingActions.savePaymentMethods(paymentMethodsFromQuotes));
-
-        timer.reset();
+        dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
 
         return fulfillWithValue(quotesSuccess);
     },

--- a/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
@@ -1,11 +1,11 @@
 import { type BuyTrade, type FormResponse } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { type Timer } from '@trezor/react-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { tradingBuyActions } from '../../reducers/buyReducer';
+import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingBuyInfo,
     selectTradingBuyQuotesRequest,
@@ -14,7 +14,6 @@ import { logErrorThunk } from '../common/logErrorThunk';
 
 export type SelectBuyQuoteThunkProps = {
     quote: BuyTrade;
-    timer: Timer;
     returnUrl: string;
 
     loginRequest: (form: FormResponse['form']) => void;
@@ -24,7 +23,7 @@ export type SelectBuyQuoteThunkProps = {
 export const selectBuyQuoteThunk = createThunk(
     `${TRADING_BUY_THUNK_PREFIX}/selectQuote`,
     async (
-        { quote, returnUrl, timer, loginRequest, nextStep }: SelectBuyQuoteThunkProps,
+        { quote, returnUrl, loginRequest, nextStep }: SelectBuyQuoteThunkProps,
         { dispatch, getState },
     ) => {
         const buyInfo = selectTradingBuyInfo(getState());
@@ -57,7 +56,7 @@ export const selectBuyQuoteThunk = createThunk(
         }
 
         dispatch(tradingBuyActions.saveSelectedQuote(quote));
-        timer.stop();
+        dispatch(tradingActions.stopRefetchQuotes());
         nextStep();
     },
 );

--- a/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/handleExchangeRequestThunk.test.ts
@@ -61,15 +61,6 @@ describe('handleExchangeRequestThunk', () => {
             },
         });
 
-        const mockTimerLoading = jest.fn();
-        const mockTimerStop = jest.fn();
-        const mockTimerReset = jest.fn();
-        const mockTimer = {
-            loading: mockTimerLoading,
-            stop: mockTimerStop,
-            reset: mockTimerReset,
-        } as unknown as HandleExchangeRequestThunkProps['timer'];
-
         const mockComposeRequestCallback = jest.fn();
 
         const formValues: TradingExchangeFormProps = {
@@ -129,22 +120,18 @@ describe('handleExchangeRequestThunk', () => {
         const input: HandleExchangeRequestThunkProps = {
             formValues,
             network: getNetwork('btc'),
-            timer: mockTimer,
             shouldSendInSats: false,
             composeRequestCallback: mockComposeRequestCallback,
         };
 
         return {
             input,
-            mockTimerLoading,
-            mockTimerStop,
-            mockTimerReset,
             store,
         };
     };
 
     it('should successfully request quotes and save them', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = [...MIN_MAX_QUOTES_OK];
 
         invityAPI.getExchangeQuotes = () => Promise.resolve(mockQuotes);
@@ -155,7 +142,6 @@ describe('handleExchangeRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.exchange.amountLimits).toBeUndefined();
         expect(state.exchange.quotes.length).toEqual(11);
         expect(quotesResponse?.length).toEqual(11);
@@ -166,12 +152,11 @@ describe('handleExchangeRequestThunk', () => {
             sendStringAmount: '0.0015',
         });
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     it('should successfully request quotes, save them, but not call composeRequestCallback', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes: ExchangeTrade[] = [
             {
                 ...MIN_MAX_QUOTES_OK[0],
@@ -196,7 +181,6 @@ describe('handleExchangeRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.exchange.amountLimits).toBeUndefined();
         expect(state.exchange.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
@@ -207,12 +191,11 @@ describe('handleExchangeRequestThunk', () => {
             sendStringAmount: '0.0015',
         });
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(0);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     describe('should not save quotes when', () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
         const outputs = input.formValues.outputs.map(output => ({
             ...output,
             amount: undefined as unknown as string,
@@ -250,8 +233,6 @@ describe('handleExchangeRequestThunk', () => {
 
             const state = store.getState().wallet.trading;
 
-            expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-            expect(mockTimerStop).toHaveBeenCalledTimes(1);
             expect(state.exchange.quotesRequest).toBeUndefined();
             expect(state.exchange.quotes.length).toEqual(0);
             expect(state.isLoading).toBe(false);
@@ -260,7 +241,7 @@ describe('handleExchangeRequestThunk', () => {
     });
 
     it('should not save quotes, when request is aborted', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getExchangeQuotes = () => Promise.resolve([]);
 
@@ -272,15 +253,13 @@ describe('handleExchangeRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.exchange.quotes.length).toEqual(0);
         expect(state.exchange.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);
     });
 
     it('should not save quotes when empty array is returned from the response', async () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getExchangeQuotes = () => Promise.resolve([]);
 
@@ -290,8 +269,6 @@ describe('handleExchangeRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.exchange.quotes.length).toEqual(0);
         expect(state.exchange.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);

--- a/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/selectExchangeQuoteThunk.test.ts
@@ -7,9 +7,8 @@ import { exchangeThunks } from '../';
 import { MIN_MAX_QUOTES_OK } from '../../../__fixtures__/exchangeUtils';
 import { invityAPI } from '../../../invityAPI';
 import { type ExchangeInfo, type TradingExchangeState } from '../../../reducers/exchangeReducer';
-import { initialState } from '../../../reducers/tradingCommonReducer';
+import { type QuoteRefetchingState, initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
-import { type SelectExchangeQuoteThunkProps } from '../selectExchangeQuoteThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -73,7 +72,10 @@ describe('selectExchangeQuoteThunk', () => {
         };
     };
 
-    const getMocks = (initialExchangeState?: Partial<TradingExchangeState>) => {
+    const getMocks = (
+        initialExchangeState?: Partial<TradingExchangeState>,
+        refetchQuotesOverride?: Partial<QuoteRefetchingState>,
+    ) => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -89,49 +91,45 @@ describe('selectExchangeQuoteThunk', () => {
                             ...initialState.exchange,
                             ...(initialExchangeState ?? {}),
                         },
+                        refetchQuotes: {
+                            ...initialState.quoteRefetchingState,
+                            ...refetchQuotesOverride,
+                        },
                     },
                 },
             },
         });
 
-        const mockTimerStop = jest.fn();
-        const mockTimer = {
-            stop: mockTimerStop,
-        } as unknown as SelectExchangeQuoteThunkProps['timer'];
-
         const mockNextStep = jest.fn();
 
         return {
             store,
-            mockTimer,
-            mockTimerStop,
             mockNextStep,
         };
     };
 
     it('should successfully select quote', async () => {
         const { quote, state } = getDataMocks();
-        const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks(state);
+        const { store, mockNextStep } = getMocks(state, { status: 'running' });
 
         await store
             .dispatch(
                 exchangeThunks.selectQuoteThunk({
                     quote,
-                    timer: mockTimer,
                     nextStep: mockNextStep,
                 }),
             )
             .unwrap();
 
         expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
+        expect(store.getState().wallet.trading.quoteRefetchingState.status).toBe('stopped');
         expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
         it('when exchangeInfo is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks({
+            const { store, mockNextStep } = getMocks({
                 ...state,
                 exchangeInfo: undefined,
             });
@@ -140,20 +138,18 @@ describe('selectExchangeQuoteThunk', () => {
                 .dispatch(
                     exchangeThunks.selectQuoteThunk({
                         quote,
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
 
         it('when quote send is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks(state);
+            const { store, mockNextStep } = getMocks(state);
 
             await store
                 .dispatch(
@@ -162,20 +158,18 @@ describe('selectExchangeQuoteThunk', () => {
                             ...quote,
                             send: undefined,
                         },
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
 
         it('when quote receive is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks(state);
+            const { store, mockNextStep } = getMocks(state);
 
             await store
                 .dispatch(
@@ -184,14 +178,12 @@ describe('selectExchangeQuoteThunk', () => {
                             ...quote,
                             receive: undefined,
                         },
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.exchange.selectedQuote).toEqual(undefined);
         });
     });

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -7,6 +7,7 @@ import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingCoinSymbolByCryptoId } from '../../selectors/tradingSelectors';
 import {
     type HandleExchangeRequestThunkProps,
@@ -78,14 +79,11 @@ export const handleExchangeRequestThunk = createThunk<
         {
             formValues,
             network,
-            timer,
             shouldSendInSats,
             composeRequestCallback,
         }: HandleExchangeRequestThunkProps,
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal },
     ) => {
-        timer.loading();
-
         const requestData = getQuoteRequestData({
             formValues,
             network,
@@ -93,21 +91,30 @@ export const handleExchangeRequestThunk = createThunk<
         });
 
         if (!requestData) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Invalid request data');
         }
 
-        const allQuotes = await getQuotesRequest({ requestData, signal });
+        let allQuotes: ExchangeTrade[] = [];
+        let requestSucceeded = false;
+        try {
+            allQuotes = (await getQuotesRequest({ requestData, signal })) ?? [];
+            requestSucceeded = true;
+        } finally {
+            if (!requestSucceeded) {
+                dispatch(tradingActions.stopRefetchQuotes());
+            }
+        }
 
         if (signal.aborted) {
-            timer.reset();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Request was aborted');
         }
 
         if (!Array.isArray(allQuotes) || allQuotes.length === 0) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
             dispatch(tradingExchangeActions.saveQuotes([]));
 
             return fulfillWithValue([]);
@@ -136,7 +143,7 @@ export const handleExchangeRequestThunk = createThunk<
             composeRequestCallback();
         }
 
-        timer.reset();
+        dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
 
         return fulfillWithValue(successQuotes);
     },

--- a/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
@@ -1,21 +1,20 @@
 import { type ExchangeTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { type Timer } from '@trezor/react-utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingExchangeInfo } from '../../selectors/tradingSelectors';
 
 export type SelectExchangeQuoteThunkProps = {
     quote: ExchangeTrade;
-    timer: Timer;
     nextStep: () => void;
 };
 
 export const selectExchangeQuoteThunk = createThunk(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/selectQuote`,
-    ({ quote, timer, nextStep }: SelectExchangeQuoteThunkProps, { dispatch, getState }) => {
+    ({ quote, nextStep }: SelectExchangeQuoteThunkProps, { dispatch, getState }) => {
         const exchangeInfo = selectTradingExchangeInfo(getState());
         const provider =
             exchangeInfo?.providerInfos && quote.exchange
@@ -30,7 +29,7 @@ export const selectExchangeQuoteThunk = createThunk(
             dispatch(tradingExchangeActions.saveSelectedQuote(quote));
         }
 
-        timer.stop();
+        dispatch(tradingActions.stopRefetchQuotes());
         nextStep();
     },
 );

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -9,7 +9,11 @@ import * as envUtils from '@trezor/env-utils';
 
 import { sellThunks } from '../';
 import { invityAPI } from '../../../invityAPI';
-import { initialState } from '../../../reducers/tradingCommonReducer';
+import {
+    type QuoteRefetchingState,
+    REFETCH_QUOTES_MAX_COUNT,
+    initialState,
+} from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import {
     type HandleSellRequestThunkProps,
@@ -40,7 +44,7 @@ describe('handleSellRequestThunk', () => {
     invityAPI.setInvityServersEnvironment = () => {};
     invityAPI.createInvityAPIKey = () => {};
 
-    const getMocks = () => {
+    const getMocks = (refetchQuotesOverride?: Partial<QuoteRefetchingState>) => {
         const store = configureMockStore({
             extra: {},
             reducer: combineReducers({
@@ -67,19 +71,14 @@ describe('handleSellRequestThunk', () => {
                                 },
                             },
                         },
+                        quoteRefetchingState: {
+                            ...initialState.quoteRefetchingState,
+                            ...refetchQuotesOverride,
+                        },
                     },
                 },
             },
         });
-
-        const mockTimerLoading = jest.fn();
-        const mockTimerStop = jest.fn();
-        const mockTimerReset = jest.fn();
-        const mockTimer = {
-            loading: mockTimerLoading,
-            stop: mockTimerStop,
-            reset: mockTimerReset,
-        } as unknown as HandleSellRequestThunkProps['timer'];
 
         const mockComposeRequestCallback = jest.fn();
 
@@ -113,7 +112,7 @@ describe('handleSellRequestThunk', () => {
                 displaySymbol: 'BTC',
                 networkName: 'Bitcoin',
                 networkSymbol: 'btc',
-                accountKey: 'descriptor-btc-123' as AccountKey, // Todo: create properly via `createAccountKey()`
+                accountKey: 'descriptor-btc-123' as AccountKey,
             } satisfies TradingAssetSellOption,
             amountInCrypto: true,
             feePerUnit: '',
@@ -134,22 +133,18 @@ describe('handleSellRequestThunk', () => {
         const input: HandleSellRequestThunkProps = {
             formValues,
             network: getNetwork('btc'),
-            timer: mockTimer,
             shouldSendInSats: false,
             composeRequestCallback: mockComposeRequestCallback,
         };
 
         return {
             input,
-            mockTimerLoading,
-            mockTimerStop,
-            mockTimerReset,
             store,
         };
     };
 
     it('should successfully request sell quotes and save them', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = [...sellUtilsFixtures.MIN_MAX_QUOTES_OK];
 
         invityAPI.getSellQuotes = () => Promise.resolve(mockQuotes);
@@ -158,7 +153,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
@@ -172,12 +166,13 @@ describe('handleSellRequestThunk', () => {
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
         });
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
+        expect(state.quoteRefetchingState.status).toBe('running');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeGreaterThan(0);
     });
 
     it('should successfully request sell quotes and save them with shouldSendInSats', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
             ...quote,
             orderId: undefined,
@@ -203,7 +198,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
@@ -217,12 +211,11 @@ describe('handleSellRequestThunk', () => {
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
         });
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     it('should successfully request sell quotes and save them when there is not currency in coins', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
             ...quote,
             cryptoCurrency: 'ethereum',
@@ -251,7 +244,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.amountLimits).toBeUndefined();
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
@@ -265,12 +257,11 @@ describe('handleSellRequestThunk', () => {
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
         });
         expect(input.composeRequestCallback).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     it('should request sell quotes and include subdivision when country has subdivisions and subdivision is selected', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
             ...quote,
             orderId: undefined,
@@ -304,7 +295,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
         expect(state.sell.quotesRequest).toEqual({
@@ -317,12 +307,11 @@ describe('handleSellRequestThunk', () => {
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
         });
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     it('should request sell quotes for US without subdivision on native', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
             ...quote,
             orderId: undefined,
@@ -354,7 +343,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
         expect(state.sell.quotesRequest).toEqual({
@@ -366,12 +354,11 @@ describe('handleSellRequestThunk', () => {
             fiatStringAmount: '50',
             flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
         });
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.isLoading).toBe(false);
     });
 
     it('should not save quotes when country has subdivisions but no subdivision is selected', async () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
         const incorrectData = {
             ...input,
             formValues: {
@@ -396,8 +383,6 @@ describe('handleSellRequestThunk', () => {
         const state = store.getState().wallet.trading;
 
         expect(invityAPI.getSellQuotes).not.toHaveBeenCalled();
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.sell.quotesRequest).toBeUndefined();
         expect(state.sell.quotes.length).toEqual(0);
         expect(state.isLoading).toBe(false);
@@ -405,7 +390,7 @@ describe('handleSellRequestThunk', () => {
     });
 
     it('should not save quotes when request is aborted', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getSellQuotes = () => Promise.resolve([]);
 
@@ -417,23 +402,23 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(0);
         expect(state.sell.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);
+        expect(state.quoteRefetchingState.status).toBe('stopped');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeUndefined();
     });
 
     it('should not save quotes when output fiat amount and output amount are incorrect at the same time', async () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
         const incorrectData = {
             ...input,
             formValues: {
                 ...input.formValues,
                 outputs: input.formValues.outputs.map(output => ({
                     ...output,
-                    fiat: undefined as unknown as string, // Invalid fiat amount
-                    amount: undefined as unknown as string, // Invalid amount
+                    fiat: undefined as unknown as string,
+                    amount: undefined as unknown as string,
                 })),
             },
         };
@@ -446,8 +431,6 @@ describe('handleSellRequestThunk', () => {
         const state = store.getState().wallet.trading;
 
         expect(invityAPI.getSellQuotes).not.toHaveBeenCalled();
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.sell.quotesRequest).toBeUndefined();
         expect(state.sell.quotes.length).toEqual(0);
         expect(state.isLoading).toBe(false);
@@ -455,7 +438,7 @@ describe('handleSellRequestThunk', () => {
     });
 
     it('should not proceed when requestData is null', async () => {
-        const { input, store, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
 
         const modifiedInput = {
             ...input,
@@ -464,8 +447,8 @@ describe('handleSellRequestThunk', () => {
                 outputs: [
                     {
                         ...input.formValues.outputs[0],
-                        amount: undefined as unknown as string, // Invalid amount
-                        fiat: undefined as unknown as string, // Invalid fiat
+                        amount: undefined as unknown as string,
+                        fiat: undefined as unknown as string,
                     },
                 ],
             },
@@ -476,7 +459,6 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(0);
         expect(state.sell.quotesRequest).toBeUndefined();
         expect(state.isLoading).toBe(false);
@@ -484,7 +466,7 @@ describe('handleSellRequestThunk', () => {
     });
 
     it('should not save quotes when empty array is returned from the response', async () => {
-        const { input, store, mockTimerLoading, mockTimerStop } = getMocks();
+        const { input, store } = getMocks();
 
         invityAPI.getSellQuotes = () => Promise.resolve([]);
 
@@ -492,16 +474,16 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(0);
         expect(state.sell.quotesRequest).toBeDefined();
         expect(state.isLoading).toBe(false);
         expect(quotesResponse).toEqual([]);
+        expect(state.quoteRefetchingState.status).toBe('stopped');
+        expect(state.quoteRefetchingState.lastFetchTimestamp).toBeUndefined();
     });
 
     it('should save quotes but not call composeRequestCallback when setMaxOutputId is defined', async () => {
-        const { input, store, mockTimerLoading, mockTimerReset } = getMocks();
+        const { input, store } = getMocks();
         const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({
             ...quote,
             orderId: undefined,
@@ -513,7 +495,7 @@ describe('handleSellRequestThunk', () => {
             ...input,
             formValues: {
                 ...input.formValues,
-                setMaxOutputId: 0, // Simulate max balance computation
+                setMaxOutputId: 0,
             },
         };
 
@@ -523,11 +505,69 @@ describe('handleSellRequestThunk', () => {
 
         const state = store.getState().wallet.trading;
 
-        expect(mockTimerLoading).toHaveBeenCalledTimes(1);
         expect(state.sell.quotes.length).toEqual(1);
         expect(quotesResponse?.length).toEqual(1);
-        expect(input.composeRequestCallback).toHaveBeenCalledTimes(0); // Callback should not be called
-        expect(mockTimerReset).toHaveBeenCalledTimes(1);
+        expect(input.composeRequestCallback).toHaveBeenCalledTimes(0);
         expect(state.isLoading).toBe(false);
+    });
+
+    it('should set refetch timestamp and decrement remaining refetches on success when refetch is running', async () => {
+        const { input, store } = getMocks({ status: 'running' });
+        const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({ ...quote }));
+        const beforeTimestamp = Date.now();
+
+        invityAPI.getSellQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(sellThunks.handleRequestThunk(input)).unwrap();
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('running');
+        expect(refetchQuotes.lastFetchTimestamp).toBeGreaterThanOrEqual(beforeTimestamp);
+        expect(refetchQuotes.remainingRefetches).toBe(REFETCH_QUOTES_MAX_COUNT - 1);
+    });
+
+    it('should stop refetch when last remaining refetch is consumed on success', async () => {
+        const { input, store } = getMocks({ status: 'running', remainingRefetches: 1 });
+        const mockQuotes = sellUtilsFixtures.MIN_MAX_QUOTES_OK.map(quote => ({ ...quote }));
+
+        invityAPI.getSellQuotes = () => Promise.resolve(mockQuotes);
+
+        await store.dispatch(sellThunks.handleRequestThunk(input)).unwrap();
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('stopped');
+        expect(refetchQuotes.remainingRefetches).toBe(0);
+        expect(refetchQuotes.lastFetchTimestamp).toBeDefined();
+    });
+
+    it('should reset refetch state when request data is invalid while refetch is running', async () => {
+        const { input, store } = getMocks({
+            status: 'running',
+            remainingRefetches: 10,
+            lastFetchTimestamp: Date.now(),
+        });
+
+        const promise = store.dispatch(
+            sellThunks.handleRequestThunk({
+                ...input,
+                formValues: {
+                    ...input.formValues,
+                    outputs: input.formValues.outputs.map(output => ({
+                        ...output,
+                        fiat: undefined as unknown as string,
+                        amount: undefined as unknown as string,
+                    })),
+                },
+            }),
+        );
+        await promise;
+
+        const { quoteRefetchingState: refetchQuotes } = store.getState().wallet.trading;
+
+        expect(refetchQuotes.status).toBe('stopped');
+        expect(refetchQuotes.remainingRefetches).toBe(REFETCH_QUOTES_MAX_COUNT);
+        expect(refetchQuotes.lastFetchTimestamp).toBeUndefined();
     });
 });

--- a/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/selectSellQuoteThunk.test.ts
@@ -9,7 +9,6 @@ import { type SellInfo, type TradingSellState } from '../../../reducers/sellRedu
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
-import { type SelectSellQuoteThunkProps } from '../selectSellQuoteThunk';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -89,44 +88,35 @@ describe('selectSellQuoteThunk', () => {
             },
         });
 
-        const mockTimerStop = jest.fn();
-        const mockTimer = {
-            stop: mockTimerStop,
-        } as unknown as SelectSellQuoteThunkProps['timer'];
-
         const mockNextStep = jest.fn();
 
         return {
             store,
-            mockTimer,
-            mockTimerStop,
             mockNextStep,
         };
     };
 
     it('should successfully select quote', async () => {
         const { quote, state } = getDataMocks();
-        const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks(state);
+        const { store, mockNextStep } = getMocks(state);
 
         await store
             .dispatch(
                 sellThunks.selectQuoteThunk({
                     quote,
-                    timer: mockTimer,
                     nextStep: mockNextStep,
                 }),
             )
             .unwrap();
 
         expect(mockNextStep).toHaveBeenCalledTimes(1);
-        expect(mockTimerStop).toHaveBeenCalledTimes(1);
         expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(quote);
     });
 
     describe('should not be possible to save selected quote', () => {
         it('when sellInfo is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks({
+            const { store, mockNextStep } = getMocks({
                 ...state,
                 sellInfo: undefined,
             });
@@ -135,20 +125,18 @@ describe('selectSellQuoteThunk', () => {
                 .dispatch(
                     sellThunks.selectQuoteThunk({
                         quote,
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quote exchange is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks({
+            const { store, mockNextStep } = getMocks({
                 ...state,
                 quotesRequest: undefined,
             });
@@ -160,20 +148,18 @@ describe('selectSellQuoteThunk', () => {
                             ...quote,
                             exchange: undefined,
                         },
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quoteRequest is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks({
+            const { store, mockNextStep } = getMocks({
                 ...state,
                 quotesRequest: undefined,
             });
@@ -182,20 +168,18 @@ describe('selectSellQuoteThunk', () => {
                 .dispatch(
                     sellThunks.selectQuoteThunk({
                         quote,
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
 
         it('when quote cryptoCurrency is undefined', async () => {
             const { quote, state } = getDataMocks();
-            const { store, mockTimer, mockNextStep, mockTimerStop } = getMocks(state);
+            const { store, mockNextStep } = getMocks(state);
 
             await store
                 .dispatch(
@@ -204,14 +188,12 @@ describe('selectSellQuoteThunk', () => {
                             ...quote,
                             cryptoCurrency: undefined,
                         },
-                        timer: mockTimer,
                         nextStep: mockNextStep,
                     }),
                 )
                 .unwrap();
 
             expect(mockNextStep).toHaveBeenCalledTimes(0);
-            expect(mockTimerStop).toHaveBeenCalledTimes(0);
             expect(store.getState().wallet.trading.sell.selectedQuote).toEqual(undefined);
         });
     });

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -100,14 +100,11 @@ export const handleSellRequestThunk = createThunk<
         {
             formValues,
             network,
-            timer,
             shouldSendInSats,
             composeRequestCallback,
         }: HandleSellRequestThunkProps,
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal },
     ) => {
-        timer.loading();
-
         const requestData = getQuoteRequestData({
             formValues,
             network,
@@ -115,21 +112,30 @@ export const handleSellRequestThunk = createThunk<
         });
 
         if (!requestData) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Invalid request data');
         }
 
-        const allQuotes = await getQuotesRequest({ requestData, signal });
+        let allQuotes: SellFiatTrade[] = [];
+        let requestSucceeded = false;
+        try {
+            allQuotes = (await getQuotesRequest({ requestData, signal })) ?? [];
+            requestSucceeded = true;
+        } finally {
+            if (!requestSucceeded) {
+                dispatch(tradingActions.stopRefetchQuotes());
+            }
+        }
 
         if (signal.aborted) {
-            timer.reset();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Request was aborted');
         }
 
         if (!Array.isArray(allQuotes) || allQuotes.length === 0) {
-            timer.stop();
+            dispatch(tradingActions.stopRefetchQuotes());
 
             const quotesSuccess: SellFiatTrade[] = [];
             dispatch(tradingSellActions.setAmountLimits(undefined));
@@ -172,7 +178,7 @@ export const handleSellRequestThunk = createThunk<
             composeRequestCallback();
         }
 
-        timer.reset();
+        dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
 
         return fulfillWithValue(successQuotes);
     },

--- a/suite-common/trading/src/thunks/sell/selectSellQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/sell/selectSellQuoteThunk.ts
@@ -1,10 +1,10 @@
 import { type SellFiatTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { type Timer } from '@trezor/react-utils';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
+import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingSellInfo,
     selectTradingSellQuotesRequest,
@@ -12,13 +12,12 @@ import {
 
 export type SelectSellQuoteThunkProps = {
     quote: SellFiatTrade;
-    timer: Timer;
     nextStep: () => void;
 };
 
 export const selectSellQuoteThunk = createThunk(
     `${TRADING_SELL_THUNK_PREFIX}/selectQuote`,
-    ({ quote, timer, nextStep }: SelectSellQuoteThunkProps, { dispatch, getState }) => {
+    ({ quote, nextStep }: SelectSellQuoteThunkProps, { dispatch, getState }) => {
         const sellInfo = selectTradingSellInfo(getState());
         const quotesRequest = selectTradingSellQuotesRequest(getState());
         const provider = quote.exchange ? sellInfo?.providerInfos[quote.exchange] : undefined;
@@ -26,7 +25,7 @@ export const selectSellQuoteThunk = createThunk(
         if (!quotesRequest || !provider || !quote.cryptoCurrency) return;
 
         dispatch(tradingSellActions.saveSelectedQuote(quote));
-        timer.stop();
+        dispatch(tradingActions.stopRefetchQuotes());
         nextStep();
     },
 );

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -33,7 +33,6 @@ import {
 } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
-import { type Timer } from '@trezor/react-utils';
 import { type Err, type Ok, type PrimitiveType } from '@trezor/type-utils';
 
 import type * as constants from './constants';
@@ -317,14 +316,12 @@ export type TradingSellUserConsentProps = {
 export type HandleBuyRequestThunkProps = {
     formValues: TradingBuyFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
 };
 
 export type HandleExchangeRequestThunkProps = {
     formValues: MinimalExchangeFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
     composeRequestCallback: () => void;
 };
@@ -332,7 +329,6 @@ export type HandleExchangeRequestThunkProps = {
 export type HandleSellRequestThunkProps = {
     formValues: MinimalSellFormProps;
     network: Network;
-    timer: Timer;
     shouldSendInSats: boolean | undefined;
     composeRequestCallback: () => void;
 };

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -1,4 +1,8 @@
-import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS, tradingBuyActions } from '@suite-common/trading';
+import {
+    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
+    tradingActions,
+    tradingBuyActions,
+} from '@suite-common/trading';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
     type PreloadedState,
@@ -19,20 +23,12 @@ import { type BuyFormValues } from '@suite-native/trading-types';
 import { useBuyForm } from '../useBuyForm';
 import { useBuyQuotes } from '../useBuyQuotes';
 
-let mockTimeSpent: number;
-
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
 
     return {
         ...originalModule,
         useDebounce: () => (fn: () => unknown) => fn(),
-        useTimer: () => {
-            const timer = originalModule.useNullTimer();
-            timer.timeSpent.seconds = mockTimeSpent;
-
-            return timer;
-        },
     };
 });
 
@@ -67,8 +63,8 @@ describe('useBuyQuotes', () => {
             { store },
         );
 
-    beforeEach(() => {
-        mockTimeSpent = 0;
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it('should query quotes once all required data is selected', () => {
@@ -206,9 +202,10 @@ describe('useBuyQuotes', () => {
     );
 
     it('should re-fetch quotes when re-fetch time elapsed', () => {
+        jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender } = renderUseBuyQuotes(store);
+        const { result } = renderUseBuyQuotes(store);
         dispatchSpy.mockClear();
 
         act(() => {
@@ -222,9 +219,14 @@ describe('useBuyQuotes', () => {
 
         expect(dispatchSpy).toHaveBeenCalledTimes(3);
 
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
         dispatchSpy.mockClear();
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
+
+        act(() => {
+            jest.advanceTimersByTime(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
+        });
 
         expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenLastCalledWith(
@@ -235,20 +237,27 @@ describe('useBuyQuotes', () => {
     });
 
     it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', () => {
+        jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender } = renderUseBuyQuotes(store);
+        const { result } = renderUseBuyQuotes(store);
 
-        dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
+        dispatchSpy.mockClear();
 
-        // 1st call - trading/buyAssetChanged
-        expect(dispatchSpy).toHaveBeenCalledTimes(1);
+        act(() => {
+            jest.advanceTimersByTime(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
+        });
+
+        expect(dispatchSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'handleRequestThunkMock' }),
+        );
     });
 
     it('should clear quotes when data in form becomes invalid', () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyFlow.ts
@@ -22,7 +22,6 @@ import { useAnalytics } from '@suite-native/services';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { buildTradingUrl, useBrowserAuth } from '@suite-native/trading-browser-auth';
 import { type BuyFormType } from '@suite-native/trading-types';
-import { useNullTimer } from '@trezor/react-utils';
 
 import { clearBuyFormQuoteData } from './useBuyForm';
 import { getAnalyticsTradingBuyPayload } from '../../utils/buy/quotesUtils';
@@ -47,7 +46,6 @@ export const useBuyFlow = (form: BuyFormType) => {
         'receiveAccount',
     ]);
 
-    const timer = useNullTimer();
     const navigation = useNavigation<NavigationProps>();
 
     const coinInfo = useSelector((state: TradingRootState) =>
@@ -157,7 +155,6 @@ export const useBuyFlow = (form: BuyFormType) => {
         await dispatch(
             buyThunks.selectQuoteThunk({
                 quote: candidateQuote,
-                timer,
                 returnUrl,
                 loginRequest: formResponse =>
                     openBrowserForFormData(formResponse, returnUrl, candidateQuote.orderId),

--- a/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
@@ -13,6 +13,7 @@ import {
     selectTradingBuyIsLoading,
     selectTradingCoinInfoByCryptoId,
     selectTradingPlatformByCryptoId,
+    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { events } from '@suite-native/analytics';
@@ -24,7 +25,6 @@ import { useDebounce } from '@trezor/react-utils';
 
 import { tradingBuyFormToTradingBuyFormProps } from '../../utils/buy/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
-import { useReloadTimer } from '../general/useReloadTimer';
 
 type ShouldFetchBuyQuotesRef = {
     cryptoId: string | undefined;
@@ -114,8 +114,8 @@ const useBuyQuotesInvalidator = (
 
 const useBuyQuotesThunk = (
     form: BuyFormType,
-    timer: ReturnType<typeof useReloadTimer>['timer'],
-    shouldRefetchQuotes: boolean,
+    isFetchAllowed: boolean,
+    shouldFetchQuotes: boolean,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -133,49 +133,46 @@ const useBuyQuotesThunk = (
         selectTradingPlatformByCryptoId(state, asset?.cryptoId),
     );
 
-    useEffect(() => {
-        if (shouldRefetchQuotes) {
-            if (quotesPromiseRef.current?.abort) {
-                quotesPromiseRef.current.abort('Request was replaced by another one.');
-            }
+    const fetchQuotes = useCallback(async () => {
+        const selectedAsset = form.getValues('asset');
+        invariant(selectedAsset, 'Asset is not defined');
+        const network = cryptoIdToNetwork(selectedAsset.cryptoId);
+        invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
 
-            debounce(async () => {
-                const selectedAsset = form.getValues('asset');
-                invariant(selectedAsset, 'Asset is not defined');
-                const network = cryptoIdToNetwork(selectedAsset.cryptoId);
-                invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
-
-                const payload: HandleBuyRequestThunkProps = {
-                    network,
-                    formValues: tradingBuyFormToTradingBuyFormProps(form, coinInfo, platformInfo),
-                    shouldSendInSats,
-                    timer,
-                };
-                const requestPromise = dispatch(buyThunks.handleRequestThunk(payload));
-                quotesPromiseRef.current = requestPromise;
-                const action = await requestPromise;
-                if (isFulfilled(action) && (action.payload as BuyTrade[]).length > 0) {
-                    analytics.report({
-                        type: events.tradingQuoteReceivedEvent.name,
-                        payload: {
-                            type: 'buy',
-                        },
-                    });
-                }
+        const payload: HandleBuyRequestThunkProps = {
+            network,
+            formValues: tradingBuyFormToTradingBuyFormProps(form, coinInfo, platformInfo),
+            shouldSendInSats,
+        };
+        const requestPromise = dispatch(buyThunks.handleRequestThunk(payload));
+        quotesPromiseRef.current = requestPromise;
+        const action = await requestPromise;
+        if (isFulfilled(action) && (action.payload as BuyTrade[]).length > 0) {
+            analytics.report({
+                type: events.tradingQuoteReceivedEvent.name,
+                payload: {
+                    type: 'buy',
+                },
             });
         }
-    }, [
-        form,
-        shouldRefetchQuotes,
-        timer,
-        quotesPromiseRef,
-        shouldSendInSats,
-        coinInfo,
-        platformInfo,
-        debounce,
-        dispatch,
-        analytics,
-    ]);
+    }, [form, coinInfo, platformInfo, shouldSendInSats, quotesPromiseRef, dispatch, analytics]);
+
+    useEffect(() => {
+        if (!isFetchAllowed || !shouldFetchQuotes) return;
+
+        if (quotesPromiseRef.current?.abort) {
+            quotesPromiseRef.current.abort('Request was replaced by another one.');
+        }
+
+        debounce(fetchQuotes);
+    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+
+    useTradingRefetchScheduler({
+        onRefetch: () => {
+            if (!isFetchAllowed) return;
+            debounce(fetchQuotes);
+        },
+    });
 };
 
 export const useBuyQuotes = (form: BuyFormType) => {
@@ -183,19 +180,7 @@ export const useBuyQuotes = (form: BuyFormType) => {
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
     const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchBuyQuotes(form);
-    const { timer, shouldReload } = useReloadTimer({ isEnabled: isFetchAllowed });
 
     useBuyQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useBuyQuotesThunk(
-        form,
-        timer,
-        isFetchAllowed && (shouldFetchQuotes || shouldReload),
-        promiseRef,
-        debounce,
-    );
-
-    return {
-        timer,
-        quotesRequest: promiseRef.current,
-    };
+    useBuyQuotesThunk(form, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -3,6 +3,7 @@ import { type CryptoId } from 'invity-api';
 import {
     INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
     type MinimalExchangeFormProps,
+    tradingActions,
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -42,20 +43,12 @@ jest.mock('@suite-native/services', () => {
     };
 });
 
-let mockTimeSpent: number;
-
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
 
     return {
         ...originalModule,
         useDebounce: () => (fn: () => unknown) => fn(),
-        useTimer: () => {
-            const timer = originalModule.useNullTimer();
-            timer.timeSpent.seconds = mockTimeSpent;
-
-            return timer;
-        },
     };
 });
 
@@ -88,16 +81,15 @@ describe('useExchangeQuotes', () => {
         renderHookWithStoreProvider(
             () => {
                 const form = useExchangeForm();
-                const quotes = useExchangeQuotes(form);
+                useExchangeQuotes(form);
 
-                return { form, quotes };
+                return { form };
             },
             { store },
         );
 
     beforeEach(() => {
         mockReport.mockClear();
-        mockTimeSpent = 0;
     });
 
     it('should query quotes once all required data is selected', async () => {
@@ -124,14 +116,9 @@ describe('useExchangeQuotes', () => {
                 network: expect.objectContaining({
                     tradeCryptoId: 'bitcoin',
                 }),
-                timer: expect.any(Object),
                 composeRequestCallback: expect.anything(),
                 shouldSendInSats: false,
             },
-        });
-
-        await act(async () => {
-            await result.current.quotes.quotesRequest;
         });
     });
 
@@ -151,10 +138,6 @@ describe('useExchangeQuotes', () => {
         expect(dispatchSpy).toHaveBeenCalledWith({
             type: 'handleRequestThunkMock',
             payload: expect.objectContaining({ shouldSendInSats: true }),
-        });
-
-        await act(async () => {
-            await result.current.quotes.quotesRequest;
         });
     });
 
@@ -237,10 +220,6 @@ describe('useExchangeQuotes', () => {
                 type: 'handleRequestThunkMock',
             }),
         );
-
-        await act(async () => {
-            await result.current.quotes.quotesRequest;
-        });
     });
 
     it('should clear exchange state on unmount', () => {
@@ -290,16 +269,12 @@ describe('useExchangeQuotes', () => {
                 type: 'handleRequestThunkMock',
             }),
         );
-
-        await act(async () => {
-            await result.current.quotes.quotesRequest;
-        });
     });
 
     it('should re-fetch quotes when re-fetch time elapsed', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender } = renderUseExchangeQuotes(store);
+        const { result } = renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         await act(async () => {
@@ -309,44 +284,52 @@ describe('useExchangeQuotes', () => {
             await Promise.resolve();
         });
 
+        act(() => {
+            store.dispatch(
+                tradingActions.setRefetchQuotesTimestamp(
+                    Date.now() - INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000,
+                ),
+            );
+        });
         dispatchSpy.mockClear();
 
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        });
 
         expect(dispatchSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: 'handleRequestThunkMock',
             }),
         );
-
-        // clean up form flush async validations
-        await act(async () => {
-            form.clearErrors();
-            await form.trigger();
-        });
     });
 
     it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', async () => {
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender } = renderUseExchangeQuotes(store);
+        const { result } = renderUseExchangeQuotes(store);
         const { form } = result.current;
 
         act(() => {
             form.setValue('sendAsset', btcAsset);
         });
 
+        act(() => {
+            store.dispatch(
+                tradingActions.setRefetchQuotesTimestamp(
+                    Date.now() - INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000,
+                ),
+            );
+        });
         dispatchSpy.mockClear();
 
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
-
-        expect(dispatchSpy).not.toHaveBeenCalled();
-
         await act(async () => {
-            await result.current.quotes.quotesRequest;
+            await new Promise(resolve => setTimeout(resolve, 0));
         });
+
+        expect(dispatchSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'handleRequestThunkMock' }),
+        );
     });
 
     it('should clear quotes when data in form becomes invalid', async () => {
@@ -381,10 +364,6 @@ describe('useExchangeQuotes', () => {
             type: 'tradingExchange/clearQuotesAndQuotesRequest',
         });
         expect(store.getState().wallet.trading.exchange.quotes).toEqual([]);
-
-        await act(async () => {
-            await result.current.quotes.quotesRequest;
-        });
     });
 
     describe('analytics', () => {
@@ -392,15 +371,15 @@ describe('useExchangeQuotes', () => {
             const { result } = renderUseExchangeQuotes(store);
             const { form } = result.current;
 
-            act(() => {
+            mockReport.mockClear();
+
+            await act(async () => {
                 form.setValue('sendAsset', btcAsset);
                 form.setValue('receiveAsset', ethAsset);
                 form.setValue('sendCryptoAmount', '1');
-            });
-
-            mockReport.mockClear();
-            await act(async () => {
-                await result.current.quotes.quotesRequest;
+                await Promise.resolve(); // flush effects → fetchQuotes called
+                await Promise.resolve(); // flush fetchQuotes first await
+                await Promise.resolve(); // flush waitForPromiseAndReport → analytics fires
             });
         };
 
@@ -442,7 +421,9 @@ describe('useExchangeQuotes', () => {
 
             await renderUseExchangeQuotesWithFilledForm(store);
 
-            expect(mockReport).not.toHaveBeenCalled();
+            expect(mockReport).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.tradingQuoteReceivedEvent.name }),
+            );
         });
 
         it('should not report when handleRequestThunk rejected', async () => {
@@ -460,7 +441,9 @@ describe('useExchangeQuotes', () => {
 
             await renderUseExchangeQuotesWithFilledForm(store);
 
-            expect(mockReport).not.toHaveBeenCalled();
+            expect(mockReport).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.tradingQuoteReceivedEvent.name }),
+            );
         });
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -293,7 +293,6 @@ describe('useExchangeSelectQuote', () => {
                     type: 'selectQuoteThunkMock',
                     payload: expect.objectContaining({
                         quote: expect.objectContaining({ swapSlippage: '1.5' }),
-                        timer: expect.objectContaining({ timeSpent: { seconds: 0 } }),
                     }),
                 }),
             );

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
@@ -10,6 +10,7 @@ import {
     cryptoIdToNetwork,
     exchangeThunks,
     selectTradingExchangeIsLoading,
+    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { type AnalyticsNativeEvents, events } from '@suite-native/analytics';
@@ -19,11 +20,10 @@ import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { exchangeActions, selectExchangeQuotes } from '@suite-native/trading-state';
 import { type AbortablePromise, type ExchangeFormType } from '@suite-native/trading-types';
 import { type Analytics } from '@trezor/analytics-uploader';
-import { type Timer, useDebounce } from '@trezor/react-utils';
+import { useDebounce } from '@trezor/react-utils';
 
 import { tradingExchangeFormToTradingExchangeFormProps } from '../../utils/exchange/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
-import { useReloadTimer } from '../general/useReloadTimer';
 
 type ShouldFetchExchangeQuotesRef = {
     sendAsset: string | undefined;
@@ -113,8 +113,8 @@ const waitForPromiseAndReport = async (
 
 const useExchangeQuotesThunk = (
     getValues: ExchangeFormType['getValues'],
-    timer: Timer,
-    shouldRefetchQuotes: boolean,
+    isFetchAllowed: boolean,
+    shouldFetchQuotes: boolean,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -126,40 +126,39 @@ const useExchangeQuotesThunk = (
         selectIsAmountInSats(state, symbol),
     );
 
+    const fetchQuotes = useCallback(async () => {
+        const selectedAsset = getValues('sendAsset');
+        invariant(selectedAsset, 'Asset is not defined');
+        const network = cryptoIdToNetwork(selectedAsset.cryptoId);
+        invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
+
+        const payload: HandleExchangeRequestThunkProps = {
+            formValues: tradingExchangeFormToTradingExchangeFormProps(getValues),
+            network,
+            shouldSendInSats,
+            composeRequestCallback: noop,
+        };
+
+        quotesPromiseRef.current = dispatch(exchangeThunks.handleRequestThunk(payload));
+        await waitForPromiseAndReport(quotesPromiseRef.current, analytics);
+    }, [getValues, shouldSendInSats, quotesPromiseRef, dispatch, analytics]);
+
     useEffect(() => {
-        if (shouldRefetchQuotes) {
-            if (quotesPromiseRef.current?.abort) {
-                quotesPromiseRef.current.abort('Request was replaced by another one.');
-            }
+        if (!isFetchAllowed || !shouldFetchQuotes) return;
 
-            debounce(() => {
-                const selectedAsset = getValues('sendAsset');
-                invariant(selectedAsset, 'Asset is not defined');
-                const network = cryptoIdToNetwork(selectedAsset.cryptoId);
-                invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
-
-                const payload: HandleExchangeRequestThunkProps = {
-                    formValues: tradingExchangeFormToTradingExchangeFormProps(getValues),
-                    network,
-                    timer,
-                    shouldSendInSats,
-                    composeRequestCallback: noop,
-                };
-
-                quotesPromiseRef.current = dispatch(exchangeThunks.handleRequestThunk(payload));
-                waitForPromiseAndReport(quotesPromiseRef.current, analytics);
-            });
+        if (quotesPromiseRef.current?.abort) {
+            quotesPromiseRef.current.abort('Request was replaced by another one.');
         }
-    }, [
-        dispatch,
-        getValues,
-        shouldRefetchQuotes,
-        timer,
-        quotesPromiseRef,
-        debounce,
-        shouldSendInSats,
-        analytics,
-    ]);
+
+        debounce(fetchQuotes);
+    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+
+    useTradingRefetchScheduler({
+        onRefetch: () => {
+            if (!isFetchAllowed) return;
+            debounce(fetchQuotes);
+        },
+    });
 };
 
 const useExchangeQuotesInvalidator = (
@@ -187,19 +186,6 @@ export const useExchangeQuotes = ({ watch, getValues, control }: ExchangeFormTyp
 
     const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchExchangeQuotes(watch, control);
 
-    const { timer, shouldReload } = useReloadTimer({ isEnabled: isFetchAllowed });
-
     useExchangeQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useExchangeQuotesThunk(
-        getValues,
-        timer,
-        isFetchAllowed && (shouldFetchQuotes || shouldReload),
-        promiseRef,
-        debounce,
-    );
-
-    return {
-        timer,
-        quotesRequest: promiseRef.current,
-    };
+    useExchangeQuotesThunk(getValues, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -26,7 +26,6 @@ import {
     selectExchangeSelectedSendAccount,
 } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
-import { useNullTimer } from '@trezor/react-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 import { clearExchangeFormQuoteData } from './useExchangeForm';
@@ -40,7 +39,6 @@ type NavigationProps = StackToStackCompositeNavigationProps<
 
 export const useExchangeSelectQuote = (form: ExchangeFormType) => {
     const dispatch = useDispatch();
-    const timer = useNullTimer();
     const [candidateQuote, receiveAsset] = form.watch(['quote', 'receiveAsset']);
 
     const isLoading = useSelector(selectTradingExchangeIsLoading);
@@ -94,7 +92,6 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
         await dispatch(
             exchangeThunks.selectQuoteThunk({
                 quote: { ...candidateQuote, swapSlippage },
-                timer,
                 nextStep: () => {
                     clearExchangeFormQuoteData(form);
                     nextStep(getApprovalStatus(candidateQuote));

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -1,4 +1,8 @@
-import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS, tradingSellActions } from '@suite-common/trading';
+import {
+    INVITY_API_RELOAD_QUOTES_AFTER_SECONDS,
+    tradingActions,
+    tradingSellActions,
+} from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
     type PreloadedState,
@@ -20,20 +24,12 @@ import { type SellFormValues } from '@suite-native/trading-types';
 import { useSellForm } from '../useSellForm';
 import { useSellQuotes } from '../useSellQuotes';
 
-let mockTimeSpent: number;
-
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
 
     return {
         ...originalModule,
         useDebounce: () => (fn: () => unknown) => fn(),
-        useTimer: () => {
-            const timer = originalModule.useNullTimer();
-            timer.timeSpent.seconds = mockTimeSpent;
-
-            return timer;
-        },
     };
 });
 
@@ -70,8 +66,8 @@ describe('useSellQuotes', () => {
             { store },
         );
 
-    beforeEach(() => {
-        mockTimeSpent = 0;
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     it('should query quotes once all required data is selected', async () => {
@@ -198,9 +194,10 @@ describe('useSellQuotes', () => {
     );
 
     it('should re-fetch quotes when re-fetch time elapsed', async () => {
+        jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender } = renderUseSellQuotes(store);
+        const { result } = renderUseSellQuotes(store);
         act(() => {
             result.current.setValue('sendAsset', usdcAsset);
             result.current.setValue('fiatCurrency', 'usd');
@@ -212,9 +209,14 @@ describe('useSellQuotes', () => {
             await Promise.resolve();
         });
 
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
         dispatchSpy.mockClear();
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
+
+        act(() => {
+            jest.advanceTimersByTime(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
+        });
 
         expect(dispatchSpy).toHaveBeenCalledTimes(1);
         expect(dispatchSpy).toHaveBeenLastCalledWith(
@@ -225,19 +227,27 @@ describe('useSellQuotes', () => {
     });
 
     it('should not re-fetch quotes when re-fetch time elapsed but not all required data are available', () => {
+        jest.useFakeTimers();
         const store = getInitializedStore();
         const dispatchSpy = jest.spyOn(store, 'dispatch');
-        const { result, rerender, unmount } = renderUseSellQuotes(store);
+        const { result, unmount } = renderUseSellQuotes(store);
 
-        dispatchSpy.mockClear();
         act(() => {
             result.current.setValue('fiatCurrency', 'usd');
         });
 
-        mockTimeSpent = INVITY_API_RELOAD_QUOTES_AFTER_SECONDS;
-        rerender({});
+        act(() => {
+            store.dispatch(tradingActions.setRefetchQuotesTimestamp(Date.now()));
+        });
+        dispatchSpy.mockClear();
 
-        expect(dispatchSpy).not.toHaveBeenCalled();
+        act(() => {
+            jest.advanceTimersByTime(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000);
+        });
+
+        expect(dispatchSpy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'handleRequestThunkMock' }),
+        );
 
         unmount();
     });

--- a/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellQuotes.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef } from 'react';
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { invariant } from '@suite-common/suite-utils';
@@ -8,17 +8,17 @@ import {
     selectTradingSellIsLoading,
     selectValidTradingSellQuotes,
     sellThunks,
+    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { useFormState } from '@suite-native/forms';
 import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { sellActions } from '@suite-native/trading-state';
 import { type AbortablePromise, type SellFormType } from '@suite-native/trading-types';
-import { type Timer, useDebounce } from '@trezor/react-utils';
+import { useDebounce } from '@trezor/react-utils';
 
 import { tradingSellFormToTradingSellFormProps } from '../../utils/sell/quotesUtils';
 import { useQuotesInvalidator } from '../general/useQuotesInvalidator';
-import { useReloadTimer } from '../general/useReloadTimer';
 
 type ShouldFetchSellQuotes = {
     isFetchAllowed: boolean;
@@ -130,8 +130,8 @@ const useSellQuotesInvalidator = (
 
 const useSellQuotesThunk = (
     getValues: SellFormType['getValues'],
-    timer: Timer,
-    shouldRefetchQuotes: boolean,
+    isFetchAllowed: boolean,
+    shouldFetchQuotes: boolean,
     quotesPromiseRef: RefObject<AbortablePromise | undefined>,
     debounce: ReturnType<typeof useDebounce>,
 ) => {
@@ -142,37 +142,37 @@ const useSellQuotesThunk = (
         selectIsAmountInSats(state, symbol),
     );
 
+    const fetchQuotes = useCallback(() => {
+        const selectedAsset = getValues('sendAsset');
+        invariant(selectedAsset, 'Asset is not defined');
+        const network = cryptoIdToNetwork(selectedAsset.cryptoId);
+        invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
+
+        const payload: HandleSellRequestThunkProps = {
+            network,
+            shouldSendInSats,
+            formValues: tradingSellFormToTradingSellFormProps(getValues),
+            composeRequestCallback: noop,
+        };
+        quotesPromiseRef.current = dispatch(sellThunks.handleRequestThunk(payload));
+    }, [getValues, shouldSendInSats, quotesPromiseRef, dispatch]);
+
     useEffect(() => {
-        if (shouldRefetchQuotes) {
-            if (quotesPromiseRef.current?.abort) {
-                quotesPromiseRef.current.abort('Request was replaced by another one.');
-            }
+        if (!isFetchAllowed || !shouldFetchQuotes) return;
 
-            debounce(() => {
-                const selectedAsset = getValues('sendAsset');
-                invariant(selectedAsset, 'Asset is not defined');
-                const network = cryptoIdToNetwork(selectedAsset.cryptoId);
-                invariant(network, `Network not found for [${selectedAsset.cryptoId}]`);
-
-                const payload: HandleSellRequestThunkProps = {
-                    network,
-                    shouldSendInSats,
-                    timer,
-                    formValues: tradingSellFormToTradingSellFormProps(getValues),
-                    composeRequestCallback: noop,
-                };
-                quotesPromiseRef.current = dispatch(sellThunks.handleRequestThunk(payload));
-            });
+        if (quotesPromiseRef.current?.abort) {
+            quotesPromiseRef.current.abort('Request was replaced by another one.');
         }
-    }, [
-        dispatch,
-        getValues,
-        shouldRefetchQuotes,
-        timer,
-        quotesPromiseRef,
-        debounce,
-        shouldSendInSats,
-    ]);
+
+        debounce(fetchQuotes);
+    }, [isFetchAllowed, shouldFetchQuotes, quotesPromiseRef, debounce, fetchQuotes]);
+
+    useTradingRefetchScheduler({
+        onRefetch: () => {
+            if (!isFetchAllowed) return;
+            debounce(fetchQuotes);
+        },
+    });
 };
 
 export const useSellQuotes = (form: SellFormType) => {
@@ -180,19 +180,7 @@ export const useSellQuotes = (form: SellFormType) => {
     const promiseRef = useRef<AbortablePromise | undefined>(undefined);
 
     const { isFetchAllowed, shouldFetchQuotes } = useShouldFetchSellQuotes(form);
-    const { timer, shouldReload } = useReloadTimer({ isEnabled: isFetchAllowed });
 
     useSellQuotesInvalidator(isFetchAllowed, promiseRef, debounce);
-    useSellQuotesThunk(
-        form.getValues,
-        timer,
-        isFetchAllowed && (shouldFetchQuotes || shouldReload),
-        promiseRef,
-        debounce,
-    );
-
-    return {
-        timer,
-        quotesPromiseRef: promiseRef.current,
-    };
+    useSellQuotesThunk(form.getValues, isFetchAllowed, shouldFetchQuotes, promiseRef, debounce);
 };

--- a/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellSelectQuote.ts
@@ -19,7 +19,6 @@ import {
 import { useSellAnalyticReportCallback } from '@suite-native/trading-analytics';
 import { selectSellSelectedSendAccount } from '@suite-native/trading-state';
 import { type SellFormType } from '@suite-native/trading-types';
-import { useNullTimer } from '@trezor/react-utils';
 
 import { clearSellFormQuoteData } from './useSellForm';
 
@@ -37,7 +36,6 @@ type SellSelectQuoteReturn = {
 export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const timer = useNullTimer();
     const { watch, control } = form;
     const { isValid } = useFormState({ control });
     const candidateQuote = watch('quote');
@@ -75,7 +73,6 @@ export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn =>
         await dispatch(
             sellThunks.selectQuoteThunk({
                 quote: candidateQuote,
-                timer,
                 nextStep,
             }),
         );
@@ -85,7 +82,6 @@ export const useSellSelectQuote = (form: SellFormType): SellSelectQuoteReturn =>
         analyticsReportCallback,
         sellInfo?.providerInfos,
         dispatch,
-        timer,
         navigation,
         form,
     ]);


### PR DESCRIPTION
## Description

- Move trading quote refetch interval state from local form timer usage to `tradingCommonReducer` (`status`, `lastFetchTimestamp`, `remainingRefetches`).
- Add `useTradingRefetchScheduler` and `useTradingRefetchCountdown` hooks and wire Buy/Sell/Exchange flows plus `TradingRefreshTime` to this shared redux-driven interval.
- Update buy/sell/exchange request and quote-selection thunks to start/stop interval via `tradingActions`, and remove timer fields from trading form initializer/types/context.

## Notes for QA

1. In Buy/Sell/Exchange, change quote inputs (amount/currency/payment method) and verify the refresh indicator counts down and quotes auto-refresh after the interval.
2. Select a quote and move to the next step; verify automatic quote refresh is stopped on the selection/confirmation flow.
3. Leave quote refresh running for multiple cycles and verify it eventually stops (max-cycle guard) and can restart after changing form inputs again.

**Test before merge:** https://dev.suite.sldev.cz/suite-web/feat/26285/refetch-timer/web/

## Related Issue

Resolve #26285

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26285/refetch-timer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26285/refetch-timer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/26285/refetch-timer&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T06:21:05.241Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T13:42:04.568Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/26285/refetch-timer/web/](https://dev.suite.sldev.cz/suite-web/feat/26285/refetch-timer/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->