### PR TITLE
fix(suite-native): use subtle green badge for confirmed transaction d…

### DIFF
--- a/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
@@ -75,6 +75,7 @@ export const TransactionDetailHeader = ({
                         !isFailedTx && (
                             <Badge
                                 intent="brand"
+                                variant="greenSubtle"
                                 label={<Translation id="transactions.status.confirmed" />}
                             />
                         )


### PR DESCRIPTION
## Description
Use a softer green badge for confirmed txs on native transaction detail

## Related Issue
https://github.com/trezor/trezor-suite/issues/26902

## Screenshots:
<img width="760" height="824" alt="image" src="https://github.com/user-attachments/assets/fdce5b69-b8f4-4092-9d2e-9b492503fd1a" />

