### PR TITLE
chore(connect-common): direct imports

### DIFF
--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -1,4 +1,4 @@
-import type { FailureType } from '@trezor/protobuf/src/definitions';
+import type { FailureType } from '@trezor/protobuf';
 import type { thp } from '@trezor/protocol';
 
 export const ERROR_CODES = {

--- a/packages/connect-common/src/events/device.ts
+++ b/packages/connect-common/src/events/device.ts
@@ -4,7 +4,7 @@ import type {
     ThpCredentials,
     ThpPairingMethod,
 } from '@trezor/protocol';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 import type { Device } from '../types/device';
 import type { MessageFactoryFn } from '../types/utils';

--- a/packages/connect-common/src/events/transport.ts
+++ b/packages/connect-common/src/events/transport.ts
@@ -1,8 +1,7 @@
 // todo: transport should eventually stop being dependency of connect-common, we don't want to pull
 // usb dependencies for example. so maybe we are going to split this package into transport-types and transport-rest
 
-import type { TRANSPORT } from '@trezor/transport/src/constants';
-import type { AbstractTransport as Transport } from '@trezor/transport/src/transports/abstract';
+import type { TRANSPORT, Transport } from '@trezor/transport';
 
 import { serializeError } from '../constants/errors';
 import type { ConnectSettings } from '../types/settings';

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -3,7 +3,7 @@
  */
 import type { DeviceModelInternal, FirmwareRelease, FirmwareType } from '@trezor/device-utils';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';

--- a/packages/connect-common/src/types/api/firmwareUpdate.ts
+++ b/packages/connect-common/src/types/api/firmwareUpdate.ts
@@ -1,6 +1,6 @@
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 import type { Params, Response } from '../params';
 

--- a/packages/connect-common/src/types/api/getNonce.ts
+++ b/packages/connect-common/src/types/api/getNonce.ts
@@ -1,4 +1,4 @@
-import type { Nonce } from '@trezor/protobuf/src/definitions';
+import type { Nonce } from '@trezor/protobuf';
 
 import type { CommonParams, Response } from '../params';
 

--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -5,7 +5,7 @@ import type {
     FirmwareType,
     IntermediaryReleaseConfig,
 } from '@trezor/device-utils';
-import type { VersionArray } from '@trezor/utils/src/versionUtils';
+import type { VersionArray } from '@trezor/utils';
 
 export type FirmwareBoundary = `${number}.${number}.${number}` | '0';
 

--- a/packages/protobuf/src/index.ts
+++ b/packages/protobuf/src/index.ts
@@ -19,3 +19,4 @@ export const { parseConfigure, decodeMessage, encodeMessage } = (() => {
 
 export { loadDefinitions } from './load-definitions';
 export * as MessagesSchema from './definitions';
+export type { FailureType, Nonce } from './definitions';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,5 +4,10 @@ export * as bridge from './protocol-bridge';
 export * as thp from './protocol-thp';
 export * as trzd from './protocol-trzd';
 export * as tpn from './protocol-tpn';
+export {
+    type DecodedTrezorPushNotification,
+    TrezorPushNotificationMode,
+    TrezorPushNotificationType,
+} from './protocol-tpn';
 export * from './errors';
 export * from './types';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-direct-imports&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-direct-imports&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-16T13:56:43.659Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-16T13:59:18.925Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->