### PR TITLE
refactor(suite-native): redesign RoundedIcon to new design system

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
@@ -11,7 +11,6 @@ import {
     selectIsCardanoStakedOutsideEverstake,
     selectIsCardanoStakedWithFiveBinaries,
 } from '@suite-native/staking';
-import { useNativeStyles } from '@trezor/styles-native';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
 
@@ -31,8 +30,6 @@ export const AdaAccountsListStakingItem = ({
     isLast,
     ...props
 }: AdaAccountsListStakingItemProps) => {
-    const { utils } = useNativeStyles();
-
     const isStakedOutsideEverstake = useSelector((state: NativeStakingRootState) =>
         selectIsCardanoStakedOutsideEverstake(state, account.key),
     );
@@ -55,13 +52,7 @@ export const AdaAccountsListStakingItem = ({
             {...props}
             isLast={isLast}
             showDivider={!isLast}
-            icon={
-                <RoundedIcon
-                    name="piggyBankFilled"
-                    color="contentSecondary"
-                    containerSize={utils.spacings.sp32}
-                />
-            }
+            icon={<RoundedIcon name="piggyBankFilled" intent="neutral" size={32} />}
             title={<Translation id="accountList.staking" />}
             secondaryTitle={
                 isStakedWithFiveBinaries && (

--- a/suite-native/accounts/src/components/AccountsList/DefaultAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/DefaultAccountsListStakingItem.tsx
@@ -2,7 +2,6 @@ import { type Account } from '@suite-common/wallet-types';
 import { RoundedIcon } from '@suite-native/atoms';
 import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
-import { useNativeStyles } from '@trezor/styles-native';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
 
@@ -21,37 +20,27 @@ export const DefaultAccountsListStakingItem = ({
     stakingCryptoBalance,
     isLast,
     ...props
-}: DefaultAccountsListStakingItemProps) => {
-    const { utils } = useNativeStyles();
-
-    return (
-        <AccountsListItemBase
-            {...props}
-            isLast={isLast}
-            showDivider={!isLast}
-            icon={
-                <RoundedIcon
-                    name="piggyBankFilled"
-                    color="contentSecondary"
-                    containerSize={utils.spacings.sp32}
-                />
-            }
-            title={<Translation id="accountList.staking" />}
-            mainValue={
-                <CryptoToFiatAmountFormatter
-                    value={stakingCryptoBalance}
-                    symbol={account.symbol}
-                    isBalance
-                />
-            }
-            secondaryValue={
-                <CryptoAmountFormatter
-                    value={stakingCryptoBalance}
-                    symbol={account.symbol}
-                    numberOfLines={1}
-                    adjustsFontSizeToFit
-                />
-            }
-        />
-    );
-};
+}: DefaultAccountsListStakingItemProps) => (
+    <AccountsListItemBase
+        {...props}
+        isLast={isLast}
+        showDivider={!isLast}
+        icon={<RoundedIcon name="piggyBankFilled" intent="neutral" size={32} />}
+        title={<Translation id="accountList.staking" />}
+        mainValue={
+            <CryptoToFiatAmountFormatter
+                value={stakingCryptoBalance}
+                symbol={account.symbol}
+                isBalance
+            />
+        }
+        secondaryValue={
+            <CryptoAmountFormatter
+                value={stakingCryptoBalance}
+                symbol={account.symbol}
+                numberOfLines={1}
+                adjustsFontSizeToFit
+            />
+        }
+    />
+);

--- a/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
+++ b/suite-native/atoms/src/Card/CompactCardWithIconLayout.tsx
@@ -9,7 +9,7 @@ import { type Color } from '@trezor/theme';
 import { Box } from '../Box';
 import { InlineAlertBox, type InlineAlertBoxProps } from '../InlineAlertBox/InlineAlertBox';
 import { Loader } from '../Loader';
-import { RoundedIcon } from '../RoundedIcon';
+import { RoundedIcon, type RoundedIconIntent } from '../RoundedIcon';
 import { HStack, VStack } from '../Stack';
 import { Text } from '../Text';
 import { useTapGesture } from '../useTapGesture';
@@ -30,8 +30,7 @@ export type CompactCardWithIconLayoutProps = {
 } & Omit<CardProps, 'children' | 'borderColor'>;
 
 type CardColorScheme = {
-    iconWrapperBackgroundColor: Color;
-    iconColor: Color;
+    iconIntent: RoundedIconIntent;
     titleColor: Color;
     subtitleColor: Color;
     caretColor: Color;
@@ -39,22 +38,19 @@ type CardColorScheme = {
 
 export const cardVariantToColorsMap = {
     normal: {
-        iconWrapperBackgroundColor: 'legacyBackgroundTertiaryDefaultOnElevation1',
-        iconColor: 'contentPrimary',
+        iconIntent: 'neutral',
         titleColor: 'contentPrimary',
         subtitleColor: 'contentSecondary',
         caretColor: 'contentSecondary',
     },
     danger: {
-        iconWrapperBackgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation1',
-        iconColor: 'contentCritical',
+        iconIntent: 'critical',
         titleColor: 'contentCritical',
         subtitleColor: 'contentCritical',
         caretColor: 'contentSecondary',
     },
     primary: {
-        iconWrapperBackgroundColor: 'legacyBackgroundPrimarySubtleOnElevation0',
-        iconColor: 'contentBrand',
+        iconIntent: 'brand',
         titleColor: 'contentBrand',
         subtitleColor: 'contentBrand',
         caretColor: 'contentBrand',
@@ -80,8 +76,7 @@ export const CompactCardWithIconLayout = ({
     ...cardProps
 }: CompactCardWithIconLayoutProps) => {
     const { applyStyle } = useNativeStyles();
-    const { caretColor, iconColor, titleColor, subtitleColor, iconWrapperBackgroundColor } =
-        cardVariantToColorsMap[variant];
+    const { caretColor, iconIntent, titleColor, subtitleColor } = cardVariantToColorsMap[variant];
 
     const { tapGesture, animatedStyle } = useTapGesture({ onPress, isDisabled });
 
@@ -102,11 +97,7 @@ export const CompactCardWithIconLayout = ({
                         spacing="sp12"
                         alignItems="center"
                     >
-                        <RoundedIcon
-                            backgroundColor={iconWrapperBackgroundColor}
-                            color={iconColor}
-                            name={icon}
-                        />
+                        <RoundedIcon intent={iconIntent} name={icon} />
                         <VStack spacing="sp2" style={applyStyle(contentStyle)}>
                             <Text color={titleColor}>{title}</Text>
                             {subtitle && (

--- a/suite-native/atoms/src/RoundedIcon.tsx
+++ b/suite-native/atoms/src/RoundedIcon.tsx
@@ -3,37 +3,67 @@ import { type TokenAddress } from '@suite-common/wallet-types';
 import { CryptoIcon, Icon, type IconName, type IconSize, icons } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
-import { isNotNullOrUndefined } from '@trezor/utils';
 
 import { Box, type BoxProps } from './Box';
+
+export const ROUNDED_ICON_INTENTS = ['neutral', 'brand', 'warning', 'critical', 'info'] as const;
+export type RoundedIconIntent = (typeof ROUNDED_ICON_INTENTS)[number];
+
+export const ROUNDED_ICON_SIZES = [20, 24, 32, 40, 48] as const;
+export type RoundedIconSize = (typeof ROUNDED_ICON_SIZES)[number];
 
 export type RoundedIconProps = {
     name?: IconName;
     symbol?: NetworkSymbol;
     contractAddress?: TokenAddress;
-    color?: Color;
-    iconSize?: IconSize;
-    containerSize?: number;
-    backgroundColor?: Color;
+    intent?: RoundedIconIntent;
+    size?: RoundedIconSize;
 } & BoxProps;
 
-const DEFAULT_CONTAINER_SIZE = 48;
+type RoundedIconStyle = {
+    backgroundColor: Color;
+    iconColor: Color;
+};
 
-const iconContainerStyle = prepareNativeStyle<{ backgroundColor?: Color; containerSize?: number }>(
-    (utils, { backgroundColor, containerSize }) => ({
+const roundedIconIntentToStylePropsMap = {
+    neutral: {
+        backgroundColor: 'legacyBackgroundTertiaryDefaultOnElevation0',
+        iconColor: 'contentSecondary',
+    },
+    brand: {
+        backgroundColor: 'legacyBackgroundPrimarySubtleOnElevation0',
+        iconColor: 'contentBrand',
+    },
+    warning: {
+        backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation0',
+        iconColor: 'contentWarning',
+    },
+    critical: {
+        backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation0',
+        iconColor: 'contentCritical',
+    },
+    info: {
+        backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation0',
+        iconColor: 'contentInfo',
+    },
+} as const satisfies Record<RoundedIconIntent, RoundedIconStyle>;
+
+const roundedIconSizeToIconSizeMap: Record<RoundedIconSize, IconSize> = {
+    20: 'small',
+    24: 'small',
+    32: 'medium',
+    40: 'mediumLarge',
+    48: 'large',
+};
+
+const iconContainerStyle = prepareNativeStyle<{ backgroundColor: Color; size: RoundedIconSize }>(
+    (utils, { backgroundColor, size }) => ({
         justifyContent: 'center',
         alignItems: 'center',
-        width: containerSize ?? DEFAULT_CONTAINER_SIZE,
-        height: containerSize ?? DEFAULT_CONTAINER_SIZE,
-        backgroundColor: utils.colors.legacyBackgroundSurfaceElevation2,
+        width: size,
+        height: size,
+        backgroundColor: utils.colors[backgroundColor],
         borderRadius: utils.borders.radii.round,
-
-        extend: {
-            condition: isNotNullOrUndefined(backgroundColor),
-            style: {
-                backgroundColor: utils.colors[backgroundColor as Color],
-            },
-        },
     }),
 );
 
@@ -41,22 +71,22 @@ export const RoundedIcon = ({
     name,
     symbol,
     contractAddress,
-    color,
-    iconSize,
-    backgroundColor,
-    containerSize,
+    intent = 'neutral',
+    size = 48,
     style,
     ...boxProps
 }: RoundedIconProps) => {
     const { applyStyle } = useNativeStyles();
+    const { backgroundColor, iconColor } = roundedIconIntentToStylePropsMap[intent];
+    const iconSize = roundedIconSizeToIconSizeMap[size];
 
     return (
         <Box
-            style={[applyStyle(iconContainerStyle, { backgroundColor, containerSize }), style]}
+            style={[applyStyle(iconContainerStyle, { backgroundColor, size }), style]}
             {...boxProps}
         >
             {name && name in icons ? (
-                <Icon name={name as IconName} color={color} size={iconSize} />
+                <Icon name={name as IconName} color={iconColor} size={iconSize} />
             ) : (
                 symbol && <CryptoIcon symbol={symbol} contractAddress={contractAddress} />
             )}

--- a/suite-native/atoms/src/stories/RoundedIcon.stories.tsx
+++ b/suite-native/atoms/src/stories/RoundedIcon.stories.tsx
@@ -1,9 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-native';
 
-import { ICON_SIZES, icons } from '@suite-native/icons';
-import { COLOR_TOKENS } from '@trezor/theme';
+import { icons } from '@suite-native/icons';
 
-import { RoundedIcon as RoundedIconComponent, type RoundedIconProps } from '../RoundedIcon';
+import {
+    ROUNDED_ICON_INTENTS,
+    ROUNDED_ICON_SIZES,
+    RoundedIcon as RoundedIconComponent,
+    type RoundedIconProps,
+} from '../RoundedIcon';
 
 type RoundedIconStory = StoryObj<RoundedIconProps>;
 
@@ -18,29 +22,21 @@ export const RoundedIcon: RoundedIconStory = {
     name: 'RoundedIcon',
     args: {
         name: 'flag',
-        color: 'contentBrand',
-        iconSize: 'mediumLarge',
-        backgroundColor: 'legacyBackgroundTertiaryDefaultOnElevation1',
-        containerSize: 48,
+        intent: 'neutral',
+        size: 48,
     },
     argTypes: {
         name: {
             control: { type: 'select' },
             options: Object.keys(icons),
         },
-        iconSize: {
+        intent: {
             control: { type: 'select' },
-            options: Object.values(ICON_SIZES),
+            options: ROUNDED_ICON_INTENTS,
         },
-
-        color: {
+        size: {
             control: { type: 'select' },
-            options: COLOR_TOKENS,
-        },
-
-        backgroundColor: {
-            control: { type: 'select' },
-            options: COLOR_TOKENS,
+            options: ROUNDED_ICON_SIZES,
         },
         symbol: {
             control: false,

--- a/suite-native/message-system/src/components/MessageBanner.tsx
+++ b/suite-native/message-system/src/components/MessageBanner.tsx
@@ -3,7 +3,15 @@ import { useDispatch } from 'react-redux';
 
 import { messageSystemActions } from '@suite-common/message-system';
 import { type Message, type Variant } from '@suite-common/suite-types';
-import { Box, HStack, PressableOpacity, RoundedIcon, Text, VStack } from '@suite-native/atoms';
+import {
+    Box,
+    HStack,
+    PressableOpacity,
+    RoundedIcon,
+    type RoundedIconIntent,
+    Text,
+    VStack,
+} from '@suite-native/atoms';
 import { Icon, type IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
@@ -20,7 +28,7 @@ type MessageBannerStyle = {
     backgroundColor: Color;
     icon: IconName;
     iconColor: Color;
-    iconBackgroundColor: Color;
+    iconIntent: RoundedIconIntent;
 };
 
 const MessageBannerVariantToStyleMap = {
@@ -28,19 +36,19 @@ const MessageBannerVariantToStyleMap = {
         backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation0',
         icon: 'info',
         iconColor: 'contentInfo',
-        iconBackgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation1',
+        iconIntent: 'info',
     },
     warning: {
         backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation0',
         icon: 'warning',
         iconColor: 'contentWarning',
-        iconBackgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation1',
+        iconIntent: 'warning',
     },
     critical: {
         backgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation0',
         icon: 'warning',
         iconColor: 'contentCritical',
-        iconBackgroundColor: 'legacyBackgroundAlertRedSubtleOnElevation1',
+        iconIntent: 'critical',
     },
 } as const satisfies Record<Variant, MessageBannerStyle>;
 
@@ -65,19 +73,14 @@ const messageTextContainerStyle = prepareNativeStyle(() => ({
 }));
 
 const MessageCloseButton = ({
-    backgroundColor,
+    intent,
     onClose,
 }: {
-    backgroundColor: Color;
+    intent: RoundedIconIntent;
     onClose: () => void;
 }) => (
     <PressableOpacity onPress={onClose}>
-        <RoundedIcon
-            name="x"
-            iconSize="medium"
-            containerSize={44}
-            backgroundColor={backgroundColor}
-        />
+        <RoundedIcon name="x" intent={intent} size={40} />
     </PressableOpacity>
 );
 
@@ -101,7 +104,7 @@ export const MessageBanner = ({ message }: MessageBannerProps) => {
         );
     };
 
-    const { backgroundColor, iconColor, icon, iconBackgroundColor } =
+    const { backgroundColor, iconColor, icon, iconIntent } =
         MessageBannerVariantToStyleMap[message.variant];
 
     return (
@@ -133,10 +136,7 @@ export const MessageBanner = ({ message }: MessageBannerProps) => {
                     )}
                 </VStack>
                 {isMessageDismissible && (
-                    <MessageCloseButton
-                        backgroundColor={iconBackgroundColor}
-                        onClose={handleDismissMessage}
-                    />
+                    <MessageCloseButton intent={iconIntent} onClose={handleDismissMessage} />
                 )}
             </HStack>
         </Animated.View>

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -38,7 +38,7 @@ export const AccountImportOverview = ({ balance, symbol, formControl }: AssetsOv
 
     return (
         <AccountImportOverviewCard
-            icon={<RoundedIcon symbol={symbol} iconSize="large" />}
+            icon={<RoundedIcon symbol={symbol} />}
             coinName={getNetwork(symbol).name}
             cryptoAmount={
                 <CryptoAmountFormatter

--- a/suite-native/module-authorize-device/src/screens/connect/ConnectDeviceCrossroadsScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/ConnectDeviceCrossroadsScreen.tsx
@@ -57,7 +57,7 @@ const ConnectCard = ({ image, title, subtitle, icon, onPress }: ConnectCardProps
                         <Text variant="headline-sm">
                             <Translation id={subtitle} />
                         </Text>
-                        <RoundedIcon name={icon} iconSize="mediumLarge" containerSize={28} />
+                        <RoundedIcon name={icon} size={32} />
                     </HStack>
                 </Box>
             </VStack>

--- a/suite-native/module-connect-popup/src/components/ConnectAppIcon.tsx
+++ b/suite-native/module-connect-popup/src/components/ConnectAppIcon.tsx
@@ -4,13 +4,9 @@ import { Image, RoundedIcon } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { IMAGE_PROXY_API_AUTH_BEARER, IMAGE_PROXY_API_URL } from '@trezor/urls';
 
-const sizeMapping = {
+const imageSizeMapping = {
     medium: 48,
     large: 60,
-};
-const fallbackIconSizeMapping = {
-    medium: 'mediumLarge' as const,
-    large: 'extraLarge' as const,
 };
 
 const imageStyle = prepareNativeStyle<{ size: number }>((_, { size }) => ({
@@ -32,11 +28,7 @@ export const ConnectAppIcon = ({
 
     if (isFallback || !src) {
         return (
-            <RoundedIcon
-                name={type === 'walletConnect' ? 'walletConnect' : 'plugs'}
-                iconSize={fallbackIconSizeMapping[size]}
-                containerSize={sizeMapping[size]}
-            />
+            <RoundedIcon name={type === 'walletConnect' ? 'walletConnect' : 'plugs'} size={48} />
         );
     }
 
@@ -48,9 +40,9 @@ export const ConnectAppIcon = ({
                     Authorization: `Bearer ${IMAGE_PROXY_API_AUTH_BEARER}`,
                 },
             }}
-            width={sizeMapping[size]}
-            height={sizeMapping[size]}
-            style={applyStyle(imageStyle, { size: sizeMapping[size] })}
+            width={imageSizeMapping[size]}
+            height={imageSizeMapping[size]}
+            style={applyStyle(imageStyle, { size: imageSizeMapping[size] })}
             onError={() => setIsFallback(true)}
         />
     );

--- a/suite-native/module-settings/src/components/ConnectionSettings.tsx
+++ b/suite-native/module-settings/src/components/ConnectionSettings.tsx
@@ -59,12 +59,7 @@ export const ConnectionSettings = () => {
                     <PressableOpacity onPress={openModal} testID="@settings/wallet-connect-add">
                         <HStack justifyContent="space-between" alignItems="center">
                             <HStack spacing="sp16" alignItems="center">
-                                <RoundedIcon
-                                    name="qrCode"
-                                    color="contentBrand"
-                                    backgroundColor="legacyBackgroundPrimarySubtleOnElevation0"
-                                    iconSize="mediumLarge"
-                                />
+                                <RoundedIcon name="qrCode" intent="brand" />
                                 <Text color="contentBrand">
                                     <Translation id="moduleSettings.items.connections.walletConnect.add" />
                                 </Text>

--- a/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencyIcon.tsx
@@ -1,25 +1,15 @@
-import { RoundedIcon } from '@suite-native/atoms';
+import { RoundedIcon, type RoundedIconSize } from '@suite-native/atoms';
 
 export type FiatCurrencyIconProps = {
     size: 'extraSmall' | 'small' | 'medium';
 };
 
-const fiatIconSizes = {
-    extraSmall: 16,
+const fiatIconSizes: Record<FiatCurrencyIconProps['size'], RoundedIconSize> = {
+    extraSmall: 20,
     small: 32,
     medium: 48,
-} as const;
-
-export const FiatCurrencyIcon = ({ size }: FiatCurrencyIconProps) => {
-    const containerSize = fiatIconSizes[size];
-
-    return (
-        <RoundedIcon
-            name="coin"
-            color="contentSecondary"
-            iconSize={size}
-            containerSize={containerSize}
-            backgroundColor="surfaceFillPage"
-        />
-    );
 };
+
+export const FiatCurrencyIcon = ({ size }: FiatCurrencyIconProps) => (
+    <RoundedIcon name="coin" intent="neutral" size={fiatIconSizes[size]} />
+);

--- a/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
@@ -58,13 +58,7 @@ export const TransactionDetailHeader = ({
         <DiscreetTextTrigger>
             <Box alignItems="center">
                 <VStack spacing="sp16" alignItems="center" justifyContent="center">
-                    <TransactionIcon
-                        transactionType={txType}
-                        isAnimated={isPendingTx}
-                        containerSize={56}
-                        iconSize="extraLarge"
-                        backgroundColor="surfaceFillRaised"
-                    />
+                    <TransactionIcon transactionType={txType} isAnimated={isPendingTx} size={48} />
 
                     {isPendingTx ? (
                         <Badge

--- a/suite-native/transactions/src/components/TransactionIcon.tsx
+++ b/suite-native/transactions/src/components/TransactionIcon.tsx
@@ -8,10 +8,15 @@ import {
     type TokenAddress,
     type TransactionType,
 } from '@suite-common/wallet-types';
-import { Box, CircularSpinner, RoundedIcon } from '@suite-native/atoms';
-import { CryptoIcon, type IconName, type IconSize } from '@suite-native/icons';
+import {
+    Box,
+    CircularSpinner,
+    RoundedIcon,
+    type RoundedIconIntent,
+    type RoundedIconSize,
+} from '@suite-native/atoms';
+import { CryptoIcon, type IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-import { type Color } from '@trezor/theme';
 
 type TransactionIconProps = {
     transactionType: TransactionType;
@@ -19,9 +24,8 @@ type TransactionIconProps = {
     symbol?: NetworkSymbol;
     contractAddress?: TokenAddress;
     isAnimated?: boolean;
-    backgroundColor?: Color;
-    containerSize?: number;
-    iconSize?: IconSize;
+    intent?: RoundedIconIntent;
+    size?: RoundedIconSize;
 };
 
 const transactionIconMap: Record<TransactionType, IconName> = {
@@ -55,9 +59,8 @@ export const TransactionIcon = ({
     contractAddress,
     transactionType,
     stakeOperationType,
-    backgroundColor,
-    containerSize = 48,
-    iconSize = 'mediumLarge',
+    intent,
+    size = 48,
     isAnimated = false,
 }: TransactionIconProps) => {
     const { applyStyle } = useNativeStyles();
@@ -76,18 +79,9 @@ export const TransactionIcon = ({
 
     return (
         <Box>
-            <RoundedIcon
-                name={iconName}
-                iconSize={iconSize}
-                backgroundColor={backgroundColor}
-                containerSize={containerSize}
-            />
+            <RoundedIcon name={iconName} intent={intent} size={size} />
             {isAnimated && (
-                <CircularSpinner
-                    size={containerSize}
-                    color="legacyBackgroundAlertYellowBold"
-                    width={3}
-                />
+                <CircularSpinner size={size} color="legacyBackgroundAlertYellowBold" width={3} />
             )}
             {iconSymbol && (
                 <Box style={applyStyle(cryptoIconStyle)}>


### PR DESCRIPTION
## Description

- Replace `color`/`backgroundColor` with a single `intent` prop (`neutral`, `brand`, `warning`, `critical`, `info`)
- Replace `iconSize`/`containerSize` with a single `size` prop (`20`, `24`, `32`, `40`, `48`), with inner icon size locked per container size to match Figma
- Update `TransactionIcon` wrapper and all `RoundedIcon` callers across `suite-native` to the new API
- Refresh the `RoundedIcon` Storybook story to expose `intent` and `size`

## Related Issue

Resolve #25205

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/ds-rounded-icon&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->