### PR TITLE
fix(ci): Adjusted llm test selector and output in job

### DIFF
--- a/.github/workflows/test-e2e-controller-pr.yml
+++ b/.github/workflows/test-e2e-controller-pr.yml
@@ -142,11 +142,13 @@ jobs:
                 const recs = result.recommendations.filter(r => r.priority === priority);
                 if (recs.length === 0) continue;
                 const label = priority.charAt(0).toUpperCase() + priority.slice(1);
-                lines.push(`${priorityEmoji[priority]} **${label} priority**`);
+                lines.push(`<details><summary>${priorityEmoji[priority]} <b>${label} priority (${recs.length})</b></summary>`);
                 lines.push('');
                 for (const rec of recs) {
                   lines.push(`- \`${rec.test}\` — ${rec.reasoning}`);
                 }
+                lines.push('');
+                lines.push('</details>');
                 lines.push('');
               }
             } else {

--- a/packages/e2e-utils/src/llmTestSelector/index.ts
+++ b/packages/e2e-utils/src/llmTestSelector/index.ts
@@ -179,51 +179,90 @@ const downloadIfStale = async (url: string, localFile: string): Promise<void> =>
 // Coverage-map lookup
 // ---------------------------------------------------------------------------
 
+interface TestMatchByFile {
+    changedFile: string;
+    tests: string[];
+}
+
+/**
+ * Returns per-file coverage data rather than a flat merged list.
+ * Keeping the changedFile→tests relationship intact lets the prompt reason about
+ * how "broad" each match is: a file that maps to many tests is likely a global
+ * utility, whereas one that maps to 1–2 tests is a targeted feature file.
+ */
 const selectTestsByChangedFiles = (
     index: CoverageIndex,
     changedFiles: string[],
-): { matched: string[]; uncovered: string[] } => {
-    const matchedTestFiles = new Set<string>();
+): { matchedByFile: TestMatchByFile[]; uncovered: string[] } => {
+    const matchedByFile: TestMatchByFile[] = [];
     const uncovered: string[] = [];
 
     for (const changedFile of changedFiles) {
         const tests = index[changedFile];
         if (tests && tests.length > 0) {
-            tests.forEach(t => matchedTestFiles.add(t));
+            matchedByFile.push({ changedFile, tests: [...tests].sort() });
         } else {
             uncovered.push(changedFile);
         }
     }
 
-    return { matched: [...matchedTestFiles], uncovered };
+    matchedByFile.sort((a, b) => a.changedFile.localeCompare(b.changedFile));
+
+    return { matchedByFile, uncovered };
 };
 
 // ---------------------------------------------------------------------------
 // Prompt
 // ---------------------------------------------------------------------------
 
+/** Maximum number of test names shown per changed file before truncating. */
+const MAX_TESTS_SHOWN_PER_FILE = 20;
+
 const buildPrompt = (
     changedFiles: string[],
-    matchedTests: string[],
+    matchedByFile: TestMatchByFile[],
     uncoveredFiles: string[],
     llmAnalysis: Record<string, unknown>,
-): string => `You are helping a CI/CD system identify which Playwright E2E tests to run based on code changes in a pull request.
+): string => {
+    const coverageMappingSection =
+        matchedByFile.length === 0
+            ? '(none — no static mapping available for these changes)'
+            : matchedByFile
+                  .map(({ changedFile, tests }) => {
+                      const shown = tests.slice(0, MAX_TESTS_SHOWN_PER_FILE);
+                      const extra = tests.length - shown.length;
+                      const lines = [
+                          `**${changedFile}** → ${tests.length} test${tests.length === 1 ? '' : 's'}`,
+                          ...shown.map(t => `  - ${t}`),
+                          ...(extra > 0 ? [`  … and ${extra} more`] : []),
+                      ];
+
+                      return lines.join('\n');
+                  })
+                  .join('\n\n');
+
+    return `You are helping a CI/CD system identify which Playwright E2E tests to run based on code changes in a pull request.
 
 ## Your goal
-Recommend the **minimal set of tests** that provides maximum confidence that the changed code works correctly, ranked by how critical each test is to run given these specific changes.
+Recommend the **minimal set of tests** that provides maximum confidence that the changed code works correctly, ranked by how critical each test is to run given these specific changes. Prefer a short, targeted list over broad coverage — running fewer, well-chosen tests is better than running everything.
 
 ## Priority definitions
 - **high**: The test directly exercises functionality that was changed, or a regression here would be immediately user-visible and hard to catch otherwise. Run these unconditionally.
-- **medium**: The test covers functionality that shares infrastructure, state, or user flows with the changed code. A regression is plausible but not certain.
-- **low**: The test is only loosely related (e.g. shares a common component or utility) and a regression is unlikely. Include only if time permits.
+- **medium**: The test covers functionality that meaningfully shares infrastructure, state, or user flows with the changed code. A regression is plausible but not certain.
+- **low**: Use this priority sparingly. Only assign **low** when there is a concrete, articulable reason the change could affect this specific test's behaviour — not merely because they share a common utility or component. When in doubt between **low** and omitting, **omit**.
 
 ## Inputs
 
 ### Changed source files (${changedFiles.length})
 ${changedFiles.map(f => `- ${f}`).join('\n')}
 
-### Tests identified by static coverage mapping (${matchedTests.length})
-${matchedTests.length > 0 ? matchedTests.map(t => `- ${t}`).join('\n') : '(none — no static mapping available for these changes)'}
+### Tests identified by static coverage mapping — per changed file
+
+Each changed file is listed with the tests that statically reference it, along with the total count.
+**A file that maps to many tests is very likely a broad global utility or shared component.**
+For such files, apply extra scrutiny: only recommend a test if you have specific evidence (from the LLM analysis below) that the change plausibly affects that test's own code path. Do not include a test just because it transitively imports the changed file.
+
+${coverageMappingSection}
 
 ### Source files with no static coverage data (${uncoveredFiles.length})
 ${uncoveredFiles.length > 0 ? uncoveredFiles.map(f => `- ${f}`).join('\n') : '(none)'}
@@ -236,11 +275,12 @@ ${JSON.stringify(llmAnalysis, null, 2)}
 \`\`\`
 
 ## Instructions
-1. For every test returned by static coverage mapping, assign a **priority** and write a concise **reasoning** (1–3 sentences) that explains *why* this test matters given the specific changed files.
-2. If static coverage mapping found no tests but you can infer from the LLM analysis that certain tests likely cover the changed functionality, include those with appropriate priority and note that they were inferred rather than statically mapped.
-3. Populate **related_changes** with the subset of changed files that are most relevant to each test.
-4. In **uncovered_changes** list the changed files that have no known test coverage at all (neither static nor inferred).
-5. Write a short **summary** (2–4 sentences) describing the overall risk profile of this change set and the recommended test strategy.
+1. For every test you consider including, assign a **priority** and write a concise **reasoning** (1–3 sentences) that explains *why* this test matters given the specific changed files. Reasoning must be concrete — avoid generic justifications like "shares a utility with the changed file".
+2. Apply the broad-utility heuristic: if a changed file maps to ≥ 10 tests, treat it as a global dependency. Only include those tests at **high** or **medium** if you have specific evidence from the LLM analysis that the change affects that test's behaviour directly. Demote or omit the rest.
+3. If static coverage mapping found no tests but you can infer from the LLM analysis that certain tests likely cover the changed functionality, include those with appropriate priority and note that they were inferred rather than statically mapped.
+4. Populate **related_changes** with the subset of changed files that are most relevant to each test.
+5. In **uncovered_changes** list the changed files that have no known test coverage at all (neither static nor inferred).
+6. Write a short **summary** (2–4 sentences) describing the overall risk profile of this change set and the recommended test strategy.
 
 ## Output format
 Return a single JSON object — no prose outside the JSON. The schema is:
@@ -260,6 +300,7 @@ Return a single JSON object — no prose outside the JSON. The schema is:
 \`\`\`
 
 Sort recommendations by priority (high → medium → low), then alphabetically within each tier.`;
+};
 
 // ---------------------------------------------------------------------------
 // Claude invocation — CLI
