### PR TITLE
chore(suite-native): remove unused bold badge intents

### DIFF
--- a/suite-native/atoms/src/Badge.tsx
+++ b/suite-native/atoms/src/Badge.tsx
@@ -9,15 +9,7 @@ import { type BoxProps } from './Box';
 import { HStack } from './Stack';
 import { Text } from './Text';
 
-export const BADGE_INTENTS = [
-    'neutral',
-    'brand',
-    'brandBold',
-    'warning',
-    'critical',
-    'info',
-    'bold',
-] as const;
+export const BADGE_INTENTS = ['neutral', 'brand', 'warning', 'critical', 'info'] as const;
 export type BadgeIntent = (typeof BADGE_INTENTS)[number];
 
 export const BADGE_SIZES = ['small', 'medium'] as const;
@@ -59,10 +51,6 @@ const badgeIntentToStylePropsMap = {
         backgroundColor: 'legacyBackgroundPrimarySubtleOnElevation0',
         textColor: 'contentBrand',
     },
-    brandBold: {
-        backgroundColor: 'legacyBackgroundPrimaryDefault',
-        textColor: 'contentPrimaryInverse',
-    },
     warning: {
         backgroundColor: 'legacyBackgroundAlertYellowSubtleOnElevation0',
         textColor: 'contentWarning',
@@ -74,10 +62,6 @@ const badgeIntentToStylePropsMap = {
     info: {
         backgroundColor: 'legacyBackgroundAlertBlueSubtleOnElevation0',
         textColor: 'contentInfo',
-    },
-    bold: {
-        backgroundColor: 'legacyBackgroundNeutralBold',
-        textColor: 'contentPrimaryInverse',
     },
 } as const satisfies Record<BadgeIntent, BadgeStyle>;
 

--- a/suite-native/atoms/src/stories/Badge.stories.tsx
+++ b/suite-native/atoms/src/stories/Badge.stories.tsx
@@ -18,7 +18,7 @@ export const Badge: BadgeStory = {
     name: 'Badge',
     args: {
         label: 'badge',
-        intent: 'brandBold',
+        intent: 'brand',
         size: 'medium',
         icon: undefined,
     },

--- a/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
+++ b/suite-native/module-dev-utils/src/screens/DemoScreen.tsx
@@ -105,14 +105,7 @@ export const DemoScreen = () => {
             buttonColorProps: { intent: 'neutral', priority: 'secondary' },
         },
     ] satisfies { label: string; buttonColorProps: ButtonColorProps }[];
-    const badgeVariants = [
-        'neutral',
-        'brandBold',
-        'brand',
-        'warning',
-        'critical',
-        'bold',
-    ] satisfies BadgeIntent[];
+    const badgeVariants = ['neutral', 'brand', 'warning', 'critical'] satisfies BadgeIntent[];
 
     const handleRadioPress = (value: string | number) => {
         setRadioChecked(value.toString());

--- a/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailHeader.tsx
@@ -74,7 +74,7 @@ export const TransactionDetailHeader = ({
                     ) : (
                         !isFailedTx && (
                             <Badge
-                                intent="brandBold"
+                                intent="brand"
                                 label={<Translation id="transactions.status.confirmed" />}
                             />
                         )


### PR DESCRIPTION
Unused `bold` and  `brandBold` badge variants removed.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/native/remove-bold-badges&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->