### PR TITLE
refactor(product-components): add intl dependency to DropZone

### DIFF
--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -18,6 +18,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@suite/intl": "workspace:*",
         "@suite-common/feedback": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-types": "workspace:*",

--- a/packages/product-components/src/components/DropZone/DropZone.tsx
+++ b/packages/product-components/src/components/DropZone/DropZone.tsx
@@ -2,7 +2,6 @@ import {
     type ChangeEvent,
     type DragEvent,
     type MouseEvent,
-    type ReactNode,
     useCallback,
     useRef,
     useState,
@@ -10,6 +9,7 @@ import {
 
 import styled from 'styled-components';
 
+import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
 import {
     Column,
     Icon,
@@ -50,21 +50,18 @@ const StyledInput = styled.input`
 export type DropZoneProps = {
     accept?: string;
     iconName?: IconName;
-    emptyLabel: ReactNode;
-    emptyError: ReactNode;
-    fileTypeError: ReactNode;
-    onSelect: (data: File, setError: (msg: ReactNode) => void) => void;
+    onSelect: (data: File, setError: (msg: ExtendedMessageDescriptor) => void) => void;
     'data-testid'?: string;
 };
 
-const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZoneProps) => {
+const useDropZone = ({ accept, onSelect }: DropZoneProps) => {
     const available = useRef(
         typeof window !== 'undefined' &&
             Boolean(window.File && window.FileReader && window.FileList && window.Blob),
     );
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const [error, setError] = useState<ReactNode>();
+    const [error, setError] = useState<ExtendedMessageDescriptor>();
     const [filename, setFilename] = useState<string>();
 
     const allowedExtensions = (accept || '')
@@ -77,14 +74,14 @@ const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZonePr
         (file?: File) => {
             setFilename(file?.name);
             if (!file) {
-                setError(emptyError);
+                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
 
                 return;
             }
             if (allowedExtensions.length) {
                 const extRegex = new RegExp(`\\.(${allowedExtensions.join('|')})$`, 'i');
                 if (!extRegex.test(file.name)) {
-                    setError(fileTypeError);
+                    setError({ id: 'TR_DROPZONE_ERROR_FILETYPE' });
 
                     return;
                 }
@@ -92,7 +89,7 @@ const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZonePr
             setError(undefined);
             onSelect(file, setError);
         },
-        [allowedExtensions, emptyError, fileTypeError, onSelect],
+        [allowedExtensions, onSelect],
     );
 
     const onClick = useCallback(() => {
@@ -123,10 +120,10 @@ const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZonePr
             if (event.dataTransfer) {
                 readFileContent(event.dataTransfer.files[0]);
             } else {
-                setError(emptyError);
+                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
             }
         },
-        [emptyError, readFileContent],
+        [readFileContent],
     );
 
     const onInputChange = useCallback(
@@ -135,10 +132,10 @@ const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZonePr
             if (event.target.value && event.target.files) {
                 readFileContent(event.target.files[0]);
             } else {
-                setError(emptyError);
+                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
             }
         },
-        [emptyError, readFileContent],
+        [readFileContent],
     );
 
     const onInputClick = useCallback((event: MouseEvent<HTMLInputElement>) => {
@@ -183,20 +180,10 @@ const useDropZone = ({ accept, emptyError, fileTypeError, onSelect }: DropZonePr
 export const DropZone = ({
     accept,
     iconName = 'fileX',
-    emptyLabel,
-    emptyError,
-    fileTypeError,
     onSelect,
     'data-testid': dataTestId,
 }: DropZoneProps) => {
-    const { getWrapperProps, getInputProps, error, filename } = useDropZone({
-        accept,
-        emptyError,
-        fileTypeError,
-        emptyLabel,
-        onSelect,
-        'data-testid': dataTestId,
-    });
+    const { getWrapperProps, getInputProps, error, filename } = useDropZone({ accept, onSelect });
     const { elevation } = useElevation();
 
     return (
@@ -222,12 +209,12 @@ export const DropZone = ({
                         intent="neutral"
                         priority={filename ? 'primary' : 'secondary'}
                     >
-                        {filename ?? emptyLabel}
+                        {filename ?? <Translation id="TR_DROPZONE" />}
                     </Text>
                 </Row>
                 {error !== undefined && (
                     <Paragraph typographyStyle="body-sm" intent="critical">
-                        {error}
+                        <Translation {...error} />
                     </Paragraph>
                 )}
             </Column>

--- a/packages/product-components/tsconfig.json
+++ b/packages/product-components/tsconfig.json
@@ -7,13 +7,20 @@
             ]
         },
         "plugins": [
-            { "name": "typescript-styled-plugin" }
+            {
+                "name": "typescript-styled-plugin"
+            }
         ],
         "outDir": "./libDev"
     },
     "include": [".", "**/*.json"],
     "references": [
-        { "path": "../../suite-common/feedback" },
+        {
+            "path": "../../suite/intl"
+        },
+        {
+            "path": "../../suite-common/feedback"
+        },
         {
             "path": "../../suite-common/suite-constants"
         },
@@ -35,13 +42,29 @@
         {
             "path": "../../suite-common/wallet-utils"
         },
-        { "path": "../asset-utils" },
-        { "path": "../components" },
-        { "path": "../device-utils" },
-        { "path": "../env-utils" },
-        { "path": "../theme" },
-        { "path": "../type-utils" },
-        { "path": "../utils" },
-        { "path": "../eslint" }
+        {
+            "path": "../asset-utils"
+        },
+        {
+            "path": "../components"
+        },
+        {
+            "path": "../device-utils"
+        },
+        {
+            "path": "../env-utils"
+        },
+        {
+            "path": "../theme"
+        },
+        {
+            "path": "../type-utils"
+        },
+        {
+            "path": "../utils"
+        },
+        {
+            "path": "../eslint"
+        }
     ]
 }

--- a/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
+++ b/packages/suite/src/components/firmware/SelectCustomFirmware.tsx
@@ -1,7 +1,7 @@
-import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import { type Dispatch, type SetStateAction } from 'react';
 
 import { validateFirmware } from '@suite/firmware-upgrade';
-import { Translation } from '@suite/intl';
+import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
 import { BulletList, Button, Row } from '@trezor/components';
 import { DropZone } from '@trezor/product-components';
 import { GITHUB_FW_BINARIES_URL } from '@trezor/urls';
@@ -20,12 +20,15 @@ export const SelectCustomFirmware = ({ setFirmwareBinary }: SelectCustomFirmware
         ? `${GITHUB_FW_BINARIES_URL}/${deviceModel.toLowerCase()}`
         : GITHUB_FW_BINARIES_URL;
 
-    const onFirmwareUpload = async (firmware: File, setError: (msg: ReactNode) => void) => {
+    const onFirmwareUpload = async (
+        firmware: File,
+        setError: (msg: ExtendedMessageDescriptor) => void,
+    ) => {
         const fw = await firmware.arrayBuffer();
         const validationError = validateFirmware(fw, device);
 
         if (validationError) {
-            setError(<Translation id={validationError} />);
+            setError({ id: validationError });
         } else {
             setFirmwareBinary(fw);
         }
@@ -45,9 +48,6 @@ export const SelectCustomFirmware = ({ setFirmwareBinary }: SelectCustomFirmware
                 <DropZone
                     data-testid="@firmware/input-area"
                     accept=".bin"
-                    emptyLabel={<Translation id="TR_DROPZONE" />}
-                    emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
-                    fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
                     onSelect={onFirmwareUpload}
                 />
             </BulletList.Item>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useState } from 'react';
+import { useState } from 'react';
 
-import { Translation } from '@suite/intl';
+import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
 import { type UserContextPayload } from '@suite-common/suite-types';
 import { networksCollection } from '@suite-common/wallet-config';
 import { parseCSV } from '@suite-common/wallet-utils';
@@ -39,20 +39,18 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
         onCancel();
     };
 
-    const onCsvSelect = (file: File, setError: (msg: ReactNode) => void) => {
+    const onCsvSelect = (file: File, setError: (msg: ExtendedMessageDescriptor) => void) => {
         const reader = new FileReader();
 
         reader.onload = () => {
             if (typeof reader.result !== 'string' || !reader.result.length) {
-                setError(<Translation id="TR_DROPZONE_ERROR_EMPTY" />);
+                setError({ id: 'TR_DROPZONE_ERROR_EMPTY' });
             } else {
                 setContent(reader.result);
             }
         };
         reader.onerror = () => {
-            setError(
-                <Translation id="TR_DROPZONE_ERROR" values={{ error: reader.error!.message }} />,
-            );
+            setError({ id: 'TR_DROPZONE_ERROR', values: { error: reader.error!.message } });
             reader.abort();
         };
         reader.readAsText(file);
@@ -98,9 +96,6 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
                             <DropZone
                                 accept=".csv,.txt,text/csv"
                                 iconName="fileCsv"
-                                emptyLabel={<Translation id="TR_DROPZONE" />}
-                                emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
-                                fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
                                 onSelect={onCsvSelect}
                             />
                         ) : (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx
@@ -85,14 +85,7 @@ export const ImageQRReader = ({ onResult }: ImageQRReaderProps) => {
                 </Card>
             ) : (
                 <>
-                    <DropZone
-                        accept={IMAGE_ACCEPT}
-                        iconName="qrCode"
-                        emptyLabel={<Translation id="TR_DROPZONE" />}
-                        emptyError={<Translation id="TR_DROPZONE_ERROR_EMPTY" />}
-                        fileTypeError={<Translation id="TR_DROPZONE_ERROR_FILETYPE" />}
-                        onSelect={handleSelect}
-                    />
+                    <DropZone accept={IMAGE_ACCEPT} iconName="qrCode" onSelect={handleSelect} />
                     {error && (
                         <Card>
                             <Column alignItems="center" gap={spacings.xs}>


### PR DESCRIPTION
This is kinda and experiment. Is this safe as connect-explorer also depends on `product-components`? 


This is kinda a partially reverted https://github.com/trezor/trezor-suite/pull/26872 as the prop drilling of the translation does not feel right to me.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the DropZone component in product-components (including its package.json and tsconfig), the SelectCustomFirmware component, the ImportTransactionModal, and the ImageQRReader. The DropZone is a shared file-upload component likely consumed by SelectCustomFirmware and ImportTransactionModal. The highest risk is in the custom firmware installation flow and CSV import flow, which directly use these components. The QR scanner (ImageQRReader) has no dedicated E2E test. The 121 tests mapped to SelectCustomFirmware, ImportTransactionModal, and ImageQRReader are due to transitive modal imports and do not warrant broad test execution.

<details><summary><b>Changed files (6)</b></summary>

- `packages/product-components/package.json`
- `packages/product-components/src/components/DropZone/DropZone.tsx`
- `packages/product-components/tsconfig.json`
- `packages/suite/src/components/firmware/SelectCustomFirmware.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises the custom firmware installation flow which uses SelectCustomFirmware.tsx. Changes to SelectCustomFirmware.tsx could break file selection, modal interactions, or the firmware installation workflow tested here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — The ImportTransactionModal.tsx handles CSV import for transactions. This test exercises the CSV import flow (opening the import modal, selecting a file, importing data into the send form). Changes to ImportTransactionModal could break this workflow. Additionally, DropZone from product-components is likely used for file selection in this modal.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/product-components/package.json`
- `packages/product-components/src/components/DropZone/DropZone.tsx`
- `packages/product-components/tsconfig.json`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/QrScannerModal/ImageQRReader.tsx`

_Updated: 2026-04-20T14:35:47.842Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=intl-product-components&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T14:36:16.013Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->