### PR TITLE
feat(suite): prepare stablecoin yield claim flow

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogo.tsx
@@ -14,7 +14,7 @@ export const AssetLogo = ({ symbol, size, ...rest }: AssetLogoProps) => {
             <CoinLogo
                 size={size}
                 symbol={symbol as NetworkSymbol | LegacyNetworkSymbol}
-                type="tokenWithNetwork"
+                type="token"
             />
         );
     }

--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -5,6 +5,7 @@ import { type PageName } from '@suite/router';
 import { ConnectPopup } from 'src/views/connect-popup';
 import { Dashboard } from 'src/views/dashboard';
 import { Earn } from 'src/views/earn';
+import { EarnClaim } from 'src/views/earn/claim';
 import { EarnSupply } from 'src/views/earn/supply';
 import { EarnWithdraw } from 'src/views/earn/withdraw';
 import PasswordManagerView from 'src/views/password-manager';
@@ -44,6 +45,7 @@ export const desktopComponents: Record<PageName, ComponentType> = {
     'suite-earn': Earn,
     'earn-supply': EarnSupply,
     'earn-withdraw': EarnWithdraw,
+    'earn-claim': EarnClaim,
     'suite-connect-popup': ConnectPopup,
     'notifications-index': Notification,
 

--- a/packages/suite-web/src/support/webComponents.ts
+++ b/packages/suite-web/src/support/webComponents.ts
@@ -27,6 +27,13 @@ export const webComponents: Record<PageName, LazyExoticComponent<ComponentType>>
             }),
         ),
     ),
