### PR TITLE
Fix Suite Sync banner for missing keys when enabling Suite Sync with disconnected trezor

### DIFF
--- a/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/__tests__/createTurnOnSuiteSync.test.ts
@@ -9,7 +9,7 @@ import { createSuiteSyncStorageMock } from '../../tests/createSuiteSyncStorageMo
 import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
 import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from '../createTurnOnSuiteSync';
 import type { GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
-import { updateSuiteSyncEnabled } from '../suiteSyncSlice';
+import { setSuiteSyncError, updateSuiteSyncEnabled } from '../suiteSyncSlice';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 
@@ -74,7 +74,7 @@ describe(createTurnOnSuiteSync.name, () => {
         expect(result).toEqual(ok());
     });
 
-    it('enables suite sync without calling ensureWalletSuiteSyncOn when remembered device is disconnected', async () => {
+    it('enables suite sync and dispatches DeviceError when remembered device is disconnected', async () => {
         const deps = createMockDeps<CreateTurnOnSuiteSyncDeps & GetDeviceForStaticSessionIdDep>({
             getIsSuiteSyncEnabled: () => false,
             dispatch: mock<Dispatch>(() => {}),
@@ -90,6 +90,12 @@ describe(createTurnOnSuiteSync.name, () => {
         const result = await turnOnSuiteSync({ deviceStaticSessionId });
 
         expect(deps.dispatch).toHaveBeenCalledWith(updateSuiteSyncEnabled({ isEnabled: true }));
+        expect(deps.dispatch).toHaveBeenCalledWith(
+            setSuiteSyncError({
+                deviceStaticSessionId,
+                error: { type: 'DeviceError', message: 'Device not connected.' },
+            }),
+        );
         expect(deps.ensureWalletSuiteSyncOn).not.toHaveBeenCalled();
         expect(result).toEqual(ok());
     });

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.ts
@@ -8,7 +8,7 @@ import {
 import { ok } from '@trezor/type-utils';
 
 import { type GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
-import { updateSuiteSyncEnabled } from './suiteSyncSlice';
+import { setSuiteSyncError, updateSuiteSyncEnabled } from './suiteSyncSlice';
 
 export type CreateTurnOnSuiteSyncDeps = {
     getIsSuiteSyncEnabled: () => boolean;
@@ -31,10 +31,13 @@ export const createTurnOnSuiteSync =
         deps.dispatch(updateSuiteSyncEnabled({ isEnabled: true }));
 
         if (
-            deviceStaticSessionId !== undefined &&
-            deviceStaticSessionId !== PORTFOLIO_TRACKER_DEVICE_STATE &&
-            isDeviceConnected
+            deviceStaticSessionId === undefined ||
+            deviceStaticSessionId === PORTFOLIO_TRACKER_DEVICE_STATE
         ) {
+            return ok();
+        }
+
+        if (isDeviceConnected) {
             const result = await deps.ensureWalletSuiteSyncOn({
                 deviceStaticSessionId,
                 isWriteMode: false,
@@ -43,6 +46,13 @@ export const createTurnOnSuiteSync =
             if (!result.success) {
                 return result;
             }
+        } else {
+            deps.dispatch(
+                setSuiteSyncError({
+                    deviceStaticSessionId,
+                    error: { type: 'DeviceError', message: 'Device not connected.' },
+                }),
+            );
         }
 
         return ok();

--- a/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
+++ b/suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/suite-sync-types';
 import { exhaustive } from '@trezor/type-utils';
 
-import { setSuiteSyncError } from '../suiteSyncSlice';
+import { resetSuiteSyncError, setSuiteSyncError } from '../suiteSyncSlice';
 
 export type CreateEnsureWalletSuiteSyncOnWithFwCheckDeps = {
     dispatch: Dispatch;
@@ -39,9 +39,8 @@ export const createEnsureWalletSuiteSyncOnWithErrorHandler =
                 case 'SuiteSyncUnavailableOnDeviceError':
                     // This error is now not handled in the UI, so we don't need to set the error. It will probably be added as a follow up.
                     deps.dispatch(
-                        setSuiteSyncError({
+                        resetSuiteSyncError({
                             deviceStaticSessionId: params.deviceStaticSessionId,
-                            error: null,
                         }),
                     );
                     break;
@@ -55,9 +54,8 @@ export const createEnsureWalletSuiteSyncOnWithErrorHandler =
             }
         } else {
             deps.dispatch(
-                setSuiteSyncError({
+                resetSuiteSyncError({
                     deviceStaticSessionId: params.deviceStaticSessionId,
-                    error: null,
                 }),
             );
         }

--- a/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOnWithErrorHandler.test.ts
+++ b/suite-common/suite-sync/src/storage/tests/createEnsureWalletSuiteSyncOnWithErrorHandler.test.ts
@@ -16,23 +16,40 @@ describe(createEnsureWalletSuiteSyncOnWithErrorHandler.name, () => {
             innerResult: err({
                 type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType' as const,
             }),
-            expectedDispatchedError: {
-                type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType',
+            expectedDispatchedAction: {
+                type: 'suiteSync/setSuiteSyncError',
+                payload: {
+                    deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+                    error: {
+                        type: 'SuiteSyncFirmwareUpgradeNeededDeviceErrorType',
+                    },
+                },
             },
         },
         {
             description: 'device error',
             innerResult: err({ type: 'DeviceError' as const, message: 'some error' }),
-            expectedDispatchedError: { type: 'DeviceError', message: 'some error' },
+            expectedDispatchedAction: {
+                type: 'suiteSync/setSuiteSyncError',
+                payload: {
+                    deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+                    error: { type: 'DeviceError', message: 'some error' },
+                },
+            },
         },
         {
             description: 'success',
             innerResult: ok({ data: {} } as any),
-            expectedDispatchedError: null,
+            expectedDispatchedAction: {
+                type: 'suiteSync/resetSuiteSyncError',
+                payload: {
+                    deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
+                },
+            },
         },
     ])(
         'dispatches correct error for $description and passes result through',
-        async ({ innerResult, expectedDispatchedError }) => {
+        async ({ innerResult, expectedDispatchedAction }) => {
             const deps = createMockDeps<CreateEnsureWalletSuiteSyncOnWithFwCheckDeps>({
                 dispatch: mock<Dispatch>(() => {}),
                 ensureWalletSuiteSyncOn: () => Promise.resolve(innerResult),
@@ -45,12 +62,7 @@ describe(createEnsureWalletSuiteSyncOnWithErrorHandler.name, () => {
 
             expect(result).toBe(innerResult);
             expect(deps.dispatch).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    payload: {
-                        deviceStaticSessionId: DEVICE_STATIC_SESSION_ID_123,
-                        error: expectedDispatchedError,
-                    },
-                }),
+                expect.objectContaining(expectedDispatchedAction),
             );
         },
     );

--- a/suite-common/suite-sync/src/suiteSyncSlice.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.ts
@@ -53,7 +53,11 @@ export const initialSuiteSyncState: SuiteSyncState = {
 
 type SetSuiteSyncErrorAction = PayloadAction<{
     deviceStaticSessionId: StaticSessionId;
-    error: SuiteSyncErrorType | null;
+    error: SuiteSyncErrorType;
+}>;
+
+type ResetSuiteSyncErrorAction = PayloadAction<{
+    deviceStaticSessionId: StaticSessionId;
 }>;
 
 type SetSuiteSyncOwnerAction = PayloadAction<{
@@ -78,11 +82,10 @@ export const suiteSyncSlice = createSlice({
             state.settings.suiteSyncRelayUrl = payload.url;
         },
         setSuiteSyncError: (state, { payload }: SetSuiteSyncErrorAction) => {
-            if (payload.error === null) {
-                delete state.suiteSyncErrors[payload.deviceStaticSessionId];
-            } else {
-                state.suiteSyncErrors[payload.deviceStaticSessionId] = payload.error;
-            }
+            state.suiteSyncErrors[payload.deviceStaticSessionId] = payload.error;
+        },
+        resetSuiteSyncError: (state, { payload }: ResetSuiteSyncErrorAction) => {
+            delete state.suiteSyncErrors[payload.deviceStaticSessionId];
         },
         setSuiteSyncOwner: (state, { payload }: SetSuiteSyncOwnerAction) => {
             if (payload.owner === null) {
@@ -109,6 +112,7 @@ export const {
     updateSuiteSyncDebugEnabled,
     setSuiteSyncRelayUrl,
     setSuiteSyncError,
+    resetSuiteSyncError,
     setSuiteSyncOwner,
 } = suiteSyncSlice.actions;
 

--- a/suite-common/suite-sync/src/suiteSyncSlice.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.ts
@@ -71,6 +71,11 @@ export const suiteSyncSlice = createSlice({
     reducers: {
         updateSuiteSyncEnabled: (state, { payload }: PayloadAction<{ isEnabled: boolean }>) => {
             state.settings.isSuiteSyncEnabled = payload.isEnabled;
+
+            if (!payload.isEnabled) {
+                state.suiteSyncErrors = {};
+                state.suiteSyncOwners = {};
+            }
         },
         updateSuiteSyncDebugEnabled: (
             state,


### PR DESCRIPTION
## Description
Recommended to review by commit.

We stopped initiating Suite Sync when the device is disconnected in d34f1b9. However, this introduced a bug where no error is triggered until the user re-selects the device, delaying the appearance of the error banner.

If there was any Suite Sync Error, SuiteSyncBanner was active even after disabling Suite Sync in settings, only rendered as null thanks to inner condition.

The frequent logs mentioning setSuiteSyncError were confusing, forcing developers to check the payload.


## Notes for QA

Focus banners when enabling Suite Sync with a disconnected/connected device.

## Related Issue

Resolve #26724


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the suite-sync module (createTurnOnSuiteSync, suiteSyncSlice, and createEnsureWalletSuiteSyncOnWithErrorHandler), which manages Suite Sync labeling functionality. While these files are transitively imported by 121 tests, the actual impact is narrowly scoped to Suite Sync and metadata/labeling flows. The highest risk is in the Suite Sync E2E tests that directly exercise sync enablement, label CRUD, multi-wallet sync, and legacy-to-sync migration. A few legacy metadata tests are included at medium priority since they share labeling infrastructure that could be affected by state management changes in the sync slice.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/suite-sync/src/createTurnOnSuiteSync.ts`
- `suite-common/suite-sync/src/storage/createEnsureWalletSuiteSyncOnWithErrorHandler.ts`
- `suite-common/suite-sync/src/suiteSyncSlice.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test directly exercises the Suite Sync migration flow, which depends on createTurnOnSuiteSync and suiteSyncSlice. It seeds Evolu relay data and verifies label migration from Dropbox to Suite Sync, directly exercising the sync enablement path that the changed files implement.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates new labels via Suite Sync (account, wallet, address, output) and verifies they sync to the Evolu relay. It directly exercises the Suite Sync enablement flow via metadataPage.enableSuiteSync(), which relies on createTurnOnSuiteSync and the suiteSyncSlice state management.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises Suite Sync across multiple wallets including passphrase wallets, testing the sync banner, declining/accepting Suite Sync, and verifying per-wallet isolation. It directly tests createTurnOnSuiteSync for multiple wallet contexts and the error handling in createEnsureWalletSuiteSyncOnWithErrorHandler.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync, verifies labels are pulled from the relay, then removes them and confirms null values sync back. It exercises the full Suite Sync lifecycle including enablement (createTurnOnSuiteSync) and the wallet sync error handler.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test verifies Suite Sync pulls labels from the Evolu relay server and displays them correctly. It tests the sync setup flow including device confirmation, directly exercising createTurnOnSuiteSync and the suiteSyncSlice for state management during initialization.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test exercises the full metadata labeling lifecycle including enabling/disabling labeling, switching wallets, and re-enabling after device ejection. While it focuses on legacy labeling, the suiteSyncSlice may be involved in the labeling state management infrastructure that determines whether legacy or Suite Sync is active.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test exercises metadata provider connect/disconnect and re-enable flows on remembered devices. The suiteSyncSlice and createEnsureWalletSuiteSyncOnWithErrorHandler may be involved in the metadata state management when toggling providers and handling device memory, making it relevant to verify no regressions in the metadata enable/disable paths.

</details>

_Updated: 2026-04-21T15:48:10.678Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync-banner-without-trezor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-sync-banner-without-trezor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-sync-banner-without-trezor/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-sync-banner-without-trezor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T10:26:07.280Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->