### PR TITLE
Electorn one trace

### DIFF
--- a/suite/e2e/support/setup.ts
+++ b/suite/e2e/support/setup.ts
@@ -1,0 +1,125 @@
+import { BrowserContext, TestInfo } from '@playwright/test';
+import { execSync } from 'child_process';
+
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+
+import { BRIDGE_VERSION } from './bridge';
+import { getVideoPath, mockRemoteMessageSystem } from './common';
+import { Suite, launchSuite } from './electron';
+import { ElectronConf } from './types';
+
+export const electronSetup = async (
+    testInfo: TestInfo,
+    locale: string | undefined,
+    colorScheme: any,
+    electronConf: ElectronConf,
+) => {
+    // Activate the test-runner's TestTracing so test.step(), beforeEach, and
+    // fixture events are recorded. Config-level trace: 'off' suppresses this by
+    // default for Electron projects (playwright#13180 workaround).
+    await (testInfo as any)._tracing.startIfNeeded('on');
+
+    const suite = await launchSuite({
+        locale,
+        colorScheme,
+        artefactFolder: testInfo.outputDir,
+        viewport: testInfo.project.use.viewport!,
+        ...electronConf,
+    });
+
+    // Mocks shell.openExternal to prevent opening real browser windows.
+    await suite.electronApp.evaluate(({ shell }) => {
+        shell.openExternal = (url: string) => {
+            console.warn(`[mock] shell.openExternal called with: ${url}`);
+
+            return Promise.resolve(); // satisfies the 'async' requirement implicitly
+        };
+    });
+
+    await suite.window
+        .context()
+        .tracing.start({ screenshots: true, snapshots: true, sources: true });
+    // this setting only takes effect for the renderer process. To emulate offline mode also in the main process, a custom runtime flag is used.
+    await suite.electronApp.context().setOffline(electronConf.offlineMode ?? false);
+
+    await mockRemoteMessageSystem(suite.window);
+
+    return suite;
+};
+
+export const electronTeardown = async (
+    suite: Suite,
+    testInfo: TestInfo,
+    electronConf: ElectronConf,
+) => {
+    // Save the CDP context trace to a path registered in TestTracing._temporaryTraceFiles.
+    // TestTracing.stopIfNeeded() (called automatically by Playwright) will merge it with
+    // the test-runner step trace (test.trace) into a single trace.zip attachment.
+    const tracingPath =
+        (testInfo as any)._tracing.maybeGenerateNextTraceRecordingPath() ??
+        `${testInfo.outputDir}/trace.electron.zip`;
+    await suite.window.context().tracing.stop({ path: tracingPath });
+    testInfo.attachments.push({
+        name: 'electron-logs.txt',
+        path: `${testInfo.outputDir}/electron-logs.txt`,
+        contentType: 'text/plain',
+    });
+    const videoPath = getVideoPath(testInfo.outputDir);
+    if (videoPath) {
+        testInfo.attachments.push({
+            name: 'video',
+            path: videoPath,
+            contentType: 'video/webm',
+        });
+    }
+    const closePromise = suite.electronApp.close();
+    // Handle modal that asks to enable auto-start
+    if (electronConf.exposeConnectWs) {
+        await suite.window.getByTestId('@auto-start-before-quit/button-quit').click();
+    }
+    await closePromise;
+};
+
+export const webSetup = async (browserContext: BrowserContext) => {
+    await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
+
+    // Need to allow this to be able to access bridge on localhost
+    // When running tests against suite deployed elsewhere
+    if (browserContext.browser()?.browserType().name() === 'chromium') {
+        await browserContext.grantPermissions(['local-network-access']);
+    }
+
+    const page = await browserContext.newPage();
+
+    // Tells the app to attach Redux Store to window object. packages/suite-web/src/support/usePlaywright.ts
+    // Which is needed for methods manupalating Redux store like onboardingPage.disableFirmwareHashCheck
+    await page.context().addInitScript(() => {
+        window.Playwright = true;
+    });
+    await page.goto('./');
+    await mockRemoteMessageSystem(page);
+
+    return page;
+};
+
+// Gives trezorUserEnv promise a 30s to complete, else restart tenv to recover from potential hangs
+export const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise(
+        (_, reject) =>
+            (timeoutId = setTimeout(() => {
+                if (process.env.COMPOSE_FILE) {
+                    execSync('docker compose restart trezor-user-env-unix', { cwd: '../../' }); // restart tenv to fix potential hangs
+                }
+                reject(new Error('TrezorUserEnv action timed out'));
+            }, 30_000)),
+    );
+
+    const promiseWithClearingTimeout = async () => {
+        await promise;
+        clearTimeout(timeoutId);
+    };
+
+    await Promise.race([promiseWithClearingTimeout(), timeoutPromise]);
+};

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,20 +1,18 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { BrowserContext, Page, TestInfo, test as base } from '@playwright/test';
-import { execSync } from 'child_process';
+import { Page, test as base } from '@playwright/test';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { SetupEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import { getUrl, getVideoPath, isDesktopProject, mockRemoteMessageSystem } from '../common';
-import { Suite, launchSuite } from '../electron';
 import { collectCoverageMap } from './coverageMapFixture';
+import { getUrl, isDesktopProject } from '../common';
 import { currentsTest } from './currentsFixture';
 import { enhancePage } from './enhancePage';
-import { BRIDGE_VERSION } from '../bridge';
 import { PlaywrightTarget, SuiteTestOptions } from './suiteTestOptions';
 import { DeviceFixture } from '../device';
 import { wipeAndRestartEvoluServer } from '../helpers/evoluClient';
+import { electronSetup, electronTeardown, trezorUserEnvStuckProtection, webSetup } from '../setup';
 import { ElectronConf, TrezorUserEnv } from '../types';
 
 type SuiteBaseFixture = {
@@ -31,113 +29,6 @@ type SuiteBaseFixture = {
     page: Page;
     exceptionLogger: void;
     coverageMapCollector: void;
-};
-
-const electronSetup = async (
-    testInfo: TestInfo,
-    locale: string | undefined,
-    colorScheme: any,
-    electronConf: ElectronConf,
-) => {
-    const suite = await launchSuite({
-        locale,
-        colorScheme,
-        artefactFolder: testInfo.outputDir,
-        viewport: testInfo.project.use.viewport!,
-        ...electronConf,
-    });
-
-    // Mocks shell.openExternal to prevent opening real browser windows.
-    await suite.electronApp.evaluate(({ shell }) => {
-        shell.openExternal = (url: string) => {
-            console.warn(`[mock] shell.openExternal called with: ${url}`);
-
-            return Promise.resolve(); // satisfies the 'async' requirement implicitly
-        };
-    });
-
-    await suite.window
-        .context()
-        .tracing.start({ screenshots: true, snapshots: true, sources: true });
-    // this setting only takes effect for the renderer process. To emulate offline mode also in the main process, a custom runtime flag is used.
-    await suite.electronApp.context().setOffline(electronConf.offlineMode ?? false);
-
-    await mockRemoteMessageSystem(suite.window);
-
-    return suite;
-};
-
-const electronTeardown = async (suite: Suite, testInfo: TestInfo, electronConf: ElectronConf) => {
-    const tracePath = `${testInfo.outputDir}/trace.electron.zip`;
-    await suite.window.context().tracing.stop({ path: tracePath });
-    testInfo.attachments.push({
-        name: 'electron-logs.txt',
-        path: `${testInfo.outputDir}/electron-logs.txt`,
-        contentType: 'text/plain',
-    });
-    testInfo.attachments.push({
-        name: 'trace',
-        path: tracePath,
-        contentType: 'application/zip',
-    });
-    const videoPath = getVideoPath(testInfo.outputDir);
-    if (videoPath) {
-        testInfo.attachments.push({
-            name: 'video',
-            path: videoPath,
-            contentType: 'video/webm',
-        });
-    }
-    const closePromise = suite.electronApp.close();
-    // Handle modal that asks to enable auto-start
-    if (electronConf.exposeConnectWs) {
-        await suite.window.getByTestId('@auto-start-before-quit/button-quit').click();
-    }
-    await closePromise;
-};
-
-const webSetup = async (browserContext: BrowserContext) => {
-    await TrezorUserEnvLink.startBridge(BRIDGE_VERSION);
-
-    // Need to allow this to be able to access bridge on localhost
-    // When running tests against suite deployed elsewhere
-    if (browserContext.browser()?.browserType().name() === 'chromium') {
-        await browserContext.grantPermissions(['local-network-access']);
-    }
-
-    const page = await browserContext.newPage();
-
-    // Tells the app to attach Redux Store to window object. packages/suite-web/src/support/usePlaywright.ts
-    // Which is needed for methods manupalating Redux store like onboardingPage.disableFirmwareHashCheck
-    await page.context().addInitScript(() => {
-        window.Playwright = true;
-    });
-    await page.goto('./');
-    await mockRemoteMessageSystem(page);
-
-    return page;
-};
-
-// Gives trezorUserEnv promise a 30s to complete, else restart tenv to recover from potential hangs
-const trezorUserEnvStuckProtection = async (promise: Promise<any>) => {
-    let timeoutId: ReturnType<typeof setTimeout>;
-
-    const timeoutPromise = new Promise(
-        (_, reject) =>
-            (timeoutId = setTimeout(() => {
-                if (process.env.COMPOSE_FILE) {
-                    execSync('docker compose restart trezor-user-env-unix', { cwd: '../../' }); // restart tenv to fix potential hangs
-                }
-                reject(new Error('TrezorUserEnv action timed out'));
-            }, 30_000)),
-    );
-
-    const promiseWithClearingTimeout = async () => {
-        await promise;
-        clearTimeout(timeoutId);
-    };
-
-    await Promise.race([promiseWithClearingTimeout(), timeoutPromise]);
 };
 
 // This is the base Suite text fixture containing all the necessary setup and core page object


### PR DESCRIPTION
As I am building the nightly agent, I had to solve the problem we have since for ever with two electron traces. Because the nightly agent will be analyzing this aritfacts.

WE will see how fragile this solution is. As it is using internal calls of Playwright. We might need to fix it from time to time when we upgrade PLaywright.

This solution solves:
- only one trace
- trace contains visual snapshots (orignal electron trace did because of 4 years old bug that MS will never fix)
- trace contains beforeEAch, fixture inticializaions, test steps (that our second trace did not have before)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=electorn-one-trace&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=electorn-one-trace&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 30 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T05:19:48.093Z • 30 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T05:18:50.796Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/electorn-one-trace/web/](https://dev.suite.sldev.cz/suite-web/electorn-one-trace/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->