### PR TITLE
feat(suite): walletconnect warning for insufficient balance

### DIFF
--- a/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx
@@ -8,7 +8,7 @@ import {
     TxSimulationProvider,
     TxSimulationTitle,
 } from '@suite/tx-simulation/src/common';
-import { EvmTxSimulationDisclaimer } from '@suite/tx-simulation/src/evm';
+import { EvmInsufficientGasWarning, EvmTxSimulationDisclaimer } from '@suite/tx-simulation/src/evm';
 import { connectPopupActions } from '@suite-common/connect-popup';
 import {
     TX_METHODS_WITH_FEES,
@@ -55,6 +55,9 @@ export function ConnectPopupTxSimulationModalInner({
             ? action.payload.transaction.gasLimit
             : undefined,
     });
+
+    const selectedFeeLevel = form.watch('selectedFee') || 'normal';
+    const currentComposedLevel = composedLevels?.[selectedFeeLevel];
 
     const simulation = useTxSimulation(action, {
         onSuccess(result) {
@@ -168,6 +171,12 @@ export function ConnectPopupTxSimulationModalInner({
                                 />
                             </FormProvider>
                         )}
+
+                        <EvmInsufficientGasWarning
+                            composedLevel={currentComposedLevel}
+                            accountBalance={account.balance}
+                            networkSymbol={account.symbol}
+                        />
                     </Column>
                 </Column>
             </Modal.ModalBase>

--- a/suite-common/tx-simulation/package.json
+++ b/suite-common/tx-simulation/package.json
@@ -16,6 +16,7 @@
         "@suite-common/wallet-config": "workspace:^",
         "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@trezor/utils": "workspace:*",
         "react": "19.2.4"
     }
 }

--- a/suite-common/tx-simulation/src/hooks/useHasSufficientFundsForGas.ts
+++ b/suite-common/tx-simulation/src/hooks/useHasSufficientFundsForGas.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import { BigNumber } from '@trezor/utils';
+
+export function computeGasFeeInWei(gasLimit: string, gasPriceInWei: string): string {
+    return new BigNumber(gasLimit).multipliedBy(gasPriceInWei).toFixed(0);
+}
+
+export function useHasSufficientFundsForGas(
+    totalFeeInWei: string | undefined,
+    accountBalance: string,
+): boolean {
+    return useMemo(
+        () => !totalFeeInWei || new BigNumber(totalFeeInWei).lte(accountBalance),
+        [totalFeeInWei, accountBalance],
+    );
+}

--- a/suite-common/tx-simulation/src/index.ts
+++ b/suite-common/tx-simulation/src/index.ts
@@ -12,3 +12,7 @@ export { useTxSimulation } from './hooks/useTxSimulation';
 
 export type { AccountSummary, TransactionSimulation } from '@blockaid/client/resources/evm';
 export { TX_METHODS_WITH_FEES } from './config';
+export {
+    computeGasFeeInWei,
+    useHasSufficientFundsForGas,
+} from './hooks/useHasSufficientFundsForGas';

--- a/suite-common/tx-simulation/tsconfig.json
+++ b/suite-common/tx-simulation/tsconfig.json
@@ -5,7 +5,8 @@
         { "path": "../react-query" },
         { "path": "../wallet-config" },
         { "path": "../wallet-constants" },
-        { "path": "../wallet-types" }
+        { "path": "../wallet-types" },
+        { "path": "../../packages/utils" }
     ],
     "include": [".", "**/*.json"]
 }

--- a/suite-native/module-connect-popup/src/components/TxSimulation/EvmInsufficientGasWarning.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulation/EvmInsufficientGasWarning.tsx
@@ -1,0 +1,43 @@
+import { computeGasFeeInWei, useHasSufficientFundsForGas } from '@suite-common/tx-simulation';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { type TxSimulationMethod } from '@suite-common/wallet-types';
+import { FullAlertBox } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+interface EvmInsufficientGasWarningProps {
+    transaction:
+        | TxSimulationMethod<'ethereumSignTransaction'>['payload']['transaction']
+        | undefined;
+    gasLimit: string;
+    accountBalance: string;
+    networkSymbol: NetworkSymbol;
+}
+
+export function EvmInsufficientGasWarning({
+    transaction,
+    gasLimit,
+    accountBalance,
+    networkSymbol,
+}: EvmInsufficientGasWarningProps) {
+    const gasPriceInWei = transaction?.maxFeePerGas ?? transaction?.gasPrice;
+    const hasSufficientFunds = useHasSufficientFundsForGas(
+        gasPriceInWei ? computeGasFeeInWei(gasLimit, gasPriceInWei) : undefined,
+        accountBalance,
+    );
+
+    if (hasSufficientFunds) return null;
+
+    return (
+        <FullAlertBox
+            variant="warning"
+            title={
+                <Translation
+                    id="transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee"
+                    values={{
+                        networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol),
+                    }}
+                />
+            }
+        />
+    );
+}

