### PR TITLE
Feat/connect web iframe 2

### DIFF
--- a/packages/connect-common/src/constants/errors.ts
+++ b/packages/connect-common/src/constants/errors.ts
@@ -4,11 +4,10 @@ import type { thp } from '@trezor/protocol';
 export const ERROR_CODES = {
     Init_NotInitialized: 'TrezorConnect not initialized', // race condition: call on not initialized Core (usually hot-reloading)
     Init_AlreadyInitialized: 'TrezorConnect has been already initialized', // thrown by .init called multiple times
-    Init_IframeBlocked: 'Iframe blocked', // iframe injection blocked (ad-blocker)
-    Init_IframeTimeout: 'Iframe timeout', // iframe didn't load in specified time
     Init_ManifestMissing:
         'Manifest not set. Read more at https://github.com/trezor/trezor-suite/blob/develop/docs/packages/connect/index.md', // manifest is not set
 
+    Handshake_Error: '', // one of: 'iframe-blocked', 'iframe-timeout', 'popup-blocked', 'handshake-timeout', 'channel-id-missing', 'origin-missing', 'env-not-supported', 'unknown' (see BootstrapError)
     Popup_ConnectionMissing: 'Unable to establish connection with iframe', // thrown by popup
     Desktop_ConnectionMissing: 'Unable to establish connection with Suite', // thrown by suite-desktop
 

--- a/packages/connect-web/src/bootstrap/__tests__/bootstrap.test.ts
+++ b/packages/connect-web/src/bootstrap/__tests__/bootstrap.test.ts
@@ -1,0 +1,327 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { BootstrapError } from '../bootstrap-errors';
+
+class MockBroadcastChannel {
+    static instances: MockBroadcastChannel[] = [];
+    name: string;
+    private listeners: ((event: MessageEvent) => void)[] = [];
+    postMessage = jest.fn();
+    close = jest.fn();
+
+    constructor(name: string) {
+        this.name = name;
+        MockBroadcastChannel.instances.push(this);
+    }
+
+    addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+        this.listeners.push(listener);
+    }
+
+    removeEventListener(_type: string, listener: (event: MessageEvent) => void) {
+        this.listeners = this.listeners.filter(l => l !== listener);
+    }
+
+    emit(data: any) {
+        const event = new MessageEvent('message', { data });
+        Object.defineProperty(event, 'currentTarget', { value: this });
+        this.listeners.forEach(l => l(event));
+    }
+}
+
+(global as any).BroadcastChannel = MockBroadcastChannel;
+
+jest.useFakeTimers();
+
+const setLocation = (url: string) => {
+    Object.defineProperty(window, 'location', {
+        value: { href: url, replace: jest.fn() },
+        writable: true,
+        configurable: true,
+    });
+};
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    MockBroadcastChannel.instances = [];
+});
+
+const POPUP_URL = 'https://suite.trezor.io/connect-popup/';
+const OWNER_ORIGIN = 'https://thirdparty.example.com';
+
+const startHandshake = (origin: string = OWNER_ORIGIN) => {
+    window.dispatchEvent(
+        new MessageEvent('message', {
+            data: {
+                type: 'channel-handshake-request',
+                channel: {
+                    here: '@trezor/connect-web',
+                    peer: '@trezor/connect-bootstrap-iframe',
+                },
+            },
+            origin,
+        }),
+    );
+};
+
+// In jsdom: window.parent === window → IFRAME_MODE = false → popup mode.
+describe('bootstrap (popup mode)', () => {
+    let bootstrap: () => Promise<void>;
+
+    beforeEach(() => {
+        setLocation(`${POPUP_URL}?connect-popup-req=abc123`);
+
+        jest.isolateModules(() => {
+            ({ bootstrap } = require('../bootstrap'));
+        });
+    });
+
+    it('creates BroadcastChannel and redirects on successful handshake', async () => {
+        const promise = bootstrap();
+
+        const bc = MockBroadcastChannel.instances[0];
+        expect(bc).toBeDefined();
+        expect(bc.name).toBe('@trezor/connect-popup/abc123');
+
+        // Bootstrap-iframe sends handshake request via BroadcastChannel.
+        bc.emit({
+            type: 'channel-handshake-request',
+            channel: {
+                here: '@trezor/connect-bootstrap-iframe',
+                peer: '@trezor/connect-bootstrap-popup',
+            },
+        });
+
+        await promise;
+
+        // Confirm was sent back.
+        expect(bc.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'channel-handshake-confirm',
+                channel: {
+                    here: '@trezor/connect-bootstrap-popup',
+                    peer: '@trezor/connect-bootstrap-iframe',
+                },
+            }),
+        );
+
+        // BroadcastChannel closed after successful handshake.
+        expect(bc.close).toHaveBeenCalled();
+
+        // Redirects to base URL preserving original query.
+        jest.advanceTimersByTime(2000);
+        expect(window.location.href).toContain('connect-popup-req=abc123');
+        expect(window.location.href).not.toContain('connect-popup-err');
+    });
+
+    it('redirects with handshake-timeout error on handshake timeout', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const promise = bootstrap();
+
+        // No peer responds — timeout fires.
+        jest.advanceTimersByTime(5000);
+
+        await promise;
+
+        // Redirect is delayed by 2s.
+        jest.advanceTimersByTime(2000);
+
+        expect(window.location.href).toBe(
+            `${POPUP_URL}?connect-popup-err=${BootstrapError.HANDSHAKE_TIMEOUT}`,
+        );
+
+        errorSpy.mockRestore();
+    });
+
+    it('redirects with broadcast-channel-not-supported error on BC failure', async () => {
+        const original = (global as any).BroadcastChannel;
+        delete (global as any).BroadcastChannel;
+
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        jest.isolateModules(() => {
+            ({ bootstrap } = require('../bootstrap'));
+        });
+
+        await bootstrap();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(window.location.href).toBe(
+            `${POPUP_URL}?connect-popup-err=${BootstrapError.ENV_NOT_SUPPORTED}`,
+        );
+
+        errorSpy.mockRestore();
+        (global as any).BroadcastChannel = original;
+    });
+});
+
+describe('bootstrap (iframe mode)', () => {
+    let bootstrap: () => Promise<void>;
+    const registeredListeners: EventListener[] = [];
+
+    const mockParentWindow = { postMessage: jest.fn(), origin: OWNER_ORIGIN };
+
+    beforeEach(() => {
+        setLocation(`${POPUP_URL}?connect-popup-req=abc123`);
+
+        // Make window.parent !== window → IFRAME_MODE = true.
+        Object.defineProperty(window, 'parent', {
+            value: mockParentWindow,
+            writable: true,
+            configurable: true,
+        });
+
+        (document as any).requestStorageAccess = jest.fn();
+
+        const origAdd = window.addEventListener.bind(window);
+        jest.spyOn(window, 'addEventListener').mockImplementation(
+            (type: string, listener: EventListenerOrEventListenerObject, ...rest: any[]) => {
+                if (type === 'message') registeredListeners.push(listener as EventListener);
+                origAdd(type, listener, ...rest);
+            },
+        );
+
+        jest.isolateModules(() => {
+            ({ bootstrap } = require('../bootstrap'));
+        });
+    });
+
+    afterEach(() => {
+        registeredListeners.forEach(l => window.removeEventListener('message', l));
+        registeredListeners.length = 0;
+        (window.addEventListener as jest.Mock)?.mockRestore?.();
+
+        Object.defineProperty(window, 'parent', {
+            value: window,
+            writable: true,
+            configurable: true,
+        });
+    });
+
+    it('rejects handshake when origin is missing', async () => {
+        bootstrap();
+        startHandshake('null');
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+            { type: 'channel-handshake-error', error: 'origin-missing' },
+            '*',
+        );
+    });
+
+    it('completes full handshake flow and starts forwarding', async () => {
+        const fakeBc = new MockBroadcastChannel('test');
+        (document as any).requestStorageAccess = jest.fn().mockResolvedValue({
+            BroadcastChannel: () => fakeBc,
+        });
+
+        const promise = bootstrap();
+        startHandshake();
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        // Bootstrap-popup confirms via BroadcastChannel.
+        fakeBc.emit({
+            type: 'channel-handshake-confirm',
+            channel: {
+                here: '@trezor/connect-bootstrap-popup',
+                peer: '@trezor/connect-bootstrap-iframe',
+            },
+        });
+
+        await promise;
+
+        // Owner handshake confirmed to 3rd-party host via window.parent.
+        expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'channel-handshake-confirm' }),
+            OWNER_ORIGIN,
+        );
+    });
+
+    it('handles requestStorageAccess failure', async () => {
+        (document as any).requestStorageAccess = jest.fn().mockRejectedValue(new Error('denied'));
+
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        bootstrap();
+        startHandshake();
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        errorSpy.mockRestore();
+    });
+
+    it('retries and eventually fails when bootstrap-popup does not respond', async () => {
+        const fakeBc = new MockBroadcastChannel('test');
+        (document as any).requestStorageAccess = jest.fn().mockResolvedValue({
+            BroadcastChannel: () => fakeBc,
+        });
+
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        bootstrap();
+        startHandshake();
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        // Exhaust all 5 retry attempts (500ms each).
+        jest.advanceTimersByTime(500 * 5);
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(errorSpy.mock.calls[0].join(' ')).toMatch('handshake-timeout');
+        expect(fakeBc.close).toHaveBeenCalled();
+
+        errorSpy.mockRestore();
+    });
+});
+
+describe('bootstrap (getParams failures)', () => {
+    let bootstrap: () => Promise<void>;
+
+    it('throws when URLSearchParams is undefined', async () => {
+        setLocation(POPUP_URL);
+
+        const original = (global as any).URLSearchParams;
+        delete (global as any).URLSearchParams;
+
+        jest.isolateModules(() => {
+            ({ bootstrap } = require('../bootstrap'));
+        });
+
+        bootstrap();
+        startHandshake();
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(window.location.href).toBe(
+            `${POPUP_URL}?connect-popup-err=${BootstrapError.ENV_NOT_SUPPORTED}`,
+        );
+
+        (global as any).URLSearchParams = original;
+    });
+
+    it('redirects with channel-id-missing error when channelId is absent', async () => {
+        setLocation(POPUP_URL);
+
+        jest.isolateModules(() => {
+            ({ bootstrap } = require('../bootstrap'));
+        });
+
+        bootstrap();
+        startHandshake();
+
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(window.location.href).toBe(
+            `${POPUP_URL}?connect-popup-err=${BootstrapError.CHANNEL_ID_MISSING}`,
+        );
+    });
+});

