### PR TITLE
fix: return correct value from selectEthNextRewardPayout

### DIFF
--- a/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts
@@ -1,0 +1,40 @@
+import { selectEthNextRewardPayout } from '../stakeSelectors';
+
+const createStateWithNextRewardPayout = (nextRewardPayout?: number) =>
+    ({
+        wallet: {
+            stake: {
+                data: {
+                    data: {
+                        eth: {
+                            stats: nextRewardPayout
+                                ? {
+                                      nextRewardPayout,
+                                  }
+                                : undefined,
+                        },
+                    },
+                },
+            },
+        },
+    }) as any;
+
+describe('selectEthNextRewardPayout', () => {
+    it('returns null when next reward payout is unavailable', () => {
+        const state = createStateWithNextRewardPayout();
+
+        expect(selectEthNextRewardPayout(state)).toBeNull();
+    });
+
+    it('returns at least 1 day for positive payout values below 1 day', () => {
+        const state = createStateWithNextRewardPayout(60 * 60);
+
+        expect(selectEthNextRewardPayout(state)).toBe(1);
+    });
+
+    it('returns rounded day value for payout values over 1 day', () => {
+        const state = createStateWithNextRewardPayout(2.2 * 24 * 60 * 60);
+
+        expect(selectEthNextRewardPayout(state)).toBe(2);
+    });
+});

--- a/suite-common/wallet-core/src/stake/stakeSelectors.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.ts
@@ -15,7 +15,7 @@ export const selectCardanoPoolsInfo = (state: StakeRootState) =>
 export const selectEthNextRewardPayout = (state: StakeRootState) => {
     const nextRewardPayout = selectStakeData(state).eth?.stats?.nextRewardPayout;
 
-    return nextRewardPayout ? secondsToDays(nextRewardPayout) : null;
+    return nextRewardPayout ? Math.max(1, secondsToDays(nextRewardPayout)) : null;
 };
 
 export const selectEthValidatorsQueue = (state: StakeRootState) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return correct value from `selectEthNextRewardPayout`

## Related Issue

Resolve #26807

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to stakeSelectors.ts and its unit tests. The stakeSelectors file maps to 121 E2E tests due to broad transitive imports, but only the staking-specific E2E tests directly exercise the selector logic that determines staking UI state (amounts, button visibility, progress indicators). The recommended strategy focuses on all staking E2E tests (ETH, ADA, SOL flows and staking form/navigation) which directly consume these selectors. Non-staking tests (backup, browser, metadata, onboarding, etc.) transitively import the file but do not exercise staking functionality, so they are omitted.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (12)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test directly exercises staking navigation flows for ETH and ADA, which rely on staking selectors to determine UI state (e.g., whether staking buttons appear). Changes to stakeSelectors.ts could affect whether staking navigation elements are rendered or clickable.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers the full ETH staking flow including staking dashboard state (empty card visibility, staking amounts, progress indicators), all of which are driven by stake selectors. Changes to stakeSelectors.ts directly impact what staking UI elements are shown.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests the stake-more flow including staking dashboard amounts (staked, pending, rewards), button enabled states, and progress indicators — all derived from stake selectors. Any regression in selector logic would directly affect these assertions.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests unstaking and claiming flows with assertions on staked/unstaking/claimable amounts and button enabled/disabled states. These UI states are computed by stake selectors, making this test directly affected by the changes.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests the staking form's available balance display and validation logic. The available staking balance is likely derived from stake selectors, and changes could affect balance calculations shown in the form.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano staking claim flow with assertions on reward amounts, balance updates, claim button enabled/disabled states, and staked balance text — all derived from stake-related selectors.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests Cardano initial staking including pre-staking state (buttons hidden), post-staking state (reward amounts, unstake button), and staking account visibility — states driven by stake selectors.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests Cardano unstaking with assertions on balance updates, staking state transitions (staked → unstaked), and UI element visibility changes that depend on stake selector computations.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests Solana initial staking flow including empty staking dashboard state, pending amounts after staking, and epoch-based transitions — UI states computed by stake selectors.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests Solana staking rewards display including staked totals, unstaking amounts, and reward values. These amounts are derived from stake selectors and would be directly affected by selector changes.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests adding to existing Solana stake with dashboard amount assertions and pending-to-staked transitions. These computed values come from stake selectors.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests full Solana unstake and claim flow with staking amount transitions, claim card visibility, and post-claim empty state — all dependent on stake selector outputs.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stake/__tests__/stakeSelectors.test.ts`

_Updated: 2026-04-20T13:36:48.618Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sol-rewards&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sol-rewards&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sol-rewards&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T13:42:03.145Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T13:40:47.380Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sol-rewards/web/](https://dev.suite.sldev.cz/suite-web/fix/sol-rewards/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->