### PR TITLE
ci(test-misc): cut unit-test log noise (~70-80%) via --silent

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -128,7 +128,7 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: yarn test:unit:${{ matrix.test-task }} --output-style=stream
+        run: yarn test:unit:${{ matrix.test-task }} --output-style=stream -- --silent
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/.github/workflows/test-misc.yml
+++ b/.github/workflows/test-misc.yml
@@ -74,9 +74,9 @@ jobs:
       - run: yarn install --immutable
       - run: yarn message-system-sign-config
       - name: Unit Tests - Suite, Connect, Common
-        run: yarn test:unit:all --exclude='@suite-native/*'
+        run: yarn test:unit:all --exclude='@suite-native/*' -- --silent
       - name: Unit Tests - Native
-        run: yarn test:unit:all --exclude='@trezor/*,@suite/*,@suite-common/*'
+        run: yarn test:unit:all --exclude='@trezor/*,@suite/*,@suite-common/*' -- --silent
 
   test-unit-windows:
     runs-on: windows-latest

--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -70,7 +70,7 @@
         "build:workers": "yarn g:rimraf build && yarn build:workers-web && yarn build:workers-module",
         "build:workers-web": "webpack --config ./webpack/workers.web.js",
         "build:workers-module": "webpack --config ./webpack/workers.module.js",
-        "test:unit": "yarn g:jest --verbose -c jest.config.unit.js",
+        "test:unit": "yarn g:jest -c jest.config.unit.js",
         "test:integration": "yarn g:jest -c jest.config.integration.js",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "depcheck": "yarn g:depcheck",

--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -6,7 +6,7 @@
     "sideEffects": false,
     "main": "src/index",
     "scripts": {
-        "test:unit": "yarn g:jest --verbose",
+        "test:unit": "yarn g:jest",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"

--- a/packages/suite-desktop-api/package.json
+++ b/packages/suite-desktop-api/package.json
@@ -14,7 +14,7 @@
     "main": "./src/main.ts",
     "browser": "./src/renderer.ts",
     "scripts": {
-        "test:unit": "yarn g:jest --verbose",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,7 @@
         "CHANGELOG.md"
     ],
     "scripts": {
-        "test:unit": "yarn g:jest --verbose",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
         "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",

--- a/packages/utxo-lib/package.json
+++ b/packages/utxo-lib/package.json
@@ -56,7 +56,7 @@
     },
     "scripts": {
         "depcheck": "yarn g:depcheck",
-        "test:unit": "yarn g:jest --verbose",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
         "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",


### PR DESCRIPTION
## Summary

CI unit-test logs currently run to ~27k lines per run, making test failures hard to locate. Two small changes address the bulk of the noise:

1. **Pass \`--silent\` to jest** in \`.github/workflows/test-misc.yml\` (both unit-test steps). Suppresses in-test \`console.log/warn/error\` output, which jest normally prints with attached stack traces. Measured: ~55-65% of current output. Thrown errors and assertion failures are unaffected.
2. **Remove \`--verbose\`** from the 5 per-package \`test:unit\` scripts that had it (\`blockchain-link\`, \`node-utils\`, \`suite-desktop-api\`, \`utils\`, \`utxo-lib\`). \`--verbose\` prints every test name and describe-block label. Measured: ~14-16% of current output. Devs can still pass \`--verbose\` locally when needed.

Combined: ~70-80% reduction on a recent passing run (27k → ~5-7k lines).

Coverage tables and the React \`act()\` warnings (151×, ~12-16% on their own) are intentionally out of scope — \`--silent\` already hides the act warnings; coverage is a separate decision.

## Measurements

Taken from job \`71749416595\` (workflow run \`24541929972\`, passing run on \`develop\`):

| Category | Lines | % |
|---|---:|---:|
| \`console.*\` output (headers + stacks + object dumps + warnings) | ~14-16k | ~55-60% |
| \`--verbose\` test names + describe labels | ~4.5k | ~16% |
| Coverage tables | 1.1k | 4% |
| PASS/FAIL, summary, blanks, nx | rest | ~20% |

## Test plan

- [ ] Trigger workflow on this PR (\`test-misc.yml\` runs on PRs that touch the workflow file) and inspect the \`test-unit\` job log size.
- [ ] Confirm the job still passes and that failures (if any) show assertion/thrown-error stack traces clearly without the console noise around them.
- [ ] Spot-check a few package runs locally (\`yarn workspace @trezor/utils test:unit\`, etc.) — no \`--verbose\` per-test listing, still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All five changed files are package.json files in various packages (blockchain-link, node-utils, suite-desktop-api, utils, utxo-lib). These changes are almost certainly dependency version bumps, metadata updates, or build configuration changes rather than functional code changes. No static coverage mapping exists for any of these files, and the LLM analysis of all available tests shows no test that directly exercises package.json parsing, dependency resolution, or build metadata from these specific packages. Since package.json changes typically only affect build/install behavior rather than runtime application logic, the risk of functional regression is extremely low. No targeted E2E tests are recommended — CI should rely on build verification and unit tests for these changes.

<details><summary><b>Changed files (5)</b></summary>

- `packages/blockchain-link/package.json`
- `packages/node-utils/package.json`
- `packages/suite-desktop-api/package.json`
- `packages/utils/package.json`
- `packages/utxo-lib/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/blockchain-link/package.json`
- `packages/node-utils/package.json`
- `packages/suite-desktop-api/package.json`
- `packages/utils/package.json`
- `packages/utxo-lib/package.json`

_Updated: 2026-04-21T14:49:54.369Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/ci-test-output&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/ci-test-output&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T15:02:48.852Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T15:01:06.289Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/ci-test-output/web/](https://dev.suite.sldev.cz/suite-web/mroz22/ci-test-output/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->