### PR TITLE
Do not show Suite Sync tooltips if the feature is turned off

### DIFF
--- a/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
@@ -169,7 +169,7 @@ export const Labeling = ({
                 />
             )}
             <SuiteSyncInteractionsTooltip
-                suiteSyncInteraction={!legacyMetadataState.enabled ? suiteSyncInteraction : null}
+                suiteSyncInteraction={isSuiteSyncEnabled ? suiteSyncInteraction : null}
             >
                 <EditableText
                     onSubmit={onSubmit ?? handleSubmit}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

User will see the tooltip once the Suite Sync is turned on, but it's not useful to see it when not enabled and it's annoying for incompatible devices.

## Notes for QA


- Check the tooltips on labelable entities (accounts, wallets, addresses) in possible states (disconnected/connected trezor, supported/unsupported model, supported/unsopported FW, online/offline)


[This can be used as a reference](https://www.notion.so/satoshilabs/Suite-Sync-UI-states-2e2dc52606068097a1f0dffc5154fdc0?source=copy_link)
	

## Related Issue

Resolve only partially: https://github.com/trezor/trezor-suite/issues/26726
This PR resolved only the tooltip, the rest was handled in https://github.com/trezor/trezor-suite/pull/26752


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync-tooltip-disconnected-terzor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T21:55:51.822Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->