### PR TITLE
chore(deps): bump ws, cbor, long, ts-mixer and other safe patches

### DIFF
--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -14,7 +14,7 @@
         "@scure/base": "^1.2.6",
         "base-x": "^5.0.1",
         "browserify-bignum": "^1.3.0-2",
-        "cbor": "^10.0.10",
+        "cbor": "^10.0.12",
         "chai": "^5.2.0",
         "crc": "^3.8.0",
         "groestl-hash-js": "1.0.0",

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -42,6 +42,6 @@
         "@types/node-fetch": "^2.6.12",
         "node-fetch": "2.6.7",
         "socks-proxy-agent": "8.0.5",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     }
 }

--- a/packages/connect-explorer-theme/package.json
+++ b/packages/connect-explorer-theme/package.json
@@ -54,7 +54,7 @@
         "postcss": "^8.4.41",
         "postcss-cli": "^10.1.0",
         "postcss-import": "^15.1.0",
-        "postcss-lightningcss": "^1.0.1",
+        "postcss-lightningcss": "^1.1.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
     },

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -70,7 +70,7 @@
         "@trezor/type-utils": "workspace:*",
         "@types/chrome": "^0.0.299",
         "@types/jest": "29.5.12",
-        "@types/w3c-web-usb": "^1.0.10",
+        "@types/w3c-web-usb": "^1.0.14",
         "@types/web": "^0.0.197",
         "babel-loader": "^10.1.1",
         "rimraf": "^6.1.2",

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -59,7 +59,7 @@
         "@babel/preset-typescript": "^7.28.5",
         "@trezor/eslint": "workspace:*",
         "@types/chrome": "^0.0.299",
-        "@types/w3c-web-usb": "^1.0.10",
+        "@types/w3c-web-usb": "^1.0.14",
         "babel-loader": "^10.1.1",
         "rimraf": "^6.1.2",
         "worker-loader": "^3.0.8"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -147,7 +147,7 @@
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "@trezor/utxo-lib": "workspace:*",
-        "cbor": "^10.0.10",
+        "cbor": "^10.0.12",
         "cross-fetch": "^4.1.0",
         "jws": "^4.0.1"
     },
@@ -158,7 +158,7 @@
         "@types/jws": "^3.2.11",
         "@types/node": "22.13.10",
         "@types/node-fetch": "^2.6.12",
-        "@types/w3c-web-usb": "^1.0.10",
+        "@types/w3c-web-usb": "^1.0.14",
         "@vitest/browser-playwright": "^4.1.0",
         "crypto-browserify": "3.12.0",
         "jest": "29.7.0",
@@ -171,7 +171,7 @@
         "vitest": "^4.1.0",
         "vm-browserify": "^1.1.2",
         "web3-utils": "^4.3.3",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -22,7 +22,7 @@
         "@trezor/utils": "workspace:*",
         "dotenv": "17.2.3",
         "express": "^5.2.1",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "devDependencies": {
         "@currents/playwright": "^1.22.2",

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -60,7 +60,7 @@
     "dependencies": {
         "@bufbuild/protobuf": "^2.11.0",
         "@trezor/schema-utils": "workspace:*",
-        "long": "5.2.5",
+        "long": "5.3.2",
         "protobufjs": "7.4.0"
     },
     "devDependencies": {

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -19,7 +19,7 @@
         "@trezor/utils": "workspace:*",
         "node-fetch": "2.6.7",
         "socks-proxy-agent": "8.0.5",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -42,7 +42,7 @@
     "dependencies": {
         "@sinclair/typebox": "^0.33.12",
         "@trezor/type-utils": "workspace:*",
-        "ts-mixer": "^6.0.3"
+        "ts-mixer": "^6.0.4"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/suite-desktop-core/package.json
+++ b/packages/suite-desktop-core/package.json
@@ -44,7 +44,7 @@
         "electron-updater": "6.8.3",
         "node-loader": "^2.1.0",
         "openpgp": "^6.3.0",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "devDependencies": {
         "@electron/fuses": "^2.1.0",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -94,7 +94,7 @@
         "@types/bytebuffer": "^5.0.49",
         "@types/node": "22.13.10",
         "@types/sharedworker": "^0.0.143",
-        "@types/w3c-web-usb": "^1.0.10",
+        "@types/w3c-web-usb": "^1.0.14",
         "jest": "29.7.0"
     },
     "dependencies": {

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -138,7 +138,7 @@ export class UsbApi extends AbstractApi {
             type: this.matchDeviceType(d.device),
             product: d.device.productId,
             vendor: d.device.vendorId,
-            id: d.device.serialNumber,
+            id: d.device.serialNumber ?? undefined,
             apiType: this.type,
             model: getUSBDescriptorModel(d.device),
         }));

--- a/packages/transport/src/api/usb.ts
+++ b/packages/transport/src/api/usb.ts
@@ -138,7 +138,7 @@ export class UsbApi extends AbstractApi {
             type: this.matchDeviceType(d.device),
             product: d.device.productId,
             vendor: d.device.vendorId,
-            id: d.device.serialNumber ?? undefined,
+            id: d.device.serialNumber,
             apiType: this.type,
             model: getUSBDescriptorModel(d.device),
         }));

