### PR TITLE
Suite: created NFC package

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5614,6 +5614,69 @@ export const messages = defineMessages({
         defaultMessage:
             'The last wallet backup attempt on this device failed. You can only back up your wallet once.',
     },
+    TR_NFC_BACKUP_HEADING: {
+        id: 'TR_NFC_BACKUP_HEADING',
+        defaultMessage: 'NFC backup',
+    },
+    TR_NFC_BACKUP_RESILIENCE: {
+        id: 'TR_NFC_BACKUP_RESILIENCE',
+        defaultMessage: 'You can recover your wallet even if one backup tag is lost or damaged.',
+    },
+    TR_NFC_BACKUP_THRESHOLD_DESCRIPTION: {
+        id: 'TR_NFC_BACKUP_THRESHOLD_DESCRIPTION',
+        defaultMessage:
+            "Any 2 of the 3 backup tags can recover your wallet. It doesn't matter which tags you use.",
+    },
+    TR_NFC_BACKUP_CONTINUE_WITH_NFC: {
+        id: 'TR_NFC_BACKUP_CONTINUE_WITH_NFC',
+        defaultMessage: 'Continue with NFC backup',
+    },
+    TR_NFC_BACKUP_CHOOSE_DIFFERENT_TYPE: {
+        id: 'TR_NFC_BACKUP_CHOOSE_DIFFERENT_TYPE',
+        defaultMessage: 'Choose different backup type',
+    },
+    TR_NFC_BACKUP_THREE_TAGS: {
+        id: 'TR_NFC_BACKUP_THREE_TAGS',
+        defaultMessage: 'Your wallet backup consists of 3 Trezor wallet backup tags.',
+    },
+    TR_NFC_BACKUP_THREE_TAGS_DESCRIPTION: {
+        id: 'TR_NFC_BACKUP_THREE_TAGS_DESCRIPTION',
+        defaultMessage: 'Each tag stores 1 of the 3 unique shares of your wallet backup.',
+    },
+    TR_NFC_BACKUP_NO_TAGS_HEADING: {
+        id: 'TR_NFC_BACKUP_NO_TAGS_HEADING',
+        defaultMessage: "Don't have NFC tags?",
+    },
+    TR_NFC_BACKUP_NO_TAGS_DESCRIPTION: {
+        id: 'TR_NFC_BACKUP_NO_TAGS_DESCRIPTION',
+        defaultMessage: 'You can finish setup now and create your wallet backup later.',
+    },
+    TR_NFC_BACKUP_FINISH_AND_ORDER_HEADING: {
+        id: 'TR_NFC_BACKUP_FINISH_AND_ORDER_HEADING',
+        defaultMessage: 'Finish setup and order NFC tags',
+    },
+    TR_NFC_BACKUP_FINISH_AND_ORDER_DESCRIPTION: {
+        id: 'TR_NFC_BACKUP_FINISH_AND_ORDER_DESCRIPTION',
+        defaultMessage:
+            'Finish setting up your device. Then you will be redirected to the Trezor Store to order NFC tags. Create your wallet backup once they arrive.',
+    },
+    TR_NFC_BACKUP_ALTERNATIVE_BADGE: {
+        id: 'TR_NFC_BACKUP_ALTERNATIVE_BADGE',
+        defaultMessage: 'Alternative',
+    },
+    TR_NFC_BACKUP_WORDLIST_HEADING: {
+        id: 'TR_NFC_BACKUP_WORDLIST_HEADING',
+        defaultMessage: 'Create wordlist backup',
+    },
+    TR_NFC_BACKUP_WORDLIST_DESCRIPTION: {
+        id: 'TR_NFC_BACKUP_WORDLIST_DESCRIPTION',
+        defaultMessage:
+            'Write down one or more 20-word wordlists (shares) on paper or metal. You can upgrade to NFC backup later.',
+    },
+    TR_NFC_BACKUP_WORDLIST_CTA: {
+        id: 'TR_NFC_BACKUP_WORDLIST_CTA',
+        defaultMessage: 'Create wordlist backup',
+    },
     DISCONNECT_DEVICE_DESCRIPTION: {
         id: 'DISCONNECT_DEVICE_DESCRIPTION',
         defaultMessage: 'Your Trezor was wiped and no longer holds any private keys.',

--- a/suite/nfc/jest.config.js
+++ b/suite/nfc/jest.config.js
@@ -1,0 +1,11 @@
+/**
+ * Jest configuration for web packages.
+ * Keeping this file next to the package.json file instead of providing configuration
+ * with `-c ../../jest.config.base` option in package.json scripts
+ * allows us to run jest tests directly from IDEs.
+ */
+const baseConfig = require('../../jest.config.base');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite/nfc/package.json
+++ b/suite/nfc/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@suite/nfc",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite/intl": "workspace:*",
+        "@suite/onboarding-components": "workspace:*",
+        "@trezor/components": "workspace:*",
+        "react": "19.2.4",
+        "styled-components": "^6.3.9"
+    }
+}

