### PR TITLE
fix(suite-native): show xpub directly for Portfolio Tracker accounts

### DIFF
--- a/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
+++ b/suite-native/qr-code/src/components/XpubQRCodeBottomSheet.tsx
@@ -49,13 +49,14 @@ export const XpubQRCodeBottomSheet = ({
     const isAddressBased = isAddressBasedNetwork(networkType);
     const { applyStyle } = useNativeStyles();
     const copyToClipboard = useCopyToClipboard();
-    const [isXpubShown, setIsXpubShown] = useState(isAddressBased);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-
     const device = useSelector(selectSelectedDevice);
+
+    const isImported = account?.imported ?? false;
+    const [isXpubShown, setIsXpubShown] = useState(isAddressBased || isImported);
 
     if (!qrCodeData) return null;
 


### PR DESCRIPTION
## Summary
- Skip device verification when displaying xpub for imported (Portfolio Tracker) accounts
- The xpub bottom sheet now shows the QR code and value immediately for imported accounts, since there is no physical device to verify against
- The xpub is already known from the `account.descriptor` provided when the user added the account

Closes #26686

## Test plan
1. Open Portfolio Tracker on mobile
2. Add a BTC xpub account
3. Go to Account Settings → tap "Show public key"
4. Verify the xpub QR code and value are displayed immediately (no device verification attempted)
5. Verify that non-imported accounts still require device verification as before

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-xpub-display-portfolio&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->