### PR TITLE
fix: unused addresses with labels [WIP!!]

### DIFF
--- a/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
+++ b/packages/suite/src/views/wallet/receive/components/FreshAddress.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncAddressLabels } from '@suite-common/suite-sync';
@@ -18,6 +16,7 @@ import {
     Tooltip,
 } from '@trezor/components';
 import { spacings } from '@trezor/theme';
+import { typedObjectValues } from '@trezor/utils';
 
 import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { showAddress } from 'src/actions/wallet/receiveActions';
@@ -26,15 +25,13 @@ import { useDispatch, useSelector } from 'src/hooks/suite/';
 import { useReceiveDisabled } from 'src/hooks/suite/useReceiveDisabled';
 import { type AppState } from 'src/types/suite';
 
-const TooltipLabel = ({
-    symbol,
-    multipleAddresses,
-    accountType,
-}: {
+type TooltipLabel = {
     symbol: string;
     multipleAddresses: boolean;
     accountType: string;
-}) => {
+};
+
+const TooltipLabel = ({ symbol, multipleAddresses, accountType }: TooltipLabel) => {
     const addressLabel = (
         <H4 intent="neutral" priority="secondary" typographyStyle="body-sm">
             <Translation id={multipleAddresses ? 'RECEIVE_ADDRESS_FRESH' : 'RECEIVE_ADDRESS'} />
@@ -100,17 +97,25 @@ export const FreshAddress = ({
             : [],
     );
 
+    const excludedAddresses = isLegacyLabelingVisible
+        ? typedObjectValues(addressLabels)
+              .filter(label => !!label)
+              .map(([address]) => address)
+        : suiteSyncAddressLabels.filter(({ label }) => !!label).map(({ address }) => address);
+
     const { isReceiveDisabled, receiveDisabledTooltipContent } = useReceiveDisabled();
     const { translationString } = useTranslation();
     const dispatch = useDispatch();
 
-    const firstFreshAddress = useMemo(() => {
-        if (account) {
-            return getFirstFreshAddress(account, addresses, pendingAddresses, isAccountUtxoBased);
-        }
-    }, [account, addresses, pendingAddresses, isAccountUtxoBased]);
-
     if (!account) return null;
+
+    const firstFreshAddress = getFirstFreshAddress(
+        account,
+        addresses,
+        pendingAddresses,
+        isAccountUtxoBased,
+        excludedAddresses,
+    );
 
     // On coinjoin account, disallow to reveal more than the first receive address until it is used,
     // because discovery of coinjoin account relies on assumption that user uses his first address first.
@@ -147,6 +152,7 @@ export const FreshAddress = ({
         minWidth: 220,
         size: 'large',
     };
+
     const firstFreshAddressLabel = firstFreshAddress?.address
         ? (suiteSyncAddressLabels.find(it => it.address === firstFreshAddress.address)?.label ??
           (isLegacyLabelingVisible ? addressLabels[firstFreshAddress.address] : undefined))

--- a/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/accountUtils.ts
@@ -433,4 +433,19 @@ export const getFirstFreshAddress = [
             transfers: ACCOUNTS.txrp.history.total,
         },
     },
+    {
+        description: 'Account with labeled unused address skips labeled address',
+        params: {
+            account: ACCOUNTS.test,
+            receive: [],
+            pendingAddresses: [],
+            utxoBasedAccount: true,
+            excludedAddresses: ['tb1qk0qgmxtaw3kc9366eccjjgklef0g8lxv3l8nvk'],
+        },
+        result: {
+            address: 'tb1q99ml7urce6m77c2hmxeppm3ylvx7lqk6avhgh7',
+            path: "m/84'/1'/0'/0/2",
+            transfers: 0,
+        },
+    },
 ];

--- a/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/accountUtils.test.ts
@@ -32,12 +32,14 @@ import {
 describe('account utils', () => {
     fixtures.getFirstFreshAddress.forEach(f => {
         it(`getFirstFreshAddress: ${f.description}`, () => {
-            const { account, receive, pendingAddresses, utxoBasedAccount } = f.params;
+            const { account, receive, pendingAddresses, utxoBasedAccount, excludedAddresses } =
+                f.params;
             const freshAddress = getFirstFreshAddress(
                 account as Account,
                 receive,
                 pendingAddresses,
                 utxoBasedAccount,
+                excludedAddresses,
             );
             expect(freshAddress).toMatchObject(f.result);
         });

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -79,6 +79,7 @@ export const getFirstFreshAddress = (
     receiveAddresses: ReceiveInfo[],
     pendingAddresses: string[],
     utxoBasedAccount: boolean,
+    excludedAddresses: string[] = [],
 ) => {
     const unused = account.addresses
         ? account.addresses.unused
@@ -93,7 +94,8 @@ export const getFirstFreshAddress = (
     const unrevealed = unused.filter(
         a =>
             !receiveAddresses.find(r => r.path === a.path) &&
-            !pendingAddresses.find(p => p === a.address),
+            !pendingAddresses.find(p => p === a.address) &&
+            !excludedAddresses.includes(a.address),
     );
 
     // const addressLabel = utxoBasedAccount ? 'RECEIVE_ADDRESS_FRESH' : 'RECEIVE_ADDRESS';


### PR DESCRIPTION
WIP 

Resolves: https://github.com/trezor/trezor-suite/issues/25905

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=address-reuse-labeling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=address-reuse-labeling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=address-reuse-labeling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T11:15:03.941Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T11:13:35.379Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->