### PR TITLE
Add auto-restaked badge to staked card

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2455,6 +2455,7 @@ export const messages = {
             yourStake: 'Your stake',
             stakedLabel: 'Staked',
             totalRewardsLabel: 'Total rewards',
+            autoRestakedBadge: 'Auto-restaked',
             nextRewardLabel: 'Next reward in {value, plural, one {# day} other {# days}}',
             unstakeButton: 'Unstake',
             stakeButton: 'Stake',

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -3,7 +3,7 @@ import { useNavigation } from '@react-navigation/native';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectEthNextRewardPayout } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { Button, Card, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
+import { Badge, Button, Card, HStack, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
 import {
@@ -96,9 +96,16 @@ export const StakingManagementStakedCard = ({
                 />
             </VStack>
             <VStack spacing="sp4" style={applyStyle(stakedSectionStyle)}>
-                <Text variant="body-md" color="textSubdued">
-                    <Translation id="earn.stakingManagementScreen.totalRewardsLabel" />
-                </Text>
+                <HStack alignItems="center" spacing="sp4">
+                    <Text variant="body-md" color="textSubdued">
+                        <Translation id="earn.stakingManagementScreen.totalRewardsLabel" />
+                    </Text>
+                    <Badge
+                        label={<Translation id="earn.stakingManagementScreen.autoRestakedBadge" />}
+                        variant="greenSubtle"
+                        size="small"
+                    />
+                </HStack>
                 <CryptoAmountFormatter
                     value={rewardsBalance}
                     symbol={networkSymbol}


### PR DESCRIPTION
## Description

Added an “Auto-restaked” badge to the native staking management staked card.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26609

## Screenshots:
<img width="381" height="398" alt="image" src="https://github.com/user-attachments/assets/b5fa09c4-41e9-4bec-82ee-afece6bed0f4" />

