### PR TITLE
feat(connect): inline devDep types via per-package vendor files

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -9,6 +9,7 @@
         "worker-loader",
         "process",
         "rimraf",
+        "rollup-plugin-dts",
         "tslib",
         "buffer",
         "node-gyp",

--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -78,8 +78,11 @@ jobs:
         run: yarn tsx ./scripts/ci/pack-packages.ts
 
       - name: Check exports
-        # For now only testing @trezor/connect-web. `attw` is the binary for @arethetypeswrong/cli
-        run: yarn exec attw --pack ./tmp/packed-packages/trezor-connect-web.tgz
+        # `attw` is the binary for @arethetypeswrong/cli
+        run: |
+          yarn exec attw --pack ./tmp/packed-packages/trezor-connect-web.tgz
+          yarn exec attw --pack ./tmp/packed-packages/trezor-connect-mobile.tgz
+          yarn exec attw --pack ./tmp/packed-packages/trezor-connect-webextension.tgz
 
       - name: Test local install
         run: ./packages/connect/e2e/test-connect-local.sh

--- a/packages/connect-common/package.json
+++ b/packages/connect-common/package.json
@@ -77,8 +77,9 @@
     },
     "scripts": {
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
-        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
-        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs && yarn build:dts:inline",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm && DTS_OUT_DIR=libESM yarn build:dts:inline",
+        "build:dts:inline": "node ../../scripts/inline-devdep-types.mjs",
         "type-check": "yarn g:tsc --build tsconfig.json",
         "test:unit": "yarn g:jest",
         "depcheck": "yarn g:depcheck",

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -28,8 +28,9 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
-        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
-        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs && yarn build:dts:inline",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm && DTS_OUT_DIR=libESM yarn build:dts:inline",
+        "build:dts:inline": "node ../../scripts/inline-devdep-types.mjs",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {

--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -50,8 +50,9 @@
         "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build",
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
-        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
-        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs && yarn build:dts:inline",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm && DTS_OUT_DIR=libESM yarn build:dts:inline",
+        "build:dts:inline": "node ../../scripts/inline-devdep-types.mjs",
         "test:e2e": "yarn playwright install && yarn xvfb-maybe -- playwright test --config=./e2e/playwright.config.ts",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },

--- a/packages/connect-webextension/package.json
+++ b/packages/connect-webextension/package.json
@@ -45,8 +45,9 @@
     "types": "src/index.ts",
     "scripts": {
         "build:lib": "yarn build:lib:cjs && yarn build:lib:esm",
-        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs",
-        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm",
+        "build:lib:cjs": "yarn g:rimraf ./lib && yarn g:tsc --build tsconfig.lib.json && ../../scripts/publish/replace-imports.sh ./lib cjs && yarn build:dts:inline",
+        "build:lib:esm": "yarn g:rimraf ./libESM && yarn g:tsc --build tsconfig.libESM.json && ../../scripts/publish/replace-imports.sh ./libESM esm && DTS_OUT_DIR=libESM yarn build:dts:inline",
+        "build:dts:inline": "node ../../scripts/inline-devdep-types.mjs",
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"

--- a/packages/connect/e2e/test-connect-local.sh
+++ b/packages/connect/e2e/test-connect-local.sh
@@ -42,7 +42,8 @@ cat > package.json << EOF
   "dependencies": {
     "@trezor/connect": "${CONNECT_PATH}",
     "@trezor/connect-web": "${CONNECT_WEB_PATH}",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.8.3"
   },
   "overrides": ${OVERRIDES_CONTENT}
 }
@@ -81,6 +82,48 @@ assert.strictEqual(typeof TrezorConnectWeb.init, 'function', 'TrezorConnectWeb.i
 
 console.log('All ESM assertions passed.');
 EOF
+
+cat > tsconfig.json << 'EOF'
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["type-check.ts"]
+}
+EOF
+
+cat > type-check.ts << 'EOF'
+import TrezorConnect from '@trezor/connect';
+import TrezorConnectWeb from '@trezor/connect-web';
+
+// Exercise subpath-imported types from devDependencies inlined into d.ts.
+// If any inline `import("@trezor/*/lib/...")` target is not resolvable
+// (e.g. due to a missing exports-map entry in the producer package),
+// tsc --noEmit would fail here, signalling a regression that the runtime
+// smoke tests below cannot detect.
+type ChangeLanguageParams = Parameters<typeof TrezorConnect.changeLanguage>[0];
+type FirmwareUpdateParams = Parameters<typeof TrezorConnect.firmwareUpdate>[0];
+type EthereumSignTypedDataParams = Parameters<typeof TrezorConnect.ethereumSignTypedData>[0];
+type CardanoSignTransactionParams = Parameters<typeof TrezorConnect.cardanoSignTransaction>[0];
+
+const _connect: typeof TrezorConnect = TrezorConnect;
+const _connectWeb: typeof TrezorConnectWeb = TrezorConnectWeb;
+
+// Force usage so TS does not discard the types above.
+export type { ChangeLanguageParams, FirmwareUpdateParams, EthereumSignTypedDataParams, CardanoSignTransactionParams };
+export { _connect, _connectWeb };
+EOF
+
+echo ""
+echo "=== Type-checking consumer (tsc --noEmit) ==="
+./node_modules/.bin/tsc --noEmit --project tsconfig.json
 
 echo ""
 echo "=== Testing CJS (node index.cjs) ==="

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -17,7 +17,12 @@
                     "types": "./lib/index.d.ts",
                     "default": "./lib/index.js"
                 }
