### PR TITLE
fix(coinjoin): stabilize flaky Status identities test

### DIFF
--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -174,6 +174,13 @@ describe('Status', () => {
             });
         });
 
+        // deterministic rotation through identities — avoids flakiness from Math.random
+        const randomSequence = [0, 0.25, 0.5, 0.75];
+        let randomIdx = 0;
+        jest.spyOn(Math, 'random').mockImplementation(
+            () => randomSequence[randomIdx++ % randomSequence.length],
+        );
+
         jest.useFakeTimers();
 
         status = new Status(server?.requestOptions);
@@ -190,8 +197,8 @@ describe('Status', () => {
         await fastForward(STATUS_TIMEOUT.registered);
         await fastForward(STATUS_TIMEOUT.registered);
 
-        // at least two identities used. probably all defined above were used but it's not deterministic
-        expect(identities.length).toBeGreaterThanOrEqual(2);
+        // all four identities (default + A, B, C) should be used
+        expect(identities.length).toEqual(4);
 
         // clear identities
         status.removeIdentity('A');


### PR DESCRIPTION
## Summary

Fixes a flaky test in `packages/coinjoin/tests/client/Status.test.ts` (`Status identities`).

### Root cause

`Status.getStatus` picks a request identity at random from the registered pool:

```ts
// packages/coinjoin/src/client/Status.ts:217
const identity = this.identities[Math.floor(Math.random() * this.identities.length)];
```

The test registers 4 identities (default `Satoshi` + `A`, `B`, `C`), runs 3 iterations, and collects the unique identities that were actually used. Because `Math.random()` is non-deterministic, nothing prevents the same identity from being selected across iterations, which could cause the assertion to flake.

The previous assertion tried to tolerate this by only requiring `identities.length >= 2`, with a comment openly admitting the check was weak:

```ts
// at least two identities used. probably all defined above were used but it's not deterministic
expect(identities.length).toBeGreaterThanOrEqual(2);
```

Even with that tolerance, a run where all iterations happened to pick the same identity would still fail, and the test was not actually verifying the rotation behavior it was named after.

### Fix

Mock `Math.random` with a deterministic sequence `[0, 0.25, 0.5, 0.75]`. Combined with `Math.floor(x * 4)` in the production code, this yields indices `0, 1, 2, 3` — exercising all four identities in rotation.

That makes it possible to tighten the assertion from `>= 2` to an exact `=== 4`, which now genuinely verifies that identity rotation covers every registered identity.

## Test plan

- [ ] `yarn workspace @trezor/coinjoin test Status` passes locally
- [ ] Run the test multiple times to confirm it is no longer flaky

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file (packages/coinjoin/tests/client/Status.test.ts), not a source/production file. This is a test-only change within the coinjoin package's own test suite and does not modify any application source code, shared utilities, or components that the E2E tests exercise. No E2E tests are affected by changes to this unit test file, so no E2E test runs are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/coinjoin/tests/client/Status.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/coinjoin/tests/client/Status.test.ts`

_Updated: 2026-04-20T14:55:12.827Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-flaky-coinjoin-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-flaky-coinjoin-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 14 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-20T15:01:12.519Z • 14 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-20T14:59:21.932Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-flaky-coinjoin-test/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-flaky-coinjoin-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->