### PR TITLE
feat(solana): add memo support

### DIFF
--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -251,6 +251,7 @@ export interface Transaction {
     solanaSpecific?: {
         status: 'confirmed';
         stakeOperation?: { type: StakeType; amount: string };
+        memo?: string;
     };
     details: TransactionDetail;
     vsize?: number;

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -714,15 +714,16 @@ const determineTransactionType = (
 };
 
 const getMemo = (tx: SolanaValidParsedTxWithMeta): string | undefined => {
-    const memoInstruction = tx.transaction.message.instructions.find(
-        ix =>
-            ix.programId === MEMO_PROGRAM_PUBLIC_KEY || ix.programId === MEMO_PROGRAM_PUBLIC_KEY_V1,
-    );
-    if (!memoInstruction || !('parsed' in memoInstruction)) return undefined;
+    const memos = tx.transaction.message.instructions
+        .filter(
+            ix =>
+                ix.programId === MEMO_PROGRAM_PUBLIC_KEY ||
+                ix.programId === MEMO_PROGRAM_PUBLIC_KEY_V1,
+        )
+        .map(ix => ('parsed' in ix ? (ix.parsed as unknown) : undefined))
+        .filter((p): p is string => typeof p === 'string');
 
-    const parsed = memoInstruction.parsed as unknown;
-
-    return typeof parsed === 'string' ? parsed : undefined;
+    return memos.length > 0 ? memos.join('\n') : undefined;
 };
 
 export const transformTransaction = (

--- a/packages/blockchain-link-utils/src/solana.ts
+++ b/packages/blockchain-link-utils/src/solana.ts
@@ -44,6 +44,8 @@ export const COMPUTE_BUDGET_PROGRAM_ID = 'ComputeBudget1111111111111111111111111
 export const SERUM_ASSET_OWNER_PROGRAM_ID = '4MNPdKu9wFMvEeZBMt3Eipfs5ovVWTJb31pEXDJAAxX5';
 export const SERUM_ASSET_OWNER_PHANTOM_DEPLOYMENT_PROGRAM_ID =
     'DeJBGdMFa1uynnnKiwrVioatTuHmNLpyFKnmB5kaFdzQ';
+export const MEMO_PROGRAM_PUBLIC_KEY = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+export const MEMO_PROGRAM_PUBLIC_KEY_V1 = 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo';
 
 const tokenProgramNames = ['spl-token', 'spl-token-2022'] as const;
 export type TokenProgramName = (typeof tokenProgramNames)[number];
@@ -382,6 +384,8 @@ export const getTxType = (
             // some wallets use Serum's Assert Owner program during SPL transfer transactions, we don't want to report these as `contract` transactions
             SERUM_ASSET_OWNER_PROGRAM_ID,
             SERUM_ASSET_OWNER_PHANTOM_DEPLOYMENT_PROGRAM_ID,
+            MEMO_PROGRAM_PUBLIC_KEY,
+            MEMO_PROGRAM_PUBLIC_KEY_V1,
         ].includes(instruction.programId);
 
     // if there are any unknown program instructions, we interpret the transaction as `contract`
@@ -407,7 +411,9 @@ export const getTxType = (
             instruction.parsed.type === 'transfer' ||
             instruction.parsed.type === 'transferChecked' ||
             (instruction.program === 'system' && instruction.parsed.type === 'advanceNonce') ||
-            isInstructionCreatingTokenAccount(instruction),
+            isInstructionCreatingTokenAccount(instruction) ||
+            instruction.programId === MEMO_PROGRAM_PUBLIC_KEY ||
+            instruction.programId === MEMO_PROGRAM_PUBLIC_KEY_V1,
     );
 
     if (isTransfer) {
@@ -707,6 +713,18 @@ const determineTransactionType = (
     }
 };
 
+const getMemo = (tx: SolanaValidParsedTxWithMeta): string | undefined => {
+    const memoInstruction = tx.transaction.message.instructions.find(
+        ix =>
+            ix.programId === MEMO_PROGRAM_PUBLIC_KEY || ix.programId === MEMO_PROGRAM_PUBLIC_KEY_V1,
+    );
+    if (!memoInstruction || !('parsed' in memoInstruction)) return undefined;
+
+    const parsed = memoInstruction.parsed as unknown;
+
+    return typeof parsed === 'string' ? parsed : undefined;
+};
+
 export const transformTransaction = (
     tx: SolanaValidParsedTxWithMeta,
     accountAddress: string,
@@ -758,6 +776,7 @@ export const transformTransaction = (
                       amount: stakeAmount,
                   }
                 : undefined,
+            memo: getMemo(tx),
         },
     };
 };

--- a/packages/connect-common/src/types/api/solana/index.ts
+++ b/packages/connect-common/src/types/api/solana/index.ts
@@ -73,6 +73,7 @@ const SolanaComposeTransactionCommon = {
             accounts: Type.Array(Type.Object({ publicKey: Type.String(), balance: Type.String() })),
         }),
     ),
+    memo: Type.Optional(Type.String()),
     coin: Type.Optional(Type.String()),
     identity: Type.Optional(Type.String()),
 };

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -117,6 +117,7 @@
         "@scure/base": "^1.2.6",
         "@scure/bip39": "^1.5.1",
         "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/memo": "^0.7.0",
         "@solana-program/system": "^0.7.0",
         "@solana-program/token": "^0.5.1",
         "@solana-program/token-2022": "^0.4.2",

--- a/packages/connect/src/api/solana/__fixtures__/solanaUtils.ts
+++ b/packages/connect/src/api/solana/__fixtures__/solanaUtils.ts
@@ -429,5 +429,52 @@ export const fixtures = {
             expectedOutput:
                 '01000306c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6ca7f0545e6ff0eb69540020573c128136015f2a26163f90081ea42fb43be1665ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc586c6ede7c260ca13beca7a3017513ac103b5dad8335213f57d38b78967c6608b90306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a4000000006ddf6e1ee758fde18425dbce46ccddab61afc4d83b90d27febdf928d8a18bfc6772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb030400050250c3000004000903a0860100000000000504010302000a0c00e1f5050000000009',
         },
