### PR TITLE
chore: bump TypeScript to 5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
         "s": "yarn native:start"
     },
     "resolutions": {
-        "typescript": "5.8.3",
+        "typescript": "5.9.3",
         "prettier": "^3.8.1",
         "react-native": "0.83.2",
         "type-fest": "5.5.0",
@@ -155,7 +155,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.6.2",
         "tsx": "^4.21.0",
-        "typescript": "5.8.3",
+        "typescript": "5.9.3",
         "typescript-eslint": "^8.57.2",
         "version-bump-prompt": "^6.1.0"
     },

--- a/packages/connect-examples/mobile-expo/package.json
+++ b/packages/connect-examples/mobile-expo/package.json
@@ -20,7 +20,7 @@
     "devDependencies": {
         "@babel/core": "7.29.0",
         "@types/react": "19.2.14",
-        "typescript": "5.8.3"
+        "typescript": "5.9.3"
     },
     "private": true
 }

--- a/packages/connect/src/api/firmware/calculateFirmwareHash.ts
+++ b/packages/connect/src/api/firmware/calculateFirmwareHash.ts
@@ -27,7 +27,7 @@ const firmwareSizeMap: Partial<Record<DeviceModelInternal, number>> = {
 
 type CalculateFirmwareHashParams = {
     internal_model: DeviceModelInternal;
-    fw: ArrayBuffer;
+    fw: Buffer;
     firmwareVersion: VersionArray;
     key?: Buffer;
 };

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -3,7 +3,7 @@ import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 import { parseConfigure } from '@trezor/protobuf';
 import { v1 as protocolV1 } from '@trezor/protocol';
 import { buildMessage } from '@trezor/transport/src/utils/send';
-import { Log } from '@trezor/utils';
+import { Log, bufferUtils } from '@trezor/utils';
 
 import * as mockFwHash from '../../api/firmware/calculateFirmwareHash';
 import { DataManager } from '../../data/DataManager';
@@ -160,6 +160,9 @@ const httpRequestMock = (version?: number[]) => {
     return Promise.resolve(binary);
 };
 
+const getFirmwareBinaryBytes = async (version?: number[]): Promise<ArrayBuffer> =>
+    bufferUtils.bufferToBytes(await httpRequestMock(version));
+
 const calculateFirmwareHashMock = (hash?: string) => ({
     hash:
         hash ||
@@ -304,7 +307,7 @@ describe('onCallFirmwareUpdate', () => {
             buildFixture('0037', {}),
         ]);
 
-        const binary = await httpRequestMock([2, 8, 3]);
+        const binary = await getFirmwareBinaryBytes([2, 8, 3]);
         const result = await runFirmwareUpdate({
             params: { binary },
             context,
@@ -426,7 +429,7 @@ describe('onCallFirmwareUpdate', () => {
             buildFixture('0037', {}),
         ]);
 
-        const binary = await httpRequestMock();
+        const binary = await getFirmwareBinaryBytes();
         const result = await runFirmwareUpdate({
             params: { binary },
             context,
@@ -451,7 +454,7 @@ describe('onCallFirmwareUpdate', () => {
             buildFixture('0037', {}),
         ]);
 
-        const binary = await httpRequestMock();
+        const binary = await getFirmwareBinaryBytes();
         const result = await runFirmwareUpdate({
             params: { binary },
             context,

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -78,7 +78,7 @@ export const checkFirmwareHash = async ({
     const { hash: expectedHash, challenge } = calculateFirmwareHash({
         internal_model: device.features.internal_model,
         firmwareVersion,
-        fw: strippedBinary,
+        fw: Buffer.from(strippedBinary),
         key: randomBytes(32),
     });
 

--- a/packages/device-authenticity/src/verifySignatures.ts
+++ b/packages/device-authenticity/src/verifySignatures.ts
@@ -2,6 +2,7 @@ import { ed25519 } from '@noble/curves/ed25519.js';
 import crypto from 'crypto';
 
 import { getSubtleCrypto } from '@trezor/crypto-utils';
+import { bufferUtils } from '@trezor/utils';
 
 import { type VerifySignature } from './types';
 import { type AlgorithmName, fixSignature } from './x509certificate';
@@ -19,7 +20,7 @@ export const verifySignatureP256: VerifySignature = async (rawKey, data, signatu
         // get ECDSA P-256 (secp256r1) key from RAW key
         const ecPubKey = await SubtleCrypto.importKey(
             'raw',
-            rawKey,
+            bufferUtils.toNonSharedBuffer(rawKey),
             { name: 'ECDSA', namedCurve: 'P-256' },
             true,
             ['verify'],

--- a/packages/protocol/tests/protocol-trzd.test.ts
+++ b/packages/protocol/tests/protocol-trzd.test.ts
@@ -1,5 +1,9 @@
 import { trzd } from '../src/index';
 
+// duplicates the same fn from bufferUtils, to avoid a new dependency
+const bufferToBytes = (buffer: Buffer<ArrayBuffer>): ArrayBuffer =>
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
 describe('protocol-v1', () => {
     it('decode', () => {
         // Testnet chain
@@ -9,7 +13,7 @@ describe('protocol-v1', () => {
         );
         let read;
 
-        read = trzd.decode(data);
+        read = trzd.decode(bufferToBytes(data));
         expect(read.magic).toEqual('trzd1');
         expect(read.definitionType).toEqual(0);
         expect(read.protobufLength).toEqual(19);
@@ -22,7 +26,7 @@ describe('protocol-v1', () => {
             '74727a643101585a686532000a147af963cf6d228e564e2a0aa0ddbf06210b38615d10051a0354535420122a11676f65726c69205465737420746f6b656eDEAD',
             'hex',
         );
-        read = trzd.decode(data);
+        read = trzd.decode(bufferToBytes(data));
         expect(read.magic).toEqual('trzd1');
         expect(read.definitionType).toEqual(1);
         expect(read.protobufLength).toEqual(50);
@@ -38,7 +42,7 @@ describe('protocol-v1', () => {
             `74727a643100585a6865${len.toString('hex')}${longName.toString('hex')}DEAD`,
             'hex',
         );
-        read = trzd.decode(data);
+        read = trzd.decode(bufferToBytes(data));
         expect(read.protobufLength).toEqual(400);
         expect(read.protobufPayload).toEqual(longName);
     });

--- a/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
+++ b/packages/suite/src/utils/suite/__tests__/homescreen.test.ts
@@ -1,4 +1,5 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { bufferUtils } from '@trezor/utils';
 
 import {
     dataUrlToImage,
@@ -113,7 +114,8 @@ describe('homescreen', () => {
     describe(isProgressiveJPG.name, () => {
         fixtures.isProgressiveJPG.forEach(fixture => {
             it(fixture.description, () => {
-                const result = isProgressiveJPG(fixture.buffer, fixture.deviceModelInternal);
+                const rawBytes = bufferUtils.bufferToBytes(Buffer.from(fixture.buffer));
+                const result = isProgressiveJPG(rawBytes, fixture.deviceModelInternal);
                 expect(result).toBe(fixture.result);
             });
         });

--- a/packages/transport/src/utils/receive.ts
+++ b/packages/transport/src/utils/receive.ts
@@ -17,7 +17,7 @@ export async function receive<T extends Receiver>(receiver: T, protocol: Transpo
         const { length, messageType, payload, header } = protocol.decode(readResult.payload);
         const [, chunkHeader] = protocol.getHeaders(data);
 
-        const result = Buffer.alloc(length);
+        const result: Buffer = Buffer.alloc(length);
         payload.copy(result);
 
         let offset = payload.length;

--- a/packages/trezor-user-env-link/package.json
+++ b/packages/trezor-user-env-link/package.json
@@ -17,6 +17,6 @@
     },
     "devDependencies": {
         "ts-node": "^10.9.2",
-        "typescript": "5.8.3"
+        "typescript": "5.9.3"
     }
 }

--- a/packages/utils/src/bufferUtils.ts
+++ b/packages/utils/src/bufferUtils.ts
@@ -1,4 +1,4 @@
-export const reverseBuffer = (src: Buffer) => {
+export const reverseBuffer = (src: Buffer): Buffer => {
     if (src.length < 1) return src;
     const buffer = Buffer.alloc(src.length);
     let j = buffer.length - 1;
@@ -11,7 +11,7 @@ export const reverseBuffer = (src: Buffer) => {
     return buffer;
 };
 
-export const getChunkSize = (n: number) => {
+export const getChunkSize = (n: number): Buffer => {
     const buf = Buffer.allocUnsafe(1);
     buf.writeUInt8(n);
 

--- a/packages/utils/src/bufferUtils.ts
+++ b/packages/utils/src/bufferUtils.ts
@@ -17,3 +17,20 @@ export const getChunkSize = (n: number) => {
 
     return buf;
 };
+
+export const bufferToBytes = (buffer: Buffer<ArrayBuffer>): ArrayBuffer =>
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
+/**
+ * Forces the broader ArrayBufferLike buffer (a shared or non-shared buffer) to the plain non-shared buffer if needed,
+ * though a non-shared buffer is left unchanged.
+ * Our codebase should generally work with the broader type, but conversion is needed to interface with APIs
+ * that only accept non-shared buffers (e.g. `crypto.subtle.digest`).
+ */
+export const toNonSharedBuffer = (view: Buffer<ArrayBufferLike>): Buffer<ArrayBuffer> => {
+    if (view.buffer instanceof ArrayBuffer) {
+        return view as Buffer<ArrayBuffer>;
+    }
+
+    return Buffer.from(view); // byte-copy of original buffer
+};

--- a/packages/utils/src/getRandomInt.ts
+++ b/packages/utils/src/getRandomInt.ts
@@ -37,8 +37,8 @@ export const getRandomInt = (min: number, max: number) => {
 
     const getRandomValues =
         typeof window !== 'undefined'
-            ? (array: Uint32Array) => window.crypto.getRandomValues(array)
-            : (array: Uint32Array) => cryptoGetRandomValues(array);
+            ? (array: ArrayBufferView<ArrayBuffer>) => window.crypto.getRandomValues(array)
+            : (array: ArrayBufferView<ArrayBuffer>) => cryptoGetRandomValues(array);
 
     const array = new Uint32Array(1); // This provides 32 bits of entropy.
 

--- a/packages/utils/src/zip.ts
+++ b/packages/utils/src/zip.ts
@@ -1,6 +1,8 @@
+type BlobableBuffer = ArrayBuffer | Uint8Array<ArrayBuffer>; // only those subtypes of BlobPart that are buffers, not strings or Blobs
+
 export const createZip = (buffers: { name: string; content: ArrayBuffer }[]) => {
-    const fileEntries: ArrayBuffer[] = [];
-    const centralDirectory: ArrayBuffer[] = [];
+    const fileEntries: BlobableBuffer[] = [];
+    const centralDirectory: BlobableBuffer[] = [];
     let offset = 0;
 
     buffers.forEach(({ name, content }) => {

--- a/packages/utils/tests/bufferUtils.test.ts
+++ b/packages/utils/tests/bufferUtils.test.ts
@@ -1,7 +1,7 @@
-import { reverseBuffer } from '../src/bufferUtils';
+import { bufferToBytes, getChunkSize, reverseBuffer, toNonSharedBuffer } from '../src/bufferUtils';
 
-describe('bufferUtils', () => {
-    it('reverseBuffer', () => {
+describe(reverseBuffer.name, () => {
+    it('reverses a buffer by bytes', () => {
         expect(reverseBuffer(Buffer.from('abcd', 'hex'))).toEqual(Buffer.from('cdab', 'hex'));
 
         expect(
@@ -12,5 +12,74 @@ describe('bufferUtils', () => {
                 ),
             ).toString('hex'),
         ).toEqual('b5f59e2273c85b93aa9deff9bba5d7deace78610d3b0fb892a7ba6d86f36ac0d');
+    });
+});
+
+describe(getChunkSize.name, () => {
+    it('returns a single-byte buffer containing the given value', () => {
+        const result = getChunkSize(5);
+
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBe(5);
+    });
+
+    it('handles boundary value 0', () => {
+        expect(getChunkSize(0)[0]).toBe(0);
+    });
+
+    it('handles boundary value 255 (max UInt8)', () => {
+        expect(getChunkSize(255)[0]).toBe(255);
+    });
+});
+
+describe(bufferToBytes.name, () => {
+    it('returns an ArrayBuffer with the same bytes as the input buffer', () => {
+        const buffer = Buffer.from([0x01, 0x02, 0x03]) as Buffer<ArrayBuffer>;
+        const result = bufferToBytes(buffer);
+
+        expect(result).toBeInstanceOf(ArrayBuffer);
+        expect(new Uint8Array(result)).toEqual(new Uint8Array([0x01, 0x02, 0x03]));
+    });
+
+    it('handles an empty buffer', () => {
+        const buffer = Buffer.alloc(0) as Buffer<ArrayBuffer>;
+        const result = bufferToBytes(buffer);
+
+        expect(result).toBeInstanceOf(ArrayBuffer);
+        expect(result.byteLength).toBe(0);
+    });
+
+    it('returns only the slice corresponding to the buffer when byteOffset is non-zero', () => {
+        const underlying = new ArrayBuffer(5);
+        new Uint8Array(underlying).set([0xaa, 0xbb, 0xcc, 0xdd, 0xee]);
+        // Create a view starting at byte 1 with length 3 → [0xbb, 0xcc, 0xdd]
+        const buffer = Buffer.from(underlying, 1, 3) as Buffer<ArrayBuffer>;
+        const result = bufferToBytes(buffer);
+
+        expect(result.byteLength).toBe(3);
+        expect(new Uint8Array(result)).toEqual(new Uint8Array([0xbb, 0xcc, 0xdd]));
+    });
+});
+
+describe(toNonSharedBuffer.name, () => {
+    it('returns the very same buffer reference when backed by a plain ArrayBuffer', () => {
+        const input = Buffer.from([1, 2, 3]) as Buffer<ArrayBufferLike>;
+        const result = toNonSharedBuffer(input);
+
+        expect(result.buffer).toBe(input.buffer);
+    });
+
+    it('copies data into a new plain ArrayBuffer when backed by a SharedArrayBuffer', () => {
+        const shared = new SharedArrayBuffer(3);
+        const input = Buffer.from(shared) as Buffer<ArrayBufferLike>;
+        input[0] = 0xaa;
+        input[1] = 0xbb;
+        input[2] = 0xcc;
+
+        const result = toNonSharedBuffer(input);
+
+        expect(result.buffer).toBeInstanceOf(ArrayBuffer);
+        expect(result.buffer).not.toBe(shared);
+        expect(Array.from(result)).toEqual([0xaa, 0xbb, 0xcc]);
     });
 });

--- a/packages/utxo-lib/src/payments/p2pkh.ts
+++ b/packages/utxo-lib/src/payments/p2pkh.ts
@@ -93,7 +93,7 @@ export function p2pkh(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { version, hash: aHash } = _address();
             if (version !== network.pubKeyHash)

--- a/packages/utxo-lib/src/payments/p2sh.ts
+++ b/packages/utxo-lib/src/payments/p2sh.ts
@@ -125,7 +125,7 @@ export function p2sh(a: Payment, opts?: PaymentOpts): Payment {
     });
 
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { version, hash: aHash } = _address();
             if (version !== network.scriptHash)

--- a/packages/utxo-lib/src/payments/p2tr.ts
+++ b/packages/utxo-lib/src/payments/p2tr.ts
@@ -123,7 +123,7 @@ export function p2tr(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { prefix, version, data } = _address();
             if (prefix !== network.bech32)

--- a/packages/utxo-lib/src/payments/p2wpkh.ts
+++ b/packages/utxo-lib/src/payments/p2wpkh.ts
@@ -101,7 +101,7 @@ export function p2wpkh(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { prefix, version, data } = _address();
             if (network && network.bech32 !== prefix)

--- a/packages/utxo-lib/src/payments/p2wsh.ts
+++ b/packages/utxo-lib/src/payments/p2wsh.ts
@@ -148,7 +148,7 @@ export function p2wsh(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { prefix, version, data } = _address();
             if (prefix !== network.bech32)

--- a/packages/utxo-lib/src/payments/sstxcommitment.ts
+++ b/packages/utxo-lib/src/payments/sstxcommitment.ts
@@ -61,7 +61,7 @@ export function sstxcommitment(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { version, hash: aHash } = _address();
             if (version !== network.pubKeyHash)

--- a/packages/utxo-lib/src/payments/sstxpkh.ts
+++ b/packages/utxo-lib/src/payments/sstxpkh.ts
@@ -57,7 +57,7 @@ export function sstxpkh(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { version, hash: aHash } = _address();
             if (version !== network.pubKeyHash)

--- a/packages/utxo-lib/src/payments/sstxsh.ts
+++ b/packages/utxo-lib/src/payments/sstxsh.ts
@@ -49,7 +49,7 @@ export function sstxsh(a: Payment, opts?: PaymentOpts): Payment {
 
     // extended validation
     if (opts.validate) {
-        let hash = Buffer.from([]);
+        let hash: Buffer = Buffer.from([]);
         if (a.address) {
             const { version, hash: aHash } = _address();
             if (version !== network.scriptHash)

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -212,7 +212,7 @@
         "ts-jest": "29.4.1",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
-        "typescript": "5.8.3",
+        "typescript": "5.9.3",
         "uri-scheme": "^2.0.18"
     },
     "private": true

--- a/suite/metadata/src/providers/DropboxProvider.ts
+++ b/suite/metadata/src/providers/DropboxProvider.ts
@@ -2,7 +2,7 @@ import { Dropbox, DropboxAuth } from 'dropbox';
 import type { users } from 'dropbox';
 
 import { AbstractMetadataProvider } from '@suite-common/metadata-types';
-import { getWeakRandomId } from '@trezor/utils';
+import { bufferUtils, getWeakRandomId } from '@trezor/utils';
 
 import { extractCredentialsFromAuthorizationFlow, getOauthReceiverUrl } from '../oauth';
 
@@ -161,7 +161,10 @@ export class DropboxProvider extends AbstractMetadataProvider {
 
     private async _setFileContent(file: string, content: Buffer) {
         try {
-            const blob = new Blob([content], { type: 'text/plain;charset=UTF-8' });
+            const blobableContent = bufferUtils.toNonSharedBuffer(content);
+            const blob = new Blob([blobableContent], {
+                type: 'text/plain;charset=UTF-8',
+            });
             await this.client.filesUpload({
                 path: `/${file}`,
                 contents: blob,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12134,7 +12134,7 @@ __metadata:
     ts-jest: "npm:29.4.1"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:5.8.3"
+    typescript: "npm:5.9.3"
     uri-scheme: "npm:^2.0.18"
     vm-browserify: "npm:^1.1.2"
     xml2js: "npm:^0.6.2"
@@ -16868,7 +16868,7 @@ __metadata:
     "@trezor/websocket-client": "workspace:*"
     cross-fetch: "npm:^4.1.0"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:5.8.3"
+    typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -22736,7 +22736,7 @@ __metadata:
     expo-status-bar: "npm:~55.0.4"
     react: "npm:19.2.4"
     react-native: "npm:0.83.2"
-    typescript: "npm:5.8.3"
+    typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -44735,7 +44735,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tslib: "npm:^2.6.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:5.8.3"
+    typescript: "npm:5.9.3"
     typescript-eslint: "npm:^8.57.2"
     version-bump-prompt: "npm:^6.1.0"
   dependenciesMeta:
@@ -45263,23 +45263,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
+"typescript@npm:5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/65c40944c51b513b0172c6710ee62e951b70af6f75d5a5da745cb7fab132c09ae27ffdf7838996e3ed603bb015dadd099006658046941bd0ba30340cc563ae92
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
-  version: 5.8.3
-  resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bump TypeScript to 5.9.3

Breaking change: stricter Array types. [Read this issue comment for more explanation by me](https://github.com/trezor/trezor-suite/issues/22515#issuecomment-4280499096).

**TL;DR:**
- in some cases need to broaden the types: accepting `ArrayBufferLike` where now we have inferred type `ArrayBuffer` (narrower), because a lot of built-ins emit the broader one. The general code should work with the more general type. 
- in some cases need stricter types: convert memory view `Buffer` to raw memory bytes `ArrayBuffer`
  - this is really different runtime thing, not just a type nuance! (Buffer is wrapper over ArrayBuffer)
  - → then we must explicitly convert in runtime, while now we rely on _implicit conversion by JS engine_

## Notes for QA

N/A. Though there are some runtime changes, I checked that they are extensively covered by unit tests :heavy_check_mark:  

## Related Issue

Resolve #22515

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/TS593&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->