### PR TITLE
fix(suite-native): use default crypto amount decimals in staking mana…

### DIFF
--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -20,7 +20,6 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
-import { CRYPTO_BALANCE_DECIMALS } from '../constants';
 import { ApyValue } from './ApyValue';
 import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
 
@@ -84,7 +83,6 @@ export const StakingManagementStakedCard = ({
                 <CryptoAmountFormatter
                     value={stakedBalance}
                     symbol={networkSymbol}
-                    decimals={CRYPTO_BALANCE_DECIMALS}
                     variant="headline-sm"
                     color="contentPrimary"
                 />
@@ -109,7 +107,6 @@ export const StakingManagementStakedCard = ({
                 <CryptoAmountFormatter
                     value={rewardsBalance}
                     symbol={networkSymbol}
-                    decimals={CRYPTO_BALANCE_DECIMALS}
                     variant="headline-sm"
                     color="contentPrimary"
                 />


### PR DESCRIPTION
## Description

Removes forced decimal precision in the native staking management card so staked and reward amounts use default crypto formatting.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26600
## Screenshots:
<img width="1290" height="2206" alt="image" src="https://github.com/user-attachments/assets/7c81b57d-617a-4b00-a40f-47e20cfc7513" />