--- a/suite/nfc/src/BackupAlternativeCard.tsx
+++ b/suite/nfc/src/BackupAlternativeCard.tsx
@@ -1,0 +1,49 @@
+import { type ComponentProps, type ReactNode } from 'react';
+
+import {
+    Badge,
+    type BadgeIntent,
+    Button,
+    type ButtonIntent,
+    Card,
+    Column,
+    H3,
+    Text,
+} from '@trezor/components';
+
+interface BackupAlternativeCardProps {
+    badge: ReactNode;
+    badgeIntent?: BadgeIntent;
+    heading: ReactNode;
+    description: ReactNode;
+    buttonLabel: ReactNode;
+    buttonIntent?: ButtonIntent;
+    buttonPriority?: ComponentProps<typeof Button>['priority'];
+    onClick?: () => void;
+}
+
+export const BackupAlternativeCard = ({
+    badge,
+    badgeIntent = 'neutral',
+    heading,
+    description,
+    buttonLabel,
+    buttonIntent = 'brand',
+    buttonPriority = 'primary',
+    onClick,
+}: BackupAlternativeCardProps) => (
+    <Card paddingType="large" fillType="flat">
+        <Column gap={32} alignItems="center">
+            <Badge intent={badgeIntent}>{badge}</Badge>
+            <Column gap={16} alignItems="center">
+                <H3>{heading}</H3>
+                <Text typographyStyle="body-md" align="center">
+                    {description}
+                </Text>
+            </Column>
+            <Button intent={buttonIntent} priority={buttonPriority} onClick={onClick}>
+                {buttonLabel}
+            </Button>
+        </Column>
+    </Card>
+);

--- a/suite/nfc/src/CreateNfcBackup.tsx
+++ b/suite/nfc/src/CreateNfcBackup.tsx
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { OnboardingCard } from '@suite/onboarding-components';
+import { Card, Column, Text } from '@trezor/components';
+
+import { NfcTag } from './NfcTag';
+
+const TagRow = styled.div`
+    display: flex;
+    gap: 8px;
+    filter: drop-shadow(0px 8px 16px rgba(0, 0, 0, 0.16));
+`;
+interface CreateNfcBackupProps {
+    onBack: () => void;
+    onCreateBackup: () => void;
+}
+
+export const CreateNfcBackup = ({ onBack, onCreateBackup }: CreateNfcBackupProps) => (
+    <OnboardingCard
+        iconName="trezorBackup"
+        heading={<Translation id="TR_NFC_BACKUP_HEADING" />}
+        innerActions={
+            <OnboardingCard.Button onClick={onCreateBackup}>
+                <Translation id="TR_CREATE_BACKUP" />
+            </OnboardingCard.Button>
+        }
+        outerActions={
+            <OnboardingCard.SecondaryButton iconLeft="caretLeft" onClick={onBack}>
+                <Translation id="TR_BACK" />
+            </OnboardingCard.SecondaryButton>
+        }
+    >
+        <Column alignItems="center">
+            <Card paddingType="large" fillType="flat" maxWidth={530}>
+                <Column gap={32} alignItems="center">
+                    <Text typographyStyle="headline-sm" align="center">
+                        <Translation id="TR_NFC_BACKUP_RESILIENCE" />
+                    </Text>
+                    <TagRow>
+                        <NfcTag active />
+                        <NfcTag active />
+                        <NfcTag />
+                    </TagRow>
+                    <Text
+                        typographyStyle="body-sm"
+                        intent="neutral"
+                        priority="secondary"
+                        align="center"
+                    >
+                        <Translation id="TR_NFC_BACKUP_THRESHOLD_DESCRIPTION" />
+                    </Text>
+                </Column>
+            </Card>
+        </Column>
+    </OnboardingCard>
+);

