### PR TITLE
Fix possibility to enable legacy labeling and condition for Suite Sync via edit label

### DIFF
--- a/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
+++ b/packages/suite/src/components/suite/labeling/Labeling/Labeling.tsx
@@ -72,7 +72,7 @@ export const Labeling = ({
             // Is there something that needs to be initiated?
             !isLegacyLabelingEnabled
         ) {
-            if (suiteSyncInteraction !== null) {
+            if (suiteSyncInteraction !== null && suiteSyncInteraction !== 'unsupported') {
                 // Keys needed is not handled by the same modal, because it in DeviceInteraction context
                 if (suiteSyncInteraction === 'keys-needed') {
                     const result = await suiteSync.ensureWalletSuiteSyncOn({

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.test.ts
@@ -246,4 +246,19 @@ describe(selectIsLabelActionEnabled.name, () => {
 
         expect(result).toBe(true);
     });
+
+    it('allows labeling when Suite Sync feature is available, disabled, and can be initialized', () => {
+        mocked(selectIsLabelingAvailableForEntity).mockReturnValue(false);
+        mocked(selectIsLabelingInitPossible).mockReturnValue(false);
+
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: false,
+            deviceOverrides: {
+                connected: true,
+            },
+        });
+
+        expect(result).toBe(true);
+    });
 });

--- a/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
+++ b/packages/suite/src/components/suite/labeling/Labeling/selectIsLabelActionEnabled.ts
@@ -9,6 +9,7 @@ import {
     type WithSuiteSyncAndDeviceState,
     getIsSuiteSyncLabelingActionEnabled,
     selectIsSuiteSyncEnabled,
+    selectIsSuiteSyncInitPossible,
 } from '@suite-common/suite-sync';
 import { type StaticSessionId } from '@trezor/connect';
 
@@ -43,14 +44,14 @@ export const selectIsLabelActionEnabled = (
         return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
     }
 
-    // If Evolu is enabled, we do not want to allow for enabling Legacy Labeling just by
-    // clicking on the stuff.
-    const isLegacyLabelingInitPossible = !isSuiteSyncEnabled && selectIsLabelingInitPossible(state);
+    const isSuiteSyncInitPossible = selectIsSuiteSyncInitPossible(state, deviceStaticSessionId);
+
+    const isLegacyLabelingInitPossible = selectIsLabelingInitPossible(state);
     const isLegacyLabelingEnabled = selectIsLabelingAvailableForEntity(
         state,
         legacyEntityKey,
         deviceStaticSessionId,
     );
 
-    return isLegacyLabelingEnabled || isLegacyLabelingInitPossible;
+    return isSuiteSyncInitPossible || isLegacyLabelingEnabled || isLegacyLabelingInitPossible;
 };

--- a/suite-common/suite-sync/src/__tests__/suiteSyncSelectors.test.ts
+++ b/suite-common/suite-sync/src/__tests__/suiteSyncSelectors.test.ts
@@ -8,7 +8,7 @@ import type { SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage'
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import type { StaticSessionId, UnavailableCapabilities } from '@trezor/connect';
 
-import { selectSuiteSyncInteraction } from '../suiteSyncSelectors';
+import { selectIsSuiteSyncInitPossible, selectSuiteSyncInteraction } from '../suiteSyncSelectors';
 import type { WithSuiteSyncAndDeviceState } from '../suiteSyncSelectors';
 import { type SuiteSyncState, initialSuiteSyncState } from '../suiteSyncSlice';
 
@@ -128,5 +128,56 @@ describe(selectSuiteSyncInteraction.name, () => {
         const result = selectSuiteSyncInteraction(state, DEVICE_STATIC_SESSION_ID_123);
 
         expect(result).toBeNull();
+    });
+});
+
+describe(selectIsSuiteSyncInitPossible.name, () => {
+    it('returns false when device static session id is null', () => {
+        const state = createMockState();
+
+        const result = selectIsSuiteSyncInitPossible(state, null);
+
+        expect(result).toBe(false);
+    });
+
+    it('returns true for a connected supported device', () => {
+        const state = createMockState({
+            connected: true,
+        });
+
+        const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false for a disconnected device', () => {
+        const state = createMockState({
+            connected: false,
+        });
+
+        const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false for an unsupported device', () => {
+        const state = createMockState({
+            unavailableCapabilities: { evolu: 'no-support' },
+        });
+
+        const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
+
+        expect(result).toBe(false);
+    });
+
+    it('returns true for a connected device with older firmware', () => {
+        const state = createMockState({
+            unavailableCapabilities: { evolu: 'update-required' },
+            connected: true,
+        });
+
+        const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
+
+        expect(result).toBe(true);
     });
 });

--- a/suite-common/suite-sync/src/index.ts
+++ b/suite-common/suite-sync/src/index.ts
@@ -7,9 +7,9 @@ export {
     selectIsSuiteSyncDebugEnabled,
     selectHasDeviceSuiteSyncError,
     selectIsSuiteSyncFeatureAvailable,
-    type WithSuiteSyncState,
+    selectIsSuiteSyncInitPossible,
 } from './suiteSyncSelectors';
-export type { WithSuiteSyncAndDeviceState } from './suiteSyncSelectors';
+export type { WithSuiteSyncAndDeviceState, WithSuiteSyncState } from './suiteSyncSelectors';
 export type { SuiteSyncInteraction } from './suiteSyncTypes';
 export { createSuiteSyncCompositionRoot } from './createSuiteSyncCompositionRoot';
 export type { SuiteSyncAnalytics, SuiteSyncAnalyticsDep } from './createSuiteSyncCompositionRoot';

--- a/suite-common/suite-sync/src/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.ts
@@ -32,6 +32,23 @@ export const selectIsSuiteSyncEnabled = (
 export const selectIsSuiteSyncDebugEnabled = (state: WithSuiteSyncAndDeviceState): boolean =>
     state.suiteSync.settings.isSuiteSyncDebugEnabled;
 
+export const selectIsSuiteSyncInitPossible = (
+    state: WithSuiteSyncAndDeviceState,
+    deviceStaticSessionId: StaticSessionId | null,
+): boolean => {
+    if (deviceStaticSessionId === null) {
+        return false;
+    }
+
+    const device = selectDeviceByStaticSessionId(state, deviceStaticSessionId);
+
+    if (device === undefined) {
+        return false;
+    }
+
+    return device.connected && isSuiteSyncSupportedByDevice(device);
+};
+
 export const selectSuiteSyncCustomRelayUrl = (
     state: WithSuiteSyncAndDeviceState,
 ): string | null => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- It wasn't possible to enable legacy labeling with models that don't support Suite Sync via Edit label buttons, it was a bug.
- Condition for when the Edit label should be disabled was super confusing a checking only legacy labeling conditions if Suite Sync was disabled. It worked almost the same with only one edge case: it was not possible to turn on Suite Sync via Edit label when Suite was offline.

## Notes for QA

- Please check enabling of both Suite Sync and Legacy labeling on models that supported Suite Sync and those that doesn't.



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/legacy-labeling-enable&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/legacy-labeling-enable&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T14:48:45.848Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->