### PR TITLE
chore(protocol): remove redundant TPN re-export

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,10 +4,5 @@ export * as bridge from './protocol-bridge';
 export * as thp from './protocol-thp';
 export * as trzd from './protocol-trzd';
 export * as tpn from './protocol-tpn';
-export {
-    type DecodedTrezorPushNotification,
-    TrezorPushNotificationMode,
-    TrezorPushNotificationType,
-} from './protocol-tpn';
 export * from './errors';
 export * from './types';


### PR DESCRIPTION
The explicit re-export block for TrezorPushNotificationType, TrezorPushNotificationMode and DecodedTrezorPushNotification is redundant: these names are already re-exported via `types.ts`, which `index.ts` pulls in with `export * from './types'`.

These exports were added by me recently, actually. Sorry, my wrong.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to packages/protocol/src/index.ts affects the core protocol layer used for all communication between Trezor Suite and hardware devices. Since this is a foundational package, the blast radius is potentially wide but indirect — it could affect any feature that communicates with a Trezor device. Without knowing the specific nature of the change (e.g., re-export restructuring vs. protocol logic changes), the risk is moderate. Priority should be given to tests that directly exercise transport/bridge communication and device interaction flows (TrezorConnect tests, bridge tests, session management), with lower priority on higher-level feature tests that only indirectly depend on the protocol layer.

<details><summary><b>Changed files (1)</b></summary>

- `packages/protocol/src/index.ts`

</details>

**Recommended tests (18)**

🟡 **Medium priority**

- `../../suite/e2e/tests/suite/bridge.test.ts` — packages/protocol/src/index.ts is part of the @trezor/protocol package which handles low-level protocol communication between Suite and Trezor devices. The bridge test exercises the transport/bridge layer which depends on protocol encoding/decoding. Changes to protocol could break bridge communication.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test validates bridge spawning, version endpoints, and device reconnection through the bridge transport layer. The protocol package is a dependency of the transport stack, so changes could affect bridge communication and session management.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests bridge daemon mode which relies on the transport/protocol stack for device communication. Protocol changes could affect how the bridge daemon handles device sessions.
- `../../suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises BridgeTransport session management (enumerate, acquire) which depends on the protocol package for message encoding. Protocol changes could break session stealing/reclaiming behavior.
- `../../suite/e2e/tests/trezor-connect/getAddress.test.ts` — TrezorConnect.getAddress communicates with the device through the protocol layer. Changes to protocol message encoding/decoding could break address export and device confirmation flows.
- `../../suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Transaction signing involves protocol-level message exchange with the device. Protocol changes could affect how transaction data is serialized and sent to the hardware wallet.
- `../../suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Ethereum transaction signing uses the protocol layer for device communication. Changes could break the multi-step confirmation flow between Suite and the device.
- `../../suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Message signing goes through the protocol layer to communicate with the Trezor device. Protocol changes could affect message serialization during the signing flow.
- `../../suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — The Connect popup flow exercises the full TrezorConnect.getAddress pipeline including protocol-level device communication. Protocol changes could break the popup handshake or device confirmation.

🟢 **Low priority**

- `../../suite/e2e/tests/trezor-connect/error.test.ts` — Tests error handling for invalid paths in TrezorConnect which goes through the protocol layer. Protocol changes are unlikely to affect error path validation but could change error message formatting.
- `../../suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — getAccountInfo uses the protocol layer for device communication. While less direct than address/signing tests, protocol changes could still affect account info retrieval.
- `../../suite/e2e/tests/trezor-connect/permissions.test.ts` — Permissions test involves TrezorConnect calls that go through the protocol layer, but the focus is on permission management UI rather than protocol-level communication.
- `../../suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Wallet creation involves protocol communication for device setup (backup, PIN). Protocol changes could affect device interaction during onboarding, though this is a less direct dependency.
- `../../suite/e2e/tests/wallet/receive.test.ts` — Receiving addresses requires protocol communication to confirm addresses on the device. Protocol changes could break the address reveal and device confirmation flow.
- `../../suite/e2e/tests/wallet/send-form-regtest.test.ts` — Send form tests involve transaction signing through the protocol layer. Protocol changes could affect how transactions are sent to the device for confirmation.
- `../../suite/e2e/tests/recovery/dry-run.test.ts` — Recovery dry run involves intensive protocol communication for mnemonic verification on the device. Protocol changes could break the seed check flow.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — Initial run test involves device connection and THP pairing which use the protocol layer. Protocol changes could affect the initial device handshake.
- `../../suite/e2e/tests/analytics/events.test.ts` — Analytics events test captures TransportType events that reference bridge transport, which depends on the protocol package. Protocol changes are unlikely to affect analytics but could change transport metadata.

⚠️ **Changes with no test coverage (1)**
- `packages/protocol/src/index.ts`

_Updated: 2026-04-20T07:59:46.898Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=protocol-remove-duplicate-tpn-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=protocol-remove-duplicate-tpn-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T08:04:42.641Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T08:03:16.895Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/protocol-remove-duplicate-tpn-export/web/](https://dev.suite.sldev.cz/suite-web/protocol-remove-duplicate-tpn-export/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->