### PR TITLE
fix(suite-native): fix AnimatedCard style targeting and button alignSelf

### DIFF
--- a/suite-native/assets/src/components/Assets.tsx
+++ b/suite-native/assets/src/components/Assets.tsx
@@ -9,7 +9,7 @@ import { useSelectorDeepComparison } from '@suite-common/redux-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { type OnSelectAccount } from '@suite-native/accounts';
-import { AnimatedCard } from '@suite-native/atoms';
+import { AnimatedContainerCard } from '@suite-native/atoms';
 import { AccountsRediscoveryNeededWarning } from '@suite-native/discovery';
 import { FiveBinariesHomeBanner, useStakingDetailNavigation } from '@suite-native/module-earn';
 import {
@@ -68,7 +68,7 @@ export const Assets = () => {
     return (
         <>
             <FiveBinariesHomeBanner />
-            <AnimatedCard noPadding layout={LinearTransition}>
+            <AnimatedContainerCard noPadding layout={LinearTransition}>
                 <AccountsRediscoveryNeededWarning hasPadding />
                 {deviceNetworks.map(symbol => (
                     <Animated.View
@@ -80,7 +80,7 @@ export const Assets = () => {
                     </Animated.View>
                 ))}
                 {isLoading && <DiscoveryAssetsLoader isListEmpty={deviceNetworks.length < 1} />}
-            </AnimatedCard>
+            </AnimatedContainerCard>
             <NetworkAssetsBottomSheet
                 symbol={selectedAssetSymbol}
                 onSelectAccount={handleSelectAssetsAccount}

--- a/suite-native/atoms/src/Button/IconButton.tsx
+++ b/suite-native/atoms/src/Button/IconButton.tsx
@@ -35,8 +35,8 @@ export type IconButtonProps = Omit<
 const iconButtonStyle = mergeNativeStyles([
     buttonStyle,
     prepareNativeStyle<ButtonStyleProps>((_, { size }) => ({
+        alignSelf: 'center',
         // Padding must be set explicitly to override the base button size styles.
-        alignSelf: 'flex-start',
         paddingVertical: iconButtonPaddingMap[size],
         paddingHorizontal: iconButtonPaddingMap[size],
         borderRadius: iconButtonBorderRadiusMap[size],

--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -42,7 +42,7 @@ type TextButtonStyleProps = {
 };
 
 const buttonContainerStyle = prepareNativeStyle(() => ({
-    alignSelf: 'flex-start',
+    alignSelf: 'center',
     maxWidth: '100%',
 }));
 

--- a/suite-native/atoms/src/Card/Card.tsx
+++ b/suite-native/atoms/src/Card/Card.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { type ComponentProps, type ReactNode } from 'react';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
@@ -167,4 +167,28 @@ export const Card = React.forwardRef<View, CardProps>(
 );
 
 Card.displayName = 'Card';
-export const AnimatedCard = Animated.createAnimatedComponent(Card);
+
+export type AnimatedContainerCardProps = CardProps &
+    Pick<ComponentProps<typeof Animated.View>, 'layout' | 'entering' | 'exiting'> & {
+        // Use for animated container styles (opacity, transform). style goes to the inner Card.
+        animatedStyle?: ComponentProps<typeof Animated.View>['style'];
+    };
+
+// Wrapping in Animated.View ensures animated styles (opacity, transform) target the outermost
+// container. createAnimatedComponent(Card) would drive the inner styled View instead, which
+// breaks transform animations. For animated inner styles (e.g. borderColor), use AnimatedBorderCard.
+export const AnimatedContainerCard = ({
+    animatedStyle,
+    layout,
+    entering,
+    exiting,
+    children,
+    ...cardProps
+}: AnimatedContainerCardProps) => (
+    <Animated.View style={animatedStyle} layout={layout} entering={entering} exiting={exiting}>
+        <Card {...cardProps}>{children}</Card>
+    </Animated.View>
+);
+
+// Use when animated styles target the inner card container (e.g. borderColor, borderWidth).
+export const AnimatedBorderCard = Animated.createAnimatedComponent(Card);

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -13,7 +13,7 @@ import { RoundedIcon } from '../RoundedIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
 import { useTapGesture } from '../useTapGesture';
-import { AnimatedCard, type CardProps } from './Card';
+import { AnimatedContainerCard, type CardProps } from './Card';
 
 export const COMPACT_CARD_VARIANTS = ['normal', 'danger', 'primary'] as const;
 type CompactCardVariant = (typeof COMPACT_CARD_VARIANTS)[number];
@@ -88,10 +88,10 @@ export const CompactCardWithIconLayout = ({
     return (
         <GestureDetector gesture={tapGesture}>
             <View collapsable={false} testID={testID}>
-                <AnimatedCard
+                <AnimatedContainerCard
                     noPadding
                     borderColor={borderColor ?? undefined}
-                    style={animatedStyle}
+                    animatedStyle={animatedStyle}
                     // Android shadow does not work well with the Reanimated opacity animation.
                     noShadow={Platform.OS === 'android' ? true : noShadow}
                     {...cardProps}
@@ -126,7 +126,7 @@ export const CompactCardWithIconLayout = ({
                             <InlineAlertBox {...alertBoxProps} />
                         </Box>
                     )}
-                </AnimatedCard>
+                </AnimatedContainerCard>
             </View>
         </GestureDetector>
     );

--- a/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/PressableCardWithIconLayout.tsx
@@ -9,7 +9,7 @@ import { Box } from '../Box';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
 import { useTapGesture } from '../useTapGesture';
-import { AnimatedCard } from './Card';
+import { AnimatedContainerCard } from './Card';
 
 const contentStyle = prepareNativeStyle(() => ({
     flexGrow: 1,
@@ -35,10 +35,10 @@ export const PressableCardWithIconLayout = ({
     return (
         <GestureDetector gesture={tapGesture}>
             <View collapsable={false}>
-                <AnimatedCard
+                <AnimatedContainerCard
                     borderColor="borderElevation1"
                     noPadding
-                    style={animatedStyle}
+                    animatedStyle={animatedStyle}
                     // Android shadow does not work well with the Reanimated opacity animation.
                     noShadow={Platform.OS === 'android'}
                 >
@@ -56,7 +56,7 @@ export const PressableCardWithIconLayout = ({
                             <Icon name="caretRight" size="mediumLarge" color="iconSubdued" />
                         </Box>
                     </HStack>
-                </AnimatedCard>
+                </AnimatedContainerCard>
             </View>
         </GestureDetector>
     );

--- a/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
+++ b/suite-native/atoms/src/CardStepper/CardStepperItem.tsx
@@ -6,7 +6,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
 
 import { Button, type ButtonColorProps } from '../Button/Button';
-import { AnimatedCard } from '../Card/Card';
+import { AnimatedContainerCard } from '../Card/Card';
 import { Divider } from '../Divider';
 import { AnimatedVStack, HStack, VStack } from '../Stack';
 import { Text } from '../Text';
@@ -86,9 +86,9 @@ export const CardStepperItem = ({
     const headerColor: Color = isChecked ? 'textPrimaryDefault' : 'textSubdued';
 
     return (
-        <AnimatedCard
+        <AnimatedContainerCard
             layout={LAYOUT_ANIMATION}
-            style={[applyStyle(cardStyle, { isDisabled: !isOpened && !isChecked })]}
+            style={applyStyle(cardStyle, { isDisabled: !isOpened && !isChecked })}
         >
             <VStack spacing="sp16">
                 <VStack spacing="sp12">
@@ -132,6 +132,6 @@ export const CardStepperItem = ({
                     </AnimatedVStack>
                 )}
             </VStack>
-        </AnimatedCard>
+        </AnimatedContainerCard>
     );
 };

--- a/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupInstructionCards.tsx
+++ b/suite-native/module-device-onboarding/src/components/WalletBackupTutorial/WalletBackupInstructionCards.tsx
@@ -1,10 +1,9 @@
 import { type ReactNode } from 'react';
 import { type SharedValue, useAnimatedStyle, withDelay, withTiming } from 'react-native-reanimated';
 
-import { AnimatedCard, Text, VStack } from '@suite-native/atoms';
+import { AnimatedContainerCard, Text, VStack } from '@suite-native/atoms';
 import { Icon, type IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 type InstructionCardProps = {
     index: number;
@@ -49,19 +48,12 @@ const getCardProps = (isMultishareSelected: boolean) =>
         },
     ] as const satisfies Omit<InstructionCardProps, 'index'>[];
 
-const cardStyle = prepareNativeStyle(utils => ({
-    borderWidth: utils.borders.widths.small,
-    borderColor: utils.colors.borderOnElevation1,
-    ...utils.boxShadows.none,
-}));
-
 const WalletBackupInstructionCard = ({
     iconName,
     title,
     index,
     isStepFocused,
 }: InstructionCardProps & { isStepFocused: SharedValue<boolean> }) => {
-    const { applyStyle } = useNativeStyles();
     const animatedCardStyle = useAnimatedStyle(() => {
         const indexDelay = ANIMATION_DURATION + ANIMATION_DELAY * index;
 
@@ -97,12 +89,16 @@ const WalletBackupInstructionCard = ({
     });
 
     return (
-        <AnimatedCard style={[animatedCardStyle, applyStyle(cardStyle)]}>
+        <AnimatedContainerCard
+            animatedStyle={animatedCardStyle}
+            borderColor="borderOnElevation1"
+            noShadow
+        >
             <VStack spacing="sp8" alignItems="center">
                 <Icon name={iconName} size={28} />
                 <Text variant="body-md-strong">{title}</Text>
             </VStack>
-        </AnimatedCard>
+        </AnimatedContainerCard>
     );
 };
 

--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import { FadeIn, LinearTransition } from 'react-native-reanimated';
 
-import { AnimatedBox, AnimatedCard, Box, HStack, VStack } from '@suite-native/atoms';
+import { AnimatedBorderCard, AnimatedBox, Box, HStack, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { CardTitle, useAnimatedBorderStyle } from '@suite-native/trading-atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -53,7 +53,7 @@ export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardP
 
     return (
         <AnimatedBox entering={enteringAnimation} layout={LinearTransition}>
-            <AnimatedCard style={animatedStyle} noPadding>
+            <AnimatedBorderCard style={animatedStyle} noPadding>
                 <VStack
                     style={applyStyle(buySectionStyle, { bottomBorder: true })}
                     testID={BUY_CARD_TEST_ID + '/fiatSection'}
@@ -95,7 +95,7 @@ export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardP
                     </HStack>
                 </VStack>
                 <BuyReceiveAccountPicker />
-            </AnimatedCard>
+            </AnimatedBorderCard>
         </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendCard.tsx
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { cryptoIdToSymbol } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
-import { AnimatedCard, HStack, VStack } from '@suite-native/atoms';
+import { AnimatedBorderCard, HStack, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { CardTitle, useAnimatedBorderStyle } from '@suite-native/trading-atoms';
 import {
@@ -41,7 +41,7 @@ export const ExchangeSendCard = ({ isAmountInputActive }: ExchangeSendCardProps)
     });
 
     return (
-        <AnimatedCard style={animatedStyle} noPadding>
+        <AnimatedBorderCard style={animatedStyle} noPadding>
             <VStack paddingHorizontal="sp12" paddingVertical="sp16">
                 <HStack justifyContent="space-between" alignItems="center">
                     <CardTitle>
@@ -66,6 +66,6 @@ export const ExchangeSendCard = ({ isAmountInputActive }: ExchangeSendCardProps)
                     />
                 )}
             </VStack>
-        </AnimatedCard>
+        </AnimatedBorderCard>
     );
 };

--- a/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
+++ b/suite-native/module-trading/src/components/fees/FeePickerCard.tsx
@@ -5,7 +5,7 @@ import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 import { type TradingExchangeType, type TradingSellType } from '@suite-common/trading';
 import { type FormDraftRootState, selectDeepCopyOfFormDraft } from '@suite-common/wallet-core';
 import { type AccountKey, type FeeLevelLabel } from '@suite-common/wallet-types';
-import { AnimatedCard, Divider } from '@suite-native/atoms';
+import { AnimatedContainerCard, Divider } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
 import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
@@ -33,7 +33,7 @@ export const FeePickerCard = ({ trade, accountKey, tradingType }: FeePickerCardP
     );
 
     return (
-        <AnimatedCard noPadding>
+        <AnimatedContainerCard noPadding>
             <TradeInfoHeader
                 title={<Translation id="moduleTrading.tradingExchangePreviewScreen.details" />}
             />
@@ -47,6 +47,6 @@ export const FeePickerCard = ({ trade, accountKey, tradingType }: FeePickerCardP
                 formDraft={formDraft}
                 formDraftKey={formDraftKey}
             />
-        </AnimatedCard>
+        </AnimatedContainerCard>
     );
 };

--- a/suite-native/module-trading/src/components/sell/SellCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { cryptoIdToSymbol } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
-import { AnimatedBox, AnimatedCard, Box, HStack, VStack } from '@suite-native/atoms';
+import { AnimatedBorderCard, AnimatedBox, Box, HStack, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { CardTitle, useAnimatedBorderStyle } from '@suite-native/trading-atoms';
 import {
@@ -65,7 +65,7 @@ export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCar
 
     return (
         <AnimatedBox entering={enteringAnimation} layout={LinearTransition}>
-            <AnimatedCard style={animatedStyle} noPadding>
+            <AnimatedBorderCard style={animatedStyle} noPadding>
                 <VStack style={applyStyle(sellSectionStyle, { bottomBorder: true })}>
                     <HStack
                         justifyContent="space-between"
@@ -112,7 +112,7 @@ export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCar
                     <SellFiatCurrencyPicker />
                 </VStack>
                 <SellReceiveMethodPicker />
-            </AnimatedCard>
+            </AnimatedBorderCard>
         </AnimatedBox>
     );
 };

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import type { BankAccount } from 'invity-api';
 
 import { type TradingRootState, selectTradingTradeByOrderId } from '@suite-common/trading';
-import { AnimatedCard, useBottomSheetModal } from '@suite-native/atoms';
+import { AnimatedContainerCard, useBottomSheetModal } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { TradeInfoHeader } from '@suite-native/trading-atoms';
 
@@ -26,7 +26,7 @@ type MemoizedSellBankAccountPickerProps = {
 // memoize the component because useWatchTrade needs useTimer and it causes re-renders
 const MemoizedSellBankAccountPicker = memo(
     ({ bankAccount, onPress = () => {}, hasCaret }: MemoizedSellBankAccountPickerProps) => (
-        <AnimatedCard noPadding>
+        <AnimatedContainerCard noPadding>
             <TradeInfoHeader
                 title={<Translation id="moduleTrading.tradingSellPreviewScreen.bankAccount" />}
             />
@@ -35,7 +35,7 @@ const MemoizedSellBankAccountPicker = memo(
                 accessoryType={hasCaret ? 'caret' : 'none'}
                 onPress={onPress}
             />
-        </AnimatedCard>
+        </AnimatedContainerCard>
     ),
 );
 

--- a/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
+++ b/suite-native/swipeable-walkthrough/src/components/SwipeableWalkthroughCloseButton.tsx
@@ -18,10 +18,6 @@ export const SwipeableWalkthroughCloseButton = ({
     onPressBack,
     currentStepIndex,
 }: SwipeableWalkthroughCloseButtonProps) => {
-    const xPaddingBottom = useDerivedValue(() =>
-        withTiming(currentStepIndex.value === 0 ? 0 : 3, { duration: ANIMATION_DURATION / 2 }),
-    );
-
     const xOpacity = useDerivedValue(() =>
         withTiming(currentStepIndex.value === 0 ? 1 : 0, {
             duration: ANIMATION_DURATION / (currentStepIndex.value === 0 ? 4 : 1),
@@ -35,7 +31,6 @@ export const SwipeableWalkthroughCloseButton = ({
     const animatedXStyle = useAnimatedStyle(() => ({
         position: 'absolute',
         opacity: xOpacity.value,
-        paddingBottom: xPaddingBottom.value,
     }));
 
     const animatedCaretStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
## Description

Two animation/layout fixes in `suite-native/atoms`:

**1. AnimatedContainerCard + AnimatedBorderCard**

createAnimatedComponent(Card) targeted the inner styled View, breaking opacity/transform animations (WalletBackupInstructionCards entrance). Split into AnimatedContainerCard (Animated.View wrapper, outer target) and AnimatedBorderCard (createAnimatedComponent, inner target for borderColor/borderWidth).
- I do not like this solution but this is the best I can do before the freeze. Will be resolved properly by implementing https://github.com/trezor/trezor-suite/issues/19123

**2. Button `alignSelf` changed to `center`**

`IconButton` had `alignSelf: 'flex-start'` and `TextButton` had `alignSelf: 'flex-start'` — both changed to `center`. In row containers `flex-start` was overriding parent `alignItems: 'center'`, pinning buttons to the left screen edge instead of centering them.

## Notes for QA
Go through the device onboarding and check if the are anomalies captured in the screenshots section are gone.

## Screenshots:

| Before | After |
|---|---|
| <img width="250"  alt="IMG_9073" src="https://github.com/user-attachments/assets/d074b5ed-0f49-476a-b111-6bd654760b4d" /> | <img width="250" alt="IMG_9075" src="https://github.com/user-attachments/assets/06ce8c6f-3acd-41fb-a39e-68a67186afeb" /> |
| <img width="250"  alt="IMG_9071" src="https://github.com/user-attachments/assets/bf5a51ba-2fd5-4b5e-8b99-878aba6dc9d1" /> | <img width="250"  alt="IMG_9072" src="https://github.com/user-attachments/assets/67c30ca5-65f5-42d0-ae5a-b0d13473b851" /> |
| <video src="https://github.com/user-attachments/assets/ef84df7d-9125-467b-b63c-de7d6cc44a77"></video>  | <video src="https://github.com/user-attachments/assets/4dfac025-f0f5-41aa-b75d-f4bbf2ca469a"></video> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/onboarding-ui-fixes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->