### PR TITLE
feat(suite-native): move KYC warning to exchange preview

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -1,16 +1,19 @@
 import { type ReactNode, memo } from 'react';
 import Animated from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
 
+import { type TradingRootState, selectTradingProviderKycPolicy } from '@suite-common/trading';
 import { InlineAlertBox, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 
 import { ExchangeFeePickerCard } from './ExchangeFeePickerCard';
 import { ExchangeFiatDeviationWarning } from './ExchangeFiatDeviationWarning';
 import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
 import { ExchangeFusionPlusInfo } from './ExchangeFusionPlusInfo';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
+import { getKycPolicyWarningTranslation } from '../../../utils/general/kycUtils';
 import { LastErrorMessage } from '../../general/Error/LastErrorMessage';
 
 export type ExchangePreviewViewProps = {
@@ -21,8 +24,16 @@ export type ExchangePreviewViewProps = {
 
 export const ExchangePreviewView = memo(
     ({ quote, txnErrorString, isApproved }: ExchangePreviewViewProps) => {
+        const { translate } = useTranslate();
+
+        const kycPolicy = useSelector((state: TradingRootState) =>
+            selectTradingProviderKycPolicy(state, quote?.exchange, 'exchange'),
+        );
+
         const isTxnError = !!txnErrorString;
         const isFusionPlus = quote?.exchange === '1inchfusionplus';
+
+        const kycWarning = getKycPolicyWarningTranslation(kycPolicy);
 
         return (
             <VStack spacing="sp20" paddingVertical="sp20">
@@ -45,6 +56,13 @@ export const ExchangePreviewView = memo(
                 <ExchangeFiatDeviationWarning quote={quote} />
                 <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
                 {isFusionPlus && <ExchangeFusionPlusInfo />}
+                {kycWarning && (
+                    <InlineAlertBox
+                        variant="warning"
+                        title={kycWarning}
+                        accessibilityHint={translate('generic.warning')}
+                    />
+                )}
             </VStack>
         );
     },

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
@@ -1,5 +1,6 @@
 import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
 import {
+    cexdirectFloatingQuote,
     exchangeQuotes,
     getWalletState,
     mercuryoFixedWorstQuote,
@@ -65,5 +66,21 @@ describe('ExchangePreviewView', () => {
         });
 
         expect(queryByText('You are swapping with 1Inch Fusion+')).toBeNull();
+    });
+
+    it('should render KYC warning for provider with "KYC-required"', () => {
+        const { getByText } = renderExchangePreviewView({
+            quote: cexdirectFloatingQuote,
+        });
+
+        expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
+    });
+
+    it('should not render KYC provider warning for providers with "noKYC"', () => {
+        const { queryByText } = renderExchangePreviewView({
+            quote: mercuryoFixedWorstQuote,
+        });
+
+        expect(queryByText('This provider requires to verify identity.')).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.tsx
@@ -6,13 +6,10 @@ import { invariant } from '@suite-common/suite-utils';
 import {
     type TradingRootState as TradingRootStateCommon,
     selectTradingProviderByNameAndTradeType,
-    selectTradingProviderKycPolicy,
 } from '@suite-common/trading';
 import { HStack, Text } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { OverviewRow, OverviewValueSkeleton, ProviderLogo } from '@suite-native/trading-atoms';
-
-import { getKycPolicyWarningTranslation } from '../../utils/general/kycUtils';
 
 type ExchangeProviderPickerRightProps = {
     isLoading: boolean;
@@ -63,15 +60,9 @@ export const ExchangeProviderPicker = ({
 }: ExchangeProviderPickerProps) => {
     const { translate } = useTranslate();
 
-    const kycPolicy = useSelector((state: TradingRootStateCommon) =>
-        selectTradingProviderKycPolicy(state, selectedValue?.exchange, 'exchange'),
-    );
-
     if (!selectedValue && !isLoading) {
         return null;
     }
-
-    const warning = isLoading ? undefined : getKycPolicyWarningTranslation(kycPolicy);
 
     return (
         <>
@@ -80,7 +71,6 @@ export const ExchangeProviderPicker = ({
                 noBottomBorder
                 onPress={handleProviderPress}
                 noCaret={isLoading}
-                warning={warning}
                 testID={PROVIDER_PICKER_TEST_ID}
             >
                 <ExchangeProviderPickerRight isLoading={isLoading} selectedValue={selectedValue} />

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
@@ -1,9 +1,5 @@
 import { type PreloadedState, renderWithStoreProvider } from '@suite-native/test-utils';
-import {
-    cexdirectFloatingQuote,
-    getWalletState,
-    mercuryoFixedWorstQuote,
-} from '@suite-native/trading-fixtures';
+import { getWalletState, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
 import {
     ExchangeProviderPicker,
@@ -52,21 +48,5 @@ describe('ExchangeProviderPicker', () => {
 
         expect(getByText('Provider')).toBeOnTheScreen();
         expect(getByText('Mercuryo')).toBeOnTheScreen();
-    });
-
-    it('should render KYC warning for provider with "KYC-required"', () => {
-        const { getByText } = renderExchangeProviderPicker({
-            selectedValue: cexdirectFloatingQuote,
-        });
-
-        expect(getByText('This provider requires to verify identity.')).toBeOnTheScreen();
-    });
-
-    it('should not render KYC provider warning for providers with "noKYC"', () => {
-        const { queryByText } = renderExchangeProviderPicker({
-            selectedValue: mercuryoFixedWorstQuote,
-        });
-
-        expect(queryByText('This provider requires to verify identity.')).toBeNull();
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Move the KYC warning to exchange preview
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/23830

## Screenshots:
<img width="320"  alt="Simulator Screenshot - iPhone 16e - 2026-04-20 at 13 06 19" src="https://github.com/user-attachments/assets/fd916d47-269b-4e7d-bbb1-d30654fbecf4" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/23830-move-kyc-warning-for-cex-to-review-step&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->