### PR TITLE
fix(suite-native): release 26.4 design token fix

### DIFF
--- a/suite-native/module-earn/src/components/PortfolioTrackerEarnBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/PortfolioTrackerEarnBottomSheet.tsx
@@ -24,12 +24,12 @@ const contentStyle = prepareNativeStyle(utils => ({
 }));
 
 const urlBoxStyle = prepareNativeStyle(utils => ({
-    backgroundColor: utils.colors.legacyBackgroundPrimarySubtleOnElevation1,
+    backgroundColor: utils.colors.backgroundPrimarySubtleOnElevation1,
     width: '100%',
     paddingVertical: utils.spacings.sp12,
     alignItems: 'center',
     borderWidth: utils.borders.widths.small,
-    borderColor: utils.colors.legacyBackgroundPrimarySubtleOnElevationNegative,
+    borderColor: utils.colors.backgroundPrimarySubtleOnElevationNegative,
     borderRadius: utils.borders.radii.r12,
     gap: utils.spacings.sp4,
 }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Due to inconsistencies between the develop and release branch [design tokens](https://github.com/trezor/trezor-suite/pull/26663), we need to fall back to the legacy tokens to fix the release branch build.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/release-26.4.1-color-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->