### PR TITLE
Introduced toggle for app focusing behavior when device is unlocked

### DIFF
--- a/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
+++ b/packages/suite/src/actions/bluetooth/bluetoothConnectDeviceThunk.ts
@@ -1,3 +1,4 @@
+import { selectFocusOnDeviceUnlock } from '@suite/settings';
 import { BLUETOOTH_PREFIX, bluetoothActions } from '@suite-common/bluetooth';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -22,13 +23,13 @@ export const bluetoothConnectDeviceThunk = createThunk<
     void
 >(
     `${BLUETOOTH_PREFIX}/bluetoothConnectDeviceThunk`,
-    async ({ deviceId }, { fulfillWithValue, dispatch }) => {
+    async ({ deviceId }, { fulfillWithValue, dispatch, getState }) => {
         dispatch(startConnectingBluetoothDevice({ deviceId }));
 
         const result = await bluetoothIpc.connectDevice(deviceId);
 
         // restore focus in case if OS bluetooth setting is opened above the app (linux/mac)
-        desktopApi.appFocus();
+        if (selectFocusOnDeviceUnlock(getState())) desktopApi.appFocus();
 
         if (!result.success) {
             // handling for this error: https://github.com/trezor/trezor-suite/blob/837cdf89c70cca80fd5dabb910e9a8509de7c3b1/packages/transport-bluetooth/src/server/platform/linux.rs#L253

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -359,6 +359,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case SUITE.EVM_CONFIRM_EXPLANATION_MODAL:
                 case SUITE.EVM_CLOSE_EXPLANATION_BANNER:
                 case suiteSettingsActions.setIsCoinsFilterVisible.type:
+                case suiteSettingsActions.setFocusOnDeviceUnlock.type:
                     api.dispatch(storageActions.saveSuiteSettings());
                     break;
                 case suiteSettingsActions.setCoinjoinReceiveWarningHidden.type: {

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { openModal } from '@suite/modal';
-import { selectFocusOnDeviceUnlock } from '@suite/settings';
 import { events } from '@suite-common/analytics';
 import {
     CALL_SOURCE_DESKTOP_WS,
@@ -23,7 +22,6 @@ export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
     const popupCall = useSelector(selectConnectPopupCall);
-    const focusOnDeviceUnlock = useSelector(selectFocusOnDeviceUnlock);
     const selectedDevice = useSelector(selectSelectedDevice);
     const selectedDeviceRef = useRef(selectedDevice);
     selectedDeviceRef.current = selectedDevice;
@@ -163,7 +161,7 @@ export const useConnectPopupDesktop = () => {
             // Remember visibility state
             desktopApi.appIsVisible().then(isVisible => {
                 setWasVisible(isVisible && document.visibilityState === 'visible');
-                if (focusOnDeviceUnlock) desktopApi.appFocus();
+                desktopApi.appFocus();
             });
         }
 
@@ -174,5 +172,5 @@ export const useConnectPopupDesktop = () => {
                 desktopApi.appHide();
             }
         }
-    }, [popupCall, currentlyOngoing, wasVisible, focusOnDeviceUnlock]);
+    }, [popupCall, currentlyOngoing, wasVisible]);
 };

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { openModal } from '@suite/modal';
+import { selectFocusOnDeviceUnlock } from '@suite/settings';
 import { events } from '@suite-common/analytics';
 import {
     CALL_SOURCE_DESKTOP_WS,
@@ -22,6 +23,7 @@ export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
     const analytics = useAnalytics();
     const popupCall = useSelector(selectConnectPopupCall);
+    const focusOnDeviceUnlock = useSelector(selectFocusOnDeviceUnlock);
     const selectedDevice = useSelector(selectSelectedDevice);
     const selectedDeviceRef = useRef(selectedDevice);
     selectedDeviceRef.current = selectedDevice;
@@ -161,7 +163,7 @@ export const useConnectPopupDesktop = () => {
             // Remember visibility state
             desktopApi.appIsVisible().then(isVisible => {
                 setWasVisible(isVisible && document.visibilityState === 'visible');
-                desktopApi.appFocus();
+                if (focusOnDeviceUnlock) desktopApi.appFocus();
             });
         }
 
@@ -172,5 +174,5 @@ export const useConnectPopupDesktop = () => {
                 desktopApi.appHide();
             }
         }
-    }, [popupCall, currentlyOngoing, wasVisible]);
+    }, [popupCall, currentlyOngoing, wasVisible, focusOnDeviceUnlock]);
 };

--- a/packages/suite/src/views/settings/SettingsGeneral/FocusOnDeviceUnlock.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/FocusOnDeviceUnlock.tsx
@@ -1,0 +1,40 @@
+import { Translation } from '@suite/intl';
+import { Anchor, SettingsAnchor } from '@suite/router';
+import { selectFocusOnDeviceUnlock, suiteSettingsActions } from '@suite/settings';
+import { Switch } from '@trezor/components';
+import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+export const FocusOnDeviceUnlock = () => {
+    const focusOnDeviceUnlock = useSelector(selectFocusOnDeviceUnlock);
+    const dispatch = useDispatch();
+
+    const handleChange = () => {
+        dispatch(suiteSettingsActions.setFocusOnDeviceUnlock(!focusOnDeviceUnlock));
+    };
+
+    return (
+        <Anchor anchorId={SettingsAnchor.FocusOnDeviceUnlock}>
+            {({ anchorId, anchorRef, shouldHighlight }) => (
+                <SectionItem
+                    data-testid={anchorId}
+                    ref={anchorRef}
+                    shouldHighlight={shouldHighlight}
+                >
+                    <TextColumn
+                        title={<Translation id="TR_FOCUS_ON_DEVICE_UNLOCK_TITLE" />}
+                        description={<Translation id="TR_FOCUS_ON_DEVICE_UNLOCK_DESCRIPTION" />}
+                    />
+                    <ActionColumn>
+                        <Switch
+                            data-testid="@settings/general/focus-on-device-unlock-switch"
+                            isChecked={focusOnDeviceUnlock}
+                            onChange={handleChange}
+                        />
+                    </ActionColumn>
+                </SectionItem>
+            )}
+        </Anchor>
+    );
+};

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -34,6 +34,7 @@ import { DisconnectLabelingProvider } from './DisconnectLabelingProvider';
 import { DustPhishing } from './DustPhishing';
 import { EarlyAccess } from './EarlyAccess';
 import { Experimental } from './Experimental';
