### PR TITLE
refactor(product-components): make symbol required in AssetLogo, derive coingeckoId internally

### DIFF
--- a/packages/product-components/src/components/AssetLogo/AssetLogo.stories.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogo.stories.tsx
@@ -3,47 +3,75 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { getFramePropsStory } from '@trezor/components';
 
 import { AssetLogo as AssetLogoComponent } from './AssetLogo';
-import {
-    type AssetLogoProps,
-    allowedAssetLogoFrameProps,
-    allowedAssetLogoSizes,
-} from './AssetLogoWithId';
+import { type AssetLogoProps } from './AssetLogo';
+import { allowedAssetLogoFrameProps, allowedAssetLogoSizes } from './AssetLogoWithId';
+
+const NETWORK_SYMBOLS = [
+    'btc',
+    'eth',
+    'pol',
+    'bsc',
+    'arb',
+    'base',
+    'op',
+    'avax',
+    'sol',
+    'trx',
+    'ada',
+    'xrp',
+    'ltc',
+    'doge',
+] as const;
 
 const meta: Meta<AssetLogoProps> = {
     title: 'AssetLogo',
     component: AssetLogoComponent,
-};
-
-export default meta;
-
-export const AssetLogo: StoryObj<AssetLogoProps> = {
-    args: {
-        size: 24,
-        coingeckoId: 'ethereum',
-        symbol: 'eth',
-        contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        shouldTryToFetch: true,
-        placeholder: 'USDC',
-        showNetworkIcon: false,
-        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
-    },
     argTypes: {
         ...getFramePropsStory(allowedAssetLogoFrameProps).argTypes,
         size: {
             options: allowedAssetLogoSizes,
-            control: {
-                type: 'select',
-            },
+            control: { type: 'select' },
+        },
+        symbol: {
+            options: NETWORK_SYMBOLS,
+            control: { type: 'select' },
+        },
+        contractAddress: {
+            control: { type: 'text' },
+        },
+        placeholder: {
+            control: { type: 'text' },
         },
         showNetworkIcon: {
-            control: {
-                type: 'boolean',
-            },
+            control: { type: 'boolean' },
         },
         shouldTryToFetch: {
-            control: {
-                type: 'boolean',
-            },
+            control: { type: 'boolean' },
         },
+    },
+};
+
+export default meta;
+
+export const NativeCoin: StoryObj<AssetLogoProps> = {
+    args: {
+        size: 24,
+        symbol: 'eth',
+        placeholder: 'ETH',
+        shouldTryToFetch: true,
+        showNetworkIcon: false,
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
+    },
+};
+
+export const Token: StoryObj<AssetLogoProps> = {
+    args: {
+        size: 24,
+        symbol: 'eth',
+        contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC on Ethereum
+        placeholder: 'USDC',
+        shouldTryToFetch: true,
+        showNetworkIcon: true,
+        ...getFramePropsStory(allowedAssetLogoFrameProps).args,
     },
 };

--- a/packages/product-components/src/components/AssetLogo/AssetLogo.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogo.tsx
@@ -4,11 +4,12 @@ import { type AssetLogoProps, AssetLogoWithId } from './AssetLogoWithId';
 import { type LegacyNetworkSymbol } from '../../constants/networks';
 import { CoinLogo } from '../CoinLogo/CoinLogo';
 
