### PR TITLE
feat(suite): extract firmware upgrade package

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -83,6 +83,7 @@
         "@suite/device": "workspace:*",
         "@suite/experimental": "workspace:*",
         "@suite/feature-feedback": "workspace:*",
+        "@suite/firmware-upgrade": "workspace:*",
         "@suite/flags": "workspace:*",
         "@suite/idb-migration-utils": "workspace:*",
         "@suite/intl": "workspace:*",

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { goto } from '@suite/router';
@@ -16,7 +17,6 @@ import { Button, Column, Icon, Paragraph, Row, Table } from '@trezor/components'
 import { BigNumber } from '@trezor/utils';
 
 import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
-import { FirmwareUpgradeNeededModal } from 'src/components/suite/modals/FirmwareUpgradeNeededModal';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { EarnYieldApyTooltip } from './EarnYieldApyTooltip';

--- a/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals.tsx
+++ b/packages/suite/src/components/suite/labeling/TurnOnSuiteSync/TurnOnSuiteSyncModals.tsx
@@ -1,9 +1,9 @@
+import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { useTranslation } from '@suite/intl';
 import { type StaticSessionId } from '@trezor/connect';
 import { exhaustive } from '@trezor/type-utils';
 
 import { selectDesktopSuiteSyncInteraction } from 'src/actions/suiteSync/suiteSyncSlice';
-import { FirmwareUpgradeNeededModal } from 'src/components/suite/modals/FirmwareUpgradeNeededModal';
 import { useSelector } from 'src/hooks/suite';
 
 import { SuiteSyncTurnOnModal } from './SuiteSyncTurnOnModal';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -160,6 +160,9 @@
         {
             "path": "../../suite/feature-feedback"
         },
+        {
+            "path": "../../suite/firmware-upgrade"
+        },
         { "path": "../../suite/flags" },
         {
             "path": "../../suite/idb-migration-utils"

--- a/suite/firmware-upgrade/package.json
+++ b/suite/firmware-upgrade/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@suite/firmware-upgrade",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@reduxjs/toolkit": "2.11.2",
+        "@suite-common/device": "workspace:*",
+        "@suite/intl": "workspace:*",
+        "@suite/router": "workspace:*",
+        "@trezor/components": "workspace:*",
+        "react": "19.2.4",
+        "react-redux": "9.2.0",
+        "redux": "^5.0.1"
+    },
+    "devDependencies": {
+        "@types/react": "19.2.14"
+    }
+}

--- a/suite/firmware-upgrade/redux.d.ts
+++ b/suite/firmware-upgrade/redux.d.ts
@@ -1,0 +1,14 @@
+import { AsyncThunkAction, ThunkAction } from '@reduxjs/toolkit';
+import type { Action, AnyAction } from 'redux';
+
+declare module 'redux' {
+    export interface Dispatch<A extends Action = AnyAction> {
+        <T extends A>(action: T, ...extraArgs: any[]): T;
+
+        <TThunk extends AsyncThunkAction<any, any, any>>(thunk: TThunk): ReturnType<TThunk>;
+
+        <ReturnType = any, State = any, ExtraThunkArg = any>(
+            thunkAction: ThunkAction<ReturnType, State, ExtraThunkArg, A>,
+        ): ReturnType;
+    }
+}

--- a/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
+++ b/suite/firmware-upgrade/src/FirmwareUpgradeNeededModal.tsx
@@ -1,9 +1,9 @@
+import { useDispatch, useSelector } from 'react-redux';
+
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { Card, Modal, Paragraph } from '@trezor/components';
-
-import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type FirmwareUpgradeNeededModalProps = {
     onClose: () => void;

--- a/suite/firmware-upgrade/src/index.ts
+++ b/suite/firmware-upgrade/src/index.ts
@@ -1,0 +1,1 @@
+export { FirmwareUpgradeNeededModal } from './FirmwareUpgradeNeededModal';

--- a/suite/firmware-upgrade/tsconfig.json
+++ b/suite/firmware-upgrade/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        { "path": "../../suite-common/device" },
+        { "path": "../intl" },
+        { "path": "../router" },
+        { "path": "../../packages/components" }
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14726,6 +14726,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/firmware-upgrade@workspace:*, @suite/firmware-upgrade@workspace:suite/firmware-upgrade":
+  version: 0.0.0-use.local
+  resolution: "@suite/firmware-upgrade@workspace:suite/firmware-upgrade"
+  dependencies:
+    "@reduxjs/toolkit": "npm:2.11.2"
+    "@suite-common/device": "workspace:*"
+    "@suite/intl": "workspace:*"
+    "@suite/router": "workspace:*"
+    "@trezor/components": "workspace:*"
+    "@types/react": "npm:19.2.14"
+    react: "npm:19.2.4"
+    react-redux: "npm:9.2.0"
+    redux: "npm:^5.0.1"
+  languageName: unknown
+  linkType: soft
+
 "@suite/flags@workspace:*, @suite/flags@workspace:suite/flags":
   version: 0.0.0-use.local
   resolution: "@suite/flags@workspace:suite/flags"
@@ -16360,6 +16376,7 @@ __metadata:
     "@suite/device": "workspace:*"
     "@suite/experimental": "workspace:*"
     "@suite/feature-feedback": "workspace:*"
+    "@suite/firmware-upgrade": "workspace:*"
     "@suite/flags": "workspace:*"
     "@suite/idb-migration-utils": "workspace:*"
     "@suite/intl": "workspace:*"


### PR DESCRIPTION
Start of extraction of the FW update code into separate package. 

## Testing

FW update maybe, but its just moving code, shall be fine. 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=suite-firmware-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=suite-firmware-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T12:58:31.859Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-17T12:57:31.074Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/suite-firmware-update/web/](https://dev.suite.sldev.cz/suite-web/suite-firmware-update/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->