--- a/packages/connect-web/src/bootstrap/bootstrap-errors.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap-errors.ts
@@ -1,0 +1,8 @@
+export const BootstrapError = {
+    ENV_NOT_SUPPORTED: 'env-not-supported', // general error for unsupported environment or missing APIs
+    HANDSHAKE_TIMEOUT: 'handshake-timeout', // handshake between iframe and popup failed (popup did not respond)
+    STORAGE_ACCESS_DENIED: 'storage-access-denied', // storage access denied in iframe
+    CHANNEL_ID_MISSING: 'channel-id-missing', // channel ID missing in handshake
+    ORIGIN_MISSING: 'origin-missing', // origin missing in handshake
+    UNKNOWN: 'unknown', // unknown error
+} as const;

--- a/packages/connect-web/src/bootstrap/bootstrap.html
+++ b/packages/connect-web/src/bootstrap/bootstrap.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+        <title>Trezor Suite</title>
+        <meta name="description" content="" />
+        <meta name="keywords" content="" />
+        <meta name="author" content="Trezor info@trezor.io" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="title" content="Trezor Suite" />
+        <meta http-equiv="Cache-control" content="no-cache" />
+        <meta http-equiv="Pragma" content="no-cache" />
+        <meta http-equiv="Expires" content="-1" />
+        <style>
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background: #151719;
+                }
+            }
+        </style>
+    </head>
+    <body></body>
+</html>

