### PR TITLE
fix(suite): fix automatic OS theme switching in desktop app

### DIFF
--- a/packages/suite-desktop-api/src/api.ts
+++ b/packages/suite-desktop-api/src/api.ts
@@ -88,6 +88,9 @@ export interface RendererChannels {
 
     'handshake/event': HandshakeEvent;
 
+    // theme
+    'theme/system-change': 'dark' | 'light';
+
     // connect
     'connect-popup/call': ConnectPopupCall;
     'connect-popup/cancel': ConnectPopupCancel;

--- a/packages/suite-desktop-api/src/validation.ts
+++ b/packages/suite-desktop-api/src/validation.ts
@@ -51,5 +51,6 @@ const validChannels: Array<keyof RendererChannels> = [
     'bio-auth/validation-status-changed',
     'bio-auth/bio-auth-availability-changed',
     'bio-auth/settings-changed',
+    'theme/system-change',
 ];
 export const isValidChannel = (channel: any) => validChannels.includes(channel);

--- a/packages/suite-desktop-core/src/modules/theme.ts
+++ b/packages/suite-desktop-core/src/modules/theme.ts
@@ -17,7 +17,7 @@ const setThemeManually = (theme: SuiteThemeVariant, store: Store) => {
 
 export const SERVICE_NAME = 'theme';
 
-export const init: ModuleInit = () => {
+export const init: ModuleInit = ({ mainWindowProxy }) => {
     const { logger } = global;
 
     const store = Store.getStore();
@@ -29,4 +29,12 @@ export const init: ModuleInit = () => {
     }
 
     ipcMain.on('theme/change', (_, newTheme) => setThemeManually(newTheme, store));
+
+    nativeTheme.on('updated', () => {
+        if (store.getThemeSettings() !== 'system') return;
+
+        const newTheme = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+        logger.info(SERVICE_NAME, `OS theme changed to ${newTheme}.`);
+        mainWindowProxy.getInstance()?.webContents.send('theme/system-change', newTheme);
+    });
 };

--- a/packages/suite/src/support/suite/Autodetect.tsx
+++ b/packages/suite/src/support/suite/Autodetect.tsx
@@ -8,6 +8,7 @@ import {
     suiteSettingsActions,
 } from '@suite/settings';
 import { type Locale } from '@suite-common/suite-types';
+import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { getOsTheme, watchOsTheme } from 'src/utils/suite/env';
@@ -28,16 +29,30 @@ const Autodetect = () => {
         [dispatch],
     );
 
+    const setTheme = useCallback(
+        (theme: 'dark' | 'light') => {
+            dispatch(suiteSettingsActions.setTheme(theme));
+        },
+        [dispatch],
+    );
+
     useEffect(() => {
         if (!autodetectTheme) return;
         const osTheme = getOsTheme();
         if (osTheme !== currentTheme) {
             dispatch(suiteSettingsActions.setTheme(osTheme));
         }
-        const unwatch = watchOsTheme(suiteSettingsActions.setTheme);
+        const unwatch = watchOsTheme(setTheme);
 
         return () => unwatch();
-    }, [autodetectTheme, currentTheme, dispatch]);
+    }, [autodetectTheme, currentTheme, dispatch, setTheme]);
+
+    useEffect(() => {
+        if (!autodetectTheme || !desktopApi.available) return;
+        desktopApi.on('theme/system-change', setTheme);
+
+        return () => desktopApi.removeAllListeners('theme/system-change');
+    }, [autodetectTheme, setTheme]);
 
     useEffect(() => {
         if (!autodetectLanguage) return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

dark/light mode should be switched immediately when changes

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26801

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-auto-theme-switching&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-auto-theme-switching&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T10:26:59.994Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T10:26:35.249Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->