### PR TITLE
fix(connect): support root URL pattern in extractBranch regex

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -47,6 +47,7 @@
     ],
     "scripts": {
         "depcheck": "yarn g:depcheck",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
         "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",

--- a/packages/connect-web/src/impl/__tests__/getSuiteWebUrl.test.ts
+++ b/packages/connect-web/src/impl/__tests__/getSuiteWebUrl.test.ts
@@ -31,6 +31,44 @@ describe('extractBranch', () => {
         expect(extractBranch(`${DEV_ORIGIN}/connect/feat/xyz`)).toBe('feat/xyz');
     });
 
+    it('extracts branch from root URL with trailing slash', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/develop/`)).toBe('develop');
+    });
+
+    it('extracts multi-segment branch from root URL with trailing slash', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/feat/xyz/`)).toBe('feat/xyz');
+    });
+
+    it('treats bare /settings without trailing slash as part of branch name', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/develop/settings`)).toBe('develop/settings');
+    });
+
+    it('handles branch name containing "methods" word', () => {
+        expect(
+            extractBranch(`${DEV_ORIGIN}/connect/fix/methods-refactor/methods/bitcoin/getAddress`),
+        ).toBe('fix/methods-refactor');
+    });
+
+    it('handles branch name containing "settings" word', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/fix/settings-page/settings/`)).toBe(
+            'fix/settings-page',
+        );
+    });
+
+    it('preserves branch named fix/methods at root URL', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/fix/methods`)).toBe('fix/methods');
+    });
+
+    it('preserves branch named fix/settings at root URL', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/fix/settings`)).toBe('fix/settings');
+    });
+
+    it('strips /methods/ delimiter even when branch contains methods', () => {
+        expect(extractBranch(`${DEV_ORIGIN}/connect/fix/methods/methods/bitcoin/getAddress`)).toBe(
+            'fix/methods',
+        );
+    });
+
     it('returns undefined for non-matching URL', () => {
         expect(extractBranch('https://example.com/other/path')).toBeUndefined();
     });

--- a/packages/connect-web/src/impl/getSuiteWebUrl.ts
+++ b/packages/connect-web/src/impl/getSuiteWebUrl.ts
@@ -4,15 +4,36 @@ const DEV_CONNECT_PREFIX = `${DEV_CONNECT_ORIGIN}/connect/`;
 /**
  * Extract branch name from a connect-explorer dev URL.
  *
- * Expected URL patterns (init can happen on methods or settings pages):
+ * Expected URL patterns:
  *   https://dev.suite.sldev.cz/connect/{branch}/methods/...
  *   https://dev.suite.sldev.cz/connect/{branch}/settings/
+ *   https://dev.suite.sldev.cz/connect/{branch}
  *
  * Branch names may contain slashes (e.g. "feat/xyz/phase-1").
  * Returns undefined if the URL doesn't match the expected pattern.
  */
-export const extractBranch = (href: string): string | undefined =>
-    href.match(/\/connect\/(.+)(?:\/methods\/.*|\/settings\/?$)/)?.[1];
+export const extractBranch = (href: string): string | undefined => {
+    let pathname: string;
+
+    try {
+        pathname = new URL(href).pathname;
+    } catch {
+        pathname = new URL(href, DEV_CONNECT_ORIGIN).pathname;
+    }
+
+    const match = pathname.match(/\/connect\/(.+)/);
+    if (!match) return undefined;
+
+    return (
+        match[1]
+            // Greedy (.+) ensures we strip the *last* /methods or /settings delimiter,
+            // so branch names containing these words (e.g. "feat/methods-fix") are safe.
+            // Only strip when the delimiter is followed by `/` to avoid truncating
+            // branch names that legitimately end with "methods" or "settings".
+            .replace(/^(.+)\/(?:methods|settings)\/.*$/, '$1')
+            .replace(/\/$/, '') || undefined
+    );
+};
 
 /**
  * Resolve the Suite Web popup URL based on the current window location.


### PR DESCRIPTION
Found this while working on #26795

The extractBranch regex only matched URLs with /methods/ or /settings/ suffixes, but the connect-explorer root URL (/connect/{branch}) is a valid entry point. This caused getSuiteWebUrl to fall back to the production popup URL instead of the correct dev URL.

This never manifested in runtime because TrezorConnect.init happens on sub routes. 

Also adds the missing test:unit script to connect-web so these tests actually run in CI.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-web-extract-branch-regex&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T08:20:19.048Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->