+    'earn-claim': lazy(() =>
+        import(/* webpackChunkName: "earn" */ 'src/views/earn/claim/index').then(
+            ({ EarnClaim }) => ({
+                default: EarnClaim,
+            }),
+        ),
+    ),
     'suite-connect-popup': lazy(() =>
         import(/* webpackChunkName: "connect-popup" */ 'src/views/connect-popup/index').then(
             ({ ConnectPopup }) => ({ default: ConnectPopup }),

--- a/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
+++ b/packages/suite/src/components/earn/dashboard/utils/earnYieldUtils.ts
@@ -1,4 +1,55 @@
+import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
+import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
+
+import { type EarnYieldClaimableAccount } from '../yield/EarnYieldClaimSelectAccountModal';
+import { type MerkleRewardsWithFiatRecord } from '../yield/hooks/useMerkleRewards';
+
+type GetClaimableAccountsParams = {
+    rewards: MerkleRewardsWithFiatRecord;
+    visibleAccounts: Account[];
+};
+
+export const getClaimableAccounts = ({
+    rewards,
+    visibleAccounts,
+}: GetClaimableAccountsParams): EarnYieldClaimableAccount[] =>
+    Object.entries(rewards).flatMap(([key, accountRewards]) => {
+        const { chainId, address } = ChainAddressKey.parse(key);
+        const network = getNetworkByEvmChainId(Number(chainId));
+
+        const account = visibleAccounts.find(
+            a =>
+                a.symbol === network?.symbol &&
+                a.descriptor.toLowerCase() === address.toLowerCase(),
+        );
+
+        if (!account) {
+            return [];
+        }
+
+        const claimableRewards = accountRewards.filter(reward =>
+            new BigNumber(reward.claimable).gt(0),
+        );
+
+        if (claimableRewards.length === 0) {
+            return [];
+        }
+
+        const hasAnyFiatAmount = claimableRewards.some(reward => reward.fiat.claimable !== null);
+        const totalFiatAmount = claimableRewards.reduce(
+            (total, reward) => total.plus(reward.fiat.claimable ?? '0'),
+            new BigNumber(0),
+        );
+
+        return [
+            {
+                account,
+                totalFiatAmount: hasAnyFiatAmount ? asBaseCurrencyAmount(totalFiatAmount) : null,
+            },
+        ];
+    });
 
 type YieldRowWithAvailableBalance = {
     additionalSupplyAmount: string;

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -1,17 +1,21 @@
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
-import { Banner } from '@trezor/components';
+import { Banner, Row, SkeletonRectangle } from '@trezor/components';
 
 type EarnYieldClaimRewardsBannerProps = {
     value: BaseCurrencyAmount;
     currency: string;
+    isValueLoading?: boolean;
+    isClaimDisabled?: boolean;
     onClaim?: () => void;
 };
 
 export const EarnYieldClaimRewardsBanner = ({
     value,
     currency,
+    isValueLoading,
+    isClaimDisabled,
     onClaim,
 }: EarnYieldClaimRewardsBannerProps) => {
     const { BaseCurrencyAmountFormatter } = useFormatters();
@@ -21,13 +25,19 @@ export const EarnYieldClaimRewardsBanner = ({
             intent="neutral"
             icon="handCoins"
             description={
-                <>
-                    <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />:{' '}
-                    <BaseCurrencyAmountFormatter value={value} currency={currency} />
-                </>
+                <Row gap={4} alignItems="center">
+                    <span>
+                        <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />:
+                    </span>
+                    {isValueLoading ? (
+                        <SkeletonRectangle width={50} height={16} animate />
+                    ) : (
+                        <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                    )}
+                </Row>
             }
             rightContent={
-                <Banner.Button onClick={onClaim}>
+                <Banner.Button isDisabled={isClaimDisabled} onClick={onClaim}>
                     <Translation id="TR_EARN_CLAIM_REWARDS_BUTTON" />
                 </Banner.Button>
             }

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -1,0 +1,63 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { type Account, type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { CardList, Column, Modal, Row, Text } from '@trezor/components';
+import { CoinLogo } from '@trezor/product-components';
+
+import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { Address } from 'src/components/suite/Address';
+
+export type EarnYieldClaimableAccount = {
+    account: Account;
+    totalFiatAmount: BaseCurrencyAmount | null;
+};
+
+type EarnYieldClaimSelectAccountModalProps = {
+    claimableAccounts: EarnYieldClaimableAccount[];
+    onSelect: (claimableAccount: EarnYieldClaimableAccount) => void;
+    onClose: () => void;
+};
+
+export const EarnYieldClaimSelectAccountModal = ({
+    claimableAccounts,
+    onSelect,
+    onClose,
+}: EarnYieldClaimSelectAccountModalProps) => {
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    return (
+        <Modal
+            heading={<Translation id="TR_EARN_YIELD_CLAIM_MODAL_TITLE" />}
+            description={<Translation id="TR_EARN_YIELD_CLAIM_MODAL_SUBTITLE" />}
+            onCancel={onClose}
+        >
+            <CardList>
+                {claimableAccounts.map(claimable => (
+                    <CardList.Item key={claimable.account.key} onClick={() => onSelect(claimable)}>
+                        <Row gap={16} flex="1" overflow="hidden">
+                            <CoinLogo symbol={claimable.account.symbol} size={32} type="token" />
+                            <Column flex="1" overflow="hidden" gap={2} alignItems="flex-start">
+                                <AccountLabel
+                                    account={claimable.account}
+                                    typographyStyle="body-md-strong"
+                                />
+                                <Address
+                                    value={claimable.account.descriptor}
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    isTruncated
+                                />
+                            </Column>
+                        </Row>
+                        <Text typographyStyle="body-md-strong">
+                            {claimable.totalFiatAmount !== null
+                                ? BaseCurrencyAmountFormatter.format(claimable.totalFiatAmount)
+                                : '—'}
+                        </Text>
+                    </CardList.Item>
+                ))}
+            </CardList>
+        </Modal>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -1,16 +1,21 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
 import { Context } from '@suite-common/message-system';
 import { NORMAL_ACCOUNT_TYPE } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { Button, Card, Column, Table } from '@trezor/components';
 
 import { ContextMessage } from 'src/components/wallet/WalletLayout/AccountBanners/ContextMessage';
-import { useSelector } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemEarnDashboard } from 'src/hooks/suite/useMessageSystemEarnDashboard';
 
 import { EarnYieldClaimRewardsBanner } from './EarnYieldClaimRewardsBanner';
+import {
+    EarnYieldClaimSelectAccountModal,
+    type EarnYieldClaimableAccount,
+} from './EarnYieldClaimSelectAccountModal';
 import { EarnYieldTableBody } from './EarnYieldTableBody';
 import { useAllYieldOpportunities } from './hooks/useAllYieldOpportunities';
 import { useMerkleRewards } from './hooks/useMerkleRewards';
@@ -20,10 +25,13 @@ import { EarnDashboardSection } from '../common/EarnDashboardSection';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 import { EarnFeatureDisabledBanner } from '../common/EarnFeatureDisabledBanner';
 import { getEarnDashboardBadgeState } from '../utils/earnDashboardBadgeUtils';
+import { getClaimableAccounts } from '../utils/earnYieldUtils';
 
 export const EarnYieldTable = () => {
+    const dispatch = useDispatch();
     const { isDisabled: isYieldDashboardDisabled, content } =
         useMessageSystemEarnDashboard('yield');
+    const [isClaimModalOpen, setIsClaimModalOpen] = useState(false);
 
     const visibleAccounts = useSelector(selectVisibleDeviceAccounts);
     const visibleAccountSymbols = useMemo(() => {
@@ -55,13 +63,51 @@ export const EarnYieldTable = () => {
         toggleIsExpanded,
     } = useYieldAccountsVisibility({ yieldAccountOpportunities });
 
-    const { merkleRewardsQuery } = useMerkleRewards(yieldAccountOpportunities);
+    const merkleRewardsSources = useMemo(
+        () =>
+            yieldAccountOpportunities.flatMap(opportunity => {
+                if (!opportunity.hasVaultPosition || !opportunity.account) {
+                    return [];
+                }
+
+                return [
+                    {
+                        networkSymbol: opportunity.networkSymbol,
+                        address: opportunity.account.descriptor,
+                    },
+                ];
+            }),
+        [yieldAccountOpportunities],
+    );
+    const { merkleRewardsQuery } = useMerkleRewards(merkleRewardsSources);
+    const { rewards } = merkleRewardsQuery.data;
+    const isClaimDisabled =
+        !merkleRewardsQuery.isSuccess || !merkleRewardsQuery.data.totalRewardsToClaim.value.gt(0);
+    const claimableAccounts = useMemo<EarnYieldClaimableAccount[]>(
+        () =>
+            merkleRewardsQuery.isSuccess ? getClaimableAccounts({ rewards, visibleAccounts }) : [],
+        [merkleRewardsQuery.isSuccess, rewards, visibleAccounts],
+    );
 
     const badge = getEarnDashboardBadgeState({
         isSectionActive: !isYieldDashboardDisabled && isYieldActive,
         activeLabelId: 'TR_EARN_DASHBOARD_ACTIVE',
         notActiveLabelId: 'TR_EARN_DASHBOARD_NOT_ACTIVE',
     });
+
+    const handleClaimableAccountSelect = (claimableAccount: EarnYieldClaimableAccount) => {
+        dispatch(
+            goto({
+                routeName: 'earn-claim',
+                params: {
+                    symbol: claimableAccount.account.symbol,
+                    accountIndex: claimableAccount.account.index,
+                    accountType: claimableAccount.account.accountType,
+                },
+            }),
+        );
+        setIsClaimModalOpen(false);
+    };
 
     return (
         <Column gap={16}>
@@ -77,16 +123,20 @@ export const EarnYieldTable = () => {
                     <EarnFeatureDisabledBanner content={content} />
                 ) : (
                     <Column gap={16} alignItems="center">
-                        {merkleRewardsQuery.isSuccess &&
-                            merkleRewardsQuery.data.totalRewardsToClaim.value.gt(0) && (
-                                <EarnYieldClaimRewardsBanner
-                                    value={merkleRewardsQuery.data.totalRewardsToClaim.value}
-                                    currency={merkleRewardsQuery.data.totalRewardsToClaim.currency}
-                                    onClaim={() => {
-                                        window.alert('TODO: Claim rewards');
-                                    }}
-                                />
-                            )}
+                        <EarnYieldClaimRewardsBanner
+                            value={merkleRewardsQuery.data.totalRewardsToClaim.value}
+                            currency={merkleRewardsQuery.data.totalRewardsToClaim.currency}
+                            isValueLoading={merkleRewardsQuery.isLoading}
+                            isClaimDisabled={isClaimDisabled}
+                            onClaim={() => setIsClaimModalOpen(true)}
+                        />
+                        {isClaimModalOpen && (
+                            <EarnYieldClaimSelectAccountModal
+                                claimableAccounts={claimableAccounts}
+                                onSelect={handleClaimableAccountSelect}
+                                onClose={() => setIsClaimModalOpen(false)}
+                            />
+                        )}
                         <Card paddingType="none">
                             <Table isRowHighlightedOnHover margin={{ top: 8 }}>
                                 <EarnDashboardTableHeader

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useMerkleRewards.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useMerkleRewards.ts
@@ -8,13 +8,18 @@ import {
     useGetMerkleRewards,
 } from '@suite-common/earn-stablecoin-api';
 import { commonQueryKeys } from '@suite-common/react-query';
-import { getNetwork, getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    getNetworkByEvmChainId,
+} from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectCurrentFiatRates,
     updateFiatRatesThunk,
 } from '@suite-common/wallet-core';
 import {
+    type BaseCurrencyAmount,
     type RatesByKey,
     type TickerId,
     type Timestamp,
@@ -34,22 +39,37 @@ import { BigNumber, unique } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-import { type YieldAccountOpportunity } from '../types';
+export type MerkleRewardWithFiat =
+    MerkleRewardsByChainAndAddress[keyof MerkleRewardsByChainAndAddress][number] & {
+        claimable: string;
+        fiat: {
+            amount: BaseCurrencyAmount | null;
+            claimed: BaseCurrencyAmount | null;
+            pending: BaseCurrencyAmount | null;
+            claimable: BaseCurrencyAmount | null;
+        };
+    };
 
-function getMerkleRewardsQueryEntries(yieldAccountOpportunities: YieldAccountOpportunity[]) {
-    const candidatesForMerkleRewards = yieldAccountOpportunities
-        .filter(
-            opportunity =>
-                opportunity.hasVaultPosition &&
-                opportunity.account &&
-                getNetwork(opportunity.networkSymbol),
-        )
-        .map(opportunity =>
-            ChainAddressKey.compose(
-                getNetwork(opportunity.networkSymbol)?.chainId as number,
-                opportunity.account?.descriptor as string,
-            ),
-        );
+export type MerkleRewardsWithFiatRecord = Record<
+    keyof MerkleRewardsByChainAndAddress,
+    MerkleRewardWithFiat[]
+>;
+
+export type MerkleRewardsSource = {
+    networkSymbol: NetworkSymbol;
+    address: string;
+};
+
+function getMerkleRewardsQueryEntries(sources: MerkleRewardsSource[]) {
+    const candidatesForMerkleRewards = sources.flatMap(source => {
+        const network = getNetwork(source.networkSymbol);
+
+        if (!network?.chainId) {
+            return [];
+        }
+
+        return [ChainAddressKey.compose(network.chainId, source.address)];
+    });
 
     return unique(candidatesForMerkleRewards).map(candidate => {
         const { chainId, address } = ChainAddressKey.parse(candidate);
@@ -88,12 +108,21 @@ function extendMerkleRewardsWithFiat(
             const network = getNetworkByEvmChainId(chainId);
 
             const rewardsWithFiat = rewards.map(reward => {
+                const claimable = new BigNumber(reward.amount)
+                    .minus(reward.claimed)
+                    .minus(reward.pending)
+                    .toFixed();
+
                 if (!network) {
                     return {
                         ...reward,
-                        amountFiat: null,
-                        claimedFiat: null,
-                        pendingFiat: null,
+                        claimable,
+                        fiat: {
+                            amount: null,
+                            claimed: null,
+                            pending: null,
+                            claimable: null,
+                        },
                     };
                 }
 
@@ -113,15 +142,15 @@ function extendMerkleRewardsWithFiat(
                     missingRateTickers.push(ticker);
                 }
 
-                const amountFiat = toFiatFromSubunits(reward.amount, reward.token.decimals, rate);
-                const claimedFiat = toFiatFromSubunits(reward.claimed, reward.token.decimals, rate);
-                const pendingFiat = toFiatFromSubunits(reward.pending, reward.token.decimals, rate);
-
                 return {
                     ...reward,
-                    amountFiat,
-                    claimedFiat,
-                    pendingFiat,
+                    claimable,
+                    fiat: {
+                        amount: toFiatFromSubunits(reward.amount, reward.token.decimals, rate),
+                        claimed: toFiatFromSubunits(reward.claimed, reward.token.decimals, rate),
+                        pending: toFiatFromSubunits(reward.pending, reward.token.decimals, rate),
+                        claimable: toFiatFromSubunits(claimable, reward.token.decimals, rate),
+                    },
                 };
             });
 
@@ -136,14 +165,14 @@ function extendMerkleRewardsWithFiat(
 }
 
 /**
- * - Fetches Merkle rewards from provided `YieldAccountOpportunity`.
+ * - Fetches Merkle rewards from provided chain/address query entries.
  * - Extends Merkle rewards with fiat rates (and fetches missing rate tickers).
  */
-export function useMerkleRewards(yieldAccountOpportunities: YieldAccountOpportunity[]) {
+export function useMerkleRewards(sources: MerkleRewardsSource[]) {
     const dispatch = useDispatch();
     const merkleRewardsQueryEntries = useMemo(
-        () => getMerkleRewardsQueryEntries(yieldAccountOpportunities),
-        [yieldAccountOpportunities],
+        () => getMerkleRewardsQueryEntries(sources),
+        [sources],
     );
 
     const baseCurrency = useSelector(selectBaseCurrency);
@@ -175,7 +204,7 @@ export function useMerkleRewards(yieldAccountOpportunities: YieldAccountOpportun
             (result, rewards) =>
                 result.plus(
                     rewards.reduce(
-                        (acc, reward) => acc.plus(reward.amountFiat ?? '0'),
+                        (acc, reward) => acc.plus(reward.fiat.claimable ?? '0'),
                         new BigNumber(0),
                     ),
                 ),

--- a/packages/suite/src/components/earn/index.ts
+++ b/packages/suite/src/components/earn/index.ts
@@ -13,6 +13,8 @@ export { EarnDashboard } from './dashboard/EarnDashboard';
 
 export { YieldPageHeader } from './yield/common/YieldPageHeader';
 
+export { YieldClaim } from './yield/claim/YieldClaim';
+export { YieldClaimPageHeader } from './yield/claim/YieldClaimPageHeader';
 export { YieldSupply } from './yield/supply/YieldSupply';
 export { YieldWithdraw } from './yield/withdraw/YieldWithdraw';
 export { EarnSupplyingInfo } from './modals/EarnInANutshell/components/EarnSupplyingInfo';

--- a/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
@@ -132,7 +132,7 @@ export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
             data-testid="@staking/claim-modal"
             heading={
                 <Translation
-                    id={isCardanoNetworkType ? 'TR_STAKE_CLAIM_REWARDS' : 'TR_STAKE_CLAIM_TOKEN'}
+                    id={isCardanoNetworkType ? 'TR_EARN_CLAIM_REWARDS' : 'TR_STAKE_CLAIM_TOKEN'}
                     values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
                 />
             }
@@ -158,7 +158,7 @@ export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
                             data-testid="@staking/claim-modal/continue-button"
                         >
                             {isCardanoNetworkType ? (
-                                <Translation id="TR_STAKE_CLAIM_REWARDS" />
+                                <Translation id="TR_EARN_CLAIM_REWARDS" />
                             ) : (
                                 <Translation id="TR_CONTINUE" />
                             )}
@@ -183,7 +183,7 @@ export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
                                         intent="warning"
                                         icon="warning"
                                         description={
-                                            <Translation id="TR_STAKING_REWARDS_NETWORK_FEE_WARNING" />
+                                            <Translation id="TR_EARN_REWARDS_NETWORK_FEE_WARNING" />
                                         }
                                     />
                                 )}

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
@@ -7,33 +7,22 @@ import { Banner, Button, Card, Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { YieldRewardsList } from './YieldRewardsList';
-import { useAllYieldOpportunities } from '../../dashboard/yield/hooks/useAllYieldOpportunities';
 import { useMerkleRewards } from '../../dashboard/yield/hooks/useMerkleRewards';
-import { useYieldTableData } from '../../dashboard/yield/hooks/useYieldTableData';
+import { YieldFlowCompleteClaim } from '../common/YieldFlowCompleteClaim';
 
 type YieldClaimProps = {
     account?: Account;
 };
 
 export const YieldClaim = ({ account }: YieldClaimProps) => {
-    const { yieldOpportunities: availableVaults, isYieldOpportunitiesLoading } =
-        useAllYieldOpportunities({
-            enabled: account !== undefined,
-        });
+    const [isClaimComplete, setIsClaimComplete] = useState(false);
 
-    const visibleAccounts = useMemo(() => (account ? [account] : []), [account]);
-    const visibleAccountSymbols = useMemo(
-        () => new Set(account ? [account.symbol] : []),
+    const merkleRewardsSources = useMemo(
+        () => (account ? [{ networkSymbol: account.symbol, address: account.descriptor }] : []),
         [account],
     );
 
-    const { yieldAccountOpportunities } = useYieldTableData({
-        availableVaults,
-        visibleAccounts,
-        visibleAccountSymbols,
-    });
-
-    const { merkleRewardsQuery } = useMerkleRewards(yieldAccountOpportunities);
+    const { merkleRewardsQuery } = useMerkleRewards(merkleRewardsSources);
     const { rewards } = merkleRewardsQuery.data;
 
     const claimableRewards = useMemo(() => {
@@ -54,6 +43,16 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
         return null;
     }
 
+    if (isClaimComplete) {
+        return (
+            <Column width="100%" alignItems="center">
+                <Column gap={24} width="100%" maxWidth={500}>
+                    <YieldFlowCompleteClaim rewards={claimableRewards} />
+                </Column>
+            </Column>
+        );
+    }
+
     return (
         <Column width="100%" alignItems="center">
             <Column gap={24} width="100%" maxWidth={500}>
@@ -69,7 +68,7 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
 
                         <YieldRewardsList
                             rewards={claimableRewards}
-                            isLoading={isYieldOpportunitiesLoading || merkleRewardsQuery.isLoading}
+                            isLoading={merkleRewardsQuery.isLoading}
                         />
                     </Column>
                 </Card>
@@ -85,11 +84,8 @@ export const YieldClaim = ({ account }: YieldClaimProps) => {
                 <Button
                     size="large"
                     width="100%"
-                    isDisabled={
-                        isYieldOpportunitiesLoading ||
-                        merkleRewardsQuery.isLoading ||
-                        claimableRewards.length === 0
-                    }
+                    isDisabled={merkleRewardsQuery.isLoading || claimableRewards.length === 0}
+                    onClick={() => setIsClaimComplete(true)}
                 >
                     <Translation id="TR_EARN_YIELD_CLAIM" />
                 </Button>

--- a/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaim.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+
+import { Translation } from '@suite/intl';
+import { ChainAddressKey } from '@suite-common/earn-stablecoin-api';
+import { type Account } from '@suite-common/wallet-types';
+import { Banner, Button, Card, Column, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { YieldRewardsList } from './YieldRewardsList';
+import { useAllYieldOpportunities } from '../../dashboard/yield/hooks/useAllYieldOpportunities';
+import { useMerkleRewards } from '../../dashboard/yield/hooks/useMerkleRewards';
+import { useYieldTableData } from '../../dashboard/yield/hooks/useYieldTableData';
+
+type YieldClaimProps = {
+    account?: Account;
+};
+
+export const YieldClaim = ({ account }: YieldClaimProps) => {
+    const { yieldOpportunities: availableVaults, isYieldOpportunitiesLoading } =
+        useAllYieldOpportunities({
+            enabled: account !== undefined,
+        });
+
+    const visibleAccounts = useMemo(() => (account ? [account] : []), [account]);
+    const visibleAccountSymbols = useMemo(
+        () => new Set(account ? [account.symbol] : []),
+        [account],
+    );
+
+    const { yieldAccountOpportunities } = useYieldTableData({
+        availableVaults,
+        visibleAccounts,
+        visibleAccountSymbols,
+    });
+
+    const { merkleRewardsQuery } = useMerkleRewards(yieldAccountOpportunities);
+    const { rewards } = merkleRewardsQuery.data;
+
+    const claimableRewards = useMemo(() => {
+        if (!account || !merkleRewardsQuery.isSuccess) return [];
+
+        return Object.entries(rewards)
+            .filter(([key]) => {
+                const { address } = ChainAddressKey.parse(key);
+
+                return address.toLowerCase() === account.descriptor.toLowerCase();
+            })
+            .flatMap(([, rewardList]) =>
+                rewardList.filter(reward => new BigNumber(reward.claimable).gt(0)),
+            );
+    }, [account, merkleRewardsQuery.isSuccess, rewards]);
+
+    if (!account) {
+        return null;
+    }
+
+    return (
+        <Column width="100%" alignItems="center">
+            <Column gap={24} width="100%" maxWidth={500}>
+                <Text typographyStyle="headline-md">
+                    <Translation id="TR_EARN_CLAIM_REWARDS" />
+                </Text>
+
+                <Card>
+                    <Column gap={24}>
+                        <Text typographyStyle="body-md-strong">
+                            <Translation id="TR_STAKE_REWARDS" />
+                        </Text>
+
+                        <YieldRewardsList
+                            rewards={claimableRewards}
+                            isLoading={isYieldOpportunitiesLoading || merkleRewardsQuery.isLoading}
+                        />
+                    </Column>
+                </Card>
+
+                {merkleRewardsQuery.isSuccess && claimableRewards.length > 0 && (
+                    <Banner
+                        intent="warning"
+                        icon="warning"
+                        description={<Translation id="TR_EARN_REWARDS_NETWORK_FEE_WARNING" />}
+                    />
+                )}
+
+                <Button
+                    size="large"
+                    width="100%"
+                    isDisabled={
+                        isYieldOpportunitiesLoading ||
+                        merkleRewardsQuery.isLoading ||
+                        claimableRewards.length === 0
+                    }
+                >
+                    <Translation id="TR_EARN_YIELD_CLAIM" />
+                </Button>
+            </Column>
+        </Column>
+    );
+};

--- a/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldClaimPageHeader.tsx
@@ -1,0 +1,47 @@
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { type Account } from '@suite-common/wallet-types';
+import { IconButton, Row } from '@trezor/components';
+
+import { AccountLabel } from 'src/components/suite/AccountLabel';
+import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { BasicName } from 'src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/BasicName';
+import { useDispatch } from 'src/hooks/suite';
+
+type YieldClaimPageHeaderProps = {
+    account?: Account;
+};
+
+export const YieldClaimPageHeader = ({ account }: YieldClaimPageHeaderProps) => {
+    const dispatch = useDispatch();
+
+    const onBackClick = () => {
+        dispatch(goto({ routeName: 'suite-earn' }));
+    };
+
+    return (
+        <PageHeader>
+            <Row width="100%" gap={16} alignItems="center">
+                <IconButton
+                    icon="caretLeft"
+                    intent="neutral"
+                    priority="secondary"
+                    size="large"
+                    onClick={onBackClick}
+                    data-testid="@account-subpage/back"
+                />
+                {account ? (
+                    <AccountLabel
+                        account={account}
+                        typographyStyle="headline-md"
+                        rowProps={{ flex: '1', overflow: 'hidden' }}
+                    />
+                ) : (
+                    <BasicName>
+                        <Translation id="TR_EARN" />
+                    </BasicName>
+                )}
+            </Row>
+        </PageHeader>
+    );
+};

--- a/packages/suite/src/components/earn/yield/claim/YieldRewardItem.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldRewardItem.tsx
@@ -1,0 +1,43 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Row, Text } from '@trezor/components';
+import { AssetLogo } from '@trezor/product-components';
+
+import { HiddenPlaceholder } from 'src/components/suite/HiddenPlaceholder';
+
+type YieldRewardItemProps = {
+    formattedAmount: string;
+    formattedFiatAmount: string | null;
+    tokenSymbol: string;
+    tokenAddress: string;
+    networkSymbol: NetworkSymbol | undefined;
+};
+
+export const YieldRewardItem = ({
+    formattedAmount,
+    formattedFiatAmount,
+    tokenSymbol,
+    tokenAddress,
+    networkSymbol,
+}: YieldRewardItemProps) => (
+    <Row justifyContent="space-between" alignItems="center" gap={16}>
+        <Row gap={12} alignItems="center" flex="1" overflow="hidden">
+            <AssetLogo
+                symbol={networkSymbol}
+                contractAddress={tokenAddress}
+                placeholder={tokenSymbol}
+                size={24}
+            />
+            <HiddenPlaceholder>
+                <Text typographyStyle="body-md-strong" ellipsisLineCount={1}>
+                    {formattedAmount} {tokenSymbol}
+                </Text>
+            </HiddenPlaceholder>
+        </Row>
+
+        <HiddenPlaceholder>
+            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                {formattedFiatAmount ? `≈ ${formattedFiatAmount}` : '—'}
+            </Text>
+        </HiddenPlaceholder>
+    </Row>
+);

--- a/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
@@ -6,8 +6,8 @@ import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Row, Spinner, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
-import { YieldRewardItem } from './YieldRewardItem';
 import { type MerkleRewardWithFiat } from '../../dashboard/yield/hooks/useMerkleRewards';
+import { YieldRewardItem } from '../common/YieldRewardItem';
 
 type YieldRewardsListProps = {
     rewards: MerkleRewardWithFiat[];
@@ -34,9 +34,14 @@ export const YieldRewardsList = ({ rewards, isLoading }: YieldRewardsListProps) 
     }
 
     return (
-        <Column gap={16} hasDivider>
+        <Column gap={16}>
             {rewards.map((reward, index) => {
                 const network = getNetworkByEvmChainId(reward.token.chainId);
+
+                if (!network) {
+                    return null;
+                }
+
                 const claimableUnits = subunitsToUnits({
                     value: asAmountSubunit(new BigNumber(reward.claimable)),
                     decimals: reward.token.decimals,
@@ -45,6 +50,8 @@ export const YieldRewardsList = ({ rewards, isLoading }: YieldRewardsListProps) 
                     symbol: toTokenSymbol(reward.token.symbol),
                     withSymbol: false,
                     isBalance: true,
+                    maxDisplayedDecimals: reward.token.decimals,
+                    isEllipsisAppended: false,
                 });
                 const formattedFiatAmount = reward.fiat.claimable
                     ? BaseCurrencyAmountFormatter.format(
@@ -59,7 +66,7 @@ export const YieldRewardsList = ({ rewards, isLoading }: YieldRewardsListProps) 
                         formattedFiatAmount={formattedFiatAmount}
                         tokenSymbol={reward.token.symbol}
                         tokenAddress={reward.token.address}
-                        networkSymbol={network?.symbol}
+                        networkSymbol={network.symbol}
                     />
                 );
             })}

--- a/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
+++ b/packages/suite/src/components/earn/yield/claim/YieldRewardsList.tsx
@@ -1,0 +1,68 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import { asBaseCurrencyAmount, toTokenSymbol } from '@suite-common/wallet-types';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { Column, Row, Spinner, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { YieldRewardItem } from './YieldRewardItem';
+import { type MerkleRewardWithFiat } from '../../dashboard/yield/hooks/useMerkleRewards';
+
+type YieldRewardsListProps = {
+    rewards: MerkleRewardWithFiat[];
+    isLoading: boolean;
+};
+
+export const YieldRewardsList = ({ rewards, isLoading }: YieldRewardsListProps) => {
+    const { BaseCurrencyAmountFormatter, CryptoAmountFormatter } = useFormatters();
+
+    if (isLoading) {
+        return (
+            <Row justifyContent="center">
+                <Spinner size={24} />
+            </Row>
+        );
+    }
+
+    if (rewards.length === 0) {
+        return (
+            <Text intent="neutral" priority="secondary">
+                <Translation id="TR_EARN_REWARDS_ARE_EMPTY" />
+            </Text>
+        );
+    }
+
+    return (
+        <Column gap={16} hasDivider>
+            {rewards.map((reward, index) => {
+                const network = getNetworkByEvmChainId(reward.token.chainId);
+                const claimableUnits = subunitsToUnits({
+                    value: asAmountSubunit(new BigNumber(reward.claimable)),
+                    decimals: reward.token.decimals,
+                });
+                const formattedAmount = CryptoAmountFormatter.format(claimableUnits.toString(), {
+                    symbol: toTokenSymbol(reward.token.symbol),
+                    withSymbol: false,
+                    isBalance: true,
+                });
+                const formattedFiatAmount = reward.fiat.claimable
+                    ? BaseCurrencyAmountFormatter.format(
+                          asBaseCurrencyAmount(new BigNumber(reward.fiat.claimable)),
+                      )
+                    : null;
+
+                return (
+                    <YieldRewardItem
+                        key={`${reward.token.address}:${index}`}
+                        formattedAmount={formattedAmount}
+                        formattedFiatAmount={formattedFiatAmount}
+                        tokenSymbol={reward.token.symbol}
+                        tokenAddress={reward.token.address}
+                        networkSymbol={network?.symbol}
+                    />
+                );
+            })}
+        </Column>
+    );
+};

--- a/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowComplete.tsx
@@ -1,41 +1,28 @@
+import { type ReactNode } from 'react';
+
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { type Rating, buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
-import type { YieldFlowCompleteValue } from '@suite-common/wallet-core';
-import { Button, Card, Column, Icon, IconCircle, Row, Text } from '@trezor/components';
+import { Button, Card, Column, Divider, Icon, IconCircle, Row, Text } from '@trezor/components';
 import { FeedbackCard } from '@trezor/product-components';
 
 import { useDispatch } from 'src/hooks/suite';
-import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
-
-import { YieldTokenValue } from './YieldTokenValue';
-
-const flowTypeContentMap = {
-    supply: {
-        heading: 'TR_EARN_YIELD_SUPPLY_COMPLETE',
-        description: 'TR_EARN_YIELD_SUPPLY_COMPLETE_DESCRIPTION',
-        input: 'TR_EARN_YIELD_SUPPLIED',
-        output: 'TR_RECEIVED',
-    },
-    withdraw: {
-        heading: 'TR_EARN_YIELD_WITHDRAW_COMPLETE',
-        description: 'TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION',
-        input: 'TR_SENT',
-        output: 'TR_RECEIVED',
-    },
-} as const;
 
 type YieldFlowCompleteProps = {
-    flowType: keyof typeof flowTypeContentMap;
-    input: YieldFlowCompleteValue;
-    output: YieldFlowCompleteValue;
-    apy?: number | null;
+    heading: ReactNode;
+    description: ReactNode;
+    showFeedback?: boolean;
+    children: ReactNode;
 };
 
-export const YieldFlowComplete = ({ flowType, input, output, apy }: YieldFlowCompleteProps) => {
+export const YieldFlowComplete = ({
+    heading,
+    description,
+    showFeedback,
+    children,
+}: YieldFlowCompleteProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
-    const flowContent = flowTypeContentMap[flowType];
 
     const handleBackToOverview = () => {
         dispatch(goto({ routeName: 'suite-earn' }));
@@ -61,20 +48,15 @@ export const YieldFlowComplete = ({ flowType, input, output, apy }: YieldFlowCom
             <IconCircle name="check" intent="brand" size={96} />
 
             <Column gap={4}>
-                <Text typographyStyle="headline-md">
-                    <Translation id={flowContent.heading} />
-                </Text>
+                <Text typographyStyle="headline-md">{heading}</Text>
 
                 <Text intent="neutral" priority="secondary">
-                    <Translation
-                        id={flowContent.description}
-                        values={{ displaySymbol: output.token.symbol }}
-                    />
+                    {description}
                 </Text>
             </Column>
 
             <Card fillType="flat" paddingType="none">
-                <Column gap={0} hasDivider>
+                <Column gap={0}>
                     <Row
                         justifyContent="space-between"
                         alignItems="center"
@@ -90,51 +72,8 @@ export const YieldFlowComplete = ({ flowType, input, output, apy }: YieldFlowCom
                             </Text>
                         </Row>
                     </Row>
-                    {flowType === 'supply' && (
-                        <Row
-                            justifyContent="space-between"
-                            alignItems="center"
-                            padding={{ vertical: 16, horizontal: 20 }}
-                        >
-                            <Text typographyStyle="body-md">
-                                <Translation id="TR_EARN_DASHBOARD_TABLE_APY" />
-                            </Text>
-                            <Text typographyStyle="body-md-strong">
-                                <ApyValue apy={apy} />
-                            </Text>
-                        </Row>
-                    )}
-                    <Row
-                        justifyContent="space-between"
-                        alignItems="center"
-                        padding={{ vertical: 16, horizontal: 20 }}
-                    >
-                        <Column gap={8}>
-                            <Text typographyStyle="body-md">
-                                <Translation id={flowContent.input} />
-                            </Text>
-                            <YieldTokenValue
-                                token={{
-                                    ...input.token,
-                                    contractAddress: input.token.contractAddress ?? null,
-                                }}
-                                amount={input.amount}
-                            />
-                        </Column>
-                        <Icon name="arrowRight" size={20} intent="neutral" priority="secondary" />
-                        <Column gap={8} alignItems="flex-end">
-                            <Text typographyStyle="body-md">
-                                <Translation id={flowContent.output} />
-                            </Text>
-                            <YieldTokenValue
-                                token={{
-                                    ...output.token,
-                                    contractAddress: output.token.contractAddress ?? null,
-                                }}
-                                amount={output.amount}
-                            />
-                        </Column>
-                    </Row>
+                    <Divider color="borderNeutral" margin={0} />
+                    {children}
                 </Column>
             </Card>
 
@@ -142,21 +81,23 @@ export const YieldFlowComplete = ({ flowType, input, output, apy }: YieldFlowCom
                 <Translation id="TR_EARN_YIELD_BACK_TO_OVERVIEW" />
             </Button>
 
-            <FeedbackCard
-                heading={
-                    <Translation
-                        id="TR_FEATURE_FEEDBACK_CARD_HEADING"
-                        values={{
-                            feature: translationString('TR_EARN_STABLECOIN_YIELD_TITLE'),
-                        }}
-                    />
-                }
-                description={<Translation id="TR_FEEDBACK_CARD_DESCRIPTION" />}
-                submitLabel={<Translation id="TR_FEEDBACK_CARD_SEND" />}
-                successHeading={<Translation id="TR_FEEDBACK_CARD_SUCCESS_TITLE" />}
-                successDescription={<Translation id="TR_FEEDBACK_CARD_SUCCESS_DESCRIPTION" />}
-                onSubmit={handleFeedbackSubmit}
-            />
+            {showFeedback && (
+                <FeedbackCard
+                    heading={
+                        <Translation
+                            id="TR_FEATURE_FEEDBACK_CARD_HEADING"
+                            values={{
+                                feature: translationString('TR_EARN_STABLECOIN_YIELD_TITLE'),
+                            }}
+                        />
+                    }
+                    description={<Translation id="TR_FEEDBACK_CARD_DESCRIPTION" />}
+                    submitLabel={<Translation id="TR_FEEDBACK_CARD_SEND" />}
+                    successHeading={<Translation id="TR_FEEDBACK_CARD_SUCCESS_TITLE" />}
+                    successDescription={<Translation id="TR_FEEDBACK_CARD_SUCCESS_DESCRIPTION" />}
+                    onSubmit={handleFeedbackSubmit}
+                />
+            )}
         </Column>
     );
 };

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteClaim.tsx
@@ -1,0 +1,73 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { getNetworkByEvmChainId } from '@suite-common/wallet-config';
+import { asBaseCurrencyAmount, toTokenSymbol } from '@suite-common/wallet-types';
+import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { Column, Text } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { YieldFlowComplete } from './YieldFlowComplete';
+import { YieldRewardItem } from './YieldRewardItem';
+import { type MerkleRewardWithFiat } from '../../dashboard/yield/hooks/useMerkleRewards';
+
+type YieldFlowCompleteClaimProps = {
+    rewards: MerkleRewardWithFiat[];
+};
+
+export const YieldFlowCompleteClaim = ({ rewards }: YieldFlowCompleteClaimProps) => {
+    const { BaseCurrencyAmountFormatter, CryptoAmountFormatter } = useFormatters();
+
+    return (
+        <YieldFlowComplete
+            heading={<Translation id="TR_EARN_YIELD_CLAIM_COMPLETE" />}
+            description={<Translation id="TR_EARN_YIELD_CLAIM_COMPLETE_DESCRIPTION" />}
+        >
+            <Column gap={16} padding={{ vertical: 16, horizontal: 20 }}>
+                <Text typographyStyle="body-md">
+                    <Translation id="TR_STAKE_REWARDS" />
+                </Text>
+
+                <Column gap={16}>
+                    {rewards.map((reward, index) => {
+                        const network = getNetworkByEvmChainId(reward.token.chainId);
+
+                        if (!network) {
+                            return null;
+                        }
+
+                        const claimableUnits = subunitsToUnits({
+                            value: asAmountSubunit(new BigNumber(reward.claimable)),
+                            decimals: reward.token.decimals,
+                        });
+                        const formattedAmount = CryptoAmountFormatter.format(
+                            claimableUnits.toString(),
+                            {
+                                symbol: toTokenSymbol(reward.token.symbol),
+                                withSymbol: false,
+                                isBalance: true,
+                                maxDisplayedDecimals: reward.token.decimals,
+                                isEllipsisAppended: false,
+                            },
+                        );
+                        const formattedFiatAmount = reward.fiat.claimable
+                            ? BaseCurrencyAmountFormatter.format(
+                                  asBaseCurrencyAmount(new BigNumber(reward.fiat.claimable)),
+                              )
+                            : null;
+
+                        return (
+                            <YieldRewardItem
+                                key={`${reward.token.address}:${index}`}
+                                formattedAmount={formattedAmount}
+                                formattedFiatAmount={formattedFiatAmount}
+                                tokenSymbol={reward.token.symbol}
+                                tokenAddress={reward.token.address}
+                                networkSymbol={network.symbol}
+                            />
+                        );
+                    })}
+                </Column>
+            </Column>
+        </YieldFlowComplete>
+    );
+};

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteSupply.tsx
@@ -1,0 +1,41 @@
+import { Translation } from '@suite/intl';
+import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
+import { Row, Text } from '@trezor/components';
+
+import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
+
+import { YieldFlowComplete } from './YieldFlowComplete';
+import { YieldFlowTransferRow } from './YieldFlowTransferRow';
+
+type YieldFlowCompleteSupplyProps = {
+    input: YieldFlowCompleteValue;
+    output: YieldFlowCompleteValue;
+    apy?: number | null;
+};
+
+export const YieldFlowCompleteSupply = ({ input, output, apy }: YieldFlowCompleteSupplyProps) => (
+    <YieldFlowComplete
+        heading={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE" />}
+        description={<Translation id="TR_EARN_YIELD_SUPPLY_COMPLETE_DESCRIPTION" />}
+        showFeedback
+    >
+        <Row
+            justifyContent="space-between"
+            alignItems="center"
+            padding={{ vertical: 16, horizontal: 20 }}
+        >
+            <Text typographyStyle="body-md">
+                <Translation id="TR_EARN_DASHBOARD_TABLE_APY" />
+            </Text>
+            <Text typographyStyle="body-md-strong">
+                <ApyValue apy={apy} />
+            </Text>
+        </Row>
+        <YieldFlowTransferRow
+            inputLabelId="TR_EARN_YIELD_SUPPLIED"
+            outputLabelId="TR_RECEIVED"
+            input={input}
+            output={output}
+        />
+    </YieldFlowComplete>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -1,0 +1,30 @@
+import { Translation } from '@suite/intl';
+import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
+
+import { YieldFlowComplete } from './YieldFlowComplete';
+import { YieldFlowTransferRow } from './YieldFlowTransferRow';
+
+type YieldFlowCompleteWithdrawProps = {
+    input: YieldFlowCompleteValue;
+    output: YieldFlowCompleteValue;
+};
+
+export const YieldFlowCompleteWithdraw = ({ input, output }: YieldFlowCompleteWithdrawProps) => (
+    <YieldFlowComplete
+        heading={<Translation id="TR_EARN_YIELD_WITHDRAW_COMPLETE" />}
+        description={
+            <Translation
+                id="TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION"
+                values={{ displaySymbol: output.token.symbol }}
+            />
+        }
+        showFeedback
+    >
+        <YieldFlowTransferRow
+            inputLabelId="TR_SENT"
+            outputLabelId="TR_RECEIVED"
+            input={input}
+            output={output}
+        />
+    </YieldFlowComplete>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
@@ -1,0 +1,51 @@
+import { Translation, type TranslationId } from '@suite/intl';
+import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
+import { Column, Icon, Row, Text } from '@trezor/components';
+
+import { YieldTokenValue } from './YieldTokenValue';
+
+type YieldFlowTransferRowProps = {
+    inputLabelId: TranslationId;
+    outputLabelId: TranslationId;
+    input: YieldFlowCompleteValue;
+    output: YieldFlowCompleteValue;
+};
+
+export const YieldFlowTransferRow = ({
+    inputLabelId,
+    outputLabelId,
+    input,
+    output,
+}: YieldFlowTransferRowProps) => (
+    <Row
+        justifyContent="space-between"
+        alignItems="center"
+        padding={{ vertical: 16, horizontal: 20 }}
+    >
+        <Column gap={8}>
+            <Text typographyStyle="body-md">
+                <Translation id={inputLabelId} />
+            </Text>
+            <YieldTokenValue
+                token={{
+                    ...input.token,
+                    contractAddress: input.token.contractAddress ?? null,
+                }}
+                amount={input.amount}
+            />
+        </Column>
+        <Icon name="arrowRight" size={20} intent="neutral" priority="secondary" />
+        <Column gap={8} alignItems="flex-end">
+            <Text typographyStyle="body-md">
+                <Translation id={outputLabelId} />
+            </Text>
+            <YieldTokenValue
+                token={{
+                    ...output.token,
+                    contractAddress: output.token.contractAddress ?? null,
+                }}
+                amount={output.amount}
+            />
+        </Column>
+    </Row>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -21,6 +21,8 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
             return 'TR_EARN_YIELD_PENDING_SUPPLY';
         case 'withdraw':
             return 'TR_EARN_YIELD_PENDING_WITHDRAW';
+        case 'claim':
+            return 'TR_EARN_YIELD_PENDING_CLAIM';
     }
 };
 

--- a/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldRewardItem.tsx
@@ -9,7 +9,7 @@ type YieldRewardItemProps = {
     formattedFiatAmount: string | null;
     tokenSymbol: string;
     tokenAddress: string;
-    networkSymbol: NetworkSymbol | undefined;
+    networkSymbol: NetworkSymbol;
 };
 
 export const YieldRewardItem = ({
@@ -28,7 +28,7 @@ export const YieldRewardItem = ({
                 size={24}
             />
             <HiddenPlaceholder>
-                <Text typographyStyle="body-md-strong" ellipsisLineCount={1}>
+                <Text typographyStyle="body-md-strong">
                     {formattedAmount} {tokenSymbol}
                 </Text>
             </HiddenPlaceholder>

--- a/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
+++ b/packages/suite/src/components/earn/yield/supply/YieldSupplyForm.tsx
@@ -9,7 +9,7 @@ import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldApproveModal } from '../common/YieldApproveModal';
 import { YieldApproveStep } from '../common/YieldApproveStep';
-import { YieldFlowComplete } from '../common/YieldFlowComplete';
+import { YieldFlowCompleteSupply } from '../common/YieldFlowCompleteSupply';
 
 export const YieldSupplyForm = () => {
     const {
@@ -57,8 +57,7 @@ export const YieldSupplyForm = () => {
             <Column width="100%" alignItems="center">
                 <Column gap={24} width="100%" maxWidth={500}>
                     {flow.currentStep === 'complete' ? (
-                        <YieldFlowComplete
-                            flowType="supply"
+                        <YieldFlowCompleteSupply
                             apy={apy}
                             input={{
                                 token,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -7,7 +7,7 @@ import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmoun
 import { useYieldWithdrawContext } from './useYieldWithdrawContext';
 import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
-import { YieldFlowComplete } from '../common/YieldFlowComplete';
+import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 
 export const YieldWithdrawForm = () => {
     const {
@@ -36,8 +36,7 @@ export const YieldWithdrawForm = () => {
         <Column width="100%" alignItems="center">
             <Column gap={24} width="100%" maxWidth={500}>
                 {flow.currentStep === 'complete' ? (
-                    <YieldFlowComplete
-                        flowType="withdraw"
+                    <YieldFlowCompleteWithdraw
                         input={{
                             token: receiptToken,
                             amount: completedReceiptAmount,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -46,7 +46,7 @@ export const Navigation = ({ children }: NavigationProps) => {
                               nameId: 'TR_EARN',
                               icon: 'piggyBank',
                               goToRoute: 'suite-earn',
-                              routes: ['suite-earn', 'earn-supply', 'earn-withdraw'],
+                              routes: ['suite-earn', 'earn-supply', 'earn-withdraw', 'earn-claim'],
                           } as NavigationItemProps,
                       ]
                     : []),

--- a/packages/suite/src/views/earn/claim/index.tsx
+++ b/packages/suite/src/views/earn/claim/index.tsx
@@ -1,0 +1,11 @@
+import { YieldClaim, YieldClaimPageHeader } from 'src/components/earn';
+import { useEarnRouteAccount } from 'src/components/earn/utils/useEarnRouteAccount';
+import { useLayout } from 'src/hooks/suite';
+
+export const EarnClaim = () => {
+    const { account } = useEarnRouteAccount();
+
+    useLayout('Earn', <YieldClaimPageHeader account={account} />);
+
+    return <YieldClaim account={account} />;
+};

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsEmpty.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsEmpty.tsx
@@ -5,7 +5,7 @@ import { AccountExceptionLayout } from 'src/components/wallet';
 
 export const RewardsEmpty = () => (
     <AccountExceptionLayout
-        title={<Translation id="TR_STAKE_REWARDS_ARE_EMPTY" />}
+        title={<Translation id="TR_EARN_REWARDS_ARE_EMPTY" />}
         description={
             <Translation
                 id="TR_STAKE_WAIT_TO_CHECK_REWARDS"

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -397,7 +397,7 @@ export const StakingCard = ({
                             intent="brand"
                             data-testid="@account/staking/claim-rewards-button"
                         >
-                            <Translation id="TR_STAKE_CLAIM_REWARDS" />
+                            <Translation id="TR_EARN_CLAIM_REWARDS" />
                         </Button>
                     )}
                     <Tooltip content={unstakingMessageContent}>

--- a/suite-common/earn-stablecoin-api/src/config/index.ts
+++ b/suite-common/earn-stablecoin-api/src/config/index.ts
@@ -18,5 +18,4 @@ const minutes = (value: number) => value * 60 * 1000;
 export const queriesStaleTime = {
     getYieldOpportunities: minutes(5),
     getMerkleRewards: minutes(5),
-    getYieldProvider: minutes(5),
 } as const satisfies Record<string, number>;

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -21,7 +21,6 @@ export const desktopQueryKeys = {
     inactiveTokens: (symbol: string, accountKey?: string) =>
         accountKey ? ['inactive-tokens', symbol, accountKey] : ['inactive-tokens', symbol],
     yieldOpportunities: (pagination: any) => ['yield-opportunities', pagination],
-    yieldProvider: (providerId?: string) => ['yield-provider', providerId],
 } as const satisfies Record<string, AllowedQueryKey>;
 
 export const mobileQueryKeys = {} as const satisfies Record<string, AllowedQueryKey>;

--- a/suite-common/wallet-core/src/stablecoinYield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoinYield/stablecoinYieldTypes.ts
@@ -40,3 +40,9 @@ export type YieldPendingTransactionState = {
     txid: string;
     amount: string;
 };
+
+export type YieldFlowCompleteRewardItem = {
+    token: YieldFlowDisplayToken;
+    value: string;
+    fiatValue?: string | null;
+};

--- a/suite-common/wallet-core/src/stablecoinYield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoinYield/stablecoinYieldTypes.ts
@@ -36,7 +36,7 @@ export type YieldApproveModalState = {
 };
 
 export type YieldPendingTransactionState = {
-    type: 'approve' | 'revoke' | 'revoke-only' | 'supply' | 'withdraw';
+    type: 'approve' | 'revoke' | 'revoke-only' | 'supply' | 'withdraw' | 'claim';
     txid: string;
     amount: string;
 };

--- a/suite/e2e/tests/staking/ada/claim.test.ts
+++ b/suite/e2e/tests/staking/ada/claim.test.ts
@@ -108,9 +108,9 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await test.step('Verify warning on too small reward claim', async () => {
                 await stakingSection.claimRewardsButton.click();
-                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_REWARDS');
+                await expect(page.modalHeader).toHaveTranslation('TR_EARN_CLAIM_REWARDS');
                 await expect(stakingSection.claimWarningBanner).toHaveTranslation(
-                    'TR_STAKING_REWARDS_NETWORK_FEE_WARNING',
+                    'TR_EARN_REWARDS_NETWORK_FEE_WARNING',
                 );
                 await expect(stakingSection.cardanoModalRewardAmount).toHaveText(
                     tooSmallRewardAmountFormatted,
@@ -156,7 +156,7 @@ test.describe('Staking - Cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await test.step('Initiate reward claim with big enough reward', async () => {
                 await stakingSection.claimRewardsButton.click();
-                await expect(page.modalHeader).toHaveTranslation('TR_STAKE_CLAIM_REWARDS');
+                await expect(page.modalHeader).toHaveTranslation('TR_EARN_CLAIM_REWARDS');
                 await expect(stakingSection.claimWarningBanner).toBeHidden();
                 await expect(stakingSection.cardanoModalRewardAmount).toHaveText(
                     bigRewardAmountFormatted,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9626,6 +9626,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_PENDING_WITHDRAW',
         defaultMessage: 'Confirming withdrawal...',
     },
+    TR_EARN_YIELD_PENDING_CLAIM: {
+        id: 'TR_EARN_YIELD_PENDING_CLAIM',
+        defaultMessage: 'Confirming claim...',
+    },
     TR_EARN_YIELD_APPROVAL_TOO_LOW: {
         id: 'TR_EARN_YIELD_APPROVAL_TOO_LOW',
         defaultMessage: 'Approval is too low. Modify approval or lower the amount.',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9578,6 +9578,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION',
         defaultMessage: '{displaySymbol} is now available in your account.',
     },
+    TR_EARN_YIELD_CLAIM_COMPLETE: {
+        id: 'TR_EARN_YIELD_CLAIM_COMPLETE',
+        defaultMessage: 'Claim complete',
+    },
+    TR_EARN_YIELD_CLAIM_COMPLETE_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_CLAIM_COMPLETE_DESCRIPTION',
+        defaultMessage: 'Rewards added to your balance.',
+    },
     TR_EARN_YIELD_STATUS: {
         id: 'TR_EARN_YIELD_STATUS',
         defaultMessage: 'Status',
@@ -9779,8 +9787,8 @@ export const messages = defineMessages({
         id: 'TR_STAKING_REWARDS_REMAIN_INTACT',
         defaultMessage: 'Your past rewards remain safe and intact.',
     },
-    TR_STAKING_REWARDS_NETWORK_FEE_WARNING: {
-        id: 'TR_STAKING_REWARDS_NETWORK_FEE_WARNING',
+    TR_EARN_REWARDS_NETWORK_FEE_WARNING: {
+        id: 'TR_EARN_REWARDS_NETWORK_FEE_WARNING',
         defaultMessage:
             'The network fee currently exceeds your rewards. Consider waiting until your rewards increase before claiming.',
     },
@@ -9874,8 +9882,8 @@ export const messages = defineMessages({
         defaultMessage:
             'An epoch in Solana is approximately {count, plural, one {# day} other {# days}} long.',
     },
-    TR_STAKE_REWARDS_ARE_EMPTY: {
-        id: 'TR_STAKE_REWARDS_ARE_EMPTY',
+    TR_EARN_REWARDS_ARE_EMPTY: {
+        id: 'TR_EARN_REWARDS_ARE_EMPTY',
         defaultMessage: 'No rewards',
     },
     TR_STAKE_WAIT_TO_CHECK_REWARDS: {
@@ -10307,8 +10315,8 @@ export const messages = defineMessages({
         id: 'TR_STAKE_UNSTAKE_TO_CLAIM',
         defaultMessage: 'Unstake to claim',
     },
-    TR_STAKE_CLAIM_REWARDS: {
-        id: 'TR_STAKE_CLAIM_REWARDS',
+    TR_EARN_CLAIM_REWARDS: {
+        id: 'TR_EARN_CLAIM_REWARDS',
         defaultMessage: 'Claim rewards',
     },
     TR_STAKE_CHANGE_DELEGATE: {
@@ -11591,5 +11599,25 @@ export const messages = defineMessages({
     TR_OUTSIDE_STAKING_CARD_TEXT: {
         id: 'TR_OUTSIDE_STAKING_CARD_TEXT',
         defaultMessage: '{amount} {displaySymbol} (= {fiat}) is currently staked elsewhere.',
+    },
+    TR_EARN_YIELD_CLAIMABLE_REWARDS: {
+        id: 'TR_EARN_YIELD_CLAIMABLE_REWARDS',
+        defaultMessage: 'Claimable rewards: {amount}',
+    },
+    TR_EARN_YIELD_CLAIMABLE_REWARDS_NO_AMOUNT: {
+        id: 'TR_EARN_YIELD_CLAIMABLE_REWARDS_NO_AMOUNT',
+        defaultMessage: 'Claimable rewards',
+    },
+    TR_EARN_YIELD_CLAIM: {
+        id: 'TR_EARN_YIELD_CLAIM',
+        defaultMessage: 'Claim',
+    },
+    TR_EARN_YIELD_CLAIM_MODAL_TITLE: {
+        id: 'TR_EARN_YIELD_CLAIM_MODAL_TITLE',
+        defaultMessage: 'Claimable rewards',
+    },
+    TR_EARN_YIELD_CLAIM_MODAL_SUBTITLE: {
+        id: 'TR_EARN_YIELD_CLAIM_MODAL_SUBTITLE',
+        defaultMessage: 'Select an account to claim rewards.',
     },
 } as const);

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -48,6 +48,12 @@ export const routes = [
         params: earnParams,
     },
     {
+        name: 'earn-claim',
+        pattern: '/earn/claim',
+        app: 'earn',
+        params: earnParams,
+    },
+    {
         name: 'suite-version',
         pattern: '/version',
         app: 'version',

--- a/suite/router/src/__tests__/router.test.ts
+++ b/suite/router/src/__tests__/router.test.ts
@@ -60,6 +60,13 @@ describe('router', () => {
                     yieldId: 'vault-1',
                 }),
             ).toEqual('/earn/withdraw#/eth/0/normal/vault-1');
+            expect(
+                test('earn-claim', {
+                    symbol: 'eth',
+                    accountIndex: 0,
+                    accountType: 'normal',
+                }),
+            ).toEqual('/earn/claim#/eth/0/normal');
             // tests below with intentionally mixed # params
             expect(
                 test('wallet-index', {
@@ -228,6 +235,21 @@ describe('router', () => {
                 app: 'earn',
                 params: undefined,
                 route: getRoute('earn-supply'),
+            });
+
+            expect(
+                getAppWithParams({
+                    pathname: '/earn/claim',
+                    hash: '#/eth/0/normal',
+                }),
+            ).toEqual({
+                app: 'earn',
+                params: {
+                    symbol: 'eth',
+                    accountIndex: 0,
+                    accountType: 'normal',
+                },
+                route: getRoute('earn-claim'),
             });
         });
     });

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -98,7 +98,7 @@ const validateWalletParams = (hash: HashString): CommonWalletParams => {
     });
 };
 
-const validateEarnParams = (hash: HashString) => {
+const validateEarnParams = (route: Route, hash: HashString) => {
     const [symbol, index, rawAccountType, rawYieldId, rawContractAddress] = parseHash(hash);
 
     const accountRouteParams = validateAccountRouteParams({
@@ -111,7 +111,15 @@ const validateEarnParams = (hash: HashString) => {
         rawContractAddress,
     });
 
-    if (!accountRouteParams || !decodedEarnRouteParams) {
+    if (!accountRouteParams) {
+        return;
+    }
+
+    if (route.name === 'earn-claim') {
+        return accountRouteParams;
+    }
+
+    if (!rawYieldId) {
         return;
     }
 
@@ -174,7 +182,7 @@ const getAppParams = (route: Route, hash: HashString = '') => {
         case 'dashboard':
             return validateDashboardParams(hash);
         case 'earn':
-            return validateEarnParams(hash);
+            return validateEarnParams(route, hash);
         case 'wallet':
             return validateWalletParams(hash);
         default:

--- a/suite/router/src/routerParams.ts
+++ b/suite/router/src/routerParams.ts
@@ -25,7 +25,7 @@ export const earnParamsSchema = yup.object({
     symbol: yup.mixed<NetworkSymbol>().required(),
     accountIndex: yup.number().required(),
     accountType: yup.mixed<AccountType>().oneOf(accountTypes).required(),
-    yieldId: yup.string().required(),
+    yieldId: yup.string().default('no-yield-id'),
     contractAddress: yup.string().notRequired(),
 });
 
@@ -66,10 +66,6 @@ export const decodeEarnRouteParams = ({
         const contractAddress = rawContractAddress
             ? decodeURIComponent(rawContractAddress)
             : undefined;
-
-        if (!yieldId) {
-            return;
-        }
 
         return {
             yieldId,


### PR DESCRIPTION
## Description

Adds the UI flow for claiming stablecoin yield rewards in the Earn section.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26633

## Screenshots:

<img width="1240" height="313" alt="image" src="https://github.com/user-attachments/assets/bce0aaa0-e609-4877-8f0e-d0e7b1be75ff" />

<img width="774" height="252" alt="image" src="https://github.com/user-attachments/assets/6f41eada-b886-4972-b6f6-c0d2bbdf0f15" />

<img width="1296" height="527" alt="image" src="https://github.com/user-attachments/assets/146f99da-7026-4108-b3a8-648fc76b23eb" />

<img width="1107" height="542" alt="image" src="https://github.com/user-attachments/assets/608fd46a-912a-4623-bca6-acddd705a5a4" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-yield-claim&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-yield-claim&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-yield-claim&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T15:39:42.549Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T08:32:12.797Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-yield-claim/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-yield-claim/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->