### PR TITLE
chore(suite-sync): upgrade @hookform/resolvers to v5

### DIFF
--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -14,7 +14,6 @@ import type { Requirement } from '../Requirement';
  */
 export const ALLOWED_DRIFTS = new Set([
     '@solana-program/stake', // 0.2.x vs 0.5.x used in different contexts (semver 0.x = breaking)
-    '@hookform/resolvers', // migration from v3 to v5 in progress
     'jest-diff', // v29 and v30 coexist during migration
     'babel-jest', // waiting for suite-native who are waiting for expo to update babel-jest
     '@scure/base', // i think i had a cjs problem, todo: investigate later

--- a/suite/suite-sync/package.json
+++ b/suite/suite-sync/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@evolu/common": "8.0.0-next.3",
         "@evolu/web": "3.0.0-next.0",
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.2.2",
         "@reduxjs/toolkit": "2.11.2",
         "@suite-common/delegated-identity-key-types": "workspace:*",
         "@suite-common/device": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4876,15 +4876,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hookform/resolvers@npm:^3.3.4":
-  version: 3.10.0
-  resolution: "@hookform/resolvers@npm:3.10.0"
-  peerDependencies:
-    react-hook-form: ^7.0.0
-  checksum: 10/92d3601b2cedb4f52e9e086cc4bd6a20b493f59ecfb1af8b8e465057f0445aa83cf5a6d482a831cdf5d1321a73269173633222eefde0adb515d3820c1525b0cb
-  languageName: node
-  linkType: hard
-
 "@hookform/resolvers@npm:^5.2.2":
   version: 5.2.2
   resolution: "@hookform/resolvers@npm:5.2.2"
@@ -14913,7 +14904,7 @@ __metadata:
   dependencies:
     "@evolu/common": "npm:8.0.0-next.3"
     "@evolu/web": "npm:3.0.0-next.0"
-    "@hookform/resolvers": "npm:^3.3.4"
+    "@hookform/resolvers": "npm:^5.2.2"
     "@reduxjs/toolkit": "npm:2.11.2"
     "@suite-common/delegated-identity-key-types": "workspace:*"
     "@suite-common/device": "workspace:*"


### PR DESCRIPTION
## Summary
- Bumps `@hookform/resolvers` in `@suite/suite-sync` from `^3.3.4` to `^5.2.2`, matching the rest of the monorepo (`packages/suite`, `suite-native/forms`).
- Removes `@hookform/resolvers` from `ALLOWED_DRIFTS` — the drift was only there because of this single holdout.
- API is unchanged; the sole call site (`SelectSuiteSyncServer.tsx` -> `yupResolver(formSchema)`) uses the same signature already in use across v5 consumers. Peer dep `react-hook-form ^7.71.2` satisfies the v5 requirement of `>= 7.55`.

## Test plan
- [ ] `yarn requirements:verify` passes (locally green — all 283 requirements)
- [ ] CI type-check / lint / tests
- [ ] Manual smoke: open Suite-Sync server selector modal, submit default + custom URL, verify validation errors still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are: (1) `requireUnifiedDependencyVersions.ts` — a build-time/CI requirement checker for dependency version consistency across packages, which is not exercised by any E2E test since it operates at the monorepo tooling level, and (2) `suite/suite-sync/package.json` — a package manifest change (likely a dependency version bump or metadata update) for the suite-sync package. While suite-sync is used by the Suite Sync / Evolu labeling feature, a package.json change alone (without corresponding source code changes) is extremely unlikely to alter runtime behavior tested by E2E tests. No E2E tests directly or indirectly exercise the dependency version requirement checker, and the suite-sync package.json change carries negligible runtime risk. No E2E tests are recommended for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `suite/suite-sync/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `suite/suite-sync/package.json`

_Updated: 2026-04-21T12:01:47.613Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/hookform-resolvers-drift&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/hookform-resolvers-drift&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T12:07:14.305Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T12:06:03.169Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/hookform-resolvers-drift/web/](https://dev.suite.sldev.cz/suite-web/mroz22/hookform-resolvers-drift/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->