-            }
+            },
+            "./lib/custom-types/*": {
+                "types": "./lib/custom-types/*.d.ts",
+                "default": "./lib/custom-types/*.js"
+            },
+            "./libESM/custom-types/*": "./libESM/custom-types/*"
         }
     },
     "files": [

--- a/scripts/inline-devdep-types.mjs
+++ b/scripts/inline-devdep-types.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+// Walks a built `lib/` (or `libESM/`) tree, finds @trezor/* imports that aren't in the
+// package's own prod+peer dependency closure (= devDep leaks the consumer can't resolve),
+// bundles each leaked package's type declarations into its own `_vendor_<pkg>.d.ts`
+// next to the entry, and rewrites every .d.ts in the tree to redirect those imports to
+// the local vendor files. Both the root entry AND any subpath import resolve self-contained
+// types without duplication: each leaked package lives in exactly one place, and vendor
+// files cross-reference each other when they depend on another leaked package.
+
+import { resolve, dirname, relative, join } from 'path';
+import { fileURLToPath } from 'url';
+import {
+    existsSync,
+    readFileSync,
+    writeFileSync,
+    readdirSync,
+    statSync,
+    rmSync,
+    renameSync,
+} from 'fs';
+
+import { rollup } from 'rollup';
+import dts from 'rollup-plugin-dts';
+
+const packagesDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'packages');
+
+function readProdClosure(startDir) {
+    const visited = new Set();
+    function visit(packageDir) {
+        const pkgJsonPath = resolve(packageDir, 'package.json');
+        if (!existsSync(pkgJsonPath)) return;
+        const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+        const directDeps = [
+            ...Object.keys(pkgJson.dependencies || {}),
+            ...Object.keys(pkgJson.peerDependencies || {}),
+        ];
+        for (const dep of directDeps) {
+            if (visited.has(dep)) continue;
+            visited.add(dep);
+            if (dep.startsWith('@trezor/')) {
+                visit(resolve(packagesDir, dep.replace('@trezor/', '')));
+            }
+        }
+    }
+    visit(startDir);
+    return new Set([...visited].filter(d => d.startsWith('@trezor/')));
+}
+
+function redirectWorkspaceSrc() {
+    return {
+        name: 'redirect-workspace-src',
+        resolveId(source) {
+            const subMatch = source.match(/^@trezor\/([^/]+)\/src\/(.+)$/);
+            if (subMatch) {
+                const [, pkg, subpath] = subMatch;
+                for (const base of [
+                    resolve(packagesDir, pkg, 'libDev', subpath),
+                    resolve(packagesDir, pkg, 'libDev', 'src', subpath),
+                ]) {
+                    for (const candidate of [`${base}.d.ts`, `${base}/index.d.ts`]) {
+                        if (existsSync(candidate)) return candidate;
+                    }
+                }
+            }
+            const rootMatch = source.match(/^@trezor\/([^/]+)$/);
+            if (rootMatch) {
+                const [, pkg] = rootMatch;
+                for (const candidate of [
+                    resolve(packagesDir, pkg, 'libDev', 'index.d.ts'),
+                    resolve(packagesDir, pkg, 'libDev', 'src', 'index.d.ts'),
+                ]) {
+                    if (existsSync(candidate)) return candidate;
+                }
+            }
+            return null;
+        },
+    };
+}
+
+function walkDts(dir, ext) {
+    const out = [];
+    if (!existsSync(dir)) return out;
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const stat = statSync(full);
+        if (stat.isDirectory()) out.push(...walkDts(full, ext));
+        else if (entry.endsWith(ext)) out.push(full);
+    }
+    return out;
+}
+
+const IMPORT_RE = /from\s*['"](@trezor\/[^'"]+)['"]/g;
+
+function rootOf(spec) {
+    return spec.split('/').slice(0, 2).join('/');
+}
+
+function scanLeaks(dtsFiles, prodClosure) {
+    const leaks = new Set();
+    for (const file of dtsFiles) {
+        const content = readFileSync(file, 'utf8');
+        for (const m of content.matchAll(IMPORT_RE)) {
+            const root = rootOf(m[1]);
+            if (!prodClosure.has(root)) leaks.add(root);
+        }
+    }
+    return leaks;
+}
+
+// Recursively expand the leak set: each leaked package's libDev .d.ts may pull in
+// other @trezor/* packages that aren't in the prod closure either; those become
+// new leaks too. Without this, vendor files for the initial leaks would inline the
+// transitive @trezor/* deps and create duplicate type definitions across vendors.
+function expandLeakSet(initialLeaks, prodClosure) {
+    const leaks = new Set(initialLeaks);
+    const queue = [...initialLeaks];
+    while (queue.length) {
+        const pkg = queue.shift();
+        const libDev = resolve(packagesDir, pkg.replace('@trezor/', ''), 'libDev');
+        for (const file of walkDts(libDev, '.d.ts')) {
+            const content = readFileSync(file, 'utf8');
+            for (const m of content.matchAll(IMPORT_RE)) {
+                const root = rootOf(m[1]);
+                if (prodClosure.has(root)) continue;
+                if (leaks.has(root)) continue;
+                leaks.add(root);
+                queue.push(root);
+            }
+        }
+    }
+    return leaks;
+}
+
+function vendorBaseName(pkg) {
+    return `_vendor_${pkg.replace('@trezor/', '').replace(/-/g, '_')}`;
+}
+
+async function buildVendorForPackage(pkg, prodClosure, leakSet, libAbs, ext) {
+    const baseName = vendorBaseName(pkg);
+    const entryPath = resolve(libAbs, `${baseName}-entry.d.ts`);
+    writeFileSync(entryPath, `export * from '${pkg}';\n`);
+
+    try {
+        const bundle = await rollup({
+            input: entryPath,
+            plugins: [redirectWorkspaceSrc(), dts({ respectExternal: true })],
+            external: id => {
+                if (id.startsWith('.') || id.startsWith('/')) return false;
+                if (!id.startsWith('@trezor/')) return true;
+                const root = rootOf(id);
+                if (prodClosure.has(root)) return true;
+                if (leakSet.has(root) && root !== pkg) return true;
+                return false;
+            },
+            onwarn(warning, warn) {
+                if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+                if (warning.code === 'UNRESOLVED_IMPORT') return;
+                warn(warning);
+            },
+        });
+        const tmpOut = resolve(libAbs, `${baseName}.d.ts`);
+        await bundle.write({ file: tmpOut, format: 'es' });
+        await bundle.close();
+        if (ext !== '.d.ts') {
+            renameSync(tmpOut, resolve(libAbs, `${baseName}${ext}`));
+        }
+    } finally {
+        rmSync(entryPath, { force: true });
+    }
+}
+
+function rewriteFile(file, leakSet, libAbs) {
+    const original = readFileSync(file, 'utf8');
+    const rewritten = original.replace(
+        /(from\s*['"])(@trezor\/[^'"]+)(['"])/g,
+        (full, pre, spec, post) => {
+            const root = rootOf(spec);
+            if (!leakSet.has(root)) return full;
+            const targetAbs = resolve(libAbs, vendorBaseName(root));
+            let rel = relative(dirname(file), targetAbs).replace(/\\/g, '/');
+            if (!rel.startsWith('.')) rel = `./${rel}`;
+            return `${pre}${rel}${post}`;
+        },
+    );
+    if (rewritten !== original) writeFileSync(file, rewritten);
+}
+
+// In ESM mode (.d.mts), TypeScript with NodeNext/Node16 module resolution requires
+// explicit file extensions in relative imports. tsc emits extensionless imports
+// (`from './foo'`); we resolve each to the right `.mjs` extension (file or directory).
+function addEsmExtensions(file) {
+    const original = readFileSync(file, 'utf8');
+    const fileDir = dirname(file);
+
+    const rewritten = original.replace(
+        /((?:from|import)\s*\(?\s*['"])(\.\.?(?:\/[^'"]*)?)(['"])/g,
+        (full, pre, spec, post) => {
+            if (/\.(mjs|cjs|js|json)$/.test(spec)) return full;
+            const absPath = resolve(fileDir, spec);
+            if (existsSync(`${absPath}.d.mts`)) {
+                return `${pre}${spec}.mjs${post}`;
+            }
+            if (existsSync(`${absPath}/index.d.mts`)) {
+                const sep = spec.endsWith('/') ? '' : '/';
+                return `${pre}${spec}${sep}index.mjs${post}`;
+            }
+            return full;
+        },
+    );
+    if (rewritten !== original) writeFileSync(file, rewritten);
+}
+
+async function main() {
+    const libDir = process.env.DTS_OUT_DIR || 'lib';
+    const libAbs = resolve(process.cwd(), libDir);
+    if (!existsSync(libAbs)) {
+        console.error(`inline-devdep-types: ${libAbs} does not exist`);
+        process.exit(1);
+    }
+
+    // Detect output extension by sampling lib/index.d.{ts,mts}.
+    const ext = existsSync(resolve(libAbs, 'index.d.mts')) ? '.d.mts' : '.d.ts';
+    const dtsFiles = walkDts(libAbs, ext);
+
+    const prodClosure = readProdClosure(process.cwd());
+    const initialLeaks = scanLeaks(dtsFiles, prodClosure);
+    const leakSet = expandLeakSet(initialLeaks, prodClosure);
+
+    if (leakSet.size === 0) {
+        console.log(`inline-devdep-types: no devDep leaks in ${libDir}, skipping`);
+        return;
+    }
+
+    console.log(`inline-devdep-types: bundling ${leakSet.size} leak package(s) into ${libDir}/`);
+    for (const pkg of leakSet) console.log(`  - ${pkg}`);
+
+    for (const pkg of leakSet) {
+        await buildVendorForPackage(pkg, prodClosure, leakSet, libAbs, ext);
+    }
+
+    // Rewrite imports in the package's own .d.ts files AND in the just-built vendor
+    // files (they may import each other when leak packages cross-reference).
+    const allFiles = walkDts(libAbs, ext);
+    for (const file of allFiles) rewriteFile(file, leakSet, libAbs);
+
+    // Add explicit `.mjs` extensions to relative imports in ESM declaration files.
+    // tsc emits extensionless imports; ESM (NodeNext/Node16) resolution requires them.
+    if (ext === '.d.mts') {
+        for (const file of allFiles) addEsmExtensions(file);
+    }
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -90,3 +90,5 @@ zod
 @types/cors
 @vitest/browser-playwright
 vitest
+rollup-plugin-dts
+rollup

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,6 +19,8 @@
         "fs-extra": "^11.3.1",
         "minimatch": "^10.2.4",
         "prettier": "^3.8.1",
+        "rollup": "^4.60.1",
+        "rollup-plugin-dts": "^6.4.1",
         "semver": "^7.7.1",
         "sort-package-json": "^3.6.1",
         "tsx": "^4.21.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,7 +42,8 @@
         "**/public",
         "**/protobuf-patches",
         "**/trezor-common",
-        "**/jest.config.*js"
+        "**/jest.config.*js",
+        "**/rollup.*.config.mjs"
     ],
     "ts-node": {
         "compilerOptions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8821,6 +8821,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.1"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.1"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.60.1":
+  version: 4.60.1
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rozenite/metro@npm:^1.4.0":
   version: 1.4.0
   resolution: "@rozenite/metro@npm:1.4.0"
@@ -16265,6 +16440,8 @@ __metadata:
     fs-extra: "npm:^11.3.1"
     minimatch: "npm:^10.2.4"
     prettier: "npm:^3.8.1"
+    rollup: "npm:^4.60.1"
+    rollup-plugin-dts: "npm:^6.4.1"
     semver: "npm:^7.7.1"
     sort-package-json: "npm:^3.6.1"
     tsx: "npm:^4.21.0"
@@ -17342,7 +17519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
@@ -41888,6 +42065,115 @@ __metadata:
   bin:
     rolldown: bin/cli.mjs
   checksum: 10/b7c76a93c6f738d6c2fd3101dfa58f1dfe149bb0bd49c7560f1d5b119196a8f53161cb6aa96dc724274d3f23c40f6f301e6e27756ace7de4b7fe92c4c848fe49
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-dts@npm:^6.4.1":
+  version: 6.4.1
+  resolution: "rollup-plugin-dts@npm:6.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.0"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+    convert-source-map: "npm:^2.0.0"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    rollup: ^3.29.4 || ^4
+    typescript: ^4.5 || ^5.0 || ^6.0
+  dependenciesMeta:
+    "@babel/code-frame":
+      optional: true
+  checksum: 10/a18685fde4c59339cacb47e084ff589b39fc680d186b496b83197370295002f748066e3c9c62ced2eca1af0bca77d3096bb24905c40c0478a6d845d63531293d
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.60.1":
+  version: 4.60.1
+  resolution: "rollup@npm:4.60.1"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.1"
+    "@rollup/rollup-android-arm64": "npm:4.60.1"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.1"
+    "@rollup/rollup-darwin-x64": "npm:4.60.1"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.1"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.1"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.1"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.1"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.1"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.1"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.1"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.1"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.1"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.1"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.1"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.1"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.1"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.1"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.1"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.1"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10/6866a35efc999990e191fc954a859ba802d13be63ca13b04746459455982f6b8784d92e5eea8db3ef8acf8baba8c43e8e6cb741f3233ba4c46adf148d3708a9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Ensures 3rd-party consumers of `@trezor/connect-{common,web,mobile,webextension}` can resolve all types on install, including types that originate in devDependencies (e.g. `@trezor/blockchain-link`), without requiring extra workspace installs.

Alternative approach to #26768: instead of rollup-bundling the root `index.d.ts` per package, this walks the built `lib/` / `libESM/` tree, detects `@trezor/*` imports not in each package's prod+peer dep closure (= devDep leaks), and emits one vendor file per leaked package that every `.d.ts` in the tree imports from. Both the root entry **and any subpath** import resolve self-contained types without duplication.

## How it works

`scripts/inline-devdep-types.mjs`:
- walks the built `lib/` or `libESM/` tree
- detects `@trezor/*` imports not in the package's prod+peer dep closure
- recursively expands the leak set (transitive leaks through `libDev/`)
- bundles each leaked package's declarations into its own `_vendor_<pkg>` file
- rewrites every `.d.ts` import of a leaked package to point at the vendor file
- for `.d.mts` (ESM) output, adds explicit `.mjs` extensions so NodeNext/Node16 resolution works

Each leaked package lives in exactly one vendor file per build output; cross-references between leaks resolve to each other, so there is no type duplication across vendors.

Wired into `connect-common`, `connect-web`, `connect-mobile`, `connect-webextension` as `build:dts:inline` step.

## Test plan
- [ ] `yarn workspace @trezor/connect-common build:lib` and inspect that `lib/_vendor_blockchain_link.d.ts` exists and is referenced from `lib/types/account.d.ts`
- [ ] `yarn workspace @trezor/connect-web build:lib`
- [ ] `yarn workspace @trezor/connect-mobile build:lib`
- [ ] `yarn workspace @trezor/connect-webextension build:lib`
- [ ] `yarn pack` each and run `@arethetypeswrong/cli` on the tarball; root entry green in CJS/ESM/bundler
- [ ] Install one of the built tarballs in a scratch consumer, import from `@trezor/connect-web`, run `tsc`; no "Cannot find module @trezor/blockchain-link" errors

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=connect-inline-dts-vendor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-inline-dts-vendor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=connect-inline-dts-vendor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T12:45:07.975Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T09:49:31.552Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-inline-dts-vendor/web/](https://dev.suite.sldev.cz/suite-web/connect-inline-dts-vendor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->