### PR TITLE
chore(publish): get rid of map files

### DIFF
--- a/scripts/publish/babel.config.cjs.json
+++ b/scripts/publish/babel.config.cjs.json
@@ -2,5 +2,5 @@
     "presets": [],
     "plugins": ["./babel-plugin-sanitize-internal-imports.js"],
     "comments": true,
-    "sourceMaps": true
+    "sourceMaps": false
 }

--- a/scripts/publish/babel.config.esm.json
+++ b/scripts/publish/babel.config.esm.json
@@ -5,5 +5,5 @@
         "./babel-plugin-add-js-extension.js"
     ],
     "comments": true,
-    "sourceMaps": true
+    "sourceMaps": false
 }

--- a/scripts/publish/replace-imports.sh
+++ b/scripts/publish/replace-imports.sh
@@ -52,8 +52,6 @@ fi
 if [ "$2" == "esm" ]; then
     # rename all esm js files to mjs
     find "$1" -name "*.js" -type f -exec sh -c 'mv "$0" "${0%.js}.mjs"' {} \;
-    find "$1" -name "*.js.map" -type f -exec sh -c 'mv "$0" "${0%.js.map}.mjs.map"' {} \;
     # rename declaration files to .d.mts so TypeScript treats them as ESM, matching the .mjs runtime files
-    find "$1" -name "*.d.ts.map" -type f -exec sh -c 'mv "$0" "${0%.d.ts.map}.d.mts.map"' {} \;
     find "$1" -name "*.d.ts" -type f -exec sh -c 'mv "$0" "${0%.d.ts}.d.mts"' {} \;
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR https://github.com/trezor/trezor-suite/pull/26886/changes was trying to get rid of map files, but it missed the bable plugins that were adding them. Also getting rid of the transformation at `scripts/publish/replace-imports.sh` since it is not needed anymore.

## Notes for QA
Nothing to test.


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `scripts/publish/babel.config.esm.json`, which is a Babel configuration file used in the publish/build pipeline for ESM output. This file is not part of the application runtime code, is not imported by any source files that the E2E tests exercise, and has no static test coverage mapping. None of the analyzed E2E tests touch build scripts or Babel configuration — they all test runtime application behavior (UI flows, device interactions, analytics, trading, etc.). There is no concrete reason any E2E test would be affected by this change, so no tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `scripts/publish/babel.config.esm.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `scripts/publish/babel.config.esm.json`

_Updated: 2026-04-21T11:22:55.661Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/get-rid-of-map-files&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/get-rid-of-map-files&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T11:30:39.909Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T11:28:27.433Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/get-rid-of-map-files/web/](https://dev.suite.sldev.cz/suite-web/chore/get-rid-of-map-files/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->