### PR TITLE
fix(suite-native): prevent app crashers after skia update

### DIFF
--- a/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
+++ b/suite-native/react-native-graph/src/AnimatedLineGraph.tsx
@@ -247,7 +247,6 @@ export function AnimatedLineGraph<TEventPayload extends object>({
                 };
             } else {
                 gradientPaths.value = {
-                    from: gradientPath,
                     to: gradientPath,
                 };
             }
@@ -265,7 +264,6 @@ export function AnimatedLineGraph<TEventPayload extends object>({
             };
         } else {
             paths.value = {
-                from: path,
                 to: path,
             };
         }
@@ -317,17 +315,17 @@ export function AnimatedLineGraph<TEventPayload extends object>({
     }, [color, enableFadeInMask]);
 
     const path = useDerivedValue(() => {
-        const from = paths.value.from ?? straightLine;
-        const to = paths.value.to ?? straightLine;
+        const { from, to } = paths.value;
+        if (from == null || to == null) return to ?? straightLine;
 
-        return to.interpolate(from, interpolateProgress.value);
+        return to.interpolate(from, interpolateProgress.value) ?? to;
     }, [interpolateProgress, paths]);
 
     const gradientPath = useDerivedValue(() => {
-        const from = gradientPaths.value.from ?? straightLine;
-        const to = gradientPaths.value.to ?? straightLine;
+        const { from, to } = gradientPaths.value;
+        if (from == null || to == null) return to ?? straightLine;
 
-        return to.interpolate(from, interpolateProgress.value);
+        return to.interpolate(from, interpolateProgress.value) ?? to;
     });
 
     const stopPulsating = useCallback(() => {
@@ -499,7 +497,6 @@ export function AnimatedLineGraph<TEventPayload extends object>({
                                         />
                                         <Group>
                                             <Path
-                                                // @ts-expect-error
                                                 path={path}
                                                 strokeWidth={lineThickness}
                                                 style="stroke"
@@ -515,10 +512,7 @@ export function AnimatedLineGraph<TEventPayload extends object>({
                                             </Path>
 
                                             {shouldFillGradient && (
-                                                <Path
-                                                    // @ts-expect-error
-                                                    path={gradientPath}
-                                                >
+                                                <Path path={gradientPath}>
                                                     <LinearGradient
                                                         start={vec(0, 0)}
                                                         end={vec(0, height)}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Why it fixes the crash:

  The key insight is that the worklet was calling to.interpolate(from, t) on every animation frame — including when paths were "non-interpolatable" (i.e., after a timeframe switch or portfolio refresh producing a different-shaped path). In Skia 2.5.1, interpolate() appears to throw a native exception rather than return null for incompatible inputs.

  Before:
  - Non-interpolatable case: paths.value = { from: path, to: path } (same object)
  - Worklet: still called path.interpolate(path, 0.7) on every frame

  After:
  - Non-interpolatable case: paths.value = { to: path } (from omitted)
  - Worklet: from == null → returns to directly, interpolate() is never called
  - Only when paths are confirmed compatible (from is set) does the worklet call interpolate()
  - The ?? to fallback handles the edge case where interpolate() still returns null for the compatible case

Bonus: The return type of both useDerivedValue callbacks is now SkPath (non-null) instead of SkPath | null, which resolved the two stale `@ts-expect-error` suppressions — Skia 2.5.1 updated its types to accept SharedValue<SkPath> on the Path component, but the null return type was preventing that.

## Notes for QA

Please test the graphs carefully on both iOS and Android, both Dashboard and Account Detail, compare to previous versions.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26961


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/skia-crashes&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->