### PR TITLE
fix(suite-native): update leftover earn-api imports after rename

### DIFF
--- a/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { type RewardDto } from '@suite-common/earn-api';
+import { type RewardDto } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';

--- a/suite-native/module-accounts-management/src/utils.ts
+++ b/suite-native/module-accounts-management/src/utils.ts
@@ -1,4 +1,4 @@
-import { type RewardDto, type RewardDtoYieldSource } from '@suite-common/earn-api';
+import { type RewardDto, type RewardDtoYieldSource } from '@suite-common/earn-stablecoin-api';
 import { type TxKeyPath } from '@suite-native/intl';
 import { BigNumber } from '@trezor/utils';
 


### PR DESCRIPTION
## Summary

Two imports in `suite-native/module-accounts-management` still referenced the old `@suite-common/earn-api` package name after the rename in commit `ab8a713b2e` (`refactor: rename suite-common/earn-api to suite-common/earn-stablecoin-api`). This broke `yarn depcheck` on develop.

- `suite-native/module-accounts-management/src/utils.ts`
- `suite-native/module-accounts-management/src/components/StablecoinYieldApyBreakdown.tsx`

## Test plan

- [x] `yarn workspace @suite-native/module-accounts-management depcheck` — passes

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mvarmuza/fix-earn-api-rename-leftover&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->