### PR TITLE
test(e2e-suite): rework migration test from legacy to Suite Sync

### DIFF
--- a/suite/e2e/support/mocks/metadataMock.ts
+++ b/suite/e2e/support/mocks/metadataMock.ts
@@ -9,6 +9,7 @@ import { step } from '../common';
 export enum MetadataProvider {
     DROPBOX = 'dropbox',
     GOOGLE = 'google',
+    LOCAL = 'file-system',
 }
 
 export type ProviderMocks = DropboxMock | GoogleMock;

--- a/suite/e2e/support/pageObjects/metadata/metadataPage.ts
+++ b/suite/e2e/support/pageObjects/metadata/metadataPage.ts
@@ -28,6 +28,8 @@ export class MetadataPage {
     readonly closeLegacyNotificationButton: Locator;
     readonly suiteSyncNotification: Locator;
     readonly closeSuiteSyncNotificationButton: Locator;
+    readonly migrateLabelsButton: Locator;
+    readonly migrateFromLocalFileButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -51,6 +53,10 @@ export class MetadataPage {
         this.suiteSyncNotification = this.page.getByTestId('@notification/feedback-banner');
         this.closeSuiteSyncNotificationButton = this.page.getByTestId(
             '@notification/feedback-banner/close-button',
+        );
+        this.migrateLabelsButton = page.getByTestId('@settings/metadata/migrate-button');
+        this.migrateFromLocalFileButton = page.getByTestId(
+            '@modal/legacy-labeling-migration/file-system-button',
         );
     }
 

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -16,6 +16,7 @@ export class DebugTab {
     readonly quotaManagerUrlInput: Locator;
     readonly quotaManagerUrlSaveButton: Locator;
     readonly quotaManagerEnforceCheckbox: Locator;
+    readonly suiteSyncDebugToggle: Locator;
 
     constructor(private readonly page: Page) {
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
@@ -39,6 +40,7 @@ export class DebugTab {
         this.quotaManagerEnforceCheckbox = page.getByTestId(
             '@settings/debug/quota-manager-enforce-for-custom-relay-checkbox',
         );
+        this.suiteSyncDebugToggle = page.getByTestId('@settings/debug/suite-sync/debug-toggle');
     }
 
     @step()

--- a/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
+++ b/suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts
@@ -4,27 +4,25 @@ import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
 
-const { accountSeed, ownerSecret, ownerId } = mnemonic12Fixtures;
+const localLabel = 'local label';
+const expectedAccount = mnemonic12Fixtures.buildExpectedAccount({ label: localLabel });
 
-test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
-    test.beforeEach(
-        async ({ metadataMock, metadataPage, evoluClient, onboardingPage, settingsPage }) => {
-            await metadataMock.start(MetadataProvider.DROPBOX);
-            await test.step('Seed Evolu relay server', async () => {
-                await evoluClient.init({ ownerSecret });
-                evoluClient.writeTo('account', accountSeed);
-                evoluClient.seedQuotaManagerData({ ownerId });
-            });
-            await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
-            await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
-            await metadataPage.enableLegacyLabeling(MetadataProvider.DROPBOX);
-        },
-    );
+    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await metadataPage.enableLegacyLabeling(MetadataProvider.LOCAL);
+    });
 
-    test('Migration from Dropbox', async ({ page, walletPage, metadataPage }) => {
-        await test.step('Set up Dropbox labeling', async () => {
+    test('Migration from local file', async ({
+        page,
+        walletPage,
+        metadataPage,
+        evoluClient,
+        settingsPage,
+    }) => {
+        await test.step('Set up local file labeling', async () => {
             await walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }).click();
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
@@ -36,19 +34,29 @@ test.describe('Labeling migration', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () 
         });
 
         await test.step('Add legacy account label', async () => {
-            await metadataPage.account.metadataInput.fill('new dropbox label');
+            await metadataPage.account.metadataInput.fill(localLabel);
             await page.keyboard.press('Enter');
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-            ).toHaveText('new dropbox label');
+            ).toHaveText(localLabel);
             await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
-        await test.step('Switch to Suite Sync labeling and confirm legacy label is retained', async () => {
+        await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
+            await settingsPage.navigateTo('debug');
+            await settingsPage.debugTab.suiteSyncDebugToggle.click();
+            await settingsPage.navigateTo('application');
+            await metadataPage.migrateLabelsButton.click();
+            await metadataPage.migrateFromLocalFileButton.click();
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
-            ).toHaveText(accountSeed.label);
+            ).toHaveText(localLabel);
+        });
+
+        await test.step('Verify data are sync to Relay', async () => {
+            await evoluClient.init({ ownerSecret: mnemonic12Fixtures.ownerSecret });
+            await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
         });
     });
 });

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -29,6 +29,8 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
         page,
         walletPage,
         metadataPage,
