### PR TITLE
Chore/message system backend migration

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -723,6 +723,74 @@
         {
             "conditions": [
                 {
+                    "duration": {
+                        "from": "2026-04-20T09:00:00.000Z",
+                        "to": "2026-04-22T08:59:59.000Z"
+                    }
+                }
+            ],
+            "message": {
+                "id": "318ef3cc-fd29-4cb7-9777-d2733ad3866e",
+                "priority": 94,
+                "dismissible": true,
+                "variant": "info",
+                "category": "context",
+                "content": {
+                    "en": "Trading will be temporarily unavailable on April 22nd from 11:00 to 12:00 CEST due to scheduled maintenance.",
+                    "es": "El trading no estará disponible temporalmente el 22 de abril de 11:00 a 12:00 CEST por mantenimiento programado.",
+                    "cs": "Obchodování bude 22. dubna od 11:00 do 12:00 CEST dočasně nedostupné z důvodu plánované údržby.",
+                    "ru": "22 апреля с 11:00 до 12:00 CEST торговля будет временно недоступна в связи с плановым техническим обслуживанием.",
+                    "ja": "定期メンテナンスのため、4月22日11:00〜12:00 CSTはトレードが一時的にご利用いただけません。",
+                    "hu": "A kereskedés április 22-én 11:00 és 12:00 CEST között tervezett karbantartás miatt átmenetileg nem lesz elérhető.",
+                    "it": "Il trading non sarà temporaneamente disponibile il 22 aprile dalle 11:00 alle 12:00 CEST per manutenzione programmata.",
+                    "fr": "Le trading sera temporairement indisponible le 22 avril de 11h00 à 12h00 CEST en raison d'une maintenance planifiée.",
+                    "de": "Das Trading wird am 22. April von 11:00 bis 12:00 CEST aufgrund geplanter Wartungsarbeiten vorübergehend nicht verfügbar sein.",
+                    "tr": "22 Nisan'da 11:00 ile 12:00 CEST arasında planlı bakım nedeniyle işlem yapma geçici olarak kullanılamayacak.",
+                    "pt": "O trading estará temporariamente indisponível no dia 22 de abril das 11:00 às 12:00 CEST devido a uma manutenção programada.",
+                    "uk": "22 квітня з 11:00 до 12:00 CEST торгівля буде тимчасово недоступна у зв'язку з плановим технічним обслуговуванням."
+                },
+                "context": {
+                    "domain": ["trading.exchange", "trading.buy", "trading.sell"]
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "duration": {
+                        "from": "2026-04-22T09:00:00.000Z",
+                        "to": "2026-04-22T10:00:00.000Z"
+                    }
+                }
+            ],
+            "message": {
+                "id": "3f1cbae7-d229-47de-a720-ab835f6ec38f",
+                "priority": 94,
+                "dismissible": false,
+                "variant": "warning",
+                "category": "context",
+                "content": {
+                    "en": "Trading is currently unavailable due to scheduled maintenance and will be restored by 12:00 CEST.",
+                    "es": "El trading no está disponible actualmente debido a un mantenimiento programado y se restablecerá a las 12:00 CEST.",
+                    "cs": "Obchodování je momentálně nedostupné z důvodu plánované údržby a bude obnoveno v 12:00 CEST.",
+                    "ru": "Торговля в настоящее время недоступна в связи с плановым техническим обслуживанием и будет восстановлена в 12:00 CEST.",
+                    "ja": "定期メンテナンスのため、現在トレードはご利用いただけません。12:00 CSTまでに復旧予定です。",
+                    "hu": "A kereskedés jelenleg nem elérhető tervezett karbantartás miatt, és 12:00 CEST-kor kerül visszaállításra.",
+                    "it": "Il trading è attualmente non disponibile a causa di una manutenzione programmata e sarà ripristinato alle 12:00 CEST.",
+                    "fr": "Le trading est actuellement indisponible en raison d'une maintenance planifiée et sera rétabli à 12h00 CEST.",
+                    "de": "Das Trading ist derzeit aufgrund geplanter Wartungsarbeiten nicht verfügbar und wird um 12:00 CEST wiederhergestellt.",
+                    "tr": "İşlem yapma, planlı bakım nedeniyle şu anda kullanılamıyor ve 12:00 CEST'te yeniden hizmete girecek.",
+                    "pt": "O trading está atualmente indisponível devido a uma manutenção programada e será restaurado às 12:00 CEST.",
+                    "uk": "Торгівля наразі недоступна у зв'язку з плановим технічним обслуговуванням і буде відновлена о 12:00 CEST."
+                },
+                "context": {
+                    "domain": ["trading.exchange", "trading.buy", "trading.sell"]
+                }
+            }
+        },
+        {
+            "conditions": [
+                {
                     "settings": [
                         {
                             "ada": true

--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-02-10T00:00:00+00:00",
-    "sequence": 133,
+    "timestamp": "2026-04-14T00:00:00+00:00",
+    "sequence": 134,
     "actions": [
         {
             "conditions": [
@@ -1505,11 +1505,11 @@
                     },
                     {
                         "variant": "B",
-                        "percentage": 90
+                        "percentage": 70
                     },
                     {
                         "variant": "C",
-                        "percentage": 10
+                        "percentage": 30
                     }
                 ]
             }


### PR DESCRIPTION
## Description

Adding a scheduled message system banner informing users about planned trading backend migration – before and during that period.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the message-system config.v1.json, which controls in-app messages, promotional banners, warnings, and feature flags displayed throughout Trezor Suite. This is a configuration-only change with no code logic modifications, so the risk of breaking core functionality is low. However, the message system can affect UI across many surfaces (dashboard banners, onboarding messages, warning notifications), so tests covering banner display and primary user flows should be prioritized. The promo-banner-events test is the most directly relevant, while dashboard and onboarding tests provide broader coverage for unintended visual regressions.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

**Recommended tests (8)**

🔴 **High priority**

- `../../suite/e2e/tests/analytics/promo-banner-events.test.ts` — The message-system config.v1.json directly controls promotional banners and in-app messages. This test exercises promo banner display and interaction on the dashboard, which is driven by the message system configuration.

🟡 **Medium priority**

- `../../suite/e2e/tests/suite/safety-checks-warning.test.ts` — The message system config controls dismissible warning banners throughout the app. Safety checks warning banners may be influenced by message system configuration changes, as banners are a common message-system feature.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — The message system config can affect modals and notifications shown during initial app load and onboarding. Changes to the config could introduce unexpected messages or banners that interfere with the initial run flow.
- `../../suite/e2e/tests/general/suite-guide.test.ts` — The Suite Guide and support panel may display messages or banners controlled by the message system. Config changes could affect content visibility or ordering within the guide panel.
- `../../suite/e2e/tests/dashboard/assets.test.ts` — The dashboard is a primary location where message-system banners and promotional messages are displayed. Changes to config.v1.json could add or modify banners that overlay or interfere with the assets section.

🟢 **Low priority**

- `../../suite/e2e/tests/general/eap-modal.test.ts` — The early access program modal could be influenced by message system configuration if feature flags or conditional messages target EAP users. The risk is low but plausible.
- `../../suite/e2e/tests/onboarding/analytics-consent.test.ts` — Message system config changes could potentially display messages during onboarding that affect the analytics consent flow. Low risk but worth running if time permits.
- `../../suite/e2e/tests/settings/general.test.ts` — Settings page may display message-system-driven banners or notifications. Config changes could affect the general settings view, though the risk is relatively low.

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-04-17T09:01:50.982Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-backend-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-backend-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-backend-migration&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T09:07:35.091Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T09:05:54.071Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->