--- a/packages/connect-web/src/bootstrap/bootstrap.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.ts
@@ -1,0 +1,409 @@
+import { BootstrapError } from './bootstrap-errors';
+
+const logger = (() => {
+    let enabled = false;
+
+    return {
+        enable: () => {
+            enabled = true;
+        },
+        log: (...args: any[]) => {
+            // eslint-disable-next-line no-console
+            if (enabled) console.log(...args);
+        },
+        error: (...args: any[]) => {
+            console.error(...args);
+        },
+    };
+})();
+
+const IFRAME_MODE = window.parent !== window;
+
+const BOOTSTRAP_IFRAME = '@trezor/connect-bootstrap-iframe';
+const BOOTSTRAP_POPUP = '@trezor/connect-bootstrap-popup';
+const PEERS = {
+    HERE: IFRAME_MODE ? BOOTSTRAP_IFRAME : BOOTSTRAP_POPUP,
+    BOOTSTRAP: IFRAME_MODE ? BOOTSTRAP_POPUP : BOOTSTRAP_IFRAME,
+    WEB: '@trezor/connect-web',
+    POPUP: '@trezor/connect-popup',
+};
+
+const HANDSHAKE_TIMEOUT = 500;
+const HANDSHAKE_REQ = 'channel-handshake-request';
+const HANDSHAKE_ERR = 'channel-handshake-error';
+const HANDSHAKE_CONF = 'channel-handshake-confirm';
+
+const getParams = () => {
+    if (typeof URLSearchParams === 'undefined') {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+
+    try {
+        const urlParams = new URLSearchParams(window.location.href.split('?')[1]);
+        const debug = urlParams.get('debug');
+        if (debug === '1' || debug === 'true') logger.enable();
+
+        const channelId = urlParams.get('connect-popup-req');
+        const channelName = channelId ? '@trezor/connect-popup/' + channelId : null;
+
+        return {
+            channelId,
+            channelName,
+            debug,
+        };
+    } catch {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+};
+
+// Required in iframes embedded in 3rd party pages. BroadcastChannel is partitioned there.
+// ✅ Chrome 125+ / Opera 111+
+// ❌ Firefox / Safari / many WebViews / some Chromium forks
+const getUnpartitionedBroadcastChannel = async (channelName: string): Promise<BroadcastChannel> => {
+    let handle: { BroadcastChannel?: (name: string) => BroadcastChannel } | null = null;
+    try {
+        // @ts-expect-error - requestStorageAccess params not yet lib.dom.d.ts
+        handle = await document.requestStorageAccess({ BroadcastChannel: true });
+    } catch {
+        throw BootstrapError.STORAGE_ACCESS_DENIED;
+    }
+
+    if (!handle || typeof handle.BroadcastChannel !== 'function') {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+
+    try {
+        return handle.BroadcastChannel(channelName);
+    } catch {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+};
+
+const getBroadcastChannel = (channelName: string) => {
+    if (typeof BroadcastChannel === 'undefined') {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+
+    try {
+        return new BroadcastChannel(channelName);
+    } catch {
+        throw BootstrapError.ENV_NOT_SUPPORTED;
+    }
+};
+
+const getConfirmHandshake = (eventData: { channel: { here: string } }) => ({
+    type: HANDSHAKE_CONF,
+    channel: {
+        here: PEERS.HERE,
+        peer: eventData.channel.here,
+    },
+});
+
+// @popup-only
+const redirectToSuite = (errorCode?: string): void => {
+    const currentUrl = new URL(window.location.href);
+    const nextUrl = new URL(currentUrl.toString());
+    nextUrl.pathname = nextUrl.pathname.replace(/\/bootstrap\.html$/, '/');
+
+    if (errorCode) {
+        nextUrl.search = '';
+        nextUrl.searchParams.set('connect-popup-err', errorCode);
+    } else {
+        nextUrl.search = currentUrl.search;
+    }
+
+    window.location.href = nextUrl.toString();
+};
+
+// @popup-only
+// Step 2. Listen for handshake from the iframe.
+const handleBootstrapHandshake = (
+    broadcast: BroadcastChannel,
+    timeout: number = 5000,
+): Promise<void> =>
+    new Promise((resolve, reject) => {
+        const onHandshakeRequest = (event: MessageEvent): void => {
+            const channel = event.data?.channel;
+            if (!channel) return;
+
+            if (
+                event.data.type === HANDSHAKE_REQ &&
+                channel.here === PEERS.BOOTSTRAP &&
+                channel.peer === PEERS.HERE
+            ) {
+                // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                clearTimeout(timer);
+                broadcast.removeEventListener('message', onHandshakeRequest);
+                broadcast.postMessage(getConfirmHandshake(event.data));
+                resolve();
+            }
+        };
+
+        broadcast.addEventListener('message', onHandshakeRequest);
+
+        const timer = setTimeout(() => {
+            broadcast.removeEventListener('message', onHandshakeRequest);
+            reject(BootstrapError.HANDSHAKE_TIMEOUT);
+        }, timeout);
+    });
+
+// @popup-only
+// Step 1. Main bootstrap function in popup mode.
+const bootstrapPopup = async (): Promise<void> => {
+    let channelName;
+    try {
+        const params = getParams();
+        channelName = params.channelName;
+    } catch (error) {
+        redirectToSuite(error);
+
+        return;
+    }
+
+    logger.log(PEERS.HERE, channelName);
+
+    if (!channelName) {
+        redirectToSuite(BootstrapError.CHANNEL_ID_MISSING);
+
+        return;
+    }
+
+    // Handle messages from 3rd party window until handshake is done.
+    // This works only on limited setups: same origin or localhost.
+    // Triggered by ../web.ts handshake (if iframe fails early then redirect early).
+    window.addEventListener('message', event => {
+        if (event.data?.type === HANDSHAKE_ERR) {
+            redirectToSuite(event.data.error);
+        }
+    });
+
+    try {
+        const broadcast = getBroadcastChannel(channelName);
+        await handleBootstrapHandshake(broadcast);
+        broadcast.close();
+
+        redirectToSuite();
+    } catch (error) {
+        redirectToSuite(typeof error === 'string' ? error : BootstrapError.UNKNOWN);
+    }
+};
+
+// @iframe-only
+// Step 3. Forward messages between suite-web and 3rd party window.
+const startForwarding = (broadcast: BroadcastChannel, owner: Window, ownerOrigin: string) => {
+    logger.log(PEERS.HERE, 'start forwarding');
+
+    const onBroadcastMessage = (event: MessageEvent): void => {
+        const channel = event.data?.channel;
+        if (!channel || channel.here !== PEERS.POPUP || channel.peer !== PEERS.WEB) {
+            return;
+        }
+
+        logger.log(PEERS.POPUP, '→', PEERS.WEB, event.data.type);
+        owner.postMessage(event.data, ownerOrigin);
+    };
+
+    const onOwnerMessage = (event: MessageEvent): void => {
+        // Only accept messages from the verified owner origin.
+        if (event.origin !== ownerOrigin) {
+            return;
+        }
+
+        const channel = event.data?.channel;
+        if (!channel || channel.here !== PEERS.WEB || channel.peer !== PEERS.POPUP) {
+            return;
+        }
+
+        logger.log(PEERS.WEB, '→', PEERS.POPUP, event.data.type);
+        // Pass through the origin of the owner window, so that it can be used for security checks in the popup.
+        broadcast.postMessage({ ...event.data, origin: event.origin });
+    };
+
+    // Messages from connect-popup (suite-web) addressed to connect-web (3rd party window).
+    broadcast.addEventListener('message', onBroadcastMessage);
+
+    // Messages from connect-web (3rd party window) addressed to connect-popup (suite-web).
+    window.addEventListener('message', onOwnerMessage);
+
+    // Return cleanup function to stop forwarding.
+    return () => {
+        logger.log(PEERS.HERE, 'stop forwarding');
+        broadcast.removeEventListener('message', onBroadcastMessage);
+        window.removeEventListener('message', onOwnerMessage);
+    };
+};
+
+// @iframe-only
+// Step 2. Handshake iframe -> popup using iterative retry. (handled by handleBootstrapHandshake)
+const startBootstrapHandshake = (
+    broadcast: BroadcastChannel,
+    maxAttempts: number = 5,
+): { abort: () => void; promise: Promise<void> } => {
+    const abortController = new AbortController();
+
+    const promise = new Promise<void>((resolve, reject) => {
+        let attempt = 0;
+        let timer: ReturnType<typeof setTimeout>;
+
+        const tryOnce = () => {
+            attempt++;
+
+            logger.log(PEERS.HERE, 'handshake attempt', attempt, 'of', maxAttempts);
+
+            const onHandshakeConfirm = (event: MessageEvent): void => {
+                const channel = event.data?.channel;
+                if (!channel) return;
+
+                if (
+                    event.data.type === HANDSHAKE_CONF &&
+                    channel.here === PEERS.BOOTSTRAP &&
+                    channel.peer === PEERS.HERE
+                ) {
+                    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+                    cleanup();
+                    resolve();
+                }
+            };
+
+            const cleanup = () => {
+                clearTimeout(timer);
+                broadcast.removeEventListener('message', onHandshakeConfirm);
+            };
+
+            abortController.signal.addEventListener('abort', () => {
+                cleanup();
+                reject(BootstrapError.HANDSHAKE_TIMEOUT);
+            });
+
+            broadcast.addEventListener('message', onHandshakeConfirm);
+
+            broadcast.postMessage({
+                type: HANDSHAKE_REQ,
+                channel: { here: PEERS.HERE, peer: PEERS.BOOTSTRAP },
+            });
+
+            timer = setTimeout(() => {
+                broadcast.removeEventListener('message', onHandshakeConfirm);
+                if (attempt < maxAttempts) {
+                    tryOnce();
+                } else {
+                    reject(BootstrapError.HANDSHAKE_TIMEOUT);
+                }
+            }, HANDSHAKE_TIMEOUT);
+        };
+
+        tryOnce();
+    });
+
+    return {
+        abort: () => abortController.abort(),
+        promise,
+    };
+};
+
+// @iframe-only
+// Step 1. Main bootstrap function in iframe mode.
+const bootstrapIframe = (): Promise<void> => {
+    let stopForwarding: (() => void) | undefined;
+    let handshakeInProgress = false;
+
+    const sendHandshakeError = (errorCode: unknown, ownerOrigin: string) => {
+        handshakeInProgress = false;
+
+        window.parent.postMessage(
+            {
+                type: HANDSHAKE_ERR,
+                error: typeof errorCode === 'string' ? errorCode : BootstrapError.UNKNOWN,
+            },
+            ownerOrigin,
+        );
+    };
+
+    return new Promise<void>(resolve => {
+        // Handle 3rd party window -> iframe.
+        window.addEventListener('message', async (event: MessageEvent) => {
+            if (event.data.channel?.here !== PEERS.WEB || event.data.channel?.peer !== PEERS.HERE) {
+                return;
+            }
+
+            if (event.data.type === HANDSHAKE_REQ) {
+                if (handshakeInProgress) {
+                    logger.log(PEERS.HERE, 'handshake already in progress');
+
+                    return;
+                }
+
+                handshakeInProgress = true;
+
+                const ownerOrigin = event.origin && event.origin !== 'null' ? event.origin : null;
+                if (!ownerOrigin) {
+                    // This is the only place where we don't know the origin, we need to use '*' to reach the parent window.
+                    // origin "null" or empty could mean that the iframe is embedded in a non-secure context (e.g. file://) or sandboxed.
+                    // We can't securely communicate with the parent window, so we treat it as an error.
+                    sendHandshakeError(BootstrapError.ORIGIN_MISSING, '*');
+
+                    return;
+                }
+
+                let channelName;
+                try {
+                    const params = getParams();
+                    channelName = params.channelName;
+                } catch (error) {
+                    sendHandshakeError(error, ownerOrigin);
+
+                    return;
+                }
+
+                logger.log(PEERS.HERE, channelName);
+
+                if (!channelName) {
+                    sendHandshakeError(BootstrapError.CHANNEL_ID_MISSING, ownerOrigin);
+
+                    return;
+                }
+
+                let broadcast: BroadcastChannel;
+                try {
+                    broadcast = await getUnpartitionedBroadcastChannel(channelName);
+                } catch (error) {
+                    sendHandshakeError(error, ownerOrigin);
+
+                    return;
+                }
+
+                const bootstrapHandshake = startBootstrapHandshake(broadcast);
+                try {
+                    await bootstrapHandshake.promise;
+
+                    // Restart forwarding messages between suite-web and 3rd party window (in case it was already started by a previous handshake attempt).
+                    // This ensures that we are forwarding messages through the correct BroadcastChannel instance.
+                    if (stopForwarding) {
+                        stopForwarding();
+                    }
+                    stopForwarding = startForwarding(broadcast, window.parent, ownerOrigin);
+
+                    window.parent.postMessage(getConfirmHandshake(event.data), ownerOrigin);
+                } catch (error) {
+                    logger.error(PEERS.BOOTSTRAP, error);
+
+                    bootstrapHandshake.abort();
+                    broadcast.close();
+
+                    sendHandshakeError(error, ownerOrigin);
+                }
+
+                handshakeInProgress = false;
+                resolve();
+            }
+        });
+    });
+};
+
+export const bootstrap = async (): Promise<void> => {
+    if (IFRAME_MODE) {
+        await bootstrapIframe();
+    } else {
+        await bootstrapPopup();
+    }
+};

--- a/packages/connect-web/src/bootstrap/index.ts
+++ b/packages/connect-web/src/bootstrap/index.ts
@@ -1,0 +1,6 @@
+// Entrypoint for the webpack bundle.
+// This file is used in bootstrap.html.
+
+import { bootstrap } from './bootstrap';
+
+bootstrap();

--- a/packages/connect-web/src/popup/abstract.ts
+++ b/packages/connect-web/src/popup/abstract.ts
@@ -51,7 +51,7 @@ export abstract class Popup extends EventEmitter {
     }
 
     protected abstract createChannel(origin: string): AbstractMessageChannel<CoreEventMessage>;
-    protected abstract open(): void;
+    protected abstract open(): Promise<void>;
     protected abstract closePopup(): void;
     protected abstract isOpen(): Promise<boolean>;
     protected abstract onReset(focus: boolean): void;
@@ -89,7 +89,7 @@ export abstract class Popup extends EventEmitter {
         this.locked = true;
         this.closedEmitted = false;
 
-        this.open();
+        return this.open();
     }
 
     protected buildPopupUrl(src: string): string {

--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -1,0 +1,100 @@
+import * as ERRORS from '@trezor/connect-common/src/constants/errors';
+import { type Deferred, createDeferred } from '@trezor/utils';
+
+const IFRAME_ID = 'trezor-connect-bootstrap';
+const IFRAME_TIMEOUT = 10000;
+
+const getIframeElement = (): HTMLIFrameElement | undefined =>
+    (document.getElementById(IFRAME_ID) as HTMLIFrameElement | null) ?? undefined;
+
+const createIframeElement = (): HTMLIFrameElement => {
+    const instance = document.createElement('iframe');
+    instance.id = IFRAME_ID;
+    instance.frameBorder = '0';
+    instance.width = '0px';
+    instance.height = '0px';
+    instance.style.position = 'absolute';
+    instance.style.display = 'none';
+    instance.style.border = '0px';
+    instance.style.width = '0px';
+    instance.style.height = '0px';
+
+    return instance;
+};
+
+export const getIframeInstance = () => {
+    let initPromise: Deferred<void> | undefined;
+    let initTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const clearInitTimeout = () => {
+        if (initTimeout) {
+            window.clearTimeout(initTimeout);
+            initTimeout = undefined;
+        }
+    };
+
+    const handleIframeBlocked = () => {
+        clearInitTimeout();
+        initPromise?.reject(ERRORS.TypedError('Handshake_Error', 'iframe-blocked'));
+    };
+
+    const handleIframeLoad = () => {
+        const instance = getIframeElement();
+        if (!instance) {
+            return handleIframeBlocked();
+        }
+
+        try {
+            // if the hosting page **is able to access** cross-origin location it means that the iframe is **NOT LOADED**
+            const iframeOrigin = instance.contentWindow?.location.origin;
+            if (!iframeOrigin || iframeOrigin === 'null') {
+                return handleIframeBlocked();
+            }
+        } catch {
+            // empty
+        }
+
+        instance.onload = null;
+        initPromise?.resolve();
+    };
+
+    const create = (src: string) => {
+        if (initPromise) {
+            return initPromise.promise;
+        }
+
+        const instance = getIframeElement();
+        if (instance) {
+            return Promise.resolve();
+        }
+
+        initPromise = createDeferred();
+
+        const newInstance = createIframeElement();
+        initTimeout = setTimeout(() => {
+            initPromise?.reject(ERRORS.TypedError('Handshake_Error', 'iframe-timeout'));
+        }, IFRAME_TIMEOUT);
+
+        newInstance.onload = handleIframeLoad;
+        newInstance.setAttribute('src', src);
+        document.body.appendChild(newInstance);
+
+        return initPromise.promise
+            .finally(() => {
+                clearInitTimeout();
+            })
+            .catch(error => {
+                // Reset state to allow initialization again.
+                if (newInstance.parentNode) {
+                    newInstance.parentNode.removeChild(newInstance);
+                }
+                // Propagate TypedError to caller.
+                throw error;
+            });
+    };
+
+    return {
+        create,
+        get: getIframeElement,
+    };
+};

--- a/packages/connect-web/src/popup/web.ts
+++ b/packages/connect-web/src/popup/web.ts
@@ -1,43 +1,116 @@
+import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import { type CoreEventMessage } from '@trezor/connect-common/src/events';
 import { type AbstractMessageChannel } from '@trezor/connect-common/src/messageChannel/abstract';
 import { WindowWindowChannel } from '@trezor/connect-common/src/messageChannel/window-window';
+import { getOrigin } from '@trezor/connect-common/src/utils/urlUtils';
+import { getWeakRandomId } from '@trezor/utils/src/getWeakRandomId';
 
 import { Popup } from './abstract';
+import { getIframeInstance } from './iframe';
+import { BootstrapError } from '../bootstrap/bootstrap-errors';
 
 export class WebPopup extends Popup {
     private popupWindow: Window | undefined;
+    private iframe = getIframeInstance();
+    private channelId = getWeakRandomId(16);
 
-    protected createChannel(origin: string): AbstractMessageChannel<CoreEventMessage> {
+    protected createChannel(): AbstractMessageChannel<CoreEventMessage> {
         return new WindowWindowChannel<CoreEventMessage>({
             windowHere: window,
-            windowPeer: () => this.popupWindow,
+            windowPeer: () => this.iframe.get()?.contentWindow || undefined,
             channel: {
                 here: '@trezor/connect-web',
                 peer: '@trezor/connect-popup',
             },
             logger: this.logger,
-            origin,
+            origin: getOrigin(this.popupSrc),
         });
     }
 
-    protected open(): void {
+    protected async open(): Promise<void> {
         const url = this.buildPopupUrl(this.popupSrc);
+        const query = `connect-popup-req=${this.channelId}`;
+        const debug = this.logger.enabled ? '&debug=1' : '';
+        const popupUrl = `${url}/bootstrap.html?${query}${debug}`;
+        const popupOrigin = getOrigin(this.popupSrc);
 
-        const windowResult = window.open(url, 'modal');
-
+        const windowResult = window.open('about:blank', '_blank');
         if (!windowResult) {
-            this.handleOpenFailure('Popup window blocked by browser');
+            const error = ERRORS.TypedError('Handshake_Error', 'popup-blocked');
+            this.handleOpenFailure(error.message);
 
-            return;
+            return Promise.reject(error);
         }
 
-        this.popupWindow = windowResult;
+        try {
+            await this.iframe.create(popupUrl);
+        } catch (error) {
+            windowResult.close();
+            this.handleOpenFailure(error.message);
+
+            return Promise.reject(error);
+        }
+
+        // Open bootstrap.html. From now on we cant control the window.
+        // Communication via postMessage is limited to the same origin or localhost.
+        windowResult.location.href = popupUrl;
+
+        // TODO: popupWindow assign conditionally when we have limited control over the window.
+        // this.popupWindow = windowResult;
+
+        const iframeWindowChannel = new WindowWindowChannel<
+            CoreEventMessage | { type: 'channel-handshake-error'; error: string }
+        >({
+            windowHere: window,
+            windowPeer: () => this.iframe.get()?.contentWindow || undefined,
+            channel: {
+                here: '@trezor/connect-web',
+                peer: '@trezor/connect-bootstrap-iframe',
+            },
+            logger: this.logger,
+            origin: popupOrigin,
+        });
+
+        iframeWindowChannel.on('message', message => {
+            if (message.type === 'channel-handshake-error') {
+                // This works only on limited setups: same origin or localhost.
+                // Handled by ../bootstrap.ts popup handshake
+                windowResult.postMessage(
+                    {
+                        type: 'channel-handshake-error',
+                        error: message.error,
+                    },
+                    popupOrigin,
+                );
+
+                this.handleOpenFailure(message.error);
+                iframeWindowChannel.abortHandshake(message.error);
+            }
+        });
+
+        try {
+            await iframeWindowChannel.init();
+            iframeWindowChannel.disconnect();
+        } catch (error) {
+            this.handleOpenFailure(error.message);
+            iframeWindowChannel.disconnect();
+
+            const isBootstrapError = Object.values(BootstrapError).includes(error.message);
+            if (isBootstrapError) {
+                // transform bootstrap-specific error
+                return Promise.reject(ERRORS.TypedError('Handshake_Error', error.message));
+            }
+
+            return Promise.reject(error);
+        }
 
         if (!this.channel.isConnected) {
             this.channel.connect();
         }
 
-        this.startCloseMonitoring();
+        // TODO: implement ping-pong this.startCloseMonitoring();
+
+        return Promise.resolve();
     }
 
     protected focusPopup(): void {
@@ -50,7 +123,7 @@ export class WebPopup extends Popup {
     }
 
     protected isOpen(): Promise<boolean> {
-        return Promise.resolve(this.popupWindow !== undefined && !this.popupWindow.closed);
+        return Promise.resolve(this.popupWindow !== undefined);
     }
 
     protected onReset(): void {}

--- a/packages/connect-web/src/popup/webextension.ts
+++ b/packages/connect-web/src/popup/webextension.ts
@@ -53,7 +53,7 @@ export class WebExtensionPopup extends Popup {
         });
     }
 
-    protected open(): void {
+    protected open(): Promise<void> {
         this.popupWindowPromise = createDeferred<chrome.tabs.Tab>();
         // Prevent unhandled rejection when open fails (e.g. popup blocked).
         // The rejection is surfaced to callers via handleOpenFailure → handshakePromise.
@@ -75,6 +75,8 @@ export class WebExtensionPopup extends Popup {
                 this.logger.error('Channel handshake failed:', error);
             });
         }
+
+        return Promise.resolve();
     }
 
     private openPopupInNewWindow(url: string): void {

--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -25,6 +25,10 @@ const config: webpack.Configuration = {
             // Use importScripts-based chunk loading so vendor/runtime chunks load in a worker context
             chunkLoading: 'import-scripts',
         },
+        'connect-popup-bootstrap': {
+            filename: 'connect-popup/bootstrap.[hash].js',
+            import: path.resolve(__dirname, '../../connect-web/src/bootstrap/index.ts'),
+        },
     },
     output: {
         path: path.join(baseDir, 'build'),
@@ -91,6 +95,18 @@ const config: webpack.Configuration = {
                     filename: path.join(baseDir, 'build', route.pattern, 'index.html'),
                 }),
         ),
+        new HtmlWebpackPlugin({
+            chunks: ['connect-popup-bootstrap'],
+            minify: false,
+            templateParameters: {
+                assetPrefix,
+                isOnionLocation: FLAGS.ONION_LOCATION_META,
+            },
+            inject: 'body' as const,
+            scriptLoading: 'blocking' as const,
+            template: path.resolve(__dirname, '../../connect-web/src/bootstrap/bootstrap.html'),
+            filename: path.join(baseDir, 'build/connect-popup/bootstrap.html'),
+        }),
         ...(!isDev ? [new CssMinimizerPlugin()] : []),
     ],
 };

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -19,8 +19,6 @@ import {
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-const FALLBACK_CLOSE_DELAY_MS = 2000;
-
 /**
  * Normalized incoming message from either the web or webextension popup link.
  */
@@ -158,14 +156,10 @@ export const useConnectPopup = (
     }, [lifecycle.status, pendingHandshake, popupLink]);
 
     // Fallback: if the caller's Popup class didn't close us after receiving
-    // POPUP.CLOSED, close the window ourselves after a short delay.
+    // POPUP.CLOSED, close the window ourselves.
     useEffect(() => {
-        if (!popupLink || popupCall?.state !== 'finished') return;
+        if (!popupLink || !responseSent || popupCall?.state !== 'finished') return;
 
-        const timer = setTimeout(() => {
-            window.close();
-        }, FALLBACK_CLOSE_DELAY_MS);
-
-        return () => clearTimeout(timer);
-    }, [popupLink, popupCall?.state]);
+        window.close();
+    }, [popupLink, responseSent, popupCall?.state]);
 };

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -24,6 +24,8 @@ export const useConnectPopupWeb = () => {
     // messages (including those carrying addresses / signatures) will be
     // scoped to that origin.
     const originRef = useRef<string>('*');
+    const initialUrl = useRef<string>(window.location.href.split('?')[1] ?? '');
+    const channelRef = useRef<BroadcastChannel | null>(null);
 
     /**
      * Send a message back to the caller (opener window or same window).
@@ -35,10 +37,11 @@ export const useConnectPopupWeb = () => {
      */
     const postMessageToParent = useCallback((message: ConnectPopupOutgoingMessage) => {
         message.channel = webChannel;
-        if (window.opener) {
-            window.opener.postMessage(message, originRef.current);
+        if (channelRef.current) {
+            channelRef.current.postMessage(message);
         } else {
-            window.postMessage(message, window.location.origin);
+            // TODO: show warning to user
+            console.error('BroadcastChannel not available', initialUrl.current);
         }
     }, []);
 
@@ -60,12 +63,61 @@ export const useConnectPopupWeb = () => {
 
     // Listen for incoming window messages and normalize them.
     useEffect(() => {
+        const urlParams = new URLSearchParams(initialUrl.current);
+        const requestId = urlParams.get('connect-popup-req');
+        const requestErr = urlParams.get('connect-popup-err');
+
+        if (!requestId && !requestErr) {
+            // no id in URL, unable to establish communication channel
+            return;
+        }
+
+        if (requestErr) {
+            // TODO: show warning to user
+            console.warn('Popup opened with error', { requestErr });
+
+            return;
+        }
+
+        let broadcastChannel: BroadcastChannel | undefined;
+        try {
+            broadcastChannel = new BroadcastChannel(`@trezor/connect-popup/${requestId}`);
+            channelRef.current = broadcastChannel;
+        } catch (error) {
+            // TODO: show warning to user
+            console.warn('BroadcastChannel is not supported in this browser', error);
+
+            return;
+        }
+
+        const handshakeTimeout = setTimeout(() => {
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            broadcastChannel.removeEventListener('message', onMessage);
+            broadcastChannel.close();
+            channelRef.current = null;
+            // TODO: show warning to user
+            console.warn('Popup handshake timeout');
+        }, 3000);
+
         const onMessage = (event: MessageEvent) => {
             const { data } = event;
             if (!data?.type) return;
 
-            // Remember the actual caller origin.
-            originRef.current = event.origin;
+            if (data.type === 'channel-handshake-request') {
+                // another popup with the same channel peer is trying to handshake.
+                // close current instance and proceed in new window.
+                if (data.channel.peer === '@trezor/connect-bootstrap-popup') {
+                    window.close();
+
+                    return;
+                }
+
+                if (data.channel.peer === webChannel.here) {
+                    clearTimeout(handshakeTimeout);
+                    // Remember the actual caller origin (sent by the bootstrap).
+                    originRef.current = data.origin;
+                }
+            }
 
             if (
                 data.type === 'channel-handshake-request' ||
@@ -86,10 +138,22 @@ export const useConnectPopupWeb = () => {
             }
         };
 
-        window.addEventListener('message', onMessage);
+        broadcastChannel.addEventListener('message', onMessage);
+
+        // TODO: replace this with broadcastChannel ping-pong
+        const onBeforeUnload = () => {
+            broadcastChannel.postMessage({
+                type: POPUP.CLOSED,
+                channel: webChannel,
+            });
+        };
+        window.addEventListener('beforeunload', onBeforeUnload);
 
         return () => {
-            window.removeEventListener('message', onMessage);
+            clearTimeout(handshakeTimeout);
+            broadcastChannel.removeEventListener('message', onMessage);
+            broadcastChannel.close();
+            window.removeEventListener('beforeunload', onBeforeUnload);
         };
     }, []);
 };

--- a/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
+++ b/suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts
@@ -35,8 +35,9 @@ async function gotoConnectExplorer(page: Page, method: string) {
 }
 
 test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] }, () => {
-    test.beforeEach(async ({ onboardingPage }) => {
+    test.beforeEach(async ({ onboardingPage, context }) => {
         await onboardingPage.completeOnboarding();
+        await context.grantPermissions(['storage-access']);
     });
     test(
         'TrezorConnect.getAddress',
@@ -200,7 +201,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             });
 
             // Close the browser popup window directly (simulates user clicking X)
-            await suite.close();
+            await suite.close({ runBeforeUnload: true });
 
             const response = page.getByTestId('@response');
             await expect(response).toHaveText(/success: false/);
@@ -234,7 +235,7 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             await expect(modal1.appName).toHaveText('Trezor Connect Explorer', {
                 timeout: 20_000,
             });
-            await suite1.close();
+            await suite1.close({ runBeforeUnload: true });
 
             await expect(page.getByTestId('@response')).toHaveText(/success: false/);
             await expect(page.getByTestId('@response')).toHaveText(/Method_Interrupted/);
@@ -262,11 +263,11 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
     );
 
     test(
-        'focuses existing popup if already open',
+        'closes existing popup if already open',
         {
             annotation: createTestAnnotation({
                 testCase:
-                    'Suite Web Connect: If popup is already open, it should be focused instead of opening a new one',
+                    'Suite Web Connect: If popup is already open, it should be closed before opening a new one',
             }),
         },
         async ({ page, device }) => {
@@ -300,25 +301,23 @@ test.describe('TrezorConnect popup web', { tag: ['@smoke', '@T3T1', '@webOnly'] 
             // focus connect-explorer again
             await page.bringToFront();
 
-            // Initiate a second call while the popup is still open
-            // Listen for new popup events
-            let newPopupOpened = false;
-            page.once('popup', () => {
-                newPopupOpened = true;
-            });
-            await page.getByTestId('@submit-button').click();
+            const [popup2] = await Promise.all([
+                page.waitForEvent('popup', { timeout: 30_000 }),
+                page.getByTestId('@submit-button').click(),
+            ]);
 
-            // Wait a short time to see if a new popup is opened
-            await page.waitForTimeout(1000);
+            // Check that the original popup is closed.
+            await expect.poll(() => popup1.isClosed(), { timeout: 5_000 }).toBe(true);
+            expect(popup2.isClosed()).toBe(false);
 
-            // Assert that no new popup was opened
-            expect(newPopupOpened).toBe(false);
-
-            // Optionally, check that the original popup is still open
-            expect(await popup1.isClosed()).toBe(false);
+            // Verify the new popup works correctly
+            // const connectPermissionsModalNew = new ConnectPermissionsModal(popup2);
+            // await expect(connectPermissionsModalNew.appName).toHaveText('Trezor Connect Explorer', {
+            //     timeout: 20_000,
+            // });
 
             // Clean up
-            await popup1.close();
+            await popup2.close();
         },
     );
 });
@@ -328,20 +327,16 @@ test.describe(
     { tag: ['@smoke', '@T3T1', '@webOnly'] },
     () => {
         test(
-            'popup blocked by browser returns handshake failed error',
+            'popup blocked by browser returns popup-blocked error',
             {
-                // note: we may use this test (after small changes) to test missing browser permissions
-                // as proposed in https://github.com/trezor/trezor-suite/pull/23468
                 annotation: createTestAnnotation({
                     testCase:
-                        'Suite Web Connect: When popup is blocked, returns handshake failed error',
+                        'Suite Web Connect: When popup is blocked, returns popup-blocked error',
                 }),
             },
             async ({ page }) => {
-                // When window.open returns null (popup blocked), the handshake
-                // times out and returns { success: false, error: "handshake failed" }.
-                // Note: PopupManager still leaves `locked = true` after this, which
-                // means subsequent calls will try to focus a non-existent window.
+                // When window.open returns null (popup blocked), the error is
+                // returned immediately as { success: false, error: "popup-blocked" }.
 
                 await gotoConnectExplorer(page, 'bitcoin/getAddress');
                 await page.getByTestId('@api-playground/collapsible-box').click();
@@ -356,7 +351,7 @@ test.describe(
                 // todo: there is quite big  timeout before handshake failed appears. Maybe we could detect that popup
                 // did not open earlier and return error faster?
                 await expect(response).toHaveText(/success: false/, { timeout: 15_000 });
-                await expect(response).toHaveText(/handshake failed/i);
+                await expect(response).toHaveText(/popup-blocked/i);
             },
         );
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Connect Popup bootstrap

A lightweight relay page (bootstrap.html) loaded in two contexts:

- Popup mode — opened by window.open() from the 3rd-party host
- Iframe mode — embedded inside the 3rd-party host page

### Why it exists
With `COOP` header enabled on the server we cant talk to suite-web directly using `popupWindow.postMessage` so we need a new layer to pass request/reposes between 3rd-party host and suite-web.

### How it works
```
[3rd-party host]
  └── <iframe src="bootstrap.html">   ← iframe mode
         |  handshake with parent (3rd party)
         |  handshake with BroadcastChannel (bootstrap.html opened via window.open)
         │ send messages from 3rd-party host to BroadcastChannel
         │ send messages BroadcastChannel to 3rd-party host
  └── window.open("bootstrap.html")  ← popup mode
        │  handshake with BroadcastChannel  (bootstrap.html embeded in iframe)
        └─ redirect to ────────────────────────── [suite-web/connect-popup]
            | communicate with 3rd-party host using BroadcastChannel
 ```

However using `BroadcastChannel` from embeded iframe comes with a price.
BroadcastChannel is storage-partitioned in third-party iframes (Chrome, Firefox). A channel opened inside a cross-origin iframe has a different partition key than one opened on suite.trezor.io, so they can't talk directly. Bootstrap works around this using [requestStorageAccess](https://developer.mozilla.org/en-US/docs/Web/API/Document/requestStorageAccess).
Unfortunately this is also not 100% reliable solution (doesnt work in Firefox, could be blocked by browser settings) in that case we should **enforce Suite Desktop app**

### TODOS:
- [x] rename server rule `iframe.html` > `bootstrap` on sldev.cz
- [ ] add server rule on suite.trezor.io
- [x] redirect on failed handshake (where to?)
- [x] fail handshake early - edgaces from the bootstrap
- [ ] fix popup window `isOpen` condition (available only during bootstrap handshake)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-web-iframe-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-web-iframe-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T12:24:50.580Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-16T16:50:31.619Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-web-iframe-2/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-web-iframe-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->