### PR TITLE
test(suite-native): silence postOnboardingInit console.error in tests

### DIFF
--- a/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
@@ -28,6 +28,16 @@ jest.mock('@react-navigation/native', () => ({
     useRoute: () => mockRoute,
 }));
 
+// Stub out postOnboardingInit so exiting the onboarding flow does not dispatch
+// initStakeDataThunk, which calls up-fetch and throws in the jsdom test env
+// because the global Request constructor is not available.
+jest.mock('@suite-native/app-init', () => ({
+    ...jest.requireActual('@suite-native/app-init'),
+    postOnboardingInit: () => ({
+        type: 'postOnboardingInitMock',
+    }),
+}));
+
 describe('BiometricsScreen', () => {
     let store: TestStore;
 


### PR DESCRIPTION
silence postOnboardingInit console.error in BiometricsScreen test

Stub out postOnboardingInit in BiometricsScreen.test.tsx so exiting the onboarding flow does not dispatch initStakeDataThunk, which calls up-fetch and throws a "Request is not defined" error in the jsdom test environment.

Matches the existing pattern already used by the sibling useExitOnboardingFlow.test.ts.

Refs https://github.com/trezor/trezor-suite/issues/26034