### PR TITLE
build: disable dead declaration and source maps for published packages

### DIFF
--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -8,7 +8,8 @@
 
         "composite": false,
         "incremental": false,
-        "declarationMap": true,
+        "declarationMap": false,
+        "sourceMap": false,
         "noEmit": false,
         "emitDeclarationOnly": false
     },


### PR DESCRIPTION
## Description

Disable `declarationMap` and `sourceMap` emission in the root `tsconfig.lib.json` that all npm-published packages extend. This stops shipping `.d.ts.map` and `.js.map` files in published tarballs where they have never been functional.

## Why these maps are useless as published today

Declaration maps (`.d.ts.map`) let editors jump from a `.d.ts` type into the original `.ts` source on "Go to Definition". Source maps (`.js.map`) let debuggers step through original TypeScript. **Both require the original `.ts` sources to be shipped alongside the maps.**

Every npm-published package in this monorepo sets:

```json
"files": ["lib/", "libESM/"]
```

`src/` is **never** published. So the maps reference paths like `../src/*.ts` that do not exist in consumers' `node_modules` — they are dead weight.

## Current state is inconsistent

Behavior across packages is not uniform today. Counting `.map` files in the latest published tarball of each package:

| Package | `.map` files in tarball |
|---|---|
| `@trezor/schema-utils@1.4.0` | 18 |
| `@trezor/connect-webextension@9.7.2` | 8 |
| `@trezor/connect-mobile@9.7.2` | 2 |
| `@trezor/connect-web@9.7.2` | 0 |
| `@trezor/utils@9.5.0` | 0 |
| `@trezor/transport@1.6.2` | 0 |
| `@trezor/connect-common@0.5.1` | 0 |
| `@trezor/connect@9.7.2` | 0 |
| `@trezor/protobuf@1.5.2` | 0 |
| … 9 more published packages | 0 |

So 3 out of 18 npm-published packages currently ship `.map` files; the other 15 do not. All of them have the same `files: ["lib/", "libESM/"]` declaration and the same build script shape, yet the tarballs differ. In any case, for packages that do ship maps, the maps reference `../src/*.ts` which is never published, so they are non-functional there too.

This PR removes the inconsistency by not producing maps in the first place — every npm-published package ends up in the same state.

## Why this is not a risk for Suite / Sentry source maps

Sentry symbolication for `suite-web` and `suite-desktop` is unaffected:

1. Suite apps extend `tsconfig.base.json`, **not** `tsconfig.lib.json`. `tsconfig.base.json` is left untouched — `sourceMap: true` stays on for apps.
2. Suite production builds do not use `tsc` for bundling — they go through webpack (`@trezor/suite-build`). Source maps for Sentry come from the webpack pipeline (`devtool`), not from `tsc` output.
3. Workspace packages are consumed via yarn workspace symlinks with `main: "src/index.ts"`. Webpack bundles the original `.ts` sources directly from `src/`, so any `.map` files sitting in `packages/*/lib/` are irrelevant to the app's source map chain.

The only consumers that would theoretically benefit from these maps are external npm installers, and for them the maps are already broken because `src/` is not published.

## Scope

Only `tsconfig.lib.json` is modified. 24 package-level `tsconfig.lib.json` files extend it (all npm-published packages). `tsconfig.base.json` and `tsconfig.libESM.json` require no changes — the latter already extends `tsconfig.lib.json` and inherits the flip.

## Notes for QA

No user-facing behavior change. Suggested checks:

- Build a published package (e.g. `yarn workspace @trezor/utils build:lib`) and confirm `lib/` / `libESM/` contain no `.d.ts.map` or `.js.map` files.
- Confirm `suite-web` / `suite-desktop` production builds still emit source maps as before (webpack-generated, not tsc-generated).
- Verify Sentry symbolication on a staging release.