### PR TITLE
fix(fiat-services): prioritize stellar soroban urls

### DIFF
--- a/suite-common/fiat-services/package.json
+++ b/suite-common/fiat-services/package.json
@@ -12,6 +12,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@stellar/stellar-sdk": "14.5.0",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",

--- a/suite-common/fiat-services/src/coingecko.ts
+++ b/suite-common/fiat-services/src/coingecko.ts
@@ -1,3 +1,5 @@
+import { Asset, Networks } from '@stellar/stellar-sdk';
+
 import { getNetwork, networks } from '@suite-common/wallet-config';
 import { type HistoricRates, type TickerId } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -88,9 +90,12 @@ const buildCoinUrls = (ticker: TickerId) => {
 
     if (networkType === 'stellar') {
         const [code, issuer] = ticker.tokenAddress.split('-');
+        // Use the public Stellar network here because CoinGecko does not provide testnet market data.
+        const sorobanContractAddress = new Asset(code, issuer).contractId(Networks.PUBLIC);
 
-        // There are currently three formats on CoinGecko, we try them in order of frequency.
+        // CoinGecko is gradually migrating Stellar assets to Soroban contract ids, so try that URL first.
         return [
+            `${baseUrl}/contract/${sorobanContractAddress}`,
             `${baseUrl}/contract/${code}-${issuer}`,
             `${baseUrl}/contract/${code}-${issuer}-1`,
             `${baseUrl}/contract/${code}:${issuer}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11021,6 +11021,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/fiat-services@workspace:suite-common/fiat-services"
   dependencies:
+    "@stellar/stellar-sdk": "npm:14.5.0"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CoinGecko is gradually migrating Stellar token contract identifiers from classic `CODE-ISSUER` formats to Soroban contract ids (`C...`).

Suite currently uses classic Stellar token addresses, so fiat rate lookups could fail for tokens that CoinGecko now resolves only under the Soroban contract endpoint. This change derives the Soroban contract id from the existing `code + issuer` pair and prioritizes that URL before falling back to the classic CoinGecko variants.

This keeps the current Suite token format unchanged while restoring fiat rate compatibility with CoinGecko's Stellar migration.

## Notes for QA

Verify fiat rates for Stellar tokens, especially tokens that CoinGecko now exposes under Soroban contract ids.

Suggested checks:
  - Open a Stellar account with a token such as USDC.
  - Confirm related graph/historical fiat data loads correctly.
  - Confirm tokens that are still available under classic CoinGecko formats continue to work.

## Related Issue

Resolve #26753 

## Screenshots:
N/A