### PR TITLE
feat(suite-native): stablecoin-yield cta buttons + apy breakdown alert

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2025,6 +2025,14 @@ export const messages = {
                 vault: 'Vault',
                 apy: 'Annual percentage yield',
                 supplied: 'Supplied',
+                supplyMore: 'Supply more',
+                withdraw: 'Withdraw',
+                apyBreakdown: {
+                    apyLabel: '{apy} APY',
+                    autoCompounded: 'Automatically added and compounded.',
+                    manualCompound: 'Manually claim and deposit to compound.',
+                    footer: 'APY may change over time.',
+                },
             },
         },
         emptyState: {

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+
+import { type RewardDto } from '@suite-common/earn-api';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type TokenAddress } from '@suite-common/wallet-types';
+import { Box, HStack, Text, VStack } from '@suite-native/atoms';
+import { CryptoIconWithNetwork, Icon, cryptoIconSizes } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+
+import { getApyBreakdownDescriptionKey, getApyPercent, sortApyRewards } from '../utils';
+
+type StablecoinYieldApyBreakdownProps = {
+    networkSymbol: NetworkSymbol;
+    rewards: RewardDto[];
+};
+
+type RewardRowProps = {
+    reward: RewardDto;
+    networkSymbol: NetworkSymbol;
+};
+
+const RewardRow = ({ reward, networkSymbol }: RewardRowProps) => {
+    const rewardRatePercent = getApyPercent(reward.rate);
+    const descriptionKey = getApyBreakdownDescriptionKey(reward.yieldSource);
+    const rewardSymbol = reward.token.symbol || reward.token.name || '';
+
+    return (
+        <HStack spacing="sp8" alignItems="center">
+            <Box flex={1}>
+                <VStack spacing={0}>
+                    <HStack justifyContent="space-between">
+                        <HStack alignItems="center">
+                            <CryptoIconWithNetwork
+                                symbol={networkSymbol}
+                                contractAddress={reward.token.address as TokenAddress | undefined}
+                                size="extraSmall"
+                            />
+                            <Text variant="body-md">{rewardSymbol}</Text>
+                        </HStack>
+                        {rewardRatePercent !== null && rewardRatePercent > 0 && (
+                            <Text variant="body-md" color="contentPrimary">
+                                +{rewardRatePercent.toFixed(2)}%
+                            </Text>
+                        )}
+                    </HStack>
+                    {descriptionKey && (
+                        <Box style={{ marginLeft: cryptoIconSizes.extraSmall }} paddingLeft="sp8">
+                            <Text variant="body-sm" color="contentSecondary">
+                                <Translation id={descriptionKey} />
+                            </Text>
+                        </Box>
+                    )}
+                </VStack>
+            </Box>
+        </HStack>
+    );
+};
+
+export const StablecoinYieldApyBreakdown = ({
+    networkSymbol,
+    rewards,
+}: StablecoinYieldApyBreakdownProps) => {
+    const sortedRewards = useMemo(() => sortApyRewards(rewards), [rewards]);
+
+    return (
+        <Box testID="@account-detail/stablecoin-yield/apy-breakdown-sheet">
+            <VStack spacing="sp20">
+                {sortedRewards.map((reward, index) => (
+                    <RewardRow
+                        key={`${reward.token.symbol}-${reward.yieldSource}-${index}`}
+                        reward={reward}
+                        networkSymbol={networkSymbol}
+                    />
+                ))}
+                <HStack spacing="sp8" alignItems="center">
+                    <Icon name="arrowsDownUp" size="medium" color="contentSecondary" />
+                    <Text variant="body-md" color="contentSecondary">
+                        <Translation id="moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.footer" />
+                    </Text>
+                </HStack>
+            </VStack>
+        </Box>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -1,15 +1,28 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { useAllYieldOpportunities } from '@suite-common/earn-api';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
-import { Box, Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
+import { useAlert } from '@suite-native/alerts';
+import {
+    Box,
+    Button,
+    Card,
+    CardDivider,
+    HStack,
+    PressableOpacity,
+    Text,
+    VStack,
+} from '@suite-native/atoms';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 import { TokenAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork, Icon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
+
+import { StablecoinYieldApyBreakdown } from './StablecoinYieldApyBreakdown';
+import { getApyPercent } from '../utils';
 
 type StablecoinYieldTokenOverviewProps = {
     accountKey: AccountKey;
@@ -20,6 +33,8 @@ export const StablecoinYieldTokenOverview = ({
     accountKey,
     tokenContract,
 }: StablecoinYieldTokenOverviewProps) => {
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
     const isEnabled = useFeatureFlag(FeatureFlag.IsStablecoinYieldEnabled);
     const { yieldOpportunities } = useAllYieldOpportunities({ enabled: isEnabled });
     const account = useSelector((state: AccountsRootState) =>
@@ -35,13 +50,52 @@ export const StablecoinYieldTokenOverview = ({
         return yieldOpportunities.find(v => v.token.address?.toLowerCase() === normalizedContract);
     }, [yieldOpportunities, tokenContract]);
 
+    const apyPercent =
+        vault?.rewardRate.total != null ? getApyPercent(vault.rewardRate.total)?.toFixed(2) : null;
+    const apy = apyPercent !== null ? `~${apyPercent}%` : null;
+
+    const handleShowWipAlert = useCallback(
+        () =>
+            showAlert({
+                title: 'Work in progress',
+                description: 'This action is not available yet.',
+                primaryButtonTitle: translate('generic.buttons.gotIt'),
+            }),
+        [showAlert, translate],
+    );
+
+    const handleOpenApyAlert = useCallback(() => {
+        if (!account || !vault) {
+            return;
+        }
+
+        showAlert({
+            title: vault.outputToken?.name ?? '',
+            description: translate(
+                'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.apyLabel',
+                { apy },
+            ),
+            appendix: (
+                <StablecoinYieldApyBreakdown
+                    networkSymbol={account.symbol}
+                    rewards={vault.rewardRate.components}
+                />
+            ),
+            textAlign: 'center',
+            titleSpacing: 'sp4',
+            primaryButtonTitle: translate('generic.buttons.close'),
+            testID: '@account-detail/stablecoin-yield/apy-breakdown-alert',
+        });
+    }, [account, apy, showAlert, translate, vault]);
+
     if (!isEnabled || !vault) return null;
 
     const vaultName = vault.outputToken?.name ?? '';
-    const apy =
-        vault.rewardRate.total != null ? `${(vault.rewardRate.total * 100).toFixed(2)}%` : null;
     const apyColor = apy === null ? 'contentSecondary' : 'contentPrimary';
     const apyValue = apy ?? <Translation id="earn.notAvailable" />;
+    const hasSuppliedValue = !!account && !!token;
+    const hasApyBreakdown = vault.rewardRate.components.length > 0;
+    const isApyRowDisabled = apy === null || !hasApyBreakdown || !account;
 
     return (
         <Box marginHorizontal="sp16">
@@ -63,20 +117,26 @@ export const StablecoinYieldTokenOverview = ({
                         <Text variant="body-sm">{vaultName}</Text>
                     </HStack>
                     <CardDivider />
-                    <HStack justifyContent="space-between" alignItems="center">
-                        <Text variant="body-sm" color="contentSecondary">
-                            <Translation id="moduleAccounts.accountDetail.stablecoinYield.apy" />
-                        </Text>
-                        <Text variant="body-sm" color={apyColor}>
-                            {apyValue}
-                        </Text>
-                    </HStack>
+                    <PressableOpacity
+                        onPress={handleOpenApyAlert}
+                        disabled={isApyRowDisabled}
+                        testID="@account-detail/stablecoin-yield/apy-row"
+                    >
+                        <HStack justifyContent="space-between" alignItems="center">
+                            <Text variant="body-sm" color="contentSecondary">
+                                <Translation id="moduleAccounts.accountDetail.stablecoinYield.apy" />
+                            </Text>
+                            <Text variant="body-sm" color={apyColor}>
+                                {apyValue}
+                            </Text>
+                        </HStack>
+                    </PressableOpacity>
                     <CardDivider />
                     <HStack justifyContent="space-between" alignItems="center">
                         <Text variant="body-sm" color="contentSecondary">
                             <Translation id="moduleAccounts.accountDetail.stablecoinYield.supplied" />
                         </Text>
-                        {account && token && (
+                        {hasSuppliedValue && (
                             <HStack alignItems="center" spacing="sp8">
                                 <CryptoIconWithNetwork
                                     symbol={account.symbol}
@@ -92,6 +152,32 @@ export const StablecoinYieldTokenOverview = ({
                             </HStack>
                         )}
                     </HStack>
+                    {hasSuppliedValue && (
+                        <HStack spacing="sp12">
+                            <Box flex={1}>
+                                <Button
+                                    onPress={handleShowWipAlert}
+                                    intent="brand"
+                                    priority="secondary"
+                                    size="medium"
+                                    testID="@account-detail/stablecoin-yield/supply-more-button"
+                                >
+                                    <Translation id="moduleAccounts.accountDetail.stablecoinYield.supplyMore" />
+                                </Button>
+                            </Box>
+                            <Box flex={1}>
+                                <Button
+                                    onPress={handleShowWipAlert}
+                                    intent="brand"
+                                    priority="secondary"
+                                    size="medium"
+                                    testID="@account-detail/stablecoin-yield/withdraw-button"
+                                >
+                                    <Translation id="moduleAccounts.accountDetail.stablecoinYield.withdraw" />
+                                </Button>
+                            </Box>
+                        </HStack>
+                    )}
                 </VStack>
             </Card>
         </Box>

--- a/suite-native/module-accounts-management/src/utils.ts
+++ b/suite-native/module-accounts-management/src/utils.ts
@@ -1,0 +1,39 @@
+import { type RewardDto, type RewardDtoYieldSource } from '@suite-common/earn-api';
+import { type TxKeyPath } from '@suite-native/intl';
+import { BigNumber } from '@trezor/utils';
+
+export const getApyPercent = (apyRate: number): number | null => {
+    if (!Number.isFinite(apyRate)) {
+        return null;
+    }
+
+    return new BigNumber(apyRate).times(100).decimalPlaces(2).toNumber();
+};
+
+export const sortApyRewards = (rewards: RewardDto[]) =>
+    rewards.toSorted((rewardA, rewardB) => {
+        if (rewardA.yieldSource === 'vault') {
+            return -1;
+        }
+
+        if (rewardB.yieldSource === 'vault') {
+            return 1;
+        }
+
+        return rewardB.rate - rewardA.rate;
+    });
+
+export const getApyBreakdownDescriptionKey = (
+    yieldSource: RewardDtoYieldSource,
+): TxKeyPath | null => {
+    switch (yieldSource) {
+        case 'vault':
+        case 'lending_interest':
+            return 'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.autoCompounded';
+        case 'protocol_incentive':
+        case 'points':
+            return 'moduleAccounts.accountDetail.stablecoinYield.apyBreakdown.manualCompound';
+        default:
+            return null;
+    }
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

added cta button on stablecoin yield dashboard
created apy breakdown alert

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:


<img width="603" height="1311" alt="IMG_4611" src="https://github.com/user-attachments/assets/716e4ff7-37a8-473e-ae11-4d3a64d11b0f" />
<img width="603" height="1311" alt="IMG_4610" src="https://github.com/user-attachments/assets/2dee894c-2b9f-45c4-bb65-9c99e791fbb3" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/stablecoin-yield-dashboard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->