+        device,
+        devicePrompt,
         evoluClient,
         settingsPage,
     }) => {
@@ -84,6 +86,8 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
             await settingsPage.navigateTo('application');
             await metadataPage.migrateLabelsButton.click();
             await metadataPage.migrateFromLocalFileButton.click();
+            await devicePrompt.confirmOnDevicePromptIsShown({ timeout: 30_000 });
+            await device.pressYes();
             await expect(
                 page.getByTestId('@toast/legacy-labeling-migration-success'),
             ).toHaveTranslation('TR_LABELING_MIGRATION_SUCCESS', {

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -11,6 +11,10 @@ const expectedOutput = mnemonic12Fixtures.buildExpectedOutput({
     outputIndex: '0',
     label: 'local output label',
 });
+const expectedAddress = mnemonic12Fixtures.buildExpectedAddress({
+    address: 'bc1qkkr2uvry034tsj4p52za2pg42ug4pxg5qfxyfa',
+    label: 'local address label',
+});
 
 test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] }, () => {
     test.use({ wipeEvoluRelay: true });
@@ -63,12 +67,27 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
             ).toHaveText(expectedOutput.label);
         });
 
+        await test.step('Change address label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await metadataPage.address.changeLabel({
+                address: expectedAddress.address,
+                label: expectedAddress.label,
+            });
+            await expect
+                .soft(metadataPage.address.label(expectedAddress.address))
+                .toHaveText(expectedAddress.label);
+        });
+
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
             await settingsPage.navigateTo('application');
             await metadataPage.migrateLabelsButton.click();
             await metadataPage.migrateFromLocalFileButton.click();
-            await expect(page.getByTestId('@toast/legacy-labeling-migration-success')).toBeVisible({
+            await expect(
+                page.getByTestId('@toast/legacy-labeling-migration-success'),
+            ).toHaveTranslation('TR_LABELING_MIGRATION_SUCCESS', {
+                values: { added: '3', skipped: '0' },
                 timeout: 30000,
             });
 
@@ -89,10 +108,19 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
                 .toHaveText(expectedOutput.label);
         });
 
+        await test.step('Verify receive address label is synced', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await walletPage.receiveButton.click();
+            await expect
+                .soft(metadataPage.address.label(expectedAddress.address))
+                .toHaveText(expectedAddress.label);
+        });
+
         await test.step('Verify data are sync to Relay', async () => {
             await evoluClient.init({ ownerSecret: mnemonic12Fixtures.ownerSecret });
             await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
             await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
+            await evoluClient.expectInTable('address', [expectedAddress], { softExpect: true });
         });
     });
 });

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -4,8 +4,13 @@ import { AccountLabelId } from '../../support/enums/accountLabelId';
 import { expect, test } from '../../support/fixtures';
 import { MetadataProvider } from '../../support/mocks/metadataMock';
 
-const localLabel = 'local label';
+const localLabel = 'local account label';
 const expectedAccount = mnemonic12Fixtures.buildExpectedAccount({ label: localLabel });
