### PR TITLE
fix(suite): update Suite Sync promo banner visibility

### DIFF
--- a/packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx
+++ b/packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { selectDeviceStaticSessionId } from '@suite-common/device';
+import { selectDeviceStaticSessionId, selectSelectedDevice } from '@suite-common/device';
 import {
     selectIsSuiteSyncDebugEnabled,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
-import { Button, Column, Icon, Row, Text, TextButton } from '@trezor/components';
+import { Button, Column, IconButton, IconCircle, Row, Text } from '@trezor/components';
 import { SidebarBanner } from '@trezor/product-components';
-import { HELP_CENTER_LABELING } from '@trezor/urls';
 
 import { selectIsLegacyLabelingVisible } from 'src/actions/labels/selectIsLegacyLabelingVisible';
 import { useSelector } from 'src/hooks/suite';
@@ -17,7 +16,9 @@ import { TurnOnSuiteSyncModals } from './TurnOnSuiteSync/TurnOnSuiteSyncModals';
 
 export const SuiteSyncPromoBanner = () => {
     const [isTurnOnSuiteSyncModalVisible, setIsTurnOnSuiteSyncModalVisible] = useState(false);
+    const [isDismissed, setIsDismissed] = useState(false);
 
+    const selectedDevice = useSelector(selectSelectedDevice);
     const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
 
     // Todo: remove for the 26.6 release when we want to start advertising for Suite Sync
@@ -28,8 +29,11 @@ export const SuiteSyncPromoBanner = () => {
         selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
     const shouldDisplayBanner =
+        !isDismissed &&
         isSuiteSyncDebugEnabled &&
         isLegacyLabelingVisible &&
+        selectedDevice !== undefined &&
+        selectedDevice.connected &&
         suiteSyncInteraction !== 'unsupported';
 
     if (!shouldDisplayBanner) {
@@ -37,6 +41,7 @@ export const SuiteSyncPromoBanner = () => {
     }
 
     const handleTurnOn = () => setIsTurnOnSuiteSyncModalVisible(true);
+    const handleDismiss = () => setIsDismissed(true);
 
     return (
         <>
@@ -49,13 +54,11 @@ export const SuiteSyncPromoBanner = () => {
             )}
 
             <SidebarBanner data-testid="@notification/legacy-labeling-upgrade">
-                <Column gap={12} alignItems="start">
-                    <Row>
-                        <Icon name="arrowsCounterClockwise" size={16} />
-                    </Row>
+                <Column gap={8} alignItems="start">
+                    <Column gap={12} alignItems="start">
+                        <IconCircle name="arrowsClockwise" size={32} intent="neutral" />
 
-                    <Column gap={4} alignItems="start">
-                        <Text typographyStyle="headline-sm">
+                        <Text typographyStyle="body-md-strong">
                             <Translation id="TR_TURN_ON_SECURE_SYNC_LABELS_MODAL_HEADING" />
                         </Text>
 
@@ -64,16 +67,24 @@ export const SuiteSyncPromoBanner = () => {
                         </Text>
                     </Column>
 
-                    <TextButton href={HELP_CENTER_LABELING} size="small" isUnderlined>
-                        <Translation id="TR_LEARN_MORE" />
-                    </TextButton>
+                    <Row gap={8} width="100%" alignItems="stretch">
+                        <Button
+                            flex="1"
+                            onClick={handleTurnOn}
+                            data-testid="@notification/legacy-labeling-upgrade/button"
+                        >
+                            <Translation id="TR_LEARN_MORE" />
+                        </Button>
 
-                    <Button
-                        onClick={handleTurnOn}
-                        data-testid="@notification/legacy-labeling-upgrade/button"
-                    >
-                        <Translation id="TR_TURN_ON_SECURE_SYNC" />
-                    </Button>
+                        <IconButton
+                            icon="x"
+                            size="medium"
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={handleDismiss}
+                            aria-label="Close"
+                        />
+                    </Row>
                 </Column>
             </SidebarBanner>
         </>

--- a/packages/theme/src/typography.ts
+++ b/packages/theme/src/typography.ts
@@ -4,14 +4,14 @@ import { type NativeFont } from './fontFamilies';
 import { type FontWeightValue, fontWeights } from './fontWeights';
 
 export const nativeTypographyStyles = [
-    'headline-lg',
-    'headline-md',
-    'headline-sm',
-    'body-md-strong',
-    'body-md',
-    'body-sm-strong',
-    'body-sm',
-    'body-xs',
+    'headline-lg', // 'titleLarge',
+    'headline-md', // 'titleMedium',
+    'headline-sm', // 'titleSmall',
+    'body-md-strong', // 'highlight',
+    'body-md', // 'body',
+    'body-sm-strong', // 'callout',
+    'body-sm', // 'hint',
+    'body-xs', // 'label'
 ] as const;
 
 export const typographyStyles = [...nativeTypographyStyles, 'inherit'] as const;


### PR DESCRIPTION
Fix: 

1. make promo banner for Suite Sync visible only when device is connected
2. fix design to match Figma

<img width="451" height="318" alt="image" src="https://github.com/user-attachments/assets/a5337b58-1b8e-4e1f-847b-a4ec20060b5f" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single UI component (SuiteSyncPromoBanner.tsx) in the labeling/Suite Sync feature area. There is no static test coverage mapping for this file, so all recommendations are inferred from the LLM analysis. The highest-confidence tests are those in the Suite Sync metadata test suite, particularly multi-wallet.test.ts which explicitly asserts on Suite Sync banner visibility and translations. The risk is moderate — a regression would likely manifest as a broken or missing promotional banner in the Suite Sync labeling flow.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/analytics/promo-banner-events.test.ts` — SuiteSyncPromoBanner.tsx is a promotional banner component. This test exercises promo banner display and analytics events on the dashboard, which is the closest test to any promotional banner component. While it tests TEX/TS7 banners specifically, changes to a promo banner component could affect shared banner infrastructure or rendering logic.
- `../../suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — The changed file is SuiteSyncPromoBanner.tsx in the labeling directory, which is part of the Suite Sync labeling feature. This test exercises the Suite Sync label creation flow, and a Suite Sync promo banner could appear during or alongside this workflow, potentially affecting the UI layout or user flow.
- `../../suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test explicitly interacts with the Suite Sync banner (suiteSyncBanner, suiteSyncBannerButton) and asserts on banner visibility/translation keys. The SuiteSyncPromoBanner component is very likely the banner being tested here, making this a direct coverage candidate for the changed file.
- `../../suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test covers Suite Sync setup and label syncing from the relay server. The SuiteSyncPromoBanner may appear as part of the Suite Sync enablement flow, and changes to it could affect the sync setup UX path tested here.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test covers migration from legacy labeling to Suite Sync. The SuiteSyncPromoBanner might appear during the migration flow to promote Suite Sync, and changes could affect whether/how the banner renders during provider switching.
- `../../suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test covers enabling/disabling labeling and switching between providers. The SuiteSyncPromoBanner could be displayed when labeling settings change, particularly when Suite Sync is an available option, making it a plausible but not certain regression vector.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx`

_Updated: 2026-04-20T13:40:09.720Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-suite-sync-promo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-suite-sync-promo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T14:04:16.371Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T14:02:54.184Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-suite-sync-promo/web/](https://dev.suite.sldev.cz/suite-web/fix-suite-sync-promo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->