--- a/packages/transport/src/types/index.ts
+++ b/packages/transport/src/types/index.ts
@@ -24,7 +24,7 @@ export type DescriptorApiLevel = {
     vendor?: number;
     apiType: ApiType;
     /** api level device id.  */
-    id?: string;
+    id?: string | null;
     /** api level device model */
     model?: DescriptorModel;
 };

--- a/packages/transport/tests/apiUsb.test.ts
+++ b/packages/transport/tests/apiUsb.test.ts
@@ -170,7 +170,7 @@ describe('api/usb', () => {
         api.usbInterface.onconnect({
             device: {
                 ...createMockedDevice(),
-                serialNumber: undefined,
+                serialNumber: null,
                 // @ts-expect-error
                 device: {
                     deviceDescriptor: {

--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -60,7 +60,7 @@
     },
     "dependencies": {
         "@trezor/utils": "workspace:*",
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/suite-common/e2e-evolu-client/package.json
+++ b/suite-common/e2e-evolu-client/package.json
@@ -11,7 +11,7 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "ws": "^8.18.0"
+        "ws": "^8.20.0"
     },
     "devDependencies": {
         "@evolu/common": "8.0.0-next.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17800,17 +17800,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/w3c-web-usb@npm:^1.0.14":
+"@types/w3c-web-usb@npm:^1.0.14, @types/w3c-web-usb@npm:^1.0.6":
   version: 1.0.14
   resolution: "@types/w3c-web-usb@npm:1.0.14"
   checksum: 10/53f04db6969fd859a3f7cf62b699060e97f39f6da30fe292c9c5e74ed3f3a8acf50c7574dcadfc1a1a6860558905e78f0de11eaf26b1905edf822e44c6dfef26
-  languageName: node
-  linkType: hard
-
-"@types/w3c-web-usb@npm:^1.0.6":
-  version: 1.0.10
-  resolution: "@types/w3c-web-usb@npm:1.0.10"
-  checksum: 10/6ac6786a0788f0846a48b103ab06ca5fde5eb95674217b522420a2f6157bee3e181a961c1b7011940f497c55f4f5cc46129657d881fdd8112b48764089679ad6
   languageName: node
   linkType: hard
 
@@ -47289,22 +47282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0":
-  version: 8.19.0
-  resolution: "ws@npm:8.19.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
-  languageName: node
-  linkType: hard
-
-"ws@npm:^8.20.0":
+"ws@npm:^8.11.0, ws@npm:^8.12.1, ws@npm:^8.13.0, ws@npm:^8.17.1, ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.19.0, ws@npm:^8.20.0":
   version: 8.20.0
   resolution: "ws@npm:8.20.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10919,7 +10919,7 @@ __metadata:
     "@suite-common/suite-sync-storage": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -15199,7 +15199,7 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     base-x: "npm:^5.0.1"
     browserify-bignum: "npm:^1.3.0-2"
-    cbor: "npm:^10.0.10"
+    cbor: "npm:^10.0.12"
     chai: "npm:^5.2.0"
     crc: "npm:^3.8.0"
     groestl-hash-js: "npm:1.0.0"
@@ -15366,7 +15366,7 @@ __metadata:
     n64: "npm:^0.2.10"
     node-fetch: "npm:2.6.7"
     socks-proxy-agent: "npm:8.0.5"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -15492,7 +15492,7 @@ __metadata:
     postcss: "npm:^8.4.41"
     postcss-cli: "npm:^10.1.0"
     postcss-import: "npm:^15.1.0"
-    postcss-lightningcss: "npm:^1.0.1"
+    postcss-lightningcss: "npm:^1.1.0"
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
     scroll-into-view-if-needed: "npm:^3.1.0"
@@ -15615,7 +15615,7 @@ __metadata:
     "@trezor/websocket-client": "workspace:*"
     "@types/chrome": "npm:^0.0.299"
     "@types/jest": "npm:29.5.12"
-    "@types/w3c-web-usb": "npm:^1.0.10"
+    "@types/w3c-web-usb": "npm:^1.0.14"
     "@types/web": "npm:^0.0.197"
     babel-loader: "npm:^10.1.1"
     rimraf: "npm:^6.1.2"
@@ -15635,7 +15635,7 @@ __metadata:
     "@trezor/connect-web": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@types/chrome": "npm:^0.0.299"
-    "@types/w3c-web-usb": "npm:^1.0.10"
+    "@types/w3c-web-usb": "npm:^1.0.14"
     babel-loader: "npm:^10.1.1"
     rimraf: "npm:^6.1.2"
     worker-loader: "npm:^3.0.8"
@@ -15680,9 +15680,9 @@ __metadata:
     "@types/jws": "npm:^3.2.11"
     "@types/node": "npm:22.13.10"
     "@types/node-fetch": "npm:^2.6.12"
-    "@types/w3c-web-usb": "npm:^1.0.10"
+    "@types/w3c-web-usb": "npm:^1.0.14"
     "@vitest/browser-playwright": "npm:^4.1.0"
-    cbor: "npm:^10.0.10"
+    cbor: "npm:^10.0.12"
     cross-fetch: "npm:^4.1.0"
     crypto-browserify: "npm:3.12.0"
     jest: "npm:29.7.0"
@@ -15696,7 +15696,7 @@ __metadata:
     vitest: "npm:^4.1.0"
     vm-browserify: "npm:^1.1.2"
     web3-utils: "npm:^4.3.3"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -15751,7 +15751,7 @@ __metadata:
     dotenv: "npm:17.2.3"
     express: "npm:^5.2.1"
     tsx: "npm:^4.21.0"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -15864,7 +15864,7 @@ __metadata:
     "@bufbuild/protoplugin": "npm:2.11.0"
     "@trezor/eslint": "workspace:*"
     "@trezor/schema-utils": "workspace:*"
-    long: "npm:5.2.5"
+    long: "npm:5.3.2"
     protobufjs: "npm:7.4.0"
     protobufjs-cli: "npm:^1.1.3"
     tsx: "npm:^4.21.0"
@@ -15913,7 +15913,7 @@ __metadata:
     node-fetch: "npm:2.6.7"
     socks-proxy-agent: "npm:8.0.5"
     ts-node: "npm:^10.9.2"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -15936,7 +15936,7 @@ __metadata:
     "@sinclair/typebox-codegen": "npm:^0.10.4"
     "@trezor/eslint": "workspace:*"
     "@trezor/type-utils": "workspace:*"
-    ts-mixer: "npm:^6.0.3"
+    ts-mixer: "npm:^6.0.4"
     ts-node: "npm:^10.9.2"
   peerDependencies:
     tslib: ^2.6.2
@@ -16114,7 +16114,7 @@ __metadata:
     rimraf: "npm:^6.1.2"
     terser-webpack-plugin: "npm:^5.4.0"
     webpack: "npm:5.105.4"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   languageName: unknown
   linkType: soft
 
@@ -16542,7 +16542,7 @@ __metadata:
     "@types/bytebuffer": "npm:^5.0.49"
     "@types/node": "npm:22.13.10"
     "@types/sharedworker": "npm:^0.0.143"
-    "@types/w3c-web-usb": "npm:^1.0.10"
+    "@types/w3c-web-usb": "npm:^1.0.14"
     cross-fetch: "npm:^4.1.0"
     jest: "npm:29.7.0"
     usb: "npm:^2.15.0"
@@ -16634,7 +16634,7 @@ __metadata:
     "@types/node": "npm:22.13.10"
     "@types/web": "npm:^0.0.197"
     "@types/ws": "npm:^8.5.13"
-    ws: "npm:^8.18.0"
+    ws: "npm:^8.20.0"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -17800,7 +17800,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/w3c-web-usb@npm:^1.0.10, @types/w3c-web-usb@npm:^1.0.6":
+"@types/w3c-web-usb@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@types/w3c-web-usb@npm:1.0.14"
+  checksum: 10/53f04db6969fd859a3f7cf62b699060e97f39f6da30fe292c9c5e74ed3f3a8acf50c7574dcadfc1a1a6860558905e78f0de11eaf26b1905edf822e44c6dfef26
+  languageName: node
+  linkType: hard
+
+"@types/w3c-web-usb@npm:^1.0.6":
   version: 1.0.10
   resolution: "@types/w3c-web-usb@npm:1.0.10"
   checksum: 10/6ac6786a0788f0846a48b103ab06ca5fde5eb95674217b522420a2f6157bee3e181a961c1b7011940f497c55f4f5cc46129657d881fdd8112b48764089679ad6
@@ -21427,12 +21434,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cbor@npm:^10.0.10":
-  version: 10.0.10
-  resolution: "cbor@npm:10.0.10"
+"cbor@npm:^10.0.12":
+  version: 10.0.12
+  resolution: "cbor@npm:10.0.12"
   dependencies:
     nofilter: "npm:^3.0.2"
-  checksum: 10/ec15770a37bb5f19f0ff6dfde1342c48035c11ff64c1083d3d22a2a3d3e0018f33c94a510d7db44fe2eb4022b3a90a2bd78da7249bd9c33e6e696a0095c93118
+  checksum: 10/296b6564c60e856aa13500ddeaf95aa979b05a80b543e85f6a2992d335e049ce2fd750a724a5d99095a9fee1c2bfcb934437683f2c19d8db4e129ea57813fb22
   languageName: node
   linkType: hard
 
@@ -32997,7 +33004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss@npm:^1.22.0, lightningcss@npm:^1.30.1, lightningcss@npm:^1.32.0":
+"lightningcss@npm:^1.30.1, lightningcss@npm:^1.32.0":
   version: 1.32.0
   resolution: "lightningcss@npm:1.32.0"
   dependencies:
@@ -33346,14 +33353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:5.2.5":
-  version: 5.2.5
-  resolution: "long@npm:5.2.5"
-  checksum: 10/972589d04a564ef4c066069d5ed06db14cd63de2a08d4f6c989512fa414bc2239479564e3a85de3efd42eb533ce142cdcaa28f12f4ecd051670015d36cbbb10b
-  languageName: node
-  linkType: hard
-
-"long@npm:^5.0.0":
+"long@npm:5.3.2, long@npm:^5.0.0":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
@@ -38459,15 +38459,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-lightningcss@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "postcss-lightningcss@npm:1.0.1"
+"postcss-lightningcss@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "postcss-lightningcss@npm:1.1.0"
   dependencies:
     browserslist: "npm:^4.19.1"
-    lightningcss: "npm:^1.22.0"
+    lightningcss: "npm:^1.32.0"
   peerDependencies:
     postcss: ^8.0.0
-  checksum: 10/cde885cf58bbdff728742be1a9d2697382b7611857011a60f267a89057d0abbc7df797b9a0f8a24eaddcb55b567c0118390204911d2374cf5678bbce2d854b00
+  checksum: 10/6d1786d95d667777d2e78168f0feb8fceb0bbccb089cbbb436a13194000a644772740ba5320d2500ebff7588535911482995c5920d8791f1de245defd6cf8dc9
   languageName: node
   linkType: hard
 
@@ -44376,10 +44376,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-mixer@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "ts-mixer@npm:6.0.3"
-  checksum: 10/ac9178bdac5e5f760472269ad4c461587a0f6793532ddbef1326bb01482425a6247be98f9bd11bf35a9fdd36b63b8c8dde393942b9b9ee52d154eef082fca39a
+"ts-mixer@npm:^6.0.4":
+  version: 6.0.4
+  resolution: "ts-mixer@npm:6.0.4"
+  checksum: 10/f20571a4a4ff7b5e1a2ff659208c1ea9d4180dda932b71d289edc99e25a2948c9048e2e676b930302ac0f8e88279e0da6022823183e67de3906a3f3a8b72ea80
   languageName: node
   linkType: hard
 
@@ -47301,6 +47301,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/b7ab934b21ffdea9f25a5af5097e8c1ec7625db553bca026c5a23e35b7c236f3fb89782f2b57fab9da553864512f9aa7d245827ef998d26ffa1b2187a19a6d10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `ws` ^8.18.0 → ^8.20.0 (7 workspaces)
- Bump `cbor` ^10.0.10 → ^10.0.12 (2 workspaces)
- Bump `long` 5.2.5 → 5.3.2 (1 workspace)
- Bump `ts-mixer` ^6.0.3 → ^6.0.4 (1 workspace)
- Bump `@types/w3c-web-usb` ^1.0.10 → ^1.0.14 (4 workspaces)
- Bump `postcss-lightningcss` ^1.0.1 → ^1.1.0 (1 workspace)

All patch/minor bumps with no breaking changes.

## Test plan
- [x] `yarn install` passes
- [x] `@trezor/protobuf` builds successfully
- [x] `@trezor/schema-utils` builds successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dep-updates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dep-updates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dep-updates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T10:10:25.543Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T10:08:48.577Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dep-updates/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dep-updates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->