--- a/suite/nfc/src/NfcTag.tsx
+++ b/suite/nfc/src/NfcTag.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const Circle = styled.div<{ $isActive: boolean }>`
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    border: 2px solid black;
+    background: ${({ $isActive }) => ($isActive ? 'blue' : 'red')};
+`;
+
+interface NfcTagProps {
+    active?: boolean;
+}
+
+export const NfcTag = ({ active = false }: NfcTagProps) => <Circle $isActive={active} />;

--- a/suite/nfc/src/NoNfcTags.tsx
+++ b/suite/nfc/src/NoNfcTags.tsx
@@ -1,0 +1,50 @@
+import { Translation } from '@suite/intl';
+import { OnboardingCard } from '@suite/onboarding-components';
+import { Row } from '@trezor/components';
+
+import { BackupAlternativeCard } from './BackupAlternativeCard';
+
+interface NoNfcTagsProps {
+    onFinishSetup: () => void;
+    onCreateWordlistBackup: () => void;
+    onBack: () => void;
+}
+
+export const NoNfcTags = ({ onFinishSetup, onCreateWordlistBackup, onBack }: NoNfcTagsProps) => (
+    <OnboardingCard
+        iconName="trezorBackup"
+        heading={<Translation id="TR_NFC_BACKUP_NO_TAGS_HEADING" />}
+        description={<Translation id="TR_NFC_BACKUP_NO_TAGS_DESCRIPTION" />}
+        outerActions={
+            <OnboardingCard.Button
+                size="small"
+                intent="neutral"
+                priority="secondary"
+                iconLeft="arrowLeft"
+                onClick={onBack}
+            >
+                <Translation id="TR_BACK" />
+            </OnboardingCard.Button>
+        }
+    >
+        <Row gap={16}>
+            <BackupAlternativeCard
+                badge={<Translation id="TR_RECOMMENDED" />}
+                badgeIntent="info"
+                heading={<Translation id="TR_NFC_BACKUP_FINISH_AND_ORDER_HEADING" />}
+                description={<Translation id="TR_NFC_BACKUP_FINISH_AND_ORDER_DESCRIPTION" />}
+                buttonLabel={<Translation id="TR_CONTINUE_SETUP" />}
+                onClick={onFinishSetup}
+            />
+            <BackupAlternativeCard
+                badge={<Translation id="TR_NFC_BACKUP_ALTERNATIVE_BADGE" />}
+                heading={<Translation id="TR_NFC_BACKUP_WORDLIST_HEADING" />}
+                description={<Translation id="TR_NFC_BACKUP_WORDLIST_DESCRIPTION" />}
+                buttonLabel={<Translation id="TR_NFC_BACKUP_WORDLIST_CTA" />}
+                buttonIntent="neutral"
+                buttonPriority="secondary"
+                onClick={onCreateWordlistBackup}
+            />
+        </Row>
+    </OnboardingCard>
+);

