### PR TITLE
chore(deps): unify jest-diff to v30

### DIFF
--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -13,7 +13,6 @@ import type { Requirement } from '../Requirement';
  * Entries SHOULD be removed once the migration or constraint is resolved.
  */
 export const ALLOWED_DRIFTS = new Set([
-    'jest-diff', // v29 and v30 coexist during migration
     'babel-jest', // waiting for suite-native who are waiting for expo to update babel-jest
     '@scure/base', // i think i had a cjs problem, todo: investigate later
 ]);

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -68,7 +68,7 @@
         "@walletconnect/types": "2.21.4",
         "dotenv": "17.2.3",
         "fs-extra": "^11.3.1",
-        "jest-diff": "^29.7.0",
+        "jest-diff": "^30.2.0",
         "lodash": "^4.18.1",
         "react-intl": "^8.1.3",
         "tsx": "^4.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16237,7 +16237,7 @@ __metadata:
     "@walletconnect/types": "npm:2.21.4"
     dotenv: "npm:17.2.3"
     fs-extra: "npm:^11.3.1"
-    jest-diff: "npm:^29.7.0"
+    jest-diff: "npm:^30.2.0"
     lodash: "npm:^4.18.1"
     react-intl: "npm:^8.1.3"
     tsx: "npm:^4.21.0"


### PR DESCRIPTION
## Summary
- Bump `jest-diff` in `suite/e2e` from `^29.7.0` to `^30.2.0` to match `suite-native/app`.
- Remove the now-stale `jest-diff` entry from `ALLOWED_DRIFTS` in `requireUnifiedDependencyVersions.ts`.

Both packages use only the public `diff` function, whose API is compatible between v29 and v30, so unification is safe.

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn workspace @trezor/requirements requirements:verify` passes
- [x] `yarn workspace @trezor/requirements test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are: (1) `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`, which is a build-time/CI requirement checker for unified dependency versions — not runtime application code exercised by any E2E test; and (2) `suite/e2e/package.json`, which is the E2E test infrastructure's own package manifest. Neither file is imported by any application source code that E2E tests exercise. Changes to these files affect build tooling and test infrastructure configuration respectively, not user-facing application behavior. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `suite/e2e/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `suite/e2e/package.json`

_Updated: 2026-04-21T08:35:51.681Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/remove-jest-diff-drift&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-jest-diff-drift&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T08:41:36.129Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T08:39:38.815Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-jest-diff-drift/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-jest-diff-drift/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->