### PR TITLE
fix(suite): Fix sidebar DeviceSelect responsiveness

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -22,6 +22,7 @@ const CaretContainer = styled.div`
     padding: 10px;
     border-radius: 50%;
     transition: background 0.15s;
+    flex-shrink: 0;
 `;
 
 const Wrapper = styled.div<{ $isSidebarCollapsed?: boolean }>`
@@ -105,7 +106,9 @@ export const DeviceSelector = () => {
                     tabIndex={0}
                     data-testid="@menu/switch-device"
                 >
-                    <SidebarDeviceStatus />
+                    <Box flex="1" minWidth="0" overflow="hidden">
+                        <SidebarDeviceStatus />
+                    </Box>
 
                     <ExpandedSidebarOnly>
                         {selectedDevice && selectedDevice.state && (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -49,17 +49,19 @@ export const DeviceStatus = ({
     );
 
     return (
-        <Row flex="1" gap={spacings.sm} justifyContent="center">
+        <>
             {isDeviceDetailVisible ? (
-                <>
+                <Row justifyContent="space-between" gap={spacings.sm} overflow="hidden">
                     {image}
                     {content}
-                </>
+                </Row>
             ) : (
-                <Tooltip hasArrow cursor="inherit" placement="right" content={content}>
-                    {image}
-                </Tooltip>
+                <Row justifyContent="center">
+                    <Tooltip hasArrow cursor="inherit" placement="right" content={content}>
+                        {image}
+                    </Tooltip>
+                </Row>
             )}
-        </Row>
+        </>
     );
 };

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceConnectionText.tsx
@@ -14,6 +14,7 @@ import {
 import { spacings } from '@trezor/theme';
 
 const Container = styled.span<{ $isAction?: boolean }>`
+    width: stretch;
     ${({ $isAction }) =>
         $isAction &&
         css`
@@ -67,7 +68,7 @@ export const DeviceConnectionText = ({
                 ) : (
                     <Icon name={icon} size={12} {...colorProps} />
                 )}
-                <Text typographyStyle="body-xs" {...colorProps}>
+                <Text ellipsisLineCount={1} typographyStyle="body-xs" {...colorProps}>
                     {children}
                 </Text>
             </Row>

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceDetail.tsx
@@ -1,12 +1,18 @@
 import { type ReactNode } from 'react';
 
-import { Column, TruncateWithTooltip } from '@trezor/components';
+import { Column, Text } from '@trezor/components';
 
 export const DeviceDetail = ({ label, children }: { label: string; children: ReactNode }) => (
     <Column overflow="hidden" flex="1" alignItems="flex-start">
-        <TruncateWithTooltip>
-            <span data-testid="@menu/device/label">{label}</span>
-        </TruncateWithTooltip>
+        <Text
+            typographyStyle="body-sm"
+            ellipsisLineCount={1}
+            width="stretch"
+            data-testid="@menu/device/label"
+        >
+            {label}
+        </Text>
+
         {children}
     </Column>
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26623


## Screenshots:

before

<img width="255" height="134" alt="image" src="https://github.com/user-attachments/assets/8df91e28-d2e9-4203-a995-7d4a0c321519" />


after

https://github.com/user-attachments/assets/063e36c3-24bb-4c96-9912-539619132db9


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-sidebar-device-select-responsiveness&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-sidebar-device-select-responsiveness&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T14:23:38.020Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T15:03:53.985Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->