### PR TITLE
Feat/native unstake claim tx display

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1871,6 +1871,7 @@ export const messages = {
         },
         detail: {
             header: '<transactionType></transactionType> transaction',
+            unstakeHeader: 'Unstake {amount}',
             exploreButton: 'Explore in blockchain',
             feeLabel: 'Fee',
             dateLabel: 'Date',

--- a/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
@@ -15,6 +15,7 @@ import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-n
 import {
     TransactionIcon,
     getTransactionValueSign,
+    getUnstakeTxAmount,
     selectTransactionFiatRate,
 } from '@suite-native/transactions';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -53,6 +54,7 @@ export const TransactionDetailHeader = ({
     const signValue = getTransactionValueSign(tokenTransfer?.type ?? transaction.type);
     const isTokenOnlyTransaction = transaction.amount === '0' && transaction.tokens.length !== 0;
     const txType = isTokenOnlyTransaction ? transaction.tokens[0].type : type;
+    const isUnstakeTx = getUnstakeTxAmount(transaction) !== undefined;
 
     return (
         <DiscreetTextTrigger>
@@ -74,43 +76,44 @@ export const TransactionDetailHeader = ({
                         )
                     )}
 
-                    <Box flexDirection="row">
-                        {!isFailedTx && (
-                            <SignValueFormatter
-                                color="contentPrimary"
-                                value={signValue}
-                                variant="headline-md"
-                            />
-                        )}
-                        <Text> </Text>
+                    {!isUnstakeTx && (
+                        <Box flexDirection="row">
+                            {!isFailedTx && (
+                                <SignValueFormatter
+                                    color="contentPrimary"
+                                    value={signValue}
+                                    variant="headline-md"
+                                />
+                            )}
 
-                        {tokenTransfer ? (
-                            <TokenAmountFormatter
-                                value={tokenTransfer.amount}
-                                tokenSymbol={tokenTransfer.symbol}
-                                decimals={tokenTransfer.decimals}
-                                variant="headline-md"
-                                color="contentPrimary"
-                                numberOfLines={1}
-                                adjustsFontSizeToFit
-                                style={applyStyle(failedTxStyle, { isFailedTx })}
-                            />
-                        ) : (
-                            <CryptoAmountFormatter
-                                value={transaction.amount}
-                                symbol={transaction.symbol}
-                                isBalance={false}
-                                variant="headline-md"
-                                color="contentPrimary"
-                                numberOfLines={1}
-                                adjustsFontSizeToFit
-                                style={applyStyle(failedTxStyle, { isFailedTx })}
-                            />
-                        )}
-                    </Box>
+                            {tokenTransfer ? (
+                                <TokenAmountFormatter
+                                    value={tokenTransfer.amount}
+                                    tokenSymbol={tokenTransfer.symbol}
+                                    decimals={tokenTransfer.decimals}
+                                    variant="headline-md"
+                                    color="contentPrimary"
+                                    numberOfLines={1}
+                                    adjustsFontSizeToFit
+                                    style={applyStyle(failedTxStyle, { isFailedTx })}
+                                />
+                            ) : (
+                                <CryptoAmountFormatter
+                                    value={transaction.amount}
+                                    symbol={transaction.symbol}
+                                    isBalance={false}
+                                    variant="headline-md"
+                                    color="contentPrimary"
+                                    numberOfLines={1}
+                                    adjustsFontSizeToFit
+                                    style={applyStyle(failedTxStyle, { isFailedTx })}
+                                />
+                            )}
+                        </Box>
+                    )}
                 </VStack>
 
-                {historicRate !== undefined && historicRate !== 0 && (
+                {!isUnstakeTx && historicRate !== undefined && historicRate !== 0 && (
                     <Box flexDirection="row" style={applyStyle(fiatValueStyle)}>
                         <Text color="contentSecondary">≈ </Text>
                         {tokenTransfer ? (

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation, usePreventRemove } from '@react-navigation/native';
 
+import { useFormatters } from '@suite-common/formatters';
 import { getExplorerUrl } from '@suite-common/wallet-config';
 import {
     type ExplorerState,
@@ -11,8 +12,9 @@ import {
     selectIsTransactionPending,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
+import { redactNumericalSubstring } from '@suite-common/wallet-utils';
 import { events } from '@suite-native/analytics';
-import { Button, HStack, Text, VStack } from '@suite-native/atoms';
+import { Button, HStack, Text, VStack, useDiscreetMode } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { useInAppRating } from '@suite-native/in-app-rating';
 import { Translation } from '@suite-native/intl';
@@ -26,7 +28,7 @@ import {
 } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-native/tokens';
-import { TransactionName } from '@suite-native/transactions';
+import { TransactionName, getUnstakeTxAmount } from '@suite-native/transactions';
 
 import { TransactionDetailData } from '../components/TransactionDetailData';
 import { TransactionDetailHeader } from '../components/TransactionDetailHeader';
@@ -37,6 +39,8 @@ export const TransactionDetailScreen = ({
     const { askForRating } = useInAppRating();
     const navigation = useNavigation();
     const analytics = useAnalytics();
+    const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
+    const { isDiscreetMode } = useDiscreetMode();
     const { txid, accountKey, tokenContract, closeActionType = 'back', source } = route.params;
     const openLink = useOpenLink();
     const transaction = useSelector((state: TransactionsRootState) =>
@@ -71,6 +75,19 @@ export const TransactionDetailScreen = ({
 
     if (!transaction) return null;
 
+    const unstakeAmount = getUnstakeTxAmount(transaction);
+    const isUnstakeTransaction = unstakeAmount !== undefined;
+    const formattedUnstakeAmount = isUnstakeTransaction
+        ? cryptoAmountFormatter.format(unstakeAmount, {
+              symbol: transaction.symbol,
+              isBalance: false,
+              isEllipsisAppended: false,
+          })
+        : '';
+    const displayedUnstakeAmount = isDiscreetMode
+        ? redactNumericalSubstring(formattedUnstakeAmount)
+        : formattedUnstakeAmount;
+
     const handleOpenBlockchain = () => {
         if (!blockchainExplorer) return;
         analytics.report({
@@ -87,24 +104,33 @@ export const TransactionDetailScreen = ({
                     closeActionType={closeActionType}
                     customContent={
                         <HStack spacing="sp8" alignItems="center" justifyContent="center">
-                            <CryptoIconWithNetwork
-                                symbol={transaction.symbol}
-                                contractAddress={tokenTransfer?.contract}
-                            />
-                            <Text variant="body-md-strong">
-                                <Translation
-                                    id="transactions.detail.header"
-                                    values={{
-                                        transactionType: _ => (
-                                            <TransactionName
-                                                key={transaction.txid}
-                                                transaction={transaction}
-                                                isPending={isPending}
-                                                variant="body-md-strong"
-                                            />
-                                        ),
-                                    }}
+                            {!isUnstakeTransaction && (
+                                <CryptoIconWithNetwork
+                                    symbol={transaction.symbol}
+                                    contractAddress={tokenTransfer?.contract}
                                 />
+                            )}
+                            <Text variant="body-md-strong">
+                                {isUnstakeTransaction ? (
+                                    <Translation
+                                        id="transactions.detail.unstakeHeader"
+                                        values={{ amount: displayedUnstakeAmount }}
+                                    />
+                                ) : (
+                                    <Translation
+                                        id="transactions.detail.header"
+                                        values={{
+                                            transactionType: () => (
+                                                <TransactionName
+                                                    key={transaction.txid}
+                                                    transaction={transaction}
+                                                    isPending={isPending}
+                                                    variant="body-md-strong"
+                                                />
+                                            ),
+                                        }}
+                                    />
+                                )}
                             </Text>
                         </HStack>
                     }

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -28,7 +28,11 @@ import {
 } from '@suite-native/navigation';
 import { useAnalytics } from '@suite-native/services';
 import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-native/tokens';
-import { TransactionName, getUnstakeTxAmount } from '@suite-native/transactions';
+import {
+    InstantStakeBanner,
+    TransactionName,
+    getUnstakeTxAmount,
+} from '@suite-native/transactions';
 
 import { TransactionDetailData } from '../components/TransactionDetailData';
 import { TransactionDetailHeader } from '../components/TransactionDetailHeader';
@@ -138,11 +142,14 @@ export const TransactionDetailScreen = ({
             }
         >
             <VStack spacing="sp24">
-                <VStack spacing="sp32">
+                <VStack spacing="sp24">
                     <TransactionDetailHeader
                         transaction={transaction}
                         tokenTransfer={tokenTransfer as TypedTokenTransfer}
                     />
+                    {isUnstakeTransaction && (
+                        <InstantStakeBanner accountKey={accountKey} transaction={transaction} />
+                    )}
                     <TransactionDetailData
                         transaction={transaction}
                         accountKey={accountKey}

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -1,10 +1,13 @@
+import { useFormatters } from '@suite-common/formatters';
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType, type WalletAccountTransaction } from '@suite-common/wallet-types';
-import { getTxStakeType } from '@suite-common/wallet-utils';
-import { Text } from '@suite-native/atoms';
+import { getTxStakeType, redactNumericalSubstring } from '@suite-common/wallet-utils';
+import { Text, useDiscreetMode } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { type NativeTypographyStyle } from '@trezor/theme';
 import { exhaustive } from '@trezor/type-utils';
+
+import { getUnstakeTxAmount } from '../utils';
 
 type TransactionNameProps = {
     transaction: WalletAccountTransaction;
@@ -107,6 +110,8 @@ const getTronTransactionMessage = (transaction: WalletAccountTransaction) => {
 };
 
 export const TransactionName = ({ transaction, isPending, variant }: TransactionNameProps) => {
+    const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
+    const { isDiscreetMode } = useDiscreetMode();
     const ethName = transaction.ethereumSpecific?.parsedData?.name;
 
     // Stellar trustline addition/removal (short version without asset code)
@@ -136,6 +141,27 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
     }
 
     const stakeType = getTxStakeType(transaction);
+    const unstakeAmount = getUnstakeTxAmount(transaction);
+
+    if (unstakeAmount !== undefined && !isPending) {
+        const formattedUnstakeAmount = cryptoAmountFormatter.format(unstakeAmount, {
+            symbol: transaction.symbol,
+            isBalance: false,
+            isEllipsisAppended: false,
+        });
+        const displayedUnstakeAmount = isDiscreetMode
+            ? redactNumericalSubstring(formattedUnstakeAmount)
+            : formattedUnstakeAmount;
+
+        return (
+            <Text variant={variant}>
+                <Translation
+                    id="transactions.detail.unstakeHeader"
+                    values={{ amount: displayedUnstakeAmount }}
+                />
+            </Text>
+        );
+    }
 
     const stakeTranslationId = stakeType ? getStakeTransactionMessage(stakeType, isPending) : null;
 

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -2,7 +2,12 @@ import { A, F, pipe } from '@mobily/ts-belt';
 
 import { type SignValue } from '@suite-common/suite-types';
 import { createSimpleTargetId } from '@suite-common/wallet-core';
-import { type TransactionType } from '@suite-common/wallet-types';
+import { type TransactionType, type WalletAccountTransaction } from '@suite-common/wallet-types';
+import {
+    getTxStakeNameByDataHex,
+    getTxStakeType,
+    getUnstakeAmountByEthereumDataHex,
+} from '@suite-common/wallet-utils';
 import { type EnhancedVinVout, type Target } from '@trezor/blockchain-link-types';
 import { isNotNullOrUndefined } from '@trezor/utils';
 
@@ -64,3 +69,16 @@ const transactionTypeToSignValueMap = {
 
 export const getTransactionValueSign = (transactionType: TransactionType) =>
     transactionTypeToSignValueMap[transactionType];
+
+const resolveStakeType = (tx: WalletAccountTransaction) =>
+    getTxStakeType(tx) ?? getTxStakeNameByDataHex(tx.ethereumSpecific?.data);
+
+export const getUnstakeTxAmount = (tx: WalletAccountTransaction) => {
+    if (resolveStakeType(tx) !== 'unstake') return undefined;
+
+    if (tx.solanaSpecific?.stakeOperation?.type === 'unstake') {
+        return tx.solanaSpecific.stakeOperation.amount;
+    }
+
+    return getUnstakeAmountByEthereumDataHex(tx.ethereumSpecific?.data) ?? undefined;
+};


### PR DESCRIPTION
## Description

Fix unstake/claim amount display in the native tx UI; add an unstake header and an instant stake banner on the detail page.

## Related Issue
Resolve https://github.com/trezor/trezor-suite/issues/15307

## Screenshots:
<img width="1290" height="1886" alt="image" src="https://github.com/user-attachments/assets/03599136-db8d-4201-8bc9-4227ea125ad7" />
<img width="722" height="628" alt="image" src="https://github.com/user-attachments/assets/b3ac7d1f-60b7-49e9-aee6-a0df444ab214" />
