### PR TITLE
fix(suite-native): fix fees selector ui

### DIFF
--- a/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelector.tsx
@@ -101,7 +101,7 @@ export const FeeSelector = ({
 
     const feeLimitSunOverride = isTrc20 ? form.watch('customFeeLimit') : undefined;
 
-    if (!symbol || !networkType || !fee) return null;
+    if (!symbol || !networkType || (!fee && !areFeesLoading)) return null;
 
     return (
         <>

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryCard.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryCard.tsx
@@ -4,11 +4,12 @@ import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-confi
 import { AnimatedPressable, Card, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
+import { useNativeStyles } from '@trezor/styles-native';
 
 import { FeeLabelTranslation } from './FeeLabelTranslation';
 
 export type FeeSummaryCardProps = {
-    fee: string;
+    fee: string | null;
     symbol: NetworkSymbol;
     networkType: NetworkType;
     areFeesLoading: boolean;
@@ -23,39 +24,45 @@ export const FeeSummaryCard = ({
     areFeesLoading,
     onPress,
     testID,
-}: FeeSummaryCardProps) => (
-    <AnimatedPressable exiting={FadeOut} entering={FadeIn} onPress={onPress} testID={testID}>
-        <Card>
-            <HStack justifyContent="space-between" alignItems="center">
-                <VStack spacing="sp4">
-                    <Text variant="body-sm">
-                        <FeeLabelTranslation networkType={networkType} />
-                    </Text>
-                </VStack>
-                <HStack alignItems="center" spacing="sp8">
-                    <VStack alignItems="flex-end" spacing="sp2">
-                        <CryptoAmountFormatter
-                            variant="body-sm"
-                            color="contentPrimary"
-                            value={fee}
-                            symbol={symbol}
-                            isBalance={false}
-                            isLoading={areFeesLoading}
-                            isDiscreetText={false}
-                            testID="@transactionManagement/fee-crypto-amount"
-                        />
-                        <CryptoToFiatAmountFormatter
-                            variant="body-sm"
-                            color="contentSecondary"
-                            value={fee}
-                            symbol={symbol}
-                            isLoading={areFeesLoading}
-                            isDiscreetText={false}
-                        />
+}: FeeSummaryCardProps) => {
+    const {
+        utils: { spacings },
+    } = useNativeStyles();
+
+    return (
+        <AnimatedPressable exiting={FadeOut} entering={FadeIn} onPress={onPress} testID={testID}>
+            <Card style={{ paddingVertical: spacings.sp12 }}>
+                <HStack justifyContent="space-between" alignItems="center">
+                    <VStack spacing="sp4">
+                        <Text variant="body-sm">
+                            <FeeLabelTranslation networkType={networkType} />
+                        </Text>
                     </VStack>
-                    <Icon name="caretDown" size="medium" color="contentSecondary" />
+                    <HStack alignItems="center" spacing="sp8">
+                        <VStack alignItems="flex-end" spacing="sp2">
+                            <CryptoAmountFormatter
+                                variant="body-sm"
+                                color="contentPrimary"
+                                value={fee}
+                                symbol={symbol}
+                                isBalance={false}
+                                isLoading={areFeesLoading}
+                                isDiscreetText={false}
+                                testID="@transactionManagement/fee-crypto-amount"
+                            />
+                            <CryptoToFiatAmountFormatter
+                                variant="body-sm"
+                                color="contentSecondary"
+                                value={fee}
+                                symbol={symbol}
+                                isLoading={areFeesLoading}
+                                isDiscreetText={false}
+                            />
+                        </VStack>
+                        <Icon name="caretDown" size="medium" color="contentSecondary" />
+                    </HStack>
                 </HStack>
-            </HStack>
-        </Card>
-    </AnimatedPressable>
-);
+            </Card>
+        </AnimatedPressable>
+    );
+};

--- a/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard.tsx
+++ b/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard.tsx
@@ -13,6 +13,7 @@ import { AnimatedPressable, Card, HStack, Text, VStack } from '@suite-native/ato
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Icon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
+import { useNativeStyles } from '@trezor/styles-native';
 
 import { FeeLabelTranslation } from './FeeLabelTranslation';
 import { selectFeeLevels } from '../../selectors';
@@ -41,6 +42,9 @@ export const TronFeeSummaryCard = ({
         selectAreFeesLoading(state, account?.symbol),
     );
     const { translate } = useTranslate();
+    const {
+        utils: { spacings },
+    } = useNativeStyles();
 
     if (!account || account.networkType !== 'tron') return null;
 
@@ -143,7 +147,7 @@ export const TronFeeSummaryCard = ({
     };
 
     const cardContent = (
-        <Card>
+        <Card style={{ paddingVertical: spacings.sp12 }}>
             <HStack justifyContent="space-between" alignItems="center">
                 <VStack spacing="sp4">
                     <Text variant="body-sm">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

change card's padding
display loader if fees are not loaded yet instead of hiding the selector

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26798

## Screenshots:

https://github.com/user-attachments/assets/a427a915-29ea-4303-bb48-7f31cb0fa193


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/fees-loader&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->