### PR TITLE
Permission Policy

### DIFF
--- a/packages/suite-web/README.md
+++ b/packages/suite-web/README.md
@@ -16,18 +16,4 @@ Visualize size of output files with [Webpack Bundle Analyzer](https://github.com
 yarn workspace @trezor/suite-web analyze
 ```
 
-## Preview
-
-Start local server with production build and applied security headers:
-
-```
-yarn workspace @trezor/suite-web preview
-```
-
-## Build & Preview
-
-Build web app and run the preview command:
-
-```
-yarn workspace @trezor/suite-web build:preview
-```
+👉 **Read more at [skills/security-headers/SKILL.md](/skills/security-headers/SKILL.md)**.

--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -32,6 +32,16 @@ const PRODUCTION_SECURITY_HEADERS = {
     'x-frame-options': 'SAMEORIGIN',
 
     /**
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy
+     * Restrict browser powerful features to the minimum required set.
+     * - Keep WebUSB, camera, clipboard write and local network access available only for this origin.
+     * - Explicitly disable unrelated features.
+     * It's experimental feature and not supported by all browsers.
+     */
+    'permissions-policy':
+        'usb=(self), camera=(self), clipboard-write=(self), local-network-access=(self), geolocation=(), microphone=(), payment=(), hid=(), serial=(), fullscreen=(), accelerometer=(), gyroscope=(), magnetometer=(), storage-access=(), bluetooth=()',
+
+    /**
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
      * This header prevents URL data leakage for foreign sites.
      * If user clicks on a link redirecting to another (non suite.trezor.io) site, the site receives only `https://suite.trezor.io` in the referrer response header instead of whole URL

--- a/packages/suite-web/types/securityHeaders.ts
+++ b/packages/suite-web/types/securityHeaders.ts
@@ -19,6 +19,7 @@ export type SecurityHeaders = {
     'upgrade-insecure-requests': '1';
     'x-content-type-options': 'nosniff';
     'x-frame-options': 'SAMEORIGIN' | 'DENY';
+    'permissions-policy': string;
     'referrer-policy':
         | 'strict-origin-when-cross-origin'
         | 'no-referrer'

--- a/skills/security-headers/SKILL.md
+++ b/skills/security-headers/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: security-headers
+description: Generated code must be aligned with security headers (e.g. no unsave JS eval). The permissions policy is especially relevant when changing any code related with the `navigator` object.
+---
+
+# Security headers
+
+## Preview
+
+Start local server with production build and applied security headers:
+
+```
+yarn workspace @trezor/suite-web preview
+```
+
+## Build & Preview
+
+Build web app and run the preview command:
+
+```
+yarn workspace @trezor/suite-web build:preview
+```
+
+or
+
+root level command:
+
+```
+yarn suite:build:web:preview
+```
+
+## Security Headers
+
+### Permissions-Policy Rationale (Enabled Directives)
+
+- `usb=(self)`:
+    - `packages/connect/src/index-browser.ts` (`window.navigator.usb.requestDevice(...)`)
+    - `packages/transport/src/transports/webusb.browser.ts`
+- `camera=(self)`:
+    - `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/CameraQRReader.tsx` (`react-zxing` camera scanner used for QR input)
+- `clipboard-write=(self)`:
+    - `packages/dom-utils/src/copyToClipboard.ts` (`navigator.clipboard.writeText(...)`)
+    - `packages/analytics-docs/src/components/AddEventModal/CopyButton.tsx`
+    - `packages/analytics-docs/src/components/EventCard.tsx`
+- `local-network-access=(self)`:
+    - `packages/suite/src/hooks/suite/useLocalNetworkAccessPermission.ts` (`navigator.permissions.query({ name: 'local-network-access' })`)
+    - `packages/connect-web/src/impl/core-in-suite-desktop.ts` (permission state check for websocket connectivity error handling)
+
+`clipboard-read` is intentionally not enabled because current direct usage is test-only (`suite/e2e/tests/wallet/receive.test.ts`) rather than Suite Web runtime behavior.
+
+Disabled directives (`=()`) are intentionally blocked because there is no direct web runtime use at this time.
+
+### Direct Code References
+
+- Header values source: `packages/suite-web/constants/webSecurityHeaders.ts`
+- Header type constraints: `packages/suite-web/types/securityHeaders.ts`
+
+MDN references:
+
+- [Permissions Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Permissions_Policy)
+- [HTTP security headers overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers)


### PR DESCRIPTION
## Description

- The goal of this header is to allow only necessary features required by the application and explicitly disallow all others. This mitigates potential attack vector.
- Set `Permission-Policy` policy header for local testing (e.g. `yarn suite:build:web:preview`).
- The same value is going to be then set for development hosting and after proper testing for production hosting too.

## Related Issue

Resolve [#187](https://github.com/trezor/trezor-suite-private/issues/187)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/permission-policy&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/permission-policy&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T12:03:37.946Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T12:01:53.830Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->