### PR TITLE
refactor(suite): extract github service package

### DIFF
--- a/packages/suite-desktop-ui/package.json
+++ b/packages/suite-desktop-ui/package.json
@@ -14,6 +14,7 @@
     },
     "dependencies": {
         "@sentry/electron": "^7.10.0",
+        "@suite-common/github": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@suite/desktop-update": "workspace:*",
         "@suite/flags": "workspace:*",

--- a/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
+++ b/packages/suite-desktop-ui/src/support/DesktopUpdater/JustUpdated.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { getReleaseUrl } from '@suite-common/github';
 import { Card, Modal, Row, TextButton } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { MarkdownWithComponents } from 'src/components/suite';
-import { getReleaseUrl } from 'src/services/github';
 
 interface AvailableProps {
     onCancel: () => void;

--- a/packages/suite-desktop-ui/tsconfig.json
+++ b/packages/suite-desktop-ui/tsconfig.json
@@ -6,6 +6,7 @@
     },
     "include": ["."],
     "references": [
+        { "path": "../../suite-common/github" },
         { "path": "../../suite/analytics" },
         { "path": "../../suite/desktop-update" },
         { "path": "../../suite/flags" },

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -41,6 +41,7 @@
         "@suite-common/firmware-authenticity": "workspace:*",
         "@suite-common/formatters": "workspace:*",
         "@suite-common/geolocation": "workspace:*",
+        "@suite-common/github": "workspace:*",
         "@suite-common/logger": "workspace:*",
         "@suite-common/message-system": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",

--- a/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/GithubIssue.tsx
@@ -1,8 +1,8 @@
+import { openGithubIssue } from '@suite-common/github';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { useDevice, useSelector } from 'src/hooks/suite';
 import { selectActiveTransports } from 'src/selectors/suite/suiteSelectors';
-import { openGithubIssue } from 'src/services/github';
 
 export const GithubIssue = () => {
     const transports = useSelector(selectActiveTransports);

--- a/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/VersionWithUpdate.tsx
@@ -6,6 +6,7 @@ import {
 } from '@suite/desktop-update';
 import { Translation } from '@suite/intl';
 import { SettingsAnchor } from '@suite/router';
+import { getReleaseUrl } from '@suite-common/github';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { Button, type ButtonProps } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
@@ -14,7 +15,6 @@ import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { SettingsSectionItem } from 'src/components/settings/SettingsSectionItem';
 import { useDispatch, useExternalLink, useSelector } from 'src/hooks/suite';
-import { getReleaseUrl } from 'src/services/github';
 
 const getUpdateStateMessage = (state: UpdateState) => {
     switch (state) {

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -60,6 +60,7 @@
         {
             "path": "../../suite-common/geolocation"
         },
+        { "path": "../../suite-common/github" },
         { "path": "../../suite-common/logger" },
         {
             "path": "../../suite-common/message-system"

--- a/suite-common/github/package.json
+++ b/suite-common/github/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@suite-common/github",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/suite-types": "workspace:*",
+        "@trezor/connect": "workspace:*",
+        "@trezor/device-utils": "workspace:*",
+        "@trezor/env-utils": "workspace:*",
+        "@trezor/urls": "workspace:*"
+    }
+}

--- a/suite-common/github/src/github.ts
+++ b/suite-common/github/src/github.ts
@@ -1,3 +1,4 @@
+import type { TrezorDevice } from '@suite-common/suite-types';
 import type { TransportInfo } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
 import {
@@ -9,8 +10,6 @@ import {
     isDesktop,
 } from '@trezor/env-utils';
 import { GITHUB_REPO_URL } from '@trezor/urls';
-
-import type { TrezorDevice } from 'src/types/suite';
 
 type DebugInfo = {
     device?: TrezorDevice;

--- a/suite-common/github/src/index.ts
+++ b/suite-common/github/src/index.ts
@@ -1,0 +1,1 @@
+export * from './github';

--- a/suite-common/github/tsconfig.json
+++ b/suite-common/github/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../suite-types" },
+        { "path": "../../packages/connect" },
+        { "path": "../../packages/device-utils" },
+        { "path": "../../packages/env-utils" },
+        { "path": "../../packages/urls" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,6 +11098,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/github@workspace:*, @suite-common/github@workspace:suite-common/github":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/github@workspace:suite-common/github"
+  dependencies:
+    "@suite-common/suite-types": "workspace:*"
+    "@trezor/connect": "workspace:*"
+    "@trezor/device-utils": "workspace:*"
+    "@trezor/env-utils": "workspace:*"
+    "@trezor/urls": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/graph@workspace:*, @suite-common/graph@workspace:suite-common/graph":
   version: 0.0.0-use.local
   resolution: "@suite-common/graph@workspace:suite-common/graph"
@@ -16138,6 +16150,7 @@ __metadata:
   resolution: "@trezor/suite-desktop-ui@workspace:packages/suite-desktop-ui"
   dependencies:
     "@sentry/electron": "npm:^7.10.0"
+    "@suite-common/github": "workspace:*"
     "@suite/analytics": "workspace:*"
     "@suite/desktop-update": "workspace:*"
     "@suite/flags": "workspace:*"
@@ -16305,6 +16318,7 @@ __metadata:
     "@suite-common/firmware-authenticity": "workspace:*"
     "@suite-common/formatters": "workspace:*"
     "@suite-common/geolocation": "workspace:*"
+    "@suite-common/github": "workspace:*"
     "@suite-common/logger": "workspace:*"
     "@suite-common/message-system": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"


### PR DESCRIPTION
Extract code to shared github package. Will be useful when for separation of the desktop update code.

## Testing

Nothing to test, just code improvements

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=github-package&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=github-package&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=github-package&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T11:04:35.159Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T11:02:42.773Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->