### PR TITLE
fix(suite-sync): disconnected device turn on suite sync

### DIFF
--- a/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
+++ b/suite-native/labeling/src/hooks/useTurnOnSuiteSyncGuard.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { selectDeviceStaticSessionId } from '@suite-common/device';
+import { selectDeviceStaticSessionId, selectIsDeviceConnected } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type WithSuiteSyncAndDeviceState,
@@ -11,6 +11,7 @@ import {
 import { useAlert } from '@suite-native/alerts';
 import { Translation, useTranslate } from '@suite-native/intl';
 import {
+    AuthorizeDeviceStackRoutes,
     DeviceSettingsStackRoutes,
     type RootStackParamList,
     RootStackRoutes,
@@ -36,6 +37,7 @@ export const useTurnOnSuiteSyncGuard = () => {
             >
         >();
     const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
+    const isDeviceConnected = useSelector(selectIsDeviceConnected);
 
     const suiteSyncInteraction = useSelector(
         (state: WithSuiteSyncAndDeviceState & MessageSystemRootState) =>
@@ -100,13 +102,19 @@ export const useTurnOnSuiteSyncGuard = () => {
     };
 
     const showSuiteSyncEnableConfirmationAlert = (onSuccess: () => void) => {
-        showAlert({
-            title: <Translation id="suiteSync.enableAlert.title" />,
-            description: <Translation id="suiteSync.enableAlert.description" />,
-            primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
-            onPressPrimaryButton: () => turnOnSuiteSync(onSuccess),
-            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-        });
+        if (!isDeviceConnected) {
+            navigation.navigate(RootStackRoutes.AuthorizeDeviceStack, {
+                screen: AuthorizeDeviceStackRoutes.DeviceConnectionGuard,
+            });
+        } else {
+            showAlert({
+                title: <Translation id="suiteSync.enableAlert.title" />,
+                description: <Translation id="suiteSync.enableAlert.description" />,
+                primaryButtonTitle: <Translation id="suiteSync.enableAlert.cta" />,
+                onPressPrimaryButton: () => turnOnSuiteSync(onSuccess),
+                secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+            });
+        }
     };
 
     const handleAddLabel = async (onSuccess: () => void) => {


### PR DESCRIPTION
## Description

When a user attempts to add or edit a label on mobile without a Trezor device connected with Suite sync off, the app does not guide them through the required connection flow. The expected behavior is that tapping "Add label" should initiate a guided flow: connect device → enter passphrase → enable Suite Sync → allow label editing.

The `useTurnOnSuiteSyncGuard` hook was missing the handling for the disconnected-device case. Previously this was covered implicitly during device discovery, but after that behavior changed, the guard was never updated to compensate. As a result, the "Add label" button appeared functional but the full flow was never completable without a device already connected.

## Steps to Reproduce

1. Open Suite on mobile with no Trezor device connected when suite sync is turned off
2. Navigate to an account or transaction
3. Tap "Add label"

## Expected Behavior

The app guides the user through connecting their Trezor, entering their passphrase, and enabling Suite Sync before allowing the label to be edited.

## Actual Behavior

The flow does not proceed correctly — the user is not guided through device connection and Suite Sync activation when the device is disconnected.

## Additional Context

- The fix involves adding disconnected-device handling to `useTurnOnSuiteSyncGuard`, similar to what was already done for the Suite Sync alert on the home screen (`SuiteSyncKeysAlert.tsx`).
- After connecting, the user is not returned to the exact point in the flow they came from — this is a known limitation considered acceptable.

## Screenshots:

https://github.com/user-attachments/assets/2ed788fe-ef25-48ad-ae45-462f3ac69847


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/disconnected-turn-on-suite-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->