### PR TITLE
Gate fee banner on amount field error state

### DIFF
--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
@@ -18,7 +18,7 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const { value: amountValue } = useField({ name: 'amount' });
+    const { value: amountValue, hasError } = useField({ name: 'amount' });
 
     const limits = getStakingLimitsByNetworkSymbol(symbol);
 
@@ -29,7 +29,10 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
     const maxStakeAmount = new BigNumber(formattedBalance).minus(limits.MIN_BALANCE_FOR_FEE_BUFFER);
 
     const isVisible =
-        !!amountValue && new BigNumber(amountValue).gte(maxStakeAmount) && maxStakeAmount.gt(0);
+        !hasError &&
+        !!amountValue &&
+        new BigNumber(amountValue).gte(maxStakeAmount) &&
+        maxStakeAmount.gt(0);
 
     if (!isVisible) return null;
 


### PR DESCRIPTION
## Description

Hide the Earn fee-buffer banner when the stake amount is invalid

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26586

## Screenshots:
<img width="379" height="382" alt="Screenshot 2026-04-14 at 19 42 15" src="https://github.com/user-attachments/assets/f4835f09-bf68-4a6e-8ec4-189a767f447a" />
