### PR TITLE
refactor(type-utils): add RequireAtLeastOne, dedupe Keys/KeysOfUnion

### DIFF
--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -5,6 +5,7 @@ import type {
     FirmwareType,
     IntermediaryReleaseConfig,
 } from '@trezor/device-utils';
+import type { RequireAtLeastOne } from '@trezor/type-utils';
 import type { VersionArray } from '@trezor/utils';
 
 export type FirmwareBoundary = `${number}.${number}.${number}` | '0';
@@ -14,18 +15,14 @@ export type FirmwareRange = Record<
     { min: FirmwareBoundary; max: FirmwareBoundary }
 >;
 
-type AtLeastOne<T> = {
-    [K in keyof T]: Pick<T, K> & Partial<Omit<T, K>>;
-}[keyof T];
-
-type RuleSelector = AtLeastOne<{
+type RuleSelector = RequireAtLeastOne<{
     coin: string[];
     coinType: string;
     methods: string[];
     capabilities: string[];
 }>;
 
-type RuleDeclaration = AtLeastOne<{
+type RuleDeclaration = RequireAtLeastOne<{
     min: Partial<Record<DeviceModelInternal, FirmwareBoundary>>;
     max: Partial<Record<DeviceModelInternal, FirmwareBoundary>>;
 }>;

--- a/packages/type-utils/src/object.ts
+++ b/packages/type-utils/src/object.ts
@@ -23,6 +23,23 @@ export type ObjectsOnly<T> = T extends Record<string, unknown> ? T : never;
  */
 export type KeysOfUnion<T> = T extends T ? keyof T : never;
 
+/**
+ * Requires at least one of the given keys of `T` to be present.
+ * If `K` is omitted, at least one of all keys of `T` is required.
+ *
+ * Example:
+ *  ```
+ *  type T = RequireAtLeastOne<{ a?: number; b?: string; c?: boolean }>;
+ *  const t1: T = { a: 1 };        // ok
+ *  const t2: T = { b: 'x', c: true }; // ok
+ *  const t3: T = {};              // error
+ *  ```
+ */
+export type RequireAtLeastOne<T, K extends keyof T = keyof T> = {
+    [P in K]-?: Pick<T, P> & Partial<Omit<T, P>>;
+}[K] &
+    Omit<T, K>;
+
 export type NarrowObjectWithKey<T, K extends PropertyKey> = T extends any
     ? K extends keyof T
         ? T

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -57,17 +57,6 @@ export type OptionalKey<M, K extends keyof M> = Omit<M, K> & Partial<Pick<M, K>>
 export type ObjectValues<T extends { [key: string]: any }> = T[keyof T];
 
 /**
- * All keys of types in a union.
- *
- * Example:
- *  ```
- *  type T = { a: number; b: string };
- *  type K: Keys<T>; // 'a' | 'b'
- *  ```
- */
-export type Keys<T> = T extends any ? keyof T : never;
-
-/**
  * Distributes the Omit across a union. using distributive conditional types to achieve this:
  * @see: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types
  * @source: https://stackoverflow.com/questions/57103834/typescript-omit-a-property-from-all-interfaces-in-a-union-but-keep-the-union-s#answer-57103940

--- a/packages/utils/src/mergeDeepObject.ts
+++ b/packages/utils/src/mergeDeepObject.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 // code shamelessly stolen from https://github.com/voodoocreation/ts-deepmerge
 
-import { type Keys } from '@trezor/type-utils';
+import { type KeysOfUnion } from '@trezor/type-utils';
 
 type TIndexValue<T, K extends PropertyKey, D = never> = T extends any
     ? K extends keyof T
@@ -22,7 +22,7 @@ type TMerged<T> = [T] extends [Array<any>]
     : [T] extends [TPrimitives]
       ? T
       : [T] extends [object]
-        ? TPartialKeys<{ [K in Keys<T>]: TMerged<TIndexValue<T, K>> }, never>
+        ? TPartialKeys<{ [K in KeysOfUnion<T>]: TMerged<TIndexValue<T, K>> }, never>
         : T;
 
 // istanbul ignore next

--- a/suite/router/src/route.ts
+++ b/suite/router/src/route.ts
@@ -1,7 +1,11 @@
 import { type routes } from '@suite/router-config';
-import { type ArrayElement, type ConstWithOptionalFields, type Keys } from '@trezor/type-utils';
+import {
+    type ArrayElement,
+    type ConstWithOptionalFields,
+    type KeysOfUnion,
+} from '@trezor/type-utils';
 
-type RouteKeys = Keys<ArrayElement<typeof routes>>;
+type RouteKeys = KeysOfUnion<ArrayElement<typeof routes>>;
 
 export type Route = ArrayElement<ConstWithOptionalFields<typeof routes, RouteKeys>>;
 


### PR DESCRIPTION
## Summary

- Add `RequireAtLeastOne<T, K>` to `@trezor/type-utils` (same API as `type-fest` equivalent, native impl so no new dep).
- Replace the private `AtLeastOne` alias in `packages/connect-common/src/types/firmware.ts` with the shared type.
- Remove the duplicate `Keys<T>` from `@trezor/type-utils` — it was identical to `KeysOfUnion<T>`. Update the two consumers (`@trezor/utils/mergeDeepObject`, `suite/router/src/route.ts`) to use `KeysOfUnion`.

## Context

`AtLeastOne` was the only occurrence of the "at least one" utility in `packages/*`. `type-fest` `RequireAtLeastOne` is already used in `suite-native/*` and `suite/e2e/*`, but `type-fest` is not a dep in core packages — adding the type to `@trezor/type-utils` keeps the core dep graph unchanged.

## Follow-ups (not in this PR)

Further overlap between `@trezor/type-utils` and `type-fest` worth considering later: `DeepPartial` vs `PartialDeep`, `RequiredKey` vs `SetRequired`, `OptionalKey` vs `SetOptional`, `ObjectValues` vs `ValueOf`, `Without` vs `DistributedOmit`. Decision needed on whether `@trezor/type-utils` should be the single source of truth across the monorepo or should re-export `type-fest` for overlaps.

## Test plan

- [ ] CI type-check passes in `@trezor/type-utils`, `@trezor/connect-common`, `@trezor/utils`, `suite/router`.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches low-level utility packages (type-utils, utils/mergeDeepObject), firmware type definitions (connect-common), and router route types. The utility files (mergeDeepObject, type-utils) are extremely broad dependencies mapping to 121+ tests, but since they are generic utilities (object merging, type helpers), the risk of breaking specific E2E flows is low unless the changes alter fundamental behavior. The firmware types and route definitions are more targeted — firmware type changes could affect firmware-related flows, and route changes could affect navigation. A focused test strategy covering firmware and routing-related tests provides adequate confidence without running the full suite.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect-common/src/types/firmware.ts`
- `packages/type-utils/src/object.ts`
- `packages/type-utils/src/utils.ts`
- `packages/utils/src/mergeDeepObject.ts`
- `suite/router/src/route.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — packages/connect-common/src/types/firmware.ts defines firmware-related types. The custom firmware test exercises firmware installation flows that likely depend on these type definitions. Changes to firmware types could affect how firmware binaries are handled during custom firmware installation.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test verifies firmware readiness detection during onboarding, which directly relates to firmware type definitions in connect-common. Changes to firmware.ts types could affect how firmware status is evaluated and reported during the onboarding firmware check step.
- `suite/e2e/tests/general/check-links.test.ts` — suite/router/src/route.ts defines route types/configuration. This test crawls all application routes defined in @suite/router-config and navigates to each one to check links. Changes to route definitions could affect which routes are discovered, how navigation works, or whether pages load correctly.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/version-page.test.ts` — This test navigates to the /version URL route. Changes to suite/router/src/route.ts could affect route resolution and whether the version page is accessible at its expected path.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/type-utils/src/object.ts`
- `packages/type-utils/src/utils.ts`

_Updated: 2026-04-21T08:45:40.952Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/type-utils-atleastone&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/type-utils-atleastone&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/type-utils-atleastone&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T08:42:28.176Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T08:49:12.317Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/type-utils-atleastone/web/](https://dev.suite.sldev.cz/suite-web/mroz22/type-utils-atleastone/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->