+        {
+            description: 'builds token transfer (SPL Token program) transaction with memo',
+            input: {
+                fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
+                toAddressOwner: SYSTEM_PROGRAM_PUBLIC_KEY,
+                tokenMint: '6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK',
+                tokenUiAmount: '0.1',
+                tokenDecimals: 9,
+                fromTokenAccounts: [
+                    {
+                        publicKey: 'CR6QfobBidQTSYdR6jihKTfMnHkRUtw8cLDCxENDVYmd',
+                        balance: '12200000000',
+                    },
+                ],
+                toTokenAccount: undefined,
+                blockhash: '7xpT7BDE7q1ZWhe6Pg8PHRYbqgDwNK3L2v97rEfsjMkn',
+                lastValidBlockHeight: 50,
+                priorityFees: {
+                    computeUnitPrice: '100000',
+                    computeUnitLimit: '50000',
+                },
+                tokenProgramName: 'spl-token' as const,
+                memo: 'Hello World',
+            },
+            expectedOutput:
+                '0100070ac80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6a99c9c4d0c7def9dd60a3a40dc5266faf41996310aa62ad6cbd9b64e1e2cca78ebaa24826cef9644c1ecf0dfcf955775b8438528e97820efc2b20ed46be1dc580000000000000000000000000000000000000000000000000000000000000000527706a12f3f7c3c852582f0f79b515c03c6ffbe6e3100044ba7c982eb5cf9f28c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f8590306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000d27c181cb023db6239e22e49e4b67f7dd9ed13f3d7ed319f9e91b3bc64cec0a9054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a96772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb050600050250c3000006000903a0860100000000000506000207040309000904010402000a0c00e1f505000000000908000b48656c6c6f20576f726c64',
+        },
+    ],
+    buildTransferTransaction: [
+        {
+            description: 'builds SOL transfer transaction with memo',
+            input: {
+                fromAddress: 'ETxHeBBcuw9Yu4dGuP3oXrD12V5RECvmi8ogQ9PkjyVF',
+                toAddress: 'FAeNERRWGL8xtnwtM5dWBUs9Z1y5fenSJcawu55NQSWk',
+                amountInSol: '0.1',
+                blockhash: '7xpT7BDE7q1ZWhe6Pg8PHRYbqgDwNK3L2v97rEfsjMkn',
+                lastValidBlockHeight: 50,
+                priorityFees: {
+                    computeUnitPrice: '100000',
+                    computeUnitLimit: '50000',
+                },
+                memo: 'Hello World',
+            },
+            expectedOutput:
+                '01000305c80f8b50107e9f3e3c16a661b8c806df454a6deb293d5e8730a9d28f2f4998c6d27c181cb023db6239e22e49e4b67f7dd9ed13f3d7ed319f9e91b3bc64cec0a900000000000000000000000000000000000000000000000000000000000000000306466fe5211732ffecadba72c39be7bc8ce5bbc5f7126b2c439b3a40000000054a535a992921064d24e87160da387c7c35b5ddbc92bb81e41fa8404105448d6772b7d36a2e66e52c817f385d7e94d3d4b6d47d7171c9f2dd86c6f1be1a93eb040300050250c3000003000903a086010000000000020200010c0200000000e1f5050000000004000b48656c6c6f20576f726c64',
+        },
     ],
 };

--- a/packages/connect/src/api/solana/__tests__/solanaUtils.test.ts
+++ b/packages/connect/src/api/solana/__tests__/solanaUtils.test.ts
@@ -3,6 +3,7 @@ import {
     buildCreateAssociatedTokenAccountInstruction,
     buildTokenTransferInstruction,
     buildTokenTransferTransaction,
+    buildTransferTransaction,
     getLamportsFromSol,
     getMinimumRequiredTokenAccountsForTransfer,
 } from '../solanaUtils';
