### PR TITLE
fix(suite): token migration color issues

### DIFF
--- a/packages/components/src/components/BulletList/BulletListItem.tsx
+++ b/packages/components/src/components/BulletList/BulletListItem.tsx
@@ -69,7 +69,7 @@ const Bullet = styled.div<{
             ? theme.legacyBackgroundPrimarySubtleOnElevation0
             : $isDarkTheme
               ? theme.contentPrimaryInverse
-              : theme.elementFillBoldDisabled};
+              : theme.legacyBackgroundNeutralSubtleOnElevation0};
     color: ${({ $state, theme }) => theme[mapStateToTextColor($state)]};
     ${({ $size }) => ($size === 'small' ? typography['body-xs'] : typography['body-sm'])}
 

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Translation } from '@suite/intl';
 import { Box, Button, Column, IMAGES, IMAGES_PATH, Row, Text } from '@trezor/components';
 import { resolveStaticPath } from '@trezor/env-utils';
-import { borders, colorVariants, spacings, spacingsPx } from '@trezor/theme';
+import { borders, spacings, spacingsPx } from '@trezor/theme';
 import { DASHBOARD_BANNER_TEX_URL } from '@trezor/urls';
 
 import { useExternalLink, useLayoutSize } from 'src/hooks/suite';
@@ -25,11 +25,7 @@ const StyledImage = styled.img`
     max-width: 40%;
 `;
 
-const NextGenerationTextBlock = styled.span`
-    color: ${colorVariants.standard.contentButtonBrandPrimary};
-`;
-
-const UnderlinedBlock = styled(NextGenerationTextBlock)`
+const UnderlinedBlock = styled.span`
     white-space: nowrap;
     background-image: url(${underlineImage});
     display: inline-block;


### PR DESCRIPTION
## Notes for QA

Fixed instances of issues created by the token migration

## Screenshots:
<img width="527" height="245" alt="image" src="https://github.com/user-attachments/assets/a8b7d7d9-aaed-4512-90b7-8c5175e3b189" />

<img width="334" height="426" alt="image" src="https://github.com/user-attachments/assets/cfca526d-6c03-443f-a335-4880be3e778d" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two UI components: BulletListItem (a shared component used across 121 tests) and TrezorExpertBanner (a dashboard promo banner). BulletListItem is a broad shared component, so most of its 121 mapped tests are unlikely to be meaningfully affected unless the change is breaking — those tests are omitted. The TrezorExpertBanner change is more targeted and directly relevant to promo banner tests and dashboard-level tests. The recommended strategy focuses on the promo-banner-events test (directly exercises the changed banner) and two dashboard tests that share the same page context.

<details><summary><b>Changed files (2)</b></summary>

- `packages/components/src/components/BulletList/BulletListItem.tsx`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/TrezorExpertBanner.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly exercises the dashboard promo banner component (TrezorExpertBanner is one of the promo banners). It clicks promo banners on the dashboard and verifies analytics events fire correctly. Changes to TrezorExpertBanner.tsx could affect banner rendering, click behavior, or event emission.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test navigates to the dashboard where the promo banner (TrezorExpertBanner) is rendered, and verifies asset display in grid/table views. While it doesn't directly test the banner, a rendering error in TrezorExpertBanner could break the dashboard layout and affect this test.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test operates on the dashboard page where TrezorExpertBanner is rendered. It interacts with dashboard elements (balance hiding, portfolio values) that share the same page layout. A crash in the banner component could affect the entire dashboard view.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/components/src/components/BulletList/BulletListItem.tsx`

_Updated: 2026-04-22T08:36:12.618Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/token-issues&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/token-issues/web/](https://dev.suite.sldev.cz/suite-web/fix/token-issues/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 26 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T08:47:33.011Z • 26 test(s) total_
<!-- QUARANTINE-LIST:web:END -->