### PR TITLE
fix(suite): Fix page header when open modal

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { selectIsAccountTabPage, selectRouteName } from '@suite/router';
+import { isAccountTabRoute, resolveEffectiveBackgroundRouteName, selectRoute } from '@suite/router';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Row } from '@trezor/components';
 import { spacingsPx, zIndices } from '@trezor/theme';
@@ -10,6 +10,7 @@ import { spacingsPx, zIndices } from '@trezor/theme';
 import { HEADER_HEIGHT } from 'src/constants/suite/layout';
 import { useSelector } from 'src/hooks/suite';
 import { selectSelectedAccountKey } from 'src/reducers/wallet/selectedAccountReducer';
+import { useSuiteServices } from 'src/support/SuiteServicesProvider';
 
 import { GlobalSendReceive } from './GlobalSendReceive/GlobalSendReceive';
 import { HeaderActions } from './HeaderActions';
@@ -53,13 +54,17 @@ interface PageHeaderProps {
 }
 
 export const PageHeader = ({ children }: PageHeaderProps) => {
-    // Select minimal state to avoid unnecessary re-renders
     const selectedAccountKey = useSelector(selectSelectedAccountKey);
-    const routeName = useSelector(selectRouteName);
-    const isAccountTabPage = useSelector(selectIsAccountTabPage);
+    const route = useSelector(selectRoute);
+    const { suiteRouterHistory } = useSuiteServices();
+    const effectiveRouteName = resolveEffectiveBackgroundRouteName(
+        route,
+        suiteRouterHistory.getLocation(),
+    );
+    const isAccountTabPage = isAccountTabRoute(effectiveRouteName);
 
     // handle moment when children are not rendered yet in the Trade section
-    const isTradeSection = !!routeName?.includes('wallet-trading');
+    const isTradeSection = !!effectiveRouteName?.includes('wallet-trading');
 
     if (isTradeSection || children != null) {
         return <Container>{children}</Container>;
@@ -69,7 +74,7 @@ export const PageHeader = ({ children }: PageHeaderProps) => {
         <Container>
             <PageName />
 
-            {routeName === 'suite-index' && <PageHeaderIndex />}
+            {effectiveRouteName === 'suite-index' && <PageHeaderIndex />}
             {!!selectedAccountKey && isAccountTabPage && <HeaderActions />}
         </Container>
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -1,9 +1,5 @@
 import { Translation } from '@suite/intl';
-import {
-    resolveEffectiveBackgroundRouteName,
-    selectIsAccountTabPage,
-    selectRoute,
-} from '@suite/router';
+import { isAccountTabRoute, resolveEffectiveBackgroundRouteName, selectRoute } from '@suite/router';
 import { selectDeviceAccountForNetworkSymbolAndAccountTypeWithIndex } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
@@ -23,7 +19,7 @@ export const PageName = () => {
         suiteRouterHistory.getLocation(),
     );
     const selectedAccount = useSelector(selectSelectedAccount);
-    const isAccountTabPage = useSelector(selectIsAccountTabPage);
+    const isAccountTabPage = isAccountTabRoute(currentRoute);
     const { params } = useSelector(state => state.wallet.selectedAccount);
 
     const fallbackAccount = useSelector(state =>

--- a/suite/router/src/routerReducer.ts
+++ b/suite/router/src/routerReducer.ts
@@ -91,11 +91,11 @@ export const selectURLSearchParams = createMemoizedSelector(
     (search): URLSearchParams | null => (search ? new URLSearchParams(search) : null),
 );
 
-export const selectIsAccountTabPage = (state: RouterRootState) => {
-    const routeName = selectRouteName(state);
+export const isAccountTabRoute = (routeName: string | undefined): boolean =>
+    routeName !== undefined && ACCOUNT_TABS.includes(routeName);
 
-    return routeName !== undefined && ACCOUNT_TABS.includes(routeName);
-};
+export const selectIsAccountTabPage = (state: RouterRootState) =>
+    isAccountTabRoute(selectRouteName(state));
 
 export const selectRouterApp = (state: RouterRootState) => state.router.app;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #13807


## Screenshots:


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-page-header-when-open-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-page-header-when-open-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T14:43:16.164Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T14:41:18.674Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->