### PR TITLE
refactor(suite): extract DropZone to product-components

### DIFF
--- a/packages/product-components/src/components/DropZone/DropZone.tsx
+++ b/packages/product-components/src/components/DropZone/DropZone.tsx
@@ -2,15 +2,14 @@ import {
     type ChangeEvent,
     type DragEvent,
     type MouseEvent,
+    type ReactNode,
     useCallback,
-    useMemo,
     useRef,
     useState,
 } from 'react';
 
 import styled from 'styled-components';
 
-import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
 import {
     Column,
     Icon,
@@ -27,137 +26,6 @@ import {
     mapElevationToBorder,
     spacings,
 } from '@trezor/theme';
-
-type DropZoneProps = {
-    accept?: string;
-    iconName?: IconName;
-    onSelect: (data: File, setError: (msg: ExtendedMessageDescriptor) => void) => void;
-    'data-testid'?: string;
-};
-
-export const useDropZone = ({ accept, onSelect }: DropZoneProps) => {
-    const available = useRef(window.File && window.FileReader && window.FileList && window.Blob);
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const inputRef = useRef<HTMLInputElement | null>(null);
-    const [error, setError] = useState<ExtendedMessageDescriptor>();
-    const [filename, setFilename] = useState<string>();
-
-    const allowedExtensions = useMemo(
-        () =>
-            (accept || '')
-                .split(',')
-                .map(s => s.trim())
-                .filter(s => s.startsWith('.'))
-                .map(ext => ext.slice(1).toLowerCase()),
-        [accept],
-    );
-
-    const readFileContent = useCallback(
-        (file?: File) => {
-            setFilename(file?.name);
-            if (!file) {
-                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
-
-                return;
-            }
-            if (allowedExtensions.length) {
-                const extRegex = new RegExp(`\\.(${allowedExtensions.join('|')})$`, 'i');
-                if (!extRegex.test(file.name)) {
-                    setError({ id: 'TR_DROPZONE_ERROR_FILETYPE' });
-
-                    return;
-                }
-            }
-            setError(undefined);
-            onSelect(file, setError);
-        },
-        [onSelect, allowedExtensions],
-    );
-
-    const onClick = useCallback(() => {
-        if (inputRef.current) {
-            inputRef.current.value = '';
-            inputRef.current.click();
-        }
-    }, [inputRef]);
-
-    const prevent = useCallback((event: MouseEvent) => {
-        event.preventDefault();
-    }, []);
-
-    const onDragEnter = useCallback((event: MouseEvent) => {
-        event.preventDefault();
-        event.currentTarget?.classList?.add('dragging');
-    }, []);
-
-    const onDragLeave = useCallback((event: MouseEvent) => {
-        event.preventDefault();
-        event.currentTarget?.classList?.remove('dragging');
-    }, []);
-
-    const onDrop = useCallback(
-        (event: DragEvent) => {
-            event.preventDefault();
-            event.currentTarget?.classList?.remove('dragging');
-            if (event.dataTransfer) {
-                readFileContent(event.dataTransfer.files[0]);
-            } else {
-                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
-            }
-        },
-        [readFileContent],
-    );
-
-    const onInputChange = useCallback(
-        (event: ChangeEvent<HTMLInputElement>) => {
-            event.stopPropagation();
-            if (event.target?.value && event.target.files) {
-                readFileContent(event.target.files[0]);
-            } else {
-                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
-            }
-        },
-        [readFileContent],
-    );
-
-    const onInputClick = useCallback((event: MouseEvent) => {
-        event.stopPropagation();
-    }, []);
-
-    const getWrapperProps = useMemo(
-        () => () => ({
-            onClick,
-            onDragEnter,
-            onDragOver: prevent,
-            onDragLeave,
-            onDrop,
-            ref: wrapperRef,
-        }),
-        [onClick, prevent, onDrop, onDragEnter, onDragLeave],
-    );
-
-    const getInputProps = useMemo(
-        () => () => ({
-            type: 'file',
-            multiple: false,
-            accept,
-            autoComplete: 'off',
-            tabIndex: -1,
-            onChange: onInputChange,
-            onClick: onInputClick,
-            ref: inputRef,
-        }),
-        [accept, onInputChange, onInputClick],
-    );
-
-    return {
-        available: available.current,
-        error,
-        filename,
-        getWrapperProps,
-        getInputProps,
-    };
-};
 
 const Wrapper = styled.div<{ $elevation: Elevation }>`
     border-radius: ${borders.radii.xs};
@@ -179,13 +47,156 @@ const StyledInput = styled.input`
     display: none;
 `;
 
+export type DropZoneProps = {
+    accept?: string;
+    iconName?: IconName;
+    emptyLabel: ReactNode;
+    emptyError: ReactNode;
+    fileTypeError: ReactNode;
+    onSelect: (data: File, setError: (msg: ReactNode) => void) => void;
+    'data-testid'?: string;
+};
+
+const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZoneProps) => {
+    const available = useRef(
+        typeof window !== 'undefined' &&
+            Boolean(window.File && window.FileReader && window.FileList && window.Blob),
+    );
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const [error, setError] = useState<ReactNode>();
+    const [filename, setFilename] = useState<string>();
+
+    const allowedExtensions = (accept || '')
+        .split(',')
+        .map(part => part.trim())
+        .filter(part => part.startsWith('.'))
+        .map(extension => extension.slice(1).toLowerCase());
+
+    const readFileContent = useCallback(
+        (file?: File) => {
+            setFilename(file?.name);
+            if (!file) {
+                setError(emptyError);
+
+                return;
+            }
+            if (allowedExtensions.length) {
+                const extRegex = new RegExp(`\\.(${allowedExtensions.join('|')})$`, 'i');
+                if (!extRegex.test(file.name)) {
+                    setError(fileTypeError);
+
+                    return;
+                }
+            }
+            setError(undefined);
+            onSelect(file, setError);
+        },
+        [allowedExtensions, emptyError, fileTypeError, onSelect],
+    );
+
+    const onClick = useCallback(() => {
+        if (inputRef.current) {
+            inputRef.current.value = '';
+            inputRef.current.click();
+        }
+    }, []);
+
+    const prevent = useCallback((event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+    }, []);
+
+    const onDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.currentTarget.classList.add('dragging');
+    }, []);
+
+    const onDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.currentTarget.classList.remove('dragging');
+    }, []);
+
+    const onDrop = useCallback(
+        (event: DragEvent<HTMLDivElement>) => {
+            event.preventDefault();
+            event.currentTarget.classList.remove('dragging');
+            if (event.dataTransfer) {
+                readFileContent(event.dataTransfer.files[0]);
+            } else {
+                setError(emptyError);
+            }
+        },
+        [emptyError, readFileContent],
+    );
+
+    const onInputChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            event.stopPropagation();
+            if (event.target.value && event.target.files) {
+                readFileContent(event.target.files[0]);
+            } else {
+                setError(emptyError);
+            }
+        },
+        [emptyError, readFileContent],
+    );
+
+    const onInputClick = useCallback((event: MouseEvent<HTMLInputElement>) => {
+        event.stopPropagation();
+    }, []);
+
+    const getWrapperProps = useCallback(
+        () => ({
+            onClick,
+            onDragEnter,
+            onDragOver: prevent,
+            onDragLeave,
+            onDrop,
+            ref: wrapperRef,
+        }),
+        [onClick, onDragEnter, onDragLeave, onDrop, prevent],
+    );
+
+    const getInputProps = useCallback(
+        () => ({
+            type: 'file' as const,
+            multiple: false,
+            accept,
+            autoComplete: 'off',
+            tabIndex: -1,
+            onChange: onInputChange,
+            onClick: onInputClick,
+            ref: inputRef,
+        }),
+        [accept, onInputChange, onInputClick],
+    );
+
+    return {
+        available: available.current,
+        error,
+        filename,
+        getWrapperProps,
+        getInputProps,
+    };
+};
+
 export const DropZone = ({
     accept,
     iconName = 'fileX',
+    emptyLabel,
+    emptyError,
+    fileTypeError,
     onSelect,
     'data-testid': dataTestId,
 }: DropZoneProps) => {
-    const { getWrapperProps, getInputProps, error, filename } = useDropZone({ accept, onSelect });
+    const { getWrapperProps, getInputProps, error, filename } = useDropZone({
+        accept,
+        emptyError,
+        fileTypeError,
+        emptyLabel,
+        onSelect,
+        'data-testid': dataTestId,
+    });
     const { elevation } = useElevation();
 
     return (
@@ -211,12 +222,12 @@ export const DropZone = ({
                         intent="neutral"
                         priority={filename ? 'primary' : 'secondary'}
                     >
-                        {filename || <Translation id="TR_DROPZONE" />}
+                        {filename ?? emptyLabel}
                     </Text>
                 </Row>
-                {error && (
+                {error !== undefined && (
                     <Paragraph typographyStyle="body-sm" intent="critical">
-                        <Translation {...error} />
+                        {error}
                     </Paragraph>
                 )}
             </Column>

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -53,6 +53,7 @@ export { TextColumn } from './components/Settings/TextColumn';
 export { StepCard } from './components/StepCard/StepCard';
 export { FeedbackCard, type FeedbackCardProps } from './components/FeedbackCard/FeedbackCard';
 export { SidebarBanner } from './components/SidebarBanner/SidebarBanner';
+export { DropZone, type DropZoneProps } from './components/DropZone/DropZone';
 export {
     EmojiRatingSelector,
     type EmojiRatingSelectorProps,

--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -1,11 +1,11 @@
-import { type Dispatch, type SetStateAction } from 'react';
+import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
 
 import { validateFirmware } from '@suite/firmware-upgrade';
-import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
+import { Translation } from '@suite/intl';
 import { BulletList, Button, Row } from '@trezor/components';
+import { DropZone } from '@trezor/product-components';
 import { GITHUB_FW_BINARIES_URL } from '@trezor/urls';
 
-import { DropZone } from 'src/components/suite/DropZone';
 import { useDevice } from 'src/hooks/suite';
 
 type SelectCustomFirmwareProps = {
@@ -20,15 +20,12 @@ export const SelectCustomFirmware = ({ setFirmwareBinary }: SelectCustomFirmware
         ? `${GITHUB_FW_BINARIES_URL}/${deviceModel.toLowerCase()}`
         : GITHUB_FW_BINARIES_URL;
 
-    const onFirmwareUpload = async (
-        firmware: File,
-        setError: (msg: ExtendedMessageDescriptor) => void,
-    ) => {
+    const onFirmwareUpload = async (firmware: File, setError: (msg: ReactNode) => void) => {
         const fw = await firmware.arrayBuffer();
         const validationError = validateFirmware(fw, device);
 
         if (validationError) {
-            setError({ id: validationError });
+            setError(<Translation id={validationError} />);
         } else {
             setFirmwareBinary(fw);
         }
@@ -48,6 +45,9 @@ export const SelectCustomFirmware = ({ setFirmwareBinary }: SelectCustomFirmware
                 <DropZone
                     data-testid="@firmware/input-area"
                     accept=".bin"
+                    emptyLabel={<Translation id="TR_DROPZONE" />}
+                    emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
+                    fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
                     onSelect={onFirmwareUpload}
                 />
             </BulletList.Item>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 
-import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
+import { Translation } from '@suite/intl';
 import { type UserContextPayload } from '@suite-common/suite-types';
 import { networksCollection } from '@suite-common/wallet-config';
 import { parseCSV } from '@suite-common/wallet-utils';
 import { Card, CollapsibleBox, Column, Modal, Tabs, Text, Textarea } from '@trezor/components';
+import { DropZone } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
-
-import { DropZone } from 'src/components/suite/DropZone';
 
 import { DelimiterForm } from './DelimiterForm';
 import { useExampleCSV } from './useExampleCSV';
@@ -40,18 +39,20 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
         onCancel();
     };
 
-    const onCsvSelect = (file: File, setError: (msg: ExtendedMessageDescriptor) => void) => {
+    const onCsvSelect = (file: File, setError: (msg: ReactNode) => void) => {
         const reader = new FileReader();
 
         reader.onload = () => {
             if (typeof reader.result !== 'string' || !reader.result.length) {
-                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
+                setError(<Translation id="TR_DROPZONE_ERROR_EMPTY" />);
             } else {
                 setContent(reader.result);
             }
         };
         reader.onerror = () => {
-            setError({ id: 'TR_DROPZONE_ERROR', values: { error: reader.error!.message } });
+            setError(
+                <Translation id="TR_DROPZONE_ERROR" values={{ error: reader.error!.message }} />,
+            );
             reader.abort();
         };
         reader.readAsText(file);
@@ -97,6 +98,9 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
                             <DropZone
                                 accept=".csv,.txt,text/csv"
                                 iconName="fileCsv"
+                                emptyLabel={<Translation id="TR_DROPZONE" />}
+                                emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
+                                fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
                                 onSelect={onCsvSelect}
                             />
                         ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { Card, Column, Icon, Paragraph, Row, ShortcutBadge, Spinner } from '@trezor/components';
+import { DropZone } from '@trezor/product-components';
 import { spacings } from '@trezor/theme';
 
-import { DropZone } from 'src/components/suite/DropZone';
 import { decodeQRFromImage } from 'src/utils/suite/qrCode';
 
 const IMAGE_ACCEPT = '.png,.jpg,.jpeg,.gif,.bmp,.webp';
@@ -85,7 +85,14 @@ export const ImageQRReader = ({ onResult }: ImageQRReaderProps) => {
                 </Card>
             ) : (
                 <>
-                    <DropZone accept={IMAGE_ACCEPT} iconName="qrCode" onSelect={handleSelect} />
+                    <DropZone
+                        accept={IMAGE_ACCEPT}
+                        iconName="qrCode"
+                        emptyLabel={<Translation id="TR_DROPZONE" />}
+                        emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
+                        fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
+                        onSelect={handleSelect}
+                    />
                     {error && (
                         <Card>
                             <Column alignItems="center" gap={spacings.xs}>


### PR DESCRIPTION
Needed for: https://github.com/trezor/trezor-suite/pull/26860

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=extract_DropZone&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=extract_DropZone&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T11:45:57.329Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T10:55:18.821Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/extract_DropZone/web/](https://dev.suite.sldev.cz/suite-web/extract_DropZone/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->