### PR TITLE
fix(suite): hide earn dashboard reward columns when no data is available     

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/__tests__/EarnDashboardTableHeader.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+
+import { EarnDashboardTableHeader } from '../EarnDashboardTableHeader';
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span>{id}</span>,
+}));
+
+const renderHeader = (showRewardsColumns?: boolean) =>
+    render(
+        <table>
+            <EarnDashboardTableHeader showRewardsColumns={showRewardsColumns} />
+        </table>,
+    );
+
+describe('EarnDashboardTableHeader', () => {
+    it('should render reward column headers by default', () => {
+        renderHeader();
+
+        expect(screen.getByText('TR_EARN_DASHBOARD_TABLE_YEARLY_REWARDS')).toBeInTheDocument();
+        expect(screen.getByText('TR_EARN_DASHBOARD_TABLE_POTENTIAL_REWARDS')).toBeInTheDocument();
+    });
+
+    it('should not render reward column headers when showRewardsColumns is false', () => {
+        renderHeader(false);
+
+        expect(
+            screen.queryByText('TR_EARN_DASHBOARD_TABLE_YEARLY_REWARDS'),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText('TR_EARN_DASHBOARD_TABLE_POTENTIAL_REWARDS'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('should always render the account and APY column headers', () => {
+        renderHeader(false);
+
+        expect(screen.getByText('TR_EARN_DASHBOARD_TABLE_ACCOUNT_VAULT')).toBeInTheDocument();
+        expect(screen.getByText('TR_EARN_DASHBOARD_TABLE_APY')).toBeInTheDocument();
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingTable.tsx
@@ -84,9 +84,7 @@ export const EarnStakingTable = () => {
         !stakingAccounts.some(account => account.symbol === 'ada') &&
         !isAdaStakingDisabled;
 
-    const stakingAccountsNotActivated = ethNotActivated && solNotActivated && adaNotActivated;
-
-    const { displayedAccounts, isExpandable, isExpanded, toggleExpanded } =
+    const { displayedAccounts, isExpandable, isExpanded, toggleExpanded, hasAnyRewardsData } =
         useStakingAccountsVisibility({
             stakingAccounts,
             currentRates,
@@ -128,7 +126,7 @@ export const EarnStakingTable = () => {
                             <Card paddingType="none">
                                 <Table isRowHighlightedOnHover margin={{ top: 8 }}>
                                     <EarnDashboardTableHeader
-                                        showRewardsColumns={!stakingAccountsNotActivated}
+                                        showRewardsColumns={hasAnyRewardsData}
                                     />
 
                                     <Table.Body>

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/__tests__/useStakingAccountsVisibility.test.tsx
@@ -1,0 +1,120 @@
+import { renderHook } from '@testing-library/react';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { useStakingAccountsVisibility } from '../useStakingAccountsVisibility';
+
+const mockGetAccountTotalStakingBalance = jest.fn<string | null, [Account]>();
+
+jest.mock('@suite-common/wallet-utils', () => ({
+    ...jest.requireActual('@suite-common/wallet-utils'),
+    getAccountTotalStakingBalance: (...args: [Account]) =>
+        mockGetAccountTotalStakingBalance(...args),
+}));
+
+const createMockAccount = (overrides: Partial<Account>): Account =>
+    ({
+        key: 'default-key',
+        index: 0,
+        symbol: 'eth',
+        networkType: 'ethereum',
+        accountType: 'normal',
+        formattedBalance: '0',
+        descriptor: '0x123',
+        tokens: [],
+        ...overrides,
+    }) as Account;
+
+const defaultProps = {
+    currentRates: { eth: 2000, sol: 100, ada: 0.5, thod: 2000, dsol: 100 },
+    ethNotActivated: false,
+    solNotActivated: false,
+    adaNotActivated: false,
+};
+
+describe('useStakingAccountsVisibility', () => {
+    beforeEach(() => {
+        mockGetAccountTotalStakingBalance.mockReturnValue(null);
+    });
+
+    describe('hasAnyRewardsData', () => {
+        it('should be false when there are no staking accounts', () => {
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [],
+                }),
+            );
+
+            expect(result.current.hasAnyRewardsData).toBe(false);
+        });
+
+        it('should be false when all accounts have insufficient funds and no staking', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-0' as Account['key'],
+                            symbol: 'eth',
+                            formattedBalance: '0.01',
+                        }),
+                        createMockAccount({
+                            key: 'sol-0' as Account['key'],
+                            symbol: 'sol',
+                            networkType: 'solana',
+                            formattedBalance: '0.001',
+                        }),
+                    ],
+                }),
+            );
+
+            expect(result.current.hasAnyRewardsData).toBe(false);
+        });
+
+        it('should be true when at least one account has sufficient funds to stake', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-0' as Account['key'],
+                            symbol: 'eth',
+                            formattedBalance: '0.01',
+                        }),
+                        createMockAccount({
+                            key: 'eth-1' as Account['key'],
+                            symbol: 'eth',
+                            formattedBalance: '1.0',
+                        }),
+                    ],
+                }),
+            );
+
+            expect(result.current.hasAnyRewardsData).toBe(true);
+        });
+
+        it('should be true when at least one account is actively staking', () => {
+            mockGetAccountTotalStakingBalance.mockReturnValue('0.5');
+
+            const { result } = renderHook(() =>
+                useStakingAccountsVisibility({
+                    ...defaultProps,
+                    stakingAccounts: [
+                        createMockAccount({
+                            key: 'eth-0' as Account['key'],
+                            symbol: 'eth',
+                            formattedBalance: '0',
+                        }),
+                    ],
+                }),
+            );
+
+            expect(result.current.hasAnyRewardsData).toBe(true);
+        });
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
@@ -159,5 +159,8 @@ export const useStakingAccountsVisibility = ({
     const displayedAccounts = isExpanded ? expandedAccounts : collapsedAccounts;
     const isExpandable = collapsedAccounts.length !== expandedAccounts.length;
 
-    return { displayedAccounts, isExpanded, toggleExpanded, isExpandable };
+    const hasAnyRewardsData =
+        accountsStakingActive.length > 0 || accountsSufficientFunds.length > 0;
+
+    return { displayedAccounts, isExpanded, toggleExpanded, isExpandable, hasAnyRewardsData };
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -40,7 +40,7 @@ export const EarnYieldAccountOpportunity = ({ opportunity }: EarnYieldAccountOpp
     const hasSuppliedBalance = opportunity.hasVaultPosition;
     const hasDisplayableSuppliedAmount = new BigNumber(opportunity.suppliedAmount).gt(0);
     const hasMatchedTokenWithBalance = new BigNumber(opportunity.additionalSupplyAmount).gt(0);
-    const hasRewardsData = hasMatchedTokenWithBalance || hasDisplayableSuppliedAmount;
+    const { hasRewardsData } = opportunity;
     const hasApy = opportunity.apyPercentage !== null;
     const yearlyRewards = hasDisplayableSuppliedAmount
         ? new BigNumber(opportunity.suppliedAmount)

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -37,12 +37,16 @@ export const EarnYieldTable = () => {
     const { yieldOpportunities: availableVaults, isYieldOpportunitiesLoading } =
         useAllYieldOpportunities({ enabled: !isYieldDashboardDisabled });
 
-    const { yieldAccountOpportunities, yieldInactiveVaultOpportunities, isYieldActive } =
-        useYieldTableData({
-            availableVaults,
-            visibleAccounts,
-            visibleAccountSymbols,
-        });
+    const {
+        yieldAccountOpportunities,
+        yieldInactiveVaultOpportunities,
+        isYieldActive,
+        hasAnyRewardsData,
+    } = useYieldTableData({
+        availableVaults,
+        visibleAccounts,
+        visibleAccountSymbols,
+    });
 
     const {
         displayedYieldAccountOpportunities,
@@ -85,7 +89,7 @@ export const EarnYieldTable = () => {
                             )}
                         <Card paddingType="none">
                             <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                                <EarnDashboardTableHeader />
+                                <EarnDashboardTableHeader showRewardsColumns={hasAnyRewardsData} />
                                 <EarnYieldTableBody
                                     isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
                                     yieldAccountOpportunities={displayedYieldAccountOpportunities}

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,16 +1,10 @@
 import { useCallback, useMemo, useState } from 'react';
 
-import { BigNumber } from '@trezor/utils';
-
 import { type YieldAccountOpportunity } from '../types';
 
 type UseYieldAccountsVisibilityProps = {
     yieldAccountOpportunities: YieldAccountOpportunity[];
 };
-
-const isOpportunityVisible = (opportunity: YieldAccountOpportunity) =>
-    new BigNumber(opportunity.suppliedAmount).gt(0) ||
-    new BigNumber(opportunity.additionalSupplyAmount).gt(0);
 
 export const useYieldAccountsVisibility = ({
     yieldAccountOpportunities,
@@ -20,7 +14,7 @@ export const useYieldAccountsVisibility = ({
     const { collapsedYieldAccountOpportunities, hiddenYieldAccountOpportunities } = useMemo(() => {
         const visibleOpportunityKeys = new Set(
             yieldAccountOpportunities
-                .filter(opportunity => isOpportunityVisible(opportunity))
+                .filter(opportunity => opportunity.hasRewardsData)
                 .map(opportunity => opportunity.key),
         );
         const networkSymbols = new Set(

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -157,7 +157,7 @@ const getYieldOpportunityData = ({
     account: Account;
     networkSymbol: NetworkSymbol;
     vault: YieldDto;
-}) => {
+}): YieldOpportunityData => {
     const matchedInputToken = getMatchedAccountToken({
         account,
         networkSymbol,
@@ -169,19 +169,24 @@ const getYieldOpportunityData = ({
         token: vault.outputToken,
     });
     const hasVaultPosition = new BigNumber(matchedOutputToken?.balance ?? '0').gt(0);
+    const suppliedAmount = getConvertedOutputTokenBalanceToInputTokenAmount({
+        matchedOutputToken,
+        networkSymbol,
+        vault,
+    });
+    const additionalSupplyAmount = matchedInputToken?.balance ?? '0';
+    const hasRewardsData =
+        new BigNumber(suppliedAmount).gt(0) || new BigNumber(additionalSupplyAmount).gt(0);
 
     return {
         matchedInputToken,
         hasVaultPosition,
-        suppliedAmount: getConvertedOutputTokenBalanceToInputTokenAmount({
-            matchedOutputToken,
-            networkSymbol,
-            vault,
-        }),
-        additionalSupplyAmount: matchedInputToken?.balance ?? '0',
+        hasRewardsData,
+        suppliedAmount,
+        additionalSupplyAmount,
         suppliedSymbol: matchedInputToken?.symbol ?? toTokenSymbol(vault.token.symbol),
         suppliedContractAddress: matchedInputToken?.contract ?? vault.token.address ?? null,
-    } satisfies YieldOpportunityData;
+    };
 };
 
 type UseYieldTableDataProps = {
@@ -287,8 +292,14 @@ export const useYieldTableData = ({
         [yieldAccountOpportunities],
     );
 
+    const hasAnyRewardsData = useMemo(
+        () => yieldAccountOpportunities.some(opportunity => opportunity.hasRewardsData),
+        [yieldAccountOpportunities],
+    );
+
     return {
         isYieldActive,
+        hasAnyRewardsData,
         yieldAccountOpportunities,
         yieldInactiveVaultOpportunities,
     };

--- a/packages/suite/src/components/earn/dashboard/yield/types.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/types.ts
@@ -9,6 +9,7 @@ export type YieldAccountOpportunity = {
     vault: YieldDto;
     matchedInputToken: TokenInfoBranded | undefined;
     hasVaultPosition: boolean;
+    hasRewardsData: boolean;
     suppliedAmount: string;
     additionalSupplyAmount: string;
     suppliedSymbol: TokenSymbol;
@@ -25,6 +26,7 @@ export type YieldOpportunityData = Pick<
     YieldAccountOpportunity,
     | 'matchedInputToken'
     | 'hasVaultPosition'
+    | 'hasRewardsData'
     | 'suppliedAmount'
     | 'additionalSupplyAmount'
     | 'suppliedSymbol'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The Earn dashboard displayed "Your yearly rewards" and "Potential rewards" column headers even when no row had reward data to show, causing empty or misleading columns in three scenarios:                                                                
  1. Disabled networks: headers visible with no data below                                                                                                                                                                                                  
  2. Activated account with zero balance: empty "Potential rewards" column                                                                                                                                                                                  
  3. Insufficient balance: minimum stake message shown under reward headers                                                                                                                                                                                 
                                                                            
This fix computes **hasAnyRewardsData** at the data layer and passes **showRewardsColumns={false}** to hide reward headers when no account has rewards to display.

 Changes:                                                                                                                                                                                                                                                   
  - Staking table: useStakingAccountsVisibility exposes hasAnyRewardsData derived from its existing account partitioning (no duplicated logic)                                                                                                               
  - Yield table: useYieldTableData computes hasRewardsData per opportunity in getYieldOpportunityData and exposes hasAnyRewardsData from the hook                                                                                                            
  - Yield types: Added hasRewardsData to YieldAccountOpportunity and YieldOpportunityData                                                                                                                                                                    
  - Row component: EarnYieldAccountOpportunity reads pre-computed opportunity.hasRewardsData instead of recomputing     

## Notes for QA

  - Navigate to the Earn dashboard                                                                                                                                                                                                                           
  - Disable ETH and Base networks and verify reward column headers are hidden                                                                                                                                                                                
  - With an activated account with zero balance, verify no empty reward columns show                                                                                                                                                                         
  - With balance below minimum (ETH < 0.1, SOL < 0.01), verify reward column headers are hidden when no other account is staking                                                                                                                             
  - When at least one account is actively staking, reward columns should still show normally

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26667    

## Screenshots:
<img width="1395" height="751" alt="Screenshot 2026-04-14 at 17 40 59" src="https://github.com/user-attachments/assets/3a3a63f7-6b45-430c-9465-3902239a6ce0" />