--- a/suite-native/module-connect-popup/src/components/TxSimulationInner.tsx
+++ b/suite-native/module-connect-popup/src/components/TxSimulationInner.tsx
@@ -24,6 +24,7 @@ import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import { ConnectAppIcon } from './ConnectAppIcon';
 import { ContractInfoBottomSheet } from './TxSimulation/ContractInfoBottomSheet';
+import { EvmInsufficientGasWarning } from './TxSimulation/EvmInsufficientGasWarning';
 import { FeeInfoBottomSheet } from './TxSimulation/FeeInfoBottomSheet';
 import { TxSimulationAsset } from './TxSimulation/TxSimulationAsset';
 import { TxSimulationBanner } from './TxSimulation/TxSimulationBanner';
@@ -293,6 +294,13 @@ export function TxSimulationInner({ action, account, source }: TxSimulationInner
                             values={{ provider: 'Blockaid' }}
                         />
                     </Text>
+
+                    <EvmInsufficientGasWarning
+                        transaction={isSigningTransaction ? action.payload.transaction : undefined}
+                        gasLimit={gasLimit}
+                        accountBalance={account.balance}
+                        networkSymbol={account.symbol}
+                    />
 
                     <Button
                         testID="@popup/confirm-simulation"

--- a/suite/tx-simulation/src/evm/components/EvmInsufficientGasWarning.tsx
+++ b/suite/tx-simulation/src/evm/components/EvmInsufficientGasWarning.tsx
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+
+import { Translation } from '@suite/intl';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { type PrecomposedTransaction } from '@suite-common/wallet-types';
+import { Banner } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+interface EvmInsufficientGasWarningProps {
+    composedLevel: PrecomposedTransaction | undefined;
+    accountBalance: string;
+    networkSymbol: NetworkSymbol;
+}
+
+export function EvmInsufficientGasWarning({
+    composedLevel,
+    accountBalance,
+    networkSymbol,
+}: EvmInsufficientGasWarningProps) {
+    const fee = composedLevel?.type === 'final' ? composedLevel.fee : undefined;
+    const hasSufficientFunds = useMemo(
+        () => !fee || new BigNumber(fee).lte(accountBalance),
+        [fee, accountBalance],
+    );
+
+    if (hasSufficientFunds) return null;
+
+    return (
+        <Banner
+            intent="warning"
+            icon
+            data-testid="@tx-simulation-modal/insufficient-gas-banner"
+            title={
+                <Translation
+                    id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
+                    values={{
+                        networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol),
+                    }}
+                />
+            }
+        />
+    );
+}

--- a/suite/tx-simulation/src/evm/index.ts
+++ b/suite/tx-simulation/src/evm/index.ts
@@ -1,2 +1,3 @@
+export { EvmInsufficientGasWarning } from './components/EvmInsufficientGasWarning';
 export { EvmTxSimulationDisclaimer } from './components/EvmTxSimulationDisclaimer';
 export { EvmTxSimulationAsset } from './components/EvmTxSimulationAsset/EvmTxSimulationAsset';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11837,6 +11837,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@trezor/utils": "workspace:*"
     react: "npm:19.2.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Add a warning to WalletConnect simulation modal if the ETH balance is not sufficient to pay for gas. 
Previously this would leave some users confused as to why it's not working, now this should make it clearer.
Uses pre-existing translation strings.

## Notes for QA

Try making some WalletConnect transaction on an account that holds tokens but with no ETH balance.
For example we have such an account with USDT (Ethereum #4 on dev seed), try to deposit on Morpho. 

## Screenshots

<img width="691" height="698" alt="Screenshot 2026-04-15 at 10 11 24" src="https://github.com/user-attachments/assets/603ae769-8ed3-4e89-a9ae-6e59a827a724" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=gas-fee-warning-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=gas-fee-warning-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=gas-fee-warning-banner&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T12:04:59.502Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T07:21:09.321Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/gas-fee-warning-banner/web/](https://dev.suite.sldev.cz/suite-web/gas-fee-warning-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->