### PR TITLE
Feat(ci): requireUnifiedDependencyVersions resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     },
     "resolutions": {
         "typescript": "5.8.3",
-        "prettier": "3.8.1",
+        "prettier": "^3.8.1",
         "react-native": "0.83.2",
         "type-fest": "5.5.0",
         "bcrypto": "5.4.0",
@@ -112,7 +112,7 @@
         "### We need promise to be same version in mobile unless it produces undefined behavior, check PR #15815": "1.0.0",
         "promise": "8.3.0",
         "elliptic": "6.6.1",
-        "@headlessui/react": "^2.2.0",
+        "@headlessui/react": "^2.2.2",
         "### Align versions of sentry internal packages, because electron & native use different versions of @core": "1.0.0",
         "@sentry/core": "10.42.0",
         "@sentry/browser": "10.42.0",

--- a/packages/requirements/src/requirements/dependency-versions/__tests__/requireUnifiedDependencyVersions.test.ts
+++ b/packages/requirements/src/requirements/dependency-versions/__tests__/requireUnifiedDependencyVersions.test.ts
@@ -50,6 +50,7 @@ const createTempRepo = () => {
             workspaces: string[],
             deps: Record<string, string> = {},
             devDeps: Record<string, string> = {},
+            resolutions: Record<string, string> = {},
         ) => {
             const pkg: Record<string, unknown> = {
                 name: 'test-monorepo',
@@ -62,6 +63,9 @@ const createTempRepo = () => {
 
             if (Object.keys(devDeps).length > 0) {
                 pkg.devDependencies = devDeps;
+            }
+            if (Object.keys(resolutions).length > 0) {
+                pkg.resolutions = resolutions;
             }
 
             writeFileSync(join(root, 'package.json'), JSON.stringify(pkg, null, 4) + '\n');
@@ -221,6 +225,20 @@ describe('requireUnifiedDependencyVersions', () => {
         const errors = await requireUnifiedDependencyVersions.verify({ repoRoot: repo.root });
 
         expect(errors).toHaveLength(1);
+    });
+
+    it('detects drift between root package.json resolutions and workspace dependency', async () => {
+        const repo = createTempRepo();
+        repo.setRootPackageJson(['packages/*'], {}, {}, { lodash: '4.17.15' });
+        repo.addWorkspace('@test/alpha', 'packages/alpha', { lodash: '^4.17.21' });
+
+        const errors = await requireUnifiedDependencyVersions.verify({ repoRoot: repo.root });
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('"lodash"');
+        expect(errors[0]).toContain('4.17.15');
+        expect(errors[0]).toContain('^4.17.21');
+        expect(errors[0]).toContain('resolutions');
     });
 
     it('reports error when ALLOWED_DRIFTS entry has unified versions', async () => {

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -25,6 +25,7 @@ export const ALLOWED_DRIFTS = new Set([
 type PackageJson = {
     readonly name?: string;
     readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
+    readonly resolutions?: Record<string, string>;
     readonly dependencies?: Record<string, string>;
     readonly devDependencies?: Record<string, string>;
 };
@@ -32,7 +33,7 @@ type PackageJson = {
 type VersionOccurrence = {
     readonly version: string;
     readonly workspace: string;
-    readonly depType: 'dependencies' | 'devDependencies';
+    readonly depType: 'dependencies' | 'devDependencies' | 'resolutions';
 };
 
 type YarnWorkspaceInfo = {
@@ -73,7 +74,7 @@ const collectDependencyVersions = (workspaceDirs: ReadonlyArray<string>) => {
         const pkg = readPackageJson(dir);
         const workspaceName = pkg.name ?? dir;
 
-        for (const depType of ['dependencies', 'devDependencies'] as const) {
+        for (const depType of ['dependencies', 'devDependencies', 'resolutions'] as const) {
             const deps = pkg[depType];
 
             if (deps === undefined) continue;

--- a/packages/suite-web/package.json
+++ b/packages/suite-web/package.json
@@ -16,7 +16,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@sentry/browser": "10.46.0",
+        "@sentry/browser": "10.42.0",
         "@suite/router": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/suite": "workspace:*",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -19,7 +19,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mobily/ts-belt": "^3.13.1",
         "@reduxjs/toolkit": "2.11.2",
-        "@sentry/core": "10.46.0",
+        "@sentry/core": "10.42.0",
         "@solana/kit": "^2.3.0",
         "@suite-common/analytics": "workspace:*",
         "@suite-common/analytics-redux": "workspace:*",

--- a/suite-common/sentry/package.json
+++ b/suite-common/sentry/package.json
@@ -11,6 +11,6 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@sentry/core": "10.46.0"
+        "@sentry/core": "10.42.0"
     }
 }

--- a/suite-native/sentry/package.json
+++ b/suite-native/sentry/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@sentry/core": "10.46.0",
+        "@sentry/core": "10.42.0",
         "@sentry/react-native": "8.5.0",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/suite/sentry/package.json
+++ b/suite/sentry/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@sentry/core": "10.46.0",
+        "@sentry/core": "10.42.0",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,7 +4851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@headlessui/react@npm:^2.2.0":
+"@headlessui/react@npm:^2.2.2":
   version: 2.2.4
   resolution: "@headlessui/react@npm:2.2.4"
   dependencies:
@@ -11282,7 +11282,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/sentry@workspace:suite-common/sentry"
   dependencies:
-    "@sentry/core": "npm:10.46.0"
+    "@sentry/core": "npm:10.42.0"
   languageName: unknown
   linkType: soft
 
@@ -13997,7 +13997,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/sentry@workspace:suite-native/sentry"
   dependencies:
-    "@sentry/core": "npm:10.46.0"
+    "@sentry/core": "npm:10.42.0"
     "@sentry/react-native": "npm:8.5.0"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
@@ -14854,7 +14854,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite/sentry@workspace:suite/sentry"
   dependencies:
-    "@sentry/core": "npm:10.46.0"
+    "@sentry/core": "npm:10.42.0"
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
@@ -16221,7 +16221,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/suite-web@workspace:packages/suite-web"
   dependencies:
-    "@sentry/browser": "npm:10.46.0"
+    "@sentry/browser": "npm:10.42.0"
     "@suite/router": "workspace:*"
     "@suite/sentry": "workspace:*"
     "@trezor/connect": "workspace:*"
@@ -16252,7 +16252,7 @@ __metadata:
     "@hookform/resolvers": "npm:^5.2.2"
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.11.2"
-    "@sentry/core": "npm:10.46.0"
+    "@sentry/core": "npm:10.42.0"
     "@solana/kit": "npm:^2.3.0"
     "@suite-common/analytics": "workspace:*"
     "@suite-common/analytics-redux": "workspace:*"
@@ -38937,7 +38937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.8.1":
+"prettier@npm:^3.8.1":
   version: 3.8.1
   resolution: "prettier@npm:3.8.1"
   bin:


### PR DESCRIPTION
## Description

Followup to #26412 to check also consistency with the `resolutions` field (in our repo, resolutions are only present on root package.json).

No actual versions are changed here, just version range declarations.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/requireUnifiedDependencyVersions-resolutions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/requireUnifiedDependencyVersions-resolutions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/requireUnifiedDependencyVersions-resolutions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-16T07:37:37.580Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-16T07:35:44.206Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->