@@ -568,16 +609,17 @@ const main = async () => {
         fs.readFileSync(llmAnalysisFile, 'utf8'),
     );
 
-    const { matched: matchedTests, uncovered: uncoveredFiles } = selectTestsByChangedFiles(
+    const { matchedByFile, uncovered: uncoveredFiles } = selectTestsByChangedFiles(
         index,
         changedFiles,
     );
+    const uniqueMatchedTests = new Set(matchedByFile.flatMap(({ tests }) => tests));
     log(
-        `Coverage mapping: ${matchedTests.length} test(s) matched, ${uncoveredFiles.length} file(s) with no coverage data.`,
+        `Coverage mapping: ${uniqueMatchedTests.size} unique test(s) matched across ${matchedByFile.length} of ${changedFiles.length} changed file(s) with coverage data, ${uncoveredFiles.length} file(s) with no coverage data.`,
     );
 
     // 5. Build prompt and call Claude
-    const prompt = buildPrompt(changedFiles, matchedTests, uncoveredFiles, llmAnalysis);
+    const prompt = buildPrompt(changedFiles, matchedByFile, uncoveredFiles, llmAnalysis);
 
     log(apiKey ? 'Calling Anthropic API...' : 'Calling local Claude Code CLI...');
 

--- a/packages/e2e-utils/src/testCoverage/buildCoverageMap.ts
+++ b/packages/e2e-utils/src/testCoverage/buildCoverageMap.ts
@@ -43,7 +43,7 @@ const main = async () => {
         }
         throw err;
     }
-    const jsonFiles = entries.filter(f => f.endsWith('.json') && f !== 'index.json');
+    const jsonFiles = entries.filter(f => f.endsWith('.json') && f !== 'index.json').sort();
 
     if (jsonFiles.length === 0) {
         console.error(`No per-test JSON files found in ${inputDir}`);
@@ -70,7 +70,12 @@ const main = async () => {
     const testFileCount = new Set(Object.values(index).flat()).size;
 
     await fs.mkdir(path.dirname(outputFile), { recursive: true });
-    await fs.writeFile(outputFile, JSON.stringify(index, null, 2));
+    const sortedIndex = Object.fromEntries(
+        Object.entries(index)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([k, v]) => [k, [...v].sort()]),
+    );
+    await fs.writeFile(outputFile, JSON.stringify(sortedIndex, null, 2));
 
     console.log(
         `Coverage map built: ${sourceFileCount} source files mapped to ${testFileCount} test files`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/e2e-utils/src/llmTestSelector/index.ts`, which is the LLM test selector utility itself — a meta-tool used to recommend which E2E tests to run. It is not exercised by any of the application's E2E tests, as none of the analyzed tests touch LLM test selection logic or import from this module. Since this change is purely within the test infrastructure/tooling layer and does not affect any application source code, runtime behavior, or user-facing functionality, there is no regression risk to the application and no E2E tests need to be run.

<details><summary><b>Changed files (1)</b></summary>

- `packages/e2e-utils/src/llmTestSelector/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/e2e-utils/src/llmTestSelector/index.ts`

_Updated: 2026-04-17T10:31:42.263Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat-ci-llm-test-select&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat-ci-llm-test-select&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T10:36:55.970Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T10:36:01.999Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->