### PR TITLE
refactor(connect): unify *GetAddress for Ripple, Stellar, Tezos, Solana, Tron

### DIFF
--- a/packages/connect/src/api/common/AbstractMiscGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractMiscGetAddress.ts
@@ -1,0 +1,159 @@
+import {
+    Bundle,
+    GetAddress as GetAddressSchema,
+    UI_REQUEST,
+    createUiMessage,
+} from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+import { Assert } from '@trezor/schema-utils';
+
+import { bundlify } from './paramsValidator';
+import type {
+    MethodContext,
+    MethodMessage,
+    MethodPermission,
+    MethodReturnType,
+} from '../../core/AbstractMethod';
+import { AbstractMethod } from '../../core/AbstractMethod';
+import { fromHardened, getSerializedPath, validatePath } from '../../utils/pathUtils';
+
+export type MiscGetAddressMethodName =
+    | 'rippleGetAddress'
+    | 'stellarGetAddress'
+    | 'tezosGetAddress'
+    | 'solanaGetAddress'
+    | 'tronGetAddress';
+
+type MiscProto = {
+    address_n: number[];
+    show_display: boolean;
+    chunkify: boolean;
+};
+
+export type MiscGetAddressParams = {
+    proto: MiscProto;
+    address?: string;
+};
+
+export abstract class AbstractMiscGetAddress<
+    Name extends MiscGetAddressMethodName,
+> extends AbstractMethod<Name, MiscGetAddressParams[]> {
+    hasBundle?: boolean;
+    progress = 0;
+
+    constructor(message: MethodMessage<Name>, pathDepth: number) {
+        const { hasBundle, payload } = bundlify(message.payload);
+
+        Assert(Bundle(GetAddressSchema), payload);
+
+        const params: MiscGetAddressParams[] = payload.bundle.map(batch => ({
+            proto: {
+                address_n: validatePath(batch.path, pathDepth),
+                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+            },
+            address: batch.address,
+        }));
+
+        super(message, params);
+
+        this.hasBundle = hasBundle;
+        this.useUi = this.getUseUi(this.params, payload.useEventListener);
+        this.confirmMissingBackup = true;
+    }
+
+    get requiredPermissions(): MethodPermission[] {
+        return ['read'];
+    }
+
+    protected getInfo(coinName: string, showAccountInInfo: boolean) {
+        if (this.params.length > 1) {
+            return `Export multiple ${coinName} addresses`;
+        }
+        if (showAccountInInfo) {
+            return `Export ${coinName} address for account #${
+                fromHardened(this.params[0].proto.address_n[2]) + 1
+            }`;
+        }
+
+        return `Export ${coinName} address`;
+    }
+
+    getButtonRequestData(code: string) {
+        if (code === 'ButtonRequest_Address') {
+            return {
+                type: 'address' as const,
+                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
+                address: this.params[this.progress].address || 'not-set',
+            };
+        }
+    }
+
+    protected getConfirmation(coinName: string) {
+        if (this.params.length > 1) {
+            return {
+                view: 'export-address' as const,
+                label: `Export multiple ${coinName} addresses`,
+            };
+        }
+
+        return {
+            view: 'export-address' as const,
+            label: `Export ${coinName} address for account #${
+                fromHardened(this.params[0].proto.address_n[2]) + 1
+            }`,
+        };
+    }
+
+    protected abstract _call(
+        params: MiscGetAddressParams,
+    ): Promise<{ address: string; mac?: string }>;
+
+    async run({ sendCoreMessage }: MethodContext): Promise<MethodReturnType<Name>> {
+        const responses: {
+            path: number[];
+            serializedPath: string;
+            address: string;
+            mac?: string;
+        }[] = [];
+
+        for (let i = 0; i < this.params.length; i++) {
+            const batch = this.params[i];
+            if (batch.proto.show_display) {
+                const silent = await this._call({
+                    ...batch,
+                    proto: { ...batch.proto, show_display: false },
+                });
+                if (typeof batch.address === 'string') {
+                    if (batch.address !== silent.address) {
+                        throw ERRORS.TypedError('Method_AddressNotMatch');
+                    }
+                } else {
+                    batch.address = silent.address;
+                }
+            }
+
+            const response = await this._call(batch);
+            responses.push({
+                path: batch.proto.address_n,
+                serializedPath: getSerializedPath(batch.proto.address_n),
+                address: response.address,
+                mac: response.mac,
+            });
+
+            if (this.hasBundle) {
+                sendCoreMessage(
+                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                        total: this.params.length,
+                        progress: i,
+                        response,
+                    }),
+                );
+            }
+
+            this.progress++;
+        }
+
+        return (this.hasBundle ? responses : responses[0]) as MethodReturnType<Name>;
+    }
+}

--- a/packages/connect/src/api/ripple/api/rippleGetAddress.ts
+++ b/packages/connect/src/api/ripple/api/rippleGetAddress.ts
@@ -1,143 +1,29 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/RippleGetAddress.js
 
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { Assert } from '@trezor/schema-utils';
-
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
-import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify } from '../../common/paramsValidator';
+import { AbstractMiscGetAddress } from '../../common/AbstractMiscGetAddress';
+import type { MiscGetAddressParams } from '../../common/AbstractMiscGetAddress';
 
-type Params = {
-    proto: PROTO.RippleGetAddress;
-    address?: string;
-};
-
-export default class RippleGetAddress extends AbstractMethod<'rippleGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+export default class RippleGetAddress extends AbstractMiscGetAddress<'rippleGetAddress'> {
     constructor(message: MethodMessage<'rippleGetAddress'>) {
-        const { hasBundle, payload } = bundlify(message.payload);
-
-        // validate bundle type
-        Assert(Bundle(GetAddressSchema), payload);
-
-        const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 3);
-
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
-
-            return { proto, address: batch.address };
-        });
-
-        super(message, params);
-
-        this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.confirmMissingBackup = true;
+        super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Ripple'];
         this.requiredFirmwareCoins = [getMiscNetwork('Ripple')];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        // set info
-        if (this.params.length === 1) {
-            return `Export Ripple address for account #${
-                fromHardened(this.params[0].proto.address_n[2]) + 1
-            }`;
-        }
-
-        return 'Export multiple Ripple addresses';
-    }
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
+        return this.getInfo('Ripple', true);
     }
 
     get confirmation() {
-        return {
-            view: 'export-address' as const,
-            label: this.info,
-        };
+        return this.getConfirmation('Ripple');
     }
 
-    async _call({ proto }: Params) {
+    async _call({ proto }: MiscGetAddressParams) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('RippleGetAddress', 'RippleAddress', proto);
 
         return response.message;
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: response.address,
-                mac: response.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }

--- a/packages/connect/src/api/solana/api/solanaGetAddress.ts
+++ b/packages/connect/src/api/solana/api/solanaGetAddress.ts
@@ -1,144 +1,27 @@
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { Assert } from '@trezor/schema-utils';
-
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
-import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify } from '../../common/paramsValidator';
+import { AbstractMiscGetAddress } from '../../common/AbstractMiscGetAddress';
+import type { MiscGetAddressParams } from '../../common/AbstractMiscGetAddress';
 
-type Params = {
-    proto: PROTO.SolanaGetAddress;
-    address?: string;
-};
-
-export default class SolanaGetAddress extends AbstractMethod<'solanaGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+export default class SolanaGetAddress extends AbstractMiscGetAddress<'solanaGetAddress'> {
     constructor(message: MethodMessage<'solanaGetAddress'>) {
-        const { hasBundle, payload } = bundlify(message.payload);
-
-        // validate bundle type
-        Assert(Bundle(GetAddressSchema), payload);
-
-        const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 2);
-
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
-
-            return { proto, address: batch.address };
-        });
-
-        super(message, params);
-        this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.confirmMissingBackup = true;
+        super(message, 2);
         this.requiredDeviceCapabilities = ['Capability_Solana'];
         this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        if (this.params.length === 1) {
-            return 'Export Solana address';
-        }
-
-        return 'Export multiple Solana addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
+        return this.getInfo('Solana', false);
     }
 
     get confirmation() {
-        return {
-            view: 'export-address' as const,
-            label:
-                this.params.length > 1
-                    ? 'Export multiple Solana addresses'
-                    : `Export Solana address for account #${
-                          fromHardened(this.params[0].proto.address_n[2]) + 1
-                      }`,
-        };
+        return this.getConfirmation('Solana');
     }
 
-    async _call({ proto }: Params) {
+    async _call({ proto }: MiscGetAddressParams) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('SolanaGetAddress', 'SolanaAddress', proto);
 
         return response.message;
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    // save address for future verification in "getButtonRequestData"
-                    batch.address = silent.address;
-                }
-            }
-
-            const message = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: message.address,
-                mac: message.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response: message,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }

--- a/packages/connect/src/api/stellar/api/stellarGetAddress.ts
+++ b/packages/connect/src/api/stellar/api/stellarGetAddress.ts
@@ -1,143 +1,29 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/StellarGetAddress.js
 
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { Assert } from '@trezor/schema-utils';
-
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
-import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify } from '../../common/paramsValidator';
+import { AbstractMiscGetAddress } from '../../common/AbstractMiscGetAddress';
+import type { MiscGetAddressParams } from '../../common/AbstractMiscGetAddress';
 
-type Params = {
-    proto: PROTO.StellarGetAddress;
-    address?: string;
-};
-
-export default class StellarGetAddress extends AbstractMethod<'stellarGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+export default class StellarGetAddress extends AbstractMiscGetAddress<'stellarGetAddress'> {
     constructor(message: MethodMessage<'stellarGetAddress'>) {
-        const { hasBundle, payload } = bundlify(message.payload);
-
-        // validate bundle type
-        Assert(Bundle(GetAddressSchema), payload);
-
-        const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 3);
-
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
-
-            return { proto, address: batch.address };
-        });
-
-        super(message, params);
-
-        this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.confirmMissingBackup = true;
+        super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Stellar'];
         this.requiredFirmwareCoins = [getMiscNetwork('Stellar')];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        if (this.params.length === 1) {
-            return `Export Stellar address for account #${
-                fromHardened(this.params[0].proto.address_n[2]) + 1
-            }`;
-        }
-
-        return 'Export multiple Stellar addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
+        return this.getInfo('Stellar', true);
     }
 
     get confirmation() {
-        return {
-            view: 'export-address' as const,
-            label: this.info,
-        };
+        return this.getConfirmation('Stellar');
     }
 
-    async _call({ proto }: Params) {
+    async _call({ proto }: MiscGetAddressParams) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('StellarGetAddress', 'StellarAddress', proto);
 
         return response.message;
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: response.address,
-                mac: response.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }

--- a/packages/connect/src/api/tezos/api/tezosGetAddress.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetAddress.ts
@@ -1,143 +1,29 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/TezosGetAddress.js
 
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { Assert } from '@trezor/schema-utils';
-
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
-import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify } from '../../common/paramsValidator';
+import { AbstractMiscGetAddress } from '../../common/AbstractMiscGetAddress';
+import type { MiscGetAddressParams } from '../../common/AbstractMiscGetAddress';
 
-type Params = {
-    proto: PROTO.TezosGetAddress;
-    address?: string;
-};
-
-export default class TezosGetAddress extends AbstractMethod<'tezosGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+export default class TezosGetAddress extends AbstractMiscGetAddress<'tezosGetAddress'> {
     constructor(message: MethodMessage<'tezosGetAddress'>) {
-        const { hasBundle, payload } = bundlify(message.payload);
-
-        // validate bundle type
-        Assert(Bundle(GetAddressSchema), payload);
-
-        const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 3);
-
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
-
-            return { proto, address: batch.address };
-        });
-
-        super(message, params);
-
-        this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.confirmMissingBackup = true;
+        super(message, 3);
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
         this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        if (this.params.length === 1) {
-            return `Export Tezos address for account #${
-                fromHardened(this.params[0].proto.address_n[2]) + 1
-            }`;
-        }
-
-        return 'Export multiple Tezos addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
+        return this.getInfo('Tezos', true);
     }
 
     get confirmation() {
-        return {
-            view: 'export-address' as const,
-            label: this.info,
-        };
+        return this.getConfirmation('Tezos');
     }
 
-    async _call({ proto }: Params) {
+    async _call({ proto }: MiscGetAddressParams) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('TezosGetAddress', 'TezosAddress', proto);
 
         return response.message;
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: response.address,
-                mac: response.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }

