### PR TITLE
refactor(coinjoin): extract named tx and block constants from BLOCKS …

### DIFF
--- a/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
+++ b/packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts
@@ -3,15 +3,20 @@ import { networks } from '@trezor/utxo-lib';
 import { CoinjoinMempoolController } from '../../src/backend/CoinjoinMempoolController';
 import { AccountAddress } from '../../src/types/backend';
 import {
-    BLOCKS,
+    BLOCK_TXS,
     SEGWIT_CHANGE_ADDRESSES,
     SEGWIT_RECEIVE_ADDRESSES,
+    TX0,
+    TX1,
+    TX2,
+    TX3,
+    TX4,
+    TX5,
 } from '../fixtures/methods.fixture';
 import { MockMempoolClient } from '../mocks/MockMempoolClient';
 
-const TXS = BLOCKS.flatMap(block => block.txs); // There is 6 of them
 const ADDRESS = SEGWIT_RECEIVE_ADDRESSES[1];
-const TXS_MATCH = [TXS[1], TXS[3]];
+const TXS_MATCH = [TX1, TX3];
 
 describe('CoinjoinMempoolController', () => {
     const client = new MockMempoolClient();
@@ -23,9 +28,9 @@ describe('CoinjoinMempoolController', () => {
     });
 
     it('All at once', async () => {
-        client.setMempoolTxs(TXS);
+        client.setMempoolTxs(BLOCK_TXS);
         await mempool.init();
-        expect(mempool.getTransactions()).toEqual(TXS);
+        expect(mempool.getTransactions()).toEqual(BLOCK_TXS);
         expect(
             mempool.getTransactions({
                 receive: [{ address: ADDRESS } as AccountAddress],
@@ -44,27 +49,27 @@ describe('CoinjoinMempoolController', () => {
     });
 
     it('Progressing', async () => {
-        [TXS[0], TXS[1]].forEach(client.fireTx.bind(client));
+        [TX0, TX1].forEach(client.fireTx.bind(client));
         expect(mempool.getTransactions()).toEqual([]);
 
         await mempool.start();
-        [TXS[2], TXS[3]].forEach(client.fireTx.bind(client));
-        expect(mempool.getTransactions()).toEqual([TXS[2], TXS[3]]);
+        [TX2, TX3].forEach(client.fireTx.bind(client));
+        expect(mempool.getTransactions()).toEqual([TX2, TX3]);
 
-        client.setMempoolTxs([TXS[1], TXS[2], TXS[3]]);
+        client.setMempoolTxs([TX1, TX2, TX3]);
         await mempool.update(true);
-        expect(mempool.getTransactions()).toEqual([TXS[2], TXS[3]]);
+        expect(mempool.getTransactions()).toEqual([TX2, TX3]);
 
-        [TXS[4]].forEach(client.fireTx.bind(client));
-        client.setMempoolTxs([TXS[3], TXS[4], TXS[5]]);
+        [TX4].forEach(client.fireTx.bind(client));
+        client.setMempoolTxs([TX3, TX4, TX5]);
         await mempool.update(true);
-        expect(mempool.getTransactions()).toEqual([TXS[3], TXS[4]]);
+        expect(mempool.getTransactions()).toEqual([TX3, TX4]);
 
-        [TXS[5]].forEach(client.fireTx.bind(client));
+        [TX5].forEach(client.fireTx.bind(client));
         await mempool.update(true);
-        expect(mempool.getTransactions()).toEqual([TXS[3], TXS[4], TXS[5]]);
+        expect(mempool.getTransactions()).toEqual([TX3, TX4, TX5]);
 
-        client.setMempoolTxs([TXS[0], TXS[1]]);
+        client.setMempoolTxs([TX0, TX1]);
         await mempool.update(true);
         expect(mempool.getTransactions()).toEqual([]);
     });
@@ -76,26 +81,26 @@ describe('CoinjoinMempoolController', () => {
             filter: address =>
                 address === SEGWIT_RECEIVE_ADDRESSES[1] || address === SEGWIT_CHANGE_ADDRESSES[0],
         });
-        client.setMempoolTxs(TXS);
+        client.setMempoolTxs(BLOCK_TXS);
         await mempool.init();
-        expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[4]]);
+        expect(mempool.getTransactions()).toEqual([TX1, TX3, TX4]);
     });
 
     it('Removing', async () => {
-        client.setMempoolTxs(TXS);
+        client.setMempoolTxs(BLOCK_TXS);
         await mempool.init();
-        expect(mempool.getTransactions()).toEqual(TXS);
+        expect(mempool.getTransactions()).toEqual(BLOCK_TXS);
 
-        mempool.removeTransactions([TXS[0].txid, TXS[2].txid, 'unknown', TXS[4].txid]);
-        expect(mempool.getTransactions()).toEqual([TXS[1], TXS[3], TXS[5]]);
+        mempool.removeTransactions([TX0.txid, TX2.txid, 'unknown', TX4.txid]);
+        expect(mempool.getTransactions()).toEqual([TX1, TX3, TX5]);
     });
 
     it('Replace-by-fee', async () => {
         const outpointCollision = { txid: 'foo', vout: 3 };
-        const a1 = TXS[1];
+        const a1 = TX1;
         a1.vin[0] = { ...a1.vin[0], ...outpointCollision };
-        const b = TXS[2];
-        const a2 = TXS[4];
+        const b = TX2;
+        const a2 = TX4;
         a2.vin[1] = { ...a2.vin[1], ...outpointCollision };
 
         client.setMempoolTxs([a1]);

--- a/packages/coinjoin/tests/backend/methods.test.ts
+++ b/packages/coinjoin/tests/backend/methods.test.ts
@@ -209,7 +209,7 @@ describe(`CoinjoinBackend methods`, () => {
     });
 
     it('scanAccount derive pending', async () => {
-        client.setFixture([{ ...FIXTURES.BLOCKS[0], txs: [] }]);
+        client.setFixture([{ ...FIXTURES.BLOCK_0, txs: [] }]);
 
         const scan1 = await scanAccount(
             { descriptor: FIXTURES.SEGWIT_XPUB, checkpoints: [EMPTY_CHECKPOINT] },
@@ -226,7 +226,7 @@ describe(`CoinjoinBackend methods`, () => {
         expect(scan1.checkpoint.receiveCount).toBe(20);
         expect(info1.addresses.unused.length).toBe(20);
 
-        client.setFixture([{ ...FIXTURES.BLOCKS[0], txs: [] }], [FIXTURES.TX_4_PENDING]);
+        client.setFixture([{ ...FIXTURES.BLOCK_0, txs: [] }], [FIXTURES.TX_4_PENDING]);
 
         const scan2 = await scanAccount(
             { descriptor: FIXTURES.SEGWIT_XPUB, checkpoints: [scan1.checkpoint] },

--- a/packages/coinjoin/tests/fixtures/methods.fixture.ts
+++ b/packages/coinjoin/tests/fixtures/methods.fixture.ts
@@ -21,82 +21,213 @@ export const BASE_HEIGHT = 0;
 export const BASE_HASH = 'craigwrightisafraud';
 
 // hash + filter must be always preserved for the filters to work
+export const TX0 = {
+    txid: '11111111111111111111111111111111',
+    filter: '03928f707d3166a2ea',
+    blockHeight: 1,
+    blockTime: 1337,
+    value: '1578597058',
+    fees: '28059',
+    vin: [
+        {
+            n: 0,
+            addresses: ['mkUzYq8aQ4xzgPoCw8QVsRzkn1dceiPzmi'],
+            isAddress: true,
+            value: '1578625117',
+            txid: 'foo',
+        },
+    ],
+    vout: [
+        {
+            value: '578597058',
+            n: 0,
+            spent: true,
+            addresses: ['n29Q5yZh813J4MHtY4KjteNs1rfRWVRRPJ'],
+            isAddress: true,
+        },
+        {
+            value: '1000000000',
+            n: 1,
+            spent: true,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const TX1 = {
+    txid: '22222222222222222222222222222222',
+    filter: '021944359ad6e0',
+    blockHeight: 2,
+    blockTime: 1337,
+    value: '999999890',
+    fees: '110',
+    vin: [
+        {
+            n: 0,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+            value: '1000000000',
+            txid: '11111111111111111111111111111111',
+            vout: 1,
+        },
+    ],
+    vout: [
+        {
+            value: '999999890',
+            n: 0,
+            spent: true,
+            addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const TX2 = {
+    txid: '33333333333333333333333333333333',
+    filter: '031e20cd856d4fa3f1',
+    blockHeight: 4,
+    blockTime: 1337,
+    value: '999999858',
+    fees: '142',
+    vin: [
+        {
+            n: 0,
+            addresses: ['bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx'],
+            isAddress: true,
+            value: '1000000000',
+            txid: 'bar',
+        },
+    ],
+    vout: [
+        {
+            value: '547',
+            n: 0,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+        },
+        {
+            value: '999999311',
+            n: 1,
+            spent: true,
+            addresses: ['bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const TX3 = {
+    txid: '44444444444444444444444444444444',
+    filter: '034a680453fcd11cf180',
+    blockHeight: 6,
+    blockTime: 1337,
+    value: '999999749',
+    fees: '141',
+    vin: [
+        {
+            n: 0,
+            addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
+            isAddress: true,
+            value: '999999890',
+            txid: '22222222222222222222222222222222',
+        },
+    ],
+    vout: [
+        {
+            value: '547',
+            n: 0,
+            spent: true,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+        },
+        {
+            value: '999999202',
+            n: 1,
+            spent: true,
+            addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const TX4 = {
+    txid: '55555555555555555555555555555555',
+    filter: '0262fbd3058600',
+    blockHeight: 7,
+    blockTime: 1337,
+    value: '999999571',
+    fees: '178',
+    vin: [
+        {
+            n: 0,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+            value: '547',
+            txid: '44444444444444444444444444444444',
+        },
+        {
+            n: 1,
+            addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
+            isAddress: true,
+            value: '999999202',
+            txid: '44444444444444444444444444444444',
+            vout: 1,
+        },
+    ],
+    vout: [
+        {
+            value: '999999571',
+            n: 0,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const TX5 = {
+    txid: '66666666666666666666666666666666',
+    filter: '0256bf6979ccc0',
+    blockHeight: 8,
+    blockTime: 1337,
+    value: '999999212',
+    fees: '99',
+    vin: [
+        {
+            n: 0,
+            addresses: ['bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz'],
+            isAddress: true,
+            value: '999999311',
+            txid: 'baz',
+        },
+    ],
+    vout: [
+        {
+            value: '999999212',
+            n: 0,
+            addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
+            isAddress: true,
+        },
+    ],
+};
+
+export const BLOCK_TXS = [TX0, TX1, TX2, TX3, TX4, TX5];
+
+export const BLOCK_0 = {
+    height: 1,
+    hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
+    filter: '03a282604dcbe72d0e', // receive 1 out
+    previousBlockHash: BASE_HASH,
+    txs: [TX0],
+};
+
 export const BLOCKS = [
-    {
-        height: 1,
-        hash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
-        filter: '03a282604dcbe72d0e', // receive 1 out
-        previousBlockHash: BASE_HASH,
-        txs: [
-            {
-                txid: '11111111111111111111111111111111',
-                filter: '03928f707d3166a2ea',
-                blockHeight: 1,
-                blockTime: 1337,
-                value: '1578597058',
-                fees: '28059',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: ['mkUzYq8aQ4xzgPoCw8QVsRzkn1dceiPzmi'],
-                        isAddress: true,
-                        value: '1578625117',
-                        txid: 'foo',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '578597058',
-                        n: 0,
-                        spent: true,
-                        addresses: ['n29Q5yZh813J4MHtY4KjteNs1rfRWVRRPJ'],
-                        isAddress: true,
-                    },
-                    {
-                        value: '1000000000',
-                        n: 1,
-                        spent: true,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
-    },
+    BLOCK_0,
     {
         height: 2,
         hash: '5513d63651bbb32985b54fa9e0e530553e3e9cebdd10feae7f019c04edb80f61',
         filter: '02044071f773c0', // receive 1 in, receive 2 out
         previousBlockHash: '09f69854a4572575e2a8af0dea70ff5efd46957e2cb60e81c0d760098ab48b44',
-        txs: [
-            {
-                txid: '22222222222222222222222222222222',
-                filter: '021944359ad6e0',
-                blockHeight: 2,
-                blockTime: 1337,
-                value: '999999890',
-                fees: '110',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                        value: '1000000000',
-                        txid: '11111111111111111111111111111111',
-                        vout: 1,
-                    },
-                ],
-                vout: [
-                    {
-                        value: '999999890',
-                        n: 0,
-                        spent: true,
-                        addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
+        txs: [TX1],
     },
     {
         height: 3,
@@ -110,44 +241,7 @@ export const BLOCKS = [
         hash: '12de06b8ae4bbc660e3f565c876c606f5a1bd3463364c6abfc882b5ff6dd86e3',
         filter: '030361ceb3dfc1c1e600', // receive 1 out
         previousBlockHash: '295578a3c8eb87736a5e657b06a0933f7ec5f82c43f8418fdb38f74c0fc066c7',
-        txs: [
-            {
-                txid: '33333333333333333333333333333333',
-                filter: '031e20cd856d4fa3f1',
-                blockHeight: 4,
-                blockTime: 1337,
-                value: '999999858',
-                fees: '142',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: [
-                            'bcrt1pswrqtykue8r89t9u4rprjs0gt4qzkdfuursfnvqaa3f2yql07zmq2fdmpx',
-                        ],
-                        isAddress: true,
-                        value: '1000000000',
-                        txid: 'bar',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '547',
-                        n: 0,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                    },
-                    {
-                        value: '999999311',
-                        n: 1,
-                        spent: true,
-                        addresses: [
-                            'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
-                        ],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
+        txs: [TX2],
     },
     {
         height: 5,
@@ -159,124 +253,28 @@ export const BLOCKS = [
     {
         height: 6,
         hash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
-        filter: '036e6e302da2ce028c', // receive 2 in, receive 1 out, change 1 out'
+        filter: '036e6e302da2ce028c', // receive 2 in, receive 1 out, change 1 out
         previousBlockHash: '2c2c65aad93eebe235955e170913fd6558453dd999a4ded6249bbdc9d54da1f7',
-        txs: [
-            {
-                txid: '44444444444444444444444444444444',
-                filter: '034a680453fcd11cf180',
-                blockHeight: 6,
-                blockTime: 1337,
-                value: '999999749',
-                fees: '141',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: ['bcrt1qldlynaqp0hy4zc2aag3pkenzvxy65saej0huey'],
-                        isAddress: true,
-                        value: '999999890',
-                        txid: '22222222222222222222222222222222',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '547',
-                        n: 0,
-                        spent: true,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                    },
-                    {
-                        value: '999999202',
-                        n: 1,
-                        spent: true,
-                        addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
+        txs: [TX3],
     },
     {
         height: 7,
         hash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-        filter: '02020f2a9a0ac0', // receive 1 in, change 1 in, receive 1 out'
+        filter: '02020f2a9a0ac0', // receive 1 in, change 1 in, receive 1 out
         previousBlockHash: '5021a2185f27ad04d45f1b53c873b2231311aea99e0f1d7a6252167540b9db4c',
-        txs: [
-            {
-                txid: '55555555555555555555555555555555',
-                filter: '0262fbd3058600',
-                blockHeight: 7,
-                blockTime: 1337,
-                value: '999999571',
-                fees: '178',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                        value: '547',
-                        txid: '44444444444444444444444444444444',
-                    },
-                    {
-                        n: 1,
-                        addresses: ['bcrt1qejqxwzfld7zr6mf7ygqy5s5se5xq7vmt8ntmj0'],
-                        isAddress: true,
-                        value: '999999202',
-                        txid: '44444444444444444444444444444444',
-                        vout: 1,
-                    },
-                ],
-                vout: [
-                    {
-                        value: '999999571',
-                        n: 0,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
+        txs: [TX4],
     },
     {
         height: 8,
         hash: '36d01c975372c363d94f0e9e22e8a61a6a52e3408c98920ef1587b024ec487e3',
         filter: '023e09f4f752a0', // receive 1 out
         previousBlockHash: '01d37c4490e9ddaf6b5c886eaa215b8d0b658c93ea42cfd871b226f606672c0b',
-        txs: [
-            {
-                txid: '66666666666666666666666666666666',
-                filter: '0256bf6979ccc0',
-                blockHeight: 8,
-                blockTime: 1337,
-                value: '999999212',
-                fees: '99',
-                vin: [
-                    {
-                        n: 0,
-                        addresses: [
-                            'bcrt1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmtsef5dqz',
-                        ],
-                        isAddress: true,
-                        value: '999999311',
-                        txid: 'baz',
-                    },
-                ],
-                vout: [
-                    {
-                        value: '999999212',
-                        n: 0,
-                        addresses: ['bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v'],
-                        isAddress: true,
-                    },
-                ],
-            },
-        ],
+        txs: [TX5],
     },
 ];
 
 export const TX_4_PENDING = {
-    ...BLOCKS[5].txs[0],
+    ...TX3,
     blockHeight: -1,
     blockTime: undefined,
 };


### PR DESCRIPTION
…fixture

TX0-TX5 and BLOCK_0 are now standalone exported constants. BLOCKS references them instead of defining inline objects. Tests import named constants directly — no indexed access needed.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are unit test files and test fixtures within the `packages/coinjoin/tests/` directory (CoinjoinMempoolController.test.ts, methods.test.ts, and methods.fixture.ts). These are internal coinjoin backend unit tests and fixtures — they do not affect any application source code, UI components, API endpoints, or shared utilities consumed by the Suite E2E tests. None of the E2E tests reference coinjoin backend test files or fixtures, and the LLM analysis of all known E2E tests shows no behavioral overlap with coinjoin mempool controller or coinjoin backend methods. There is no risk of regression in any E2E test flow, so no E2E tests need to be run.

<details><summary><b>Changed files (3)</b></summary>

- `packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts`
- `packages/coinjoin/tests/backend/methods.test.ts`
- `packages/coinjoin/tests/fixtures/methods.fixture.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/coinjoin/tests/backend/CoinjoinMempoolController.test.ts`
- `packages/coinjoin/tests/backend/methods.test.ts`
- `packages/coinjoin/tests/fixtures/methods.fixture.ts`

_Updated: 2026-04-21T12:45:31.428Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coinjoin-mempool-test-fixtures&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coinjoin-mempool-test-fixtures&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T12:50:45.792Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T12:49:22.227Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/coinjoin-mempool-test-fixtures/web/](https://dev.suite.sldev.cz/suite-web/fix/coinjoin-mempool-test-fixtures/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->