--- a/suite/nfc/src/SelectBackupType.tsx
+++ b/suite/nfc/src/SelectBackupType.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+import { Translation } from '@suite/intl';
+import { OnboardingCard } from '@suite/onboarding-components';
+import { Column, Row, Text } from '@trezor/components';
+
+import { NfcTag } from './NfcTag';
+
+type SelectBackupTypeProps = {
+    onBack: () => void;
+    onContinueWithNfc: () => void;
+    onContinueWithoutNfc: () => void;
+};
+
+const TagRow = styled.div`
+    display: flex;
+
+    & > *:not(:first-child) {
+        margin-left: -24px;
+    }
+`;
+
+export const SelectBackupType = ({
+    onBack,
+    onContinueWithNfc,
+    onContinueWithoutNfc,
+}: SelectBackupTypeProps) => (
+    <OnboardingCard
+        iconName="trezorBackup"
+        heading={<Translation id="TR_WALLET_BACKUP_TYPE" />}
+        innerActions={
+            <Row gap={12}>
+                <OnboardingCard.Button onClick={onContinueWithNfc}>
+                    <Translation id="TR_NFC_BACKUP_CONTINUE_WITH_NFC" />
+                </OnboardingCard.Button>
+                <OnboardingCard.Button
+                    intent="neutral"
+                    priority="secondary"
+                    onClick={onContinueWithoutNfc}
+                >
+                    <Translation id="TR_NFC_BACKUP_CHOOSE_DIFFERENT_TYPE" />
+                </OnboardingCard.Button>
+            </Row>
+        }
+        outerActions={
+            <OnboardingCard.SecondaryButton iconLeft="caretLeft" onClick={onBack}>
+                <Translation id="TR_BACK" />
+            </OnboardingCard.SecondaryButton>
+        }
+    >
+        <Column>
+            <Column gap={32} alignItems="center">
+                <TagRow>
+                    <NfcTag />
+                    <NfcTag />
+                    <NfcTag />
+                </TagRow>
+
+                <Column alignItems="center">
+                    <Text intent="neutral">
+                        <Translation id="TR_NFC_BACKUP_THREE_TAGS" />
+                    </Text>
+                    <Text intent="neutral" priority="secondary">
+                        <Translation id="TR_NFC_BACKUP_THREE_TAGS_DESCRIPTION" />
+                    </Text>
+                </Column>
+            </Column>
+        </Column>
+    </OnboardingCard>
+);

--- a/suite/nfc/src/index.ts
+++ b/suite/nfc/src/index.ts
@@ -1,0 +1,5 @@
+export { BackupAlternativeCard } from './BackupAlternativeCard';
+export { CreateNfcBackup } from './CreateNfcBackup';
+export { NfcTag } from './NfcTag';
+export { NoNfcTags } from './NoNfcTags';
+export { SelectBackupType } from './SelectBackupType';

--- a/suite/nfc/tsconfig.json
+++ b/suite/nfc/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../intl" },
+        { "path": "../onboarding-components" },
+        { "path": "../../packages/components" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14523,6 +14523,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/nfc@workspace:suite/nfc":
+  version: 0.0.0-use.local
+  resolution: "@suite/nfc@workspace:suite/nfc"
+  dependencies:
+    "@suite/intl": "workspace:*"
+    "@suite/onboarding-components": "workspace:*"
+    "@trezor/components": "workspace:*"
+    react: "npm:19.2.4"
+    styled-components: "npm:^6.3.9"
+  languageName: unknown
+  linkType: soft
+
 "@suite/onboarding-components@workspace:*, @suite/onboarding-components@workspace:suite/onboarding-components":
   version: 0.0.0-use.local
   resolution: "@suite/onboarding-components@workspace:suite/onboarding-components"


### PR DESCRIPTION
I have added a NFC package, that currently includes a UI for backup flow. These are plain components not used anywhere yet, it's atomic PR created from https://github.com/trezor/trezor-suite/pull/25901

The flow will be in the follow up PR since the onboarding was made the same way as on mobile.

**changes**:
- added NFC package
- added translations

## Notes for QA

Can't be tested, this just adds a new package that is not consumed yet.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/nfc-suite-package&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/nfc-suite-package&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-14T23:21:06.223Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-14T23:20:01.912Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->