### PR TITLE
chore(tests): migrate compatible web packages to @swc/jest

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -3,6 +3,7 @@
     "ignores": [
         "babel*",
         "@babel/*",
+        "@swc/jest",
         "@playwright/*",
         "webpack*",
         "worker-loader",

--- a/.github/workflows/benchmark-jest-transform.yml
+++ b/.github/workflows/benchmark-jest-transform.yml
@@ -1,0 +1,133 @@
+# TEMPORARY — jest transform benchmark for PR #26873 (babel-jest vs @swc/jest).
+# Delete this file once the SWC migration is merged.
+
+name: "[Benchmark] jest transform (babel vs swc)"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/benchmark-jest-transform.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    if: github.repository == 'trezor/trezor-suite'
+    strategy:
+      fail-fast: false
+      matrix:
+        transform: [babel, swc]
+        run: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: yarn install --immutable
+      - run: yarn message-system-sign-config
+
+      - name: Force babel transform
+        if: matrix.transform == 'babel'
+        run: |
+          # Point every migrated jest config back at the babel base.
+          # Matches `require('../../jest.config.base.swc')` (with any depth) and
+          # rewrites the trailing `.swc` away.
+          mapfile -t files < <(grep -rl "jest\.config\.base\.swc" --include='jest.config*.js' --include='jest.config*.cjs' .)
+          echo "Reverting ${#files[@]} jest configs to babel-jest"
+          for f in "${files[@]}"; do
+            sed -i "s|jest\\.config\\.base\\.swc|jest.config.base|g" "$f"
+          done
+
+      - name: Clear caches
+        run: |
+          rm -rf .nx/cache
+          find . -type d -name ".jest-cache" -prune -exec rm -rf {} +
+
+      - name: Measure unit tests — Suite, Connect, Common (cold cache)
+        id: measure
+        run: |
+          set -o pipefail
+          START=$(date +%s%N)
+          yarn nx run-many \
+            --target=test:unit \
+            --exclude='@suite-native/*' \
+            --skip-nx-cache \
+            -- --no-cache 2>&1 | tee run.log
+          END=$(date +%s%N)
+          DURATION_MS=$(( (END - START) / 1000000 ))
+          echo "duration_ms=${DURATION_MS}" >> "$GITHUB_OUTPUT"
+          OUT="timing-${{ matrix.transform }}-${{ matrix.run }}.csv"
+          printf '%s,%s,%s\n' "${{ matrix.transform }}" "${{ matrix.run }}" "${DURATION_MS}" > "$OUT"
+          printf '### %s run %s — %d ms (%.1f s)\n' \
+            "${{ matrix.transform }}" "${{ matrix.run }}" "${DURATION_MS}" \
+            "$(awk "BEGIN { printf \"%.1f\", ${DURATION_MS}/1000 }")" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload timing
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: timing-${{ matrix.transform }}-${{ matrix.run }}
+          path: timing-${{ matrix.transform }}-${{ matrix.run }}.csv
+
+  summary:
+    needs: measure
+    runs-on: ubuntu-latest
+    if: always() && github.repository == 'trezor/trezor-suite'
+    steps:
+      - name: Download timings
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: timing-*
+          path: timings
+          merge-multiple: true
+
+      - name: Aggregate
+        run: |
+          set -euo pipefail
+          cat timings/*.csv > all.csv || true
+          if [ ! -s all.csv ]; then
+            echo "No timings collected" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          awk -F, '
+            {
+              t = $1
+              ms = $3
+              count[t]++
+              sum[t] += ms
+              sumsq[t] += ms * ms
+              if (!(t in min) || ms < min[t]) min[t] = ms
+              if (!(t in max) || ms > max[t]) max[t] = ms
+            }
+            END {
+              printf "# Jest transform benchmark\n\n"
+              printf "| transform | runs | min (s) | max (s) | mean (s) | stddev (s) |\n"
+              printf "|---|---|---|---|---|---|\n"
+              for (t in count) {
+                n = count[t]
+                mean = sum[t] / n
+                var = (sumsq[t] / n) - (mean * mean)
+                if (var < 0) var = 0
+                sd = sqrt(var)
+                printf "| %s | %d | %.2f | %.2f | %.2f | %.2f |\n", \
+                  t, n, min[t]/1000, max[t]/1000, mean/1000, sd/1000
+              }
+              if (("babel" in count) && ("swc" in count)) {
+                mb = sum["babel"] / count["babel"]
+                ms = sum["swc"] / count["swc"]
+                printf "\n**Mean speedup:** %.2fx (%.1fs → %.1fs)\n", \
+                  mb / ms, mb/1000, ms/1000
+              }
+            }
+          ' all.csv >> "$GITHUB_STEP_SUMMARY"
+          cat "$GITHUB_STEP_SUMMARY"

--- a/jest.config.base.swc.js
+++ b/jest.config.base.swc.js
@@ -1,0 +1,55 @@
+const path = require('path');
+
+const swcConfig = {
+    jsc: {
+        parser: {
+            syntax: 'typescript',
+            tsx: true,
+            decorators: true,
+        },
+        transform: {
+            react: {
+                runtime: 'automatic',
+            },
+            decoratorVersion: '2022-03',
+        },
+        target: 'esnext',
+    },
+    module: {
+        type: 'commonjs',
+    },
+};
+
+module.exports = {
+    rootDir: process.cwd(),
+    moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
+
+    testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+
+    testPathIgnorePatterns: [
+        '/node_modules/',
+        '/libDev/',
+        '/lib/',
+        '/dist/',
+        '/build/',
+        '/build-electron/',
+        '/coverage/',
+        '/public/',
+    ],
+
+    transform: {
+        '\\.(js|jsx|ts|tsx)$': ['@swc/jest', swcConfig],
+    },
+
+    transformIgnorePatterns: ['node_modules/?!(uuid|react-intl|@formatjs/*|intl-messageformat)/'],
+
+    watchPathIgnorePatterns: ['libDev', 'lib'],
+
+    modulePathIgnorePatterns: ['libDev'],
+    moduleNameMapper: {
+        '^reselect$': path.resolve(__dirname, 'suite-native/test-utils/src/mocks/reselectMock.ts'),
+        '^bcrypto/lib/(.*)$': 'bcrypto/lib/$1-browser',
+        '^uint8array-tools$': require.resolve('uint8array-tools'),
+        '^usb$': '<rootDir>../../packages/transport/mocks/usb.js',
+    },
+};

--- a/package.json
+++ b/package.json
@@ -133,6 +133,8 @@
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
         "@babel/runtime": "7.29.2",
+        "@swc/core": "^1.15.24",
+        "@swc/jest": "^0.2.39",
         "@trezor/eslint": "workspace:*",
         "@types/jest": "29.5.12",
         "@types/node": "22.13.10",

--- a/packages/address-validator/jest.config.js
+++ b/packages/address-validator/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/analytics-docs/jest.config.cjs
+++ b/packages/analytics-docs/jest.config.cjs
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/analytics-uploader/jest.config.js
+++ b/packages/analytics-uploader/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/blockchain-link-types/jest.config.js
+++ b/packages/blockchain-link-types/jest.config.js
@@ -1,3 +1,3 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = { ...baseConfig };

--- a/packages/blockchain-link-utils/jest.config.js
+++ b/packages/blockchain-link-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/blockchain-link/jest.config.integration.js
+++ b/packages/blockchain-link/jest.config.integration.js
@@ -2,7 +2,7 @@
  * Integration tests for library build in `./lib` and `./build` directory
  */
 
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/blockchain-link/jest.config.unit.js
+++ b/packages/blockchain-link/jest.config.unit.js
@@ -2,7 +2,7 @@
  * Unit tests for source with coverage
  */
 
-const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base');
+const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/bundler-security/jest.config.js
+++ b/packages/bundler-security/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/connect-common/jest.config.js
+++ b/packages/connect-common/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/connect-plugin-ethereum/jest.config.js
+++ b/packages/connect-plugin-ethereum/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/connect-plugin-stellar/jest.config.js
+++ b/packages/connect-plugin-stellar/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/connect-web/jest.config.js
+++ b/packages/connect-web/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/device-authenticity/jest.config.js
+++ b/packages/device-authenticity/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/device-utils/jest.config.js
+++ b/packages/device-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/env-utils/jest.config.js
+++ b/packages/env-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/ipc-proxy/jest.config.js
+++ b/packages/ipc-proxy/jest.config.js
@@ -1,4 +1,4 @@
-const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base');
+const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/node-utils/jest.config.js
+++ b/packages/node-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/protobuf/jest.config.js
+++ b/packages/protobuf/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/protocol/jest.config.js
+++ b/packages/protocol/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/request-manager/jest.config.js
+++ b/packages/request-manager/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base.js');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/requirements/jest.config.cjs
+++ b/packages/requirements/jest.config.cjs
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/schema-utils/jest.config.js
+++ b/packages/schema-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/styles-common/jest.config.js
+++ b/packages/styles-common/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/suite-desktop-api/jest.config.js
+++ b/packages/suite-desktop-api/jest.config.js
@@ -1,4 +1,4 @@
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/suite-desktop-core/jest.config.js
+++ b/packages/suite-desktop-core/jest.config.js
@@ -1,4 +1,4 @@
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/transport-bridge/jest.config.js
+++ b/packages/transport-bridge/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/transport-native-bluetooth/jest.config.js
+++ b/packages/transport-native-bluetooth/jest.config.js
@@ -1,4 +1,4 @@
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/transport/jest.config.js
+++ b/packages/transport/jest.config.js
@@ -1,4 +1,4 @@
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/urls/jest.config.js
+++ b/packages/urls/jest.config.js
@@ -1,4 +1,4 @@
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/utxo-lib/jest.config.js
+++ b/packages/utxo-lib/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/websocket-client/jest.config.js
+++ b/packages/websocket-client/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -19,6 +19,8 @@
 @solana/rpc-api
 @solana/rpc-types
 @stellar/stellar-sdk
+@swc/core
+@swc/jest
 @testing-library/dom
 @testing-library/jest-dom
 @testing-library/react

--- a/suite-common/analytics-redux/jest.config.js
+++ b/suite-common/analytics-redux/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/assets/jest.config.js
+++ b/suite-common/assets/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/bip329/jest.config.js
+++ b/suite-common/bip329/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/bluetooth/jest.config.js
+++ b/suite-common/bluetooth/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/calldata/jest.config.js
+++ b/suite-common/calldata/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/connect-init/jest.config.js
+++ b/suite-common/connect-init/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/delegated-identity-key/jest.config.js
+++ b/suite-common/delegated-identity-key/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/device-authenticity/jest.config.js
+++ b/suite-common/device-authenticity/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/device/jest.config.js
+++ b/suite-common/device/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/earn-stablecoin-api/jest.config.js
+++ b/suite-common/earn-stablecoin-api/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/fiat-services/jest.config.js
+++ b/suite-common/fiat-services/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/formatters/jest.config.js
+++ b/suite-common/formatters/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/graph/jest.config.js
+++ b/suite-common/graph/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/logger/jest.config.js
+++ b/suite-common/logger/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/redux-utils/jest.config.js
+++ b/suite-common/redux-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/staking-solana-types/jest.config.js
+++ b/suite-common/staking-solana-types/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/staking-solana/jest.config.js
+++ b/suite-common/staking-solana/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/staking/jest.config.js
+++ b/suite-common/staking/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/suite-sync-types/jest.config.js
+++ b/suite-common/suite-sync-types/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/suite-sync/jest.config.js
+++ b/suite-common/suite-sync/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/suite-utils/jest.config.js
+++ b/suite-common/suite-utils/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/thp/jest.config.js
+++ b/suite-common/thp/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/toast-notifications/jest.config.js
+++ b/suite-common/toast-notifications/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/transaction-search/jest.config.js
+++ b/suite-common/transaction-search/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/wallet-config/jest.config.js
+++ b/suite-common/wallet-config/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/wallet-core/jest.config.js
+++ b/suite-common/wallet-core/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/wallet-utils/jest.config.js
+++ b/suite-common/wallet-utils/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/backup/jest.config.js
+++ b/suite/backup/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/desktop-update/jest.config.js
+++ b/suite/desktop-update/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/device/jest.config.js
+++ b/suite/device/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/feature-feedback/jest.config.js
+++ b/suite/feature-feedback/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/flags/jest.config.js
+++ b/suite/flags/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/idb-migration-utils/jest.config.js
+++ b/suite/idb-migration-utils/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const { ...baseConfig } = require('../../jest.config.base');
+const { ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/locks/jest.config.js
+++ b/suite/locks/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/metadata/jest.config.js
+++ b/suite/metadata/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/recovery/jest.config.js
+++ b/suite/recovery/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/router/jest.config.js
+++ b/suite/router/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/settings/jest.config.js
+++ b/suite/settings/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite/trading/jest.config.js
+++ b/suite/trading/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5373,6 +5373,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/create-cache-key-function@npm:^30.0.0":
+  version: 30.3.0
+  resolution: "@jest/create-cache-key-function@npm:30.3.0"
+  dependencies:
+    "@jest/types": "npm:30.3.0"
+  checksum: 10/67ed57eda68e77e73e7ceb9cdd142a14d0fd028099762e3405d15ac530d0726eebb5d203f885b84436dc8d5582e4c3d290af7bbbe0445ffeae97de8e3604ea05
+  languageName: node
+  linkType: hard
+
 "@jest/diff-sequences@npm:30.3.0":
   version: 30.3.0
   resolution: "@jest/diff-sequences@npm:30.3.0"
@@ -15123,6 +15132,149 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@swc/core-darwin-arm64@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-darwin-arm64@npm:1.15.24"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-darwin-x64@npm:1.15.24"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.24"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.24"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.24"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-ppc64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.24"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-s390x-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.24"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.24"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.24"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.24"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.24"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.24"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.15.24":
+  version: 1.15.24
+  resolution: "@swc/core@npm:1.15.24"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.15.24"
+    "@swc/core-darwin-x64": "npm:1.15.24"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.24"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.24"
+    "@swc/core-linux-arm64-musl": "npm:1.15.24"
+    "@swc/core-linux-ppc64-gnu": "npm:1.15.24"
+    "@swc/core-linux-s390x-gnu": "npm:1.15.24"
+    "@swc/core-linux-x64-gnu": "npm:1.15.24"
+    "@swc/core-linux-x64-musl": "npm:1.15.24"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.24"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.24"
+    "@swc/core-win32-x64-msvc": "npm:1.15.24"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.26"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.17"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-ppc64-gnu":
+      optional: true
+    "@swc/core-linux-s390x-gnu":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10/8528e4bd6845671ad6e0ab2184d9d5bc9317d89c05945a06b1f7aad99ccec90fa88318f1bed093304f8a7a47a2b18ec85746e46336c4cbbf2a5851e87165943d
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10/df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:0.5.15":
   version: 0.5.15
   resolution: "@swc/helpers@npm:0.5.15"
@@ -15138,6 +15290,28 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/03c7efa3e62d965fddd0baea98ee7a4c3ba7fa58187f07f26ec8d86740572f5ffd6f7517578a1d3201f64c85399be1538eba4dd30cef79d073060ecb101d753c
+  languageName: node
+  linkType: hard
+
+"@swc/jest@npm:^0.2.39":
+  version: 0.2.39
+  resolution: "@swc/jest@npm:0.2.39"
+  dependencies:
+    "@jest/create-cache-key-function": "npm:^30.0.0"
+    "@swc/counter": "npm:^0.1.3"
+    jsonc-parser: "npm:^3.2.0"
+  peerDependencies:
+    "@swc/core": "*"
+  checksum: 10/a2b7ed6fbb908867e673d1bbff9efde7eee225a57ad75735216ce2005e40c5cfb92285bd807d2058f1c0317e3d48ed71f5577fe85b28bebc80c1bc2c3a03306e
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.26":
+  version: 0.1.26
+  resolution: "@swc/types@npm:0.1.26"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10/07de03b9da3928cdf69bda70bf2c809dd86f16ef23e357759e577bbd975529cb20218c2e54e72b00585abae2b5e04e39b8947cea7a6f4de2d40a7633be441919
   languageName: node
   linkType: hard
 
@@ -44522,6 +44696,8 @@ __metadata:
     "@babel/preset-react": "npm:^7.28.5"
     "@babel/preset-typescript": "npm:^7.28.5"
     "@babel/runtime": "npm:7.29.2"
+    "@swc/core": "npm:^1.15.24"
+    "@swc/jest": "npm:^0.2.39"
     "@trezor/eslint": "workspace:*"
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:22.13.10"


### PR DESCRIPTION
## Summary

Progressive migration from `babel-jest` to `@swc/jest` for the web-side Jest runner. This PR introduces a new SWC-based Jest base config (`jest.config.base.swc.js`) and opts in every web package whose tests pass cleanly under SWC — **71 of 80 web packages**. The remaining 9 stay on `babel-jest` for now; see the migration plan below for the exit strategy.

## Why

`babel-jest` is the dominant cost in our Jest cold-cache runs. Swapping it for `@swc/jest` (Rust-based) dramatically reduces transform time. Measured on two representative packages (best of 3 cold-cache runs — Jest-reported time / wall time / user CPU):

| Package | Tests | Babel | SWC | Speedup |
|---|---|---|---|---|
| `@suite-common/wallet-utils` | 403 | 14.10s / 15.22s / 70.4s | 4.26s / 5.78s / 17.9s | **3.3× / 2.6× / 3.9×** |
| `@trezor/utxo-lib` (coverage) | 2435 | 6.81s / 7.96s / 33.3s | 3.62s / 4.71s / 20.2s | **1.9× / 1.7× / 1.7×** |

Warm-cache differences are much smaller (both paths skip the transform), on the order of 1.2-1.5×. The biggest win is on CI, where the cache is cold and CPU minutes are real money.

## Scope

### Migrated to `@swc/jest` (71 packages)

All web packages that inherit their transform from the shared base config AND whose tests pass under SWC:

- **`packages/*`** (32): `address-validator`, `analytics-docs`, `analytics-uploader`, `blockchain-link`, `blockchain-link-types`, `blockchain-link-utils`, `bundler-security`, `components`, `connect-common`, `connect-plugin-ethereum`, `connect-plugin-stellar`, `connect-web`, `device-authenticity`, `device-utils`, `env-utils`, `ipc-proxy`, `node-utils`, `protobuf`, `protocol`, `request-manager`, `requirements`, `schema-utils`, `styles-common`, `suite-desktop-api`, `suite-desktop-core`, `transport`, `transport-bridge`, `transport-native-bluetooth`, `urls`, `utils`, `utxo-lib`, `websocket-client`
- **`suite-common/*`** (27): `analytics-redux`, `assets`, `bip329`, `bluetooth`, `calldata`, `connect-init`, `delegated-identity-key`, `device`, `device-authenticity`, `earn-api`, `fiat-services`, `formatters`, `graph`, `logger`, `redux-utils`, `staking`, `staking-solana`, `staking-solana-types`, `suite-sync`, `suite-sync-types`, `suite-utils`, `thp`, `toast-notifications`, `transaction-search`, `wallet-config`, `wallet-core`, `wallet-utils`
- **`suite/*`** (12): `backup`, `desktop-update`, `device`, `feature-feedback`, `flags`, `idb-migration-utils`, `locks`, `metadata`, `recovery`, `router`, `settings`, `trading`

Each change is a one-line diff in the package's Jest config: `require('../../jest.config.base')` → `require('../../jest.config.base.swc')`.

### Still on `babel-jest` (9 packages)

| Package | Reason |
|---|---|
| `@trezor/suite` | 3 failing suites (spyOn on namespace imports) + inline Babel transform in its `jest.config.js` |
| `@trezor/connect` | 4 failing suites, 67 failing tests (spyOn pattern) |
| `@trezor/coinjoin` | Failing suites (spyOn pattern) |
| `@suite-common/trading` | 5 failing suites, 15 failing tests (spyOn pattern) |
| `@suite-common/message-system` | Failing suites (spyOn pattern) |
| `@suite-common/feedback` | Failing suites (spyOn pattern) |
| `@suite-common/suite-sync-quota-manager` | Failing suites (spyOn pattern) |
| `@suite-common/suite-sync-evolu` | Failing with `Cannot read 'CONNECTING' of undefined` (ESM interop edge) |
| `@suite-common/token-definitions` | Failing suites (spyOn pattern) |

### Not in scope

- **`suite-native/*`** — uses Metro + `babel-preset-expo` + `react-native-reanimated/plugin` + `react-native-worklets/plugin`. Neither Metro nor those plugins have SWC equivalents, so `suite-native` stays on Babel indefinitely. `jest.config.native.js` is untouched.
- **`@trezor/transport-test`** — e2e-only package, does not run a `test:unit` target. Its `jest.config.ts` for bridge e2e tests has its own inline transform and is untouched.

## Root cause of the failing-package pattern

Every failing suite (except `suite-sync-evolu`) has the same shape:

```ts
import * as mod from './foo';
jest.spyOn(mod, 'fn');              // TypeError: Cannot redefine property
jest.replaceProperty(mod, 'x', y);  // Property 'x' is not declared configurable
```

SWC emits CommonJS re-exports as `Object.defineProperty(exports, name, { get })` without `configurable: true`. Babel's CJS output is structured so Jest can still replace the binding. I probed every SWC `module.*` option (`strict`, `strictMode`, `lazy`, `noInterop`, `importInterop`) — the emitted shape is the same in all cases. This is an architectural difference, not a configuration bug.

## How the scope was determined

1. Temporarily aliased `jest.config.base.js` to delegate to `jest.config.base.swc.js`.
2. Ran `yarn nx run-many --target=test:unit` across every web package (excluding `suite-native/*`).
3. Collected failures. The 9 packages above failed; every other package passed.
4. Reverted the temporary alias.
5. Flipped each passing package's Jest config individually to `jest.config.base.swc`.

## Migration plan going forward

### This PR

- Introduce `jest.config.base.swc.js`.
- Migrate 71 web packages to SWC.

### Follow-up 1 — refactor the 9 blocked packages (gradual, low-priority)

- For each failing test file, replace `import * as X + jest.spyOn(X, 'fn')` with one of:
  - `jest.mock('./foo', ...)` hoisted at module top, or
  - Importing the target and spying on the owning object (a class instance, a module-level registry) instead of the namespace import.
- Each refactor is small and local. PRs can be done by the team owning each area as they touch those files.
- When all test files in a package are converted, flip that package's Jest config to SWC.
- `@trezor/suite` additionally needs its inline Babel config replaced with an inline SWC config; this can land together with its test refactor.

### Follow-up 2 — replace `jest.config.base.js` and drop Babel from the web

- Once no web package requires `jest.config.base.js`, swap the SWC config in as the default and remove the Babel variant.
- Drop web-only Babel devDependencies from root `package.json` (`@babel/preset-env`, `preset-react`, `preset-typescript`, `plugin-proposal-decorators`, `babel-jest`). Keep what `suite-native` still needs.

### Follow-up 3 (optional) — Webpack `swc-loader`

- Migrate `packages/suite-build/configs/base.webpack.config.ts` from `babel-loader` to `swc-loader` for `suite-web` and `suite-desktop` production builds. Larger blast radius (bundle size, runtime) — separate PR, separate evaluation.

## Risk & rollback

- No changes to the 9 Babel packages; their test output is identical to `develop`.
- If one of the 71 SWC-migrated packages turns out to have a subtle behavior regression we missed in the mass validation, reverting its Jest config one-liner restores it to Babel. Per-package rollback is trivial.
- The whole PR can also be reverted as one unit.

## Test plan

- [ ] CI `test:unit` target is green
- [ ] Spot-check a handful of migrated packages locally (`yarn workspace <name> test:unit`)
- [ ] Measure CI duration impact vs `develop` after merge
- [ ] No coverage threshold regressions in `@trezor/utxo-lib`, `@trezor/blockchain-link`, `@suite-common/trading` (still Babel), `@suite/trading` (SWC)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/jest-swc-migration-phase-1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/jest-swc-migration-phase-1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/jest-swc-migration-phase-1/web/](https://dev.suite.sldev.cz/suite-web/chore/jest-swc-migration-phase-1/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T15:20:09.853Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->