+const expectedOutput = mnemonic12Fixtures.buildExpectedOutput({
+    txId: 'aa545d95cf07892e1ae70b40e856b9b476f703e2e20647d0985830fd7b734393',
+    outputIndex: '0',
+    label: 'local output label',
+});
 
 test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] }, () => {
     test.use({ wipeEvoluRelay: true });
@@ -43,6 +48,21 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
             await metadataPage.account.successIconIsVisible(AccountLabelId.BitcoinDefault1);
         });
 
+        await test.step('Change output label', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await metadataPage.output.changeLabel({
+                outputId: expectedOutput.txId,
+                txNumber: Number(expectedOutput.outputIndex),
+                label: expectedOutput.label,
+            });
+            await expect(
+                metadataPage.output.outputLabel(
+                    expectedOutput.txId,
+                    Number(expectedOutput.outputIndex),
+                ),
+            ).toHaveText(expectedOutput.label);
+        });
+
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
             await settingsPage.navigateTo('application');
@@ -51,14 +71,28 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
             await expect(page.getByTestId('@toast/legacy-labeling-migration-success')).toBeVisible({
                 timeout: 30000,
             });
+
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText(localLabel);
         });
 
+        await test.step('Verify output label is synced', async () => {
+            await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+            await expect
+                .soft(
+                    metadataPage.output.outputLabel(
+                        expectedOutput.txId,
+                        Number(expectedOutput.outputIndex),
+                    ),
+                )
+                .toHaveText(expectedOutput.label);
+        });
+
         await test.step('Verify data are sync to Relay', async () => {
             await evoluClient.init({ ownerSecret: mnemonic12Fixtures.ownerSecret });
             await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
+            await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
         });
     });
 });

--- a/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
+++ b/suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts
@@ -10,8 +10,9 @@ const expectedAccount = mnemonic12Fixtures.buildExpectedAccount({ label: localLa
 test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] }, () => {
     test.use({ wipeEvoluRelay: true });
 
-    test.beforeEach(async ({ onboardingPage, metadataPage }) => {
+    test.beforeEach(async ({ onboardingPage, settingsPage, metadataPage }) => {
         await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
+        await settingsPage.changeNetworks({ enableNetworks: ['btc'] });
         await metadataPage.enableLegacyLabeling(MetadataProvider.LOCAL);
     });
 
@@ -44,11 +45,12 @@ test.describe('Labeling migration', { tag: ['@T3W1', '@T3T1', '@desktopOnly'] },
 
         await test.step('Switch to Suite Sync labeling and confirm legacy label is migrated', async () => {
             await metadataPage.enableSuiteSync();
-            await settingsPage.navigateTo('debug');
-            await settingsPage.debugTab.suiteSyncDebugToggle.click();
             await settingsPage.navigateTo('application');
             await metadataPage.migrateLabelsButton.click();
             await metadataPage.migrateFromLocalFileButton.click();
+            await expect(page.getByTestId('@toast/legacy-labeling-migration-success')).toBeVisible({
+                timeout: 30000,
+            });
             await expect(
                 walletPage.accountLabel({ symbol: 'btc', type: 'normal', atIndex: 0 }),
             ).toHaveText(localLabel);

--- a/suite/suite-sync/src/SuiteSyncSettings.tsx
+++ b/suite/suite-sync/src/SuiteSyncSettings.tsx
@@ -124,6 +124,7 @@ export const SuiteSyncSettings = ({ onError }: SuiteSyncSettingsProps) => {
                 <TextColumn title="Suite Sync (Evolu) Debug" />
                 <ActionColumn>
                     <Checkbox
+                        data-testid="@settings/debug/suite-sync/debug-toggle"
                         isChecked={isSuiteSyncDebugEnabled}
                         onChange={handleToggleSuiteSyncDebug}
                     />


### PR DESCRIPTION
## Description

Extract the legacy-label-to-Suite Sync e2e rework into a dedicated PR targeting develop.

This isolates the test updates and related e2e support changes for the new flow.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=legacy-labeling-migration-develop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=legacy-labeling-migration-develop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-28T10:41:20.052Z • 9 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-05-28T15:00:21.667Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/legacy-labeling-migration-develop/web/](https://dev.suite.sldev.cz/suite-web/legacy-labeling-migration-develop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->