### PR TITLE
fix(connect-explorer): checkbox click issue

### DIFF
--- a/packages/connect-explorer/src/components/fields/Checkbox.tsx
+++ b/packages/connect-explorer/src/components/fields/Checkbox.tsx
@@ -11,8 +11,12 @@ interface CheckboxProps {
 
 const Checkbox = ({ field, onChange, ...rest }: CheckboxProps) => (
     <Row>
-        <Card paddingType="small" onClick={() => onChange(field, !field.value)}>
-            <CheckboxComponent onChange={() => {}} isChecked={field.value} {...rest}>
+        <Card paddingType="small">
+            <CheckboxComponent
+                onChange={() => onChange(field, !field.value)}
+                isChecked={field.value}
+                {...rest}
+            >
                 {field.name}
             </CheckboxComponent>
         </Card>


### PR DESCRIPTION
## Description

Seems that checkboxes in Connect Explorer stopped working after some component refactor. 
The old solution was somewhat strange anyway, this fixes it.

## Notes for QA

Make sure checkboxes in Connect Explorer's method testing tool are functioning properly

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-connect-explorer-checkbox&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-connect-explorer-checkbox/web/](https://dev.suite.sldev.cz/suite-web/fix-connect-explorer-checkbox/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-17T14:15:26.898Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->