### PR TITLE
Fix out of sync detection

### DIFF
--- a/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
+++ b/suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts
@@ -32,16 +32,21 @@ function rewardsOutOfSync(account: Account, rewards: SolRewardsHistory['rewards'
         return false;
     }
 
-    const currentActiveEpoch = account.misc?.solEpoch;
-    const latestRewardEpoch = rewards[0]?.epoch;
+    const activeEpoch = account.misc?.solEpoch;
 
-    if (!isInt(currentActiveEpoch) || !isInt(latestRewardEpoch)) {
+    const latestRewardEpoch = rewards[0]?.epoch;
+    const latestRewardTime = rewards[0]?.time;
+
+    if (!isInt(activeEpoch) || !isInt(latestRewardEpoch) || !latestRewardTime) {
         return false;
     }
 
-    const missingRewardEpochs = currentActiveEpoch - 1 - latestRewardEpoch;
+    const sinceLatestRewardInHours = (Date.now() - Date.parse(latestRewardTime)) / 1000 / 60 / 60;
+    const epochDurationLimitInHours = 52; // 2 days + 4h
 
-    return missingRewardEpochs > 1;
+    const epochsSinceLatestReward = activeEpoch - latestRewardEpoch;
+
+    return sinceLatestRewardInHours > epochDurationLimitInHours || epochsSinceLatestReward > 2;
 }
 
 interface UseSolanaRewardsProps {


### PR DESCRIPTION
fix(suite-common-earn-staking-api): fix out of sync detection in `useSolanaRewardsHistory` hook.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to `useSolanaRewardsHistory.ts`, a hook in the earn-staking-api package responsible for fetching and managing Solana staking rewards history. No static test coverage mapping exists for this file, but the Solana staking E2E tests — particularly the rewards test — directly exercise the rewards display functionality this hook provides. The highest risk is a regression in Solana rewards history rendering, with secondary risk to other Solana staking views that display reward amounts on the staking dashboard.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/earn-staking-api/src/staking/hooks/useSolanaRewardsHistory.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/staking/sol/rewards.test.ts` — This test directly exercises Solana staking rewards display functionality. The changed file `useSolanaRewardsHistory.ts` is a hook for fetching and displaying Solana rewards history, and this test verifies that rewards are fetched, displayed correctly after epoch advancement, and that individual reward entries match mocked data — exactly the behavior this hook powers.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test covers the full Solana staking flow including progress indicators and amount tracking through epochs. While it focuses on staking initiation rather than rewards history directly, the staking dashboard components likely consume data from the rewards history hook to show rewards amounts (verified as '0' initially and after epoch advance).
- `../../suite/e2e/tests/staking/sol/stake-more.test.ts` — This test verifies the Solana staking dashboard including rewards display (showing '0' rewards) and progress indicators through epoch advancement. The staking dashboard components that render reward amounts may depend on the `useSolanaRewardsHistory` hook.
- `../../suite/e2e/tests/staking/sol/unstake.test.ts` — This test exercises the Solana staking dashboard showing staked amounts and rewards (initially '0'), then transitions through unstaking and claiming flows. The rewards display on the staking dashboard may be powered by the changed hook.

</details>

_Updated: 2026-04-21T11:05:02.641Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sol-rewards-out-of-sync&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sol-rewards-out-of-sync&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sol-rewards-out-of-sync&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T11:10:11.883Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T11:08:52.882Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sol-rewards-out-of-sync/web/](https://dev.suite.sldev.cz/suite-web/fix/sol-rewards-out-of-sync/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->