### PR TITLE
fix: direct file imports for QueryClientProviders

### DIFF
--- a/packages/suite/src/support/suite/Main.tsx
+++ b/packages/suite/src/support/suite/Main.tsx
@@ -1,7 +1,7 @@
 import { HelmetProvider } from 'react-helmet-async';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { ReactQueryProvider } from '@suite-common/react-query';
+import { ReactQueryProvider } from '@suite-common/react-query/src/components/ReactQueryProvider';
 import { SelectCacheProvider } from '@trezor/components';
 
 import { useFormattersConfig } from 'src/hooks/suite';

--- a/suite-common/react-query/src/index.ts
+++ b/suite-common/react-query/src/index.ts
@@ -9,7 +9,6 @@ export {
     type UseQueryOptions,
     keepPreviousData,
 } from '@tanstack/react-query';
-export * from './components/ReactQueryProvider';
-export * from './components/ReactNativeQueryProvider';
 export * from './constants/queryKeys';
 export * from './constants/mutationKeys';
+// QueryClientProvider wrappers are not exported here, to keep this package compatible with nodeJS-only environments (which can't parse .tsx)

--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -10,7 +10,7 @@ import * as Sentry from '@sentry/react-native';
 import * as SplashScreen from 'expo-splash-screen';
 
 import { FormatterProvider } from '@suite-common/formatters';
-import { ReactNativeQueryProvider } from '@suite-common/react-query';
+import { ReactNativeQueryProvider } from '@suite-common/react-query/src/components/ReactNativeQueryProvider';
 import { applicationInit } from '@suite-native/app-init';
 import { useIsBiometricsOverlayVisible } from '@suite-native/biometrics';
 import { configureNetInfo } from '@suite-native/connection-status';


### PR DESCRIPTION
## Description

Fix Suite Desktop Electron-main build which [currently crashes](https://github.com/trezor/trezor-suite/actions/runs/24464136960/job/71486395004?pr=26757) because of an import tree that contains JSX, and webpack cannot handle it if not equiped with babel jsx parser – nor should it. These common packages should be possible to run in a nodeJS-only environment.

:point_right: .tsx files shall not be exported through barrel file, but deep-imported. EDIT: this is just hotfix **for now**. A better permanent solution should be found.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-desktop-build-because-tsx&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-desktop-build-because-tsx&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-desktop-build-because-tsx&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-15T16:22:57.289Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-15T16:21:43.760Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->