### PR TITLE
fix(suite): add legacy labeling disabled tooltip

### DIFF
--- a/packages/suite/src/views/settings/labeling/Labeling.tsx
+++ b/packages/suite/src/views/settings/labeling/Labeling.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
+import { type OptionProps } from 'react-select';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { metadataLabelingActions, metadataThunks } from '@suite/metadata';
@@ -9,7 +10,8 @@ import {
     selectIsSuiteSyncEnabled,
     selectIsSuiteSyncFeatureAvailable,
 } from '@suite-common/suite-sync';
-import { LoadingContent } from '@trezor/components';
+import { Box, LoadingContent, Tooltip } from '@trezor/components';
+import { Option as SelectOption } from '@trezor/components/src/components/form/Select/customComponents';
 import { ActionColumn, ActionSelect, TextColumn } from '@trezor/product-components';
 import { exhaustive } from '@trezor/type-utils';
 import { HELP_CENTER_LABELING } from '@trezor/urls';
@@ -30,6 +32,35 @@ import { useLabelingDeviceState } from 'src/hooks/suite/useLabelingDeviceState';
 import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 import { useAnalytics } from 'src/support/useAnalytics';
 
+type LabelingTranslatedOption = LabelingOption<string> & {
+    tooltipContent?: ReactNode;
+};
+
+const LABELING_SELECT_TEST_ID = '@settings/labeling-select';
+
+const LabelingOption = ({
+    children,
+    data,
+    isDisabled,
+    ...rest
+}: OptionProps<LabelingTranslatedOption, false>) => (
+    <SelectOption
+        {...rest}
+        data={data}
+        isDisabled={isDisabled}
+        size="small"
+        data-testid={LABELING_SELECT_TEST_ID}
+    >
+        <Tooltip
+            content={data.tooltipContent}
+            isActive={isDisabled && !!data.tooltipContent}
+            cursor={isDisabled ? 'default' : 'pointer'}
+        >
+            <Box width="100%">{children}</Box>
+        </Tooltip>
+    </SelectOption>
+);
+
 export const Labeling = () => {
     const { translationString } = useTranslation();
     const { suiteSync } = useSuiteServices();
@@ -45,12 +76,16 @@ export const Labeling = () => {
 
     const legacyMetadataState = useSelector(state => state.metadata);
 
-    const translatedOptions: LabelingOption<string>[] = LABELING_SELECT_OPTIONS.map(option => ({
+    const translatedOptions: LabelingTranslatedOption[] = LABELING_SELECT_OPTIONS.map(option => ({
         ...option,
         label:
             !showSuiteSync && option.value === 'legacy'
                 ? translationString(LABELING_LEGACY_OPTION_LABEL)
                 : translationString(option.label),
+        tooltipContent:
+            option.value === 'legacy' && isDeviceLabelingDisabled
+                ? translationString('TR_LABELING_LEGACY_DISABLED_TOOLTIP')
+                : undefined,
     })).filter(option => option.value !== 'suite-sync' || showSuiteSync);
 
     const handleLegacyOptionSelect = async () => {
@@ -168,7 +203,8 @@ export const Labeling = () => {
                         options={translatedOptions}
                         value={getSelectedOption()}
                         onChange={handleOnChange}
-                        data-testid="@settings/labeling-select"
+                        components={{ Option: LabelingOption }}
+                        data-testid={LABELING_SELECT_TEST_ID}
                         isDisabled={isDeviceLabelingDisabled && !showSuiteSync}
                         isOptionDisabled={option => isOptionDisabled(option.value)}
                     />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6582,6 +6582,10 @@ export const messages = defineMessages({
         id: 'TR_LABELING_LEGACY',
         defaultMessage: 'Legacy',
     },
+    TR_LABELING_LEGACY_DISABLED_TOOLTIP: {
+        id: 'TR_LABELING_LEGACY_DISABLED_TOOLTIP',
+        defaultMessage: 'Connect your Trezor to switch to Legacy labeling',
+    },
     TR_LABELING_SECURE_SYNC: {
         id: 'TR_LABELING_SECURE_SYNC',
         defaultMessage: 'Suite Sync',


### PR DESCRIPTION
Resolves: https://github.com/trezor/trezor-suite/issues/26497

<img width="1628" height="296" alt="image" src="https://github.com/user-attachments/assets/ec721e5b-fc19-4ec9-a6c1-482520037ad7" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tooltip-disabled-labeling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tooltip-disabled-labeling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T13:52:31.794Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T13:49:57.371Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->