### PR TITLE
fix(ci): patch-package in yarn focus

### DIFF
--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -43,9 +43,10 @@ jobs:
           yarn workspaces focus @suite-native/app
           yarn workspace @suite-native/app exec patch-package # Apply global patches.
       - name: Trigger adhoc build Android
+        working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}
         run: |
-          yarn native:adhoc \
+          eas build --profile adhoc \
             -p android \
             --non-interactive \
             --no-wait \
@@ -53,9 +54,10 @@ jobs:
             --message ${{ github.sha }} \
             2>&1 | sed -E 's/UDID: [A-Za-z0-9-]+/UDID: [REDACTED]/g' # remove UDIDs from output
       - name: Trigger adhoc build iOS
+        working-directory: suite-native/app
         if: ${{ github.event.inputs.PLATFORM == 'ios' || github.event.inputs.PLATFORM == 'all' }}
         run: |
-          yarn native:adhoc \
+          eas build --profile adhoc \
             -p ios \
             --auto-submit \
             --non-interactive \

--- a/.github/workflows/build-suite-native-adhoc.yml
+++ b/.github/workflows/build-suite-native-adhoc.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
       - name: Trigger adhoc build Android
         if: ${{ github.event.inputs.PLATFORM == 'android' || github.event.inputs.PLATFORM == 'all' }}
         run: |

--- a/.github/workflows/build-suite-native-preview.yml
+++ b/.github/workflows/build-suite-native-preview.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
 
       - name: Check runtimeVersion builds
         run: |

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
       - name: Build on EAS Android
         run: eas build
           --platform android

--- a/.github/workflows/release-suite-native-production.yml
+++ b/.github/workflows/release-suite-native-production.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
       - name: Build on EAS iOS
         run: eas build
           --platform ios
@@ -73,7 +73,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
       - name: Build on EAS Android
         run: eas build
           --platform android
@@ -109,7 +109,7 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
-          yarn exec patch-package # Apply global patches.
+          yarn workspace @suite-native/app exec patch-package # Apply global patches.
 
       - name: Get Suite version
         id: get_version

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
         "native:ios": "yarn workspace @suite-native/app ios",
         "native:prebuild": "yarn workspace @suite-native/app prebuild",
         "native:prebuild:clean": "yarn workspace @suite-native/app prebuild:clean",
-        "native:adhoc": "yarn workspace @suite-native/app build:adhoc",
         "native:reverse-ports": "yarn workspace @suite-native/app reverse-ports",
         "ws": "./scripts/workspace-run.sh",
         "_______ Aliases _______": "Aliases for longer commands which we often have to run manually. Names don't have to be pretty or make total sense.",

--- a/suite-native/app/.depcheckrc.json
+++ b/suite-native/app/.depcheckrc.json
@@ -29,6 +29,7 @@
         "expo-web-browser",
         "expo-file-system",
         "lottie-react-native",
+        "patch-package",
         "react-intl",
         "react-native-ble-plx",
         "react-native-edge-to-edge",

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -206,6 +206,7 @@
         "jest-diff": "^30.2.0",
         "jest-junit": "^16.0.0",
         "lodash": "^4.18.1",
+        "patch-package": "8.0.1",
         "react-native-performance": "^5.1.4",
         "ts-jest": "29.4.1",
         "ts-node": "^10.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12079,6 +12079,7 @@ __metadata:
     lottie-react-native: "npm:7.3.5"
     metro-config: "npm:^0.83.0"
     minimist: "npm:^1.2.8"
+    patch-package: "npm:8.0.1"
     react: "npm:19.2.4"
     react-freeze: "npm:^1.0.4"
     react-intl: "npm:^8.1.3"


### PR DESCRIPTION
## Description

Fix `patch-package` in yarn workspace focus CI, broken by https://github.com/trezor/trezor-suite/pull/26515/changes

Also, change Adhoc build to use the eas-cli installed by EAS github action, instead of npx. The npx command was removed in that same PR, unbeknownst to me that it was still needed here.

[Ad hoc build ran here](https://github.com/trezor/trezor-suite/actions/runs/24405429809/job/71287316262) :heavy_check_mark: 
Consistent output [with last working state](https://github.com/trezor/trezor-suite/actions/runs/24196222835/job/70626862943) for both Android & iOS :heavy_check_mark: 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native-yarn-focus&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native-yarn-focus&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-yarn-focus&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T15:05:49.527Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T15:03:58.169Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->