### PR TITLE
feat(suite-native): Mobile Trade: connect Revoke flow to Exchange form

### DIFF
--- a/suite-native/analytics/src/definitions.ts
+++ b/suite-native/analytics/src/definitions.ts
@@ -36,7 +36,7 @@ export type TradingNavigateFrom =
     | 'trade/buy'
     | 'trade/sell'
     | 'trade/exchange';
-export type TradingExchangeAction = 'continue' | 'cancel' | 'retry' | 'visit';
+export type TradingExchangeAction = 'continue' | 'cancel' | 'retry' | 'visit' | 'revoke';
 export type TradingExchangeStep =
     | 'exchange-form'
     | 'account-selection'

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -26,13 +26,14 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
     const receiveAsset = form.watch('receiveAsset');
     const receiveCryptoId = receiveAsset?.cryptoId;
 
-    const { canProceed, selectQuote } = useExchangeSelectQuote(form);
+    const { canProceed, selectQuote, selectQuoteForRevoke } = useExchangeSelectQuote(form);
 
     const quote = form.watch('quote');
     const approvalStatus = getApprovalStatus(quote);
-    const canRevoke = (['approved', 'needs_increase', 'needs_revoke'] as ApprovalStatus[]).includes(
-        approvalStatus,
-    );
+    const canRevoke =
+        (['approved', 'needs_increase', 'needs_revoke'] as ApprovalStatus[]).includes(
+            approvalStatus,
+        ) && canProceed;
 
     const { isReceivingInactiveStellarToken, activateButtonElement } =
         useTradingStellarActivateToken({
@@ -57,7 +58,7 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
                     {canRevoke && (
                         <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
                             <Button
-                                onPress={() => {}}
+                                onPress={selectQuoteForRevoke}
                                 testID={REVOKE_TEST_ID}
                                 intent="neutral"
                                 priority="secondary"

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -29,6 +29,16 @@ describe('ExchangeConfirmation', () => {
     const mockUseTradingStellarActivateToken =
         require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
+    const mockSelectQuote = (canProceed = true) =>
+        mockUseExchangeSelectQuote.mockReturnValue({
+            canProceed,
+            selectQuote: jest.fn(),
+            selecteQuoteForRevoke: jest.fn(),
+            isConsentRequested: false,
+            giveConsent: jest.fn(),
+            cancelConsent: jest.fn(),
+        });
+
     const renderConfirmation = () =>
         renderWithStoreProvider(<ExchangeConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
@@ -55,13 +65,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render "Continue" button when canProceed is true', () => {
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -70,13 +74,7 @@ describe('ExchangeConfirmation', () => {
 
     it('should not render "Continue" button when canProceed is false', () => {
         mockQuote.isDex = false;
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: false,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote(false);
 
         renderConfirmation();
 
@@ -84,13 +82,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render "Revoke" button when approval is not needed', () => {
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -99,13 +91,7 @@ describe('ExchangeConfirmation', () => {
 
     it('should not render "Revoke" button when approval is needed', () => {
         mockQuote.isDex = true;
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -115,13 +101,7 @@ describe('ExchangeConfirmation', () => {
     it('should render "Revoke" button when approval status is approved', () => {
         mockQuote.isDex = true;
         mockQuote.preapprovedStringAmount = '100';
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -133,13 +113,7 @@ describe('ExchangeConfirmation', () => {
         mockQuote.preapprovedStringAmount = '100';
         mockQuote.status = 'APPROVAL_REQ';
 
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -149,13 +123,7 @@ describe('ExchangeConfirmation', () => {
     it('should not render "Revoke" button when approval status is null', () => {
         mockQuote.isDex = false;
 
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -168,13 +136,7 @@ describe('ExchangeConfirmation', () => {
         mockQuote.status = 'APPROVAL_REQ';
         mockQuote.send = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
 
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         renderConfirmation();
 
@@ -182,13 +144,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should render activate button when trading inactive Stellar token', () => {
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: true,
@@ -201,13 +157,7 @@ describe('ExchangeConfirmation', () => {
     });
 
     it('should not render activate button when not trading inactive Stellar token', () => {
-        mockUseExchangeSelectQuote.mockReturnValue({
-            canProceed: true,
-            selectQuote: jest.fn(),
-            isConsentRequested: false,
-            giveConsent: jest.fn(),
-            cancelConsent: jest.fn(),
-        });
+        mockSelectQuote();
 
         mockUseTradingStellarActivateToken.mockReturnValue({
             isReceivingInactiveStellarToken: false,
@@ -217,5 +167,18 @@ describe('ExchangeConfirmation', () => {
         const { queryByText } = renderConfirmation();
         expect(queryByText('Activate')).toBeNull();
         expect(queryByText('Continue')).toBeTruthy();
+    });
+
+    it('should not render Revoke button, when canProceed is false', () => {
+        mockQuote.isDex = true;
+        mockQuote.preapprovedStringAmount = '100';
+        mockQuote.status = 'APPROVAL_REQ';
+        mockQuote.send = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
+
+        mockSelectQuote(false);
+
+        renderConfirmation();
+
+        expect(queryRevokeButton()).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -134,16 +134,40 @@ describe('useExchangeSelectQuote', () => {
             const { result } = renderUseExchangeSelectQuote();
             expect(result.current.canProceed).toBe(false);
         });
+
+        it('selectQuote should not dispatch selectQuoteThunk when isLoading', () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = renderUseExchangeSelectQuote();
+
+            dispatchSpy.mockClear();
+            act(() => {
+                result.current.selectQuote();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalled();
+        });
+
+        it('selectQuoteForRevoke should not dispatch selectQuoteThunk when isLoading', () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = renderUseExchangeSelectQuote();
+
+            dispatchSpy.mockClear();
+            act(() => {
+                result.current.selectQuoteForRevoke();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalled();
+        });
     });
 
     describe('while prefetching dex quote approval info', () => {
-        beforeEach(async () => {
-            store = await getInitializedStore({
+        beforeEach(() => {
+            store = getInitializedStore({
                 isLoading: false,
                 dexQuoteApprovalPrefetchLoadingQuoteId: invityDexQuote.quoteId!,
             });
 
-            const { result } = await renderExchangeForm();
+            const { result } = renderExchangeForm();
             exchangeForm = result.current;
 
             act(() => {
@@ -152,16 +176,16 @@ describe('useExchangeSelectQuote', () => {
         });
 
         it('should canProceed be false while prefetch is loading for approval-required quote', async () => {
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(false);
         });
 
-        it('should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', async () => {
+        it('should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', () => {
             const dispatchSpy = jest.spyOn(store, 'dispatch');
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             dispatchSpy.mockClear();
             act(() => {
@@ -176,7 +200,7 @@ describe('useExchangeSelectQuote', () => {
                 exchangeForm.setValue('quote', mercuryoFixedBestQuote);
             });
 
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
@@ -191,11 +215,23 @@ describe('useExchangeSelectQuote', () => {
                 });
             });
 
-            const { result } = await renderUseExchangeSelectQuote();
+            const { result } = renderUseExchangeSelectQuote();
 
             await act(() => Promise.resolve());
 
             expect(result.current.canProceed).toBe(true);
+        });
+
+        it('selectQuoteForRevoke should not dispatch selectQuoteThunk while prefetch is loading for approval-required quote', () => {
+            const dispatchSpy = jest.spyOn(store, 'dispatch');
+            const { result } = renderUseExchangeSelectQuote();
+
+            dispatchSpy.mockClear();
+            act(() => {
+                result.current.selectQuoteForRevoke();
+            });
+
+            expect(dispatchSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -320,6 +356,67 @@ describe('useExchangeSelectQuote', () => {
             });
 
             expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangePreview', {});
+        });
+
+        describe('selectQuoteForRevoke', () => {
+            it('should call selectQuoteThunk when selectQuoteForRevoke is called', () => {
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+
+                const { result } = renderUseExchangeSelectQuote();
+
+                act(() => {
+                    result.current.selectQuoteForRevoke();
+                });
+
+                expect(dispatchSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        type: 'selectQuoteThunkMock',
+                        payload: expect.objectContaining({
+                            quote: expect.objectContaining({
+                                quoteId: mercuryoFixedBestQuote.quoteId,
+                            }),
+                            timer: expect.objectContaining({ timeSpent: { seconds: 0 } }),
+                        }),
+                    }),
+                );
+            });
+
+            it('should not call selectQuoteThunk when account is not fully selected', () => {
+                act(() => {
+                    [
+                        tradingExchangeActions.setReceiveAccountKey(
+                            'btc-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        ),
+                        tradingExchangeActions.setTradingAccountKey(
+                            'eth-account-key' as AccountKey, // Todo: create properly via `createAccountKey()`
+                        ),
+                    ].forEach(store.dispatch);
+                    exchangeForm.setValue('receiveAsset', btcAsset);
+                });
+
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const { result, reportMock } = renderUseExchangeSelectQuote();
+
+                dispatchSpy.mockClear();
+                act(() => {
+                    result.current.selectQuoteForRevoke();
+                });
+
+                expect(dispatchSpy).not.toHaveBeenCalled();
+                expect(mockNavigation.navigate).toHaveBeenCalledWith('ReceiveAccounts', {
+                    symbol: 'btc',
+                    tradingType: 'exchange',
+                });
+
+                expect(reportMock).toHaveBeenCalledWith({
+                    type: events.tradingExchangeEvent.name,
+                    payload: expect.objectContaining({
+                        step: 'account-selection',
+                        action: 'revoke',
+                        exchangeName: 'mercuryo',
+                    }),
+                });
+            });
         });
     });
 
@@ -472,5 +569,67 @@ describe('useExchangeSelectQuote', () => {
                 shouldIncreaseLimit: true,
             });
         });
+
+        it.each(['needs_increase', 'needs_revoke', 'approved'])(
+            'selectQuoteForRevoke should navigate to TradingExchangeRevoke with shouldIncreaseLimit: false when approval status is [%s]',
+            approvalStatus => {
+                mockGetApprovalStatus.mockReturnValue(approvalStatus);
+
+                act(() => {
+                    exchangeForm.setValue('quote', mercuryoFixedBestQuote);
+                });
+
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const { result } = renderUseExchangeSelectQuote();
+                dispatchSpy.mockClear();
+
+                act(() => {
+                    result.current.selectQuoteForRevoke();
+                });
+
+                const dispatchCall = dispatchSpy.mock.calls[0][0];
+                const { nextStep } = (dispatchCall as any).payload;
+
+                act(() => {
+                    nextStep();
+                });
+
+                expect(mockNavigation.navigate).toHaveBeenCalledWith('TradingExchangeRevoke', {
+                    shouldIncreaseLimit: false,
+                });
+                expect(dispatchSpy).toHaveBeenCalledWith({
+                    type: '@trading-exchange/savePreselectedQuote',
+                    payload: mercuryoFixedBestQuote,
+                });
+            },
+        );
+
+        it.each(['not_needed', 'needs_approval'])(
+            'selectQuoteForRevoke should not navigate when approval status is [%s]',
+            approvalStatus => {
+                mockGetApprovalStatus.mockReturnValue(approvalStatus);
+
+                act(() => {
+                    exchangeForm.setValue('quote', mercuryoFixedBestQuote);
+                });
+
+                const dispatchSpy = jest.spyOn(store, 'dispatch');
+                const { result } = renderUseExchangeSelectQuote();
+                dispatchSpy.mockClear();
+
+                act(() => {
+                    result.current.selectQuoteForRevoke();
+                });
+
+                const dispatchCall = dispatchSpy.mock.calls[0][0];
+                const { nextStep } = (dispatchCall as any).payload;
+
+                act(() => {
+                    nextStep();
+                });
+
+                expect(mockNavigation.navigate).not.toHaveBeenCalled();
+            },
+        );
     });
 });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeSelectQuote.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 
 import {
+    type ApprovalStatus,
     type TradingRootState,
     exchangeThunks,
     getApprovalStatus,
@@ -75,14 +76,17 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
         }
     };
 
-    const selectQuote = async () => {
+    const dispatchSelectQuote = async (
+        analyticsAction: 'continue' | 'revoke',
+        nextStep: (approvalStatus: ApprovalStatus) => void,
+    ) => {
         if (!candidateQuote || isLoading || isCandidateQuotePrefetchBlocked) {
             return;
         }
 
         if (!isFullySelectedReceiveAccount(receiveAccount)) {
             selectReceiveAccount();
-            analyticsReportCallback('account-selection', 'continue');
+            analyticsReportCallback('account-selection', analyticsAction);
 
             return;
         }
@@ -93,42 +97,64 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
                 timer,
                 nextStep: () => {
                     clearExchangeFormQuoteData(form);
-
-                    const approvalStatus = getApprovalStatus(candidateQuote);
-                    if (approvalStatus === 'approved' || approvalStatus === 'not_needed') {
-                        return navigation.navigate(TradingStackRoutes.TradingExchangePreview, {});
-                    }
-
-                    dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
-
-                    switch (approvalStatus) {
-                        case 'needs_increase':
-                            return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
-                                shouldIncreaseLimit: true,
-                            });
-
-                        case 'needs_revoke':
-                            return navigation.navigate(TradingStackRoutes.TradingExchangeRevoke, {
-                                shouldIncreaseLimit: true,
-                            });
-
-                        case 'needs_approval':
-                            return navigation.navigate(
-                                TradingStackRoutes.TradingExchangeApproval,
-                                {},
-                            );
-
-                        case null:
-                            // do nothing (should not happen when quote is defined)
-                            return;
-
-                        default:
-                            return exhaustive(approvalStatus);
-                    }
+                    nextStep(getApprovalStatus(candidateQuote));
                 },
             }),
         );
     };
+
+    const selectQuote = () =>
+        dispatchSelectQuote('continue', approvalStatus => {
+            if (approvalStatus === 'approved' || approvalStatus === 'not_needed') {
+                return navigation.navigate(TradingStackRoutes.TradingExchangePreview, {});
+            }
+
+            dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
+
+            switch (approvalStatus) {
+                case 'needs_increase':
+                    return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {
+                        shouldIncreaseLimit: true,
+                    });
+
+                case 'needs_revoke':
+                    return navigation.navigate(TradingStackRoutes.TradingExchangeRevoke, {
+                        shouldIncreaseLimit: true,
+                    });
+
+                case 'needs_approval':
+                    return navigation.navigate(TradingStackRoutes.TradingExchangeApproval, {});
+
+                case null:
+                    // do nothing (should not happen when quote is defined)
+                    return;
+
+                default:
+                    return exhaustive(approvalStatus);
+            }
+        });
+
+    const selectQuoteForRevoke = () =>
+        dispatchSelectQuote('revoke', approvalStatus => {
+            switch (approvalStatus) {
+                case 'not_needed':
+                case 'needs_approval':
+                case null:
+                    return;
+
+                case 'needs_increase':
+                case 'needs_revoke':
+                case 'approved':
+                    dispatch(tradingExchangeActions.savePreselectedQuote(candidateQuote));
+
+                    return navigation.navigate(TradingStackRoutes.TradingExchangeRevoke, {
+                        shouldIncreaseLimit: false,
+                    });
+
+                default:
+                    return exhaustive(approvalStatus);
+            }
+        });
 
     return {
         canProceed,
@@ -138,5 +164,6 @@ export const useExchangeSelectQuote = (form: ExchangeFormType) => {
         isLoading,
         selectReceiveAccount,
         selectQuote,
+        selectQuoteForRevoke,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Allows user to revoke approval.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26202

## Screenshots:

https://github.com/user-attachments/assets/1a739740-0f62-4c2b-ae3a-29206e10a7f7


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=exchange-revoke-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->