### PR TITLE
fix(trading): fix post-trade survey UI styling

### DIFF
--- a/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
+++ b/packages/suite/src/components/suite/banners/MessageSystemButton.tsx
@@ -11,7 +11,7 @@ import { getTorUrlIfAvailable } from 'src/utils/suite/tor';
 type MessageSystemButtonProps = {
     cta?: Message['cta'];
     id?: Message['id'];
-} & Pick<ButtonProps, 'iconLeft' | 'iconRight' | 'size'>;
+} & Pick<ButtonProps, 'iconLeft' | 'iconRight' | 'size' | 'intent'>;
 
 export const MessageSystemButton = ({ cta, id, ...props }: MessageSystemButtonProps) => {
     const { isTorEnabled } = useSelector(selectTorState);
@@ -43,6 +43,7 @@ export const MessageSystemButton = ({ cta, id, ...props }: MessageSystemButtonPr
     return (
         <Banner.Button
             onClick={onClick!}
+            priority="primary"
             {...(id ? { 'data-testid': `@message-system/${id}/cta` } : {})}
             {...props}
         >

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSurvey.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailSurvey.tsx
@@ -6,7 +6,7 @@ import {
     selectFeatureConfig,
     validateTradingSurvey,
 } from '@suite-common/message-system';
-import { Card, Column, Paragraph, Text } from '@trezor/components';
+import { Card, Column, H2, Paragraph } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { MessageSystemButton } from 'src/components/suite/banners/MessageSystemButton';
@@ -40,12 +40,19 @@ export const TradingDetailSurvey = () => {
 
     return (
         <Card>
-            <Column gap={spacings.lg}>
+            <Column gap={spacings.lg} padding={8}>
                 <Column gap={spacings.xs}>
-                    <Text typographyStyle="headline-sm">{title}</Text>
-                    <Paragraph maxWidth={400}>{description}</Paragraph>
+                    <H2>{title}</H2>
+                    <Paragraph typographyStyle="body-sm" color="contentSecondary">
+                        {description}
+                    </Paragraph>
                 </Column>
-                <MessageSystemButton cta={survey.cta} iconRight="arrowSquareOut" />
+                <MessageSystemButton
+                    cta={survey.cta}
+                    iconRight="arrowSquareOut"
+                    intent="brand"
+                    size="large"
+                />
             </Column>
         </Card>
     );


### PR DESCRIPTION
## Description

- Use `H2` component for survey title instead of `Text` with inline typography style
- Apply `intent="brand"` and `size="large"` to the survey CTA button for proper visual prominence
- Add `intent` to `MessageSystemButton` forwarded props and set `priority="primary"` on the inner `Banner.Button`
- Text content has to edited in the MessageSystem

## Notes for QA

- Text does not matching Figma till is updated in MessageSystem

## Screenshot
@matous-jemelka you can test it here: https://dev.suite.sldev.cz/suite-web/fix/25343-dex-post-trade-survey-ui/web/start

<img width="739" height="360" alt="image" src="https://github.com/user-attachments/assets/55adbfd8-ddd1-4e5d-be72-77e8f73b6894" />


## Related Issue

Resolve #25343

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25343-dex-post-trade-survey-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25343-dex-post-trade-survey-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T11:46:51.345Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T11:45:47.626Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/25343-dex-post-trade-survey-ui/web/](https://dev.suite.sldev.cz/suite-web/fix/25343-dex-post-trade-survey-ui/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->