### PR TITLE
fix(trading): use Concierge wording in OTC CTAs

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOfferOTC.tsx
@@ -90,8 +90,6 @@ export const TradingFormOfferOTC = () => {
         return null;
     }
 
-    const providerName = otcProviders[0]?.name;
-
     return (
         <Banner
             intent="info"
@@ -120,7 +118,6 @@ export const TradingFormOfferOTC = () => {
                                     ? 'TR_TRADING_OTC_LINK_BUY'
                                     : 'TR_TRADING_OTC_LINK_SELL'
                             }
-                            values={{ providerName }}
                         />
                     </Banner.Button>
                 </Column>

--- a/packages/suite/src/views/wallet/trading/concierge/TradingConciergeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/concierge/TradingConciergeForm.tsx
@@ -48,7 +48,7 @@ export const TradingConciergeForm = () => {
                     />
                 </Column>
             </Card>
-            <Button width="100%" isDisabled={!provider} href={provider?.url}>
+            <Button width="100%" isDisabled={!provider} href={provider?.url} size="large">
                 <Translation id="TR_CONTINUE" />
             </Button>
         </>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -1251,11 +1251,11 @@ export const messages = defineMessages({
         id: 'TR_TRADING_OTC_INFO_SELL',
     },
     TR_TRADING_OTC_LINK_BUY: {
-        defaultMessage: 'Buy with {providerName}',
+        defaultMessage: 'Buy with Concierge',
         id: 'TR_TRADING_OTC_LINK_BUY',
     },
     TR_TRADING_OTC_LINK_SELL: {
-        defaultMessage: 'Sell with {providerName}',
+        defaultMessage: 'Sell with Concierge',
         id: 'TR_TRADING_OTC_LINK_SELL',
     },
     TR_TRADING_PROVIDER: {


### PR DESCRIPTION
## Description

- Replace OTC CTA translation copy to use fixed Concierge wording instead of injecting providerName.
- Remove now-unused providerName interpolation from the OTC offer banner CTA.
- Set the Concierge form Continue button to large size for consistent CTA prominence.

## Notes for QA

1. Open wallet trading OTC flow and verify the CTA text reads Buy with Concierge or Sell with Concierge (never provider-specific name).
2. Open the Concierge form and verify the Continue button is visibly larger than before and links to the selected provider URL.
3. Confirm no regressions in OTC banner rendering for both buy and sell offer types.

## Related Issue

Resolve #26697

## Screenshots:
<img width="1129" height="696" alt="image" src="https://github.com/user-attachments/assets/33724d63-bd49-4f1c-8812-536e974d4d37" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26697/otc-cta&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26697/otc-cta&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T09:16:55.804Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T09:16:27.161Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->