### PR TITLE
fix(suite-native): dismiss bottom sheet before presenting another one

### DIFF
--- a/suite-native/atoms/src/Sheet/hooks/useBottomSheetModal.ts
+++ b/suite-native/atoms/src/Sheet/hooks/useBottomSheetModal.ts
@@ -1,13 +1,21 @@
 import { useCallback, useRef } from 'react';
 
-import { type BottomSheetModal } from '@gorhom/bottom-sheet';
+import {
+    type BottomSheetModal,
+    useBottomSheetModal as useGorhomBottomSheetModal,
+} from '@gorhom/bottom-sheet';
 
 export const useBottomSheetModal = () => {
+    const { dismiss } = useGorhomBottomSheetModal();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
 
     const openModal = useCallback(() => {
+        // When rapidly presenting and dismissing multiple bottom sheets, already dismissed bottom
+        // sheet may reappear because dismiss() is not actually called until the closing animation
+        // finishes & unmounts. Dismissing the last presented bottom sheet prevents this.
+        dismiss();
         bottomSheetRef.current?.present();
-    }, []);
+    }, [dismiss]);
 
     const closeModal = useCallback(() => {
         bottomSheetRef.current?.dismiss();


### PR DESCRIPTION
When rapidly presenting and dismissing multiple bottom sheets, already dismissed bottom sheet may reappear because dismiss() is not actually called until the closing animation finishes & unmounts. Dismissing the last presented bottom sheet prevents this.

## Related Issue

Resolve #26014

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/bottom-sheet-ghost&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->