### PR TITLE
fix(send): clear signed transaction state on push failure to re-enable swap signing

### DIFF
--- a/packages/suite/src/actions/wallet/send/sendFormThunks.ts
+++ b/packages/suite/src/actions/wallet/send/sendFormThunks.ts
@@ -294,6 +294,8 @@ export const signAndPushSendFormTransactionThunk = createThunk(
         );
 
         if (isRejected(pushResponse)) {
+            dispatch(sendFormActions.clearSignedTransactionData());
+
             return pushResponse.payload?.metadata;
         }
 

--- a/suite-common/wallet-core/src/send/sendFormActions.ts
+++ b/suite-common/wallet-core/src/send/sendFormActions.ts
@@ -45,6 +45,8 @@ const storeSignedTransaction = createAction(
 
 const discardTransaction = createAction(`${SEND_MODULE_PREFIX}/discard-transaction`);
 
+const clearSignedTransactionData = createAction(`${SEND_MODULE_PREFIX}/clear-signed-transaction`);
+
 const sendRaw = createAction(`${SEND_MODULE_PREFIX}/sendRaw`, (payload: boolean) => ({
     payload,
 }));
@@ -57,6 +59,7 @@ export const sendFormActions = {
     storePrecomposedTransaction,
     storeSignedTransaction,
     discardTransaction,
+    clearSignedTransactionData,
     sendRaw,
     dispose,
 };

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -88,6 +88,10 @@ export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (
             delete state.signedTx;
             delete state.accountKey;
         })
+        .addCase(sendFormActions.clearSignedTransactionData, state => {
+            delete state.serializedTx;
+            delete state.signedTx;
+        })
         .addCase(sendFormActions.sendRaw, (state, { payload: sendRaw }) => {
             state.sendRaw = sendRaw;
         })


### PR DESCRIPTION
## Description

- Adds a `clearSignedTransaction` action that clears `serializedTx` and `signedTx` from send form state
- Dispatches it when a transaction push is rejected, so the swap button is correctly disabled on a retry signing attempt

## Notes for QA

1. Go to the Swap feature in Suite
2. Initiate a swap and cause the first push to fail (e.g. disconnect network)
3. Retry — verify the swap button is disabled while waiting for device confirmation

## Related Issue

Resolve #23866

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are core send form infrastructure: sendFormThunks.ts handles transaction composition and sending logic, sendFormActions.ts dispatches send form state changes, and sendFormReducer.ts manages the send form Redux state including drafts and serialized transactions. These changes carry high risk for any flow that sends cryptocurrency (direct sends, sell trades, swap trades, staking). The recommended strategy prioritizes direct send form tests (BTC, ETH, SOL, DOGE, LTC, CSV import) as high priority since they most directly exercise the changed code paths, then trading sell/swap tests and staking forms as medium priority since they use send form infrastructure for transaction composition.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/actions/wallet/send/sendFormThunks.ts`
- `suite-common/wallet-core/src/send/sendFormActions.ts`
- `suite-common/wallet-core/src/send/sendFormReducer.ts`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test directly exercises the Bitcoin send form with multiple outputs, locktime, OP_RETURN, and unit switching. Changes to sendFormThunks.ts, sendFormActions.ts, and sendFormReducer.ts directly control send form state management, draft handling, and transaction composition that this test validates end-to-end.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test performs a complete ETH send transaction on Base network including custom fee configuration, device confirmation, and verifies Redux state wallet.send.serializedTx and wallet.send.drafts - both of which are managed by the changed sendFormReducer and sendFormActions. It also checks that drafts become empty after transaction processing.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test validates Ethereum send form filling, custom gas fee configuration, and device prompt verification. The sendFormThunks and sendFormReducer directly handle send form state for ETH transactions including fee calculation and form submission flows.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test validates the Solana send form including Send Max calculation, fee handling, review modal, and device confirmation. The send form state, draft management, and transaction composition are directly controlled by the changed files.
- `suite/e2e/tests/wallet/send-doge.test.ts` — This test exercises the send form in broadcast mode for DOGE including MAX_SAFE_INTEGER validation and device confirmation. The send form thunks handle transaction signing and error handling (toast error on signing failure) that this test validates.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — This test validates LTC send form with broadcast mode, Set Max functionality, and sending from a MimbleWimble peg-out output. The sendFormThunks and sendFormReducer handle Set Max calculation and broadcast mode logic.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a CSV file into the BTC send form to populate multiple outputs. The sendFormReducer manages the send form outputs state, and sendFormActions dispatches updates when outputs are populated from CSV import.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions and tracks their pending/confirmed status. The sendFormThunks handle the actual transaction sending flow, and the test verifies multi-output send form behavior and transaction lifecycle that depends on these actions.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — This test validates the send form behavior when the device is disconnected, including the review/send button triggering a connection modal. The sendFormThunks handle the review flow that checks device connectivity before sending.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow involves composing a send transaction to the provider's address. The sendFormThunks and sendFormReducer manage the transaction composition that powers the sell confirmation and device prompt steps in this test.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test validates selling ETH with custom gas fees, which involves composing a send transaction. The changed send form actions and reducer manage the composed transaction state that feeds into the sell confirmation flow.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The Solana sell flow sends crypto to a provider, involving send form transaction composition. The sendFormThunks handle Solana transaction building and the test verifies fee calculation and device prompt amounts that depend on it.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token involves composing a token transfer transaction through the send form infrastructure. Changes to sendFormThunks could affect token send composition used in the sell flow.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — This test validates sell form input validation (decimal limits, insufficient funds) and percentage/max buttons for BTC and SOL. These validations are driven by the send form state managed by the changed reducer and actions.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test sets custom BTC fees for a swap and verifies composedTransactionInfo from wallet.trading Redux state. The sendFormThunks handle transaction composition that populates this state, and the test explicitly checks the Redux state is not empty.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test validates custom Ethereum gas fees during a swap and checks wallet.trading.composedTransactionInfo. The send form infrastructure handles ETH transaction composition that this test depends on.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test performs a SOL-to-BTC swap that sends crypto to a provider. The swap flow uses composedTransactionInfo from the Redux state managed by the send form reducer, and the test verifies device prompt amounts derived from transaction composition.
- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form validates minimum amounts, decimal precision, insufficient funds, and percentage/max buttons for ETH staking. These input validations share send form infrastructure managed by the changed files.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test explicitly verifies that after onboarding, the send form button is visible on the wallet page. While it doesn't exercise send form deeply, it confirms the send form entry point renders correctly, which depends on the send form state initialization in the changed reducer.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This swap test sends SOL to a provider and verifies device prompt amounts. The swap flow uses transaction composition from the send form infrastructure, though the primary path is through the trading module.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This swap test sends a Solana token (USDT) to a swap provider and verifies transaction amounts on the device. The send infrastructure handles token transfer composition used in this flow.

</details>

_Updated: 2026-04-21T13:42:46.656Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/23866/swap-resigning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/23866/swap-resigning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/23866/swap-resigning&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T05:03:38.136Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T13:45:38.412Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/23866/swap-resigning/web/](https://dev.suite.sldev.cz/suite-web/fix/23866/swap-resigning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->