-export const AssetLogo = ({ coingeckoId, symbol, size, ...rest }: AssetLogoProps) => {
-    const resolvedCoingeckoId =
-        (symbol && isNetworkSymbol(symbol) ? getCoingeckoId(symbol) : undefined) ?? coingeckoId;
+export type { AssetLogoProps };
 
-    if (!resolvedCoingeckoId) {
+export const AssetLogo = ({ symbol, size, ...rest }: AssetLogoProps) => {
+    const coingeckoId = isNetworkSymbol(symbol) ? getCoingeckoId(symbol) : undefined;
+
+    if (!coingeckoId) {
         return (
             <CoinLogo
                 size={size}
@@ -18,7 +19,5 @@ export const AssetLogo = ({ coingeckoId, symbol, size, ...rest }: AssetLogoProps
         );
     }
 
-    return (
-        <AssetLogoWithId coingeckoId={resolvedCoingeckoId} symbol={symbol} size={size} {...rest} />
-    );
+    return <AssetLogoWithId coingeckoId={coingeckoId} symbol={symbol} size={size} {...rest} />;
 };

--- a/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
+++ b/packages/product-components/src/components/AssetLogo/AssetLogoWithId.tsx
@@ -40,10 +40,8 @@ export type AssetLogoSize = (typeof allowedAssetLogoSizes)[number];
 export const allowedAssetLogoFrameProps = ['margin'] as const satisfies FramePropsKeys[];
 export type AllowedFrameProps = Pick<FrameProps, (typeof allowedAssetLogoFrameProps)[number]>;
 
-export type AssetLogoProps = AllowedFrameProps & {
+type AssetLogoBaseProps = AllowedFrameProps & {
     size: AssetLogoSize;
-    coingeckoId?: string;
-    symbol?: NetworkSymbolExtended;
     contractAddress?: string | null;
     shouldTryToFetch?: boolean;
     placeholderWithTooltip?: boolean;
@@ -52,7 +50,14 @@ export type AssetLogoProps = AllowedFrameProps & {
     showNetworkIcon?: boolean;
 };
 
-export type AssetLogoWithIdProps = Omit<AssetLogoProps, 'coingeckoId'> & { coingeckoId: string };
+export type AssetLogoProps = AssetLogoBaseProps & {
+    symbol: NetworkSymbolExtended;
+};
+
+export type AssetLogoWithIdProps = AssetLogoBaseProps & {
+    coingeckoId: string;
+    symbol?: NetworkSymbolExtended;
+};
 
 const Container = styled.div<TransientProps<AllowedFrameProps> & { $size: number }>`
     ${({ $size }) => `

--- a/packages/product-components/src/components/Notifications/ExchangeAssetWithFallback.tsx
+++ b/packages/product-components/src/components/Notifications/ExchangeAssetWithFallback.tsx
@@ -1,4 +1,4 @@
-import { getCoingeckoId, getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 
 import { type ExchangeInfoAsset } from './notificationsTypes';
 import { AssetLogo } from '../AssetLogo/AssetLogo';
@@ -9,13 +9,11 @@ type ExchangeAssetWithFallbackProps = {
 
 export const ExchangeAssetWithFallback = ({ asset }: ExchangeAssetWithFallbackProps) => {
     const resolvedDisplaySymbol = asset.displaySymbol ?? getDisplaySymbol(asset.symbol);
-    const resolvedCoingeckoId = asset.coingeckoId ?? getCoingeckoId(asset.symbol) ?? '';
 
     return (
         asset.icon ?? (
             <AssetLogo
                 size={20}
-                coingeckoId={resolvedCoingeckoId}
                 contractAddress={asset.contractAddress}
                 symbol={asset.symbol}
                 placeholder={resolvedDisplaySymbol}

--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { type NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 
 import {
     type TransactionNotificationToken,
@@ -13,7 +13,6 @@ type TransactionIconProps = {
     icon?: ReactNode;
     notificationType: TransactionNotificationType;
     symbol: NetworkSymbol;
-    accountSymbol: NetworkSymbol;
     token?: TransactionNotificationToken;
 };
 
@@ -38,7 +37,6 @@ export const TransactionIcon = ({
     icon,
     notificationType,
     symbol,
-    accountSymbol,
     token,
 }: TransactionIconProps) => {
     if (icon) {
@@ -49,7 +47,6 @@ export const TransactionIcon = ({
         return (
             <AssetLogo
                 symbol={symbol}
-                coingeckoId={getCoingeckoId(accountSymbol) ?? ''}
                 contractAddress={token.contract ?? null}
                 placeholder={token.symbol ?? token.name ?? symbol}
                 size={20}

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -27,10 +27,7 @@ const transactionNotificationConfig: Record<
         intent: ToastProps['intent'];
         message: string;
         amount: string;
-        transaction: Pick<
-            TransactionNotificationProps,
-            'notificationType' | 'symbol' | 'accountSymbol' | 'token'
-        >;
+        transaction: Pick<TransactionNotificationProps, 'notificationType' | 'symbol' | 'token'>;
     }
 > = {
     'tx-received': {
@@ -41,7 +38,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-received',
             symbol: 'eth',
-            accountSymbol: 'eth',
         },
     },
     'tx-confirmed': {
@@ -51,7 +47,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-confirmed',
             symbol: 'eth',
-            accountSymbol: 'eth',
         },
     },
     'tx-revoked': {
@@ -62,7 +57,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-revoked',
             symbol: 'eth',
-            accountSymbol: 'eth',
             token: {
                 contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
                 name: 'LINK',
@@ -78,7 +72,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-claimed',
             symbol: 'sol',
-            accountSymbol: 'sol',
         },
     },
     'tx-unstaked': {
@@ -89,7 +82,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-unstaked',
             symbol: 'eth',
-            accountSymbol: 'eth',
         },
     },
     'tx-staked': {
@@ -100,7 +92,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-staked',
             symbol: 'eth',
-            accountSymbol: 'eth',
         },
     },
     'tx-approved': {
@@ -111,7 +102,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-approved',
             symbol: 'eth',
-            accountSymbol: 'eth',
             token: {
                 contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
                 name: 'LINK',
@@ -127,7 +117,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-sent',
             symbol: 'eth',
-            accountSymbol: 'eth',
             token: {
                 contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
                 name: 'LINK',
@@ -143,7 +132,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-yield-supply',
             symbol: 'base',
-            accountSymbol: 'base',
             token: {
                 contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
                 name: 'USD Coin',
@@ -159,7 +147,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-yield-withdraw',
             symbol: 'base',
-            accountSymbol: 'base',
             token: {
                 contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
                 name: 'USD Coin',
@@ -175,7 +162,6 @@ const transactionNotificationConfig: Record<
         transaction: {
             notificationType: 'tx-yield-claim',
             symbol: 'base',
-            accountSymbol: 'base',
             token: {
                 contract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
                 name: 'USD Coin',
@@ -190,7 +176,6 @@ export const Default: Story = {
         message: 'Sent from Ethereum #1',
         notificationType: 'tx-sent',
         symbol: 'eth',
-        accountSymbol: 'eth',
         token: {
             contract: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
             name: 'LINK',

--- a/packages/product-components/src/components/Notifications/TransactionNotification.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.tsx
@@ -15,7 +15,6 @@ export type TransactionNotificationProps = {
     amount: ReactNode;
     notificationType: TransactionNotificationType;
     symbol: NetworkSymbol;
-    accountSymbol: NetworkSymbol;
     token?: TransactionNotificationToken;
     icon?: ReactNode;
     tokenSymbol?: string;
@@ -29,7 +28,6 @@ export const TransactionNotification = ({
     amount,
     notificationType,
     symbol,
-    accountSymbol,
     token,
     icon,
     tokenSymbol,
@@ -44,7 +42,6 @@ export const TransactionNotification = ({
                 icon={icon}
                 notificationType={notificationType}
                 symbol={symbol}
-                accountSymbol={accountSymbol}
                 token={token}
             />
             <TransactionAmount

--- a/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
+++ b/packages/product-components/src/components/SelectAssetModal/AssetItem.tsx
@@ -71,7 +71,6 @@ export const AssetItem = ({
                     {coingeckoId ? (
                         <AssetLogo
                             size={24}
-                            coingeckoId={coingeckoId}
                             symbol={symbol}
                             contractAddress={contractAddress}
                             placeholder={displaySymbol}

--- a/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
+++ b/packages/product-components/src/components/TokenIconSet/TokenIconSet.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { type NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Text } from '@trezor/components';
 import { type SpacingValuesNew, borders } from '@trezor/theme';
 
@@ -104,13 +104,11 @@ export const TokenIconSet = ({
     const visibleTokensContent = useMemo(() => {
         const visibleTokens = tokens.slice(0, MAX_VISIBLE_TOKENS);
         const orderedTokens = reverseVisibleTokens ? visibleTokens.reverse() : visibleTokens;
-        const coingeckoId = getCoingeckoId(symbol);
 
         return orderedTokens?.map(token => (
             <IconWrapper key={token.contract} $size={size} $gap={gap} $length={length}>
                 <AssetLogo
                     size={size}
-                    coingeckoId={coingeckoId ?? ''}
                     symbol={symbol}
                     contractAddress={token.contract}
                     placeholder={token.symbol ?? ''}

--- a/packages/product-components/src/components/TopAssets/TopAssets.stories.tsx
+++ b/packages/product-components/src/components/TopAssets/TopAssets.stories.tsx
@@ -12,6 +12,7 @@ const popularAssets: Asset[] = [
     {
         id: 'btc',
         symbol: 'btc',
+        networkSymbol: 'btc',
         displaySymbol: 'BTC',
         contractAddress: null,
         coingeckoId: 'bitcoin',
@@ -19,6 +20,7 @@ const popularAssets: Asset[] = [
     },
     {
         symbol: 'eth',
+        networkSymbol: 'eth',
         displaySymbol: 'ETH',
         contractAddress: null,
         coingeckoId: 'ethereum',
@@ -27,6 +29,7 @@ const popularAssets: Asset[] = [
     },
     {
         symbol: 'sol',
+        networkSymbol: 'sol',
         displaySymbol: 'SOL',
         id: 'sol',
         contractAddress: 'WCTk5xWdn5SYg56twGj32sUF3W4WFQ48ogezLBuYTBY',
@@ -35,6 +38,7 @@ const popularAssets: Asset[] = [
     },
     {
         symbol: 'usdc',
+        networkSymbol: 'eth',
         displaySymbol: 'USDC',
         contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
         coingeckoId: 'ethereum',
@@ -43,6 +47,7 @@ const popularAssets: Asset[] = [
     },
     {
         symbol: 'base',
+        networkSymbol: 'base',
         displaySymbol: 'BASE',
         id: 'base',
         contractAddress: null,

--- a/packages/product-components/src/components/TopAssets/TopAssets.tsx
+++ b/packages/product-components/src/components/TopAssets/TopAssets.tsx
@@ -1,3 +1,4 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Column, GhostContainer, Row, Text } from '@trezor/components';
 
 import { AssetLogo } from '../AssetLogo/AssetLogo';
@@ -7,6 +8,7 @@ import { CoinLogo } from '../CoinLogo/CoinLogo';
 export type Asset = {
     id: string;
     symbol: string;
+    networkSymbol: NetworkSymbol;
     displaySymbol: string;
     contractAddress: string | null;
     coingeckoId: string;
@@ -56,8 +58,7 @@ export function TopAssets({
                             ) : (
                                 <AssetLogo
                                     size={logoSize}
-                                    coingeckoId={asset.coingeckoId}
-                                    symbol={asset.symbol}
+                                    symbol={asset.networkSymbol}
                                     contractAddress={asset.contractAddress}
                                     placeholder={asset.displaySymbol}
                                 />

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -31,8 +31,10 @@ export { DeviceWithScene } from './components/DeviceWithScene/DeviceWithScene';
 export { getModelFrontColor, getLargeModelImagePath } from './utils/getModelFrontColor';
 export { DataAnalytics } from './components/DataAnalytics';
 export { AssetLogo } from './components/AssetLogo/AssetLogo';
+export { AssetLogoWithId } from './components/AssetLogo/AssetLogoWithId';
 export {
     type AssetLogoProps,
+    type AssetLogoWithIdProps,
     type AssetLogoSize,
     allowedAssetLogoSizes,
 } from './components/AssetLogo/AssetLogoWithId';

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -34,7 +34,6 @@ export const EarnAccountCell = ({
         <Row gap={16} cursor="inherit">
             <Column alignItems="center">
                 <AssetLogo
-                    coingeckoId={iconToken?.coinGeckoId ?? undefined}
                     placeholder={iconToken?.symbol || iconToken?.name || ''}
                     symbol={networkSymbol}
                     contractAddress={iconToken?.address ?? null}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -46,7 +46,6 @@ export const EarnYieldApyBreakdown = ({ rewards, networkSymbol }: EarnYieldApyBr
             return (
                 <Row key={index} gap={8} alignItems="center">
                     <AssetLogo
-                        coingeckoId={reward.token.coinGeckoId}
                         placeholder={reward.token.symbol || reward.token.name || 'token'}
                         symbol={networkSymbol}
                         contractAddress={reward.token.address}

--- a/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
@@ -1,8 +1,7 @@
 import { Translation } from '@suite/intl';
-import { getCoingeckoId } from '@suite-common/wallet-config';
 import type { YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { Card, IconButton, Row, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetLogo } from '@trezor/product-components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -16,47 +15,31 @@ export const YieldApprovedAmountCard = ({
     token,
     amount,
     onRevoke,
-}: YieldApprovedAmountCardProps) => {
-    const assetLogo =
-        token.contractAddress || token.coingeckoId
-            ? {
-                  coingeckoId: getCoingeckoId(token.networkSymbol) ?? token.coingeckoId,
-                  placeholder: token.symbol,
-                  contractAddress: token.contractAddress ?? null,
-              }
-            : undefined;
-
-    return (
-        <Card fillType="flat" paddingType="small">
-            <Row justifyContent="space-between" alignItems="center" width="100%">
-                <Text typographyStyle="body-md">
-                    <Translation id="TR_EARN_YIELD_APPROVED_AMOUNT" />
-                </Text>
-                <Row alignItems="center" gap={8}>
-                    {assetLogo?.coingeckoId ? (
-                        <AssetLogo
-                            size={20}
-                            coingeckoId={assetLogo.coingeckoId}
-                            placeholder={assetLogo.placeholder}
-                            symbol={token.networkSymbol}
-                            contractAddress={assetLogo.contractAddress}
-                            showNetworkIcon
-                        />
-                    ) : (
-                        <CoinLogo size={20} symbol={token.networkSymbol} type="tokenWithNetwork" />
-                    )}
-                    <FormattedCryptoAmount value={amount} symbol={token.symbol} />
-                    {onRevoke && (
-                        <IconButton
-                            icon="x"
-                            size="small"
-                            intent="neutral"
-                            priority="secondary"
-                            onClick={onRevoke}
-                        />
-                    )}
-                </Row>
+}: YieldApprovedAmountCardProps) => (
+    <Card fillType="flat" paddingType="small">
+        <Row justifyContent="space-between" alignItems="center" width="100%">
+            <Text typographyStyle="body-md">
+                <Translation id="TR_EARN_YIELD_APPROVED_AMOUNT" />
+            </Text>
+            <Row alignItems="center" gap={8}>
+                <AssetLogo
+                    size={20}
+                    symbol={token.networkSymbol}
+                    contractAddress={token.contractAddress ?? null}
+                    placeholder={token.symbol}
+                    showNetworkIcon
+                />
+                <FormattedCryptoAmount value={amount} symbol={token.symbol} />
+                {onRevoke && (
+                    <IconButton
+                        icon="x"
+                        size="small"
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={onRevoke}
+                    />
+                )}
             </Row>
-        </Card>
-    );
-};
+        </Row>
+    </Card>
+);

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -72,7 +72,6 @@ export const YieldPageHeader = ({ analyticsStep, account, routeParams }: YieldPa
                     <Row alignItems="center" gap={12} overflow="hidden">
                         {networkSymbol && (
                             <AssetLogo
-                                coingeckoId={vault?.token?.coinGeckoId}
                                 placeholder={vault?.token?.symbol || vault?.token?.name || ''}
                                 symbol={networkSymbol}
                                 contractAddress={vault?.token?.address}

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -1,12 +1,11 @@
-import { type NetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Row, Text } from '@trezor/components';
-import { AssetLogo, CoinLogo } from '@trezor/product-components';
+import { AssetLogo } from '@trezor/product-components';
 import { BigNumber } from '@trezor/utils';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
 type YieldTokenValueToken = {
-    coingeckoId?: string;
     symbol: string;
     networkSymbol: NetworkSymbol;
     contractAddress: string | null;
@@ -18,31 +17,17 @@ type YieldTokenValueProps = {
 };
 
 export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => {
-    const assetLogo =
-        token.contractAddress || token.coingeckoId
-            ? {
-                  coingeckoId: getCoingeckoId(token.networkSymbol) ?? token.coingeckoId,
-                  placeholder: token.symbol,
-                  contractAddress: token.contractAddress,
-              }
-            : undefined;
-
     const roundedAmount = new BigNumber(amount).decimalPlaces(2, BigNumber.ROUND_DOWN).toFixed();
 
     return (
         <Row alignItems="center" gap={8}>
-            {assetLogo?.coingeckoId ? (
-                <AssetLogo
-                    size={24}
-                    coingeckoId={assetLogo.coingeckoId}
-                    placeholder={assetLogo.placeholder}
-                    symbol={token.networkSymbol}
-                    contractAddress={assetLogo.contractAddress}
-                    showNetworkIcon
-                />
-            ) : (
-                <CoinLogo size={24} symbol={token.networkSymbol} type="tokenWithNetwork" />
-            )}
+            <AssetLogo
+                size={24}
+                symbol={token.networkSymbol}
+                contractAddress={token.contractAddress}
+                placeholder={token.symbol}
+                showNetworkIcon
+            />
             <Text typographyStyle="body-md-strong">
                 <FormattedCryptoAmount value={roundedAmount} symbol={token.symbol} />
             </Text>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -29,7 +29,6 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
                 ) : (
                     <AssetLogo
                         size={40}
-                        coingeckoId={asset.coingeckoId}
                         symbol={asset.networkSymbol}
                         contractAddress={asset.contractAddress}
                         placeholder={asset.displaySymbol}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -1,4 +1,4 @@
-import { getCoingeckoId, getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
 import { AssetLogo, shouldShowNetworkIcon } from '@trezor/product-components';
@@ -35,7 +35,6 @@ export function AssetRowToken({
             <Row data-testid={dataTestId} gap={12} overflow="hidden">
                 <AssetLogo
                     size={40}
-                    coingeckoId={getCoingeckoId(account.symbol)!}
                     symbol={account.symbol}
                     contractAddress={token.contract}
                     placeholder={getDisplaySymbol(token.symbol!, token.contract)}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -59,7 +59,6 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
                     {network.coingeckoId ? (
                         <AssetLogo
                             size={20}
-                            coingeckoId={network.coingeckoId}
                             symbol={symbol}
                             contractAddress={contractAddress}
                             placeholder={displaySymbol ?? ''}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/TransactionRenderer.tsx
@@ -123,7 +123,6 @@ export const TransactionRenderer = ({ render: View, ...props }: TransactionRende
                         }
                         notificationType={props.notification.type}
                         symbol={props.notification.symbol}
-                        accountSymbol={account.symbol}
                         token={transactionToken}
                         amount={props.notification.formattedAmount}
                         isInfiniteApproval={

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -5,7 +5,6 @@ import { Translation } from '@suite/intl';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
 import {
     type Explorer,
-    getCoingeckoId,
     getNetwork,
     getNetworkDisplaySymbolName,
 } from '@suite-common/wallet-config';
@@ -122,7 +121,6 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                     <Row justifyContent="flex-start" gap={spacings.sm}>
                         {selectedToken ? (
                             <AssetLogo
-                                coingeckoId={getCoingeckoId(account.symbol)!}
                                 symbol={account.symbol}
                                 contractAddress={selectedToken?.contract}
                                 size={24}

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -8,7 +8,7 @@ import {
     selectIsSpecificCoinDefinitionKnown,
 } from '@suite-common/token-definitions';
 import { getUnusedAddressFromAccount } from '@suite-common/trading';
-import { type Network, getCoingeckoId } from '@suite-common/wallet-config';
+import { type Network } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { Column, Row, Table, Text } from '@trezor/components';
 import { AssetLogo } from '@trezor/product-components';
@@ -58,7 +58,6 @@ export const TokenRow = ({
     const [showDeactivateModal, setShowDeactivateModal] = useState(false);
 
     const { address: unusedAddress } = getUnusedAddressFromAccount(account);
-    const coingeckoId = getCoingeckoId(account.symbol);
 
     if (!unusedAddress || !device) return null;
 
@@ -68,7 +67,6 @@ export const TokenRow = ({
                 <Table.Cell>
                     <Row gap={spacings.xs}>
                         <AssetLogo
-                            coingeckoId={coingeckoId || ''}
                             placeholder={token.name || token.symbol || 'token'}
                             symbol={account.symbol}
                             contractAddress={token.contract}

--- a/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/inactive-tokens/InactiveTokensTable.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Translation } from '@suite/intl';
 import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getCoingeckoId } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded, type StellarTokenInfo } from '@suite-common/wallet-types';
 import { getStellarInactiveTokens } from '@suite-common/wallet-utils';
 import { Button, Card, Row, Table, Text, Tooltip } from '@trezor/components';
@@ -40,7 +39,6 @@ interface InactiveTokensTableProps {
 export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTokensTableProps) => {
     const dispatch = useDispatch();
     const { account } = selectedAccount;
-    const coingeckoId = getCoingeckoId(account.symbol);
     const [tokenToActivate, setTokenToActivate] = useState<StellarTokenInfo | null>(null);
 
     const {
@@ -134,7 +132,6 @@ export const InactiveTokensTable = ({ selectedAccount, searchQuery }: InactiveTo
                             <Table.Cell>
                                 <Row gap={spacings.xs}>
                                     <AssetLogo
-                                        coingeckoId={coingeckoId || ''}
                                         placeholder={token.name || token.symbol || ''}
                                         symbol={account.symbol}
                                         contractAddress={token.contract}

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import { parseCryptoId, useTradingUtils } from '@suite-common/trading';
+import { parseCryptoId } from '@suite-common/trading';
+import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { AssetLogo } from '@trezor/product-components';
 
 import { type TradingCoinLogoProps } from 'src/types/trading/trading';
@@ -15,13 +16,13 @@ export const TradingCoinLogo = ({
     showNetworkIcon,
 }: TradingCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
-    const { cryptoIdToNativeCoinSymbol } = useTradingUtils();
-    const networkSymbol = cryptoIdToNativeCoinSymbol(cryptoId);
+    const networkSymbol = getNetworkByCoingeckoId(networkId)?.symbol;
+
+    if (!networkSymbol) return null;
 
     return (
         <Wrapper className={className}>
             <AssetLogo
-                coingeckoId={networkId}
                 symbol={networkSymbol}
                 contractAddress={contractAddress}
                 size={size}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -29,7 +29,6 @@ export function AssetPickerInputContent({ value }: AssetPickerInputContentProps)
         symbol,
         displaySymbol,
         name,
-        coingeckoId,
         contractAddress,
         networkName,
     } = value;
@@ -43,7 +42,6 @@ export function AssetPickerInputContent({ value }: AssetPickerInputContentProps)
             ) : (
                 <AssetLogo
                     size={32}
-                    coingeckoId={coingeckoId}
                     symbol={networkSymbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -53,7 +53,6 @@ export const TradingInfoItem = ({
         isNativeToken,
         networkSymbol,
         name,
-        coingeckoId,
         displaySymbol,
         networkName,
         contractAddress,
@@ -118,7 +117,6 @@ export const TradingInfoItem = ({
                             ) : (
                                 <AssetLogo
                                     size={40}
-                                    coingeckoId={coingeckoId}
                                     symbol={networkSymbol}
                                     contractAddress={contractAddress}
                                     placeholder={displaySymbol}

--- a/suite/tx-simulation/src/components/TxSimulationAsset/TxSimulationAssetLogo.tsx
+++ b/suite/tx-simulation/src/components/TxSimulationAsset/TxSimulationAssetLogo.tsx
@@ -23,10 +23,9 @@ export function TxSimulationAssetLogo({
         return <CoinLogo symbol={coinSymbol} size={size} />;
     }
 
-    if (asset?.symbol && 'address' in asset && network.coingeckoId) {
+    if (asset?.symbol && 'address' in asset) {
         return (
             <AssetLogo
-                coingeckoId={network.coingeckoId}
                 symbol={network.symbol}
                 contractAddress={asset.address}
                 size={size}


### PR DESCRIPTION
## Description

- AssetLogo now requires symbol (network symbol) and derives coingeckoId internally — previously coingeckoId was required and symbol optional, which caused logo bugs when callers passed both (wrong one took priority)
- AssetLogoWithId type-split into AssetLogoBaseProps / AssetLogoProps / AssetLogoWithIdProps — AssetLogoWithId stays as internal implementation detail, not intended for direct use
- Removed coingeckoId prop from all <AssetLogo> callers (~15 files)
- TopAssets.Asset type extended with networkSymbol so AssetLogo can be used directly
- TradingCoinLogo returns null when network symbol can't be resolved (unknown/unsupported network)
- Storybook stories fixed — controls now actually work (symbol change reflects in logo)


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/asset-logo-symbol-required&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/asset-logo-symbol-required&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/asset-logo-symbol-required/web/](https://dev.suite.sldev.cz/suite-web/fix/asset-logo-symbol-required/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-26T22:14:34.114Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-21T19:00:19.218Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->