### PR TITLE
Connect Popup silent mode

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { events } from '@suite-common/analytics';
 import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
@@ -21,6 +22,7 @@ export const ConnectPermissionsModal = () => {
     const [isSilentMode, setIsSilentMode] = useState(false);
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
     if (!popupCall || popupCall?.state !== 'permission-request') return null;
 
     const { method, methodInfo, source } = popupCall;
@@ -158,7 +160,7 @@ export const ConnectPermissionsModal = () => {
                                     >
                                         <Translation id="TR_CONNECT_MODAL_REMEMBER" />
                                     </Checkbox>
-                                    {isRemembered && (
+                                    {isRemembered && isDebugModeActive && (
                                         <Tooltip
                                             content={
                                                 <Translation id="TR_CONNECT_APP_SILENT_MODE_DESCRIPTION" />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectPermissionsModal.tsx
@@ -4,7 +4,7 @@ import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { connectPopupActions, selectConnectPopupCall } from '@suite-common/connect-popup';
 import { CALL_SOURCE_WALLETCONNECT } from '@suite-common/connect-popup/src/connectPopupTypes';
-import { Card, Checkbox, Column, Icon, List, Modal, Row, Text } from '@trezor/components';
+import { Card, Checkbox, Column, Icon, List, Modal, Row, Text, Tooltip } from '@trezor/components';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { spacings } from '@trezor/theme';
 
@@ -18,6 +18,7 @@ import { getPermissionText } from 'src/views/settings/SettingsConnectedApps/Conn
 export const ConnectPermissionsModal = () => {
     const analytics = useAnalytics();
     const [isRemembered, setIsRemembered] = useState(false);
+    const [isSilentMode, setIsSilentMode] = useState(false);
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
     if (!popupCall || popupCall?.state !== 'permission-request') return null;
@@ -28,6 +29,7 @@ export const ConnectPermissionsModal = () => {
     const rememberPayload = {
         types: permissionTypes,
         ...source,
+        silentMode: isSilentMode,
     };
     const onConfirm = () => {
         if (isRemembered) {
@@ -148,13 +150,31 @@ export const ConnectPermissionsModal = () => {
                             </Text>
 
                             <Card>
-                                <Checkbox
-                                    data-testid="@connect-permissions-modal/remember-checkbox"
-                                    isChecked={isRemembered}
-                                    onChange={() => setIsRemembered(!isRemembered)}
-                                >
-                                    <Translation id="TR_CONNECT_MODAL_REMEMBER" />
-                                </Checkbox>
+                                <Column gap={spacings.sm}>
+                                    <Checkbox
+                                        data-testid="@connect-permissions-modal/remember-checkbox"
+                                        isChecked={isRemembered}
+                                        onChange={() => setIsRemembered(!isRemembered)}
+                                    >
+                                        <Translation id="TR_CONNECT_MODAL_REMEMBER" />
+                                    </Checkbox>
+                                    {isRemembered && (
+                                        <Tooltip
+                                            content={
+                                                <Translation id="TR_CONNECT_APP_SILENT_MODE_DESCRIPTION" />
+                                            }
+                                            placement="bottom"
+                                        >
+                                            <Checkbox
+                                                data-testid="@connect-permissions-modal/silent-mode-checkbox"
+                                                isChecked={isSilentMode}
+                                                onChange={() => setIsSilentMode(!isSilentMode)}
+                                            >
+                                                <Translation id="TR_CONNECT_APP_SILENT_MODE" />
+                                            </Checkbox>
+                                        </Tooltip>
+                                    )}
+                                </Column>
                             </Card>
                         </>
                     )}

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -300,6 +300,7 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 isAnyOf(
                     connectPopupActions.rememberAppPermissions,
                     connectPopupActions.forgetAppPermissions,
+                    connectPopupActions.setAppSilentMode,
                     walletConnectActions.saveSession,
                     walletConnectActions.removeSession,
                 )(action)

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { openModal } from '@suite/modal';
+import { MODAL_CONTEXT_DEVICE, openModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import {
     CALL_SOURCE_DESKTOP_WS,
@@ -10,9 +10,14 @@ import {
     getPopupCallDeferred,
     queuePopupCall,
     selectConnectPopupCall,
+    selectIsConnectAppSilentModeByOrigin,
 } from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
-import TrezorConnect, { type CallMethodKeys, type CallMethodPayload } from '@trezor/connect';
+import TrezorConnect, {
+    type CallMethodKeys,
+    type CallMethodPayload,
+    UI_REQUEST,
+} from '@trezor/connect';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -145,15 +150,47 @@ export const useConnectPopupDesktop = () => {
     }, [dispatch, analytics, lifecycle.status]);
 
     // App focus control
+    const callOrigin = popupCall && 'source' in popupCall ? popupCall.source.origin : undefined;
+    const isSilentMode = useSelector(state =>
+        selectIsConnectAppSilentModeByOrigin(state, callOrigin),
+    );
+    // True when Suite is showing a modal that needs user input (passphrase,
+    // PIN, recovery word). Silent mode still focuses the window in these cases
+    // because the user can't respond to the device without seeing Suite.
+    const isUserInputModalOpen = useSelector(state => {
+        const { modal } = state;
+        if (modal.context !== MODAL_CONTEXT_DEVICE) return false;
+        if (!('windowType' in modal) || !modal.windowType) return false;
+
+        return (
+            [
+                UI_REQUEST.REQUEST_PIN,
+                UI_REQUEST.INVALID_PIN,
+                UI_REQUEST.REQUEST_PASSPHRASE,
+                UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE,
+                UI_REQUEST.REQUEST_WORD,
+            ] as string[]
+        ).includes(modal.windowType);
+    });
+
     const [currentlyOngoing, setCurrentlyOngoing] = useState(false);
     const [wasVisible, setWasVisible] = useState(false);
     useEffect(() => {
-        if (
-            // Permission request
-            popupCall?.state === 'permission-request' ||
-            // Call ongoing - show only if method uses UI
-            (popupCall?.state === 'ongoing' && popupCall?.methodInfo.useUi)
-        ) {
+        const shouldFocus = (() => {
+            if (!popupCall) return false;
+            if (popupCall.state === 'permission-request') return true;
+            if (popupCall.state === 'address-confirmation') return true;
+            if (popupCall.state === 'ongoing' && popupCall.methodInfo.useUi) {
+                // Silent mode only focuses when the user has to type something
+                // into Suite (passphrase/PIN/word). Device-side confirmations
+                // and simple ongoing calls stay in the background.
+                return !isSilentMode || isUserInputModalOpen;
+            }
+
+            return false;
+        })();
+
+        if (shouldFocus) {
             // Only trigger once
             if (currentlyOngoing) return;
 
@@ -166,11 +203,12 @@ export const useConnectPopupDesktop = () => {
         }
 
         if (popupCall?.state === 'finished') {
-            setCurrentlyOngoing(false);
-            // Once finished, hide app if it was not visible before
-            if (!wasVisible) {
+            // Only hide if we actually focused during this call, otherwise
+            // we'd hide a window the user was using before the call started.
+            if (currentlyOngoing && !wasVisible) {
                 desktopApi.appHide();
             }
+            setCurrentlyOngoing(false);
         }
-    }, [popupCall, currentlyOngoing, wasVisible]);
+    }, [popupCall, currentlyOngoing, wasVisible, isSilentMode, isUserInputModalOpen]);
 };

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { selectIsDebugModeActive } from '@suite/settings';
 import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/connect-popup';
 import { Card, Column, Dropdown, H3, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
@@ -34,6 +35,7 @@ export const getPermissionText = (permissionType: string) => {
 export const ConnectPermissions = () => {
     const dispatch = useDispatch();
     const apps = useSelector(selectConnectAppPermissions);
+    const isDebugModeActive = useSelector(selectIsDebugModeActive);
 
     if (apps.length === 0) {
         return (
@@ -93,30 +95,36 @@ export const ConnectPermissions = () => {
                             data-testid={`@settings/connect-apps/${index}/dropdown`}
                             placement={{ position: 'bottom', alignment: 'end' }}
                             items={[
-                                {
-                                    icon: 'bellSlash',
-                                    iconRight: app.silentMode ? 'check' : undefined,
-                                    label: (
-                                        <Tooltip
-                                            content={
-                                                <Translation id="TR_CONNECT_APP_SILENT_MODE_DESCRIPTION" />
-                                            }
-                                            placement="left"
-                                            as="span"
-                                        >
-                                            <Translation id="TR_CONNECT_APP_SILENT_MODE" />
-                                        </Tooltip>
-                                    ),
-                                    'data-testid': `@settings/connect-apps/${index}/silent-mode`,
-                                    onClick: () => {
-                                        dispatch(
-                                            connectPopupActions.setAppSilentMode({
-                                                origin: app.origin,
-                                                silentMode: !app.silentMode,
-                                            }),
-                                        );
-                                    },
-                                },
+                                ...(isDebugModeActive
+                                    ? [
+                                          {
+                                              icon: 'bellSlash' as const,
+                                              iconRight: app.silentMode
+                                                  ? ('check' as const)
+                                                  : undefined,
+                                              label: (
+                                                  <Tooltip
+                                                      content={
+                                                          <Translation id="TR_CONNECT_APP_SILENT_MODE_DESCRIPTION" />
+                                                      }
+                                                      placement="left"
+                                                      as="span"
+                                                  >
+                                                      <Translation id="TR_CONNECT_APP_SILENT_MODE" />
+                                                  </Tooltip>
+                                              ),
+                                              'data-testid': `@settings/connect-apps/${index}/silent-mode`,
+                                              onClick: () => {
+                                                  dispatch(
+                                                      connectPopupActions.setAppSilentMode({
+                                                          origin: app.origin,
+                                                          silentMode: !app.silentMode,
+                                                      }),
+                                                  );
+                                              },
+                                          },
+                                      ]
+                                    : []),
                                 {
                                     icon: 'xCircle',
                                     label: <Translation id="TR_FORGET" />,

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { connectPopupActions, selectConnectAppPermissions } from '@suite-common/connect-popup';
-import { Card, Column, Dropdown, H3, Row, Text } from '@trezor/components';
+import { Card, Column, Dropdown, H3, Row, Text, Tooltip } from '@trezor/components';
 import { spacings } from '@trezor/theme';
 
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
@@ -93,6 +93,30 @@ export const ConnectPermissions = () => {
                             data-testid={`@settings/connect-apps/${index}/dropdown`}
                             placement={{ position: 'bottom', alignment: 'end' }}
                             items={[
+                                {
+                                    icon: 'bellSlash',
+                                    iconRight: app.silentMode ? 'check' : undefined,
+                                    label: (
+                                        <Tooltip
+                                            content={
+                                                <Translation id="TR_CONNECT_APP_SILENT_MODE_DESCRIPTION" />
+                                            }
+                                            placement="left"
+                                            as="span"
+                                        >
+                                            <Translation id="TR_CONNECT_APP_SILENT_MODE" />
+                                        </Tooltip>
+                                    ),
+                                    'data-testid': `@settings/connect-apps/${index}/silent-mode`,
+                                    onClick: () => {
+                                        dispatch(
+                                            connectPopupActions.setAppSilentMode({
+                                                origin: app.origin,
+                                                silentMode: !app.silentMode,
+                                            }),
+                                        );
+                                    },
+                                },
                                 {
                                     icon: 'xCircle',
                                     label: <Translation id="TR_FORGET" />,

--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -77,6 +77,13 @@ const forgetAppPermissions = createAction(
     }),
 );
 
+const setAppSilentMode = createAction(
+    `${ACTION_PREFIX}/setAppSilentMode`,
+    (payload: { origin: string; silentMode: boolean }) => ({
+        payload,
+    }),
+);
+
 const txSimulation = createAction(
     `${ACTION_PREFIX}/txSimulation`,
     (payload: Pick<ConnectPopupCallWithState<'tx-simulation'>, 'fromAddress'>) => ({
@@ -105,6 +112,7 @@ export const connectPopupActions = {
     setError,
     rememberAppPermissions,
     forgetAppPermissions,
+    setAppSilentMode,
     txSimulation,
     setSelectedFee,
     switchDevice,

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -144,6 +144,12 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
             .addCase(connectPopupActions.forgetAppPermissions, (state, { payload }) => {
                 state.permissions = state.permissions.filter(p => p.origin !== payload.origin);
             })
+            .addCase(connectPopupActions.setAppSilentMode, (state, { payload }) => {
+                const permission = state.permissions.find(p => p.origin === payload.origin);
+                if (permission) {
+                    permission.silentMode = payload.silentMode;
+                }
+            })
             .addCase(connectPopupActions.txSimulation, (state, { payload }) => {
                 if (state.activeCall?.state === 'ongoing') {
                     const newActiveCall = {
@@ -192,6 +198,13 @@ export const selectConnectPopupCallWithState = <CallState extends ConnectPopupCa
 
 export const selectConnectAppPermissions = (state: ConnectPopupStateRootState) =>
     state.connectPopup.permissions.filter(p => p.type !== CALL_SOURCE_WALLETCONNECT);
+
+export const selectIsConnectAppSilentModeByOrigin = (
+    state: ConnectPopupStateRootState,
+    origin: string | undefined,
+) =>
+    !!origin &&
+    state.connectPopup.permissions.some(p => p.origin === origin && p.silentMode === true);
 
 export const selectWalletConnectAppPermissions = (state: ConnectPopupStateRootState) =>
     state.connectPopup.permissions.filter(p => p.type === CALL_SOURCE_WALLETCONNECT);

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -145,4 +145,5 @@ export type ConnectPopupCallWithState<
 
 export type AppRememberedPermission = {
     types: MethodPermission[];
+    silentMode?: boolean;
 } & ConnectCallSource;

--- a/suite/e2e/support/pageObjects/connectPermissionsModal.ts
+++ b/suite/e2e/support/pageObjects/connectPermissionsModal.ts
@@ -5,6 +5,7 @@ export class ConnectPermissionsModal {
     readonly appName: Locator;
     readonly processParagraph: Locator;
     readonly rememberCheckbox: Locator;
+    readonly silentModeCheckbox: Locator;
     readonly confirmButton: Locator;
     readonly cancelButton: Locator;
 
@@ -15,6 +16,9 @@ export class ConnectPermissionsModal {
         this.appName = page.getByTestId('@connect-permissions-modal/app-name');
         this.processParagraph = page.getByTestId('@connect-permissions-modal/paragraph-process');
         this.rememberCheckbox = page.getByTestId('@connect-permissions-modal/remember-checkbox');
+        this.silentModeCheckbox = page.getByTestId(
+            '@connect-permissions-modal/silent-mode-checkbox',
+        );
         this.confirmButton = page.getByTestId('@connect-permissions-modal/confirm-button');
         this.cancelButton = page.getByTestId('@connect-permissions-modal/cancel-button');
     }

--- a/suite/e2e/support/testExtends/suiteBaseFixture.ts
+++ b/suite/e2e/support/testExtends/suiteBaseFixture.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { Page, test as base } from '@playwright/test';
+import { ElectronApplication, Page, test as base } from '@playwright/test';
 
 import { TestAnnotationType } from '@trezor/e2e-utils';
 import { SetupEmu, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
@@ -26,6 +26,7 @@ type SuiteBaseFixture = {
     device: DeviceFixture;
     url: string;
     trezorUserEnv: TrezorUserEnv;
+    electronApp: ElectronApplication | undefined;
     page: Page;
     exceptionLogger: void;
     coverageMapCollector: void;
@@ -145,12 +146,21 @@ const suiteBaseTest = currentsTest.extend<SuiteTestOptions & SuiteBaseFixture>({
         await use(getUrl(testInfo, target));
     },
 
-    page: async ({ target, locale, colorScheme, context, electronConf }, use, testInfo) => {
+    electronApp: async ({ target, locale, colorScheme, electronConf }, use, testInfo) => {
         if (isDesktopProject(target)) {
             const suite = await electronSetup(testInfo, locale, colorScheme, electronConf);
-            enhancePage(suite.window);
-            await use(suite.window);
+            await use(suite.electronApp);
             await electronTeardown(suite, testInfo, electronConf);
+        } else {
+            await use(undefined);
+        }
+    },
+
+    page: async ({ target, context, electronApp }, use) => {
+        if (isDesktopProject(target)) {
+            const window = await electronApp!.firstWindow();
+            enhancePage(window);
+            await use(window);
         } else {
             const page = await webSetup(context);
             enhancePage(page);

--- a/suite/e2e/tests/trezor-connect/silentMode.test.ts
+++ b/suite/e2e/tests/trezor-connect/silentMode.test.ts
@@ -45,7 +45,7 @@ const confirmSignMessageOnDevice = async (page: Page, device: DeviceFixture) => 
 test.describe('TrezorConnect silent mode', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
     test.use({ electronConf: { exposeConnectWs: true } });
     test.beforeEach(async ({ onboardingPage }) => {
-        await onboardingPage.completeOnboarding();
+        await onboardingPage.completeOnboarding({ keepDebugModeEnabled: true });
         await test.step('Initialize TrezorConnect', async () => {
             await TrezorConnect.init({
                 manifest: {

--- a/suite/e2e/tests/trezor-connect/silentMode.test.ts
+++ b/suite/e2e/tests/trezor-connect/silentMode.test.ts
@@ -1,0 +1,128 @@
+import { ElectronApplication, Page } from '@playwright/test';
+
+import { messages } from '@suite/intl';
+import TrezorConnect from '@trezor/connect-web';
+
+import { DeviceFixture } from '../../support/device';
+import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+// Spy runs in the Electron main process to intercept ipcMain 'app/focus' events.
+// We cannot spy in the renderer because contextBridge.exposeInMainWorld freezes
+// the exposed desktopApi object, making property assignment silently fail.
+const installAppFocusSpy = (electronApp: ElectronApplication) =>
+    electronApp.evaluate(({ ipcMain }) => {
+        (global as any).__appFocusCalls = 0;
+        ipcMain.on('app/focus', () => {
+            (global as any).__appFocusCalls = ((global as any).__appFocusCalls ?? 0) + 1;
+        });
+    });
+
+const resetAppFocusSpy = (electronApp: ElectronApplication) =>
+    electronApp.evaluate(() => {
+        (global as any).__appFocusCalls = 0;
+    });
+
+const getAppFocusCallCount = (electronApp: ElectronApplication): Promise<number> =>
+    electronApp.evaluate(() => (global as any).__appFocusCalls ?? 0);
+
+const signMessage = () =>
+    TrezorConnect.signMessage({
+        path: "m/44'/0'/0'/0/0",
+        coin: 'btc',
+        message: 'hello',
+    });
+
+const confirmSignMessageOnDevice = async (page: Page, device: DeviceFixture) => {
+    await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'visible' });
+    // T3T1/T3W1: swipe through address screen, then message screen, then hold to confirm.
+    await device.pressContinue();
+    await device.pressContinue();
+    await device.pressYes();
+    await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'hidden' });
+};
+
+test.describe('TrezorConnect silent mode', { tag: ['@T3T1', '@T3W1', '@desktopOnly'] }, () => {
+    test.use({ electronConf: { exposeConnectWs: true } });
+    test.beforeEach(async ({ onboardingPage }) => {
+        await onboardingPage.completeOnboarding();
+        await test.step('Initialize TrezorConnect', async () => {
+            await TrezorConnect.init({
+                manifest: {
+                    appUrl: 'http://localhost:8080',
+                    email: '',
+                    appName: 'Tester',
+                },
+                coreMode: 'suite-desktop',
+                debug: true,
+            });
+        });
+    });
+
+    test(
+        'Silent mode suppresses Suite focus on subsequent calls',
+        {
+            annotation: createTestAnnotation({
+                testCase:
+                    'Suite Connect: Silent mode prevents Suite from being brought to foreground during ongoing calls.',
+            }),
+        },
+        async ({ settingsPage, connectPermissionsModal, page, device, electronApp }) => {
+            await settingsPage.navigateTo('connect');
+            await page.getByTestId('@settings/connect-apps/tabs/trezor-connect').click();
+            await page.getByTestId('@settings/connect-apps/no-apps').waitFor({ state: 'visible' });
+
+            await installAppFocusSpy(electronApp!);
+
+            // First call: grant permissions, remember WITHOUT silent mode.
+            // Also verify the silent mode checkbox is hidden until Remember is ticked.
+            signMessage();
+            await expect(connectPermissionsModal.processParagraph).toHaveText(
+                /^(node|MainThread)$/,
+            );
+            await expect(connectPermissionsModal.silentModeCheckbox).toBeHidden();
+            await connectPermissionsModal.rememberCheckbox.click();
+            await expect(connectPermissionsModal.silentModeCheckbox).toHaveTranslation(
+                'TR_CONNECT_APP_SILENT_MODE',
+            );
+            await connectPermissionsModal.confirmButton.click();
+            await confirmSignMessageOnDevice(page, device);
+
+            // Baseline: silent mode OFF — subsequent call should bring Suite to foreground.
+            await resetAppFocusSpy(electronApp!);
+            signMessage();
+            await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'visible' });
+            await expect
+                .poll(() => getAppFocusCallCount(electronApp!), { timeout: 5000 })
+                .toBeGreaterThan(0);
+            await device.pressContinue();
+            await device.pressContinue();
+            await device.pressYes();
+            await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'hidden' });
+
+            // Turn silent mode ON via the settings dropdown.
+            await page.getByTestId(`@settings/connect-apps/0/dropdown`).click();
+            // todo: it looks like data-test is not passed down to list items in dropdown
+            const silentModeLabel = messages['TR_CONNECT_APP_SILENT_MODE'].defaultMessage;
+            await page.getByText(silentModeLabel).click();
+            await expect(async () => {
+                const permissions = await page.getReduxObject('connectPopup.permissions');
+                expect(permissions[0]).toMatchObject({ silentMode: true });
+            }).toPass();
+
+            // Silent mode ON — Suite must NOT focus. The confirm-on-device prompt still
+            // renders (silent mode only suppresses window focus, not Suite UI).
+            await resetAppFocusSpy(electronApp!);
+            signMessage();
+            await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'visible' });
+            // Focus fires via a useEffect chained through async appIsVisible() IPC —
+            // wait briefly so that chain can settle before asserting zero.
+            await page.waitForTimeout(300);
+            expect(await getAppFocusCallCount(electronApp!)).toBe(0);
+            await device.pressContinue();
+            await device.pressContinue();
+            await device.pressYes();
+            await page.getByTestId('@prompts/confirm-on-device').waitFor({ state: 'hidden' });
+        },
+    );
+});

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11184,6 +11184,15 @@ export const messages = defineMessages({
         id: 'TR_NO_CONNECTED_APPS_DESCRIPTION',
         defaultMessage: 'Use your Trezor with third-party apps and wallets to manage your assets.',
     },
+    TR_CONNECT_APP_SILENT_MODE: {
+        id: 'TR_CONNECT_APP_SILENT_MODE',
+        defaultMessage: 'Keep Suite hidden',
+    },
+    TR_CONNECT_APP_SILENT_MODE_DESCRIPTION: {
+        id: 'TR_CONNECT_APP_SILENT_MODE_DESCRIPTION',
+        defaultMessage:
+            'Suite will only appear when action is required, such as entering PIN or passphrase.',
+    },
     TR_PERMISSION_READ: {
         id: 'TR_PERMISSION_READ',
         defaultMessage: 'Access public keys from your Trezor device',


### PR DESCRIPTION
## Description

Adds a new option to Suite desktop for Connect popup apps, that let's them communicate with the device without Suite showing up in the meantime. 
This option is labeled "Keep Suite hidden" and can be enabled in the permission modal or in the connected apps settings.

For now available **only with DEBUG enabled**

## Notes for QA

- Connect an app/wallet via Connect popup to desktop. 
- Enable "Keep Suite hidden"
- With subsequent calls/signatures, Suite should not show up
- In case an action needs to be taken (eg. device disconnected, enter passphrase, ...) it will show up

## Related

Resolves #23802

## Screenshots

<img width="829" height="281" alt="Screenshot 2026-05-04 at 17 23 14" src="https://github.com/user-attachments/assets/bcece146-6559-48e3-8e20-39c630800636" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-silent-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-silent-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-silent-mode&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T16:25:00.720Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-21T16:23:24.799Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-silent-mode/web/](https://dev.suite.sldev.cz/suite-web/connect-silent-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->