### PR TITLE
refactor(suite-native): redesign Badge component for new design system

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -51,7 +51,6 @@ const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
 
     return (
         <Badge
-            elevation="1"
             size="small"
             label={<Translation id="accountList.numberOfTokens" values={{ numberOfTokens }} />}
         />
@@ -165,9 +164,7 @@ export const AccountsListItem = ({
             title={title}
             badges={
                 <>
-                    {formattedAccountType && (
-                        <Badge label={formattedAccountType} size="small" elevation="1" />
-                    )}
+                    {formattedAccountType && <Badge label={formattedAccountType} size="small" />}
                     {shouldShowStakingBadge && (
                         <StakingBadge networkSymbol={account.symbol} account={account} />
                     )}

--- a/suite-native/accounts/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/accounts/src/components/SelectableNetworkItem.tsx
@@ -59,7 +59,7 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
                                 <Box style={applyStyle(tokensBadgeStyle)}>
                                     <Badge
                                         label={<Translation id="generic.tokens" />}
-                                        variant="neutral"
+                                        intent="neutral"
                                         size="small"
                                     />
                                 </Box>

--- a/suite-native/accounts/src/components/TokenReceiveCard.tsx
+++ b/suite-native/accounts/src/components/TokenReceiveCard.tsx
@@ -68,7 +68,6 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
                                 />
                             }
                             size="small"
-                            iconSize="extraSmall"
                         />
                     </Box>
                 </Box>

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -135,11 +135,7 @@ export const AssetItem = React.memo(({ cryptoCurrencySymbol, onPress }: AssetIte
                         <StakingBadge networkSymbol={cryptoCurrencySymbol} />
                     )}
                     {hasAnyTokensWithBalance && (
-                        <Badge
-                            elevation="1"
-                            size="small"
-                            label={<Translation id="generic.tokens" />}
-                        />
+                        <Badge size="small" label={<Translation id="generic.tokens" />} />
                     )}
                 </>
             }

--- a/suite-native/atoms/src/Badge.tsx
+++ b/suite-native/atoms/src/Badge.tsx
@@ -4,23 +4,21 @@ import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config
 import { CryptoIcon, Icon, type IconName, type IconSize, icons } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
-import { isNotNullOrUndefined } from '@trezor/utils';
 
 import { type BoxProps } from './Box';
 import { HStack } from './Stack';
 import { Text } from './Text';
-import { type SurfaceElevation } from './types';
 
-export const BADGE_VARIANTS = [
+export const BADGE_INTENTS = [
     'neutral',
-    'green',
-    'greenSubtle',
-    'yellow',
-    'red',
-    'blue',
+    'brand',
+    'brandBold',
+    'warning',
+    'critical',
+    'info',
     'bold',
 ] as const;
-export type BadgeVariant = (typeof BADGE_VARIANTS)[number];
+export type BadgeIntent = (typeof BADGE_INTENTS)[number];
 
 export const BADGE_SIZES = ['small', 'medium'] as const;
 export type BadgeSize = (typeof BADGE_SIZES)[number];
@@ -28,132 +26,74 @@ export type BadgeSize = (typeof BADGE_SIZES)[number];
 type IconType = IconName | NetworkSymbol;
 export type BadgeProps = {
     label: ReactNode;
-    variant?: BadgeVariant;
+    intent?: BadgeIntent;
     size?: BadgeSize;
     icon?: IconType;
-    iconSize?: IconSize;
-    elevation?: SurfaceElevation;
-    isDisabled?: boolean;
 } & BoxProps;
 
 type BadgeStyle = {
-    backgroundColorElevation0: Color;
-    backgroundColorElevation1: Color;
-    activeTextColor: Color;
-    activeIconColor: Color;
-    borderColor?: Color;
+    backgroundColor: Color;
+    textColor: Color;
 };
 
 type BadgeStyleProps = {
     backgroundColor: Color;
-    isDisabled: boolean;
     size?: BadgeSize;
-    borderColor?: Color;
 };
 
-const badgeStyle = prepareNativeStyle<BadgeStyleProps>(
-    (utils, { backgroundColor, isDisabled, size, borderColor }) => ({
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: utils.colors[backgroundColor],
-        paddingHorizontal: utils.spacings.sp8 - (size === 'medium' ? 0 : 2),
-        paddingVertical: utils.spacings.sp2,
-        borderRadius: utils.borders.radii.round,
-        extend: [
-            {
-                condition: isDisabled,
-                style: {
-                    backgroundColor: utils.colors.legacyBackgroundNeutralSubtleOnElevation0,
-                },
-            },
-            {
-                condition: isNotNullOrUndefined(borderColor),
-                style: {
-                    borderColor: utils.colors[borderColor!],
-                    borderWidth: utils.borders.widths.small,
-                },
-            },
-        ],
-    }),
-);
+const badgeStyle = prepareNativeStyle<BadgeStyleProps>((utils, { backgroundColor, size }) => ({
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: utils.colors[backgroundColor],
+    paddingHorizontal: size === 'medium' ? utils.spacings.sp8 : utils.spacings.sp6,
+    paddingVertical: utils.spacings.sp2,
+    borderRadius: utils.borders.radii.round,
+}));
 
-const badgeVariantToStylePropsMap = {
+const badgeIntentToStylePropsMap = {
     neutral: {
-        backgroundColorElevation0: 'legacyBackgroundNeutralSubtleOnElevation0',
-        backgroundColorElevation1: 'legacyBackgroundNeutralSubtleOnElevation1',
-        activeTextColor: 'contentSecondary',
-        activeIconColor: 'contentSecondary',
-        borderColor: undefined,
+        backgroundColor: 'legacyBackgroundNeutralSubtleOnElevation0',
+        textColor: 'contentSecondary',
     },
-    green: {
-        backgroundColorElevation0: 'legacyBackgroundPrimaryDefault',
-        backgroundColorElevation1: 'legacyBackgroundPrimaryDefault',
-        activeTextColor: 'contentButtonBrandPrimary',
-        activeIconColor: 'contentButtonBrandPrimary',
-        borderColor: undefined,
+    brand: {
+        backgroundColor: 'legacyBackgroundPrimarySubtleOnElevation0',
+        textColor: 'contentBrand',
     },
-    greenSubtle: {
-        backgroundColorElevation0: 'legacyBackgroundPrimarySubtleOnElevation0',
-        backgroundColorElevation1: 'legacyBackgroundPrimarySubtleOnElevation1',
-        activeTextColor: 'contentBrand',
-        activeIconColor: 'contentBrand',
-        borderColor: undefined,
+    brandBold: {
+        backgroundColor: 'legacyBackgroundPrimaryDefault',
+        textColor: 'contentPrimaryInverse',
     },
-    yellow: {
-        backgroundColorElevation0: 'legacyBackgroundAlertYellowSubtleOnElevation0',
-        backgroundColorElevation1: 'legacyBackgroundAlertYellowSubtleOnElevation1',
-        activeTextColor: 'contentWarning',
-        activeIconColor: 'contentWarning',
-        borderColor: 'legacyBackgroundAlertYellowSubtleOnElevationNegative',
+    warning: {
+        backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation0',
+        textColor: 'contentWarning',
     },
-    red: {
-        backgroundColorElevation0: 'legacyBackgroundAlertRedSubtleOnElevation0',
-        backgroundColorElevation1: 'legacyBackgroundAlertRedSubtleOnElevation1',
-        activeTextColor: 'contentCritical',
-        activeIconColor: 'contentCritical',
-        borderColor: undefined,
+    critical: {
+        backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation0',
+        textColor: 'contentCritical',
     },
-    blue: {
-        backgroundColorElevation0: 'legacyBackgroundAlertBlueSubtleOnElevation0',
-        backgroundColorElevation1: 'legacyBackgroundAlertBlueSubtleOnElevation1',
-        activeTextColor: 'contentInfo',
-        activeIconColor: 'contentInfo',
-        borderColor: undefined,
+    info: {
+        backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation0',
+        textColor: 'contentInfo',
     },
     bold: {
-        backgroundColorElevation0: 'legacyBackgroundNeutralBold',
-        backgroundColorElevation1: 'legacyBackgroundNeutralBold',
-        activeTextColor: 'contentButtonBrandPrimary',
-        activeIconColor: 'contentButtonBrandPrimary',
-        borderColor: undefined,
+        backgroundColor: 'legacyBackgroundNeutralBold',
+        textColor: 'contentPrimaryInverse',
     },
-} as const satisfies Record<BadgeVariant, BadgeStyle>;
+} as const satisfies Record<BadgeIntent, BadgeStyle>;
 
 export const Badge = ({
     label,
     icon,
-    iconSize,
     size = 'medium',
-    variant = 'neutral',
-    elevation = '0',
-    isDisabled = false,
+    intent = 'neutral',
     style,
     ...boxProps
 }: BadgeProps) => {
     const { applyStyle, utils } = useNativeStyles();
-    const {
-        backgroundColorElevation0,
-        backgroundColorElevation1,
-        activeTextColor,
-        activeIconColor,
-        borderColor,
-    } = badgeVariantToStylePropsMap[variant];
+    const { backgroundColor, textColor } = badgeIntentToStylePropsMap[intent];
 
     const textVariant = size === 'medium' ? 'body-sm' : 'body-xs';
-    const textColor = isDisabled ? 'contentDisabled' : activeTextColor;
-    const iconColor = isDisabled ? 'contentDisabled' : activeIconColor;
-    const backgroundColor =
-        elevation === '0' ? backgroundColorElevation0 : backgroundColorElevation1;
+    const iconSize: IconSize = size === 'small' ? 'medium' : 'mediumLarge';
 
     const getCryptoIcon = (iconInput: IconType) =>
         isNetworkSymbol(iconInput) ? (
@@ -162,7 +102,7 @@ export const Badge = ({
 
     const getBadgeIcon = (iconInput: IconType) =>
         iconInput in icons ? (
-            <Icon name={icon as IconName} color={iconColor} size={iconSize ?? 'small'} />
+            <Icon name={icon as IconName} color={textColor} size={iconSize} />
         ) : (
             getCryptoIcon(iconInput)
         );
@@ -172,9 +112,7 @@ export const Badge = ({
             style={[
                 applyStyle(badgeStyle, {
                     backgroundColor,
-                    isDisabled,
                     size,
-                    borderColor,
                 }),
                 style,
             ]}

--- a/suite-native/atoms/src/PriceChangeBadge.tsx
+++ b/suite-native/atoms/src/PriceChangeBadge.tsx
@@ -1,6 +1,6 @@
 import { type IconName } from '@suite-native/icons';
 
-import { Badge, type BadgeVariant } from './Badge';
+import { Badge, type BadgeIntent } from './Badge';
 import { BoxSkeleton } from './Skeleton/BoxSkeleton';
 
 export type PriceChangeBadgeProps = {
@@ -18,20 +18,12 @@ export const PriceChangeBadge = ({ valuePercentageChange }: PriceChangeBadgeProp
     const priceHasIncreased = percentageChange >= 0;
 
     const icon: IconName = priceHasIncreased ? 'caretUpFilled' : 'caretDownFilled';
-    const badgeVariant: BadgeVariant = priceHasIncreased ? 'greenSubtle' : 'red';
+    const badgeVariant: BadgeIntent = priceHasIncreased ? 'brand' : 'critical';
     const formattedPercentage = percentFormatter.format(percentageChange);
 
     if (valuePercentageChange == null) {
         return <BoxSkeleton width={70} height={24} borderRadius={12} />;
     }
 
-    return (
-        <Badge
-            icon={icon}
-            iconSize="medium"
-            size="medium"
-            variant={badgeVariant}
-            label={formattedPercentage}
-        />
-    );
+    return <Badge icon={icon} size="medium" intent={badgeVariant} label={formattedPercentage} />;
 };

--- a/suite-native/atoms/src/SelectableItem.tsx
+++ b/suite-native/atoms/src/SelectableItem.tsx
@@ -79,7 +79,7 @@ export const SelectableItem = ({
                         <View style={applyStyle(badgeWrapperStyle)}>
                             <Badge
                                 key="defaultType"
-                                variant="greenSubtle"
+                                intent="brand"
                                 label={<Translation id="generic.default" />}
                                 icon="checkCircle"
                             />

--- a/suite-native/atoms/src/stories/Badge.stories.tsx
+++ b/suite-native/atoms/src/stories/Badge.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
 
-import { ICON_NAMES, ICON_SIZES } from '@suite-native/icons';
+import { ICON_NAMES } from '@suite-native/icons';
 
-import { BADGE_SIZES, BADGE_VARIANTS, Badge as BadgeComponent, type BadgeProps } from '../Badge';
-import { SURFACE_ELEVATIONS } from '../types';
+import { BADGE_INTENTS, BADGE_SIZES, Badge as BadgeComponent, type BadgeProps } from '../Badge';
 
 type BadgeStory = StoryObj<BadgeProps>;
 
@@ -19,20 +18,17 @@ export const Badge: BadgeStory = {
     name: 'Badge',
     args: {
         label: 'badge',
-        variant: 'green',
+        intent: 'brandBold',
         size: 'medium',
         icon: undefined,
-        iconSize: 'small',
-        elevation: '0',
-        isDisabled: false,
     },
     argTypes: {
         label: {
             control: { type: 'text' },
         },
-        variant: {
+        intent: {
             control: { type: 'select' },
-            options: BADGE_VARIANTS,
+            options: BADGE_INTENTS,
         },
         icon: {
             control: { type: 'select' },
@@ -41,17 +37,6 @@ export const Badge: BadgeStory = {
         size: {
             control: { type: 'select' },
             options: BADGE_SIZES,
-        },
-        iconSize: {
-            control: { type: 'select' },
-            options: ICON_SIZES,
-        },
-        elevation: {
-            control: { type: 'select' },
-            options: SURFACE_ELEVATIONS,
-        },
-        isDisabled: {
-            control: { type: 'boolean' },
         },
     },
 };

--- a/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
+++ b/suite-native/firmware/src/components/FirmwareLanguageCard.tsx
@@ -24,7 +24,7 @@ type NavigationProps = StackNavigationProps<
 >;
 
 const BetaBadge = () => (
-    <Badge label={<Translation id="firmware.languageCard.betaBadge" />} variant="blue" />
+    <Badge label={<Translation id="firmware.languageCard.betaBadge" />} intent="info" />
 );
 
 export const FirmwareLanguageCard = () => {

--- a/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectSessionPopupScreen.tsx
@@ -123,7 +123,7 @@ export const WalletConnectSessionPopupScreen = () => {
                                         pendingProposal?.validation === 'VALID' && (
                                             <Badge
                                                 icon="check"
-                                                variant="greenSubtle"
+                                                intent="brand"
                                                 label={
                                                     <Translation id="moduleConnectPopup.walletConnect.serviceStatus.verified" />
                                                 }
@@ -133,7 +133,7 @@ export const WalletConnectSessionPopupScreen = () => {
                                         pendingProposal?.validation === 'UNKNOWN' && (
                                             <Badge
                                                 icon="question"
-                                                variant="neutral"
+                                                intent="neutral"
                                                 label={
                                                     <Translation id="moduleConnectPopup.walletConnect.serviceStatus.unknown" />
                                                 }
@@ -143,7 +143,7 @@ export const WalletConnectSessionPopupScreen = () => {
                                         pendingProposal?.validation === 'INVALID') && (
                                         <Badge
                                             icon="warning"
-                                            variant="red"
+                                            intent="critical"
                                             label={
                                                 <Translation id="moduleConnectPopup.walletConnect.serviceStatus.dangerous" />
                                             }

--- a/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
+++ b/suite-native/module-dev-utils/src/components/AnalyticsLogging.tsx
@@ -65,7 +65,7 @@ export const AnalyticsLogging = () => {
     const renderAnalyticsDisabledBadge = () => (
         <Badge
             label="Enable analytics to see the events."
-            variant="yellow"
+            intent="warning"
             icon="info"
             size="small"
         />

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 
 import {
     Badge,
-    type BadgeVariant,
+    type BadgeIntent,
     Box,
     Button,
     type ButtonColorProps,
@@ -107,12 +107,12 @@ export const DemoScreen = () => {
     ] satisfies { label: string; buttonColorProps: ButtonColorProps }[];
     const badgeVariants = [
         'neutral',
-        'green',
-        'greenSubtle',
-        'yellow',
-        'red',
+        'brandBold',
+        'brand',
+        'warning',
+        'critical',
         'bold',
-    ] satisfies BadgeVariant[];
+    ] satisfies BadgeIntent[];
 
     const handleRadioPress = (value: string | number) => {
         setRadioChecked(value.toString());
@@ -129,13 +129,12 @@ export const DemoScreen = () => {
                         {badgeVariants.map(badgeVariant => (
                             <Badge
                                 key={badgeVariant}
-                                variant={badgeVariant}
+                                intent={badgeVariant}
                                 label={badgeVariant}
                                 icon="question"
-                                elevation="0"
                             />
                         ))}
-                        <Badge key="disabled" label="disabled" icon="question" isDisabled />
+                        <Badge key="disabled" label="disabled" icon="question" />
                     </HStack>
                 </VStack>
                 <VStack>

--- a/suite-native/module-earn/src/components/ChooseAccountItem.tsx
+++ b/suite-native/module-earn/src/components/ChooseAccountItem.tsx
@@ -44,9 +44,7 @@ export const ChooseAccountItem = ({
             icon={<CryptoIcon symbol={account.symbol} />}
             title={<AccountLabel account={account} />}
             badges={
-                formattedAccountType ? (
-                    <Badge label={formattedAccountType} size="small" elevation="1" />
-                ) : null
+                formattedAccountType ? <Badge label={formattedAccountType} size="small" /> : null
             }
             mainValue={
                 <CryptoAmountFormatter

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -45,9 +45,7 @@ const EarnItemSecondaryDescription = ({
                 <Text color="contentSecondary" variant="body-sm">
                     {accountLabel}
                 </Text>
-                {formattedAccountType && (
-                    <Badge label={formattedAccountType} size="small" elevation="1" />
-                )}
+                {formattedAccountType && <Badge label={formattedAccountType} size="small" />}
             </HStack>
         );
     }

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -116,7 +116,7 @@ export const StakingManagementStakedCard = ({
                     </Text>
                     <Badge
                         label={<Translation id="earn.stakingManagementScreen.autoRestakedBadge" />}
-                        variant="greenSubtle"
+                        intent="brand"
                         size="small"
                     />
                 </HStack>

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.tsx
@@ -87,11 +87,11 @@ export const BuyFormFieldErrorBadge = ({ fieldName, children }: BuyFormFieldErro
 
     if (!isLoading) {
         if (hasError) {
-            return <Badge label={errorMessage} variant="red" size="small" />;
+            return <Badge label={errorMessage} intent="critical" size="small" />;
         }
 
         if (mismatchedAmountMessage) {
-            return <Badge label={mismatchedAmountMessage} variant="neutral" size="small" />;
+            return <Badge label={mismatchedAmountMessage} intent="neutral" size="small" />;
         }
     }
 

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.tsx
@@ -40,7 +40,7 @@ export const ExchangeSendAmountBadge = () => {
 
     const { errorMessage, hasError, value } = useField({ name: 'sendCryptoAmount' });
     if (!isLoading && hasError) {
-        return <Badge label={errorMessage} variant="red" size="small" />;
+        return <Badge label={errorMessage} intent="critical" size="small" />;
     }
 
     const asset = watch('sendAsset');

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.tsx
@@ -18,9 +18,7 @@ export const AccountListItem = ({ receiveAccount, onPress }: AccountListItemProp
         selectFormattedAccountType(state, account.key),
     );
 
-    const typeBadge = formattedAccountType && (
-        <Badge label={formattedAccountType} size="small" elevation="1" />
-    );
+    const typeBadge = formattedAccountType && <Badge label={formattedAccountType} size="small" />;
 
     return (
         <AccountListBaseItem

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListSectionHeader.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListSectionHeader.tsx
@@ -38,8 +38,7 @@ export const MyAssetListSectionHeader = ({ account, isFirst }: MyAssetListSectio
                     <Badge
                         label={formattedAccountType}
                         size="small"
-                        elevation="1"
-                        variant="blue"
+                        intent="info"
                         testID={TEST_ID_ACCOUNT_TYPE_BADGE}
                     />
                 )}

--- a/suite-native/module-trading/src/components/history/TradeStatusBadge.tsx
+++ b/suite-native/module-trading/src/components/history/TradeStatusBadge.tsx
@@ -1,5 +1,5 @@
 import { type TradingTransactionStatus } from '@suite-common/trading';
-import { Badge, type BadgeVariant } from '@suite-native/atoms';
+import { Badge, type BadgeIntent } from '@suite-native/atoms';
 import { useCoinLabel } from '@suite-native/device';
 import { type IconName } from '@suite-native/icons';
 import { Translation, useTranslate } from '@suite-native/intl';
@@ -9,21 +9,21 @@ export type TransactionStatusProps = {
     status: TradingTransactionStatus;
 };
 
-export const getBadgeVariant = (status: TradingTransactionStatus): BadgeVariant => {
+export const getBadgeVariant = (status: TradingTransactionStatus): BadgeIntent => {
     switch (status) {
         case undefined:
             return 'neutral';
 
         case 'SUCCESS':
-            return 'greenSubtle';
+            return 'brand';
 
         case 'BLOCKED':
         case 'ERROR':
         case 'REFUNDED':
-            return 'red';
+            return 'critical';
 
         default:
-            return 'yellow';
+            return 'warning';
     }
 };
 
@@ -117,7 +117,7 @@ export const TradeStatusBadge = ({ status }: TransactionStatusProps) => {
         <Badge
             label={getLabel(status, coinLabel)}
             size="small"
-            variant={getBadgeVariant(status)}
+            intent={getBadgeVariant(status)}
             icon={getBadgeIconName(status)}
             accessibilityHint={translate('moduleTrading.tradeHistory.status.badge')}
         />

--- a/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
+++ b/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
@@ -1,5 +1,5 @@
 import { type TradingTransactionStatus } from '@suite-common/trading';
-import { type BadgeVariant } from '@suite-native/atoms';
+import { type BadgeIntent } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '@suite-native/trading-fixtures';
@@ -89,15 +89,15 @@ describe('TradeStatusBadge', () => {
     describe('getBadgeVariant', () => {
         it.each([
             [undefined, 'neutral'],
-            ['CANCELLED', 'yellow'],
-            ['SUCCESS', 'greenSubtle'],
-            ['REFUNDED', 'red'],
-            ['BLOCKED', 'red'],
-            ['ERROR', 'red'],
-            ['SUBMITTED', 'yellow'],
-            ['CONVERTING', 'yellow'],
-            ['KYC', 'yellow'],
-        ] as [TradingTransactionStatus, BadgeVariant][])(
+            ['CANCELLED', 'warning'],
+            ['SUCCESS', 'brand'],
+            ['REFUNDED', 'critical'],
+            ['BLOCKED', 'critical'],
+            ['ERROR', 'critical'],
+            ['SUBMITTED', 'warning'],
+            ['CONVERTING', 'warning'],
+            ['KYC', 'warning'],
+        ] as [TradingTransactionStatus, BadgeIntent][])(
             'should render badge with correct text for status %s',
             (status, expectedVariant) => {
                 expect(getBadgeVariant(status)).toBe(expectedVariant);

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.tsx
@@ -117,11 +117,11 @@ export const SellFormFieldErrorBadge = ({ fieldName }: SellFormFieldErrorBadgePr
 
     if (!isLoading) {
         if (hasError) {
-            return <Badge label={errorMessage} variant="red" size="small" />;
+            return <Badge label={errorMessage} intent="critical" size="small" />;
         }
 
         if (mismatchedAmountMessage) {
-            return <Badge label={mismatchedAmountMessage} variant="neutral" size="small" />;
+            return <Badge label={mismatchedAmountMessage} intent="neutral" size="small" />;
         }
     }
 

--- a/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
@@ -68,14 +68,13 @@ export const TransactionDetailHeader = ({
 
                     {isPendingTx ? (
                         <Badge
-                            variant="yellow"
+                            intent="warning"
                             label={<Translation id="transactions.status.pending" />}
-                            elevation="1"
                         />
                     ) : (
                         !isFailedTx && (
                             <Badge
-                                variant="green"
+                                intent="brandBold"
                                 label={<Translation id="transactions.status.confirmed" />}
                             />
                         )

--- a/suite-native/transactions/src/components/TransactionListItemContainer.tsx
+++ b/suite-native/transactions/src/components/TransactionListItemContainer.tsx
@@ -186,7 +186,7 @@ export const TransactionListItemContainer = ({
                                         label={<Translation id="transactions.phishing.badge" />}
                                         size="small"
                                         icon="warning"
-                                        variant="red"
+                                        intent="critical"
                                     />
                                 )}
                             </Box>


### PR DESCRIPTION
## Description

Updates the `Badge` atom to match the new design system spec (trezor/trezor-suite#24959):

- Renames `variant` prop to `intent` with new semantic values: `greenSubtle→brand`, `green→brandBold`, `red→critical`, `yellow→warning`, `blue→info`
- Removes deprecated props: `elevation`, `isDisabled`, `iconSize`
- Hardcodes icon sizes per badge size (`mediumLarge` for medium, `medium` for small)
- Fixes yellow variant incorrectly rendering a border
- Updates all 24 call sites across suite-native

## Notes for QA

- Check all Badge variants render correctly in the Storubook (`Settings → DEV utils → Storybook → Badge section`)


## Related Issue

Resolve trezor/trezor-suite#24959

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/new-ds-badge-component&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->