### PR TITLE
fix(suite): copy electrum signature format when electrum is selected

### DIFF
--- a/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
+++ b/packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts
@@ -7,6 +7,7 @@ import { useDispatch } from 'src/hooks/suite';
 type SignedMessageData = {
     message?: string;
     address?: string;
+    isElectrum?: boolean;
 
     /* Due to wrong abstraction in `useSignVerifyForm` this needs to be optional.
     If we ever separate Sign and Verify forms this shall be set to required.
@@ -25,7 +26,7 @@ ${signature}
 -----END ${network} SIGNED MESSAGE-----`;
 
 export const useCopySignedMessage = <T extends SignedMessageData>(
-    { message, address, signature }: T,
+    { message, address, signature, isElectrum }: T,
     network?: Network,
 ) => {
     const dispatch = useDispatch();
@@ -33,7 +34,7 @@ export const useCopySignedMessage = <T extends SignedMessageData>(
     const canCopy = address && signature;
 
     const formatMessage = () => {
-        if (network?.networkType === 'cardano') {
+        if (network?.networkType === 'cardano' || isElectrum) {
             return signature || '';
         }
 


### PR DESCRIPTION
Hi! I was looking for first issues to work on, since I want to start to be more active in the open source community, and this seemed like a good start since I already have some experience working with Electrum.

## Description

The "Copy signed message" button on Bitcoin Sign & Verify was always copying the Trezor-formatted signature envelope, even when Electrum format was selected and shown in the signature field.

The root cause is in `packages/suite/src/hooks/wallet/sign-verify/useCopySignedMessage.ts`: `formatMessage()` branches on `network?.networkType === 'cardano'` to return the raw signature, but has no equivalent branch for Electrum mode. The `isElectrum` flag exists on the form but was never threaded into the hook.

The fix I did adds `isElectrum?: boolean` to `SignedMessageData`, destructure it in the hook, and extend the existing Cardano early-return to also apply when `isElectrum` is true. The caller already passes `formValues` (which includes `isElectrum` via `SignVerifyFields`), so no changes are needed at the call site.

## Related Issue

