### PR TITLE
fix(suite-native): staking navigation fix

### DIFF
--- a/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
+++ b/suite-native/module-earn/src/hooks/useEarnReviewBackNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -6,14 +6,13 @@ import { useNavigation } from '@react-navigation/native';
 import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { getFormDraftKey } from '@suite-common/wallet-utils';
-import { useOverrideBackNavigation } from '@suite-native/navigation';
 import {
     type TransactionReviewOutputsState,
     selectIsTransactionReviewInProgress,
     useShowReviewCancellationAlert,
 } from '@suite-native/transaction-management';
 
-type EarnReviewFormType = 'stake' | 'claim';
+type EarnReviewFormType = 'stake' | 'unstake' | 'claim';
 
 export const useEarnReviewBackNavigation = (
     formType: EarnReviewFormType,
@@ -27,21 +26,27 @@ export const useEarnReviewBackNavigation = (
     const navigation = useNavigation();
     const showReviewCancellationAlert = useShowReviewCancellationAlert();
 
-    const onNavigateBack = useCallback(async () => {
-        if (isTransactionReviewInProgress) {
-            const { wasReviewCanceled } = await showReviewCancellationAlert();
-            if (!wasReviewCanceled) return;
-        }
-        dispatch(sendFormActions.discardTransaction());
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey(formType, '') }));
-        navigation.goBack();
+    useEffect(() => {
+        const unsubscribe = navigation.addListener('beforeRemove', e => {
+            if (e.data.action.type === 'GO_BACK' && isTransactionReviewInProgress) {
+                e.preventDefault();
+                showReviewCancellationAlert().then(({ wasReviewCanceled }) => {
+                    if (wasReviewCanceled) navigation.dispatch(e.data.action);
+                });
+
+                return;
+            }
+
+            dispatch(sendFormActions.discardTransaction());
+            dispatch(formDraftActions.removeDraft({ key: getFormDraftKey(formType, '') }));
+        });
+
+        return unsubscribe;
     }, [
+        navigation,
         isTransactionReviewInProgress,
         showReviewCancellationAlert,
         dispatch,
-        navigation,
         formType,
     ]);
-
-    useOverrideBackNavigation({ onNavigateBack });
 };

--- a/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnClaimTransactionReview.ts
@@ -1,25 +1,19 @@
-import { useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
-import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import { signEthClaimTransactionNativeThunk } from '@suite-native/staking';
-import {
-    type TransactionReviewOutputsState,
-    selectIsTransactionReviewInProgress,
-    useShowReviewCancellationAlert,
-} from '@suite-native/transaction-management';
 
 import { handleEarnReviewError } from '../utils';
+import { useEarnReviewBackNavigation } from './useEarnReviewBackNavigation';
 import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
 import { useShowPushTransactionFailedDuringReviewAlert } from './useShowPushTransactionFailedDuringReviewAlert';
 
@@ -37,32 +31,13 @@ export const useHandleOnClaimTransactionReview = ({
     accountKey,
     onTransactionSubmitted,
 }: HandleOnClaimTransactionReviewProps) => {
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'claim', accountKey),
-    );
+    useEarnReviewBackNavigation('claim', accountKey);
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const showReviewCancellationAlert = useShowReviewCancellationAlert();
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
         useShowPushTransactionFailedDuringReviewAlert('claim');
-
-    useEffect(() => {
-        const unsubscribe = navigation.addListener('beforeRemove', e => {
-            if (e.data.action.type === 'GO_BACK' && isTransactionReviewInProgress) {
-                e.preventDefault();
-                showReviewCancellationAlert();
-
-                return;
-            }
-
-            dispatch(sendFormActions.discardTransaction());
-            dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('claim', '') }));
-        });
-
-        return unsubscribe;
-    }, [navigation, isTransactionReviewInProgress, showReviewCancellationAlert, dispatch]);
 
     const handleOnClaimTransactionReview = useCallback(async () => {
         const response = await dispatch(signEthClaimTransactionNativeThunk({ accountKey }));

--- a/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
+++ b/suite-native/module-earn/src/hooks/useHandleOnUnstakeTransactionReview.ts
@@ -1,25 +1,18 @@
 import { useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
-import { formDraftActions, sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getFormDraftKey } from '@suite-common/wallet-utils';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     type StackNavigationProps,
-    useOverrideBackNavigation,
 } from '@suite-native/navigation';
 import { signEthUnstakeTransactionNativeThunk } from '@suite-native/staking';
-import {
-    type TransactionReviewOutputsState,
-    selectIsTransactionReviewInProgress,
-    useShowReviewCancellationAlert,
-} from '@suite-native/transaction-management';
 
+import { useEarnReviewBackNavigation } from './useEarnReviewBackNavigation';
 import { useShowDeviceDisconnectedDuringEarnReviewAlert } from './useShowDeviceDisconnectedDuringEarnReviewAlert';
 import { useShowPushTransactionFailedDuringUnstakeReviewAlert } from './useShowPushTransactionFailedDuringUnstakeReviewAlert';
 
@@ -45,28 +38,13 @@ export const useHandleOnUnstakeTransactionReview = ({
     amount,
     onTransactionSubmitted,
 }: HandleOnUnstakeTransactionReviewProps) => {
-    const isTransactionReviewInProgress = useSelector((state: TransactionReviewOutputsState) =>
-        selectIsTransactionReviewInProgress(state, 'unstake', accountKey),
-    );
+    useEarnReviewBackNavigation('unstake', accountKey);
 
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
-    const showReviewCancellationAlert = useShowReviewCancellationAlert();
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const { showPushTransactionFailedAlert, showPendingTransactionConflictAlert } =
         useShowPushTransactionFailedDuringUnstakeReviewAlert();
-
-    const onNavigateBack = useCallback(async () => {
-        if (isTransactionReviewInProgress) {
-            const { wasReviewCanceled } = await showReviewCancellationAlert();
-            if (!wasReviewCanceled) return;
-        }
-        dispatch(sendFormActions.discardTransaction());
-        dispatch(formDraftActions.removeDraft({ key: getFormDraftKey('unstake', '') }));
-        navigation.goBack();
-    }, [isTransactionReviewInProgress, showReviewCancellationAlert, dispatch, navigation]);
-
-    useOverrideBackNavigation({ onNavigateBack });
 
     const handleOnUnstakeTransactionReview = useCallback(async () => {
         const response = await dispatch(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fixing the issue when the user tries to complete the unstake flow for the second time 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26575

## Screenshots:


https://github.com/user-attachments/assets/9eb85fd0-c276-473b-9684-1c9f0f26002e


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/stake-fix-cancel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->