### PR TITLE
Wrong balance in the unstake account card

### DIFF
--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -64,6 +64,7 @@ export const UnstakeFlowScreen = () => {
                 accountKey={accountKey}
                 isStakeVariant
                 titleLabel={<Translation id="earn.earnFormScreen.availableBalance" />}
+                cryptoAmount={stakedBalance ?? undefined}
             />
 
             <Box marginTop="sp16">


### PR DESCRIPTION
## Description

Need to change the total balance into staked for the account card in the unstake screen


## Related Issue
https://github.com/trezor/trezor-suite/issues/26774


## Screenshots:
<img width="380" height="496" alt="image" src="https://github.com/user-attachments/assets/c4f30424-1f19-4de0-8ad9-a95842cd596c" />
<img width="382" height="484" alt="image" src="https://github.com/user-attachments/assets/01b26777-c90f-4feb-b3b2-049a5b7a4e59" />
<img width="378" height="225" alt="image" src="https://github.com/user-attachments/assets/3e66ba8e-20e2-42af-bde8-f7122ccc47aa" />
