### PR TITLE
fix(suite-native): hide earn estimated rewards when form is disabled

### DIFF
--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import Animated, {
+    SlideInDown,
+    SlideOutDown,
+    useAnimatedStyle,
+    withTiming,
+} from 'react-native-reanimated';
 
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
@@ -29,6 +34,7 @@ type EarnFormScreenFooterProps = {
     symbol: NetworkSymbol;
     amountValue: string;
     isDisabled: boolean;
+    isDirty: boolean;
     onPress: () => void;
 };
 
@@ -37,6 +43,7 @@ export const EarnFormScreenFooter = ({
     symbol,
     amountValue,
     isDisabled,
+    isDirty,
     onPress,
 }: EarnFormScreenFooterProps) => {
     const { applyStyle } = useNativeStyles();
@@ -61,12 +68,17 @@ export const EarnFormScreenFooter = ({
 
     const buttonIntent = isDisabled ? 'neutral' : 'brand';
     const buttonPriority = isDisabled ? 'secondary' : 'primary';
+    const hasValidationError = isDirty && isDisabled;
+
+    const rewardsAnimatedStyle = useAnimatedStyle(() => ({
+        opacity: withTiming(hasValidationError ? 0 : 1, { duration: 100 }),
+    }));
 
     return (
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
-                <Box style={applyStyle(rewardsBoxStyle)}>
+                <Animated.View style={[applyStyle(rewardsBoxStyle), rewardsAnimatedStyle]}>
                     <VStack spacing="sp4" paddingVertical="sp12" alignItems="center">
                         <Text variant="body-sm" color="contentPrimary">
                             <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
@@ -77,18 +89,18 @@ export const EarnFormScreenFooter = ({
                             )}
                         </Text>
                     </VStack>
-                    <Button
-                        key={`${buttonIntent}-${buttonPriority}`}
-                        accessibilityRole="button"
-                        accessibilityLabel={translate('generic.validateForm')}
-                        intent={buttonIntent}
-                        priority={buttonPriority}
-                        onPress={onPress}
-                        isDisabled={isDisabled}
-                    >
-                        <Translation id="generic.buttons.continue" />
-                    </Button>
-                </Box>
+                </Animated.View>
+                <Button
+                    key={`${buttonIntent}-${buttonPriority}`}
+                    accessibilityRole="button"
+                    accessibilityLabel={translate('generic.validateForm')}
+                    intent={buttonIntent}
+                    priority={buttonPriority}
+                    onPress={onPress}
+                    isDisabled={isDisabled}
+                >
+                    <Translation id="generic.buttons.continue" />
+                </Button>
             </Box>
         </Animated.View>
     );

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -30,7 +30,7 @@ export const EarnFormScreen = () => {
 
     const { form, amountValue, account, formDraft, formDraftKey, updateFeeLevelThunk } = earnForm;
     const {
-        formState: { isValid },
+        formState: { isValid, isDirty },
     } = form;
 
     const handleSubmit = form.handleSubmit(() => {
@@ -50,6 +50,7 @@ export const EarnFormScreen = () => {
                     symbol={account.symbol}
                     amountValue={amountValue}
                     isDisabled={!isValid}
+                    isDirty={isDirty}
                     onPress={() => handleSubmit()}
                 />
             }


### PR DESCRIPTION
## Description

Hides estimated earnings in the Earn form whenever the form is invalid/disabled


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26584

## Screenshots:
<img width="1290" height="2448" alt="image" src="https://github.com/user-attachments/assets/be9876d6-5f22-4fc4-b2c3-a92a8e5db52c" />

