### PR TITLE
Test/fix onboarding t1b1 create wallet

### DIFF
--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -49,6 +49,11 @@ interface StartEmuFromBranchType extends StartEmuFromBranch {
 
 export type EmuStartOptsType = StartEmuType | StartEmuFromUrlType | StartEmuFromBranchType;
 
+export interface PressYesMultiple {
+    count: number;
+    delay?: number;
+}
+
 interface ClickEmu {
     x: number;
     y: number;
@@ -259,6 +264,15 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     async pressYes() {
         await resolveAfter(EMU_RACE_CONDITION_WORKAROUND_DELAY);
         await this.client.send({ type: 'emulator-press-yes' });
+
+        return null;
+    }
+    async pressYesMultiple(options: PressYesMultiple) {
+        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await this.client.send({
+            type: 'emulator-press-yes-multiple',
+            ...options,
+        });
 
         return null;
     }

--- a/packages/trezor-user-env-link/src/api.ts
+++ b/packages/trezor-user-env-link/src/api.ts
@@ -49,6 +49,11 @@ interface StartEmuFromBranchType extends StartEmuFromBranch {
 
 export type EmuStartOptsType = StartEmuType | StartEmuFromUrlType | StartEmuFromBranchType;
 
+export interface PressYesMultiple {
+    count: number;
+    delay?: number;
+}
+
 interface ClickEmu {
     x: number;
     y: number;
@@ -259,6 +264,15 @@ export class TrezorUserEnvLinkClass extends TypedEmitter<WebsocketClientEvents> 
     async pressYes() {
         await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
         await this.client.send({ type: 'emulator-press-yes' });
+
+        return null;
+    }
+    async pressYesMultiple(options: PressYesMultiple) {
+        await new Promise(resolve => setTimeout(resolve, EMU_RACE_CONDITION_WORKAROUND_DELAY));
+        await this.client.send({
+            type: 'emulator-press-yes-multiple',
+            ...options,
+        });
 
         return null;
     }

--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test';
 import type { ApplySettings } from '@trezor/protobuf/src/definitions';
 import {
     Model,
+    PressYesMultiple,
     ReadAndConfirmAtomicShamirMnemonicEmu,
     ReadAndConfirmShamirMnemonicEmu,
     SetupEmu,
@@ -64,6 +65,11 @@ export class DeviceFixture {
     @step()
     async pressYes() {
         await TrezorUserEnvLink.pressYes();
+    }
+
+    @step()
+    async pressYesMultiple(options: PressYesMultiple) {
+        await TrezorUserEnvLink.pressYesMultiple(options);
     }
 
     @step()

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -59,12 +59,18 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 
+            // Issue: Clicking setPinButton causes toast error: 'Error: Initialize failed: messages.c:257:Unknown message, code: Failure_UnexpectedMessage'
+            // Second click on setPinButton does continue the flow correctly
             await test.step('Lets set PIN', async () => {
                 await page.waitForTimeout(2_000);
                 const pin = '12345';
 
-                await onboardingPage.pin.setPinButton.click();
-                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(async () => {
+                    await onboardingPage.pin.setPinButton.click();
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                }).toPass({
+                    timeout: 15_000,
+                });
                 await device.pressYes();
                 // enter the PIN
                 await trezorInput.enterPinOnBlindMatrix(pin);
@@ -74,7 +80,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
 
             await test.step('Finish wallet creation', async () => {
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
-                await expect(dashboardPage.walletReady).toBeVisible();
+                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
             });
         },
     );

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -53,9 +53,8 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
 
                 // Confirm 2 x 24 words
                 await page.waitForTimeout(1_000);
-                for (let i = 0; i < 48; i++) {
-                    await device.pressYes();
-                }
+
+                await device.pressYesMultiple({ count: 48 });
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -59,12 +59,18 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 
+            // Issue: Clicking setPinButton causes toast error: 'Error: Initialize failed: messages.c:257:Unknown message, code: Failure_UnexpectedMessage'
+            // Second click on setPinButton does continue the flow correctly
             await test.step('Lets set PIN', async () => {
                 await page.waitForTimeout(2_000);
                 const pin = '12345';
 
-                await onboardingPage.pin.setPinButton.click();
-                await devicePrompt.confirmOnDevicePromptIsShown();
+                await expect(async () => {
+                    await onboardingPage.pin.setPinButton.click();
+                    await devicePrompt.confirmOnDevicePromptIsShown();
+                }).toPass({
+                    timeout: 15_000,
+                });
                 await device.pressYes();
                 // enter the PIN
                 await trezorInput.enterPinOnBlindMatrix(pin);

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -53,9 +53,8 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
                 await device.pressYes();
                 // Emulator needs to initialize the seed first
                 await page.waitForTimeout(1_000);
-                for (let i = 0; i < 48; i++) {
-                    await device.pressYes();
-                }
+
+                await device.pressYesMultiple({ count: 48 });
                 await page.getByTestId('@onboarding/continue-button').click();
             });
 
@@ -80,7 +79,8 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
 
             await test.step('Finish wallet creation', async () => {
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
-                await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+                // await expect(dashboardPage.walletReady).toBeVisible({ timeout: 30_000 });
+                await expect(dashboardPage.walletReady).toBeVisible();
             });
         },
     );


### PR DESCRIPTION
## Description

Error: 

`Initialize failed: messages.c:257:Unknown message, code: Failure_UnexpectedMessage`, is caused by a concurrency conflict on the T1B1 emulator's communication channel, triggered by an excessive number of `pressYes()` calls.

Fix: 

Add a `press-yes-multiple ` function to the emulator and set the default delay between presses to 100ms. This appears to be more reliable since the presses occur within a single WebSocket request.
https://github.com/trezor/trezor-user-env/pull/361

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-onboarding-t1b1-create-wallet&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-onboarding-t1b1-create-wallet&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Trading - Swap SPL token to coin via CEX,Swap USDT to SOL via CEX" | 🙋 manual |
| Quarantine test: "sol staking,unstake and claim on SOL account" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-29T15:41:26.879Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-06-29T15:40:18.254Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-onboarding-t1b1-create-wallet/web/](https://dev.suite.sldev.cz/suite-web/test/fix-onboarding-t1b1-create-wallet/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->