### PR TITLE
feat: gap limit experimental

### DIFF
--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -51,7 +51,7 @@ export interface AccountInfoParams {
     from?: number; // from block
     to?: number; // to block
     contractFilter?: string; // blockbook only, ethereum token filter
-    gap?: number; // blockbook only, derived addresses gap
+    gap?: number; // derived addresses gap
     // since xrpl.js cannot use pages "marker" is used as first unknown point in history (block and sequence of transaction)
     marker?: {
         ledger: number;

--- a/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
+++ b/packages/blockchain-link/src/workers/electrum/methods/getAccountInfo.ts
@@ -72,7 +72,7 @@ export const sumAddressValues = <T>(
         .reduce((a, b) => a + b, 0);
 
 const getAccountInfo: Api<Req, Res> = async ({ client, addressCache }, payload) => {
-    const { descriptor, details = 'basic', pageSize = PAGE_SIZE_DEFAULT } = payload;
+    const { descriptor, details = 'basic', pageSize = PAGE_SIZE_DEFAULT, gap } = payload;
     const network = client.getInfo()?.network;
 
     const parsed = tryGetScripthash(descriptor, network);
@@ -108,10 +108,10 @@ const getAccountInfo: Api<Req, Res> = async ({ client, addressCache }, payload) 
         };
     }
     const discover = discoverAddress(client);
-    const receive = await discovery(discover, addressCache(descriptor, 'receive')).then(
+    const receive = await discovery(discover, addressCache(descriptor, 'receive'), gap).then(
         getBalances(client),
     );
-    const change = await discovery(discover, addressCache(descriptor, 'change')).then(
+    const change = await discovery(discover, addressCache(descriptor, 'change'), gap).then(
         getBalances(client),
     );
     const batch = receive.concat(change);

--- a/packages/connect-common/src/types/api/discoverAccounts.ts
+++ b/packages/connect-common/src/types/api/discoverAccounts.ts
@@ -72,7 +72,7 @@ export type AccountTypeKey = DistributivePick<AccountTypeItem, 'symbol' | 'type'
 
 export type AdditionalParams = Pick<
     BlockchainLinkParams<'getAccountInfo'>,
-    'details' | 'pageSize' | 'includeErc4626'
+    'details' | 'pageSize' | 'includeErc4626' | 'gap'
 > & {
     identity?: string;
 };

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -323,8 +323,17 @@ export default class DiscoverAccounts extends AbstractMethod<
         request: Request,
         sendCoreMessage: MethodContext['sendCoreMessage'],
     ): Promise<{ nonempty: number; error?: string }> {
-        const { details, identity, pageSize, includeErc4626, coinInfo, derivation, offset, skip } =
-            request;
+        const {
+            details,
+            identity,
+            pageSize,
+            gap,
+            includeErc4626,
+            coinInfo,
+            derivation,
+            offset,
+            skip,
+        } = request;
         const { path: bip43, ...accountKey } = request.account;
         const backendType = coinInfo.blockchainLink?.type;
         const utxoRequired = isUtxoBased(coinInfo) && details && details !== 'basic';
@@ -358,6 +367,7 @@ export default class DiscoverAccounts extends AbstractMethod<
                     details,
                     pageSize,
                     includeErc4626,
+                    gap,
                 });
 
                 // eslint-disable-next-line no-nested-ternary

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -2,13 +2,25 @@ import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { selectModalType } from '@suite/modal';
+import { selectHasExperimentalFeature } from '@suite/settings';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
-import { Badge, Banner, Card, CollapsibleBox, Column, Modal, Row, Text } from '@trezor/components';
+import {
+    Badge,
+    Banner,
+    Card,
+    CollapsibleBox,
+    Column,
+    Input,
+    Modal,
+    Row,
+    Text,
+} from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { toggleTor } from 'src/actions/suite/suiteActions';
 import { useBackendsForm } from 'src/hooks/settings/backends';
 import { useExplorerForm } from 'src/hooks/settings/useExplorerForm';
+import { useGapLimitForm } from 'src/hooks/settings/useGapLimitForm';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectTorState } from 'src/selectors/suite/suiteSelectors';
 
@@ -33,11 +45,19 @@ export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSett
     const explorer = useSelector(state => state.wallet.explorer[symbol]);
     const usesCustomExplorer = explorer.custom !== undefined;
 
+    const isBitcoinNetwork = network.networkType === 'bitcoin';
+    const isGapLimitEnabled = useSelector(selectHasExperimentalFeature('gap-limit'));
+
+    const gapLimitForm = useGapLimitForm(symbol);
     const explorerForm = useExplorerForm(symbol);
     const backendsForm = useBackendsForm(symbol);
 
     const onSaveClick = async () => {
         explorerForm.save();
+
+        if (isBitcoinNetwork && isGapLimitEnabled) {
+            gapLimitForm.save();
+        }
 
         if (!isTorEnabled && backendsForm.hasOnlyOnions()) {
             setTorModalOpen(true);
@@ -155,6 +175,31 @@ export const AdvancedCoinSettingsModal = ({ symbol, onCancel }: AdvancedCoinSett
                 >
                     <ExplorerConfigForm form={explorerForm} />
                 </CollapsibleBox>
+
+                {isBitcoinNetwork && isGapLimitEnabled && (
+                    <CollapsibleBox
+                        heading={<Translation id="SETTINGS_BACKEND_SETTINGS_CUSTOM_GAP_LIMIT" />}
+                    >
+                        <Column gap={spacings.sm} alignItems="flex-start">
+                            <Input
+                                type="number"
+                                value={gapLimitForm.value}
+                                size="small"
+                                onChange={e => gapLimitForm.setValue(e.target.value)}
+                                hasError={!!gapLimitForm.error}
+                                bottomText={
+                                    gapLimitForm.error ? (
+                                        <Translation
+                                            id={gapLimitForm.error.id}
+                                            values={gapLimitForm.error.values}
+                                        />
+                                    ) : undefined
+                                }
+                                width={125}
+                            />
+                        </Column>
+                    </CollapsibleBox>
+                )}
 
                 <CollapsibleBox heading={<Translation id="SETTINGS_ADV_COIN_CONN_INFO_TITLE" />}>
                     <ConnectionInfo symbol={symbol} />

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -2,6 +2,7 @@ import type { ExperimentalFeature } from '@suite/experimental';
 import { type ExtendedMessageDescriptor } from '@suite/intl';
 import { type Route } from '@suite/router';
 import { networksCollection } from '@suite-common/wallet-config';
+import { blockchainActions } from '@suite-common/wallet-core';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import {
@@ -12,6 +13,7 @@ import {
 } from '@trezor/urls';
 
 import { type SuiteServices } from '../../support/extraDependencies';
+import { type Dispatch } from '../../types/suite';
 
 const experimentalNetworks = networksCollection.filter(
     network => network.isExperimentalOnlyNetwork,
@@ -24,7 +26,15 @@ export type ExperimentalFeatureConfig = {
     knowledgeBaseUrl?: Url;
     routeName?: Route['name'];
     isDisabled?: (context: { isDebug: boolean }) => boolean;
-    onToggle?: ({ newValue, services }: { newValue: boolean; services: SuiteServices }) => void;
+    onToggle?: ({
+        newValue,
+        services,
+        dispatch,
+    }: {
+        newValue: boolean;
+        services: SuiteServices;
+        dispatch: Dispatch;
+    }) => void;
 };
 
 export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeatureConfig> = {
@@ -90,6 +100,22 @@ export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeat
         isDisabled: () => !isDesktop(),
         onToggle: async ({ newValue }) => {
             await desktopApi.mcpSetEnabled(newValue);
+        },
+    },
+    'gap-limit': {
+        title: { id: 'TR_EXPERIMENTAL_GAP_LIMIT' },
+        description: { id: 'TR_EXPERIMENTAL_GAP_LIMIT_DESCRIPTION' },
+        // TODO: let's add some knowledgeBaseUrl post if we move this forward.
+        onToggle: ({ newValue, dispatch }) => {
+            if (!newValue) {
+                networksCollection
+                    .filter(network => network.networkType === 'bitcoin')
+                    .forEach(({ symbol }) =>
+                        dispatch(
+                            blockchainActions.setBackendGapLimit({ symbol, gapLimit: undefined }),
+                        ),
+                    );
+            }
         },
     },
 };

--- a/packages/suite/src/hooks/settings/useGapLimitForm.ts
+++ b/packages/suite/src/hooks/settings/useGapLimitForm.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from 'react';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { blockchainActions } from '@suite-common/wallet-core';
+
+import { useDispatch, useSelector } from '../suite';
+
+const DEFAULT_GAP_LIMIT = 20;
+
+export const useGapLimitForm = (symbol: NetworkSymbol) => {
+    const dispatch = useDispatch();
+    const savedGapLimit = useSelector(state => state.wallet.blockchain[symbol]?.backends.gapLimit);
+
+    const [value, setValue] = useState(String(savedGapLimit ?? DEFAULT_GAP_LIMIT));
+
+    const error = useMemo(() => {
+        const trimmed = value.trim();
+        const num = Number(trimmed);
+
+        if (trimmed === '' || !Number.isInteger(num) || isNaN(num) || num <= 0) {
+            return { id: 'TR_GAP_LIMIT_ERROR_POSITIVE' } as const;
+        }
+        if (num < DEFAULT_GAP_LIMIT) {
+            return {
+                id: 'TR_GAP_LIMIT_ERROR_TOO_LOW',
+                values: { min: DEFAULT_GAP_LIMIT },
+            } as const;
+        }
+
+        return undefined;
+    }, [value]);
+
+    const isSame = value.trim() === String(savedGapLimit ?? DEFAULT_GAP_LIMIT);
+
+    const save = () => {
+        dispatch(blockchainActions.setBackendGapLimit({ symbol, gapLimit: Number(value.trim()) }));
+    };
+
+    return { value, setValue, error, isSame, save };
+};

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -183,6 +183,10 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 api.dispatch(storageActions.saveBackend(action.payload.symbol));
             }
 
+            if (blockchainActions.setBackendGapLimit.match(action)) {
+                api.dispatch(storageActions.saveBackend(action.payload.symbol));
+            }
+
             if (explorerActions.setExplorer.match(action)) {
                 storageActions.saveExplorer(action.payload);
             }

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -40,7 +40,7 @@ const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
         const newValue = !checked;
 
         try {
-            await config?.onToggle?.({ services, newValue });
+            await config?.onToggle?.({ services, newValue, dispatch });
             dispatch(
                 suiteSettingsActions.setExperimentalFeatures(
                     newValue
@@ -129,6 +129,7 @@ export const Experimental = () => {
             EXPERIMENTAL_FEATURES[feature]?.onToggle?.({
                 services,
                 newValue: !isExperimentalEnabled,
+                dispatch,
             }),
         );
 

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -21,7 +21,7 @@ import { reportWalletBalanceDebounced } from './accountBalanceAnalytics';
 import { accountsActions } from './accountsActions';
 import { ACCOUNTS_MODULE_PREFIX } from './accountsConstants';
 import { selectAccountByKey } from './accountsSelectors';
-import { selectBlockchainHeightBySymbol } from '../blockchain/blockchainReducer';
+import { selectBlockchainHeightBySymbol, selectGapLimit } from '../blockchain/blockchainReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
 import { selectTransactions } from '../transactions/transactionsSelectors';
@@ -96,6 +96,10 @@ export const fetchAndUpdateAccountThunk = createThunk(
             account.networkType === 'solana'
                 ? account.tokens?.flatMap(t => t.accounts ?? []).map(a => a.publicKey)
                 : undefined;
+        const gap =
+            account.networkType === 'bitcoin'
+                ? selectGapLimit(getState(), account.symbol)
+                : undefined;
 
         const basic = await TrezorConnect.getAccountInfo({
             coin: account.symbol,
@@ -104,6 +108,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             details: account.networkType === 'solana' ? 'txids' : 'basic',
             suppressBackupWarning: true,
             tokenAccountsPubKeys,
+            gap,
         });
 
         if (!basic.success) return;
@@ -135,6 +140,10 @@ export const fetchAndUpdateAccountThunk = createThunk(
             pageSize,
             suppressBackupWarning: true,
             includeErc4626: account.networkType === 'ethereum' ? true : undefined,
+            gap:
+                account.networkType === 'bitcoin'
+                    ? selectGapLimit(getState(), account.symbol)
+                    : undefined,
         });
 
         if (response.success) {

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -30,8 +30,14 @@ const setBackend = createAction(
     }),
 );
 
+const setBackendGapLimit = createAction(
+    `${BLOCKCHAIN_MODULE_PREFIX}/setBackendGapLimit`,
+    (payload: { symbol: NetworkSymbol; gapLimit: number | undefined }) => ({ payload }),
+);
+
 export const blockchainActions = {
     setBackend,
+    setBackendGapLimit,
     connected,
     synced,
 };

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -171,6 +171,14 @@ export const prepareBlockchainReducer = createReducerWithExtraDeps(
                     };
                 }
             })
+            .addCase(blockchainActions.setBackendGapLimit, (state, action) => {
+                const { symbol, gapLimit } = action.payload;
+                if (gapLimit === undefined) {
+                    delete state[symbol].backends.gapLimit;
+                } else {
+                    state[symbol].backends.gapLimit = gapLimit;
+                }
+            })
             .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadBlockchain)
             .addMatcher(
                 action => action.type === TREZOR_CONNECT_BLOCKCHAIN_ACTIONS.CONNECT,
@@ -225,6 +233,9 @@ export const selectBlockchainBackendType = createMemoizedSelector(
     [selectNetworkBlockchainInfo],
     blockchain => blockchain.backends.selected,
 );
+
+export const selectGapLimit = (state: BlockchainRootState, symbol: NetworkSymbol) =>
+    state.wallet.blockchain[symbol]?.backends.gapLimit;
 
 export const selectEnabledCustomBackends = createMemoizedSelector(
     [selectBlockchainState, selectEnabledNetworks],

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -24,6 +24,7 @@ import {
     selectIsDeviceAccountless,
     selectVisibleDeviceAccounts,
 } from './accounts/accountsSelectors';
+import { type BlockchainRootState, selectGapLimit } from './blockchain/blockchainReducer';
 import { selectSupportedNetworkByDevice } from './device/deviceSelectors';
 import { type DiscoveryRootState } from './discovery/discoveryReducer';
 import { selectHasRunningDiscovery } from './discovery/discoverySelectors';
@@ -40,7 +41,8 @@ to prevent circular dependencies between reducers
 export type WalletCoreCompoundRootState = AccountsRootState &
     DeviceRootState &
     DiscoveryRootState &
-    WalletSettingsRootState;
+    WalletSettingsRootState &
+    BlockchainRootState;
 const createMemoizedSelector = createWeakMapSelector.withTypes<WalletCoreCompoundRootState>();
 
 const selectEnabledSupportedNetworks = createMemoizedSelector(

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -142,6 +142,7 @@ export const selectDiscoveryAccountsParam = (
             includeErc4626,
             known,
             knownOnly,
+            gap: bitcoinGap,
         } as DiscoveryAccountsParam[number];
     });
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -114,12 +114,18 @@ export const selectDiscoveryAccountsParam = (
     getDeviceAccountsPerEnabledNetwork(state, deviceState).map(({ symbol, accounts }) => {
         const { networkType } = networks[symbol];
         const identity = tryGetAccountIdentity({ networkType, deviceState });
+        const bitcoinGap = networkType === 'bitcoin' ? selectGapLimit(state, symbol) : undefined;
 
         const includeErc4626 = networkType === 'ethereum' ? true : undefined;
 
         // undiscovered network; discover as a whole
         if (!accounts)
-            return { symbol, identity, includeErc4626 } as DiscoveryAccountsParam[number];
+            return {
+                symbol,
+                identity,
+                includeErc4626,
+                gap: bitcoinGap,
+            } as DiscoveryAccountsParam[number];
 
         const known = getLastAccountsPerAccountType(accounts).map(({ type, lastAccount }) => {
             // last account is a failed one; try to discover it again

--- a/suite-common/wallet-types/src/backend.ts
+++ b/suite-common/wallet-types/src/backend.ts
@@ -21,6 +21,7 @@ export type BackendSettings = Partial<{
     urls: Partial<{
         [type in BackendType]: string[];
     }>;
+    gapLimit: number;
 }>;
 
 export interface ConnectionStatus {

--- a/suite/experimental/src/index.ts
+++ b/suite/experimental/src/index.ts
@@ -12,7 +12,8 @@ export type ExperimentalFeature =
     | 'slip24'
     | 'experimental-networks'
     | 'tron-view-only'
-    | 'mcp-server';
+    | 'mcp-server'
+    | 'gap-limit';
 
 /**
  * Set of features that are truly experimental (as opposed to regular features
@@ -41,6 +42,7 @@ export const translatedExperimentalFeatures: ExperimentalFeatureTranslation = {
     slip24: 'TR_EXPERIMENTAL_SLIP24',
     'tron-view-only': 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
     'mcp-server': 'TR_EXPERIMENTAL_MCP_SERVER',
+    'gap-limit': 'TR_EXPERIMENTAL_GAP_LIMIT',
 };
 
 export type FeedbackFeatureName = ExperimentalFeature | 'suite-sync' | 'stablecoin-yield';

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2605,6 +2605,22 @@ export const messages = defineMessages({
         id: 'TR_DUST_PHISHING_ERROR_EMPTY',
         defaultMessage: 'Dust threshold cannot be empty',
     },
+    TR_GAP_LIMIT_ERROR_EMPTY: {
+        id: 'TR_GAP_LIMIT_ERROR_EMPTY',
+        defaultMessage: 'Gap limit cannot be empty',
+    },
+    TR_GAP_LIMIT_ERROR_NUMBER: {
+        id: 'TR_GAP_LIMIT_ERROR_NUMBER',
+        defaultMessage: 'Enter a valid whole number',
+    },
+    TR_GAP_LIMIT_ERROR_POSITIVE: {
+        id: 'TR_GAP_LIMIT_ERROR_POSITIVE',
+        defaultMessage: 'Gap limit must be a positive number',
+    },
+    TR_GAP_LIMIT_ERROR_TOO_LOW: {
+        id: 'TR_GAP_LIMIT_ERROR_TOO_LOW',
+        defaultMessage: 'Gap limit must be at least {min}',
+    },
     TR_CONFIRM_AUTO_EJECT: {
         defaultMessage: 'Enable auto-eject',
         id: 'TR_CONFIRM_AUTO_EJECT',
@@ -5424,6 +5440,15 @@ export const messages = defineMessages({
         defaultMessage:
             'Enable the Tron Network with the latest firmware to check your balance, send and receive TRX and tokens, view charts and transaction history, and use WalletConnect. Full support, including freezing and voting, is coming soon.',
     },
+    TR_EXPERIMENTAL_GAP_LIMIT: {
+        id: 'TR_EXPERIMENTAL_GAP_LIMIT',
+        defaultMessage: 'Gap Limit',
+    },
+    TR_EXPERIMENTAL_GAP_LIMIT_DESCRIPTION: {
+        id: 'TR_EXPERIMENTAL_GAP_LIMIT_DESCRIPTION',
+        defaultMessage:
+            'When recovering or scanning a wallet, Trezor checks addresses one by one and stops after finding 20 consecutive unused ones. If some of your transactions are missing, raise this limit to scan further.',
+    },
     TR_EXPERIMENTAL_MCP_SERVER: {
         id: 'TR_EXPERIMENTAL_MCP_SERVER',
         defaultMessage: 'MCP Server',
@@ -6567,6 +6592,10 @@ export const messages = defineMessages({
     TR_LABELING_ENABLED: {
         id: 'TR_LABELING_ENABLED',
         defaultMessage: 'Labeling',
+    },
+    SETTINGS_BACKEND_SETTINGS_CUSTOM_GAP_LIMIT: {
+        id: 'SETTINGS_BACKEND_SETTINGS_CUSTOM_GAP_LIMIT',
+        defaultMessage: 'Custom Gap Limit',
     },
     SETTINGS_BACKEND_SETTINGS_DESCRIPTION: {
         id: 'SETTINGS_BACKEND_SETTINGS_DESCRIPTION',

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -38,6 +38,7 @@ export const SettingsAnchor = {
     NetworkReserve: '@general-settings/network-reserve',
     DustPhishing: '@general-settings/dust-phishing',
     DustPhishingThreshold: '@general-settings/dust-phishing-threshold',
+    GapLimit: '@general-settings/gap-limit',
 
     BackupFailed: '@device-settings/backup-failed',
     BackupRecoverySeed: '@device-settings/backup-recovery-seed',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Providing as experimental feature the option to set a custom Gap Limit so users with issues like the one described https://github.com/trezor/trezor-suite/issues/3504  can find their funds in Trezor Suite.

## Notes for QA

There is new experimental feature called "Gap Limit" it should enable a new field in the application configuration to set a custom Gap Limit that should allow to find funds in wallets with more than 20 consecutive unused addresses.

You can test it with the Bitcoin Testnet default (segwit) account with the all seed. I put some funds in an address with a gap limit of 25 and the default limit is 20, so if you increase the limit gap to 25 you will see the regtest account actually gets some funds available (hopefully nobody takes them).

You can test it with electrum custom backend as well.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/3504

## Screenshots:
* Experimental feature enabled

<img width="651" height="160" alt="image" src="https://github.com/user-attachments/assets/f3ada8b3-7e1a-4dcf-aaa0-8202cd53b766" />

* Configuration in coin backend configuration

<img width="655" height="642" alt="image" src="https://github.com/user-attachments/assets/99239648-6e99-4e75-95b6-6219282c28d5" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/gap-limit-experimental&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/gap-limit-experimental&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/gap-limit-experimental&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T15:07:27.941Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-16T14:59:51.635Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/gap-limit-experimental/web/](https://dev.suite.sldev.cz/suite-web/feat/gap-limit-experimental/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->