### PR TITLE
test(e2e-suite): rework migration test from legacy to Suite Sync

### DIFF
--- a/suite/e2e/support/mocks/metadataMock.ts
+++ b/suite/e2e/support/mocks/metadataMock.ts
@@ -9,6 +9,7 @@ import { step } from '../common';
 export enum MetadataProvider {
     DROPBOX = 'dropbox',
     GOOGLE = 'google',
+    LOCAL = 'file-system',
 }
 
 export type ProviderMocks = DropboxMock | GoogleMock;

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -24,6 +24,8 @@ export class MetadataPage {
     readonly suiteSyncBannerButton: Locator;
     readonly metadataProviderButton = (provider: MetadataProvider) =>
         this.page.getByTestId(`@modal/metadata-provider/${provider}-button`);
+    readonly migrateLabelsButton: Locator;
+    readonly migrateFromLocalFileButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -40,6 +42,10 @@ export class MetadataPage {
         this.copyAddressButton = page.getByTestId('@metadata/copy-address-button');
         this.suiteSyncBanner = page.getByTestId('@notification/suite-sync-keys');
         this.suiteSyncBannerButton = page.getByTestId('@notification/suite-sync-keys/button');
+        this.migrateLabelsButton = page.getByTestId('@settings/metadata/migrate-button');
+        this.migrateFromLocalFileButton = page.getByTestId(
+            '@modal/legacy-labeling-migration/file-system-button',
+        );
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -16,6 +16,7 @@ export class DebugTab {
     readonly quotaManagerUrlInput: Locator;
     readonly quotaManagerUrlSaveButton: Locator;
     readonly quotaManagerEnforceCheckbox: Locator;
+    readonly suiteSyncDebugToggle: Locator;
 
     constructor(private readonly page: Page) {
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
@@ -39,6 +40,7 @@ export class DebugTab {
         this.quotaManagerEnforceCheckbox = page.getByTestId(
             '@settings/debug/quota-manager-enforce-for-custom-relay-checkbox',
         );
+        this.suiteSyncDebugToggle = page.getByTestId('@settings/debug/suite-sync/debug-toggle');
     }
 
     @step()

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -4,24 +4,25 @@ import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
 
-const { accountSeed, ownerSecret, ownerId } = mnemonic12Fixtures;
+const localLabel = 'local label';
+const expectedAccount = mnemonic12Fixtures.buildExpectedAccount({ label: localLabel });
 
-test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
-    test.beforeEach(async ({ metadataMock, metadataPage, evoluClient, onboardingPage }) => {
-        await metadataMock.start(MetadataProvider.DROPBOX);
-        await test.step('Seed Evolu relay server', async () => {
-            await evoluClient.init({ ownerSecret });
-            evoluClient.writeTo('account', accountSeed);
-            evoluClient.seedQuotaManagerData({ ownerId });
-        });
+    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-        await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
+        await metadataPage.enableLegacyLabeling(MetadataProvider.LOCAL);
     });
 
-    test('Migration from Dropbox', async ({ page, walletPage, metadataPage }) => {
-        await test.step('Set up Dropbox labeling', async () => {
+    test('Migration from local file', async ({
+        page,
+        walletPage,
+        metadataPage,
+        evoluClient,
+        settingsPage,
+    }) => {
+        await test.step('Set up local file labeling', async () => {
             await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
@@ -33,19 +34,29 @@ test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
         });
 
         await test.step('Add legacy account label', async () => {
-            await metadataPage.account.metadataInput.fill('new dropbox label');
+            await metadataPage.account.metadataInput.fill(localLabel);
             await page.keyboard.press('Enter');
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-            ).toHaveText('new dropbox label');
+            ).toHaveText(localLabel);
             await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
-        await test.step('Switch to Suite Sync labeling and confirm legacy label is retained', async () => {
+        await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
+            await settingsPage.navigateTo('debug');
+            await settingsPage.debugTab.suiteSyncDebugToggle.click();
+            await settingsPage.navigateTo('application');
+            await metadataPage.migrateLabelsButton.click();
+            await metadataPage.migrateFromLocalFileButton.click();
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-            ).toHaveText(accountSeed.label);
+            ).toHaveText(localLabel);
+        });
+
+        await test.step('Verify data are sync to Relay', async () => {
+            await evoluClient.init({ ownerSecret: mnemonic12Fixtures.ownerSecret });
+            await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
         });
     });
 });

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -123,6 +123,7 @@ export const SuiteSyncSettings = ({ onError, suiteSync }: SuiteSyncSettingsProps
                 <TextColumn title="Suite Sync (Evolu) Debug" />
                 <ActionColumn>
                     <Checkbox
+                        data-testid="@settings/debug/suite-sync/debug-toggle"
                         isChecked={isSuiteSyncDebugEnabled}
                         onChange={handleToggleSuiteSyncDebug}
                     />


### PR DESCRIPTION
## Description

Extract the legacy-label-to-Suite Sync e2e rework into a dedicated stacked PR.

This keeps the migration feature branch focused while isolating the test updates and related e2e support changes needed for the new flow.

## Notes for QA

Focus on the legacy labeling to Suite Sync migration flow in e2e.

## Related Issue

Resolve 

## Screenshots:
