### PR TITLE
feat(suite): resolve fiat rates for ERC4626 tokens

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -330,8 +330,10 @@ export interface Token {
     totalReceived?: string;
     /** Total amount of tokens sent. */
     totalSent?: string;
-    /** Data containing information about the ERC4626 vault token. */
-    erc4626?: Erc4626;
+    /** Token protocols (e.g. erc4626). */
+    protocols?: {
+        erc4626?: Erc4626;
+    };
 }
 export interface Address {
     /** Current page index. */
@@ -675,8 +677,8 @@ export interface WsAccountInfoReq {
     secondaryCurrency?: string;
     /** Gap limit for XPUB scanning, if relevant. */
     gap?: number;
-    /** Include ERC4626 vault tokens in the response. */
-    includeErc4626?: boolean;
+    /** Protocols to include in the response (e.g. 'erc4626'). */
+    protocols?: string[];
 }
 export interface WsBackendInfo {
     /** Backend version string. */

--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -261,6 +261,28 @@ export interface StakingPool {
     /** Any balance automatically reinvested into the pool. */
     autocompoundBalance: string;
 }
+
+export interface Erc4626 {
+    asset?: {
+        contract: string;
+        name: string;
+        symbol: string;
+        decimals: number;
+    };
+    share?: {
+        contract: string;
+        name: string;
+        symbol: string;
+        decimals: number;
+    };
+    totalAssets?: string;
+    convertToAssets1Share?: string;
+    convertToShares1Asset?: string;
+    previewDeposit1Asset?: string;
+    previewRedeem1Share?: string;
+    error?: string;
+}
+
 export interface ContractInfo {
     /** @deprecated: Use standard instead. */
     type: '' | 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155' | 'BEP20' | 'BEP721' | 'BEP1155';
@@ -309,26 +331,7 @@ export interface Token {
     /** Total amount of tokens sent. */
     totalSent?: string;
     /** Data containing information about the ERC4626 vault token. */
-    erc4626?: {
-        asset?: {
-            contract: string;
-            name: string;
-            symbol: string;
-            decimals: number;
-        };
-        share?: {
-            contract: string;
-            name: string;
-            symbol: string;
-            decimals: number;
-        };
-        totalAssets?: string;
-        convertToAssets1Share?: string;
-        convertToShares1Asset?: string;
-        previewDeposit1Asset?: string;
-        previewRedeem1Share?: string;
-        error?: string;
-    };
+    erc4626?: Erc4626;
 }
 export interface Address {
     /** Current page index. */
@@ -640,7 +643,8 @@ export interface WsReq {
         | 'getCurrentFiatRates'
         | 'getFiatRatesForTimestamps'
         | 'getFiatRatesTickersList'
-        | 'getMempoolFilters';
+        | 'getMempoolFilters'
+        | 'getContractInfo';
     /** Parameters for the requested method in raw JSON format. */
     params: any;
 }
@@ -874,4 +878,20 @@ export interface MempoolTxidFilterEntries {
     entries?: { [key: string]: string };
     /** Indicates if a zeroed key was used in filter calculation. */
     usedZeroedKey?: boolean;
+}
+export interface WsContractInfoReq {
+    contract: string;
+    currency?: string;
+    protocols?: string[];
+}
+export interface WsContractInfoRes {
+    contract: string;
+    standard?: string;
+    name?: string;
+    symbol?: string;
+    decimals?: number;
+    protocols?: {
+        erc4626?: Erc4626;
+    };
+    blockHeight: number;
 }

--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -261,28 +261,6 @@ export interface StakingPool {
     /** Any balance automatically reinvested into the pool. */
     autocompoundBalance: string;
 }
-
-export interface Erc4626 {
-    asset?: {
-        contract: string;
-        name: string;
-        symbol: string;
-        decimals: number;
-    };
-    share?: {
-        contract: string;
-        name: string;
-        symbol: string;
-        decimals: number;
-    };
-    totalAssets?: string;
-    convertToAssets1Share?: string;
-    convertToShares1Asset?: string;
-    previewDeposit1Asset?: string;
-    previewRedeem1Share?: string;
-    error?: string;
-}
-
 export interface ContractInfo {
     /** @deprecated: Use standard instead. */
     type: '' | 'XPUBAddress' | 'ERC20' | 'ERC721' | 'ERC1155' | 'BEP20' | 'BEP721' | 'BEP1155';
@@ -299,6 +277,34 @@ export interface ContractInfo {
     createdInBlock?: number;
     /** Block height where contract was destroyed (if any). */
     destructedInBlock?: number;
+}
+export interface Erc4626TokenMetadata {
+    /** Token contract address. */
+    contract: string;
+    /** Human-readable token name. */
+    name?: string;
+    /** Token symbol. */
+    symbol?: string;
+    /** Token decimals. */
+    decimals: number;
+}
+export interface Erc4626Token {
+    /** Metadata of the underlying asset token. */
+    asset?: Erc4626TokenMetadata;
+    /** Metadata of the vault share token. */
+    share?: Erc4626TokenMetadata;
+    /** Total underlying assets managed by the vault. */
+    totalAssets?: string;
+    /** Underlying assets for one whole share unit. */
+    convertToAssets1Share?: string;
+    /** Shares for one whole underlying asset unit. */
+    convertToShares1Asset?: string;
+    /** Previewed shares minted for one whole underlying asset unit. */
+    previewDeposit1Asset?: string;
+    /** Previewed assets redeemed for one whole share unit. */
+    previewRedeem1Share?: string;
+    /** Error message for partial failures while fetching ERC4626 fields. */
+    error?: string;
 }
 export interface Token {
     /** @deprecated: Use standard instead. */
@@ -330,10 +336,8 @@ export interface Token {
     totalReceived?: string;
     /** Total amount of tokens sent. */
     totalSent?: string;
-    /** Token protocols (e.g. erc4626). */
-    protocols?: {
-        erc4626?: Erc4626;
-    };
+    /** Optional protocol-specific enrichments requested by the caller. */
+    protocols?: ContractInfoProtocols;
 }
 export interface Address {
     /** Current page index. */
@@ -398,6 +402,64 @@ export interface Address {
     chainExtraData?:
         | { payloadType: 'tron'; payload?: TronAccountExtraData }
         | { payloadType: string; payload?: any };
+}
+export type ContractInfoProtocol = 'erc4626';
+export interface ContractInfoProtocols {
+    /** ERC4626 vault details when explicitly requested and detected. */
+    erc4626?: Erc4626Token;
+}
+export interface ContractInfoRates {
+    /** Current price of one whole token in the chain base currency, when available. */
+    baseRate?: number;
+    /** Requested secondary currency code for the secondaryRate field, lower-cased. */
+    currency?: string;
+    /** Current price of one whole token in the requested secondary currency, when available. */
+    secondaryRate?: number;
+}
+export interface ContractInfoResult {
+    /** @deprecated: Use standard instead. */
+    type:
+        | ''
+        | 'XPUBAddress'
+        | 'ERC20'
+        | 'ERC721'
+        | 'ERC1155'
+        | 'BEP20'
+        | 'BEP721'
+        | 'BEP1155'
+        | 'TRC20'
+        | 'TRC721'
+        | 'TRC1155';
+    standard:
+        | ''
+        | 'XPUBAddress'
+        | 'ERC20'
+        | 'ERC721'
+        | 'ERC1155'
+        | 'BEP20'
+        | 'BEP721'
+        | 'BEP1155'
+        | 'TRC20'
+        | 'TRC721'
+        | 'TRC1155';
+    /** Smart contract address. */
+    contract: string;
+    /** Readable name of the contract. */
+    name: string;
+    /** Symbol for tokens under this contract, if applicable. */
+    symbol: string;
+    /** Number of decimal places, if applicable. */
+    decimals: number;
+    /** Block height where contract was first created. */
+    createdInBlock?: number;
+    /** Block height where contract was destroyed (if any). */
+    destructedInBlock?: number;
+    /** Current rate data for the contract when available. */
+    rates?: ContractInfoRates;
+    /** Optional protocol-specific enrichments requested by the caller. */
+    protocols?: ContractInfoProtocols;
+    /** Indexed best block height used as freshness metadata for this response. */
+    blockHeight: number;
 }
 export interface Utxo {
     /** Transaction ID in which this UTXO was created. */
@@ -624,6 +686,7 @@ export interface WsReq {
     /** Requested method name. */
     method:
         | 'getAccountInfo'
+        | 'getContractInfo'
         | 'getInfo'
         | 'getBlockHash'
         | 'getBlock'
@@ -645,8 +708,7 @@ export interface WsReq {
         | 'getCurrentFiatRates'
         | 'getFiatRatesForTimestamps'
         | 'getFiatRatesTickersList'
-        | 'getMempoolFilters'
-        | 'getContractInfo';
+        | 'getMempoolFilters';
     /** Parameters for the requested method in raw JSON format. */
     params: any;
 }
@@ -663,6 +725,8 @@ export interface WsAccountInfoReq {
     details?: 'basic' | 'tokens' | 'tokenBalances' | 'txids' | 'txslight' | 'txs';
     /** Which tokens to include in the account info. */
     tokens?: 'derived' | 'used' | 'nonzero';
+    /** Optional protocol enrichments to include. Supported values currently include 'erc4626'. */
+    protocols?: ContractInfoProtocol[];
     /** Number of items per page, if paging is used. */
     pageSize?: number;
     /** Requested page index, if paging is used. */
@@ -677,8 +741,14 @@ export interface WsAccountInfoReq {
     secondaryCurrency?: string;
     /** Gap limit for XPUB scanning, if relevant. */
     gap?: number;
-    /** Protocols to include in the response (e.g. 'erc4626'). */
-    protocols?: string[];
+}
+export interface WsContractInfoReq {
+    /** Contract address to query. */
+    contract: string;
+    /** Optional secondary currency code used to include fiat pricing information. */
+    currency?: string;
+    /** Optional protocol enrichments to include. Supported values currently include 'erc4626'. */
+    protocols?: ContractInfoProtocol[];
 }
 export interface WsBackendInfo {
     /** Backend version string. */
@@ -880,20 +950,4 @@ export interface MempoolTxidFilterEntries {
     entries?: { [key: string]: string };
     /** Indicates if a zeroed key was used in filter calculation. */
     usedZeroedKey?: boolean;
-}
-export interface WsContractInfoReq {
-    contract: string;
-    currency?: string;
-    protocols?: string[];
-}
-export interface WsContractInfoRes {
-    contract: string;
-    standard?: string;
-    name?: string;
-    symbol?: string;
-    decimals?: number;
-    protocols?: {
-        erc4626?: Erc4626;
-    };
-    blockHeight: number;
 }

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -4,6 +4,7 @@ import type {
     AvailableVsCurrencies,
     Address as BlockbookAddress,
     Block as BlockbookBlock,
+    Erc4626 as BlockbookErc4626,
     Token as BlockbookToken,
     TokenTransfer as BlockbookTokenTransfer,
     Tx as BlockbookTx,
@@ -14,6 +15,7 @@ import type {
     WsBlockFilterReq,
     WsBlockFiltersBatchReq,
     WsBlockHashRes,
+    WsContractInfoRes,
     WsEstimateFeeRes,
     WsInfoRes,
     WsMempoolFiltersReq,
@@ -165,6 +167,10 @@ export interface FiatRatesForTimestamp {
 
 export type AvailableCurrencies = Omit<RequiredKey<AvailableVsCurrencies, 'ts'>, 'error'>;
 
+export type Erc4626 = BlockbookErc4626;
+
+export type ContractInfoResponse = WsContractInfoRes;
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
 declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
@@ -206,6 +212,10 @@ declare function FSend(
 ): Promise<FiatRatesForTimestamp>;
 declare function FSend(method: 'estimateFee', params: EstimateFeeParams): Promise<Fee>;
 declare function FSend(method: 'rpcCall', params: RpcCallParams): Promise<{ data: string }>;
+declare function FSend(
+    method: 'getContractInfo',
+    params: { contract: string; currency?: string; protocols?: string[] },
+): Promise<ContractInfoResponse>;
 declare function FSend(
     method: 'subscribeAddresses',
     params: { addresses: string[] },

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -4,17 +4,19 @@ import type {
     AvailableVsCurrencies,
     Address as BlockbookAddress,
     Block as BlockbookBlock,
+    ContractInfoProtocol as BlockbookContractInfoProtocol,
     Token as BlockbookToken,
     TokenTransfer as BlockbookTokenTransfer,
     Tx as BlockbookTx,
     Utxo as BlockbookUtxo,
+    ContractInfoResult,
     FiatTicker,
     MempoolTxidFilterEntries,
     WsAccountUtxoReq,
     WsBlockFilterReq,
     WsBlockFiltersBatchReq,
     WsBlockHashRes,
-    WsContractInfoRes,
+    WsContractInfoReq,
     WsEstimateFeeRes,
     WsInfoRes,
     WsMempoolFiltersReq,
@@ -166,7 +168,10 @@ export interface FiatRatesForTimestamp {
 
 export type AvailableCurrencies = Omit<RequiredKey<AvailableVsCurrencies, 'ts'>, 'error'>;
 
-export type ContractInfoResponse = WsContractInfoRes;
+export type ContractInfoProtocol = BlockbookContractInfoProtocol;
+
+export type ContractInfoParams = WsContractInfoReq;
+export type ContractInfoResponse = ContractInfoResult;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
@@ -211,7 +216,7 @@ declare function FSend(method: 'estimateFee', params: EstimateFeeParams): Promis
 declare function FSend(method: 'rpcCall', params: RpcCallParams): Promise<{ data: string }>;
 declare function FSend(
     method: 'getContractInfo',
-    params: { contract: string; currency?: string; protocols?: string[] },
+    params: ContractInfoParams,
 ): Promise<ContractInfoResponse>;
 declare function FSend(
     method: 'subscribeAddresses',

--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -4,7 +4,6 @@ import type {
     AvailableVsCurrencies,
     Address as BlockbookAddress,
     Block as BlockbookBlock,
-    Erc4626 as BlockbookErc4626,
     Token as BlockbookToken,
     TokenTransfer as BlockbookTokenTransfer,
     Tx as BlockbookTx,
@@ -166,8 +165,6 @@ export interface FiatRatesForTimestamp {
 }
 
 export type AvailableCurrencies = Omit<RequiredKey<AvailableVsCurrencies, 'ts'>, 'error'>;
-
-export type Erc4626 = BlockbookErc4626;
 
 export type ContractInfoResponse = WsContractInfoRes;
 

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,7 +1,11 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { BaseCurrencyCode } from './baseCurrency';
-import type { Erc4626, TronAccountExtraData, TronChainExtraData } from './blockbook-api';
+import type {
+    ContractInfoProtocols,
+    TronAccountExtraData,
+    TronChainExtraData,
+} from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -322,9 +326,7 @@ export interface TokenInfo {
     accounts?: TokenAccount[];
     policyId?: string;
     fingerprint?: string;
-    protocols?: {
-        erc4626?: Erc4626;
-    };
+    protocols?: ContractInfoProtocols;
 }
 
 /**

--- a/packages/blockchain-link-types/src/common.ts
+++ b/packages/blockchain-link-types/src/common.ts
@@ -1,11 +1,7 @@
 import type { SocksProxyAgentOptions } from 'socks-proxy-agent';
 
 import type { BaseCurrencyCode } from './baseCurrency';
-import type {
-    Token as BlockbookToken,
-    TronAccountExtraData,
-    TronChainExtraData,
-} from './blockbook-api';
+import type { Erc4626, TronAccountExtraData, TronChainExtraData } from './blockbook-api';
 
 /* Shared types — canonical definitions used by both common and backend-specific modules */
 
@@ -326,7 +322,9 @@ export interface TokenInfo {
     accounts?: TokenAccount[];
     policyId?: string;
     fingerprint?: string;
-    erc4626?: BlockbookToken['erc4626'];
+    protocols?: {
+        erc4626?: Erc4626;
+    };
 }
 
 /**

--- a/packages/blockchain-link-types/src/constants/messages.ts
+++ b/packages/blockchain-link-types/src/constants/messages.ts
@@ -11,6 +11,7 @@ export const GET_BLOCK_HASH = 'm_get_block_hash';
 export const GET_BLOCK = 'm_get_block';
 export const GET_ACCOUNT_INFO = 'm_get_account_info';
 export const GET_ACCOUNT_UTXO = 'm_get_account_utxo';
+export const GET_CONTRACT_INFO = 'm_get_contract_info';
 export const GET_TRANSACTION = 'm_get_transaction';
 export const GET_TRANSACTION_HEX = 'm_get_transaction_hex';
 export const ESTIMATE_FEE = 'm_estimate_fee';

--- a/packages/blockchain-link-types/src/constants/responses.ts
+++ b/packages/blockchain-link-types/src/constants/responses.ts
@@ -10,6 +10,7 @@ export const GET_FIAT_RATES_TICKERS_LIST = 'r_GET_FIAT_RATES_TICKERS_LIST';
 export const GET_ACCOUNT_INFO = 'r_account_info';
 export const GET_ACCOUNT_UTXO = 'r_get_account_utxo';
 export const GET_ACCOUNT_BALANCE_HISTORY = 'r_get_account_balance_history';
+export const GET_CONTRACT_INFO = 'r_get_contract_info';
 export const GET_TRANSACTION = 'r_get_transaction';
 export const GET_TRANSACTION_HEX = 'r_get_transaction_hex';
 export const ESTIMATE_FEE = 'r_estimate_fee';

--- a/packages/blockchain-link-types/src/index.ts
+++ b/packages/blockchain-link-types/src/index.ts
@@ -19,6 +19,7 @@ export type {
     AccountUtxo as BlockbookAccountUtxo,
     AddressNotification as BlockbookAddressNotification,
     BlockNotification as BlockbookBlockNotification,
+    ContractInfoResponse as BlockbookContractInfoResponse,
     Fee as BlockbookFee,
     FiatRatesNotification as BlockbookFiatRatesNotification,
     FilterRequestParams as BlockbookFilterRequestParams,

--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -1,3 +1,4 @@
+import { type ContractInfoParams } from './blockbook';
 import type { BlockchainSettings, ChannelMessage, SubscriptionAccountInfo } from './common';
 import type * as MESSAGES from './constants/messages';
 import type {
@@ -146,11 +147,7 @@ export interface ValidateEvmRpc {
 
 export interface GetContractInfo {
     type: typeof MESSAGES.GET_CONTRACT_INFO;
-    payload: {
-        contract: string;
-        currency?: string;
-        protocols?: string[];
-    };
+    payload: ContractInfoParams;
 }
 
 export type Message =

--- a/packages/blockchain-link-types/src/messages.ts
+++ b/packages/blockchain-link-types/src/messages.ts
@@ -144,6 +144,15 @@ export interface ValidateEvmRpc {
     };
 }
 
+export interface GetContractInfo {
+    type: typeof MESSAGES.GET_CONTRACT_INFO;
+    payload: {
+        contract: string;
+        currency?: string;
+        protocols?: string[];
+    };
+}
+
 export type Message =
     | ChannelMessage<{ type: typeof MESSAGES.TERMINATE; payload?: typeof undefined }>
     | ChannelMessage<{ type: typeof MESSAGES.HANDSHAKE; settings: BlockchainSettings }>
@@ -165,4 +174,5 @@ export type Message =
     | ChannelMessage<Subscribe>
     | ChannelMessage<Unsubscribe>
     | ChannelMessage<PushTransaction>
-    | ChannelMessage<ValidateEvmRpc>;
+    | ChannelMessage<ValidateEvmRpc>
+    | ChannelMessage<GetContractInfo>;

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -58,5 +58,5 @@ export interface AccountInfoParams {
         seq: number;
     };
     tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
-    includeErc4626?: boolean; // blockbook only, include ERC4626 vault tokens
+    protocols?: string[]; // protocols to include in the response (e.g. 'erc4626')
 }

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -58,5 +58,5 @@ export interface AccountInfoParams {
         seq: number;
     };
     tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
-    protocols?: string[]; // protocols to include in the response (e.g. 'erc4626')
+    protocols?: 'erc4626'[]; // protocols to include in the response (e.g. 'erc4626')
 }

--- a/packages/blockchain-link-types/src/responses.ts
+++ b/packages/blockchain-link-types/src/responses.ts
@@ -1,4 +1,4 @@
-import type { Block, MempoolTransactionNotification } from './blockbook';
+import type { Block, ContractInfoResponse, MempoolTransactionNotification } from './blockbook';
 import { type Eip1559Fees } from './blockbook-api';
 import type {
     AccountBalanceHistory,
@@ -167,6 +167,11 @@ export interface ValidateEvmRpc {
     };
 }
 
+export interface GetContractInfo {
+    type: typeof RESPONSES.GET_CONTRACT_INFO;
+    payload: ContractInfoResponse;
+}
+
 interface WithoutPayload {
     id: number;
     type: typeof HANDSHAKE | typeof RESPONSES.CONNECTED;
@@ -196,4 +201,5 @@ export type Response =
     | ChannelMessage<Unsubscribe>
     | ChannelMessage<Notification>
     | ChannelMessage<PushTransaction>
-    | ChannelMessage<ValidateEvmRpc>;
+    | ChannelMessage<ValidateEvmRpc>
+    | ChannelMessage<GetContractInfo>;

--- a/packages/blockchain-link/src/index.ts
+++ b/packages/blockchain-link/src/index.ts
@@ -237,6 +237,15 @@ export class BlockchainLink extends TypedEmitter<Events> {
         });
     }
 
+    getContractInfo(
+        payload: MessageTypes.GetContractInfo['payload'],
+    ): Promise<ResponseTypes.GetContractInfo['payload']> {
+        return this.sendMessage({
+            type: MESSAGES.GET_CONTRACT_INFO,
+            payload,
+        });
+    }
+
     /**
      * Subscribe for live changes in
      * - blockchain i.e new blocks mined.

--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -177,6 +177,16 @@ const rpcCall = async (request: Request<MessageTypes.RpcCall>) => {
     } as const;
 };
 
+const getContractInfo = async (request: Request<MessageTypes.GetContractInfo>) => {
+    const api = await request.connect();
+    const response = await api.getContractInfo(request.payload);
+
+    return {
+        type: RESPONSES.GET_CONTRACT_INFO,
+        payload: response,
+    } as const;
+};
+
 const onNewBlock = ({ post }: Context, event: BlockNotification) => {
     post({
         id: -1,
@@ -433,6 +443,8 @@ const onRequest = (request: Request<MessageTypes.Message>) => {
             return estimateFee(request);
         case MESSAGES.RPC_CALL:
             return rpcCall(request);
+        case MESSAGES.GET_CONTRACT_INFO:
+            return getContractInfo(request);
         case MESSAGES.PUSH_TRANSACTION:
             return pushTransaction(request);
         case MESSAGES.SUBSCRIBE:

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -12,6 +12,7 @@ import type {
     RpcCallParams,
     BlockbookSend as Send,
 } from '@trezor/blockchain-link-types';
+import { type GetContractInfo } from '@trezor/blockchain-link-types/src/messages';
 import { getSuiteVersion } from '@trezor/env-utils';
 
 import { BaseWebsocket } from '../baseWebsocket';
@@ -123,6 +124,10 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     rpcCall(payload: RpcCallParams) {
         return this.send('rpcCall', payload);
+    }
+
+    getContractInfo(payload: GetContractInfo['payload']) {
+        return this.send('getContractInfo', payload);
     }
 
     getCurrentFiatRates(payload: GetCurrentFiatRates['payload']) {

--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -75,6 +75,7 @@ const connectCallableMethodGroups = {
         'blockchainGetTransactions',
         'blockchainEvmRpcCall',
         'blockchainGetCurrentFiatRates',
+        'blockchainGetContractInfo',
         'blockchainGetFiatRatesForTimestamps',
         'blockchainSubscribeFiatRates',
         'blockchainUnsubscribeFiatRates',

--- a/packages/connect-common/src/types/api/blockchainGetContractInfo.ts
+++ b/packages/connect-common/src/types/api/blockchainGetContractInfo.ts
@@ -1,7 +1,8 @@
 import type { BlockchainLinkResponse } from '@trezor/blockchain-link';
+import { type ContractInfoParams } from '@trezor/blockchain-link-types/src/blockbook';
 
 import type { CommonParamsWithCoin, Response } from '../params';
 
 export declare function blockchainGetContractInfo(
-    params: CommonParamsWithCoin & { contract: string; currency?: string; protocols?: string[] },
+    params: CommonParamsWithCoin & ContractInfoParams,
 ): Response<BlockchainLinkResponse<'getContractInfo'>>;

--- a/packages/connect-common/src/types/api/blockchainGetContractInfo.ts
+++ b/packages/connect-common/src/types/api/blockchainGetContractInfo.ts
@@ -1,0 +1,7 @@
+import type { BlockchainLinkResponse } from '@trezor/blockchain-link';
+
+import type { CommonParamsWithCoin, Response } from '../params';
+
+export declare function blockchainGetContractInfo(
+    params: CommonParamsWithCoin & { contract: string; currency?: string; protocols?: string[] },
+): Response<BlockchainLinkResponse<'getContractInfo'>>;

--- a/packages/connect-common/src/types/api/discoverAccounts.ts
+++ b/packages/connect-common/src/types/api/discoverAccounts.ts
@@ -72,7 +72,7 @@ export type AccountTypeKey = DistributivePick<AccountTypeItem, 'symbol' | 'type'
 
 export type AdditionalParams = Pick<
     BlockchainLinkParams<'getAccountInfo'>,
-    'details' | 'pageSize' | 'includeErc4626' | 'gap'
+    'details' | 'pageSize' | 'protocols' | 'gap'
 > & {
     identity?: string;
 };

--- a/packages/connect-common/src/types/api/index.ts
+++ b/packages/connect-common/src/types/api/index.ts
@@ -11,6 +11,7 @@ import type { blockchainDisconnect } from './blockchainDisconnect';
 import type { blockchainEstimateFee } from './blockchainEstimateFee';
 import type { blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 import type { blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
+import type { blockchainGetContractInfo } from './blockchainGetContractInfo';
 import type { blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
 import type { blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';
 import type { blockchainGetInfo } from './blockchainGetInfo';
@@ -240,6 +241,9 @@ export const TrezorConnectBlockchain = Type.Object({
 
     // For internal use, no public documentation.
     blockchainGetCurrentFiatRates: Type.Unsafe<typeof blockchainGetCurrentFiatRates>(),
+
+    // For internal use, no public documentation.
+    blockchainGetContractInfo: Type.Unsafe<typeof blockchainGetContractInfo>(),
 
     // For internal use, no public documentation.
     blockchainGetFiatRatesForTimestamps: Type.Unsafe<typeof blockchainGetFiatRatesForTimestamps>(),

--- a/packages/connect/src/api/blockchainGetContractInfo.ts
+++ b/packages/connect/src/api/blockchainGetContractInfo.ts
@@ -1,0 +1,71 @@
+import type { CoinInfo } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import { initBlockchain, isBackendSupported } from '../backend/BlockchainLink';
+import type {
+    MethodContext,
+    MethodMessage,
+    MethodPermission,
+    Payload,
+} from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { getCoinInfo } from '../data/coinInfo';
+import { validateParams } from './common/paramsValidator';
+
+type Params = {
+    coinInfo: CoinInfo;
+    identity?: string;
+    request: Pick<Payload<'blockchainGetContractInfo'>, 'contract' | 'currency' | 'protocols'>;
+};
+
+export default class BlockchainGetContractInfo extends AbstractMethod<
+    'blockchainGetContractInfo',
+    Params
+> {
+    constructor(message: MethodMessage<'blockchainGetContractInfo'>) {
+        const { payload } = message;
+
+        validateParams(payload, [
+            { name: 'coin', type: 'string', required: true },
+            { name: 'contract', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
+        ]);
+
+        const coinInfo = getCoinInfo(payload.coin);
+
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+
+        isBackendSupported(coinInfo);
+
+        const request = {
+            contract: payload.contract,
+            currency: payload.currency,
+            protocols: payload.protocols,
+        };
+
+        super(message, {
+            coinInfo,
+            identity: payload.identity,
+            request,
+        });
+
+        this.useDevice = false;
+        this.useUi = false;
+    }
+
+    get requiredPermissions(): MethodPermission[] {
+        return [];
+    }
+
+    async run({ sendCoreMessage }: MethodContext) {
+        const backend = await initBlockchain(
+            this.params.coinInfo,
+            sendCoreMessage,
+            this.params.identity,
+        );
+
+        return backend.getContractInfo(this.params.request);
+    }
+}

--- a/packages/connect/src/api/discoverAccounts.ts
+++ b/packages/connect/src/api/discoverAccounts.ts
@@ -99,7 +99,7 @@ export default class DiscoverAccounts extends AbstractMethod<
                 { name: 'identity', type: 'string' },
                 { name: 'details', type: 'string' },
                 { name: 'pageSize', type: 'number' },
-                { name: 'includeErc4626', type: 'boolean' },
+                { name: 'protocols', type: 'array' },
             ]);
 
             const { symbol, known: knownAccs, knownOnly, ...rest } = coin;
@@ -323,17 +323,8 @@ export default class DiscoverAccounts extends AbstractMethod<
         request: Request,
         sendCoreMessage: MethodContext['sendCoreMessage'],
     ): Promise<{ nonempty: number; error?: string }> {
-        const {
-            details,
-            identity,
-            pageSize,
-            gap,
-            includeErc4626,
-            coinInfo,
-            derivation,
-            offset,
-            skip,
-        } = request;
+        const { details, identity, pageSize, gap, protocols, coinInfo, derivation, offset, skip } =
+            request;
         const { path: bip43, ...accountKey } = request.account;
         const backendType = coinInfo.blockchainLink?.type;
         const utxoRequired = isUtxoBased(coinInfo) && details && details !== 'basic';
@@ -366,7 +357,7 @@ export default class DiscoverAccounts extends AbstractMethod<
                     descriptor,
                     details,
                     pageSize,
-                    includeErc4626,
+                    protocols,
                     gap,
                 });
 

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -61,7 +61,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 { name: 'contractFilter', type: 'string' },
                 { name: 'gap', type: 'number' },
                 { name: 'marker', type: 'object' },
-                { name: 'includeErc4626', type: 'boolean' },
+                { name: 'protocols', type: 'array' },
                 { name: 'defaultAccountType', type: 'string' },
                 { name: 'derivationType', type: 'number' },
                 { name: 'suppressBackupWarning', type: 'boolean' },
@@ -262,7 +262,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     gap: request.gap,
                     marker: request.marker,
                     tokenAccountsPubKeys: request.tokenAccountsPubKeys,
-                    includeErc4626: request.includeErc4626,
+                    protocols: request.protocols,
                 });
 
                 if (this.disposed) break;
@@ -439,7 +439,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
             contractFilter: request.contractFilter,
             gap: request.gap,
             marker: request.marker,
-            includeErc4626: request.includeErc4626,
+            protocols: request.protocols,
         });
 
         let utxo: AccountUtxo[] | undefined;

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -10,6 +10,7 @@ export { default as blockchainDisconnect } from './blockchainDisconnect';
 export { default as blockchainEstimateFee } from './blockchainEstimateFee';
 export { default as blockchainGetAccountBalanceHistory } from './blockchainGetAccountBalanceHistory';
 export { default as blockchainGetCurrentFiatRates } from './blockchainGetCurrentFiatRates';
+export { default as blockchainGetContractInfo } from './blockchainGetContractInfo';
 export { default as blockchainGetInfo } from './blockchainGetInfo';
 export { default as blockchainEvmRpcCall } from './blockchainEvmRpcCall';
 export { default as blockchainGetFiatRatesForTimestamps } from './blockchainGetFiatRatesForTimestamps';

--- a/packages/connect/src/backend/Blockchain.ts
+++ b/packages/connect/src/backend/Blockchain.ts
@@ -194,6 +194,10 @@ export class Blockchain {
         return this.link.getCurrentFiatRates(params);
     }
 
+    getContractInfo(params: BlockchainLinkParams<'getContractInfo'>) {
+        return this.link.getContractInfo(params);
+    }
+
     getFiatRatesForTimestamps(params: {
         currencies?: string[];
         timestamps: number[];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddTokenModal.tsx
@@ -37,7 +37,7 @@ export const AddTokenModal = ({ onCancel }: AddTokenModalProps) => {
                 details: 'tokenBalances',
                 contractFilter: contractAddress,
                 suppressBackupWarning: true,
-                includeErc4626: acc.networkType === 'ethereum' ? true : undefined,
+                protocols: acc.networkType === 'ethereum' ? ['erc4626'] : undefined,
             });
 
             if (response.success) {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFormActions.ts
@@ -92,6 +92,7 @@ export const useTradingFormActions = <T extends TradingSellExchangeFormProps>({
         cryptoId: sendCryptoSelect?.id,
         amount: sendCryptoAccount?.balance,
         fiatCurrency: getValues().outputs?.[0]?.currency?.value || undefined,
+        isErc4626: !!tokenData?.protocols?.erc4626,
     });
 
     const { getAssetDecimals } = useTradingAssetDecimals();

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -200,6 +200,7 @@ export const BaseCurrencyInput = ({
                             {
                                 symbol: account.symbol,
                                 tokenAddress: token?.contract as TokenAddress,
+                                protocols: token?.protocols?.erc4626 ? ['erc4626'] : undefined,
                             },
                         ],
                         baseCurrencyCode: selected.value as BaseCurrencyCode,

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -92,6 +92,7 @@ export function SelectTokenAssetModal({
                     {
                         symbol: account.symbol,
                         tokenAddress: (newlySelectedToken?.contract || '') as TokenAddress,
+                        protocols: newlySelectedToken?.protocols?.erc4626 ? ['erc4626'] : undefined,
                     },
                 ],
                 baseCurrencyCode: currencyValue.value as BaseCurrencyCode,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputBalance.tsx
@@ -25,20 +25,23 @@ export const AssetPickerInputBalance = memo(function AssetPickerInputBalance({
     const { watch, getValues } = useFormContext<TradingSellFormProps | TradingExchangeFormProps>();
     const value = watch(name);
     const findAccountOrToken = useTradingFindAccountOrToken();
-    const amount = useMemo(() => {
+
+    const accountOrToken = useMemo(() => {
         if (!value) return undefined;
 
-        const accountOrToken = findAccountOrToken.current({
+        return findAccountOrToken.current({
             accountKey: value.accountKey,
             cryptoId: value.id,
         });
+    }, [findAccountOrToken, value]);
 
+    const amount = useMemo(() => {
         if (!accountOrToken) return undefined;
 
         return accountOrToken.token
             ? accountOrToken.token.balance
             : accountOrToken.account.formattedBalance;
-    }, [findAccountOrToken, value]);
+    }, [accountOrToken]);
 
     const { getAssetDecimals } = useTradingAssetDecimals();
     const assetDecimals = useMemo(() => {
@@ -51,6 +54,7 @@ export const AssetPickerInputBalance = memo(function AssetPickerInputBalance({
         amount,
         cryptoId: value?.id,
         fiatCurrency: getValues('outputs')?.[0]?.currency?.value || undefined,
+        isErc4626: !!accountOrToken?.token?.protocols?.erc4626,
     });
 
     if (!fiatValues || !value) {

--- a/suite-common/trading/src/hooks/useTradingFiatValues.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.ts
@@ -36,6 +36,7 @@ export interface TradingFiatRatesProps {
     cryptoId?: CryptoId;
     amount?: string;
     shouldSendInSats?: boolean;
+    isErc4626?: boolean;
 }
 
 export interface TradingFiatRatesReturn {
@@ -57,6 +58,7 @@ export const useTradingFiatValues = ({
     fiatCurrency,
     amount,
     shouldSendInSats,
+    isErc4626,
 }: TradingFiatRatesProps): TradingFiatRatesReturn | null => {
     const dispatch = useDispatch();
 
@@ -100,6 +102,7 @@ export const useTradingFiatValues = ({
                         {
                             symbol,
                             tokenAddress: isNativeToken ? undefined : tokenAddress,
+                            protocols: isErc4626 ? ['erc4626'] : undefined,
                         },
                     ],
                     baseCurrencyCode: value,
@@ -124,7 +127,7 @@ export const useTradingFiatValues = ({
 
             return null;
         },
-        [contractAddress, dispatch, symbol, isNativeToken],
+        [contractAddress, dispatch, symbol, isNativeToken, isErc4626],
     );
 
     useEffect(() => {

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -55,7 +55,7 @@ const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['
             details: 'tokenBalances',
             contractFilter: t.contract,
             suppressBackupWarning: true,
-            includeErc4626: isEvmNetwork ? true : undefined,
+            protocols: isEvmNetwork ? ['erc4626'] : undefined,
         }),
     );
 
@@ -108,6 +108,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             details: account.networkType === 'solana' ? 'txids' : 'basic',
             suppressBackupWarning: true,
             tokenAccountsPubKeys,
+            protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
             gap,
         });
 
@@ -139,7 +140,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             page: 1, // useful for every network except ripple and stellar
             pageSize,
             suppressBackupWarning: true,
-            includeErc4626: account.networkType === 'ethereum' ? true : undefined,
+            protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
             gap:
                 account.networkType === 'bitcoin'
                     ? selectGapLimit(getState(), account.symbol)

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesMiddleware.ts
@@ -1,7 +1,7 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
 import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
+import { type TickerId, type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
 import { isNative } from '@trezor/env-utils';
 
 import {
@@ -111,7 +111,8 @@ export const prepareFiatRatesMiddleware = createMiddlewareWithExtraDeps(
             const tokenTickers = tokens.map(token => ({
                 symbol,
                 tokenAddress: token.contract as TokenAddress,
-            }));
+                protocols: token.protocols?.erc4626 ? ['erc4626'] : undefined,
+            })) satisfies TickerId[];
             // include main account fiat rate ticker
             const tickers = [...tokenTickers, { symbol }];
 

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.ts
@@ -12,6 +12,7 @@ import {
     type RatesByTimestamps,
     type TickerId,
     type Timestamp,
+    type TokenAddress,
 } from '@suite-common/wallet-types';
 import {
     getFiatRateKeyFromTicker,
@@ -101,8 +102,9 @@ export const selectTickerFromAccounts = (
                     token =>
                         ({
                             symbol: account.symbol,
-                            tokenAddress: token.contract,
-                        }) as TickerId,
+                            tokenAddress: token.contract as TokenAddress,
+                            protocols: token.protocols?.erc4626 ? ['erc4626'] : undefined,
+                        }) satisfies TickerId,
                 ),
         ]),
         A.flat,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -1,7 +1,11 @@
 import { fetchCurrentFiatRates, fetchLastWeekFiatRates } from '@suite-common/fiat-services';
 import { createThunk } from '@suite-common/redux-utils';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
-import { getNetworkFeatures } from '@suite-common/wallet-config';
+import {
+    type BackendType,
+    type NetworkSymbol,
+    getNetworkFeatures,
+} from '@suite-common/wallet-config';
 import {
     type AccountKey,
     type FiatRatesResult,
@@ -9,6 +13,7 @@ import {
     type TickerId,
     type TickerResult,
     type Timestamp,
+    type TokenAddress,
     type WalletAccountTransaction,
     asTimestamp,
     toTokenAddress,
@@ -16,20 +21,101 @@ import {
 import {
     fetchTransactionsRates,
     groupTokensTransactionsByContractAddress,
+    isErc4626,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import TrezorConnect from '@trezor/connect';
 import { type TimerId, exhaustive } from '@trezor/type-utils';
-import { typedObjectKeys } from '@trezor/utils';
+import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
 import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
 import { selectTickersToBeUpdated } from './fiatRatesSelectors';
-import { selectAccountByKey } from '../accounts/accountsSelectors';
+import { selectAccountByKey, selectDeviceAccounts } from '../accounts/accountsSelectors';
 import {
     selectActiveBackendType,
     selectIsElectrumBackendSelected,
 } from '../blockchain/blockchainSelectors';
 import { selectTransactionsWithMissingRates } from '../transactions/transactionsSelectors';
+
+interface FetchErc4626DataProps {
+    coin: NetworkSymbol;
+    contract: TokenAddress;
+}
+
+const fetchErc4626Data = async ({ coin, contract }: FetchErc4626DataProps) => {
+    const response = await TrezorConnect.blockchainGetContractInfo({
+        coin,
+        contract,
+        protocols: ['erc4626'],
+    });
+
+    if (!response.success) {
+        throw new Error(`Error fetching ERC4626 token info for ${contract}`);
+    }
+
+    if (!response.payload.protocols?.erc4626) {
+        throw new Error(`ERC4626 token ${contract} is missing ERC4626 data`);
+    }
+
+    return response.payload.protocols.erc4626;
+};
+
+interface FetchErc4626FiatRateProps {
+    ticker: TickerId;
+    rateType: RateTypeWithoutHistoric;
+    baseCurrencyCode: BaseCurrencyCode;
+    backendType: BackendType | undefined;
+    skipCache: boolean;
+}
+
+const fetchErc4626FiatRate = async ({
+    ticker,
+    rateType,
+    baseCurrencyCode,
+    backendType,
+    skipCache,
+}: FetchErc4626FiatRateProps): Promise<FiatRatesResult> => {
+    if (!ticker.tokenAddress) {
+        throw new Error('Token address is missing from ERC4626 token');
+    }
+
+    const erc4626 = await fetchErc4626Data({ coin: ticker.symbol, contract: ticker.tokenAddress });
+
+    if (!erc4626.asset) {
+        throw new Error(`ERC4626 token ${ticker.tokenAddress} is missing underlying asset data`);
+    }
+
+    // convertToAssets1Share is raw underlying asset units per 1 whole vault share
+    if (!erc4626.convertToAssets1Share) {
+        throw new Error(`ERC4626 token ${ticker.tokenAddress} is missing convertToAssets1Share`);
+    }
+
+    const fetchFiatRatesFn =
+        rateType === 'current' ? fetchCurrentFiatRates : fetchLastWeekFiatRates;
+
+    const underlyingAssetRate = await fetchFiatRatesFn({
+        ticker: { symbol: ticker.symbol, tokenAddress: toTokenAddress(erc4626.asset.contract) },
+        localCurrency: baseCurrencyCode,
+        backendType,
+        skipCache,
+    });
+
+    if (!underlyingAssetRate?.rate) {
+        throw new Error(
+            `Failed to fetch underlying asset fiat rate for ERC4626 token ${erc4626.asset.contract}`,
+        );
+    }
+
+    // get exchange ratio
+    const exchangeRate = new BigNumber(erc4626.convertToAssets1Share).shiftedBy(
+        -erc4626.asset.decimals,
+    );
+    // calculate vault fiat rate
+    const vaultRate = new BigNumber(underlyingAssetRate.rate).multipliedBy(exchangeRate).toNumber();
+
+    return { rate: vaultRate, lastTickerTimestamp: underlyingAssetRate.lastTickerTimestamp };
+};
 
 type UpdateTxsFiatRatesThunkPayload = {
     accountKey: AccountKey;
@@ -119,6 +205,22 @@ export const updateFiatRatesThunk = createThunk<
         { tickers, baseCurrencyCode, rateType, forceFetchToken, skipCache = false },
         { getState },
     ) => {
+        const accounts = selectDeviceAccounts(getState());
+
+        const findTokenByTicker = (ticker: TickerId) => {
+            if (!ticker.tokenAddress) return undefined;
+
+            for (const account of accounts) {
+                if (account.symbol !== ticker.symbol) continue;
+
+                for (const token of account.tokens ?? []) {
+                    if (token.contract === ticker.tokenAddress) return token;
+                }
+            }
+
+            return undefined;
+        };
+
         const fetchRate = async (ticker: TickerId) => {
             if (isTestnet(ticker.symbol)) {
                 throw new Error('Testnet');
@@ -140,6 +242,21 @@ export const updateFiatRatesThunk = createThunk<
             }
 
             const backendType = selectActiveBackendType(getState(), ticker.symbol);
+
+            // fetch ERC4626 fiat rate from Blockbook
+            if (ticker.tokenAddress && backendType === 'blockbook') {
+                const token = findTokenByTicker(ticker);
+
+                if (token && isErc4626(token)) {
+                    return fetchErc4626FiatRate({
+                        ticker,
+                        rateType,
+                        baseCurrencyCode,
+                        backendType,
+                        skipCache,
+                    });
+                }
+            }
 
             const rate = await ((): Promise<FiatRatesResult | null> => {
                 switch (rateType) {

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -21,7 +21,6 @@ import {
 import {
     fetchTransactionsRates,
     groupTokensTransactionsByContractAddress,
-    isErc4626,
     isTestnet,
 } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -31,7 +30,7 @@ import { BigNumber, typedObjectKeys } from '@trezor/utils';
 
 import { FIAT_RATES_MODULE_PREFIX, REFETCH_INTERVAL } from './fiatRatesConstants';
 import { selectTickersToBeUpdated } from './fiatRatesSelectors';
-import { selectAccountByKey, selectDeviceAccounts } from '../accounts/accountsSelectors';
+import { selectAccountByKey } from '../accounts/accountsSelectors';
 import {
     selectActiveBackendType,
     selectIsElectrumBackendSelected,
@@ -205,25 +204,25 @@ export const updateFiatRatesThunk = createThunk<
         { tickers, baseCurrencyCode, rateType, forceFetchToken, skipCache = false },
         { getState },
     ) => {
-        const accounts = selectDeviceAccounts(getState());
-
-        const findTokenByTicker = (ticker: TickerId) => {
-            if (!ticker.tokenAddress) return undefined;
-
-            for (const account of accounts) {
-                if (account.symbol !== ticker.symbol) continue;
-
-                for (const token of account.tokens ?? []) {
-                    if (token.contract === ticker.tokenAddress) return token;
-                }
-            }
-
-            return undefined;
-        };
-
         const fetchRate = async (ticker: TickerId) => {
             if (isTestnet(ticker.symbol)) {
                 throw new Error('Testnet');
+            }
+
+            const backendType = selectActiveBackendType(getState(), ticker.symbol);
+
+            // fetch ERC4626 fiat rate from Blockbook
+            if (
+                ticker.protocols?.includes('erc4626') &&
+                (!backendType || backendType === 'blockbook')
+            ) {
+                return fetchErc4626FiatRate({
+                    ticker,
+                    rateType,
+                    baseCurrencyCode,
+                    backendType,
+                    skipCache,
+                });
             }
 
             const hasCoinDefinitions = getNetworkFeatures(ticker.symbol).includes(
@@ -238,23 +237,6 @@ export const updateFiatRatesThunk = createThunk<
 
                 if (!isTokenKnown) {
                     throw new Error('Missing token definition');
-                }
-            }
-
-            const backendType = selectActiveBackendType(getState(), ticker.symbol);
-
-            // fetch ERC4626 fiat rate from Blockbook
-            if (ticker.tokenAddress && backendType === 'blockbook') {
-                const token = findTokenByTicker(ticker);
-
-                if (token && isErc4626(token)) {
-                    return fetchErc4626FiatRate({
-                        ticker,
-                        rateType,
-                        baseCurrencyCode,
-                        backendType,
-                        skipCache,
-                    });
                 }
             }
 

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -13,6 +13,7 @@ import {
     sortByCoin,
     tryGetAccountIdentity,
 } from '@suite-common/wallet-utils';
+import { type ContractInfoProtocol } from '@trezor/blockchain-link-types/src/blockbook';
 import { type StaticSessionId, type TrezorConnect } from '@trezor/connect';
 import { arrayToDictionary } from '@trezor/utils';
 
@@ -116,7 +117,8 @@ export const selectDiscoveryAccountsParam = (
         const identity = tryGetAccountIdentity({ networkType, deviceState });
         const bitcoinGap = networkType === 'bitcoin' ? selectGapLimit(state, symbol) : undefined;
 
-        const protocols = networkType === 'ethereum' ? ['erc4626'] : undefined;
+        const protocols: ContractInfoProtocol[] | undefined =
+            networkType === 'ethereum' ? ['erc4626'] : undefined;
 
         // undiscovered network; discover as a whole
         if (!accounts)

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -116,14 +116,14 @@ export const selectDiscoveryAccountsParam = (
         const identity = tryGetAccountIdentity({ networkType, deviceState });
         const bitcoinGap = networkType === 'bitcoin' ? selectGapLimit(state, symbol) : undefined;
 
-        const includeErc4626 = networkType === 'ethereum' ? true : undefined;
+        const protocols = networkType === 'ethereum' ? ['erc4626'] : undefined;
 
         // undiscovered network; discover as a whole
         if (!accounts)
             return {
                 symbol,
                 identity,
-                includeErc4626,
+                protocols,
                 gap: bitcoinGap,
             } as DiscoveryAccountsParam[number];
 
@@ -139,7 +139,7 @@ export const selectDiscoveryAccountsParam = (
         return {
             symbol,
             identity,
-            includeErc4626,
+            protocols,
             known,
             knownOnly,
             gap: bitcoinGap,

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -481,7 +481,7 @@ export const fetchTransactionsPageThunk = createThunk(
             // if back on first page, the marker is reset
             ...(marker && !isFirstPage ? { marker } : {}),
             suppressBackupWarning: true,
-            includeErc4626: account.networkType === 'ethereum' ? true : undefined,
+            protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
         });
 
         // Account might have changed during async getAccountInfo call, so we fetch current state

--- a/suite-common/wallet-types/src/fiatRates.ts
+++ b/suite-common/wallet-types/src/fiatRates.ts
@@ -8,6 +8,7 @@ import { type TokenAddress } from './account';
 export interface TickerId {
     symbol: NetworkSymbol;
     tokenAddress?: TokenAddress;
+    protocols?: 'erc4626'[];
 }
 
 export interface TimestampedRates {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -1182,6 +1182,7 @@ export const prepareNewAccountPayload = async ({
             useEmptyPassphrase: device.useEmptyPassphrase,
         },
         details: 'txs',
+        protocols: network.networkType === 'ethereum' ? ['erc4626'] : undefined,
     });
 
     if (!res.success) return new Error(res.error.message);

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -112,4 +112,4 @@ const PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS: ReadonlySet<TokenStandard> = new Set
 export const shouldUppercaseTokenSymbol = (token: TokenInfo) =>
     token.standard ? !PRESERVE_TOKEN_SYMBOL_CASE_STANDARDS.has(token.standard) : true;
 
-export const isErc4626 = (token: TokenInfo) => 'erc4626' in token;
+export const isErc4626 = (token: TokenInfo) => !!token.protocols?.erc4626;

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -106,7 +106,7 @@ export const getAccountInfoThunk = createThunk<
                     descriptor: taprootXpubWithApostrophes ?? xpubAddress,
                     details: 'txs',
                     suppressBackupWarning: true,
-                    includeErc4626: getNetworkType(symbol) === 'ethereum' ? true : undefined,
+                    protocols: getNetworkType(symbol) === 'ethereum' ? ['erc4626'] : undefined,
                 }),
                 dispatch(
                     updateFiatRatesThunk({


### PR DESCRIPTION
## Description

This PR implements the following:

- calculation of fiat rates for `ERC4626` tokens
- new `getContractInfo` Blockbook endpoint that fetches fresh token data
- `protocols: ['erc4626']` field in `getContractInfo` and `getAccountInfo` to include `ERC4646` data for tokens

## Related Issue

Resolve #25645 

## Screenshots

<img width="100%" alt="Screenshot 2026-04-22 at 17 33 46" src="https://github.com/user-attachments/assets/b50ab2e7-82a5-441e-adab-f6ce131eb4ff" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/erc4626-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/erc4626-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/erc4626-fiat-rates&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T08:06:57.050Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T10:54:50.458Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/erc4626-fiat-rates/web/](https://dev.suite.sldev.cz/suite-web/feat/erc4626-fiat-rates/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->