### PR TITLE
fix(suite-native): show correct animation in auto-eject alert

### DIFF
--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -16,6 +16,7 @@ import {
     getFwUpdateVersion,
     getIsDeviceConnectedAndAuthorized,
     getIsDeviceConnectedViaBluetooth,
+    getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceInitialized,
     getIsDeviceRemembered,
     getIsThpDevice,
@@ -115,6 +116,11 @@ export const selectIsDeviceLanguageConfigurable = createMemoizedSelector(
 export const selectIsBluetoothSupportedByDevice = createMemoizedSelector(
     [selectDeviceCapabilities],
     capabilities => !!capabilities?.includes('Capability_BLE'),
+);
+
+export const selectIsDeviceApiTypeBluetooth = createMemoizedSelector(
+    [selectSelectedDevice],
+    device => !!device && getIsDeviceDescriptorApiTypeBluetooth(device),
 );
 
 export const selectIsDeviceProtectedByPin = createMemoizedSelector(

--- a/suite-common/suite-utils/src/__fixtures__/device.ts
+++ b/suite-common/suite-utils/src/__fixtures__/device.ts
@@ -74,6 +74,30 @@ const getStatus: Array<{ device: TrezorDevice; status: string }> = [
     },
 ];
 
+const getIsDeviceDescriptorApiTypeBluetooth = [
+    {
+        description: 'device descriptor is missing',
+        device: mockSuiteDevice({
+            descriptor: undefined,
+        }),
+        result: false,
+    },
+    {
+        description: 'device api type is usb',
+        device: mockSuiteDevice({
+            descriptor: { apiType: 'usb' },
+        }),
+        result: false,
+    },
+    {
+        description: 'device api type is bluetooth',
+        device: mockSuiteDevice({
+            descriptor: { apiType: 'bluetooth' },
+        }),
+        result: true,
+    },
+];
+
 const getIsDeviceConnectedViaBluetooth = [
     {
         description: 'device is connected via bluetooth',
@@ -597,6 +621,7 @@ const getFirmwareDowngradeUrl = [
 
 export default {
     getStatus,
+    getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceConnectedViaBluetooth,
     isSelectedDevice,
     isSelectedInstance,

--- a/suite-common/suite-utils/src/__tests__/device.test.ts
+++ b/suite-common/suite-utils/src/__tests__/device.test.ts
@@ -10,6 +10,7 @@ import {
     getFirmwareDowngradeUrl,
     getFirstDeviceInstance,
     getIsDeviceConnectedViaBluetooth,
+    getIsDeviceDescriptorApiTypeBluetooth,
     getIsDeviceRemembered,
     getNewInstanceNumber,
     getNewWalletNumber,
@@ -27,6 +28,14 @@ describe(getStatus.name, () => {
         it(f.status, () => {
             const status = getStatus(f.device);
             expect(status).toEqual(f.status);
+        });
+    });
+});
+
+describe(getIsDeviceDescriptorApiTypeBluetooth.name, () => {
+    fixtures.getIsDeviceDescriptorApiTypeBluetooth.forEach(f => {
+        it(f.description, () => {
+            expect(getIsDeviceDescriptorApiTypeBluetooth(f.device)).toEqual(f.result);
         });
     });
 });

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -525,7 +525,7 @@ export const getIsDeviceConnectedAndAuthorized = ({
 }) => !!deviceState && !!deviceFeatures;
 
 export const getIsDeviceDescriptorApiTypeBluetooth = (device: Device | TrezorDevice) =>
-    device.descriptor.apiType === 'bluetooth';
+    device.descriptor?.apiType === 'bluetooth';
 
 export const getIsDeviceConnectedViaBluetooth = (device?: TrezorDevice): boolean =>
     !!device?.connected && getIsDeviceDescriptorApiTypeBluetooth(device);

--- a/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/AutoEjectAnimation.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectIsBluetoothSupportedByDevice } from '@suite-common/device';
+import { selectIsDeviceApiTypeBluetooth } from '@suite-common/device';
 import { LottieAnimation } from '@suite-native/atoms';
 
 import autoEjectCableLottie from '../../../assets/auto-eject-cable-lottie.json';
 import autoEjectWirelessLottie from '../../../assets/auto-eject-wireless-lottie.json';
 
 export const AutoEjectAnimation = () => {
-    const isBluetoothSupportedByDevice = useSelector(selectIsBluetoothSupportedByDevice);
+    const isDeviceApiTypeBluetooth = useSelector(selectIsDeviceApiTypeBluetooth);
 
     return (
         <LottieAnimation
-            source={isBluetoothSupportedByDevice ? autoEjectWirelessLottie : autoEjectCableLottie}
+            source={isDeviceApiTypeBluetooth ? autoEjectWirelessLottie : autoEjectCableLottie}
         />
     );
 };


### PR DESCRIPTION
When the auto-eject alert is shown, the right animation is chosen based on the API type (not by Bluetooth capability).

## Screenshots:
<img width="1080" height="2340" alt="Screenshot_20260414_165859" src="https://github.com/user-attachments/assets/69b8cb07-be1f-44dd-95f6-ffe664f55b85" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/auto-eject-alert&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/auto-eject-alert&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/auto-eject-alert&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T15:47:24.519Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T15:08:21.167Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->