### PR TITLE
fix(connect): enforce PAYTOADDRESS for external outputs in signTransaction

### DIFF
--- a/packages/connect-common/src/types/api/__tests__/bitcoin.ts
+++ b/packages/connect-common/src/types/api/__tests__/bitcoin.ts
@@ -450,8 +450,7 @@ export const signTransaction = async (api: TrezorConnect) => {
                 op_return_data: 'deadbeef',
                 script_type: 'PAYTOOPRETURN',
             },
-            // NOTE: Previously there was a "@ts-expect-error unexpected script_type" directive here
-            // The type in TxOutputType was loosened to allow this (see issue #10474)
+            // @ts-expect-error unexpected script_type on external output
             {
                 address: 'abcd',
                 amount: '100',

--- a/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
+++ b/packages/connect/e2e/__fixtures__/signTransactionReplace.ts
@@ -112,10 +112,9 @@ export default {
                 ],
                 outputs: [
                     {
-                        // NOTE: address_n should be correctly used instead of address (issue #10474)
                         address: 'tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9',
                         amount: '100000',
-                        script_type: 'PAYTOWITNESS',
+                        script_type: 'PAYTOADDRESS',
                         orig_hash:
                             '70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e',
                         orig_index: 0,
@@ -189,10 +188,10 @@ export default {
                     },
                 ],
                 outputs: [
-                    // NOTE: script_type should not be undefined (issue #10474)
                     {
                         address: 'moE1dVYvebvtaMuNdXQKvu4UxUftLmS1Gt',
                         amount: '100000000',
+                        script_type: 'PAYTOADDRESS',
                         orig_hash:
                             'ed89acb52cfa438e3653007478e7c7feae89fdde12867943eec91293139730d1',
                         orig_index: 1,
@@ -200,6 +199,7 @@ export default {
                     {
                         address: '2MvUUSiQZDSqyeSdofKX9KrSCio1nANPDTe',
                         amount: '1000000',
+                        script_type: 'PAYTOADDRESS',
                         orig_hash:
                             '334cd7ad982b3b15d07dd1c84e939e95efb0803071648048a7f289492e7b4c8a',
                         orig_index: 0,

--- a/packages/connect/e2e/__txcache__/testnet/65b768dacccfb209eebd95a1fb80a04f1dd6a3abc6d7b41d5e9d9f91605b37d9.json
+++ b/packages/connect/e2e/__txcache__/testnet/65b768dacccfb209eebd95a1fb80a04f1dd6a3abc6d7b41d5e9d9f91605b37d9.json
@@ -26,7 +26,7 @@
         {
             "address": "tb1qldlynaqp0hy4zc2aag3pkenzvxy65saesxw3wd",
             "amount": 10000,
-            "script_type": "PAYTOWITNESS"
+            "script_type": "PAYTOADDRESS"
         },
         {
             "address_n": [2147483732, 2147483649, 2147483648, 1, 2],

--- a/packages/connect/e2e/__txcache__/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json
+++ b/packages/connect/e2e/__txcache__/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json
@@ -26,7 +26,7 @@
         {
             "address": "tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9",
             "amount": 100000,
-            "script_type": "PAYTOWITNESS"
+            "script_type": "PAYTOADDRESS"
         },
         {
             "address_n": [2147483732, 2147483649, 2147483648, 1, 1],

--- a/packages/connect/src/api/bitcoin/__fixtures__/outputs.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/outputs.ts
@@ -1,0 +1,100 @@
+export const validateTrezorOutputs = [
+    {
+        description: 'external output with explicit PAYTOADDRESS',
+        params: [
+            {
+                address: '1BitcoinEaterAddressDontSendf59kuE',
+                amount: '100000',
+                script_type: 'PAYTOADDRESS',
+            },
+        ],
+        result: [{ address: '1BitcoinEaterAddressDontSendf59kuE', script_type: 'PAYTOADDRESS' }],
+    },
+    {
+        description: 'external output with missing script_type defaults to PAYTOADDRESS',
+        params: [
+            {
+                address: '1BitcoinEaterAddressDontSendf59kuE',
+                amount: '100000',
+            },
+        ],
+        result: [{ address: '1BitcoinEaterAddressDontSendf59kuE', script_type: 'PAYTOADDRESS' }],
+    },
+    {
+        description: 'change output with address_n infers script_type from path',
+        params: [
+            {
+                address_n: "m/44'/0'/0'/1/0",
+                amount: '100000',
+            },
+        ],
+        result: [{ script_type: 'PAYTOADDRESS' }],
+    },
+    {
+        description: 'external output with PAYTOWITNESS throws',
+        params: [
+            {
+                address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+                amount: '100000',
+                script_type: 'PAYTOWITNESS',
+            },
+        ],
+        error: 'External output (with address) must use script_type PAYTOADDRESS',
+    },
+    {
+        description: 'external output with PAYTOP2SHWITNESS throws',
+        params: [
+            {
+                address: '1BitcoinEaterAddressDontSendf59kuE',
+                amount: '100000',
+                script_type: 'PAYTOP2SHWITNESS',
+            },
+        ],
+        error: 'External output (with address) must use script_type PAYTOADDRESS',
+    },
+    {
+        description: 'external output with PAYTOTAPROOT throws',
+        params: [
+            {
+                address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+                amount: '100000',
+                script_type: 'PAYTOTAPROOT',
+            },
+        ],
+        error: 'External output (with address) must use script_type PAYTOADDRESS',
+    },
+    {
+        description: 'output with both address and address_n throws',
+        params: [
+            {
+                address: '1BitcoinEaterAddressDontSendf59kuE',
+                address_n: [0],
+                amount: '100000',
+                script_type: 'PAYTOADDRESS',
+            },
+        ],
+        error: 'Cannot use address and address_n in one output',
+    },
+    {
+        description: 'external output with invalid address throws',
+        params: [
+            {
+                address: 'not-a-valid-bitcoin-address',
+                amount: '100000',
+                script_type: 'PAYTOADDRESS',
+            },
+        ],
+        error: 'Invalid Bitcoin output address not-a-valid-bitcoin-address',
+    },
+    {
+        description: 'non-string script_type throws at param validation',
+        params: [
+            {
+                address: '1BitcoinEaterAddressDontSendf59kuE',
+                amount: '100000',
+                script_type: 0,
+            },
+        ],
+        error: 'Parameter "script_type" has invalid type. "string" expected.',
+    },
+];

--- a/packages/connect/src/api/bitcoin/__tests__/outputs.test.ts
+++ b/packages/connect/src/api/bitcoin/__tests__/outputs.test.ts
@@ -1,0 +1,19 @@
+import { networks } from '@trezor/utxo-lib';
+
+import * as fixtures from '../__fixtures__/outputs';
+import { validateTrezorOutputs } from '../outputs';
+
+describe('core/methods/tx/outputs', () => {
+    describe('validateTrezorOutputs', () => {
+        const coinInfo: any = { network: networks.bitcoin, label: 'Bitcoin' };
+        fixtures.validateTrezorOutputs.forEach((f: any) => {
+            it(f.description, () => {
+                if (f.result) {
+                    expect(validateTrezorOutputs(f.params, coinInfo)).toMatchObject(f.result);
+                } else {
+                    expect(() => validateTrezorOutputs(f.params, coinInfo)).toThrow(f.error);
+                }
+            });
+        });
+    });
+});

--- a/packages/connect/src/api/bitcoin/outputs.ts
+++ b/packages/connect/src/api/bitcoin/outputs.ts
@@ -32,6 +32,7 @@ export const validateTrezorOutputs = (
             { name: 'address', type: 'string' },
             { name: 'amount', type: 'uint' },
             { name: 'op_return_data', type: 'string' },
+            { name: 'script_type', type: 'string' },
             { name: 'multisig', type: 'object' },
         ]);
 
@@ -49,16 +50,22 @@ export const validateTrezorOutputs = (
             output.script_type = getOutputScriptType(output.address_n);
         }
 
-        if (
-            'address' in output &&
-            typeof output.address === 'string' &&
-            !isValidAddress(output.address, coinInfo)
-        ) {
-            // validate address with coin info
-            throw ERRORS.TypedError(
-                'Method_InvalidParameter',
-                `Invalid ${coinInfo.label} output address ${output.address}`,
-            );
+        if ('address' in output && typeof output.address === 'string') {
+            const externalOutput = output as { address: string; script_type?: string };
+            if (!externalOutput.script_type) {
+                externalOutput.script_type = 'PAYTOADDRESS';
+            } else if (externalOutput.script_type !== 'PAYTOADDRESS') {
+                throw ERRORS.TypedError(
+                    'Method_InvalidParameter',
+                    `External output (with address) must use script_type PAYTOADDRESS, got ${externalOutput.script_type}`,
+                );
+            }
+            if (!isValidAddress(externalOutput.address, coinInfo)) {
+                throw ERRORS.TypedError(
+                    'Method_InvalidParameter',
+                    `Invalid ${coinInfo.label} output address ${externalOutput.address}`,
+                );
+            }
         }
     });
 

--- a/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
+++ b/packages/protobuf/scripts/protobuf-patches/TxOutputType.ts
@@ -10,7 +10,7 @@ export type TxOutputType =
     | {
           address: string;
           address_n?: typeof undefined;
-          script_type: 'PAYTOADDRESS';
+          script_type?: 'PAYTOADDRESS';
           amount: UintType;
           multisig?: MultisigRedeemScriptType;
           orig_hash?: string;
@@ -20,18 +20,6 @@ export type TxOutputType =
     | {
           address?: typeof undefined;
           address_n: number[];
-          script_type?: ChangeOutputScriptType;
-          amount: UintType;
-          multisig?: MultisigRedeemScriptType;
-          orig_hash?: string;
-          orig_index?: number;
-          payment_req_index?: number;
-      }
-    // NOTE: the type was loosened for compatibility (issue #10474)
-    // It is not originally intended to use address instead of address_n with change output
-    | {
-          address: string;
-          address_n?: typeof undefined;
           script_type?: ChangeOutputScriptType;
           amount: UintType;
           multisig?: MultisigRedeemScriptType;

--- a/packages/protobuf/src/definitions/messages-bitcoin.ts
+++ b/packages/protobuf/src/definitions/messages-bitcoin.ts
@@ -374,7 +374,7 @@ export const TxOutputType = Type.Union(
         Type.Object({
             address: Type.String(),
             address_n: Type.Optional(Type.Undefined()),
-            script_type: Type.Literal('PAYTOADDRESS'),
+            script_type: Type.Optional(Type.Literal('PAYTOADDRESS')),
             amount: Type.Uint(),
             multisig: Type.Optional(MultisigRedeemScriptType),
             orig_hash: Type.Optional(Type.String()),
@@ -384,16 +384,6 @@ export const TxOutputType = Type.Union(
         Type.Object({
             address: Type.Optional(Type.Undefined()),
             address_n: Type.Array(Type.Number()),
-            script_type: Type.Optional(ChangeOutputScriptType),
-            amount: Type.Uint(),
-            multisig: Type.Optional(MultisigRedeemScriptType),
-            orig_hash: Type.Optional(Type.String()),
-            orig_index: Type.Optional(Type.Number()),
-            payment_req_index: Type.Optional(Type.Number()),
-        }),
-        Type.Object({
-            address: Type.String(),
-            address_n: Type.Optional(Type.Undefined()),
             script_type: Type.Optional(ChangeOutputScriptType),
             amount: Type.Uint(),
             multisig: Type.Optional(MultisigRedeemScriptType),


### PR DESCRIPTION
Closes #10474

## Summary

Followup to the schema/validations refactor (#10280) which uncovered two places where `TxOutputType` types did not match the intended protocol and runtime was bugged. Back then we decided to loosen the schema to match the buggy runtime (so as not to break existing integrations). With v10 coming up and breaking changes on the table, this PR finally fixes it at the schema + runtime level.

### Bugs fixed

1. **External outputs without `script_type`** — runtime only inferred `script_type` when `address_n` was present; when `address` was set and `script_type` missing, nothing was filled in and the transaction relied on the protobuf default (`PAYTOADDRESS`). Runtime now explicitly defaults to `PAYTOADDRESS` for external outputs.
2. **External outputs with change-type `script_type`** — `address` + `PAYTOWITNESS` / `PAYTOP2SHWITNESS` / `PAYTOTAPROOT` was previously accepted despite those script types being intended only for change outputs (`address_n`). The loosened union branch in `TxOutputType` that permitted this has been removed, and the runtime now throws `Method_InvalidParameter` on such combinations.

### Changes

- `packages/protobuf/scripts/protobuf-patches/TxOutputType.ts` — removed loosened union branch
- `packages/protobuf/src/definitions/messages-bitcoin.ts` — regenerated accordingly
- `packages/connect/src/api/bitcoin/outputs.ts` — default + reject in `validateTrezorOutputs`
- `packages/connect/src/api/bitcoin/__tests__/outputs.test.ts` + `__fixtures__/outputs.ts` — new unit tests covering default `PAYTOADDRESS`, reject of non-`PAYTOADDRESS` script types, and address validation in `validateTrezorOutputs`.
- Fixtures aligned with the stricter schema: `signTransactionReplace.ts`, two `__txcache__` JSONs, and `connect-common` type test (restored `@ts-expect-error`).

## Breaking change

Integrators who currently pass external outputs with `script_type` other than `PAYTOADDRESS` will now be rejected. Integrators who omit `script_type` on external outputs are unaffected — runtime defaults it to `PAYTOADDRESS`.

## Test plan

- [x] `yarn g:tsc --build` — clean
- [x] `yarn workspace @trezor/connect test:unit` — 466/466
- [x] `yarn workspace @trezor/protobuf test:unit` — 565/565
- [x] `yarn workspace @trezor/connect-common test:unit` — 1/1
- [ ] e2e signTransaction tests against emulator (RBF, bech32, external, coinjoin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on Bitcoin transaction output handling: protobuf TxOutputType definitions (messages-bitcoin.ts and protobuf patches), the connect API's bitcoin output processing (outputs.ts), and related test fixtures/tx cache for signTransaction. The primary risk is regressions in Bitcoin transaction signing and output labeling. The connect e2e fixtures (signTransactionReplace.ts, tx cache JSONs) and protobuf patches have no direct Suite E2E test coverage but are covered by connect's own e2e tests. The recommended strategy focuses on tests that exercise Bitcoin output labeling and Bitcoin send/transaction flows.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect-common/src/types/api/__tests__/bitcoin.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__txcache__/testnet/65b768dacccfb209eebd95a1fb80a04f1dd6a3abc6d7b41d5e9d9f91605b37d9.json`
- `packages/connect/e2e/__txcache__/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json`
- `packages/connect/src/api/bitcoin/outputs.ts`
- `packages/protobuf/scripts/protobuf-patches/TxOutputType.ts`
- `packages/protobuf/src/definitions/messages-bitcoin.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — The changes to packages/connect/src/api/bitcoin/outputs.ts directly affect Bitcoin transaction output processing. This test specifically exercises output labeling for Bitcoin transactions, including labeling specific transaction outputs, editing labels, and verifying exported CSV contains output labels - all of which depend on correct output type handling.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and syncs output labels for Bitcoin transactions. Changes to TxOutputType definitions and bitcoin output processing could affect how transaction outputs are identified and labeled in the Suite Sync flow.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test removes output labels and verifies they reset correctly. Since output label identification depends on transaction output processing (changed in outputs.ts) and protobuf message definitions (changed in messages-bitcoin.ts), regressions could cause label removal to fail.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs output labels from the Evolu relay server and displays them on the account transaction list. Changes to Bitcoin output type definitions could affect how outputs are matched and labeled during sync.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends Bitcoin transactions with multiple outputs, locktime, and OP_RETURN data outputs on regtest. Changes to bitcoin outputs.ts processing and TxOutputType protobuf definitions directly affect how send transaction outputs are constructed and signed.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends Bitcoin transactions with multiple outputs and verifies pending/confirmed transaction display. The changes to bitcoin output processing and protobuf TxOutputType could affect transaction construction and output rendering.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/connect-common/src/types/api/__tests__/bitcoin.ts`
- `packages/connect/e2e/__fixtures__/signTransactionReplace.ts`
- `packages/connect/e2e/__txcache__/testnet/65b768dacccfb209eebd95a1fb80a04f1dd6a3abc6d7b41d5e9d9f91605b37d9.json`
- `packages/connect/e2e/__txcache__/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json`
- `packages/protobuf/scripts/protobuf-patches/TxOutputType.ts`

_Updated: 2026-04-21T12:50:20.581Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-10474&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-10474&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/issue-10474&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T13:12:17.193Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T13:10:57.940Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-10474/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-10474/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->