+import { FocusOnDeviceUnlock } from './FocusOnDeviceUnlock';
 import { Language } from './Language';
 import { LegacyLabelingMigration } from './LegacyLabelingMigration';
 import { McpServer } from './McpServer';
@@ -175,6 +176,7 @@ export const SettingsGeneral = () => {
                 >
                     <AutoStart />
                     <ShowOnTray />
+                    <FocusOnDeviceUnlock />
                 </SettingsSection>
             )}
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10718,6 +10718,15 @@ export const messages = defineMessages({
         id: 'TR_SHOW_ON_TRAY',
         defaultMessage: 'Show icon in tray',
     },
+    TR_FOCUS_ON_DEVICE_UNLOCK_TITLE: {
+        id: 'TR_FOCUS_ON_DEVICE_UNLOCK_TITLE',
+        defaultMessage: 'Bring window to front on device connect',
+    },
+    TR_FOCUS_ON_DEVICE_UNLOCK_DESCRIPTION: {
+        id: 'TR_FOCUS_ON_DEVICE_UNLOCK_DESCRIPTION',
+        defaultMessage:
+            'Automatically restore and focus the Trezor Suite window when a device is connected or unlocked, including Bluetooth devices.',
+    },
     TR_SHOW_ON_TRAY_DESCRIPTION: {
         id: 'TR_SHOW_ON_TRAY_DESCRIPTION',
         defaultMessage: 'Monitor when Trezor Suite is running in the background.',

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -32,6 +32,7 @@ export const SettingsAnchor = {
     VersionWithUpdate: '@general-settings/version-with-update',
     EarlyAccess: '@general-settings/early-access',
     AutoStart: '@general-settings/auto-start',
+    FocusOnDeviceUnlock: '@general-settings/focus-on-device-unlock',
     AutomaticUpdate: '@general-settings/automatic-update',
     AutoEject: '@general-settings/auto-eject',
     MevProtection: '@general-settings/mev-protection',

--- a/suite/settings/src/settingsSelectors.ts
+++ b/suite/settings/src/settingsSelectors.ts
@@ -52,3 +52,5 @@ export const selectIsCoinsFilterVisible = (state: SuiteSettingsRootState) =>
     state.suiteSettings.isCoinsFilterVisible;
 export const selectIsN4w1BackupEnabled = (state: SuiteSettingsRootState) =>
     state.suiteSettings.debug.isN4w1BackupEnabled;
+export const selectFocusOnDeviceUnlock = (state: SuiteSettingsRootState) =>
+    state.suiteSettings.focusOnDeviceUnlock;

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -50,6 +50,7 @@ export interface SuiteSettingsState {
     isCoinsFilterVisible: boolean;
     suiteSyncRelayUrl: string | null;
     autoEject: boolean;
+    focusOnDeviceUnlock: boolean;
 }
 
 export type SuiteSettingsRootState = {
@@ -88,6 +89,7 @@ export const suiteSettingsInitialState: SuiteSettingsState = {
     isCoinsFilterVisible: false,
     suiteSyncRelayUrl: null,
     autoEject: false,
+    focusOnDeviceUnlock: true,
 };
 
 const suiteSettingsSlice = createSliceWithExtraDeps({
@@ -144,6 +146,9 @@ const suiteSettingsSlice = createSliceWithExtraDeps({
         },
         toggleDeviceMetaChecks: (state, { payload }: PayloadAction<boolean>) => {
             state.enabledSecurityChecks.deviceMeta = payload;
+        },
+        setFocusOnDeviceUnlock: (state, { payload }: PayloadAction<boolean>) => {
+            state.focusOnDeviceUnlock = payload;
         },
     },
     extraReducers: (builder, extra) => {


### PR DESCRIPTION
## Description

Hi, I reported such [issue](https://github.com/trezor/trezor-suite/issues/23847)(not PR) previously but it wasn't well received. After some time, I realised that my description and explanation wasn't very good.
So... probably Trezor team assumes that the main interface that user interacts and initiate transactions is Trezor Suite, so it is indeed reasonable to bring Trezor Suite into front when user unlocks their device. 

But this is not the case for all of users, for instance I use mainly third parties wallets like Rabby, Metamask or Jupiter for Solana. For me when I unlock my device before initiating a tx (because I give my device time to bluetooth sync), I see Trezor Suite popup which often covers extension wallet interface, so I need to minimise Trezor Suite then initiate or accept a tx in extension and finally THIS EXTENSION is responsible of bringing Trezor Suite window to the front. This becomes a little mess.

So in my opinion there should be an option to disable default behavior - for users who don't use Trezor Suite to send/swap/do defi inside Trezor Suite, because they use other apps and Trezor Suite is only needed for bringing confirmation screen. This option can be enabled by default - but still user can turn this behavior off.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23847

## Screenshots:

<img width="909" height="590" alt="Screenshot 2026-04-18 at 19 50 28" src="https://github.com/user-attachments/assets/525c8f05-84c0-4621-b030-2cb77323b08f" />