--- a/packages/connect/src/api/tron/api/tronGetAddress.ts
+++ b/packages/connect/src/api/tron/api/tronGetAddress.ts
@@ -1,143 +1,25 @@
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import type { PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
-import { Assert } from '@trezor/schema-utils';
+import type { MethodMessage } from '../../../core/AbstractMethod';
+import { AbstractMiscGetAddress } from '../../common/AbstractMiscGetAddress';
+import type { MiscGetAddressParams } from '../../common/AbstractMiscGetAddress';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
-import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
-import { bundlify } from '../../common/paramsValidator';
-
-type Params = {
-    proto: PROTO.TronGetAddress;
-    address?: string;
-};
-
-export default class TronGetAddress extends AbstractMethod<'tronGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+export default class TronGetAddress extends AbstractMiscGetAddress<'tronGetAddress'> {
     constructor(message: MethodMessage<'tronGetAddress'>) {
-        const { hasBundle, payload } = bundlify(message.payload);
-
-        // validate bundle type
-        Assert(Bundle(GetAddressSchema), payload);
-
-        const params = payload.bundle.map(batch => {
-            const path = validatePath(batch.path, 2);
-
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
-
-            return { proto, address: batch.address };
-        });
-
-        super(message, params);
-
-        this.hasBundle = hasBundle;
-        this.useUi = this.getUseUi(this.params, payload.useEventListener);
-        this.confirmMissingBackup = true;
+        super(message, 2);
         this.requiredDeviceCapabilities = ['Capability_Tron'];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        if (this.params.length === 1) {
-            return 'Export Tron address';
-        }
-
-        return 'Export multiple Tron addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
+        return this.getInfo('Tron', false);
     }
 
     get confirmation() {
-        return {
-            view: 'export-address' as const,
-            label:
-                this.params.length > 1
-                    ? 'Export multiple Tron addresses'
-                    : `Export Tron address for account #${
-                          fromHardened(this.params[0].proto.address_n[2]) + 1
-                      }`,
-        };
+        return this.getConfirmation('Tron');
     }
 
-    async _call({ proto }: Params) {
+    async _call({ proto }: MiscGetAddressParams) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('TronGetAddress', 'TronAddress', proto);
 
         return response.message;
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    // save address for future verification in "getButtonRequestData"
-                    batch.address = silent.address;
-                }
-            }
-
-            const message = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: message.address,
-                mac: message.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response: message,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }


### PR DESCRIPTION
## Summary

Extracts `AbstractMiscGetAddress` base class. The five `*GetAddress` methods were near-identical copies — same constructor, same `run` loop, same `getButtonRequestData`, same `confirmation`. This PR collapses them into a shared base; each subclass is now ~20 lines with the coin-specific bits (capability, proto names, path depth, whether to show account # in info text).

~425 lines of duplication removed.

Monero stays separate — different proto shape (`network_type`, `account`, `minor`, `payment_id`), custom hex to utf8 decoding, no bundle progress — it genuinely is not the same shape, so forcing it into the base would make things worse.

## Up for discussion

Not sure this is clearly a win. The tradeoff:

- **Pro:** ~60% fewer lines, one place to fix a bug, smaller files to load.
- **Con:** Each subclass is now a thin shell that only makes sense if you also open the base class. A change affecting one coin has to go through a config flag (`showAccountInInfo`) or an override, which is more indirection than just editing a 140-line self-contained file.

Happy to close this if the team prefers the copy-paste version. Mostly opening it to have the conversation.

## Behavior changes

None intended. `confirmation.label` is now always generated centrally — for Ripple/Stellar/Tezos it previously read `this.info` (which included the account #); for Solana/Tron it had inline logic that also included the account #. Unified version produces the same strings in all five cases.

## Test plan

- [x] `yarn workspace @trezor/connect type-check` — clean (pre-existing e2e fixture errors unrelated)
- [x] `yarn workspace @trezor/connect test:unit` — 466/466 pass
- [ ] Manual smoke test of address export flow on each of the 5 coins

Generated with Claude Code

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-refactor-ideas&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-refactor-ideas&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-refactor-ideas/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-refactor-ideas/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T13:25:07.724Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->