@@ -78,8 +79,28 @@ describe('solana utils', () => {
                     input.lastValidBlockHeight,
                     input.priorityFees,
                     input.tokenProgramName,
+                    input.memo,
                 );
                 const message = tx.transaction.serializeMessage();
+
+                expect(message).toEqual(expectedOutput);
+            });
+        });
+    });
+
+    describe('buildTransferTransaction', () => {
+        fixtures.buildTransferTransaction.forEach(({ description, input, expectedOutput }) => {
+            it(description, async () => {
+                const tx = await buildTransferTransaction(
+                    input.fromAddress,
+                    input.toAddress,
+                    input.amountInSol,
+                    input.blockhash,
+                    input.lastValidBlockHeight,
+                    input.priorityFees,
+                    input.memo,
+                );
+                const message = tx.serializeMessage();
 
                 expect(message).toEqual(expectedOutput);
             });

--- a/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
+++ b/packages/connect/src/api/solana/api/solanaComposeTransaction.ts
@@ -94,6 +94,7 @@ export default class SolanaComposeTransaction extends AbstractMethod<
                       this.params.lastValidBlockHeight,
                       this.params.priorityFees || dummyPriorityFeesForFeeEstimation,
                       this.params.token.program,
+                      this.params.memo,
                   )
                 : undefined;
 
@@ -109,6 +110,7 @@ export default class SolanaComposeTransaction extends AbstractMethod<
                   this.params.blockHash,
                   this.params.lastValidBlockHeight,
                   this.params.priorityFees || dummyPriorityFeesForFeeEstimation,
+                  this.params.memo,
               );
 
         const isCreatingAccount =

--- a/packages/connect/src/api/solana/solanaUtils.ts
+++ b/packages/connect/src/api/solana/solanaUtils.ts
@@ -5,6 +5,7 @@ import {
     type Transaction,
     type TransactionMessage,
 } from '@solana/kit';
+import { getAddMemoInstruction } from '@solana-program/memo';
 
 import type { TokenAccount } from '@trezor/blockchain-link-types';
 import { solanaUtils as SolanaBlockchainLinkUtils } from '@trezor/blockchain-link-utils';
@@ -23,9 +24,6 @@ const loadSolanaComputeBudgetProgramLib = async () =>
     );
 const loadSolanaSystemProgramLib = async () =>
     await import(/* webpackChunkName: "vendor-solana-program-system" */ '@solana-program/system');
-
-const loadSolanaMemoProgramLib = async () =>
-    await import(/* webpackChunkName: "vendor-solana-program-memo" */ '@solana-program/memo');
 
 const loadSolanaTokenProgramLib = async (tokenProgramName: TokenProgramName) => {
     switch (tokenProgramName) {
@@ -171,7 +169,6 @@ export const buildTransferTransaction = async (
         priorityFees,
     );
     if (memo) {
-        const { getAddMemoInstruction } = await loadSolanaMemoProgramLib();
         messageWithFees = appendTransactionMessageInstruction(
             getAddMemoInstruction({ memo }),
             messageWithFees,
@@ -400,7 +397,6 @@ export const buildTokenTransferTransaction = async (
 
     // Step 7: Append memo instruction if provided
     if (memo) {
-        const { getAddMemoInstruction } = await loadSolanaMemoProgramLib();
         message = appendTransactionMessageInstruction(getAddMemoInstruction({ memo }), message);
     }
 

--- a/packages/connect/src/api/solana/solanaUtils.ts
+++ b/packages/connect/src/api/solana/solanaUtils.ts
@@ -42,6 +42,17 @@ const loadSolanaTokenProgramLib = async (tokenProgramName: TokenProgramName) => 
 
 export const SOLANA_BASE_FEE = 5000; // lamports
 
+const SOLANA_MEMO_MAX_BYTES = 566; // https://www.solana-program.com/docs/memo
+
+const validateMemo = (memo: string) => {
+    const byteLength = Buffer.from(memo, 'utf8').length;
+    if (byteLength > SOLANA_MEMO_MAX_BYTES) {
+        throw new Error(
+            `Memo exceeds maximum length of ${SOLANA_MEMO_MAX_BYTES} bytes (got ${byteLength})`,
+        );
+    }
+};
+
 export const getLamportsFromSol = (amountInSol: string) =>
     BigInt(new BigNumber(amountInSol).times(10 ** 9).toString());
 
@@ -169,6 +180,7 @@ export const buildTransferTransaction = async (
         priorityFees,
     );
     if (memo) {
+        validateMemo(memo);
         messageWithFees = appendTransactionMessageInstruction(
             getAddMemoInstruction({ memo }),
             messageWithFees,
@@ -397,6 +409,7 @@ export const buildTokenTransferTransaction = async (
 
     // Step 7: Append memo instruction if provided
     if (memo) {
+        validateMemo(memo);
         message = appendTransactionMessageInstruction(getAddMemoInstruction({ memo }), message);
     }
 

--- a/packages/connect/src/api/solana/solanaUtils.ts
+++ b/packages/connect/src/api/solana/solanaUtils.ts
@@ -24,6 +24,9 @@ const loadSolanaComputeBudgetProgramLib = async () =>
 const loadSolanaSystemProgramLib = async () =>
     await import(/* webpackChunkName: "vendor-solana-program-system" */ '@solana-program/system');
 
+const loadSolanaMemoProgramLib = async () =>
+    await import(/* webpackChunkName: "vendor-solana-program-memo" */ '@solana-program/memo');
+
 const loadSolanaTokenProgramLib = async (tokenProgramName: TokenProgramName) => {
     switch (tokenProgramName) {
         case 'spl-token':
@@ -125,6 +128,7 @@ export const buildTransferTransaction = async (
     blockhash: string,
     lastValidBlockHeight: number,
     priorityFees: PriorityFees,
+    memo?: string,
 ) => {
     const [
         // @solana/kit
@@ -162,7 +166,17 @@ export const buildTransferTransaction = async (
         }),
         messageWithLifetime,
     );
-    const messageWithFees = await addPriorityFees(messageWithTransfer, priorityFees);
+    let messageWithFees: CompilableTransactionMessage = await addPriorityFees(
+        messageWithTransfer,
+        priorityFees,
+    );
+    if (memo) {
+        const { getAddMemoInstruction } = await loadSolanaMemoProgramLib();
+        messageWithFees = appendTransactionMessageInstruction(
+            getAddMemoInstruction({ memo }),
+            messageWithFees,
+        );
+    }
 
     return await createTransactionShim(messageWithFees);
 };
@@ -296,6 +310,7 @@ export const buildTokenTransferTransaction = async (
     lastValidBlockHeight: number,
     priorityFees: PriorityFees,
     tokenProgramName: TokenProgramName,
+    memo?: string,
 ): Promise<TokenTransferTxWithDestinationAddress> => {
     const {
         address,
@@ -383,7 +398,13 @@ export const buildTokenTransferTransaction = async (
     // Step 6: Add the token transfer instruction(s) to the transaction
     message = appendTransactionMessageInstructions(await Promise.all(instructionPromises), message);
 
-    // Step 7: Return the transaction
+    // Step 7: Append memo instruction if provided
+    if (memo) {
+        const { getAddMemoInstruction } = await loadSolanaMemoProgramLib();
+        message = appendTransactionMessageInstruction(getAddMemoInstruction({ memo }), message);
+    }
+
+    // Step 8: Return the transaction
     return {
         transaction: await createTransactionShim(message),
         destinationAddress: finalReceiverAddress,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -275,7 +275,7 @@ export const BasicTxDetails = ({
                 )}
 
                 {tx.solanaSpecific?.memo && (
-                    <Item label={<Translation id="DESTINATION_TAG_SHORT" />} iconName="tag">
+                    <Item label={<Translation id="MEMO" />} iconName="tag">
                         <BlurUrls text={tx.solanaSpecific.memo} />
                     </Item>
                 )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -274,6 +274,12 @@ export const BasicTxDetails = ({
                     </Item>
                 )}
 
+                {tx.solanaSpecific?.memo && (
+                    <Item label={<Translation id="DESTINATION_TAG_SHORT" />} iconName="tag">
+                        <BlurUrls text={tx.solanaSpecific.memo} />
+                    </Item>
+                )}
+
                 {/* TX ID */}
                 <Item label={<Translation id="TR_TXID" />} iconName="fingerprint">
                     <Link

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -140,10 +140,10 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
     // used in "loadDraft" useEffect and "importTransaction" callback
     const getLoadedValues = useCallback(
         (loadedState?: Partial<FormState>) => ({
-            ...getDefaultValues(localCurrencyOption),
+            ...getDefaultValues(localCurrencyOption, networkType),
             ...loadedState,
         }),
-        [localCurrencyOption],
+        [localCurrencyOption, networkType],
     );
 
     // update custom values

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
@@ -32,7 +32,7 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
 
     const { networkType, name } = getNetwork(networkSymbol);
 
-    if (networkType !== 'ripple' && networkType !== 'stellar' && networkType !== 'solana') {
+    if (networkType !== 'ripple' && networkType !== 'stellar') {
         return null;
     }
 
@@ -72,15 +72,6 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
         openNodeById(DESTINATION_TAG_GUIDE_PATH);
     };
 
-    let destinationTagMaxLength;
-    if (networkType === 'ripple') {
-        destinationTagMaxLength = formInputsMaxLength.xrpDestinationTag;
-    } else if (networkType === 'stellar') {
-        destinationTagMaxLength = formInputsMaxLength.stellarTextMemo;
-    } else if (networkType === 'solana') {
-        destinationTagMaxLength = formInputsMaxLength.solanaMemo;
-    }
-
     return (
         <Column gap={spacings.md}>
             <Row justifyContent="space-between">
@@ -105,7 +96,11 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
                         hasError={!!error}
                         data-testid={inputName}
                         defaultValue={inputValue}
-                        maxLength={destinationTagMaxLength}
+                        maxLength={
+                            networkType === 'ripple'
+                                ? formInputsMaxLength.xrpDestinationTag
+                                : formInputsMaxLength.stellarTextMemo
+                        }
                         label={<Translation id="DESTINATION_TAG" />}
                         bottomText={error?.message || null}
                         innerRef={inputRef}

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
@@ -32,7 +32,7 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
 
     const { networkType, name } = getNetwork(networkSymbol);
 
-    if (networkType !== 'ripple' && networkType !== 'stellar') {
+    if (networkType !== 'ripple' && networkType !== 'stellar' && networkType !== 'solana') {
         return null;
     }
 
@@ -72,6 +72,15 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
         openNodeById(DESTINATION_TAG_GUIDE_PATH);
     };
 
+    let destinationTagMaxLength;
+    if (networkType === 'ripple') {
+        destinationTagMaxLength = formInputsMaxLength.xrpDestinationTag;
+    } else if (networkType === 'stellar') {
+        destinationTagMaxLength = formInputsMaxLength.stellarTextMemo;
+    } else if (networkType === 'solana') {
+        destinationTagMaxLength = formInputsMaxLength.solanaMemo;
+    }
+
     return (
         <Column gap={spacings.md}>
             <Row justifyContent="space-between">
@@ -96,11 +105,7 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
                         hasError={!!error}
                         data-testid={inputName}
                         defaultValue={inputValue}
-                        maxLength={
-                            networkType === 'ripple'
-                                ? formInputsMaxLength.xrpDestinationTag
-                                : formInputsMaxLength.stellarTextMemo
-                        }
+                        maxLength={destinationTagMaxLength}
                         label={<Translation id="DESTINATION_TAG" />}
                         bottomText={error?.message || null}
                         innerRef={inputRef}

--- a/packages/suite/src/views/wallet/send/Options/Options.tsx
+++ b/packages/suite/src/views/wallet/send/Options/Options.tsx
@@ -14,7 +14,9 @@ export const Options = () => {
         <>
             {networkType === 'bitcoin' && <BitcoinOptions />}
             {networkType === 'ethereum' && <EthereumOptions />}
-            {(networkType === 'ripple' || networkType === 'stellar') && <MiscNetworkOptions />}
+            {(networkType === 'ripple' ||
+                networkType === 'stellar' ||
+                networkType === 'solana') && <MiscNetworkOptions />}
             {networkType === 'cardano' && <CardanoOptions />}
         </>
     );

--- a/packages/suite/src/views/wallet/send/Options/Options.tsx
+++ b/packages/suite/src/views/wallet/send/Options/Options.tsx
@@ -4,6 +4,7 @@ import { BitcoinOptions } from './BitcoinOptions/BitcoinOptions';
 import { CardanoOptions } from './CardanoOptions';
 import { EthereumOptions } from './EthereumOptions/EthereumOptions';
 import { MiscNetworkOptions } from './MiscNetworkOptions/MiscNetworkOptions';
+import { SolanaOptions } from './SolanaOptions/SolanaOptions';
 
 export const Options = () => {
     const {
@@ -14,9 +15,8 @@ export const Options = () => {
         <>
             {networkType === 'bitcoin' && <BitcoinOptions />}
             {networkType === 'ethereum' && <EthereumOptions />}
-            {(networkType === 'ripple' ||
-                networkType === 'stellar' ||
-                networkType === 'solana') && <MiscNetworkOptions />}
+            {(networkType === 'ripple' || networkType === 'stellar') && <MiscNetworkOptions />}
+            {networkType === 'solana' && <SolanaOptions />}
             {networkType === 'cardano' && <CardanoOptions />}
         </>
     );

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
@@ -1,6 +1,6 @@
 import { Translation } from '@suite/intl';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { Card, Column, H4, IconButton, Input, Row } from '@trezor/components';
+import { Card, Column, H4, IconButton, Row, Textarea } from '@trezor/components';
 
 import { useSendFormContext } from 'src/hooks/wallet';
 
@@ -11,7 +11,8 @@ type SolanaMemoProps = {
 export const SolanaMemo = ({ close }: SolanaMemoProps) => {
     const {
         register,
-        formState: { errors, isValid },
+        watch,
+        formState: { errors },
         getDefaultValue,
         composeTransaction,
         resetDefaultValue,
@@ -20,6 +21,8 @@ export const SolanaMemo = ({ close }: SolanaMemoProps) => {
     const inputName = 'destinationTag';
     const inputValue = getDefaultValue(inputName) || '';
     const error = errors[inputName];
+    const memoByteSize = Buffer.from(watch(inputName) || '', 'utf8').length;
+    const isMemoTooLong = memoByteSize > formInputsMaxLength.solanaMemo;
 
     const handleClose = () => {
         resetDefaultValue(inputName);
@@ -45,13 +48,17 @@ export const SolanaMemo = ({ close }: SolanaMemoProps) => {
                         onClick={handleClose}
                     />
                 </Row>
-                <Input
-                    hasError={!isValid}
+                <Textarea
+                    hasError={isMemoTooLong || !!error}
                     defaultValue={inputValue}
                     maxLength={formInputsMaxLength.solanaMemo}
                     bottomText={error?.message}
                     innerRef={inputRef}
                     {...inputField}
+                    characterCount={{
+                        current: memoByteSize,
+                        max: formInputsMaxLength.solanaMemo,
+                    }}
                 />
             </Column>
         </Card>

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
@@ -11,7 +11,7 @@ type SolanaMemoProps = {
 export const SolanaMemo = ({ close }: SolanaMemoProps) => {
     const {
         register,
-        formState: { errors },
+        formState: { errors, isValid },
         getDefaultValue,
         composeTransaction,
         resetDefaultValue,
@@ -35,23 +35,21 @@ export const SolanaMemo = ({ close }: SolanaMemoProps) => {
             <Column gap={12}>
                 <Row justifyContent="space-between">
                     <H4 typographyStyle="body-md">
-                        <Translation id="DESTINATION_TAG" />
+                        <Translation id="MEMO" />
                     </H4>
                     <IconButton
                         intent="neutral"
                         priority="secondary"
                         icon="x"
                         size="small"
-                        data-testid="send/close-solana-memo"
                         onClick={handleClose}
                     />
                 </Row>
                 <Input
-                    hasError={!!error}
-                    data-testid={inputName}
+                    hasError={!isValid}
                     defaultValue={inputValue}
                     maxLength={formInputsMaxLength.solanaMemo}
-                    bottomText={error?.message || null}
+                    bottomText={error?.message}
                     innerRef={inputRef}
                     {...inputField}
                 />

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaMemo.tsx
@@ -1,0 +1,61 @@
+import { Translation } from '@suite/intl';
+import { formInputsMaxLength } from '@suite-common/validators';
+import { Card, Column, H4, IconButton, Input, Row } from '@trezor/components';
+
+import { useSendFormContext } from 'src/hooks/wallet';
+
+type SolanaMemoProps = {
+    close: () => void;
+};
+
+export const SolanaMemo = ({ close }: SolanaMemoProps) => {
+    const {
+        register,
+        formState: { errors },
+        getDefaultValue,
+        composeTransaction,
+        resetDefaultValue,
+    } = useSendFormContext();
+
+    const inputName = 'destinationTag';
+    const inputValue = getDefaultValue(inputName) || '';
+    const error = errors[inputName];
+
+    const handleClose = () => {
+        resetDefaultValue(inputName);
+        close();
+    };
+
+    const { ref: inputRef, ...inputField } = register(inputName, {
+        onChange: () => composeTransaction(inputName),
+    });
+
+    return (
+        <Card>
+            <Column gap={12}>
+                <Row justifyContent="space-between">
+                    <H4 typographyStyle="body-md">
+                        <Translation id="DESTINATION_TAG" />
+                    </H4>
+                    <IconButton
+                        intent="neutral"
+                        priority="secondary"
+                        icon="x"
+                        size="small"
+                        data-testid="send/close-solana-memo"
+                        onClick={handleClose}
+                    />
+                </Row>
+                <Input
+                    hasError={!!error}
+                    data-testid={inputName}
+                    defaultValue={inputValue}
+                    maxLength={formInputsMaxLength.solanaMemo}
+                    bottomText={error?.message || null}
+                    innerRef={inputRef}
+                    {...inputField}
+                />
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaOptions.tsx
@@ -19,14 +19,8 @@ export const SolanaOptions = () => {
     return (
         <>
             {!memoEnabled && (
-                <Button
-                    intent="neutral"
-                    priority="secondary"
-                    iconLeft="tag"
-                    data-testid="send/open-solana-memo"
-                    onClick={toggleMemo}
-                >
-                    <Translation id="DESTINATION_TAG_SWITCH" />
+                <Button intent="neutral" priority="secondary" iconLeft="tag" onClick={toggleMemo}>
+                    <Translation id="MEMO_SWITCH" />
                 </Button>
             )}
 

--- a/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/SolanaOptions/SolanaOptions.tsx
@@ -1,0 +1,36 @@
+import { Translation } from '@suite/intl';
+import { Button } from '@trezor/components';
+
+import { useSendFormContext } from 'src/hooks/wallet';
+
+import { SolanaMemo } from './SolanaMemo';
+
+export const SolanaOptions = () => {
+    const { getDefaultValue, toggleOption, composeTransaction } = useSendFormContext();
+
+    const options = getDefaultValue('options', []);
+    const memoEnabled = options.includes('destinationTag');
+
+    const toggleMemo = () => {
+        toggleOption('destinationTag');
+        composeTransaction();
+    };
+
+    return (
+        <>
+            {!memoEnabled && (
+                <Button
+                    intent="neutral"
+                    priority="secondary"
+                    iconLeft="tag"
+                    data-testid="send/open-solana-memo"
+                    onClick={toggleMemo}
+                >
+                    <Translation id="DESTINATION_TAG_SWITCH" />
+                </Button>
+            )}
+
+            {memoEnabled && <SolanaMemo close={toggleMemo} />}
+        </>
+    );
+};

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -17,6 +17,7 @@
 @solana/keys
 @solana/kit
 @solana/rpc-api
+@solana-program/memo
 @solana/rpc-types
 @stellar/stellar-sdk
 @swc/core

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -13,11 +13,11 @@
 @solana-program/system
 @solana-program/token
 @solana-program/token-2022
+@solana-program/memo
 @solana/addresses
 @solana/keys
 @solana/kit
 @solana/rpc-api
-@solana-program/memo
 @solana/rpc-types
 @stellar/stellar-sdk
 @swc/core

--- a/suite-common/validators/src/inputsLengthConfig.ts
+++ b/suite-common/validators/src/inputsLengthConfig.ts
@@ -18,4 +18,5 @@ export const formInputsMaxLength = {
     xrpDestinationTag: 10, // max: 4294967295
 
     stellarTextMemo: 28, // https://developers.stellar.org/docs/learn/encyclopedia/transactions-specialized/memos
+    solanaMemo: 566, // https://www.solana-program.com/docs/memo
 } as const;

--- a/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormSolanaThunks.ts
@@ -221,6 +221,7 @@ export const composeSolanaTransactionFeeLevelsThunk = createThunk<
                 : undefined,
             blockHash,
             lastValidBlockHeight,
+            memo: formState.destinationTag || undefined,
             coin: account.symbol,
             identity: getAccountIdentity(account),
             priorityFees: {
@@ -369,6 +370,7 @@ export const signSolanaSendFormTransactionThunk = createThunk<
                 : undefined,
             blockHash,
             lastValidBlockHeight,
+            memo: formState.destinationTag || undefined,
             priorityFees: {
                 computeUnitPrice: precomposedTransaction.feePerByte,
                 computeUnitLimit: precomposedTransaction.feeLimit,

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -82,7 +82,7 @@ export interface FormState {
     ethereumDataAscii?: string;
     ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
     transactionData?: string; // used for solana serialized txn from trading api or ethereum txn hex data
-    destinationTag?: string; // For Ripple and Stellar
+    destinationTag?: string; // For Ripple, Stellar, and Solana
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;
     hasCoinControlBeenOpened: boolean;

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -480,6 +480,13 @@ const constructNewFlow = ({
         });
     }
 
+    if (isSolana && precomposedForm.destinationTag) {
+        outputs.push({
+            type: 'destination-tag',
+            value: precomposedForm.destinationTag,
+        });
+    }
+
     return outputs;
 };
 

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -528,9 +528,12 @@ export const restoreOrigOutputsOrder = (
         });
 };
 
-export const getDefaultValues = (currency: Output['currency']): FormState => ({
+export const getDefaultValues = (
+    currency: Output['currency'],
+    networkType?: NetworkType,
+): FormState => ({
     ...DEFAULT_VALUES,
-    options: ['broadcast', 'destinationTag'],
+    options: networkType === 'solana' ? ['broadcast'] : ['broadcast', 'destinationTag'],
     outputs: [{ ...DEFAULT_PAYMENT, currency }],
     selectedUtxos: [],
 });

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2422,6 +2422,16 @@ export const messages = {
                         primaryButton: 'I understand',
                     },
                 },
+                solana: {
+                    memo: {
+                        label: 'Memo',
+                        addButton: 'Add memo',
+                        editButton: 'Edit memo',
+                        inputPlaceholder: 'Enter your memo',
+                        saveButton: 'Save memo',
+                        removeButton: 'Remove memo',
+                    },
+                },
             },
         },
         tron: {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2168,6 +2168,7 @@ export const messages = {
                 broadcast: 'Broadcast',
                 transactionId: 'Transaction ID',
                 transactionIdCopied: 'Transaction ID copied',
+                memo: 'Memo',
                 ethereum: {
                     gasLimit: 'Gas limit',
                     gasUsed: 'Gas used',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2169,6 +2169,7 @@ export const messages = {
                 transactionId: 'Transaction ID',
                 transactionIdCopied: 'Transaction ID copied',
                 memo: 'Memo',
+                memoCopied: 'Memo copied',
                 ethereum: {
                     gasLimit: 'Gas limit',
                     gasUsed: 'Gas used',

--- a/suite-native/module-send/src/components/RecipientInputs.tsx
+++ b/suite-native/module-send/src/components/RecipientInputs.tsx
@@ -9,6 +9,7 @@ import { CardDivider, VStack } from '@suite-native/atoms';
 import { AddressInput } from './AddressInput';
 import { AmountInputs } from './AmountInputs';
 import { DestinationTagInput } from './DestinationTagInput';
+import { SolanaMemoInput } from './SolanaMemoInput';
 
 type RecipientInputsProps = {
     index: number;
@@ -21,10 +22,7 @@ export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => 
 
     if (!account) return null;
 
-    const hasDestinationTag =
-        account.networkType === 'ripple' ||
-        account.networkType === 'stellar' ||
-        account.networkType === 'solana';
+    const hasDestinationTag = account.networkType === 'ripple' || account.networkType === 'stellar';
 
     return (
         <VStack spacing="sp16">
@@ -36,6 +34,14 @@ export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => 
                     <VStack spacing="sp16">
                         <CardDivider />
                         <DestinationTagInput networkSymbol={account.symbol} />
+                    </VStack>
+                </Animated.View>
+            )}
+            {account.networkType === 'solana' && (
+                <Animated.View layout={LinearTransition}>
+                    <VStack spacing="sp16">
+                        <CardDivider />
+                        <SolanaMemoInput />
                     </VStack>
                 </Animated.View>
             )}

--- a/suite-native/module-send/src/components/RecipientInputs.tsx
+++ b/suite-native/module-send/src/components/RecipientInputs.tsx
@@ -21,7 +21,10 @@ export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => 
 
     if (!account) return null;
 
-    const hasDestinationTag = account.networkType === 'ripple' || account.networkType === 'stellar';
+    const hasDestinationTag =
+        account.networkType === 'ripple' ||
+        account.networkType === 'stellar' ||
+        account.networkType === 'solana';
 
     return (
         <VStack spacing="sp16">

--- a/suite-native/module-send/src/components/RecipientInputs.tsx
+++ b/suite-native/module-send/src/components/RecipientInputs.tsx
@@ -9,7 +9,6 @@ import { CardDivider, VStack } from '@suite-native/atoms';
 import { AddressInput } from './AddressInput';
 import { AmountInputs } from './AmountInputs';
 import { DestinationTagInput } from './DestinationTagInput';
-import { SolanaMemoInput } from './SolanaMemoInput';
 
 type RecipientInputsProps = {
     index: number;
@@ -34,14 +33,6 @@ export const RecipientInputs = ({ index, accountKey }: RecipientInputsProps) => 
                     <VStack spacing="sp16">
                         <CardDivider />
                         <DestinationTagInput networkSymbol={account.symbol} />
-                    </VStack>
-                </Animated.View>
-            )}
-            {account.networkType === 'solana' && (
-                <Animated.View layout={LinearTransition}>
-                    <VStack spacing="sp16">
-                        <CardDivider />
-                        <SolanaMemoInput />
                     </VStack>
                 </Animated.View>
             )}

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -1,6 +1,7 @@
 import { useFieldArray } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
+import { getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountFormattedBalance,
@@ -17,6 +18,7 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { RecipientInputs } from './RecipientInputs';
+import { SolanaMemoInput } from './SolanaMemoInput';
 import { TronAccountActivationInfo } from './TronAccountActivationInfo';
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
 import { CorrectNetworkMessageCard } from './CorrectNetworkMessageCard';
@@ -78,6 +80,7 @@ export const SendOutputFields = ({
                     <TronAccountActivationInfo accountKey={accountKey} />
                 </VStack>
             </Card>
+            {symbol && getNetworkType(symbol) === 'solana' && <SolanaMemoInput />}
         </VStack>
     );
 };

--- a/suite-native/module-send/src/components/SolanaMemoInput.tsx
+++ b/suite-native/module-send/src/components/SolanaMemoInput.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { Button, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { TextInputField, useFormContext } from '@suite-native/forms';
+import { Translation } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { type SendFieldName, type SendOutputsFormValues } from '../sendOutputsFormSchema';
+
+const wrapperStyle = prepareNativeStyle(utils => ({
+    gap: utils.spacings.sp12,
+}));
+
+export const SolanaMemoInput = () => {
+    const [isMemoOpen, setIsMemoOpen] = useState(false);
+    const { setValue } = useFormContext<SendOutputsFormValues>();
+    const { applyStyle } = useNativeStyles();
+
+    const memoFieldName: SendFieldName = 'destinationTag';
+
+    const handleClose = () => {
+        setValue(memoFieldName, '');
+        setIsMemoOpen(false);
+    };
+
+    if (!isMemoOpen) {
+        return (
+            <Button
+                iconLeft="tag"
+                intent="neutral"
+                priority="secondary"
+                onPress={() => setIsMemoOpen(true)}
+            >
+                <Translation id="moduleSend.outputs.recipients.destinationTag.label" />
+            </Button>
+        );
+    }
+
+    return (
+        <VStack style={applyStyle(wrapperStyle)}>
+            <HStack justifyContent="space-between" alignItems="center">
+                <Text variant="body-sm">
+                    <Translation id="moduleSend.outputs.recipients.destinationTag.label" />
+                </Text>
+                <IconButton
+                    iconName="x"
+                    intent="neutral"
+                    priority="secondary"
+                    onPress={handleClose}
+                />
+            </HStack>
+            <TextInputField name={memoFieldName} />
+        </VStack>
+    );
+};

--- a/suite-native/module-send/src/components/SolanaMemoInput.tsx
+++ b/suite-native/module-send/src/components/SolanaMemoInput.tsx
@@ -1,55 +1,121 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
-import { Button, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
-import { TextInputField, useFormContext } from '@suite-native/forms';
-import { Translation } from '@suite-native/intl';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { formInputsMaxLength } from '@suite-common/validators';
+import {
+    BottomSheetModal,
+    Button,
+    Card,
+    HStack,
+    IconButton,
+    Input,
+    Text,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
+import { useFormContext } from '@suite-native/forms';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { type SendFieldName, type SendOutputsFormValues } from '../sendOutputsFormSchema';
 
-const wrapperStyle = prepareNativeStyle(utils => ({
-    gap: utils.spacings.sp12,
-}));
-
 export const SolanaMemoInput = () => {
-    const [isMemoOpen, setIsMemoOpen] = useState(false);
-    const { setValue } = useFormContext<SendOutputsFormValues>();
-    const { applyStyle } = useNativeStyles();
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { translate } = useTranslate();
+    const [localMemo, setLocalMemo] = useState('');
 
     const memoFieldName: SendFieldName = 'destinationTag';
+    const currentMemo = watch(memoFieldName) ?? '';
+    const memoByteSize = Buffer.from(localMemo, 'utf8').length;
 
-    const handleClose = () => {
-        setValue(memoFieldName, '');
-        setIsMemoOpen(false);
+    const handleOpen = () => {
+        setLocalMemo(currentMemo);
+        openModal();
     };
 
-    if (!isMemoOpen) {
-        return (
-            <Button
-                iconLeft="tag"
-                intent="neutral"
-                priority="secondary"
-                onPress={() => setIsMemoOpen(true)}
-            >
-                <Translation id="moduleSend.outputs.recipients.destinationTag.label" />
-            </Button>
-        );
-    }
+    const handleSave = () => {
+        setValue(memoFieldName, localMemo);
+        closeModal();
+    };
+
+    const handleRemove = () => {
+        setValue(memoFieldName, '');
+        setLocalMemo('');
+        closeModal();
+    };
 
     return (
-        <VStack style={applyStyle(wrapperStyle)}>
-            <HStack justifyContent="space-between" alignItems="center">
-                <Text variant="body-sm">
-                    <Translation id="moduleSend.outputs.recipients.destinationTag.label" />
-                </Text>
-                <IconButton
-                    iconName="x"
+        <>
+            {currentMemo ? (
+                <Card>
+                    <HStack alignItems="center">
+                        <VStack spacing="sp2" flex={1}>
+                            <Text variant="body-sm">
+                                <Translation id="moduleSend.outputs.recipients.solana.memo.label" />
+                            </Text>
+                            <Text variant="body-sm" color="contentSecondary" numberOfLines={1}>
+                                {currentMemo}
+                            </Text>
+                        </VStack>
+                        <IconButton
+                            iconName="pencilSimpleLine"
+                            intent="neutral"
+                            priority="secondary"
+                            onPress={handleOpen}
+                        />
+                    </HStack>
+                </Card>
+            ) : (
+                <Button
+                    iconLeft="pencilSimpleLine"
                     intent="neutral"
                     priority="secondary"
-                    onPress={handleClose}
-                />
-            </HStack>
-            <TextInputField name={memoFieldName} />
-        </VStack>
+                    onPress={handleOpen}
+                >
+                    <Translation id="moduleSend.outputs.recipients.solana.memo.addButton" />
+                </Button>
+            )}
+            <BottomSheetModal
+                ref={bottomSheetRef}
+                title={<Translation id="moduleSend.outputs.recipients.solana.memo.label" />}
+                isCloseDisplayed
+                onClose={closeModal}
+            >
+                <VStack spacing="sp16">
+                    <VStack spacing="sp4">
+                        <Input
+                            value={localMemo}
+                            onChangeText={setLocalMemo}
+                            placeholder={translate(
+                                'moduleSend.outputs.recipients.solana.memo.inputPlaceholder',
+                            )}
+                            maxLength={formInputsMaxLength.solanaMemo}
+                            asBottomSheetInput
+                        />
+                        <Text
+                            variant="body-xs"
+                            color={
+                                memoByteSize > formInputsMaxLength.solanaMemo
+                                    ? 'contentCritical'
+                                    : 'contentSecondary'
+                            }
+                            textAlign="left"
+                        >
+                            {memoByteSize}/{formInputsMaxLength.solanaMemo} bytes
+                        </Text>
+                    </VStack>
+                    <Button
+                        onPress={handleSave}
+                        isDisabled={memoByteSize > formInputsMaxLength.solanaMemo}
+                    >
+                        <Translation id="moduleSend.outputs.recipients.solana.memo.saveButton" />
+                    </Button>
+                    {currentMemo && (
+                        <Button intent="neutral" priority="secondary" onPress={handleRemove}>
+                            <Translation id="moduleSend.outputs.recipients.solana.memo.removeButton" />
+                        </Button>
+                    )}
+                </VStack>
+            </BottomSheetModal>
+        </>
     );
 };

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -289,7 +289,7 @@ export const sendOutputsFormValidationSchema = yup.object({
 
                 if (!symbol) return true;
                 const networkType = getNetworkType(symbol);
-                if (networkType === 'stellar') return true;
+                if (networkType === 'stellar' || networkType === 'solana') return true;
 
                 if (!value) return true;
 
@@ -312,7 +312,12 @@ export const sendOutputsFormValidationSchema = yup.object({
 
                 if (!symbol) return true;
                 const networkType = getNetworkType(symbol);
-                if (networkType !== 'ripple' && networkType !== 'stellar') return true;
+                if (
+                    networkType !== 'ripple' &&
+                    networkType !== 'stellar' &&
+                    networkType !== 'solana'
+                )
+                    return true;
 
                 // isDestinationTagEnabled is enabled, tag should be set
                 if (!value && isDestinationTagEnabled) return false;
@@ -347,11 +352,16 @@ export const sendOutputsFormValidationSchema = yup.object({
                 const { symbol } = context!;
 
                 if (!symbol) return true;
-                if (getNetworkType(symbol) !== 'stellar') return true;
+                const networkType = getNetworkType(symbol);
+                if (networkType !== 'stellar' && networkType !== 'solana') return true;
 
                 if (!value) return true;
 
-                if (value.length > formInputsMaxLength.stellarTextMemo) {
+                const destinationTagMaxLength =
+                    networkType === 'stellar'
+                        ? formInputsMaxLength.stellarTextMemo
+                        : formInputsMaxLength.solanaMemo;
+                if (value.length > destinationTagMaxLength) {
                     return false;
                 }
 

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -357,15 +357,18 @@ export const sendOutputsFormValidationSchema = yup.object({
 
                 if (!value) return true;
 
-                const destinationTagMaxLength =
-                    networkType === 'stellar'
-                        ? formInputsMaxLength.stellarTextMemo
-                        : formInputsMaxLength.solanaMemo;
-                if (value.length > destinationTagMaxLength) {
-                    return false;
-                }
+                const destinationTagMaxLength = (() => {
+                    switch (networkType) {
+                        case 'stellar':
+                            return formInputsMaxLength.stellarTextMemo;
+                        case 'solana':
+                            return formInputsMaxLength.solanaMemo;
+                        default:
+                            throw new Error(`Unsupported network type: ${networkType}`);
+                    }
+                })();
 
-                return true;
+                return value.length <= destinationTagMaxLength;
             },
         ),
     setMaxOutputId: yup.number(),

--- a/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
@@ -156,6 +156,18 @@ export const TransactionDetailParametersSheet = ({
                     </TransactionDetailRow>
                 </Card>
 
+                {transaction.solanaSpecific?.memo && (
+                    <Card>
+                        <TransactionDetailRow
+                            title={translate(
+                                'transactions.TransactionDetailScreen.parametersSheet.memo',
+                            )}
+                        >
+                            {transaction.solanaSpecific.memo}
+                        </TransactionDetailRow>
+                    </Card>
+                )}
+
                 {parametersCardIsDisplayed && (
                     <Card>
                         {displayedParameters.includes('ethereumSpecific') &&

--- a/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
@@ -163,7 +163,31 @@ export const TransactionDetailParametersSheet = ({
                                 'transactions.TransactionDetailScreen.parametersSheet.memo',
                             )}
                         >
-                            {transaction.solanaSpecific.memo}
+                            <Box
+                                flexDirection="row"
+                                alignItems="center"
+                                paddingLeft="sp16"
+                                justifyContent="flex-end"
+                            >
+                                <Text numberOfLines={1} style={{ flexShrink: 1 }}>
+                                    {transaction.solanaSpecific.memo}
+                                </Text>
+                                <Box marginLeft="sp8">
+                                    <IconButton
+                                        iconName="copy"
+                                        onPress={() =>
+                                            copyToClipboard(
+                                                transaction.solanaSpecific!.memo!,
+                                                translate(
+                                                    'transactions.TransactionDetailScreen.parametersSheet.memoCopied',
+                                                ),
+                                            )
+                                        }
+                                        intent="neutral"
+                                        priority="secondary"
+                                    />
+                                </Box>
+                            </Box>
                         </TransactionDetailRow>
                     </Card>
                 )}

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11624,4 +11624,12 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_CLAIM_MODAL_SUBTITLE',
         defaultMessage: 'Select an account to claim rewards.',
     },
+    MEMO: {
+        id: 'MEMO',
+        defaultMessage: 'Memo',
+    },
+    MEMO_SWITCH: {
+        id: 'MEMO_SWITCH',
+        defaultMessage: 'Add memo',
+    },
 } as const);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9885,6 +9885,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@solana-program/memo@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@solana-program/memo@npm:0.7.0"
+  peerDependencies:
+    "@solana/kit": ^2.1.0
+  checksum: 10/f3db6462a02d78d77e609fe3fde6c4d2dd7604f3985f9dd711125e377133131f5f5c5623b4a001cfca3ecf4d9a690732aef0ad7efaad4a38307e1d731b797f6c
+  languageName: node
+  linkType: hard
+
 "@solana-program/stake@npm:^0.2.1":
   version: 0.2.1
   resolution: "@solana-program/stake@npm:0.2.1"
@@ -16092,6 +16101,7 @@ __metadata:
     "@scure/base": "npm:^1.2.6"
     "@scure/bip39": "npm:^1.5.1"
     "@solana-program/compute-budget": "npm:^0.8.0"
+    "@solana-program/memo": "npm:^0.7.0"
     "@solana-program/system": "npm:^0.7.0"
     "@solana-program/token": "npm:^0.5.1"
     "@solana-program/token-2022": "npm:^0.4.2"


### PR DESCRIPTION
## Description

~~Add the existing MiscNetworkOptions/DestinationTag (From XRP and XLM) to Solana transactions and pass the value into the Solana transaction builder~~

Add memo options to the Solana send form and show memos in the tx detail/send modals

## Related Issue

Resolve #26260 

## Screenshots:
<img width="2383" height="1485" alt="image" src="https://github.com/user-attachments/assets/460d502c-7463-4aee-a598-1ee360c1a668" />
<br>
<img width="432" height="969" alt="Screenshot_20260421-203852" src="https://github.com/user-attachments/assets/897b495e-bca9-4c2b-a530-dd0ae2dd765c" />



