### PR TITLE
chore(vite): refactor app initialization to avoid #app element duplication

### DIFF
--- a/packages/suite-build/vite.config.mts
+++ b/packages/suite-build/vite.config.mts
@@ -1,6 +1,6 @@
 import { viteCommonjs } from '@originjs/vite-plugin-commonjs';
-import react from '@vitejs/plugin-react';
 import babel from '@rolldown/plugin-babel';
+import react from '@vitejs/plugin-react';
 import { execSync } from 'child_process';
 import fs, { readdirSync } from 'fs';
 import { createRequire } from 'module';
@@ -61,11 +61,7 @@ const processTemplate = (template: string): string =>
         // Remove the webpack template conditional (opening + closing statements as well as the HTML in between)
         .replace(/<%\s*if\([^%]*%>[\s\S]*?<%\s*}\s*%>/g, '')
         // Add the script tag for vite-index.ts
-        .replace('</head>', '<script type="module" src="./vite-index.ts"></script></head>')
-        // Add the app div to the body, the browser detection does work in vite
-        .replace('</body>', '<div id="app"></div></body>')
-        // in case if the id="app" is added multiple times
-        .replace('<div id="app"></div><div id="app"></div>', '<div id="app"></div>');
+        .replace('</head>', '<script type="module" src="./vite-index.ts"></script></head>');
 
 // Custom plugin to use the same template as webpack
 const htmlTemplatePlugin = (): Plugin => ({

--- a/packages/suite-web/src/static/vite-index.ts
+++ b/packages/suite-web/src/static/vite-index.ts
@@ -2,9 +2,17 @@
  * This entry is only used for Vite dev server!
  */
 
-const appElement = document.getElementById('app');
-if (appElement) {
-    import('../MainWeb').then(comp => comp.init(appElement)).catch(err => console.error(err)); // Fatal error
-}
+const observer = new MutationObserver(() => {
+    const appElement = document.getElementById('app');
+    if (appElement) {
+        observer.disconnect();
+
+        import('../MainWeb').then(comp => comp.init(appElement)).catch(err => console.error(err)); // Fatal error
+    }
+});
+
+observer.observe(document.body, {
+    childList: true,
+});
 
 export {};


### PR DESCRIPTION
## Description

- Remove manual `<div id="app"></div>` injection and deduplication logic from `vite.config.mts` — the element already exists in the HTML template, so appending it via Vite caused duplication and screen jumping.

## Notes for QA

Just DEV thing. No need QA.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-04-21T06:52:32.237Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/vite-screen-jumping&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/vite-screen-jumping&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T06:57:42.908Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T06:56:39.170Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/vite-screen-jumping/web/](https://dev.suite.sldev.cz/suite-web/chore/vite-screen-jumping/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->