### PR TITLE
chore(address-validator): update scure base to v2

### DIFF
--- a/packages/address-validator/jest.config.js
+++ b/packages/address-validator/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    transformIgnorePatterns: ['/node_modules/'],
+    transformIgnorePatterns: ['/node_modules/(?!@scure/base/)'],
 };

--- a/packages/address-validator/package.json
+++ b/packages/address-validator/package.json
@@ -36,7 +36,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
-        "@scure/base": "^1.2.6",
+        "@scure/base": "^2.0.0",
         "base-x": "^5.0.1",
         "browserify-bignum": "^1.3.0-2",
         "cbor": "^10.0.12",

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -13,8 +13,8 @@ import type { Requirement } from '../Requirement';
  * Entries SHOULD be removed once the migration or constraint is resolved.
  */
 export const ALLOWED_DRIFTS = new Set([
+    '@scure/base', // ESM-only v2 is used only where CJS compatibility is not required yet.
     'babel-jest', // waiting for suite-native who are waiting for expo to update babel-jest
-    '@scure/base', // i think i had a cjs problem, todo: investigate later
 ]);
 
 type PackageJson = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15684,7 +15684,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/address-validator@workspace:packages/address-validator"
   dependencies:
-    "@scure/base": "npm:^1.2.6"
+    "@scure/base": "npm:^2.0.0"
     "@trezor/eslint": "workspace:*"
     base-x: "npm:^5.0.1"
     browserify-bignum: "npm:^1.3.0-2"


### PR DESCRIPTION
## Description

Updates `@trezor/address-validator` to `@scure/base@2` now that the address-validator ESM refactor is merged.

`@trezor/connect` and `@trezor/utxo-lib` intentionally stay on `@scure/base@1.2.6` because they are public packages with CJS entrypoints, while `@scure/base@2` is ESM-only.

## Changes

- Bump `packages/address-validator` direct dependency to `@scure/base@^2.0.0`.
- Keep `@scure/base` in the dependency-version drift allowlist until public CJS packages can move.
- Adjust the address-validator Jest config so `@scure/base` is transformed from `node_modules` while other dependencies remain ignored.
- Refresh `yarn.lock`.

## Validation

- `yarn install --mode=skip-build`
- `yarn why @scure/base`
- `PATH="$PWD/node_modules/.bin:$PATH" yarn workspace @trezor/address-validator type-check`
- `PATH="$PWD/node_modules/.bin:$PATH" yarn workspace @trezor/address-validator lint:js`
- `PATH="$PWD/node_modules/.bin:$PATH" yarn workspace @trezor/address-validator test:unit` - 173 tests passed
- `PATH="$PWD/node_modules/.bin:$PATH" yarn workspace @trezor/address-validator build:lib`
- `PATH="$PWD/node_modules/.bin:$PATH" yarn requirements:verify`

## Notes

- `@trezor/connect` and `@trezor/utxo-lib` are deliberately not bumped in this PR.
- A CJS runtime smoke for `@trezor/utxo-lib` still fails on existing `@noble/hashes@2` ESM-only usage, unrelated to `@scure/base`.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/scure-base-v2/web/](https://dev.suite.sldev.cz/suite-web/mroz22/scure-base-v2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->