### PR TITLE
test(suite-native): add composable test providers and global services…

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -128,7 +128,17 @@ jobs:
       - name: "Minimal yarn install"
         uses: ./.github/actions/minimal-yarn-install
       - name: Unit Tests
-        run: yarn test:unit:${{ matrix.test-task }} --output-style=stream -- --silent
+        run: |
+          if [ "${{ matrix.test-task }}" = "native" ]; then
+            yarn nx run-many --target=test:unit \
+              --exclude='@trezor/*,@suite/*,@suite-common/*' \
+              --skip-nx-cache \
+              --parallel=1 \
+              --output-style=stream \
+              -- --silent
+          else
+            yarn test:unit:${{ matrix.test-task }} --output-style=stream -- --silent
+          fi
 
   build-libs-for-publishing:
     name: "Build libs for publishing"

--- a/.github/workflows/native-unit-benchmark.yml
+++ b/.github/workflows/native-unit-benchmark.yml
@@ -1,0 +1,68 @@
+name: "[Benchmark] Native Unit Tests"
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    paths:
+      - ".github/workflows/native-unit-benchmark.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  native-unit-benchmark:
+    name: Native Unit Benchmark (Nx ${{ matrix.nx-parallel }}, Jest ${{ matrix.jest-mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 600
+    strategy:
+      fail-fast: false
+      matrix:
+        nx-parallel: [1, 2, 3]
+        jest-mode: [default, run-in-band, max-workers-2]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: true
+      - name: "Checkout branches for Nx"
+        uses: ./.github/actions/nx-checkout
+      - name: "Minimal yarn install"
+        uses: ./.github/actions/minimal-yarn-install
+      - name: Native Unit Tests Benchmark
+        run: |
+          set -euo pipefail
+
+          jest_args="--silent"
+
+          if [ "${{ matrix.jest-mode }}" = "run-in-band" ]; then
+            jest_args="$jest_args --runInBand"
+          elif [ "${{ matrix.jest-mode }}" = "max-workers-2" ]; then
+            jest_args="$jest_args --maxWorkers=2"
+          fi
+
+          SECONDS=0
+          set +e
+          yarn nx run-many --target=test:unit \
+            --exclude='@trezor/*,@suite/*,@suite-common/*' \
+            --skip-nx-cache \
+            --parallel=${{ matrix.nx-parallel }} \
+            --output-style=stream \
+            -- $jest_args
+          exit_code=$?
+          set -e
+
+          elapsed_seconds=$SECONDS
+
+          {
+            echo "## Native Unit Benchmark"
+            echo ""
+            echo "- Nx parallel: ${{ matrix.nx-parallel }}"
+            echo "- Jest mode: ${{ matrix.jest-mode }}"
+            echo "- Jest args: \`$jest_args\`"
+            echo "- Test command duration: ${elapsed_seconds}s"
+            echo "- Exit code: ${exit_code}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit $exit_code

--- a/docs/tests/suite-native-test-utils.md
+++ b/docs/tests/suite-native-test-utils.md
@@ -9,8 +9,8 @@ It also reexports everything from `@testing-library/react-native`, so you should
 ```mermaid
 flowchart TD
     A{{Do you need redux store?}} -- Yes --> B[Use 'renderWithStoreProvider']
-    A -- No --> C{{Do you need any other provider? Such as theme, formatters, etc.}}
-    C -- Yes --> D[Use 'renderWithBasicProvider']
+    A -- No --> C{{Do you need any other provider? Such as intl, navigation, etc.}}
+    C -- Yes --> D[Use 'renderWithProviders' with the needed providers]
     C -- No --> E{{Are you sure?}}
     E -- Yes --> F[Use 'render']
     E -- No --> D
@@ -23,33 +23,45 @@ the [official documentation](https://testing-library.com/docs/react-native-testi
 
 You most probably do not want to use this function directly.
 
-### Using renderWithBasicProvider
+### Using renderWithProviders
 
-`renderWithBasicProvider` is a custom utility that provides basic context providers. Namely:
+`renderWithProviders` is a custom utility that wraps the element in a composable provider stack. Two providers are
+always on:
 
-- **IntlProvider**: Simplified variant for tests. Always uses `en-US` locale.
+- **SafeAreaProvider**
 - **StylesProvider**: With `colorVariant` set to `standard`.
-- **NavigationContainer**
-- **NativeServicesProvider**: With `extraDependenciesNativeMock.services`.
-- **FormatterProvider**: With `locale` set to `en` and `baseCurrency` set to `USD`.
-- **BottomSheetModalProvider**
+
+The rest are opt-in via the `providers` option (`ProviderKey[]`):
+
+- `'intl'` — **IntlProvider** simplified for tests. Always uses `en-US` locale.
+- `'navigation'` — **NavigationContainer** from `@react-navigation/native`.
+- `'services'` — **NativeServicesProvider** with `extraDependenciesNativeMock.services`.
+- `'formatter'` — **FormatterProvider** with `locale: 'en'` and `baseCurrency: 'usd'` (override via `formattersConfig`).
+- `'bottomSheet'` — **BottomSheetModalProvider**.
+
+Pick the smallest list that makes the component under test render. Leaving providers out keeps the test fast, because
+each opt-in provider pulls in its module graph at import time.
+
+If you need the full stack, import `ALL_PROVIDERS` and pass it as the `providers` option.
 
 #### Usage example
 
 Basic usage
 
 ```tsx
-import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { renderWithProviders, userEvent } from '@suite-native/test-utils';
 
 describe('Counter', () => {
     it('should start with 0 value', () => {
-        const { getByLabelText } = renderWithBasicProvider(<Counter />);
+        const { getByLabelText } = renderWithProviders(<Counter />, { providers: ['intl'] });
 
         expect(getByLabelText('Counter value')).toHaveTextContent('0');
     });
 
     it('should increment value on button press', async () => {
-        const { getByLabelText, getByText } = renderWithBasicProvider(<Counter />);
+        const { getByLabelText, getByText } = renderWithProviders(<Counter />, {
+            providers: ['intl'],
+        });
 
         await userEvent.press(getByText('+'));
 
@@ -60,8 +72,8 @@ describe('Counter', () => {
 
 ### Using renderWithStoreProvider
 
-`renderWithStoreProvider` is a custom utility that provides all the context providers from `renderWithBasicProvider`
-plus:
+`renderWithStoreProvider` is a custom utility that provides all the context providers from `renderWithProviders` (with
+the full `ALL_PROVIDERS` stack) plus:
 
 - **Redux store provider**
 - Formatters config is now loaded from store instead of being hardcoded.
@@ -154,7 +166,7 @@ describe('Counter', () => {
 
 #### Injecting custom providers
 
-To inject custom provider, you can use `wrapper` option of either `render`, `renderWithBasicProvider` or
+To inject custom provider, you can use `wrapper` option of either `render`, `renderWithProviders` or
 `renderWithStoreProvider`.
 
 ```tsx
@@ -162,7 +174,8 @@ const renderCounterA = () =>
     renderWithStoreProvider(<Counter />, { store, wrapper: MyCustomProvider });
 
 const renderCounterB = () =>
-    renderWithBasicProvider(<Counter />, {
+    renderWithProviders(<Counter />, {
+        providers: ['intl'],
         wrapper: ({ children }) => (
             <MyCustomProvider someProp={someValue}>{children}</MyCustomProvider>
         ),
@@ -174,8 +187,8 @@ const renderCounterB = () =>
 ```mermaid
 flowchart TD
     A{{Do you need redux store?}} -- Yes --> B[Use 'renderHookWithStoreProvider']
-    A -- No --> C{{Do you need any other provider? Such as theme, formatters, etc.}}
-    C -- Yes --> D[Use 'renderHookWithBasicProvider']
+    A -- No --> C{{Do you need any other provider? Such as intl, navigation, etc.}}
+    C -- Yes --> D[Use 'renderHookWithProviders' with the needed providers]
     C -- No --> F[Use 'renderHook']
 ```
 
@@ -186,18 +199,19 @@ the [official documentation](https://testing-library.com/docs/react-native-testi
 
 You should use it when your hook does not depend on any context providers.
 
-### Using renderHookWithBasicProvider
+### Using renderHookWithProviders
 
-`renderHookWithBasicProvider` is a custom utility that provides the same context providers as `renderWithBasicProvider`.
-For more information, please refer to the section about `renderWithBasicProvider`.
+`renderHookWithProviders` is a custom utility that provides the same composable provider stack as `renderWithProviders`.
+For more information, please refer to the section about `renderWithProviders`.
 
 #### Usage example
 
 ```ts
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 describe('useCounter', () => {
-    const renderUseCounter = () => renderHookWithBasicProvider(() => useCounter());
+    const renderUseCounter = () =>
+        renderHookWithProviders(() => useCounter(), { providers: ['intl'] });
 
     it('should initialize with count 0', () => {
         const { result } = renderUseCounter();
@@ -274,7 +288,7 @@ describe('useCounter', () => {
 
 #### Injecting custom providers
 
-To inject custom provider, you can use `wrapper` option of either `renderHook`, `renderHookWithBasicProvider` or
+To inject custom provider, you can use `wrapper` option of either `renderHook`, `renderHookWithProviders` or
 `renderHookWithStoreProvider`.
 
 ```tsx
@@ -282,7 +296,8 @@ const renderUseCounterA = () =>
     renderHookWithStoreProvider(() => useCounter(), { store, wrapper: MyCustomProvider });
 
 const renderUseCounterB = () =>
-    renderHookWithBasicProvider(() => useCounter(), {
+    renderHookWithProviders(() => useCounter(), {
+        providers: ['intl'],
         wrapper: ({ children }) => (
             <MyCustomProvider someProp={someValue}>{children}</MyCustomProvider>
         ),

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -41,6 +41,7 @@ module.exports = {
         '<rootDir>/../../suite-native/test-utils/src/mocks/expoAndRNMock.jsx',
         '<rootDir>/../../suite-native/test-utils/src/mocks/everstakeJestSetup.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/TextEncoderMock.js',
+        '<rootDir>/../../suite-native/test-utils/src/mocks/nativeServicesJestSetup.ts',
         '<rootDir>/../../node_modules/@shopify/react-native-skia/jestSetup.js',
         '<rootDir>/../../node_modules/@shopify/flash-list/jestSetup.js',
         '<rootDir>/../../node_modules/react-native-gesture-handler/jestSetup.js',

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "type-check:all": "yarn nx run-many --target=type-check",
         "test:unit": "yarn nx affected --target=test:unit",
         "test:unit:suite": "yarn nx affected --target=test:unit --exclude='@suite-native/*'",
-        "test:unit:native": "yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*,@suite-native/module-trading'",
+        "test:unit:native": "yarn nx affected --target=test:unit --exclude='@trezor/*,@suite/*,@suite-common/*'",
         "test:unit:all": "yarn nx run-many --target=test:unit",
         "lint:js": "yarn nx affected --target=lint:js",
         "lint:js:fix": "yarn lint:js --fix",

--- a/skills/tests-native/SKILL.md
+++ b/skills/tests-native/SKILL.md
@@ -37,7 +37,7 @@ Before submitting code, ensure:
 
 - [ ] Tests were written BEFORE implementation
 - [ ] Using `@suite-native/test-utils` (not direct `@testing-library/react-native`)
-- [ ] Correct render function used (renderWithStoreProvider, renderWithBasicProvider, render)
+- [ ] Correct render function used (renderWithStoreProvider, renderWithProviders, render)
 - [ ] Translation IDs used instead of literal strings
 - [ ] Fixtures are properly typed
 - [ ] Tests focus on behavior, not implementation

--- a/suite-native/accounts/src/components/__tests__/AccountLabelFieldHint.test.tsx
+++ b/suite-native/accounts/src/components/__tests__/AccountLabelFieldHint.test.tsx
@@ -1,12 +1,12 @@
 import { getTranslation } from '@suite-native/intl';
-import { renderHook, renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderHook, renderWithProviders } from '@suite-native/test-utils';
 
 import { useAccountLabelForm } from '../../hooks/useAccountLabelForm';
 import { AccountLabelFieldHint, type AccountLabelFieldHintProps } from '../AccountLabelFieldHint';
 
 describe('AccountLabelFieldHint', () => {
     const renderComponent = (props: AccountLabelFieldHintProps) =>
-        renderWithBasicProvider(<AccountLabelFieldHint {...props} />);
+        renderWithProviders(<AccountLabelFieldHint {...props} />, { providers: ['intl'] });
 
     it('should render', () => {
         const { result } = renderHook(() => useAccountLabelForm('Account label'));

--- a/suite-native/app/src/navigation/__tests__/AppTabNavigator.test.tsx
+++ b/suite-native/app/src/navigation/__tests__/AppTabNavigator.test.tsx
@@ -36,6 +36,7 @@ const baseState = {
 describe('AppTabNavigator', () => {
     const renderTabs = (overrides: Record<string, unknown> = {}) =>
         renderWithStoreProvider(<AppTabNavigator />, {
+            providers: ['intl', 'navigation'],
             preloadedState: mergePreloadedState(baseState, overrides),
         });
 

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleInput.test.tsx
@@ -1,11 +1,11 @@
-import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { renderWithProviders, userEvent } from '@suite-native/test-utils';
 
 import { Input } from '../../Input/Input';
 import { AnimatedDoubleInput, type AnimatedDoubleInputProps } from '../AnimatedDoubleInput';
 
 describe('AnimatedDoubleInput', () => {
     const renderAnimatedDoubleInput = (props: Partial<AnimatedDoubleInputProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <AnimatedDoubleInput
                 renderPrimary={({ onPress, isDisabled, inputRef }) => (
                     <Input
@@ -27,6 +27,7 @@ describe('AnimatedDoubleInput', () => {
                 )}
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     it('should call onViewSwitch when Switch button is pressed', async () => {

--- a/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/__tests__/AnimatedDoubleView.test.tsx
@@ -1,16 +1,17 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { Box } from '../../Box';
 import { AnimatedDoubleView, type AnimatedDoubleViewProps } from '../AnimatedDoubleView';
 
 describe('AnimatedDoubleView', () => {
     const renderAnimatedDoubleView = (props: Partial<AnimatedDoubleViewProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <AnimatedDoubleView
                 renderPrimary={() => <Box accessibilityLabel="PRIMARY_VIEW" />}
                 renderSecondary={() => <Box accessibilityLabel="SECONDARY_VIEW" />}
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     it('should render primary and secondary component and switcher in between', () => {

--- a/suite-native/atoms/src/Button/__tests__/AsyncButton.test.tsx
+++ b/suite-native/atoms/src/Button/__tests__/AsyncButton.test.tsx
@@ -1,12 +1,12 @@
 import { Text } from 'react-native';
 
-import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { AsyncButton, type AsyncButtonProps } from '../AsyncButton';
 
 describe('AsyncButton', () => {
     const renderAsyncButton = (props: Partial<AsyncButtonProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <AsyncButton
                 onPress={() => new Promise(resolve => setTimeout(resolve, 1000))}
                 testID="async-button"
@@ -14,6 +14,7 @@ describe('AsyncButton', () => {
             >
                 <Text>Press me</Text>
             </AsyncButton>,
+            { providers: ['intl'] },
         );
 
     beforeEach(() => {

--- a/suite-native/atoms/src/Card/__tests__/Card.test.tsx
+++ b/suite-native/atoms/src/Card/__tests__/Card.test.tsx
@@ -1,6 +1,6 @@
 import { Text } from 'react-native';
 
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { Card, type CardProps } from '../Card';
 
@@ -11,7 +11,7 @@ describe('Card', () => {
             ...props,
         } as CardProps;
 
-        return renderWithBasicProvider(<Card {...cardProps} />);
+        return renderWithProviders(<Card {...cardProps} />, { providers: ['intl'] });
     };
 
     it('should render children prop', () => {

--- a/suite-native/atoms/src/__tests__/PriceChangeBadge.test.tsx
+++ b/suite-native/atoms/src/__tests__/PriceChangeBadge.test.tsx
@@ -1,8 +1,4 @@
-import {
-    BasicProviderForTests,
-    renderHook,
-    renderWithBasicProvider,
-} from '@suite-native/test-utils';
+import { BasicProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
 
 import { Box as MockBox } from '../Box';
@@ -21,40 +17,44 @@ describe('PriceChangeBadge', () => {
     });
 
     it('should render green badge for change > 0', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <PriceChangeBadge valuePercentageChange={0.01} />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('1.00%')).toHaveStyle({ color: colors.contentBrand });
     });
 
     it('should render green badge for change = 0', () => {
-        const { getByText } = renderWithBasicProvider(
-            <PriceChangeBadge valuePercentageChange={0} />,
-        );
+        const { getByText } = renderWithProviders(<PriceChangeBadge valuePercentageChange={0} />, {
+            providers: ['intl'],
+        });
 
         expect(getByText('0.00%')).toHaveStyle({ color: colors.contentBrand });
     });
 
     it('should render red badge for change < 0', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <PriceChangeBadge valuePercentageChange={-0.01} />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('-1.00%')).toHaveStyle({ color: colors.contentCritical });
     });
 
     it('should render skeleton when value is null', () => {
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <PriceChangeBadge valuePercentageChange={null} />,
+            { providers: ['intl'] },
         );
 
         expect(getByTestId('skeleton-box')).toBeTruthy();
     });
 
     it('should render 3 significant digits', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <PriceChangeBadge valuePercentageChange={0.1234} />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('12.3%')).toBeTruthy();

--- a/suite-native/atoms/src/__tests__/PriceChangeBadge.test.tsx
+++ b/suite-native/atoms/src/__tests__/PriceChangeBadge.test.tsx
@@ -1,4 +1,4 @@
-import { BasicProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
+import { ProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
 
 import { Box as MockBox } from '../Box';
@@ -12,7 +12,7 @@ describe('PriceChangeBadge', () => {
     let colors: NativeStyleUtils['colors'];
 
     beforeAll(() => {
-        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProviderForTests });
+        const { result } = renderHook(() => useNativeStyles(), { wrapper: ProviderForTests });
         ({ colors } = result.current.utils);
     });
 

--- a/suite-native/device-authorization/src/hooks/__tests__/useOnThpPairingCanceled.test.ts
+++ b/suite-native/device-authorization/src/hooks/__tests__/useOnThpPairingCanceled.test.ts
@@ -1,4 +1,4 @@
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import { type DeviceThpPairingStatus } from '@trezor/connect';
 
 import { useOnThpPairingCanceled } from '../useOnThpPairingCanceled';
@@ -23,7 +23,7 @@ describe('useOnThpPairingCanceled', () => {
         mockDeviceThpPairingStatusChange({ status: 'canceled' });
         const callback = jest.fn();
 
-        renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
+        renderHookWithProviders(() => useOnThpPairingCanceled(callback), { providers: ['intl'] });
 
         expect(callback).toHaveBeenCalled();
     });
@@ -32,7 +32,7 @@ describe('useOnThpPairingCanceled', () => {
         mockDeviceThpPairingStatusChange({ status: 'finished' });
         const callback = jest.fn();
 
-        renderHookWithBasicProvider(() => useOnThpPairingCanceled(callback));
+        renderHookWithProviders(() => useOnThpPairingCanceled(callback), { providers: ['intl'] });
 
         expect(callback).not.toHaveBeenCalled();
     });

--- a/suite-native/formatters/src/components/__tests__/TokenAmountFormatter.test.tsx
+++ b/suite-native/formatters/src/components/__tests__/TokenAmountFormatter.test.tsx
@@ -7,6 +7,7 @@ describe('TokenAmountFormatter', () => {
     const renderTokenAmountFormatter = (props: Partial<TokenAmountFormatterProps>) =>
         renderWithStoreProvider(
             <TokenAmountFormatter tokenSymbol={'USDC' as TokenSymbol} value="1234.56" {...props} />,
+            { providers: ['intl', 'formatter'] },
         );
 
     it('should render formatted value', () => {

--- a/suite-native/formatters/src/hooks/__tests__/useFormattedGraphHeaderValues.test.ts
+++ b/suite-native/formatters/src/hooks/__tests__/useFormattedGraphHeaderValues.test.ts
@@ -27,6 +27,7 @@ const setNewStoreMockup = (preloadedState: any) => {
 describe(useFormattedGraphHeaderValues.name, () => {
     const renderUseFormattedGraphHeaderValues = (value?: string) =>
         renderHookWithStoreProvider(() => useFormattedGraphHeaderValues(value), {
+            providers: ['intl', 'formatter'],
             store,
         });
 

--- a/suite-native/helpers/src/hooks/__tests__/useUpdateEffect.test.ts
+++ b/suite-native/helpers/src/hooks/__tests__/useUpdateEffect.test.ts
@@ -1,12 +1,13 @@
 import { type EffectCallback } from 'react';
 
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 
 import { useUpdateEffect } from '../useUpdateEffect';
 
 describe('useUpdateEffect', () => {
     const renderUseUpdateEffect = (initialEffect: EffectCallback) =>
-        renderHookWithBasicProvider(({ effect }) => useUpdateEffect(effect), {
+        renderHookWithProviders(({ effect }) => useUpdateEffect(effect), {
+            providers: ['intl'],
             initialProps: { effect: initialEffect },
         });
 

--- a/suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx
+++ b/suite-native/icons/src/tests/CryptoIconWithNetwork.test.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { CryptoIconWithNetwork } from '../CryptoIconWithNetwork';
 
 const cryptoIconHint = 'Crypto Icon';
 const networkIconHint = 'Network Icon';
 
+const renderIcon = (element: Parameters<typeof renderWithProviders>[0]) =>
+    renderWithProviders(element, { providers: ['intl'] });
+
 describe('CryptoIconWithNetwork', () => {
     it('should render without network icon for networks that are not l2 networks = op, arb, base', () => {
-        const { getByHintText, getByLabelText, queryByHintText } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText, queryByHintText } = renderIcon(
             <CryptoIconWithNetwork symbol="btc" />,
         );
 
@@ -20,7 +23,7 @@ describe('CryptoIconWithNetwork', () => {
     });
 
     it('should render network with network icon for l2 networks = op, arb, base and ETH as icon', () => {
-        const { getByHintText, getByLabelText, queryByHintText } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText, queryByHintText } = renderIcon(
             <CryptoIconWithNetwork symbol="op" />,
         );
 
@@ -31,7 +34,7 @@ describe('CryptoIconWithNetwork', () => {
 
     it('should render with network icon for contracts', () => {
         const contract = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo' as TokenAddress;
-        const { getByHintText, getByLabelText } = renderWithBasicProvider(
+        const { getByHintText, getByLabelText } = renderIcon(
             <CryptoIconWithNetwork symbol="op" contractAddress={contract} />,
         );
 

--- a/suite-native/intl/src/IntlProviderForTests.tsx
+++ b/suite-native/intl/src/IntlProviderForTests.tsx
@@ -3,13 +3,11 @@ import { IntlProvider as ReactIntlProvider } from 'react-intl';
 import { messages } from './messages';
 import { flatten } from './utils';
 
-// For uni test we always expect the messages to be in english, so the language selection logic can be omitted here.
-export const IntlProviderForTests = ({ children }: { children: React.ReactNode }) => {
-    const x = flatten(messages);
+const flatMessages = flatten(messages);
 
-    return (
-        <ReactIntlProvider locale="en-US" messages={x}>
-            {children}
-        </ReactIntlProvider>
-    );
-};
+// For uni test we always expect the messages to be in english, so the language selection logic can be omitted here.
+export const IntlProviderForTests = ({ children }: { children: React.ReactNode }) => (
+    <ReactIntlProvider locale="en-US" messages={flatMessages}>
+        {children}
+    </ReactIntlProvider>
+);

--- a/suite-native/labeling/src/components/__tests__/AccountLabel.test.tsx
+++ b/suite-native/labeling/src/components/__tests__/AccountLabel.test.tsx
@@ -44,6 +44,7 @@ describe('AccountLabel', () => {
 
     const renderAccountLabel = (props: AccountLabelPropsWithAccount) =>
         renderWithStoreProvider(<AccountLabel {...props} />, {
+            providers: [],
             store: createLightStore({
                 reducer,
                 preloadedState: {

--- a/suite-native/message-system/src/components/__tests__/ContextMessage.test.tsx
+++ b/suite-native/message-system/src/components/__tests__/ContextMessage.test.tsx
@@ -76,6 +76,7 @@ describe('ContextMessage', () => {
         renderWithStoreProvider(
             <ContextMessage context={context} accessibilityHint={contextActionId} />,
             {
+                providers: [],
                 preloadedState: { messageSystem: emptyMessageSystem, ...preloadedState },
             },
         );

--- a/suite-native/module-accounts-import/src/components/__tests__/SelectableNetworkList.test.tsx
+++ b/suite-native/module-accounts-import/src/components/__tests__/SelectableNetworkList.test.tsx
@@ -15,7 +15,7 @@ describe('SelectableNetworkList', () => {
         const onSelectItem = jest.fn();
         const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
-            { preloadedState: getMockPreloadedState(true) },
+            { providers: ['intl', 'formatter'], preloadedState: getMockPreloadedState(true) },
         );
 
         expect(getByText('Select a coin to sync')).toBeTruthy();
@@ -26,7 +26,7 @@ describe('SelectableNetworkList', () => {
         const onSelectItem = jest.fn();
         const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
-            { preloadedState: getMockPreloadedState(true) },
+            { providers: ['intl', 'formatter'], preloadedState: getMockPreloadedState(true) },
         );
 
         expect(getByText('Bitcoin')).toBeTruthy();
@@ -39,7 +39,7 @@ describe('SelectableNetworkList', () => {
         const onSelectItem = jest.fn();
         const { getByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
-            { preloadedState: getMockPreloadedState(true) },
+            { providers: ['intl', 'formatter'], preloadedState: getMockPreloadedState(true) },
         );
 
         fireEvent.press(getByText('Bitcoin'));
@@ -52,7 +52,7 @@ describe('SelectableNetworkList', () => {
         const onSelectItem = jest.fn();
         const { getByText, queryByText } = renderWithStoreProvider(
             <SelectableNetworkList onSelectItem={onSelectItem} />,
-            { preloadedState: getMockPreloadedState(false) },
+            { providers: ['intl', 'formatter'], preloadedState: getMockPreloadedState(false) },
         );
 
         expect(getByText('Select a coin to sync')).toBeTruthy();

--- a/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.tsx
+++ b/suite-native/module-earn/src/hooks/__tests__/useEarnDepositsCardData.test.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import { useTranslate } from '@suite-native/intl';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 
 import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../../types';
 import { useEarnDepositsCardData } from '../useEarnDepositsCardData';
@@ -134,11 +134,13 @@ describe('useEarnDepositsCardData', () => {
     });
 
     it('returns specific titles and a combined total for single active positions', () => {
-        const { result } = renderHookWithBasicProvider(() =>
-            useEarnDepositsCardData({
-                stakingActiveItems: [stakingActiveItem],
-                stablecoinYieldActiveItems: [stablecoinYieldActiveItem],
-            }),
+        const { result } = renderHookWithProviders(
+            () =>
+                useEarnDepositsCardData({
+                    stakingActiveItems: [stakingActiveItem],
+                    stablecoinYieldActiveItems: [stablecoinYieldActiveItem],
+                }),
+            { providers: ['intl'] },
         );
 
         expect(result.current.shouldShowCard).toBe(true);
@@ -175,14 +177,16 @@ describe('useEarnDepositsCardData', () => {
     });
 
     it('uses generic titles when there are multiple active positions of the same type', () => {
-        const { result } = renderHookWithBasicProvider(() =>
-            useEarnDepositsCardData({
-                stakingActiveItems: [stakingActiveItem, secondStakingActiveItem],
-                stablecoinYieldActiveItems: [
-                    stablecoinYieldActiveItem,
-                    secondStablecoinYieldActiveItem,
-                ],
-            }),
+        const { result } = renderHookWithProviders(
+            () =>
+                useEarnDepositsCardData({
+                    stakingActiveItems: [stakingActiveItem, secondStakingActiveItem],
+                    stablecoinYieldActiveItems: [
+                        stablecoinYieldActiveItem,
+                        secondStablecoinYieldActiveItem,
+                    ],
+                }),
+            { providers: ['intl'] },
         );
 
         expect(result.current.totalDepositedFiatAmount.toString()).toBe('2400');
@@ -200,11 +204,13 @@ describe('useEarnDepositsCardData', () => {
     });
 
     it('uses generic staking title when active staking positions have different symbols', () => {
-        const { result } = renderHookWithBasicProvider(() =>
-            useEarnDepositsCardData({
-                stakingActiveItems: [stakingActiveItem, solStakingActiveItem],
-                stablecoinYieldActiveItems: [],
-            }),
+        const { result } = renderHookWithProviders(
+            () =>
+                useEarnDepositsCardData({
+                    stakingActiveItems: [stakingActiveItem, solStakingActiveItem],
+                    stablecoinYieldActiveItems: [],
+                }),
+            { providers: ['intl'] },
         );
 
         expect(result.current.shouldShowCard).toBe(true);
@@ -218,14 +224,16 @@ describe('useEarnDepositsCardData', () => {
     });
 
     it('filters out invalid active items before building rows', () => {
-        const { result } = renderHookWithBasicProvider(() =>
-            useEarnDepositsCardData({
-                stakingActiveItems: [stakingActiveItem, invalidStakingActiveItem],
-                stablecoinYieldActiveItems: [
-                    stablecoinYieldActiveItem,
-                    invalidStablecoinYieldActiveItem,
-                ],
-            }),
+        const { result } = renderHookWithProviders(
+            () =>
+                useEarnDepositsCardData({
+                    stakingActiveItems: [stakingActiveItem, invalidStakingActiveItem],
+                    stablecoinYieldActiveItems: [
+                        stablecoinYieldActiveItem,
+                        invalidStablecoinYieldActiveItem,
+                    ],
+                }),
+            { providers: ['intl'] },
         );
 
         expect(result.current.shouldShowCard).toBe(true);
@@ -237,11 +245,13 @@ describe('useEarnDepositsCardData', () => {
     });
 
     it('hides the card when there are no active positions', () => {
-        const { result } = renderHookWithBasicProvider(() =>
-            useEarnDepositsCardData({
-                stakingActiveItems: [],
-                stablecoinYieldActiveItems: [],
-            }),
+        const { result } = renderHookWithProviders(
+            () =>
+                useEarnDepositsCardData({
+                    stakingActiveItems: [],
+                    stablecoinYieldActiveItems: [],
+                }),
+            { providers: ['intl'] },
         );
 
         expect(result.current.shouldShowCard).toBe(false);

--- a/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
+++ b/suite-native/module-home/src/screens/HomeScreen/components/__tests__/EmptyHomeRenderer.test.tsx
@@ -14,6 +14,7 @@ const defaultMessageSystem = {
 describe('EmptyHomeRenderer', () => {
     const renderEmptyHomeRenderer = (preloadedState: Record<string, unknown>) =>
         renderWithStoreProvider(<EmptyHomeRenderer />, {
+            providers: ['intl', 'navigation'],
             preloadedState: { messageSystem: defaultMessageSystem, ...preloadedState },
         });
 

--- a/suite-native/module-onboarding/src/hooks/__tests__/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/__tests__/useExitOnboardingFlow.test.ts
@@ -30,7 +30,10 @@ describe('useExitOnboardingFlow', () => {
     let store: TestStore;
 
     const renderUseExitOnboardingFlow = () =>
-        renderHookWithStoreProvider(() => useExitOnboardingFlow(), { store });
+        renderHookWithStoreProvider(() => useExitOnboardingFlow(), {
+            providers: [],
+            store,
+        });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/BiometricsScreen.test.tsx
@@ -49,7 +49,7 @@ describe('BiometricsScreen', () => {
                 }
                 route={mockRoute}
             />,
-            { store },
+            { providers: ['intl', 'navigation'], store },
         );
 
     beforeEach(() => {

--- a/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/__tests__/TradingLocationScreen.test.tsx
@@ -41,6 +41,7 @@ const defaultMessageSystem = {
 describe('TradingLocationOnboardingScreen', () => {
     const renderTradingLocationScreen = () =>
         renderWithStoreProvider(<TradingLocationScreen />, {
+            providers: ['intl', 'navigation', 'bottomSheet'],
             preloadedState: {
                 messageSystem: defaultMessageSystem,
                 wallet: {

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxoScreenFooter.test.tsx
@@ -10,6 +10,7 @@ describe('SendUtxosScreenFooter', () => {
     it('should render footer with selected total and continue button', () => {
         const { getByText } = renderWithStoreProvider(
             <SendUtxoScreenFooter symbol="btc" selectedTotal="800000000" onSubmit={jest.fn()} />,
+            { providers: ['intl', 'formatter'] },
         );
 
         expect(getByText('Selected')).toBeTruthy();
@@ -25,6 +26,7 @@ describe('SendUtxosScreenFooter', () => {
                 onSubmit={jest.fn()}
                 amount="800000000"
             />,
+            { providers: ['intl', 'formatter'] },
         );
 
         expect(getByText('Remaining to select')).toBeTruthy();
@@ -39,6 +41,7 @@ describe('SendUtxosScreenFooter', () => {
                 onSubmit={jest.fn()}
                 amount="800000000"
             />,
+            { providers: ['intl', 'formatter'] },
         );
 
         expect(queryByText('Remaining to select')).toBeNull();

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SendUtxosScreenHeader.test.tsx
@@ -1,5 +1,5 @@
 import { type AccountKey } from '@suite-common/wallet-types';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { useUtxoSelection } from '../../../hooks/useUtxoSelection';
 import { SendUtxoScreenHeader } from '../SendUtxoScreenHeader';
@@ -25,12 +25,13 @@ describe('SendUtxosScreenHeader', () => {
             setSelectedUtxos: jest.fn(),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <SendUtxoScreenHeader
                 accountKey={
                     'testAccKey' as AccountKey // Todo: create properly via `createAccountKey()`
                 }
             />,
+            { providers: ['intl', 'navigation'] },
         );
 
         expect(getByTestId('coin-control-delete-button')).toBeTruthy();
@@ -42,12 +43,13 @@ describe('SendUtxosScreenHeader', () => {
             setSelectedUtxos: jest.fn(),
         });
 
-        const { queryByTestId } = renderWithBasicProvider(
+        const { queryByTestId } = renderWithProviders(
             <SendUtxoScreenHeader
                 accountKey={
                     'testAccKey' as AccountKey // Todo: create properly via `createAccountKey()`
                 }
             />,
+            { providers: ['intl', 'navigation'] },
         );
 
         expect(queryByTestId('coin-control-delete-button')).toBeNull();

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.test.tsx
@@ -1,9 +1,5 @@
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    BasicProviderForTests,
-    renderHook,
-    renderWithBasicProvider,
-} from '@suite-native/test-utils';
+import { BasicProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
@@ -41,8 +37,9 @@ describe('renders button with correct color scheme', () => {
             totalSelectedAmount: BigNumber(500),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
+            { providers: ['intl', 'navigation'] },
         );
 
         const button = getByTestId('switch-coin-control-button');
@@ -65,8 +62,9 @@ describe('renders button with correct color scheme', () => {
             ],
             totalSelectedAmount: BigNumber(1000),
         });
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <SwitchCoinControlButton accountKey={accountKey} amount="1000" />,
+            { providers: ['intl', 'navigation'] },
         );
 
         const button = getByTestId('switch-coin-control-button');
@@ -80,8 +78,9 @@ describe('renders button with correct color scheme', () => {
             totalSelectedAmount: BigNumber(1000),
         });
 
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <SwitchCoinControlButton accountKey={accountKey} />,
+            { providers: ['intl', 'navigation'] },
         );
 
         const button = getByTestId('switch-coin-control-button');

--- a/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/__tests__/SwitchCoinControlButton.test.tsx
@@ -1,5 +1,5 @@
 import { type AccountKey } from '@suite-common/wallet-types';
-import { BasicProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
+import { ProviderForTests, renderHook, renderWithProviders } from '@suite-native/test-utils';
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
@@ -16,7 +16,7 @@ describe('renders button with correct color scheme', () => {
     let colors: NativeStyleUtils['colors'];
 
     beforeAll(() => {
-        const { result } = renderHook(() => useNativeStyles(), { wrapper: BasicProviderForTests });
+        const { result } = renderHook(() => useNativeStyles(), { wrapper: ProviderForTests });
         ({ colors } = result.current.utils);
     });
 

--- a/suite-native/module-send/src/hooks/__tests__/useRequestDelayedNavigationToOutputsReview.test.ts
+++ b/suite-native/module-send/src/hooks/__tests__/useRequestDelayedNavigationToOutputsReview.test.ts
@@ -20,11 +20,13 @@ jest.mock('@react-navigation/native', () => ({
 
 describe('useRequestDelayedNavigationToOutputsReview', () => {
     const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProvider(() =>
-            useRequestDelayedNavigationToOutputsReview({
-                accountKey: 'accountKey' as AccountKey,
-                tokenContract: 'tokenContract' as TokenAddress,
-            }),
+        renderHookWithStoreProvider(
+            () =>
+                useRequestDelayedNavigationToOutputsReview({
+                    accountKey: 'accountKey' as AccountKey,
+                    tokenContract: 'tokenContract' as TokenAddress,
+                }),
+            { providers: [] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -89,6 +89,7 @@ describe('useAddressValidationAlerts', () => {
         const result = renderHookWithStoreProvider(
             () => useAddressValidationAlerts({ inputIndex }),
             {
+                providers: [],
                 preloadedState,
                 wrapper: ({ children }) => (
                     <Form form={{ setValue: mockSetValue, watch: mockWatch } as any}>

--- a/suite-native/module-settings/src/components/__tests__/FaqCard.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/FaqCard.test.tsx
@@ -22,6 +22,7 @@ const defaultPreloadedState = {
 describe('FaqCard', () => {
     const renderFaqCard = (preloadedState = {}) =>
         renderWithStoreProvider(<FaqCard />, {
+            providers: ['intl'],
             preloadedState: { ...defaultPreloadedState, ...preloadedState },
         });
 

--- a/suite-native/module-settings/src/components/__tests__/GeneralSettings.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/GeneralSettings.test.tsx
@@ -9,7 +9,8 @@ jest.mock('@suite-native/trading-state', () => ({
 }));
 
 describe('GeneralSettings', () => {
-    const renderGeneralSettings = () => renderWithStoreProvider(<GeneralSettings />);
+    const renderGeneralSettings = () =>
+        renderWithStoreProvider(<GeneralSettings />, { providers: ['intl', 'navigation'] });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.test.tsx
+++ b/suite-native/module-settings/src/components/__tests__/TradingSettingsCard.test.tsx
@@ -13,7 +13,9 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('TradingSettingsCard', () => {
     const renderTradingSettingsCard = (props: Partial<TradingSettingsCardProps> = {}) =>
-        renderWithStoreProvider(<TradingSettingsCard onPress={jest.fn()} {...props} />);
+        renderWithStoreProvider(<TradingSettingsCard onPress={jest.fn()} {...props} />, {
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         mockIsTradingCountrySet = false;

--- a/suite-native/module-stellar-token-management/src/hooks/__tests__/useStellarFeeScreen.test.ts
+++ b/suite-native/module-stellar-token-management/src/hooks/__tests__/useStellarFeeScreen.test.ts
@@ -197,6 +197,7 @@ describe('useStellarFeeScreen', () => {
 
     const renderUseStellarFeeScreen = (props: UseStellarFeeScreenParams = defaultProps) =>
         renderHookWithStoreProvider(hookProps => useStellarFeeScreen(hookProps), {
+            providers: [],
             store,
             initialProps: props,
         });

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
@@ -14,11 +14,12 @@ describe('BuyAlert', () => {
     const renderFormHook = () =>
         renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
     const renderTradingAlert = () =>
         renderWithProviders(<BuyAlert />, {
-            providers: ['intl'],
+            providers: ['intl', 'navigation'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyAlert.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
@@ -17,7 +17,8 @@ describe('BuyAlert', () => {
         });
 
     const renderTradingAlert = () =>
-        renderWithBasicProvider(<BuyAlert />, {
+        renderWithProviders(<BuyAlert />, {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyConfirmation.test.tsx
@@ -26,6 +26,7 @@ describe('BuyConfirmation', () => {
     const renderConfirmation = () =>
         renderWithStoreProvider(<BuyConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
+            providers: ['intl'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyCryptoAmountInput.test.tsx
@@ -23,7 +23,7 @@ describe('BuyCryptoAmountInput', () => {
             <Form form={form}>
                 <BuyCryptoAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
-            { overrides },
+            { overrides, providers: ['intl', 'navigation', 'formatter'] },
         );
 
     const renderUseTradingBuyForm = (
@@ -31,6 +31,7 @@ describe('BuyCryptoAmountInput', () => {
     ) => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
             overrides,
+            providers: ['intl', 'navigation', 'formatter'],
         });
 
         return result.current;

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatAmountInput.test.tsx
@@ -20,7 +20,7 @@ describe('BuyFiatAmountInput', () => {
             <Form form={form}>
                 <BuyFiatAmountInput />
             </Form>,
-            { tradeType: 'buy', overrides },
+            { tradeType: 'buy', overrides, providers: ['intl', 'navigation'] },
         );
 
     const renderUseTradingBuyForm = (
@@ -29,6 +29,7 @@ describe('BuyFiatAmountInput', () => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
             tradeType: 'buy',
             overrides,
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencyPicker.test.tsx
@@ -29,6 +29,7 @@ describe('BuyFiatCurrencyPicker', () => {
         const preloadedState = { wallet: { trading: getInitializedTradingState() } };
         const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
         return renderWithStoreProvider(
@@ -37,6 +38,7 @@ describe('BuyFiatCurrencyPicker', () => {
             </Form>,
             {
                 preloadedState,
+                providers: ['intl', 'navigation'],
             },
         );
     };

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFiatCurrencySheet.test.tsx
@@ -7,7 +7,10 @@ describe('BuyFiatCurrencySheet', () => {
     const renderBuyFiatCurrencySheet = () =>
         renderWithStoreProvider(
             <BuyFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
-            { preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) } },
+            {
+                preloadedState: { wallet: getWalletState({ tradeType: 'buy' }) },
+                providers: ['intl'],
+            },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyForm.test.tsx
@@ -33,7 +33,10 @@ describe('BuyForm', () => {
     };
 
     const renderFormHook = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderHookWithTradingProvider(() => useBuyForm(), { overrides });
+        renderHookWithTradingProvider(() => useBuyForm(), {
+            overrides,
+            providers: ['intl', 'navigation'],
+        });
 
     const renderBuyForm = (
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
@@ -42,6 +45,7 @@ describe('BuyForm', () => {
         renderWithTradingProvider(<BuyForm />, {
             overrides,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'navigation'],
         });
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyFormFieldErrorBadge.test.tsx
@@ -27,6 +27,7 @@ describe('BuyFormFieldErrorBadge', () => {
     ) => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
             overrides,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -40,6 +41,7 @@ describe('BuyFormFieldErrorBadge', () => {
         renderWithTradingProvider(<BuyFormFieldErrorBadge {...props} />, {
             overrides,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -64,6 +64,7 @@ describe('BuyPaymentMethodPicker', () => {
         const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: mergedFormPreloadedState,
             store,
+            providers: ['intl', 'navigation', 'formatter'],
         });
         form = result.current;
 
@@ -71,7 +72,11 @@ describe('BuyPaymentMethodPicker', () => {
             <Form form={form}>
                 <BuyPaymentMethodPicker />
             </Form>,
-            { preloadedState: mergedComponentPreloadedState, store },
+            {
+                preloadedState: mergedComponentPreloadedState,
+                store,
+                providers: ['intl', 'navigation', 'formatter'],
+            },
         );
     };
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyPaymentMethodPicker.test.tsx
@@ -32,15 +32,6 @@ import { BuyPaymentMethodPicker } from '../BuyPaymentMethodPicker';
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('BuyPaymentMethodPicker', () => {
     let form: BuyFormType;
     const defaultPreloadedState = {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
@@ -23,15 +23,6 @@ import { BuyProviderPicker } from '../BuyProviderPicker';
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('BuyProviderPicker', () => {
     let form: BuyFormType;
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyProviderPicker.test.tsx
@@ -33,7 +33,10 @@ describe('BuyProviderPicker', () => {
             <Form form={form}>
                 <BuyProviderPicker />
             </Form>,
-            { overrides },
+            {
+                overrides,
+                providers: ['intl', 'services', 'bottomSheet', 'navigation', 'formatter'],
+            },
         );
 
     afterEach(() => {
@@ -47,7 +50,9 @@ describe('BuyProviderPicker', () => {
             report: reportMock,
         });
 
-        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {});
+        const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
+            providers: ['intl', 'navigation', 'formatter'],
+        });
         form = result.current;
     });
 

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountCryptoBalance.test.tsx
@@ -20,6 +20,7 @@ describe('BuyReceiveAccountCryptoBalance', () => {
     const renderBuyForm = () => {
         const { result } = renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -29,6 +30,7 @@ describe('BuyReceiveAccountCryptoBalance', () => {
         renderWithStoreProvider(<BuyReceiveAccountCryptoBalance />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyReceiveAccountPicker.test.tsx
@@ -47,6 +47,7 @@ describe('BuyReceiveAccountPicker', () => {
     const renderBuyForm = () => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
             tradeType: 'buy',
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;
@@ -57,6 +58,7 @@ describe('BuyReceiveAccountPicker', () => {
             tradeType: 'buy',
             overrides,
             wrapper: ({ children }) => <Form form={buyForm}>{children}</Form>,
+            providers: ['intl', 'navigation'],
         });
 
     const setSelectedAsset = (asset: TradeableAsset) => {

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTab.test.tsx
@@ -30,7 +30,7 @@ describe('BuyTab', () => {
     });
 
     const renderBuyTab = (overrides?: PreloadedStatePartial<TradingTestPreloadedState>) =>
-        renderWithTradingProvider(<BuyTab />, { overrides });
+        renderWithTradingProvider(<BuyTab />, { overrides, providers: ['intl', 'navigation'] });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);

--- a/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/__tests__/BuyTradeableAssetPicker.test.tsx
@@ -26,6 +26,7 @@ describe('BuyTradeableAssetPicker', () => {
     const renderFormHook = () => {
         const { result } = renderHookWithTradingProvider(() => useBuyForm(), {
             store,
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;
@@ -36,7 +37,7 @@ describe('BuyTradeableAssetPicker', () => {
             <Form form={form}>
                 <BuyTradeableAssetPicker />
             </Form>,
-            { store },
+            { store, providers: ['intl', 'bottomSheet', 'navigation'] },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitCard.test.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@suite-native/atoms';
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import {
     ExchangeApprovalLimitCard,
@@ -10,13 +10,14 @@ const mockOnChange = jest.fn();
 
 describe('ExchangeApprovalLimitCard', () => {
     const renderExchangeApprovalLimitCard = (props: Partial<ExchangeApprovalLimitCardProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <ExchangeApprovalLimitCard
                 title={<Text>Test limit</Text>}
                 description="Test description"
                 onChange={mockOnChange}
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/__tests__/ExchangeApprovalLimitSheet.test.tsx
@@ -27,6 +27,7 @@ const renderSheet = (
             overrides: {
                 wallet: { trading: { exchange: { selectedQuote: testQuote } } },
             },
+            providers: ['intl', 'formatter', 'bottomSheet'],
         },
     );
 

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ApprovalButton.test.tsx
@@ -21,6 +21,7 @@ describe('ApprovalButton', () => {
     const renderApprovalButton = (props: Partial<ApprovalButtonProps>) =>
         renderWithStoreProvider(<ApprovalButton flowType="approve" isReady {...props} />, {
             store,
+            providers: ['intl'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeApprovalDetails.test.tsx
@@ -41,6 +41,7 @@ describe('ExchangeApprovalDetails', () => {
             {
                 tradeType: 'exchange',
                 overrides,
+                providers: ['intl', 'formatter', 'bottomSheet', 'navigation'],
             },
         );
 

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeRevokeDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/ExchangeRevokeDetails.test.tsx
@@ -29,6 +29,7 @@ describe('ExchangeRevokeDetails', () => {
         renderWithTradingProvider(<ExchangeRevokeDetails exchange="mercuryo" />, {
             tradeType: 'exchange',
             overrides,
+            providers: ['intl', 'formatter', 'bottomSheet'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/LimitPicker.test.tsx
@@ -29,7 +29,7 @@ describe('LimitPicker', () => {
                     );
                 }}
             />,
-            { store },
+            { store, providers: ['intl', 'formatter', 'bottomSheet', 'navigation'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/OriginalLimit.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/OriginalLimit.test.tsx
@@ -22,6 +22,7 @@ describe('OriginalLimit', () => {
                     tradeType: 'exchange',
                 }),
             },
+            providers: ['intl', 'formatter'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/__tests__/RevokeLimitInfoRow.test.tsx
@@ -14,6 +14,7 @@ describe('RevokeLimitInfoRow', () => {
         renderWithTradingProvider(<RevokeLimitInfoRow />, {
             tradeType: 'exchange',
             overrides,
+            providers: ['intl', 'formatter'],
         });
 
     const withPreselectedQuote: PreloadedStatePartial<TradingTestPreloadedState> = {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFeePickerCard.test.tsx
@@ -21,6 +21,7 @@ describe('ExchangeFeePickerCard', () => {
             overrides: {
                 wallet: { trading: { exchange: { tradingAccountKey } } },
             },
+            providers: ['intl', 'formatter'],
         });
 
     it('should render nothing when isTxnError', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFiatDeviationWarning.test.tsx
@@ -19,6 +19,7 @@ describe('ExchangeFiatDeviationWarning', () => {
             preloadedState: {
                 wallet: { settings: { localCurrency: 'usd' } },
             },
+            providers: ['intl'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -29,6 +29,7 @@ describe('ExchangeFromAccountTradePreviewCard', () => {
                     },
                 },
             },
+            providers: ['intl', 'formatter'],
         });
 
     it('should render nothing when there is no quote', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFusionPlusInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeFusionPlusInfo.test.tsx
@@ -1,16 +1,20 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { ExchangeFusionPlusInfo } from '../ExchangeFusionPlusInfo';
 
 describe('ExchangeFusionPlusInfo', () => {
     it('should render the Fusion+ card with header', () => {
-        const { getByText } = renderWithBasicProvider(<ExchangeFusionPlusInfo />);
+        const { getByText } = renderWithProviders(<ExchangeFusionPlusInfo />, {
+            providers: ['intl'],
+        });
 
         expect(getByText('You are swapping with 1Inch Fusion+')).toBeOnTheScreen();
     });
 
     it('should render all three bullet points', () => {
-        const { getByText } = renderWithBasicProvider(<ExchangeFusionPlusInfo />);
+        const { getByText } = renderWithProviders(<ExchangeFusionPlusInfo />, {
+            providers: ['intl'],
+        });
 
         expect(
             getByText('Simply sign the order - no need to send transactions manually'),

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
@@ -56,6 +56,7 @@ describe('ExchangePreviewContinueButton', () => {
             {
                 tradeType: 'exchange',
                 overrides: mergeDeepObject(baseOverrides, extraOverrides),
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewView.test.tsx
@@ -39,6 +39,7 @@ describe('ExchangePreviewView', () => {
                         },
                     },
                 },
+                providers: ['intl', 'formatter'],
             },
         );
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangeToAccountTradePreviewCard.test.tsx
@@ -29,6 +29,7 @@ describe('ExchangeToAccountTradePreviewCard', () => {
                     },
                 },
             },
+            providers: ['intl', 'formatter'],
         });
 
     it('should render nothing when there is no quote', () => {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
@@ -22,11 +22,12 @@ describe('ExchangeAlert', () => {
     const renderFormHook = () =>
         renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
     const renderTradingAlert = () =>
         renderWithProviders(<ExchangeAlert />, {
-            providers: ['intl'],
+            providers: ['intl', 'navigation'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeAlert.test.tsx
@@ -1,6 +1,6 @@
 import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-flags';
 import { Form } from '@suite-native/forms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
@@ -25,7 +25,8 @@ describe('ExchangeAlert', () => {
         });
 
     const renderTradingAlert = () =>
-        renderWithBasicProvider(<ExchangeAlert />, {
+        renderWithProviders(<ExchangeAlert />, {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeConfirmation.test.tsx
@@ -42,6 +42,7 @@ describe('ExchangeConfirmation', () => {
     const renderConfirmation = () =>
         renderWithStoreProvider(<ExchangeConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
+            providers: ['intl'],
         });
 
     const queryContinueButton = () =>

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeForm.test.tsx
@@ -38,6 +38,7 @@ describe('ExchangeForm', () => {
     const renderForm = () =>
         renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState: defaultPreloadedState,
+            providers: ['intl', 'navigation'],
         });
 
     const renderExchangeForm = () =>
@@ -50,6 +51,7 @@ describe('ExchangeForm', () => {
                     trading: getInitializedTradingState(),
                 },
             },
+            providers: ['intl', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeProviderPicker.test.tsx
@@ -21,6 +21,7 @@ describe('ExchangeProviderPicker', () => {
             />,
             {
                 preloadedState,
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
@@ -17,15 +17,6 @@ import { ExchangeRateAndProviderPicker } from '../ExchangeRateAndProviderPicker'
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('ExchangeRateAndProviderPicker', () => {
     let exchangeForm: ExchangeFormType;
     let unmount: (() => void) | undefined;

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeRateAndProviderPicker.test.tsx
@@ -35,6 +35,7 @@ describe('ExchangeRateAndProviderPicker', () => {
             tradeType: 'exchange',
             overrides: { ...baseOverrides, ...extraOverrides },
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
+            providers: ['intl', 'services', 'bottomSheet', 'navigation', 'formatter'],
         });
 
         ({ unmount } = result);
@@ -52,6 +53,7 @@ describe('ExchangeRateAndProviderPicker', () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
+            providers: ['intl', 'navigation', 'formatter'],
         });
         exchangeForm = result.current;
     });

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTab.test.tsx
@@ -28,7 +28,10 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('ExchangeTab', () => {
     const renderExchangeTab = () =>
-        renderWithTradingProvider(<ExchangeTab />, { tradeType: 'exchange' });
+        renderWithTradingProvider(<ExchangeTab />, {
+            tradeType: 'exchange',
+            providers: ['intl', 'navigation'],
+        });
 
     beforeEach(() => {
         mockIsDeviceInViewOnlyMode = false;

--- a/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/__tests__/ExchangeTabContent.test.tsx
@@ -24,7 +24,10 @@ describe('ExchangeTab', () => {
     });
 
     const renderExchangeTab = () =>
-        renderWithTradingProvider(<ExchangeTabContent />, { tradeType: 'exchange' });
+        renderWithTradingProvider(<ExchangeTabContent />, {
+            tradeType: 'exchange',
+            providers: ['intl', 'navigation'],
+        });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -28,6 +28,7 @@ describe('ExchangeReceiveAccountCryptoBalance', () => {
     const renderExchangeForm = () => {
         const { result } = renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -37,6 +38,7 @@ describe('ExchangeReceiveAccountCryptoBalance', () => {
         renderWithStoreProvider(<ExchangeReceiveAccountCryptoBalance />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAccountPicker.test.tsx
@@ -57,6 +57,7 @@ describe('ExchangeReceiveAccountPicker', () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;
@@ -67,6 +68,7 @@ describe('ExchangeReceiveAccountPicker', () => {
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, overrides),
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
+            providers: ['intl', 'navigation'],
         });
 
     const setSelectedAsset = (asset: TradeableAsset) => {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveAmountInput.test.tsx
@@ -37,6 +37,7 @@ describe('ExchangeReceiveAmountInput', () => {
                 tradeType: 'exchange',
                 overrides: { ...baseOverrides, ...extraOverrides },
                 wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+                providers: ['intl', 'navigation'],
             },
         );
 
@@ -44,6 +45,7 @@ describe('ExchangeReceiveAmountInput', () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
+            providers: ['intl', 'navigation'],
         });
         form = result.current;
     });

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeReceiveCard.test.tsx
@@ -38,12 +38,14 @@ describe('ExchangeReceiveCard', () => {
     const renderForm = () =>
         renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     const renderExchangeBuyCard = () =>
         renderWithStoreProvider(<ExchangeReceiveCard />, {
             preloadedState,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/__tests__/ExchangeTradeableAssetPicker.test.tsx
@@ -31,6 +31,7 @@ describe('ExchangeTradeableAssetPicker', () => {
     const renderFormHook = () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             store,
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;
@@ -40,6 +41,7 @@ describe('ExchangeTradeableAssetPicker', () => {
         renderWithTradingProvider(<ExchangeTradeableAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'bottomSheet', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAccountCryptoBalance.test.tsx
@@ -19,6 +19,7 @@ describe('ExchangeSendAccountCryptoBalance', () => {
     const renderExchangeForm = () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -28,6 +29,7 @@ describe('ExchangeSendAccountCryptoBalance', () => {
         renderWithTradingProvider(<ExchangeSendAccountCryptoBalance />, {
             tradeType: 'exchange',
             wrapper: ({ children }) => <Form form={exchangeForm}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountBadge.test.tsx
@@ -31,12 +31,14 @@ describe('ExchangeSendAmountBadge', () => {
             tradeType: 'exchange',
             overrides: { ...baseOverrides, ...extraOverrides },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: baseOverrides,
+            providers: ['intl', 'formatter', 'navigation'],
         });
         form = result.current;
     });

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAmountInput.test.tsx
@@ -49,6 +49,7 @@ describe('ExchangeSendAmountInput', () => {
             {
                 tradeType: 'exchange',
                 overrides: mergeDeepObject(baseOverrides, extraOverrides),
+                providers: ['intl', 'navigation'],
             },
         );
 
@@ -58,6 +59,7 @@ describe('ExchangeSendAmountInput', () => {
         const { result } = renderHookWithTradingProvider(() => useExchangeForm(), {
             tradeType: 'exchange',
             overrides: mergeDeepObject(baseOverrides, extraOverrides),
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendAssetPicker.test.tsx
@@ -89,12 +89,16 @@ describe('ExchangeSendAssetPicker', () => {
     });
 
     const renderExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), {
+            store,
+            providers: ['intl', 'formatter', 'navigation'],
+        });
 
     const renderExchangeSendAssetPicker = () =>
         renderWithStoreProvider(<ExchangeSendAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/__tests__/ExchangeSendCard.test.tsx
@@ -29,12 +29,14 @@ describe('ExchangeSendCard', () => {
     const renderForm = () =>
         renderHookWithStoreProvider(() => useExchangeForm(), {
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     const renderExchangeSendCard = (isAmountInputActive: boolean) =>
         renderWithStoreProvider(<ExchangeSendCard isAmountInputActive={isAmountInputActive} />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/fees/__tests__/FeePickerCard.test.tsx
@@ -28,7 +28,9 @@ describe('FeePickerCard', () => {
     const renderFeePickerCard = (props = {}) => {
         const finalProps = { ...defaultProps, ...props };
 
-        return renderWithTradingProvider(<FeePickerCard {...finalProps} />);
+        return renderWithTradingProvider(<FeePickerCard {...finalProps} />, {
+            providers: ['intl'],
+        });
     };
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountList.test.tsx
@@ -119,7 +119,7 @@ describe('AccountList', () => {
                 onSetPickerMode={jest.fn()}
                 {...props}
             />,
-            { store },
+            { store, providers: ['intl', 'formatter'] },
         );
     };
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListAddressItem.test.tsx
@@ -53,6 +53,7 @@ describe(AccountListAddressItem.name, () => {
     const renderAccountListAddressItem = (receiveAccount: ReceiveAccount) =>
         renderWithTradingProvider(
             <AccountListAddressItem receiveAccount={receiveAccount} onPress={onPressMock} />,
+            { providers: ['intl', 'formatter'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListFooter.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListFooter.test.tsx
@@ -1,12 +1,13 @@
 import { getTranslation } from '@suite-native/intl';
-import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { AccountListFooter, type AccountsListFooterProps } from '../AccountListFooter';
 
 describe('AccountListFooter', () => {
     const renderAccountsListFooter = (props: Partial<AccountsListFooterProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <AccountListFooter hasTextualDivider onAddAccountTap={jest.fn()} {...props} />,
+            { providers: ['intl'] },
         );
 
     it('should not render "OR" when hasTextualDivider props is false', () => {

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/AccountListItem.test.tsx
@@ -66,7 +66,7 @@ describe('AccountListItem', () => {
 
         return renderWithStoreProvider(
             <AccountListItem onPress={onPressMock} receiveAccount={receiveAccount} />,
-            { store },
+            { store, providers: ['intl', 'formatter'] },
         );
     };
 

--- a/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/__tests__/NoAccountsComponent.test.tsx
@@ -20,6 +20,7 @@ describe('NoAccountsComponent', () => {
                     },
                 },
             },
+            providers: ['intl'],
         });
 
     it('should render for not connected device', () => {

--- a/suite-native/module-trading/src/components/general/Error/__tests__/LastErrorMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/__tests__/LastErrorMessage.test.tsx
@@ -26,7 +26,10 @@ describe('LastErrorMessage', () => {
     } as const;
 
     const renderLastErrorMessage = (props: LastErrorMessageProps) =>
-        renderWithStoreProvider(<LastErrorMessage {...props} />, { store });
+        renderWithStoreProvider(<LastErrorMessage {...props} />, {
+            store,
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         store = createLightStore({ reducer });

--- a/suite-native/module-trading/src/components/general/Error/__tests__/TradingTypeDisabled.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/__tests__/TradingTypeDisabled.test.tsx
@@ -1,11 +1,11 @@
 import { type TradingType } from '@suite-common/trading';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { TradingTypeDisabled, type TradingTypeDisabledProps } from '../TradingTypeDisabled';
 
 describe('TradingTypeDisabled', () => {
     const renderTradingTypeDisabled = (props: TradingTypeDisabledProps) =>
-        renderWithBasicProvider(<TradingTypeDisabled {...props} />);
+        renderWithProviders(<TradingTypeDisabled {...props} />, { providers: ['intl'] });
 
     it.each<[TradingType, string]>([
         ['buy', 'Buy disabled'],

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/__tests__/FiatCurrencyListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/__tests__/FiatCurrencyListItem.test.tsx
@@ -1,16 +1,17 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { FiatCurrencyListItem, type FiatCurrencyListItemProps } from '../FiatCurrencyListItem';
 
 describe('FiatCurrencyListItem', () => {
     const renderFiatCurrencyListItem = (props: Partial<FiatCurrencyListItemProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <FiatCurrencyListItem
                 label="LABEL"
                 displayValue="DISPLAY_VALUE"
                 onPress={jest.fn()}
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     it('should render label and display value', () => {

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
@@ -40,7 +40,10 @@ describe('Header', () => {
         const reportMock = setupReportMock();
 
         return {
-            renderer: renderWithTradingProvider(<Header />, { overrides }),
+            renderer: renderWithTradingProvider(<Header />, {
+                overrides,
+                providers: ['intl', 'services'],
+            }),
             reportMock,
         };
     };
@@ -51,7 +54,10 @@ describe('Header', () => {
         const reportMock = setupReportMock();
 
         return {
-            renderer: renderWithTradingProvider(<Header />, { store }),
+            renderer: renderWithTradingProvider(<Header />, {
+                store,
+                providers: ['intl', 'services'],
+            }),
             reportMock,
         };
     };

--- a/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/__tests__/Header.test.tsx
@@ -12,15 +12,6 @@ import {
 } from '../../../../__tests__/tradingTestUtils';
 import { Header } from '../Header';
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('Header', () => {
     const getFFOverrides = ({
         areTradingExchangeDexesEnabled = true,

--- a/suite-native/module-trading/src/components/general/Input/__tests__/AmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/general/Input/__tests__/AmountInput.test.tsx
@@ -1,17 +1,18 @@
-import { fireEvent, renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders, userEvent } from '@suite-native/test-utils';
 import { paletteV2 } from '@trezor/theme';
 
 import { AMOUNT_INPUT_TEST_ID, AmountInput, type AmountInputProps } from '../AmountInput';
 
 describe('AmountInput', () => {
     const renderAmountInput = (props: Partial<AmountInputProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <AmountInput
                 inputTransformer={v => v}
                 onChangeText={jest.fn()}
                 accessibilityLabel="INPUT"
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     it('should respect maxLength property', async () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetListItem.test.tsx
@@ -81,7 +81,7 @@ describe('MyAssetListItem', () => {
     ) =>
         renderWithStoreProvider(
             <MyAssetListItem asset={asset} account={account} onPress={onPress} />,
-            { preloadedState },
+            { preloadedState, providers: ['intl', 'formatter'] },
         );
 
     it('should render with correct labels', () => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetSheet.test.tsx
@@ -75,7 +75,10 @@ describe('MyAssetSheet', () => {
                 tradingType="exchange"
                 {...props}
             />,
-            { overrides: getOverrides() },
+            {
+                overrides: getOverrides(),
+                providers: ['intl', 'formatter', 'bottomSheet'],
+            },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetsDisabledListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/__tests__/MyAssetsDisabledListItem.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import {
     MyAssetsDisabledListItem,
@@ -7,7 +7,7 @@ import {
 
 describe('MyAssetsDisabledListItem', () => {
     const renderMyAssetsDisabledListItem = (props: MyAssetsDisabledListItemProps) =>
-        renderWithBasicProvider(<MyAssetsDisabledListItem {...props} />);
+        renderWithProviders(<MyAssetsDisabledListItem {...props} />, { providers: ['intl'] });
 
     it.each<[number, string]>([
         [1, '+ 1 non-tradeable token'],

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/__tests__/PaymentMethodListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/__tests__/PaymentMethodListItem.test.tsx
@@ -16,7 +16,10 @@ describe('PaymentMethodListItem', () => {
                 onPress={jest.fn()}
                 {...props}
             />,
-            { preloadedState: getPreloadedState() },
+            {
+                preloadedState: getPreloadedState(),
+                providers: ['intl', 'formatter'],
+            },
         );
 
     it('should render given name and rate', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/NoProvidersPlaceholder.test.tsx
@@ -1,9 +1,10 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { NoProvidersPlaceholder } from '../NoProvidersPlaceholder';
 
 describe('NoProvidersPlaceholder', () => {
-    const renderNoProvidersPlaceholder = () => renderWithBasicProvider(<NoProvidersPlaceholder />);
+    const renderNoProvidersPlaceholder = () =>
+        renderWithProviders(<NoProvidersPlaceholder />, { providers: ['intl'] });
 
     it('should render text and icon with label', () => {
         const { getByLabelText, getByText } = renderNoProvidersPlaceholder();

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItem.test.tsx
@@ -35,7 +35,7 @@ describe('ProviderListItem', () => {
                 tradingType="buy"
                 {...props}
             />,
-            { overrides: baseOverrides },
+            { overrides: baseOverrides, providers: ['intl', 'formatter'] },
         );
 
     it('should render provider information correctly', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItemValueRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderListItemValueRow.test.tsx
@@ -21,6 +21,7 @@ describe('ProviderListItemValueRow', () => {
     const renderProviderListItemValueRow = (quote: TradingTradeType) =>
         renderWithTradingProvider(<ProviderListItemValueRow quote={quote} />, {
             overrides: overridesWithQuotes,
+            providers: ['intl', 'formatter'],
         });
 
     it('should render formatted rate for a buy quote', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheet.test.tsx
@@ -24,7 +24,7 @@ describe('ProviderSheet', () => {
                 tradingType="buy"
                 {...props}
             />,
-            { overrides },
+            { overrides, providers: ['intl', 'formatter', 'bottomSheet'] },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetHandle.test.tsx
@@ -38,7 +38,7 @@ describe('ProviderSheetHandle', () => {
                 ]}
                 {...props}
             />,
-            { overrides },
+            { overrides, providers: ['intl'] },
         );
 
     it('should render component with title and filter', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/__tests__/ProviderSheetSectionHeader.test.tsx
@@ -8,7 +8,9 @@ import {
 
 describe('ProviderSheetSectionHeader', () => {
     const renderProviderSheetSectionHeader = (props: ProviderSheetSectionHeaderProps) =>
-        renderWithTradingProvider(<ProviderSheetSectionHeader {...props} />);
+        renderWithTradingProvider(<ProviderSheetSectionHeader {...props} />, {
+            providers: ['intl'],
+        });
 
     it.each<[QuotesCategory, string]>([
         ['fixed', 'Fixed-rate CEX'],

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/__tests__/ReceiveAccountPicker.test.tsx
@@ -45,7 +45,7 @@ describe('ReceiveAccountPicker', () => {
                 }}
                 {...props}
             />,
-            { store },
+            { store, providers: ['intl'] },
         );
     };
 

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/ProviderInfoRow.test.tsx
@@ -13,6 +13,7 @@ describe('ProviderInfoRow', () => {
 
         return renderWithStoreProvider(<ProviderInfoRow exchange="mercuryo" {...props} />, {
             preloadedState,
+            providers: ['intl'],
         });
     };
 

--- a/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/__tests__/TradeFiatSideCard.test.tsx
@@ -1,11 +1,11 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
 import { TradeFiatSideCard, type TradeFiatSideCardProps } from '../TradeFiatSideCard';
 
 describe('TradeFiatSideCard', () => {
     const renderTradeFiatSideCard = (props: TradeFiatSideCardProps) =>
-        renderWithBasicProvider(<TradeFiatSideCard {...props} />);
+        renderWithProviders(<TradeFiatSideCard {...props} />, { providers: ['intl'] });
 
     it('should render credit card payment method', () => {
         const { getByText } = renderTradeFiatSideCard({

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/FavouriteIcon.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/FavouriteIcon.test.tsx
@@ -1,26 +1,29 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { FavouriteIcon } from '../FavouriteIcon';
 
 describe('FavouriteIcon', () => {
     it('should have correct hint when marked as favourite', () => {
-        const { getByA11yHint } = renderWithBasicProvider(
+        const { getByA11yHint } = renderWithProviders(
             <FavouriteIcon isFavourite={true} onPress={jest.fn()} />,
+            { providers: ['intl'] },
         );
         expect(getByA11yHint('Remove from favourites')).toBeTruthy();
     });
 
     it('should have correct hint when not marked as favourite', () => {
-        const { getByA11yHint } = renderWithBasicProvider(
+        const { getByA11yHint } = renderWithProviders(
             <FavouriteIcon isFavourite={false} onPress={jest.fn()} />,
+            { providers: ['intl'] },
         );
         expect(getByA11yHint('Add to favourites')).toBeTruthy();
     });
 
     it('should call onPress callback', () => {
         const pressSpy = jest.fn();
-        const { getByA11yHint } = renderWithBasicProvider(
+        const { getByA11yHint } = renderWithProviders(
             <FavouriteIcon isFavourite={false} onPress={pressSpy} />,
+            { providers: ['intl'] },
         );
 
         const button = getByA11yHint('Add to favourites');

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetFilterTabs.test.tsx
@@ -29,6 +29,7 @@ describe('TradeableAssetFilterTabs', () => {
                 animationDuration={300}
                 onSelectedNetworkFilter={onSelectedNetworkFilter}
             />,
+            { providers: ['intl'] },
         );
 
     it('should render all filter tabs including "All" option', () => {
@@ -46,6 +47,7 @@ describe('TradeableAssetFilterTabs', () => {
                 animationDuration={300}
                 onSelectedNetworkFilter={jest.fn()}
             />,
+            { providers: ['intl'] },
         );
 
         expect(queryByText('All')).toBeNull();

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetListItem.test.tsx
@@ -43,6 +43,7 @@ describe('TradeableAssetListItem', () => {
 
         return renderWithStoreProvider(<TradeableAssetListItem asset={asset} onPress={onPress} />, {
             store,
+            providers: ['intl'],
         });
     };
 

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheet.test.tsx
@@ -20,6 +20,7 @@ describe('TradeableAssetSheet', () => {
                 flashListKey="test-key"
                 {...props}
             />,
+            { providers: ['intl', 'bottomSheet'] },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/__tests__/TradeableAssetSheetHeader.test.tsx
@@ -20,6 +20,7 @@ describe('TradeableAssetSheetHeader', () => {
                 onFilterChange={jest.fn()}
                 onSelectedNetworkFilter={jest.fn()}
             />,
+            { providers: ['intl'] },
         );
 
     it('should display "Coins" and do not display tabs by default', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/ActiveTab.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ActiveTab.test.tsx
@@ -17,7 +17,7 @@ jest.mock('@suite-native/trading-state', () => ({
 
 describe('ActiveTab', () => {
     const renderActiveTab = (overrides: PreloadedStatePartial<TradingTestPreloadedState>) =>
-        renderWithTradingProvider(<ActiveTab />, { overrides });
+        renderWithTradingProvider(<ActiveTab />, { overrides, providers: ['intl'] });
 
     it.each<[TradingType, string]>([
         ['buy', 'Buy disabled'],

--- a/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/CryptoToFiatValueBadge.test.tsx
@@ -21,6 +21,7 @@ describe('CryptoToFiatValueBadge', () => {
     const renderCryptoToFiatValueBadge = async (props: CryptoToFiatValueBadgeProps) => {
         const res = renderWithStoreProvider(<CryptoToFiatValueBadge {...props} />, {
             preloadedState: getPreloadedState(),
+            providers: ['intl', 'formatter'],
         });
 
         // await mocked loading of rates

--- a/suite-native/module-trading/src/components/general/__tests__/FiatAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FiatAmountBadge.test.tsx
@@ -1,12 +1,12 @@
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { BigNumber } from '@trezor/utils';
 
 import { FiatAmountBadge, type FiatAmountBadgeProps } from '../FiatAmountBadge';
 
 describe('FiatAmountBadge', () => {
     const renderFiatAmountBadge = (props: FiatAmountBadgeProps) =>
-        renderWithBasicProvider(<FiatAmountBadge {...props} />);
+        renderWithProviders(<FiatAmountBadge {...props} />, { providers: ['intl', 'formatter'] });
 
     it('should display nothing when amount is not provided', () => {
         const { toJSON } = renderFiatAmountBadge({ amount: undefined });

--- a/suite-native/module-trading/src/components/general/__tests__/FiatCurrencyButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FiatCurrencyButton.test.tsx
@@ -1,12 +1,12 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { FiatCurrencyButton, type FiatCurrencyButtonProps } from '../FiatCurrencyButton';
 
 describe('FiatCurrencyButton', () => {
     const renderFiatCurrencyButton = (props: Partial<FiatCurrencyButtonProps>) =>
-        renderWithBasicProvider(
-            <FiatCurrencyButton currency="czk" onPress={jest.fn()} {...props} />,
-        );
+        renderWithProviders(<FiatCurrencyButton currency="czk" onPress={jest.fn()} {...props} />, {
+            providers: ['intl'],
+        });
 
     it('should render fiat currency uppercase', () => {
         const { getByLabelText } = renderFiatCurrencyButton({});

--- a/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/FilterTabs.test.tsx
@@ -20,6 +20,7 @@ describe('FilterTabs', () => {
                 value={value}
                 keyExtractor={keyExtractor}
             />,
+            { providers: [] },
         );
 
     it('should render all filter tabs', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/Footer.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/Footer.test.tsx
@@ -15,7 +15,7 @@ describe('Footer', () => {
     const mockOpenLink = jest.spyOn(Linking, 'openURL');
 
     const renderFooter = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
-        renderWithTradingProvider(<Footer />, { overrides });
+        renderWithTradingProvider(<Footer />, { overrides, providers: ['intl'] });
 
     beforeEach(() => {
         mockOpenLink.mockClear();

--- a/suite-native/module-trading/src/components/general/__tests__/GeneralAlert.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/GeneralAlert.test.tsx
@@ -1,10 +1,10 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { GeneralAlert, type GeneralAlertProps } from '../GeneralAlert';
 
 describe('GeneralAlert', () => {
     const renderGeneralAlert = (props: GeneralAlertProps) =>
-        renderWithBasicProvider(<GeneralAlert {...props} />);
+        renderWithProviders(<GeneralAlert {...props} />, { providers: ['intl'] });
 
     it('should render nothing when no text is provided', () => {
         const { toJSON } = renderGeneralAlert({});

--- a/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/HistoryButton.test.tsx
@@ -30,6 +30,7 @@ describe('HistoryButton', () => {
     ) =>
         renderWithTradingProvider(<HistoryButton />, {
             overrides,
+            providers: ['intl'],
         });
 
     it('should render nothing where no trades are available', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/LegalGatewayContextMessage.test.tsx
@@ -15,7 +15,7 @@ jest.mock('@suite-common/message-system', () => {
 
 describe('LegalGatewayContextMessage', () => {
     const renderLegalGatewayContextMessage = () =>
-        renderWithStoreProvider(<LegalGatewayContextMessage />);
+        renderWithStoreProvider(<LegalGatewayContextMessage />, { providers: ['intl'] });
 
     it('should render legal.gateway context message', () => {
         const { getByText } = renderLegalGatewayContextMessage();

--- a/suite-native/module-trading/src/components/general/__tests__/NetworkSymbolExtendedFormatter.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/NetworkSymbolExtendedFormatter.test.tsx
@@ -1,12 +1,12 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { NetworkSymbolExtendedFormatter } from '../NetworkSymbolExtendedFormatter';
 
 describe('NetworkSymbolExtendedFormatter', () => {
     it('should render symbol uppercase', () => {
-        const { getByText } = renderWithBasicProvider(
-            <NetworkSymbolExtendedFormatter symbol="btc" />,
-        );
+        const { getByText } = renderWithProviders(<NetworkSymbolExtendedFormatter symbol="btc" />, {
+            providers: ['intl'],
+        });
 
         expect(getByText('BTC')).toBeTruthy();
     });

--- a/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/ProviderReceiveAddress.test.tsx
@@ -50,6 +50,7 @@ describe('ProviderReceiveAddress', () => {
 
         return renderWithStoreProvider(<ProviderReceiveAddress trade={trade} />, {
             preloadedState: { wallet: walletState },
+            providers: ['intl'],
         });
     };
 
@@ -82,7 +83,7 @@ describe('ProviderReceiveAddress', () => {
 
         const { queryByText } = renderWithStoreProvider(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
-            { preloadedState: { wallet: walletState } },
+            { preloadedState: { wallet: walletState }, providers: ['intl'] },
         );
 
         // Component should not render when provider info is missing
@@ -96,7 +97,7 @@ describe('ProviderReceiveAddress', () => {
 
         const { queryByText } = renderWithStoreProvider(
             <ProviderReceiveAddress trade={mockExchangeTrade} />,
-            { preloadedState: { wallet: walletState } },
+            { preloadedState: { wallet: walletState }, providers: ['intl'] },
         );
 
         // Component should not render when company name is missing

--- a/suite-native/module-trading/src/components/general/__tests__/SelectTradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SelectTradeableAssetButton.test.tsx
@@ -1,12 +1,13 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { adaAsset } from '@suite-native/trading-fixtures';
 
 import { SelectTradeableAssetButton } from '../SelectTradeableAssetButton';
 
 describe('SelectTradeableAssetButton', () => {
     it('should render "Select asset" when no network is selected', () => {
-        const { getByLabelText } = renderWithBasicProvider(
+        const { getByLabelText } = renderWithProviders(
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={undefined} caret />,
+            { providers: ['intl'] },
         );
 
         const button = getByLabelText('Select asset');
@@ -14,16 +15,18 @@ describe('SelectTradeableAssetButton', () => {
     });
 
     it('should render TradeableAssetButton when network is selected', () => {
-        const { getByLabelText } = renderWithBasicProvider(
+        const { getByLabelText } = renderWithProviders(
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={adaAsset} caret />,
+            { providers: ['intl'] },
         );
         const button = getByLabelText('Select asset');
         expect(button).toHaveTextContent(/^ADA.$/);
     });
 
     it('should not display caret when caret prop is falsy', () => {
-        const { getByLabelText } = renderWithBasicProvider(
+        const { getByLabelText } = renderWithProviders(
             <SelectTradeableAssetButton onPress={jest.fn()} selectedAsset={adaAsset} />,
+            { providers: ['intl'] },
         );
         const button = getByLabelText('Select asset');
         expect(button).toHaveTextContent('ADA');

--- a/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/SimpleSheetHeader.test.tsx
@@ -1,10 +1,10 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { SimpleSheetHeader, type SimpleSheetHeaderProps } from '../SimpleSheetHeader';
 
 describe('SimpleSheetHeader', () => {
     const renderSimpleSheetHeader = (props: SimpleSheetHeaderProps) =>
-        renderWithBasicProvider(<SimpleSheetHeader {...props} />);
+        renderWithProviders(<SimpleSheetHeader {...props} />, { providers: ['intl'] });
 
     it('should render title', () => {
         const { getByText } = renderSimpleSheetHeader({

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetAccountBalance.test.tsx
@@ -26,7 +26,7 @@ describe('TradeableAssetAccountBalance', () => {
                 testID="TEST_ID"
                 {...props}
             />,
-            { preloadedState },
+            { preloadedState, providers: ['intl', 'formatter'] },
         );
 
     it('should render nothing without asset selected', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetButton.test.tsx
@@ -1,40 +1,43 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 import { btcAsset, ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
 
 import { TradeableAssetButton } from '../TradeableAssetButton';
 
 describe('TradeableAssetButton', () => {
     it('should render display name of given symbol', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <TradeableAssetButton
                 asset={btcAsset}
                 onPress={jest.fn()}
                 accessibilityLabel="a11yLabel"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('BTC')).toBeTruthy();
     });
 
     it('should render display ETH as display symbol for L2 EVMs', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <TradeableAssetButton
                 asset={ethOnBaseAsset}
                 onPress={jest.fn()}
                 accessibilityLabel="a11yLabel"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('ETH')).toBeTruthy();
     });
 
     it('should render display token name when token is present', () => {
-        const { getByText, getByLabelText } = renderWithBasicProvider(
+        const { getByText, getByLabelText } = renderWithProviders(
             <TradeableAssetButton
                 asset={usdcAsset}
                 onPress={jest.fn()}
                 accessibilityLabel="a11yLabel"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('USDC')).toBeTruthy();
@@ -43,12 +46,13 @@ describe('TradeableAssetButton', () => {
 
     it('should call onPress callback', () => {
         const pressSpy = jest.fn();
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <TradeableAssetButton
                 asset={btcAsset}
                 onPress={pressSpy}
                 accessibilityLabel="a11yLabel"
             />,
+            { providers: ['intl'] },
         );
 
         const button = getByText('BTC');
@@ -58,12 +62,13 @@ describe('TradeableAssetButton', () => {
     });
 
     it('should render ETH icon for ETH on BASE asset', () => {
-        const { getByText, getByLabelText } = renderWithBasicProvider(
+        const { getByText, getByLabelText } = renderWithProviders(
             <TradeableAssetButton
                 asset={ethOnBaseAsset}
                 onPress={jest.fn()}
                 accessibilityLabel="a11yLabel"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('ETH')).toBeTruthy();

--- a/suite-native/module-trading/src/components/general/__tests__/TradeableAssetNetworkInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradeableAssetNetworkInfo.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { btcAsset, ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
 
 import {
@@ -8,7 +8,7 @@ import {
 
 describe('TradeableAssetNetworkInfo', () => {
     const renderTradeableAssetNetworkInfo = (asset: TradeableAssetNetworkInfoProps['asset']) =>
-        renderWithBasicProvider(<TradeableAssetNetworkInfo asset={asset} />);
+        renderWithProviders(<TradeableAssetNetworkInfo asset={asset} />, { providers: ['intl'] });
 
     it('should render nothing when asset is not set', () => {
         const { toJSON } = renderTradeableAssetNetworkInfo(undefined);

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCoinAmountFormatter.test.tsx
@@ -14,6 +14,7 @@ describe('TradingCoinAmountFormatter', () => {
     ) =>
         renderWithStoreProvider(<TradingCoinAmountFormatter {...props} />, {
             preloadedState: { wallet: getWalletState() },
+            providers: ['intl', 'formatter'],
         });
 
     it('should render formatted value for network', () => {

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
@@ -20,15 +20,6 @@ import { TradingCountryOfResidencePicker } from '../TradingCountryOfResidencePic
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('TradingCountryOfResidencePicker', () => {
     let form: UseFormReturn<{ country: TradingCountryOption }>;
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingCountryOfResidencePicker.test.tsx
@@ -26,7 +26,7 @@ describe('TradingCountryOfResidencePicker', () => {
     const renderForm = () =>
         renderHookWithTradingProvider(
             () => useForm<{ country: TradingCountryOption }>({ validation: yup.object() }),
-            { overrides: residenceCheckDisabledState },
+            { overrides: residenceCheckDisabledState, providers: ['intl', 'navigation'] },
         );
 
     const renderCountryOfResidencePicker = (
@@ -37,6 +37,7 @@ describe('TradingCountryOfResidencePicker', () => {
             {
                 wrapper: ({ children }) => <Form form={form}>{children}</Form>,
                 overrides,
+                providers: ['intl', 'services', 'bottomSheet', 'navigation'],
             },
         );
 

--- a/suite-native/module-trading/src/components/general/__tests__/TradingDeviceConnectionGuard.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingDeviceConnectionGuard.test.tsx
@@ -32,7 +32,7 @@ describe('TradingDeviceConnectionGuard', () => {
             <TradingDeviceConnectionGuard>
                 <Text>CHILDREN</Text>
             </TradingDeviceConnectionGuard>,
-            { store },
+            { store, providers: ['intl', 'navigation'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTabContent.test.tsx
@@ -35,6 +35,7 @@ describe('TradingTabContent', () => {
                     'trading.restrictions.blacklist': isBlacklisted,
                 }),
             },
+            providers: ['intl', 'navigation'],
         });
 
     const expectDeviceOffline = () => {

--- a/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/__tests__/TradingTypeAwareContextMessage.test.tsx
@@ -39,7 +39,11 @@ describe('TradingTypeAwareContextMessage', () => {
 
     const renderTradingTypeAwareContextMessage = (
         overrides: PreloadedStatePartial<TradingTestPreloadedState>,
-    ) => renderWithTradingProvider(<TradingTypeAwareContextMessage />, { overrides });
+    ) =>
+        renderWithTradingProvider(<TradingTypeAwareContextMessage />, {
+            overrides,
+            providers: ['intl'],
+        });
 
     it.each<[TradingType, string]>([
         ['buy', 'Trading buy message'],

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAlert.test.tsx
@@ -135,7 +135,7 @@ describe('TradeDetailAlert', () => {
                 orderId={orderId || trade.data.orderId}
                 onOpenedBrowser={mockOnOpenedBrowser}
             />,
-            { preloadedState: preloadedStateWithTrades([trade], statusUrl) },
+            { preloadedState: preloadedStateWithTrades([trade], statusUrl), providers: ['intl'] },
         );
     };
 
@@ -172,7 +172,7 @@ describe('TradeDetailAlert', () => {
                     orderId="nonexistent-order-id"
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([], undefined) },
+                { preloadedState: preloadedStateWithTrades([], undefined), providers: ['intl'] },
             );
 
             expect(getByText('Proceed to pay')).toBeTruthy();
@@ -224,7 +224,7 @@ describe('TradeDetailAlert', () => {
                     orderId="test-order-id"
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([]) },
+                { preloadedState: preloadedStateWithTrades([]), providers: ['intl'] },
             );
 
             expect(toJSON()).toBeNull();
@@ -269,7 +269,7 @@ describe('TradeDetailAlert', () => {
                     orderId="test-order-id"
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([]) },
+                { preloadedState: preloadedStateWithTrades([]), providers: ['intl'] },
             );
 
             expect(toJSON()).toBeNull();
@@ -284,7 +284,7 @@ describe('TradeDetailAlert', () => {
                     orderId="test-order-id"
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([]) },
+                { preloadedState: preloadedStateWithTrades([]), providers: ['intl'] },
             );
 
             expect(toJSON()).toBeNull();
@@ -299,7 +299,7 @@ describe('TradeDetailAlert', () => {
                     orderId="test-order-id"
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithoutTestProvider([]) },
+                { preloadedState: preloadedStateWithoutTestProvider([]), providers: ['intl'] },
             );
 
             expect(getByText('Transaction failed')).toBeTruthy();
@@ -315,7 +315,7 @@ describe('TradeDetailAlert', () => {
                     orderId={undefined}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([], null) },
+                { preloadedState: preloadedStateWithTrades([], null), providers: ['intl'] },
             );
 
             act(() => {
@@ -338,7 +338,10 @@ describe('TradeDetailAlert', () => {
                     orderId={buyTrade.data.orderId!}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([buyTrade], undefined) }, // No support URL
+                {
+                    preloadedState: preloadedStateWithTrades([buyTrade], undefined), // No support URL
+                    providers: ['intl'],
+                },
             );
 
             act(() => {
@@ -367,6 +370,7 @@ describe('TradeDetailAlert', () => {
                         [exchangeTrade],
                         TEST_PROVIDER_STATUS_URL,
                     ),
+                    providers: ['intl'],
                 },
             );
 
@@ -392,7 +396,10 @@ describe('TradeDetailAlert', () => {
                     orderId={buyTrade.data.orderId!}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithoutTestProvider([buyTrade]) },
+                {
+                    preloadedState: preloadedStateWithoutTestProvider([buyTrade]),
+                    providers: ['intl'],
+                },
             );
 
             act(() => {
@@ -420,7 +427,10 @@ describe('TradeDetailAlert', () => {
                     orderId={sellTrade.data.orderId!}
                     onOpenedBrowser={mockOnOpenedBrowser}
                 />,
-                { preloadedState: preloadedStateWithTrades([sellTrade], TEST_PROVIDER_STATUS_URL) },
+                {
+                    preloadedState: preloadedStateWithTrades([sellTrade], TEST_PROVIDER_STATUS_URL),
+                    providers: ['intl'],
+                },
             );
 
             act(() => {

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailAmountStack.test.tsx
@@ -1,17 +1,18 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { btcAsset } from '@suite-native/trading-fixtures';
 
 import { TradeDetailAmountStack } from '../TradeDetailAmountStack';
 
 describe('TradeDetailAmountStack', () => {
     it('should render fiat amount without crypto icon and fiat badge', () => {
-        const { getByText, queryByText } = renderWithBasicProvider(
+        const { getByText, queryByText } = renderWithProviders(
             <TradeDetailAmountStack
                 isCrypto={false}
                 amountString="$100.00"
                 amountValue="0.002"
                 currency="USD"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('$100.00')).toBeOnTheScreen();
@@ -19,13 +20,14 @@ describe('TradeDetailAmountStack', () => {
     });
 
     it('should render crypto amount with fiat badge', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <TradeDetailAmountStack
                 isCrypto={true}
                 amountString="0.5 BTC"
                 amountValue="0.5"
                 currency="bitcoin"
             />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('0.5 BTC')).toBeOnTheScreen();

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailFooter.test.tsx
@@ -29,7 +29,7 @@ describe('TradeDetailFooter', () => {
 
         const { toJSON } = renderWithStoreProvider(
             <TradeDetailFooter orderId="nonexistent_order_id" />,
-            { preloadedState },
+            { preloadedState, providers: ['intl'] },
         );
 
         expect(toJSON()).toBeNull();
@@ -41,7 +41,7 @@ describe('TradeDetailFooter', () => {
 
         const { getByText } = renderWithStoreProvider(
             <TradeDetailFooter orderId={sellTrade.data.orderId!} />,
-            { preloadedState },
+            { preloadedState, providers: ['intl'] },
         );
 
         fireEvent.press(getByText('Copy'));

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailHeader.test.tsx
@@ -26,7 +26,7 @@ describe('TradeDetailHeader', () => {
     const renderHeader = (orderId: string, trades: TradingTransaction[] = []) =>
         renderWithTradingProvider(
             <TradeDetailHeader orderId={orderId} onOpenedBrowser={jest.fn()} />,
-            { overrides: createOverrides(trades) },
+            { overrides: createOverrides(trades), providers: ['intl'] },
         );
 
     describe('Trade Not Found', () => {

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
@@ -54,7 +54,7 @@ describe('TradeDetailInfo', () => {
 
         const { toJSON } = renderWithStoreProvider(
             <TradeDetailInfo orderId="nonexistent_order_id" />,
-            { preloadedState },
+            { preloadedState, providers: ['intl', 'formatter'] },
         );
 
         expect(toJSON()).toBeNull();
@@ -67,7 +67,7 @@ describe('TradeDetailInfo', () => {
 
         const { getByText } = renderWithStoreProvider(
             <TradeDetailInfo orderId={buyTrade.data.orderId!} />,
-            { preloadedState },
+            { preloadedState, providers: ['intl', 'formatter'] },
         );
 
         expect(getByText('Mercuryo')).toBeTruthy();
@@ -84,7 +84,7 @@ describe('TradeDetailInfo', () => {
 
         const { getByText, queryByText } = renderWithStoreProvider(
             <TradeDetailInfo orderId={exchangeTrade.data.orderId!} />,
-            { preloadedState },
+            { preloadedState, providers: ['intl', 'formatter'] },
         );
 
         expect(getByText(/0[23]\/12\/2025/)).toBeTruthy();

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailInfo.test.tsx
@@ -8,6 +8,37 @@ import {
 
 import { TradeDetailInfo } from '../TradeDetailInfo';
 
+// The date assertions below encode the en-US format (MM/DD/YYYY). That's
+// fragile in two ways:
+//   1. `prepareDateFormatter` in @suite-common/formatters intentionally calls
+//      `new Intl.DateTimeFormat(undefined, …)` — it ignores the app's configured
+//      locale and follows the *device* locale. CI runs on Ubuntu with en_US, so
+//      there the test happens to pass; on a cs_CZ or de_DE dev box it fails.
+//   2. The assertion therefore tests the CI environment, not any behavior of
+//      this component. The cleaner long-term fix is either to loosen the regex
+//      or to make `prepareDateFormatter` respect `_config.locale` — that latter
+//      is a product decision (dates would start following the in-app language
+//      instead of the OS), so it's out of scope for a test fix.
+// As a localized workaround, wrap Intl.DateTimeFormat in a Proxy that defaults
+// the locale arg to en-US. Proxy (rather than `jest.spyOn(...).mockImplementation`)
+// is needed so that static methods like `supportedLocalesOf` keep working —
+// react-intl calls them during render.
+const OriginalDateTimeFormat = Intl.DateTimeFormat;
+beforeAll(() => {
+    (Intl as { DateTimeFormat: typeof Intl.DateTimeFormat }).DateTimeFormat = new Proxy(
+        OriginalDateTimeFormat,
+        {
+            construct: (target, args) => new target(args[0] ?? 'en-US', args[1]),
+            apply: (target, _thisArg, args) =>
+                Reflect.apply(target, undefined, [args[0] ?? 'en-US', args[1]]),
+        },
+    );
+});
+afterAll(() => {
+    (Intl as { DateTimeFormat: typeof Intl.DateTimeFormat }).DateTimeFormat =
+        OriginalDateTimeFormat;
+});
+
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {
         trading: {

--- a/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeDetailSheet/__tests__/TradeDetailTransactionInfo.test.tsx
@@ -71,6 +71,7 @@ describe('TradeDetailTransactionInfo', () => {
     ) =>
         renderWithTradingProvider(<TradeDetailTransactionInfo orderId={orderId} />, {
             overrides,
+            providers: ['intl', 'formatter'],
         });
 
     it('should not render when trade is not found', () => {

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
@@ -4,6 +4,37 @@ import { getBuyTrade, getInitializedTradingState } from '@suite-native/trading-f
 import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 import { TradeHistoryListItem } from '../TradeHistoryListItem';
 
+// The date assertions below encode the en-US format (MM/DD/YYYY at HH:MM).
+// That's fragile in two ways:
+//   1. `prepareDateFormatter` in @suite-common/formatters intentionally calls
+//      `new Intl.DateTimeFormat(undefined, …)` — it ignores the app's configured
+//      locale and follows the *device* locale. CI runs on Ubuntu with en_US, so
+//      there the test happens to pass; on a cs_CZ or de_DE dev box it fails.
+//   2. The assertion therefore tests the CI environment, not any behavior of
+//      this component. The cleaner long-term fix is either to loosen the regex
+//      or to make `prepareDateFormatter` respect `_config.locale` — that latter
+//      is a product decision (dates would start following the in-app language
+//      instead of the OS), so it's out of scope for a test fix.
+// As a localized workaround, wrap Intl.DateTimeFormat in a Proxy that defaults
+// the locale arg to en-US. Proxy (rather than `jest.spyOn(...).mockImplementation`)
+// is needed so that static methods like `supportedLocalesOf` keep working —
+// react-intl calls them during render.
+const OriginalDateTimeFormat = Intl.DateTimeFormat;
+beforeAll(() => {
+    (Intl as { DateTimeFormat: typeof Intl.DateTimeFormat }).DateTimeFormat = new Proxy(
+        OriginalDateTimeFormat,
+        {
+            construct: (target, args) => new target(args[0] ?? 'en-US', args[1]),
+            apply: (target, _thisArg, args) =>
+                Reflect.apply(target, undefined, [args[0] ?? 'en-US', args[1]]),
+        },
+    );
+});
+afterAll(() => {
+    (Intl as { DateTimeFormat: typeof Intl.DateTimeFormat }).DateTimeFormat =
+        OriginalDateTimeFormat;
+});
+
 describe('TradeHistoryListItem', () => {
     const renderTradeHistoryListItem = (transaction: TradingTransaction) =>
         renderWithTradingProvider(

--- a/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
+++ b/suite-native/module-trading/src/components/history/TradeHistoryListItem/__tests__/TradeHistoryListItem.test.tsx
@@ -39,7 +39,10 @@ describe('TradeHistoryListItem', () => {
     const renderTradeHistoryListItem = (transaction: TradingTransaction) =>
         renderWithTradingProvider(
             <TradeHistoryListItem transaction={transaction} onPress={jest.fn()} />,
-            { overrides: { wallet: { trading: getInitializedTradingState() } } },
+            {
+                overrides: { wallet: { trading: getInitializedTradingState() } },
+                providers: ['intl', 'formatter'],
+            },
         );
 
     it('should render trade correctly', () => {

--- a/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
+++ b/suite-native/module-trading/src/components/history/__tests__/TradeStatusBadge.test.tsx
@@ -8,7 +8,9 @@ import { TradeStatusBadge, getBadgeIconName, getBadgeVariant } from '../TradeSta
 
 describe('TradeStatusBadge', () => {
     it('should render nothing when status is undefined', () => {
-        const { toJSON } = renderWithTradingProvider(<TradeStatusBadge status={undefined} />);
+        const { toJSON } = renderWithTradingProvider(<TradeStatusBadge status={undefined} />, {
+            providers: ['intl'],
+        });
 
         expect(toJSON()).toBeNull();
     });
@@ -28,6 +30,7 @@ describe('TradeStatusBadge', () => {
             const buyTrade = getBuyTrade({ status });
             const { getByAccessibilityHint } = renderWithTradingProvider(
                 <TradeStatusBadge status={buyTrade.data.status} />,
+                { providers: ['intl'] },
             );
             const expectedText = new RegExp(
                 getTranslation(`moduleTrading.tradeHistory.status.${statusKey}`),
@@ -54,6 +57,7 @@ describe('TradeStatusBadge', () => {
             const exchangeTrade = getExchangeTrade({ status });
             const { getByAccessibilityHint } = renderWithTradingProvider(
                 <TradeStatusBadge status={exchangeTrade.data.status} />,
+                { providers: ['intl'] },
             );
             const expectedText = new RegExp(
                 getTranslation(`moduleTrading.tradeHistory.status.${statusKey}`),
@@ -78,6 +82,7 @@ describe('TradeStatusBadge', () => {
             const sellTrade = getSellTrade({ status });
             const { getByAccessibilityHint } = renderWithTradingProvider(
                 <TradeStatusBadge status={sellTrade.data.status} />,
+                { providers: ['intl'] },
             );
             const expectedText = new RegExp(
                 getTranslation(`moduleTrading.tradeHistory.status.${statusKey}`),

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsContent.test.tsx
@@ -44,6 +44,7 @@ describe('ReviewOutputsContent', () => {
                 exchangeFlowType="swap"
                 {...props}
             />,
+            { providers: ['intl', 'formatter', 'bottomSheet'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/__tests__/ReviewOutputsFooter.test.tsx
@@ -19,7 +19,7 @@ describe('ReviewOutputsFooter', () => {
                 testID="TEST_ID"
                 {...props}
             />,
-            { overrides },
+            { overrides, providers: ['intl'] },
         );
 
     it('should display "Send transaction" button', () => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountItem.test.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 
-import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { renderWithProviders, userEvent } from '@suite-native/test-utils';
 import { unverifiedBankAccount, verifiedBankAccount } from '@suite-native/trading-fixtures';
 
 import { BANK_ACCOUNT_ITEM_TEST_ID, SellBankAccountItem } from '../SellBankAccountItem';
 
 describe('SellBankAccountItem', () => {
     const renderSellBankAccountItem = (props = {}) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <SellBankAccountItem
                 bankAccount={verifiedBankAccount}
                 accessoryType="none"
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     describe('Rendering', () => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountPicker.test.tsx
@@ -38,6 +38,7 @@ describe('SellBankAccountPicker', () => {
         renderWithTradingProvider(<SellBankAccountPicker {...props} />, {
             tradeType: 'sell',
             overrides,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountSheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/__tests__/SellBankAccountSheet.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { renderWithProviders, userEvent } from '@suite-native/test-utils';
 import { bankAccounts, verifiedBankAccount } from '@suite-native/trading-fixtures';
 
 import { SellBankAccountSheet } from '../SellBankAccountSheet';
@@ -11,7 +11,7 @@ describe('SellBankAccountSheet', () => {
     const mockRef = { current: null };
 
     const renderSellBankAccountSheet = (props = {}) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <SellBankAccountSheet
                 ref={mockRef}
                 bankAccounts={bankAccounts}
@@ -20,6 +20,7 @@ describe('SellBankAccountSheet', () => {
                 closeModal={mockCloseModal}
                 {...props}
             />,
+            { providers: ['intl', 'bottomSheet'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFeePickerCard.test.tsx
@@ -28,6 +28,7 @@ describe('SellFeePickerCard', () => {
                     },
                 },
             },
+            providers: ['intl'],
         });
 
     it('should render nothing when isTxnError', () => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellFromAccountTradePreviewCard.test.tsx
@@ -19,6 +19,7 @@ describe('SellFromAccountTradePreviewCard', () => {
                     trading: { sell: { tradingAccountKey } },
                 },
             },
+            providers: ['intl', 'formatter'],
         });
 
     it('should render nothing when there is no quote', () => {

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewContinueButton.test.tsx
@@ -51,6 +51,7 @@ describe('SellPreviewContinueButton', () => {
             {
                 tradeType: 'sell',
                 overrides: mergeDeepObject(baseOverrides, extraOverrides),
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewScreenHeader.test.tsx
@@ -4,7 +4,7 @@ import { SellPreviewScreenHeader } from '../SellPreviewScreenHeader';
 
 describe('SellPreviewScreenHeader', () => {
     const renderSellPreviewScreenHeader = () =>
-        renderWithStoreProvider(<SellPreviewScreenHeader />);
+        renderWithStoreProvider(<SellPreviewScreenHeader />, { providers: ['intl', 'navigation'] });
 
     it('should render screen header with correct title', () => {
         const { getByText } = renderSellPreviewScreenHeader();

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellPreviewView.test.tsx
@@ -58,6 +58,7 @@ describe('SellPreviewView', () => {
             {
                 tradeType: 'sell',
                 overrides: baseOverrides(formStep),
+                providers: ['intl', 'formatter'],
             },
         );
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/__tests__/SellToFiatTradePreviewCard.test.tsx
@@ -20,6 +20,7 @@ describe('SellToFiatTradePreviewCard', () => {
 
         return renderWithStoreProvider(<SellToFiatTradePreviewCard {...props} />, {
             preloadedState,
+            providers: ['intl', 'formatter'],
         });
     };
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
@@ -14,11 +14,12 @@ describe('SellAlert', () => {
     const renderFormHook = () =>
         renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
     const renderTradingAlert = () =>
         renderWithProviders(<SellAlert />, {
-            providers: ['intl'],
+            providers: ['intl', 'navigation'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellAlert.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
@@ -17,7 +17,8 @@ describe('SellAlert', () => {
         });
 
     const renderTradingAlert = () =>
-        renderWithBasicProvider(<SellAlert />, {
+        renderWithProviders(<SellAlert />, {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellCard.test.tsx
@@ -19,6 +19,7 @@ describe('SellCard', () => {
     const renderForm = () =>
         renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     const renderSellCard = (isAmountInputActive: boolean) => {
@@ -32,6 +33,7 @@ describe('SellCard', () => {
         return renderWithStoreProvider(<SellCard isAmountInputActive={isAmountInputActive} />, {
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
             preloadedState: cardPreloadedState,
+            providers: ['intl', 'formatter', 'navigation'],
         });
     };
 

--- a/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellConfirmation.test.tsx
@@ -32,6 +32,7 @@ describe('SellConfirmation', () => {
     const renderConfirmation = () =>
         renderWithStoreProvider(<SellConfirmation />, {
             preloadedState: { wallet: { trading: getInitializedTradingStateWithQuotes() } },
+            providers: ['intl'],
         });
 
     it('should render continue button when canProceed is true', () => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
@@ -31,6 +31,7 @@ describe('SellForm', () => {
         renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
             overrides,
+            providers: ['intl', 'navigation', 'formatter'],
         });
 
     const renderSellForm = (
@@ -41,6 +42,7 @@ describe('SellForm', () => {
             tradeType: 'sell',
             overrides,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'services', 'navigation', 'formatter'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellForm.test.tsx
@@ -26,15 +26,6 @@ jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('SellForm', () => {
     const renderFormHook = (overrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
         renderHookWithTradingProvider(() => useSellForm(), {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellFormFieldErrorBadge.test.tsx
@@ -22,6 +22,7 @@ describe('SellFormFieldErrorBadge', () => {
     const renderUseTradingSellForm = () => {
         const { result } = renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -42,7 +43,7 @@ describe('SellFormFieldErrorBadge', () => {
             <Form form={form}>
                 <SellFormFieldErrorBadge {...props} />
             </Form>,
-            { tradeType: 'sell', overrides },
+            { tradeType: 'sell', overrides, providers: ['intl', 'formatter', 'navigation'] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTab.test.tsx
@@ -27,6 +27,7 @@ describe('SellTab', () => {
         const result = renderWithTradingProvider(<SellTab />, {
             tradeType: 'sell',
             overrides,
+            providers: ['intl', 'navigation'],
         });
 
         // wait for form reactions to run

--- a/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/__tests__/SellTabContent.test.tsx
@@ -23,7 +23,10 @@ describe('SellTabContent', () => {
     });
 
     const renderSellTabContent = () =>
-        renderWithTradingProvider(<SellTabContent />, { tradeType: 'sell' });
+        renderWithTradingProvider(<SellTabContent />, {
+            tradeType: 'sell',
+            providers: ['intl', 'navigation'],
+        });
 
     const expectSkeleton = () => {
         expect(screen.getAllByTestId('BoxSkeleton').length).toBeGreaterThan(0);

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatAmountInput.test.tsx
@@ -15,12 +15,13 @@ describe('SellFiatAmountInput', () => {
             <Form form={form}>
                 <SellFiatAmountInput />
             </Form>,
-            { tradeType: 'sell' },
+            { tradeType: 'sell', providers: ['intl', 'navigation'] },
         );
 
     const renderUseTradingSellForm = () => {
         const { result } = renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencyPicker.test.tsx
@@ -33,6 +33,7 @@ describe('SellFiatCurrencyPicker', () => {
         const preloadedState = { wallet: getWalletState({ tradeType: 'sell' }) };
         const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
         return renderWithStoreProvider(
@@ -41,6 +42,7 @@ describe('SellFiatCurrencyPicker', () => {
             </Form>,
             {
                 preloadedState,
+                providers: ['intl', 'bottomSheet', 'navigation'],
             },
         );
     };

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellFiatCurrencySheet.test.tsx
@@ -7,7 +7,10 @@ describe('SellFiatCurrencySheet', () => {
     const renderSellFiatCurrencySheet = () =>
         renderWithStoreProvider(
             <SellFiatCurrencySheet onFiatSelect={jest.fn()} onClose={jest.fn()} isVisible={true} />,
-            { preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) } },
+            {
+                preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
+                providers: ['intl', 'bottomSheet'],
+            },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -30,6 +30,7 @@ describe('SellReceiveMethodPicker', () => {
         renderWithStoreProvider(<SellReceiveMethodPicker />, {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell', overrides }),
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'navigation', 'formatter'],
         });
 
     beforeEach(() => {
@@ -41,6 +42,7 @@ describe('SellReceiveMethodPicker', () => {
 
         const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell' }),
+            providers: ['intl', 'navigation', 'formatter'],
         });
         form = result.current;
     });

--- a/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/__tests__/SellReceiveMethodPicker.test.tsx
@@ -21,15 +21,6 @@ import { SellReceiveMethodPicker } from '../SellReceiveMethodPicker';
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('SellReceiveMethodPicker', () => {
     let form: SellFormType;
 

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
@@ -21,15 +21,6 @@ import { SellProviderPicker } from '../SellProviderPicker';
 
 const reportMock = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 describe('SellProviderPicker', () => {
     let form: SellFormType;
 

--- a/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/__tests__/SellProviderPicker.test.tsx
@@ -30,6 +30,7 @@ describe('SellProviderPicker', () => {
         renderWithStoreProvider(<SellProviderPicker />, {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell', overrides }),
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'navigation', 'formatter'],
         });
 
     beforeEach(() => {
@@ -41,6 +42,7 @@ describe('SellProviderPicker', () => {
 
         const { result } = renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: createTradingPreloadedState({ tradeType: 'sell' }),
+            providers: ['intl', 'navigation', 'formatter'],
         });
         form = result.current;
     });

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAccountCryptoBalance.test.tsx
@@ -19,6 +19,7 @@ describe('SellSendAccountCryptoBalance', () => {
     const renderSellForm = () => {
         const { result } = renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
         return result.current;
@@ -28,6 +29,7 @@ describe('SellSendAccountCryptoBalance', () => {
         renderWithTradingProvider(<SellSendAccountCryptoBalance />, {
             tradeType: 'sell',
             wrapper: ({ children }) => <Form form={sellForm}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAmountInput.test.tsx
@@ -34,7 +34,7 @@ describe('SellSendAmountInput', () => {
             <Form form={form}>
                 <SellSendAmountInput showAssetsSheet={jest.fn()} {...props} />
             </Form>,
-            { tradeType: 'sell', overrides },
+            { tradeType: 'sell', overrides, providers: ['intl', 'navigation'] },
         );
 
     const renderUseTradingSellForm = (
@@ -43,6 +43,7 @@ describe('SellSendAmountInput', () => {
         const { result } = renderHookWithTradingProvider(() => useSellForm(), {
             tradeType: 'sell',
             overrides,
+            providers: ['intl', 'navigation'],
         });
 
         return result.current;

--- a/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/__tests__/SellSendAssetPicker.test.tsx
@@ -59,12 +59,17 @@ describe('SellSendAssetPicker', () => {
         },
     ];
 
-    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderSellForm = () =>
+        renderHookWithStoreProvider(() => useSellForm(), {
+            store,
+            providers: ['intl', 'formatter', 'navigation'],
+        });
 
     const renderSellSendAssetPicker = () =>
         renderWithStoreProvider(<SellSendAssetPicker />, {
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'formatter', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
+++ b/suite-native/module-trading/src/components/settings/__tests__/MaxSlippageForm.test.tsx
@@ -35,6 +35,7 @@ describe('MaxSlippageForm', () => {
     ) => {
         const ret = renderWithStoreProvider(<MaxSlippageForm onSubmit={jest.fn()} {...props} />, {
             store,
+            providers: ['intl'],
         });
 
         // wait for validators to run

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyData.test.tsx
@@ -58,6 +58,7 @@ describe('useBuyData', () => {
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store,
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyFlow.test.ts
@@ -41,10 +41,17 @@ describe('useBuyFlow', () => {
             },
         });
 
-    const renderBuyForm = () => renderHookWithStoreProvider(() => useBuyForm(), { store });
+    const renderBuyForm = () =>
+        renderHookWithStoreProvider(() => useBuyForm(), {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     const renderUseTradingBuyFlow = () =>
-        renderHookWithStoreProvider(() => useBuyFlow(buyForm), { store });
+        renderHookWithStoreProvider(() => useBuyFlow(buyForm), {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     describe('while loading quotes', () => {
         beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyForm.test.tsx
@@ -45,7 +45,10 @@ const btc3AccountKey = 'btc-account-3' as AccountKey; // Todo: create properly v
 
 describe('useBuyForm', () => {
     const renderUseTradingBuyForm = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useBuyForm(), { store });
+        renderHookWithStoreProvider(() => useBuyForm(), {
+            store,
+            providers: ['intl', 'navigation', 'formatter'],
+        });
 
     const getInitializedStore = (amountInSats = false) => {
         const tradingState = getInitializedTradingState();

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyInputFormControls.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import { type BuyFormType } from '@suite-native/trading-types';
 
 import { renderHookWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -12,7 +12,8 @@ describe('useBuyInputFormControls', () => {
     const renderBuyFormHook = () => renderHookWithTradingProvider(() => useBuyForm());
 
     const renderUseBuyInputFormControls = () =>
-        renderHookWithBasicProvider(() => useBuyInputFormControls('fiatValue'), {
+        renderHookWithProviders(() => useBuyInputFormControls('fiatValue'), {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/buy/__tests__/useBuyQuotes.test.ts
@@ -57,7 +57,7 @@ describe('useBuyQuotes', () => {
 
                 return form;
             },
-            { store },
+            { store, providers: ['intl', 'navigation'] },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/Approval/__tests__/useEvmApprovalFees.test.ts
@@ -71,7 +71,11 @@ describe('useEvmApprovalFees', () => {
     const renderUseEvmApprovalFees = (
         store: TestStore,
         params?: Parameters<typeof useEvmApprovalFees>[0],
-    ) => renderHookWithStoreProvider(() => useEvmApprovalFees(params), { store });
+    ) =>
+        renderHookWithStoreProvider(() => useEvmApprovalFees(params), {
+            store,
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         mockComposeEvmApprovalFeeLevelsThunk.mockReset().mockImplementation(() => ({

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.tsx
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeBuyTradeableAssetsFilteredData.test.tsx
@@ -17,6 +17,7 @@ describe('useExchangeBuyTradeableAssetsFilteredData', () => {
     const renderUseExchangeBuyTradeableAssetsFilteredData = () =>
         renderHookWithTradingProvider(() => useExchangeBuyTradeableAssetsFilteredData(), {
             tradeType: 'exchange',
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeData.test.ts
@@ -49,6 +49,7 @@ describe('useExchangeData', () => {
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store: effectiveStore,
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -60,7 +60,10 @@ describe('useExchangeFlow', () => {
 
         return {
             reportMock,
-            result: renderHookWithStoreProvider(() => useExchangeFlow(), { store }).result,
+            result: renderHookWithStoreProvider(() => useExchangeFlow(), {
+                store,
+                providers: ['intl'],
+            }).result,
         };
     };
 

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeFlow.test.ts
@@ -10,15 +10,6 @@ import {
 import { createTradingTestStore } from '../../../__tests__/tradingTestUtils';
 import { useExchangeFlow } from '../useExchangeFlow';
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 // Mock TrezorConnect to prevent errors during cleanup
 jest.mock('@trezor/connect', () => ({
     ...jest.requireActual('@trezor/connect'),

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -8,6 +8,7 @@ import {
 import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { FeatureFlag } from '@suite-native/feature-flags';
+import { useAnalytics } from '@suite-native/services';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
@@ -44,17 +45,6 @@ const createPrefetchDexQuoteApprovalThunkMock = (
     return () => result;
 };
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: () => ({
-            report: mockReport,
-        }),
-    };
-});
-
 const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('useExchangeForm', () => {
@@ -82,6 +72,10 @@ describe('useExchangeForm', () => {
         jest.restoreAllMocks();
         jest.clearAllMocks();
         store = getInitializedStore();
+
+        (useAnalytics as jest.Mock).mockReturnValue({
+            report: mockReport,
+        });
 
         jest.spyOn(exchangeThunks, 'prefetchDexQuoteApprovalThunk').mockImplementation(
             createPrefetchDexQuoteApprovalThunkMock,

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeForm.test.ts
@@ -51,7 +51,10 @@ describe('useExchangeForm', () => {
     let store: TestStore;
 
     const renderUseExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), {
+            store,
+            providers: ['intl', 'navigation', 'formatter'],
+        });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
+import { useAnalytics } from '@suite-native/services';
 import { type TestStore, act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import {
     btcAsset,
@@ -27,16 +28,7 @@ import { useExchangeQuotes } from '../useExchangeQuotes';
 
 const mockReport = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: () => ({
-            report: mockReport,
-        }),
-    };
-});
+let mockTimeSpent: number;
 
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
@@ -85,6 +77,7 @@ describe('useExchangeQuotes', () => {
 
     beforeEach(() => {
         mockReport.mockClear();
+        mockTimeSpent = 0;
     });
 
     it('should query quotes once all required data is selected', async () => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeQuotes.test.ts
@@ -28,8 +28,6 @@ import { useExchangeQuotes } from '../useExchangeQuotes';
 
 const mockReport = jest.fn();
 
-let mockTimeSpent: number;
-
 jest.mock('@trezor/react-utils', () => {
     const originalModule = jest.requireActual('@trezor/react-utils');
 
@@ -72,12 +70,14 @@ describe('useExchangeQuotes', () => {
 
                 return { form };
             },
-            { store },
+            { store, providers: ['intl', 'navigation'] },
         );
 
     beforeEach(() => {
         mockReport.mockClear();
-        mockTimeSpent = 0;
+        (useAnalytics as jest.Mock).mockReturnValue({
+            report: mockReport,
+        });
     });
 
     it('should query quotes once all required data is selected', async () => {

--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -102,12 +102,15 @@ describe('useExchangeSelectQuote', () => {
     };
 
     const renderExchangeForm = () =>
-        renderHookWithStoreProvider(() => useExchangeForm(), { store });
+        renderHookWithStoreProvider(() => useExchangeForm(), {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     const renderUseExchangeSelectQuote = () => {
         const hook = renderHookWithStoreProvider(
             () => useExchangeSelectQuoteWithReportSpy(exchangeForm),
-            { store },
+            { store, providers: ['intl', 'navigation'] },
         );
 
         const spy = hook.result.current.reportSpy;

--- a/suite-native/module-trading/src/hooks/general/__tests__/useActiveTradingTypeReaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useActiveTradingTypeReaction.test.ts
@@ -45,7 +45,10 @@ describe('useActiveTradingTypeReaction', () => {
     } as const;
 
     const renderUseActiveTradingTypeReaction = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), { store });
+        renderHookWithStoreProvider(() => useActiveTradingTypeReaction(), {
+            store,
+            providers: [],
+        });
 
     beforeEach(() => {
         castedSelectEnabledTradingTypes.mockReturnValue(['buy', 'exchange', 'sell']);

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAllTradesReloadTimer.test.ts
@@ -57,7 +57,7 @@ describe('useAllTradesReloadTimer', () => {
         });
 
     const renderUseAllTradesReloadTimer = (store: TestStore) =>
-        renderHookWithTradingProvider(() => useAllTradesReloadTimer(), { store });
+        renderHookWithTradingProvider(() => useAllTradesReloadTimer(), { store, providers: [] });
 
     it('should enable reload timer when there are trades to watch', () => {
         const mockTrades = [

--- a/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useAmountInputDecimals.test.ts
@@ -23,7 +23,9 @@ jest.mock('@suite-native/tokens', () => ({
 
 describe('useAmountInputDecimals', () => {
     const renderUseAmountInputDecimals = (account?: Account, contractAddress?: TokenAddress) =>
-        renderHookWithStoreProvider(() => useAmountInputDecimals(account, contractAddress));
+        renderHookWithStoreProvider(() => useAmountInputDecimals(account, contractAddress), {
+            providers: [],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useConvertFormValueToBaseUnit.test.ts
@@ -10,6 +10,7 @@ describe('useConvertFormValueToBaseUnit', () => {
 
         return renderHookWithStoreProvider(() => useConvertFormValueToBaseUnit(), {
             preloadedState,
+            providers: [],
         });
     };
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFiatCurrencyFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFiatCurrencyFilteredData.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 import { type FiatCurrencyItem } from '@suite-native/trading-types';
 
 import { useFiatCurrencyFilteredData } from '../useFiatCurrencyFilteredData';
@@ -23,7 +23,9 @@ const supportedFiatCurrencies: FiatCurrencyItem[] = [
 
 describe('useFiatCurrencyFilteredData', () => {
     const renderUseFiatCurrencyFilteredData = () =>
-        renderHookWithBasicProvider(() => useFiatCurrencyFilteredData(supportedFiatCurrencies));
+        renderHookWithProviders(() => useFiatCurrencyFilteredData(supportedFiatCurrencies), {
+            providers: ['intl'],
+        });
 
     it('should return section list data structure', () => {
         const { result } = renderUseFiatCurrencyFilteredData();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useFocusedValueWatch.test.tsx
@@ -42,6 +42,7 @@ describe('useFocusedValueWatch', () => {
     const renderForm = () =>
         renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState,
+            providers: ['intl', 'navigation'],
         });
 
     const renderUseFocusedValueWatch = () =>
@@ -49,6 +50,7 @@ describe('useFocusedValueWatch', () => {
             initialProps: { watch: form.watch },
             store,
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            providers: ['intl', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useGeolocationCountryCode.test.ts
@@ -40,7 +40,7 @@ describe('useGeolocationCountryCode', () => {
         });
 
     const renderUseGeolocationCountryCode = (store: TestStore) =>
-        renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store });
+        renderHookWithStoreProvider(() => useGeolocationCountryCode(), { store, providers: [] });
 
     it('should call geolocation thunk on mount', () => {
         const store = createGeolocationTestStore();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useMountedRecentlyFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useMountedRecentlyFlag.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 import { RECENT_DURATION, useMountedRecentlyFlag } from '../useMountedRecentlyFlag';
 
@@ -6,7 +6,8 @@ jest.mock('../useMountedRecentlyFlag', () => jest.requireActual('../useMountedRe
 
 describe('useMountedRecentlyFlag', () => {
     const renderUseMountedRecentlyFlag = () =>
-        renderHookWithBasicProvider(({ context }) => useMountedRecentlyFlag(context), {
+        renderHookWithProviders(({ context }) => useMountedRecentlyFlag(context), {
+            providers: ['intl'],
             initialProps: { context: 'context_1' },
         });
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useProviderFilters.test.ts
@@ -1,6 +1,6 @@
 import type { ExchangeTrade } from 'invity-api';
 
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 import { type QuotesByCategories } from '@suite-native/trading-types';
 
 import { useProviderFilters } from '../useProviderFilters';
@@ -12,15 +12,13 @@ type UseProviderFilterProps = {
 };
 describe('useProviderFilters', () => {
     const renderUseProviderFilters = (initialProps: UseProviderFilterProps) =>
-        renderHookWithBasicProvider(
+        renderHookWithProviders(
             ({
                 quotes = { fixed: [], float: [], dex: [] },
                 shouldShowFilters = true,
                 areTradingExchangeDexesEnabled = true,
             }) => useProviderFilters(quotes, shouldShowFilters, areTradingExchangeDexesEnabled),
-            {
-                initialProps,
-            },
+            { providers: ['intl'], initialProps },
         );
 
     it('filterItems should be stable', () => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useQuotesInvalidator.test.ts
@@ -34,6 +34,7 @@ describe('useQuotesInvalidator', () => {
                 getClearRequestAction,
                 getClearStateAction,
             },
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useReceiveAccountsListData.test.tsx
@@ -50,6 +50,7 @@ describe('useReceiveAccountsListData', () => {
                     selectedAccount: initialSelectedAccount,
                     mode: initialMode,
                 },
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetDominantColor.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradeableAssetDominantColor.test.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import { useNativeStyles } from '@trezor/styles-native';
 import { type CoinsColors, type Colors } from '@trezor/theme';
 
@@ -14,7 +14,7 @@ describe('useTradeableAssetDominantColor', () => {
         givenSymbol: NetworkSymbol,
         givenContractAddress?: TokenAddress,
     ) =>
-        renderHookWithBasicProvider(
+        renderHookWithProviders(
             ({
                 symbol,
                 contractAddress,
@@ -23,12 +23,13 @@ describe('useTradeableAssetDominantColor', () => {
                 contractAddress: TokenAddress | undefined;
             }) => useTradeableAssetDominantColor(symbol, contractAddress),
             {
+                providers: ['intl'],
                 initialProps: { symbol: givenSymbol, contractAddress: givenContractAddress },
             },
         );
 
     beforeAll(() => {
-        const { result } = renderHookWithBasicProvider(useNativeStyles);
+        const { result } = renderHookWithProviders(useNativeStyles, { providers: ['intl'] });
         ({ coinsColors, colors } = result.current.utils);
     });
 

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingFiatValues.test.ts
@@ -42,6 +42,7 @@ const renderUseTradingFiatValues = async (
 ) => {
     const res = renderHookWithTradingProvider(() => useTradingFiatValues(amount, cryptoId), {
         overrides,
+        providers: [],
     });
 
     // await mocked loading of rates

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTradingTransaction.test.ts
@@ -93,6 +93,7 @@ describe('useTradingTransaction', () => {
     const renderUseTradingTransaction = ({ store }: { store: TestStore }) =>
         renderHookWithTradingProvider(() => useTradingTransaction({ tradeType: 'exchange' }), {
             store,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { type TradingTransaction } from '@suite-common/trading';
 import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
-import { renderHook, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHook, renderHookWithProviders } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade } from '@suite-native/trading-fixtures';
 
 import { useTransactionStateChangeAnalyticsReporting } from '../useTransactionStateChangeAnalyticsReporting';
@@ -30,10 +30,10 @@ describe('useTransactionStateChangeAnalyticsReporting', () => {
     let reportMock: jest.Mock;
 
     const setup = (initialTrades: TradingTransaction[]) => {
-        const hook = renderHookWithBasicProvider(
-            ({ trades }: Props) => useHookWithReportSpy(trades),
-            { initialProps: { trades: initialTrades } },
-        );
+        const hook = renderHookWithProviders(({ trades }: Props) => useHookWithReportSpy(trades), {
+            providers: ['intl'],
+            initialProps: { trades: initialTrades },
+        });
 
         const spy = hook.result.current;
         activeSpies.push(spy);

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchAllTrades.test.ts
@@ -65,7 +65,7 @@ describe('useWatchAllTrades', () => {
         });
 
     const renderUseWatchAllTrades = (store: TestStore) =>
-        renderHookWithTradingProvider(() => useWatchAllTrades(), { store });
+        renderHookWithTradingProvider(() => useWatchAllTrades(), { store, providers: [] });
 
     it('should return empty arrays when no trades', () => {
         const store = getInitializedStore();

--- a/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/__tests__/useWatchTrade.test.ts
@@ -100,6 +100,7 @@ describe('useWatchTrade', () => {
     ) =>
         renderHookWithTradingProvider(() => useWatchTradeWithReportSpy(props), {
             store,
+            providers: ['services'],
         });
 
     describe('Trade Watching Behavior', () => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useContextForTradingForm.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useContextForTradingForm.test.ts
@@ -15,6 +15,7 @@ describe('useContextForTradingForm', () => {
     ) =>
         renderHookWithTradingProvider(() => useContextForTradingForm(limits), {
             overrides,
+            providers: ['intl', 'formatter'],
         });
 
     it('should return base context without limits and balance on initial render', () => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useCountryChangeEffect.test.tsx
@@ -26,7 +26,10 @@ describe('useCountryChangeEffect', () => {
     } as const;
 
     const renderUseCountryChangeEffect = (watch: CountryFormWatch) =>
-        renderHookWithStoreProvider(() => useCountryChangeEffect(watch), { store });
+        renderHookWithStoreProvider(() => useCountryChangeEffect(watch), {
+            store,
+            providers: [],
+        });
 
     beforeEach(() => {
         store = createLightStore({ reducer });

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useProviderMetadataChangeEffect.test.ts
@@ -29,6 +29,7 @@ describe('useProviderMetadataChangeEffect', () => {
         renderHookWithTradingProvider(() => useProviderMetadataChangeEffect(watch, 'buy'), {
             store,
             tradeType: 'buy',
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useReceiveAccountChangeEffect.test.ts
@@ -33,7 +33,7 @@ describe('useReceiveAccountChangeEffect', () => {
     const renderUseReceiveAccountChangeEffect = () =>
         renderHookWithStoreProvider(
             () => useReceiveAccountChangeEffect(setValue, selectExchangeSelectedReceiveAccount),
-            { store },
+            { store, providers: [] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountAssetBalance.test.ts
@@ -23,6 +23,7 @@ describe('useSendAccountAssetBalance', () => {
             {
                 preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
                 initialProps,
+                providers: [],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/__tests__/useSendAccountChangeEffect.test.ts
@@ -38,7 +38,7 @@ describe('useSendAccountChangeEffect', () => {
             () => {
                 useSendAccountChangeEffect(setValue, selectExchangeSelectedSendAccount);
             },
-            { store },
+            { store, providers: [] },
         );
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useChangeStringsExtractor.test.ts
@@ -15,6 +15,7 @@ describe('useChangeStringsExtractor', () => {
     const renderUseChangeStringsExtractor = (data: TradingTradeType | undefined) =>
         renderHookWithStoreProvider(() => useChangeStringsExtractor(data), {
             preloadedState: getPreloadedState(),
+            providers: ['formatter', 'intl'],
         });
 
     it('should extract strings for buy trade', () => {

--- a/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
+++ b/suite-native/module-trading/src/hooks/history/__tests__/useSymbolExtractor.test.ts
@@ -9,7 +9,10 @@ describe('useSymbolExtractor', () => {
     it('should return symbol for known cryptoId', () => {
         const { result } = renderHookWithStoreProvider(
             () => useSymbolExtractor('bitcoin' as CryptoId),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
+            {
+                preloadedState: { wallet: { trading: getInitializedTradingState() } },
+                providers: [],
+            },
         );
 
         expect(result.current).toBe('BTC');
@@ -18,7 +21,10 @@ describe('useSymbolExtractor', () => {
     it('should return original cryptoId for unknown cryptoId', () => {
         const { result } = renderHookWithStoreProvider(
             () => useSymbolExtractor('unknown-crypto' as CryptoId),
-            { preloadedState: { wallet: { trading: getInitializedTradingState() } } },
+            {
+                preloadedState: { wallet: { trading: getInitializedTradingState() } },
+                providers: [],
+            },
         );
 
         expect(result.current).toBe('unknown-crypto');
@@ -27,6 +33,7 @@ describe('useSymbolExtractor', () => {
     it('should handle undefined cryptoId', () => {
         const { result } = renderHookWithStoreProvider(() => useSymbolExtractor(undefined), {
             preloadedState: { wallet: { trading: getInitializedTradingState() } },
+            providers: [],
         });
 
         expect(result.current).toBeUndefined();

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useDelayedReviewOutputListDisplayFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useDelayedReviewOutputListDisplayFlag.test.ts
@@ -11,7 +11,9 @@ jest.mock('@suite-common/device', () => ({
 
 describe('useDelayedReviewOutputListDisplayFlag', () => {
     const renderUseRequestDelayedNavigationToOutputsReview = () =>
-        renderHookWithStoreProvider(() => useDelayedReviewOutputListDisplayFlag());
+        renderHookWithStoreProvider(() => useDelayedReviewOutputListDisplayFlag(), {
+            providers: [],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewErrorAlert.test.ts
@@ -21,6 +21,7 @@ describe('useTradingOutputsReviewErrorAlert', () => {
     const renderUseTradingOutputsReviewErrorAlert = (accountKey: AccountKey) =>
         renderHookWithTradingProvider(() => useTradingOutputsReviewErrorAlert(accountKey), {
             store,
+            providers: ['intl'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/__tests__/useTradingOutputsReviewScreenControls.test.ts
@@ -92,6 +92,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
                 }),
             {
                 store,
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellData.test.tsx
@@ -49,6 +49,7 @@ describe('useSellData', () => {
             {
                 initialProps: { reloadRequestOrdinal: reloadRequestOrdinalInitialValue },
                 store: store ?? getDefaultStore(),
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellFlow.test.ts
@@ -65,7 +65,8 @@ const btc1AccountKey = 'btc-account-1' as AccountKey; // Todo: create properly v
 describe('useSellFlow', () => {
     let store: TestStore;
 
-    const renderUseSellFlow = () => renderHookWithStoreProvider(() => useSellFlow(), { store });
+    const renderUseSellFlow = () =>
+        renderHookWithStoreProvider(() => useSellFlow(), { store, providers: ['intl'] });
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'sell' });

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -36,7 +36,11 @@ const btc1account = 'btc-account-1' as AccountKey; // Todo: create properly via 
 describe('useSellForm', () => {
     let store: TestStore;
 
-    const renderUseSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderUseSellForm = () =>
+        renderHookWithStoreProvider(() => useSellForm(), {
+            store,
+            providers: ['intl', 'navigation', 'formatter'],
+        });
 
     const getInitializedStore = (bitcoinAmountUnit = PROTO.AmountUnit.BITCOIN) =>
         createTradingLightStore({

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellForm.test.tsx
@@ -4,6 +4,7 @@ import { tradingSellActions } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { events } from '@suite-native/analytics';
 import { Form, useField } from '@suite-native/forms';
+import { useAnalytics } from '@suite-native/services';
 import {
     type TestStore,
     act,
@@ -30,17 +31,6 @@ import { useSellForm } from '../useSellForm';
 
 const mockReport = jest.fn();
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: () => ({
-            report: mockReport,
-        }),
-    };
-});
-
 const btc1account = 'btc-account-1' as AccountKey; // Todo: create properly via `createAccountKey()`
 
 describe('useSellForm', () => {
@@ -58,6 +48,10 @@ describe('useSellForm', () => {
 
     beforeEach(() => {
         store = getInitializedStore();
+        mockReport.mockClear();
+        (useAnalytics as jest.Mock).mockReturnValue({
+            report: mockReport,
+        });
     });
 
     afterEach(() => {

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellInputFormControls.test.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@suite-native/forms';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import { type SellFormType } from '@suite-native/trading-types';
 
 import { renderHookWithTradingProvider } from '../../../__tests__/tradingTestUtils';
@@ -13,7 +13,8 @@ describe('useSellInputFormControls', () => {
         renderHookWithTradingProvider(() => useSellForm(), { tradeType: 'sell' });
 
     const renderUseSellInputFormControls = () =>
-        renderHookWithBasicProvider(() => useSellInputFormControls('fiatStringAmount'), {
+        renderHookWithProviders(() => useSellInputFormControls('fiatStringAmount'), {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellQuotes.test.ts
@@ -56,7 +56,7 @@ describe('useSellQuotes', () => {
 
                 return form;
             },
-            { store },
+            { store, providers: ['intl', 'navigation'] },
         );
 
     afterEach(() => {

--- a/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/sell/__tests__/useSellSelectQuote.test.ts
@@ -19,10 +19,17 @@ describe('useSellSelectQuote', () => {
     let store: TestStore;
     let sellForm: SellFormType;
 
-    const renderSellForm = () => renderHookWithStoreProvider(() => useSellForm(), { store });
+    const renderSellForm = () =>
+        renderHookWithStoreProvider(() => useSellForm(), {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     const renderUseSellSelectQuote = () =>
-        renderHookWithStoreProvider(() => useSellSelectQuote(sellForm), { store });
+        renderHookWithStoreProvider(() => useSellSelectQuote(sellForm), {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     beforeEach(() => {
         store = createTradingLightStore({ tradeType: 'sell' });

--- a/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
+++ b/suite-native/module-trading/src/hooks/settings/__tests__/useMaxSlippageForm.test.ts
@@ -8,7 +8,7 @@ import { useMaxSlippageForm } from '../useMaxSlippageForm';
 
 describe('useMaxSlippageForm', () => {
     const renderUseMaxSlippageForm = (store: TestStore) =>
-        renderHookWithTradingProvider(() => useMaxSlippageForm(), { store });
+        renderHookWithTradingProvider(() => useMaxSlippageForm(), { store, providers: ['intl'] });
 
     it('should have default value from store', () => {
         const store = createTradingTestStore();

--- a/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.test.tsx
+++ b/suite-native/module-trading/src/navigation/__tests__/TradingStackNavigator.test.tsx
@@ -22,6 +22,7 @@ describe('TradingStackNavigator', () => {
                     [FeatureFlag.IsTradingBuyEnabled]: true,
                 }),
             },
+            providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
         });
 
         expect(getByTestId('@screen/Trading')).toBeTruthy();

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeApprovalScreen.test.tsx
@@ -74,7 +74,11 @@ describe('TradingExchangeApprovalScreen', () => {
     const renderScreen = () => {
         const result = renderWithTradingProvider(
             <TradingExchangeApprovalScreen route={{ params: {} } as any} navigation={{} as any} />,
-            { store, tradeType: 'exchange' },
+            {
+                store,
+                tradeType: 'exchange',
+                providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
+            },
         );
 
         ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -44,15 +44,6 @@ jest.mock('@react-navigation/native', () => ({
         }) as RouteProp<TradingStackParamList, TradingStackRoutes.TradingExchangePreview>,
 }));
 
-jest.mock('@suite-native/services', () => {
-    const original = jest.requireActual('@suite-native/services');
-
-    return {
-        ...original,
-        useAnalytics: jest.fn(),
-    };
-});
-
 let mockIsDeviceConnected = true;
 jest.mock('@suite-common/device', () => ({
     ...jest.requireActual('@suite-common/device'),

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangePreviewScreen.test.tsx
@@ -136,7 +136,7 @@ describe('TradingExchangePreviewScreen', () => {
                 navigation={createNavigationProps()}
                 route={createRouteProps(isApproved)}
             />,
-            { store: testStore },
+            { store: testStore, providers: ['intl', 'navigation', 'formatter'] },
         );
 
         ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingExchangeRevokeScreen.test.tsx
@@ -72,7 +72,11 @@ describe('TradingExchangeRevokeScreen', () => {
     const renderScreen = () => {
         const result = renderWithTradingProvider(
             <TradingExchangeRevokeScreen route={{ params: {} } as any} navigation={{} as any} />,
-            { store, tradeType: 'exchange' },
+            {
+                store,
+                tradeType: 'exchange',
+                providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
+            },
         );
 
         ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingHistoryScreen.test.tsx
@@ -61,7 +61,10 @@ describe('TradingHistoryScreen', () => {
     let unmount: (() => void) | undefined;
 
     const renderScreen = () => {
-        const result = renderWithTradingProvider(<TradingHistoryScreen />, { overrides });
+        const result = renderWithTradingProvider(<TradingHistoryScreen />, {
+            overrides,
+            providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
+        });
 
         ({ unmount } = result);
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingOutputsReviewScreen.test.tsx
@@ -139,7 +139,7 @@ describe('TradingSellOutputsReviewScreen', () => {
         ) => {
             const result = renderWithTradingProvider(
                 <TradingSellOutputsReviewScreen route={route} navigation={mockNavigation} />,
-                { store },
+                { store, providers: ['intl', 'navigation', 'formatter', 'bottomSheet'] },
             );
 
             ({ unmount } = result);
@@ -182,7 +182,7 @@ describe('TradingSellOutputsReviewScreen', () => {
         ) => {
             const result = renderWithTradingProvider(
                 <TradingExchangeOutputsReviewScreen route={route} navigation={mockNavigation} />,
-                { store },
+                { store, providers: ['intl', 'navigation', 'formatter', 'bottomSheet'] },
             );
 
             ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingReceiveAccountsPickerScreen.test.tsx
@@ -51,6 +51,7 @@ describe('TradingReceiveAccountsPickerScreen', () => {
         const result = renderWithTradingProvider(<TradingReceiveAccountsPickerScreen />, {
             tradeType: mockRouteParams.tradingType,
             overrides,
+            providers: ['intl', 'navigation', 'formatter'],
         });
 
         ({ unmount } = result);

--- a/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingScreen.test.tsx
@@ -69,7 +69,10 @@ describe('TradingScreen', () => {
     let unmount: (() => void) | undefined;
 
     const renderTradingScreen = (overrides?: PreloadedStatePartial<TradingTestPreloadedState>) => {
-        const result = renderWithTradingProvider(<TradingScreen />, { overrides });
+        const result = renderWithTradingProvider(<TradingScreen />, {
+            overrides,
+            providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
+        });
 
         ({ unmount } = result);
 

--- a/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
+++ b/suite-native/module-trading/src/screens/__tests__/TradingSellPreviewScreen.test.tsx
@@ -65,6 +65,7 @@ describe('TradingSellPreviewScreen', () => {
         const result = renderWithTradingProvider(<TradingSellPreviewScreen />, {
             overrides,
             tradeType: 'sell',
+            providers: ['intl', 'navigation', 'formatter', 'bottomSheet'],
         });
 
         unmount = result.unmount;

--- a/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/buy/__tests__/quotesUtils.test.ts
@@ -19,6 +19,7 @@ describe('quotesUtils', () => {
     const renderUseTradingBuyForm = () =>
         renderHookWithStoreProvider(() => useBuyForm(), {
             preloadedState: { wallet: { trading: getInitializedTradingState() } },
+            providers: ['intl', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
+++ b/suite-native/module-trading/src/utils/exchange/__tests__/quotesUtils.test.ts
@@ -24,6 +24,7 @@ describe('quotesUtils', () => {
     const renderUseTradingBuyForm = () =>
         renderHookWithTradingProvider(() => useExchangeForm(), {
             overrides: { wallet: { trading: getInitializedTradingState() } },
+            providers: ['intl', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
+++ b/suite-native/module-trading/src/utils/general/__tests__/kycUtils.test.tsx
@@ -1,7 +1,7 @@
 import type { ExchangeKYCType } from 'invity-api';
 
 import { Text } from '@suite-native/atoms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { getKycPolicyWarningTranslation } from '../kycUtils';
 
@@ -10,7 +10,7 @@ describe('getKycPolicyWarningTranslation', () => {
         const component = getKycPolicyWarningTranslation(type);
         if (!component) return null;
 
-        return renderWithBasicProvider(<Text>{component}</Text>);
+        return renderWithProviders(<Text>{component}</Text>, { providers: ['intl'] });
     };
 
     it.each([

--- a/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
+++ b/suite-native/module-trading/src/utils/general/__tests__/utils.test.ts
@@ -3,7 +3,7 @@ import type { BuyTradeStatus, ExchangeTradeStatus, SellTradeStatus } from 'invit
 import type { TradingTransaction, TradingType } from '@suite-common/trading';
 import { type FormDraftKeyPrefix } from '@suite-common/wallet-types';
 import { useTranslate } from '@suite-native/intl';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '@suite-native/trading-fixtures';
 
 import {
@@ -131,7 +131,9 @@ describe('utils', () => {
             ['Swap', 'exchange'],
         ])('should return "%s" for [%s] tradeType', (expectedTitle, tradeType) => {
             const trade = { tradeType } as TradingTransaction;
-            const { result } = renderHookWithBasicProvider(() => useTranslate());
+            const { result } = renderHookWithProviders(() => useTranslate(), {
+                providers: ['intl'],
+            });
 
             expect(getTradeTitle(trade, result.current.translate)).toBe(expectedTitle);
         });

--- a/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
+++ b/suite-native/module-trading/src/utils/sell/__tests__/quoteUtils.test.ts
@@ -14,6 +14,7 @@ describe('quoteUtils', () => {
     const renderUseTradingSellForm = () =>
         renderHookWithStoreProvider(() => useSellForm(), {
             preloadedState: { wallet: getWalletState({ tradeType: 'sell' }) },
+            providers: ['intl', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/test-utils-store/src/StoreProviderForTests.tsx
+++ b/suite-native/test-utils-store/src/StoreProviderForTests.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import type { EnhancedStore } from '@reduxjs/toolkit';
 
 import { useFormattersConfig } from '@suite-native/formatters-config';
-import { BasicProviderForTests } from '@suite-native/test-utils';
+import { ALL_PROVIDERS, ProviderForTests, type ProviderKey } from '@suite-native/test-utils';
 
 import { createStoreFromPreloadedState } from './createStoreFromPreloadedState';
 
@@ -14,15 +14,22 @@ type ReduxProviderProps = {
     children: ReactNode;
     preloadedState?: Record<string, unknown>;
     injectedStore?: TestStore;
+    providers?: ProviderKey[];
 };
 
-const BasicProviderWithFormattingConfig = ({ children }: { children: ReactNode }) => {
+const ProviderForTestsWithFormattingConfig = ({
+    children,
+    providers,
+}: {
+    children: ReactNode;
+    providers?: ProviderKey[];
+}) => {
     const formattersConfig = useFormattersConfig();
 
     return (
-        <BasicProviderForTests formattersConfig={formattersConfig}>
+        <ProviderForTests providers={providers} formattersConfig={formattersConfig}>
             {children}
-        </BasicProviderForTests>
+        </ProviderForTests>
     );
 };
 
@@ -35,6 +42,7 @@ export const StoreProviderForTests = ({
     children,
     injectedStore,
     preloadedState,
+    providers = ALL_PROVIDERS,
 }: ReduxProviderProps) => {
     const store = useMemo(() => {
         if (injectedStore) {
@@ -46,7 +54,9 @@ export const StoreProviderForTests = ({
 
     return (
         <Provider store={store}>
-            <BasicProviderWithFormattingConfig>{children}</BasicProviderWithFormattingConfig>
+            <ProviderForTestsWithFormattingConfig providers={providers}>
+                {children}
+            </ProviderForTestsWithFormattingConfig>
         </Provider>
     );
 };

--- a/suite-native/test-utils-store/src/renderWithStore.tsx
+++ b/suite-native/test-utils-store/src/renderWithStore.tsx
@@ -7,25 +7,33 @@ import {
     renderHook,
 } from '@testing-library/react-native';
 
+import type { ProviderKey } from '@suite-native/test-utils';
+
 import { StoreProviderForTests, type TestStore } from './StoreProviderForTests';
 
 export type RenderOptionsExtended = RenderOptions & {
     preloadedState?: Record<string, unknown>;
     store?: TestStore;
+    providers?: ProviderKey[];
 };
 
 export type RenderHookOptionsExtended<Props> = RenderHookOptions<Props> & {
     preloadedState?: Record<string, unknown>;
     store?: TestStore;
+    providers?: ProviderKey[];
 };
 
 export const renderWithStoreProvider = (
     element: ReactElement,
-    { preloadedState, wrapper: Wrapper, store, ...options }: RenderOptionsExtended = {},
+    { preloadedState, wrapper: Wrapper, store, providers, ...options }: RenderOptionsExtended = {},
 ) =>
     render(element, {
         wrapper: ({ children }) => (
-            <StoreProviderForTests preloadedState={preloadedState} injectedStore={store}>
+            <StoreProviderForTests
+                preloadedState={preloadedState}
+                injectedStore={store}
+                providers={providers}
+            >
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
             </StoreProviderForTests>
         ),
@@ -34,11 +42,21 @@ export const renderWithStoreProvider = (
 
 export const renderHookWithStoreProvider = <Result = unknown, Props = unknown>(
     callback: (props: Props) => Result,
-    { preloadedState, wrapper: Wrapper, store, ...options }: RenderHookOptionsExtended<Props> = {},
+    {
+        preloadedState,
+        wrapper: Wrapper,
+        store,
+        providers,
+        ...options
+    }: RenderHookOptionsExtended<Props> = {},
 ) =>
     renderHook(callback, {
         wrapper: ({ children }) => (
-            <StoreProviderForTests preloadedState={preloadedState} injectedStore={store}>
+            <StoreProviderForTests
+                preloadedState={preloadedState}
+                injectedStore={store}
+                providers={providers}
+            >
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
             </StoreProviderForTests>
         ),

--- a/suite-native/test-utils/README.md
+++ b/suite-native/test-utils/README.md
@@ -6,19 +6,27 @@ If your test needs a store (selectors, dispatched actions), use [`@suite-native/
 
 ## What it provides
 
-- `BasicProviderForTests` — wraps children in the providers needed to render atoms and intl-aware components outside a full app (theme, safe-area, intl, optional formatters).
-- `renderWithBasicProvider(element, options?)` — `@testing-library/react-native`'s `render` with `BasicProviderForTests` pre-applied.
-- `renderHookWithBasicProvider(callback, options?)` — same for hook tests.
+- `ProviderForTests` — wraps children in a composable provider stack. `SafeAreaProvider` and `StylesProvider` are always on; the rest (`intl`, `navigation`, `services`, `formatter`, `bottomSheet`) are opt-in via the `providers` prop.
+- `renderWithProviders(element, options?)` — `@testing-library/react-native`'s `render` with `ProviderForTests` pre-applied.
+- `renderHookWithProviders(callback, options?)` — same for hook tests.
+- `ALL_PROVIDERS` — convenience constant containing every opt-in provider key.
 - `extraDependenciesNativeMock` — native-side `extraDependencies` mock for slices that need it in tests.
 - Re-exports all of `@testing-library/react-native`.
 
-Both render helpers accept the standard render options plus a `formattersConfig?: FormatterProviderConfig` if the component under test renders formatted values.
+Both render helpers accept the standard render options plus:
+
+- `providers?: ProviderKey[]` — opt-in providers to include (default: `[]`, i.e. only the always-on base).
+- `formattersConfig?: FormatterProviderConfig` — only applied when `'formatter'` is in `providers`.
 
 ## Example
 
 ```tsx
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
-const { getByText } = renderWithBasicProvider(<MyStatelessComponent label="Hello" />);
+const { getByText } = renderWithProviders(<MyStatelessComponent label="Hello" />, {
+    providers: ['intl'],
+});
 expect(getByText('Hello')).toBeOnTheScreen();
 ```
+
+Pick the smallest `providers` list that makes the component render. Only add heavier providers (`navigation`, `services`, `formatter`, `bottomSheet`) if the component or a hook it calls actually needs them.

--- a/suite-native/test-utils/src/BasicProviderForTests.tsx
+++ b/suite-native/test-utils/src/BasicProviderForTests.tsx
@@ -12,8 +12,19 @@ import { prepareNativeTheme } from '@trezor/theme';
 
 import { extraDependenciesNativeMock } from './extraDependenciesNative.mock';
 
-type ProviderProps = {
+export type ProviderKey = 'intl' | 'navigation' | 'services' | 'formatter' | 'bottomSheet';
+
+export const ALL_PROVIDERS: ProviderKey[] = [
+    'intl',
+    'navigation',
+    'services',
+    'formatter',
+    'bottomSheet',
+];
+
+type ProviderForTestsProps = {
     children: ReactNode;
+    providers?: ProviderKey[];
     formattersConfig?: FormatterProviderConfig;
 };
 
@@ -27,18 +38,59 @@ const DEFAULT_FORMATTERS_CONFIG: FormatterProviderConfig = {
     is24HourFormat: true,
 };
 
-export const BasicProviderForTests = ({ children, formattersConfig }: ProviderProps) => (
-    <SafeAreaProvider>
-        <IntlProviderForTests>
-            <StylesProvider theme={theme} renderer={renderer}>
-                <NavigationContainer>
-                    <NativeServicesProvider services={extraDependenciesNativeMock.services}>
-                        <FormatterProvider config={formattersConfig ?? DEFAULT_FORMATTERS_CONFIG}>
-                            <BottomSheetModalProvider>{children}</BottomSheetModalProvider>
-                        </FormatterProvider>
-                    </NativeServicesProvider>
-                </NavigationContainer>
-            </StylesProvider>
-        </IntlProviderForTests>
-    </SafeAreaProvider>
+export const ProviderForTests = ({
+    children,
+    providers = [],
+    formattersConfig,
+}: ProviderForTestsProps) => {
+    const has = (key: ProviderKey) => providers.includes(key);
+
+    let tree: ReactNode = children;
+
+    if (has('bottomSheet')) {
+        tree = <BottomSheetModalProvider>{tree}</BottomSheetModalProvider>;
+    }
+    if (has('formatter')) {
+        tree = (
+            <FormatterProvider config={formattersConfig ?? DEFAULT_FORMATTERS_CONFIG}>
+                {tree}
+            </FormatterProvider>
+        );
+    }
+    if (has('services')) {
+        tree = (
+            <NativeServicesProvider services={extraDependenciesNativeMock.services}>
+                {tree}
+            </NativeServicesProvider>
+        );
+    }
+    if (has('navigation')) {
+        tree = <NavigationContainer>{tree}</NavigationContainer>;
+    }
+
+    tree = (
+        <StylesProvider theme={theme} renderer={renderer}>
+            {tree}
+        </StylesProvider>
+    );
+
+    if (has('intl')) {
+        tree = <IntlProviderForTests>{tree}</IntlProviderForTests>;
+    }
+
+    return <SafeAreaProvider>{tree}</SafeAreaProvider>;
+};
+
+type BasicProviderForTestsProps = {
+    children: ReactNode;
+    formattersConfig?: FormatterProviderConfig;
+};
+
+export const BasicProviderForTests = ({
+    children,
+    formattersConfig,
+}: BasicProviderForTestsProps) => (
+    <ProviderForTests providers={ALL_PROVIDERS} formattersConfig={formattersConfig}>
+        {children}
+    </ProviderForTests>
 );

--- a/suite-native/test-utils/src/ProviderForTests.tsx
+++ b/suite-native/test-utils/src/ProviderForTests.tsx
@@ -80,17 +80,3 @@ export const ProviderForTests = ({
 
     return <SafeAreaProvider>{tree}</SafeAreaProvider>;
 };
-
-type BasicProviderForTestsProps = {
-    children: ReactNode;
-    formattersConfig?: FormatterProviderConfig;
-};
-
-export const BasicProviderForTests = ({
-    children,
-    formattersConfig,
-}: BasicProviderForTestsProps) => (
-    <ProviderForTests providers={ALL_PROVIDERS} formattersConfig={formattersConfig}>
-        {children}
-    </ProviderForTests>
-);

--- a/suite-native/test-utils/src/index.tsx
+++ b/suite-native/test-utils/src/index.tsx
@@ -1,6 +1,6 @@
 export * from '@testing-library/react-native';
 
-export * from './BasicProviderForTests';
+export * from './ProviderForTests';
 export { extraDependenciesNativeMock } from './extraDependenciesNative.mock';
 
 export * from './renderBasic';

--- a/suite-native/test-utils/src/mocks/nativeServicesJestSetup.ts
+++ b/suite-native/test-utils/src/mocks/nativeServicesJestSetup.ts
@@ -1,0 +1,1 @@
+jest.mock('@suite-native/services', () => require('./nativeServicesMock'));

--- a/suite-native/test-utils/src/mocks/nativeServicesMock.tsx
+++ b/suite-native/test-utils/src/mocks/nativeServicesMock.tsx
@@ -1,13 +1,13 @@
 import { type ReactNode } from 'react';
 
 const analyticsMock = {
-    report: () => {},
-    isEnabled: () => true,
-    disable: () => {},
-    enable: () => {},
-    setUrl: () => {},
-    setLoggerEnabled: () => {},
-    init: () => {},
+    report: jest.fn(),
+    isEnabled: jest.fn(() => true),
+    disable: jest.fn(),
+    enable: jest.fn(),
+    setUrl: jest.fn(),
+    setLoggerEnabled: jest.fn(),
+    init: jest.fn(),
 };
 
 const servicesMock = {
@@ -16,6 +16,6 @@ const servicesMock = {
 
 export const NativeServicesProvider = ({ children }: { children: ReactNode }) => <>{children}</>;
 
-export const useNativeServices = () => servicesMock;
+export const useNativeServices = jest.fn(() => servicesMock);
 
-export const useAnalytics = () => analyticsMock;
+export const useAnalytics = jest.fn(() => analyticsMock);

--- a/suite-native/test-utils/src/mocks/nativeServicesMock.tsx
+++ b/suite-native/test-utils/src/mocks/nativeServicesMock.tsx
@@ -1,0 +1,21 @@
+import { type ReactNode } from 'react';
+
+const analyticsMock = {
+    report: () => {},
+    isEnabled: () => true,
+    disable: () => {},
+    enable: () => {},
+    setUrl: () => {},
+    setLoggerEnabled: () => {},
+    init: () => {},
+};
+
+const servicesMock = {
+    analytics: analyticsMock,
+};
+
+export const NativeServicesProvider = ({ children }: { children: ReactNode }) => <>{children}</>;
+
+export const useNativeServices = () => servicesMock;
+
+export const useAnalytics = () => analyticsMock;

--- a/suite-native/test-utils/src/renderBasic.tsx
+++ b/suite-native/test-utils/src/renderBasic.tsx
@@ -9,7 +9,7 @@ import {
 
 import type { FormatterProviderConfig } from '@suite-common/formatters';
 
-import { ALL_PROVIDERS, ProviderForTests, type ProviderKey } from './BasicProviderForTests';
+import { ProviderForTests, type ProviderKey } from './ProviderForTests';
 
 type ExtraOptions = {
     providers?: ProviderKey[];
@@ -51,13 +51,3 @@ export const renderHookWithProviders = <Result, Props>(
         ),
         ...options,
     });
-
-export const renderWithBasicProvider = <Props,>(
-    element: ReactElement<Props>,
-    options: RenderOptions & { formattersConfig?: FormatterProviderConfig } = {},
-) => renderWithProviders(element, { providers: ALL_PROVIDERS, ...options });
-
-export const renderHookWithBasicProvider = <Result, Props>(
-    callback: (props: Props) => Result,
-    options: RenderHookOptions<Props> & { formattersConfig?: FormatterProviderConfig } = {},
-) => renderHookWithProviders(callback, { providers: ALL_PROVIDERS, ...options });

--- a/suite-native/test-utils/src/renderBasic.tsx
+++ b/suite-native/test-utils/src/renderBasic.tsx
@@ -9,42 +9,55 @@ import {
 
 import type { FormatterProviderConfig } from '@suite-common/formatters';
 
-import { BasicProviderForTests } from './BasicProviderForTests';
+import { ALL_PROVIDERS, ProviderForTests, type ProviderKey } from './BasicProviderForTests';
 
-export const renderWithBasicProvider = <Props,>(
+type ExtraOptions = {
+    providers?: ProviderKey[];
+    formattersConfig?: FormatterProviderConfig;
+};
+
+export const renderWithProviders = <Props,>(
     element: ReactElement<Props>,
     {
+        providers,
         formattersConfig,
         wrapper: Wrapper,
         ...options
-    }: RenderOptions & {
-        formattersConfig?: FormatterProviderConfig;
-    } = {},
+    }: RenderOptions & ExtraOptions = {},
 ) =>
     render(element, {
         wrapper: ({ children }) => (
-            <BasicProviderForTests formattersConfig={formattersConfig}>
+            <ProviderForTests providers={providers} formattersConfig={formattersConfig}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
-            </BasicProviderForTests>
+            </ProviderForTests>
         ),
         ...options,
     });
 
-export const renderHookWithBasicProvider = <Result, Props>(
+export const renderHookWithProviders = <Result, Props>(
     callback: (props: Props) => Result,
     {
+        providers,
         formattersConfig,
         wrapper: Wrapper,
         ...options
-    }: RenderHookOptions<Props> & {
-        formattersConfig?: FormatterProviderConfig;
-    } = {},
+    }: RenderHookOptions<Props> & ExtraOptions = {},
 ) =>
     renderHook(callback, {
         wrapper: ({ children }) => (
-            <BasicProviderForTests formattersConfig={formattersConfig}>
+            <ProviderForTests providers={providers} formattersConfig={formattersConfig}>
                 {Wrapper ? <Wrapper>{children}</Wrapper> : children}
-            </BasicProviderForTests>
+            </ProviderForTests>
         ),
         ...options,
     });
+
+export const renderWithBasicProvider = <Props,>(
+    element: ReactElement<Props>,
+    options: RenderOptions & { formattersConfig?: FormatterProviderConfig } = {},
+) => renderWithProviders(element, { providers: ALL_PROVIDERS, ...options });
+
+export const renderHookWithBasicProvider = <Result, Props>(
+    callback: (props: Props) => Result,
+    options: RenderHookOptions<Props> & { formattersConfig?: FormatterProviderConfig } = {},
+) => renderHookWithProviders(callback, { providers: ALL_PROVIDERS, ...options });

--- a/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useExchangeAnalyticReportCallback.test.ts
@@ -45,6 +45,7 @@ describe('useExchangeAnalyticReportCallback', () => {
     } = {}) =>
         renderHookWithStoreProvider(() => useExchangeAnalyticReportCallback(candidateQuote), {
             preloadedState,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
+++ b/suite-native/trading-analytics/src/hooks/__tests__/useTradingAnalyticReportCallback.test.ts
@@ -56,7 +56,7 @@ describe('useTradingAnalyticReportCallback', () => {
         it('should return sell analytics callback', () => {
             const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('sell'),
-                { preloadedState },
+                { preloadedState, providers: [] },
             );
 
             (result.current as (step: TradingSellStep, action: TradingSellAction) => void)(
@@ -93,7 +93,7 @@ describe('useTradingAnalyticReportCallback', () => {
         it('should return exchange analytics callback', () => {
             const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('exchange'),
-                { preloadedState },
+                { preloadedState, providers: [] },
             );
 
             (result.current as (step: TradingExchangeStep, action: TradingExchangeAction) => void)(
@@ -122,7 +122,7 @@ describe('useTradingAnalyticReportCallback', () => {
         it('should return null action (no analytics)', () => {
             const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback(undefined),
-                { preloadedState },
+                { preloadedState, providers: [] },
             );
 
             result.current('fee-selection', 'visit');
@@ -141,7 +141,7 @@ describe('useTradingAnalyticReportCallback', () => {
         it('should return null action (no analytics)', () => {
             const { result } = renderHookWithStoreProvider(
                 () => useTradingAnalyticReportCallback('buy'),
-                { preloadedState },
+                { preloadedState, providers: [] },
             );
 
             result.current('fee-selection', 'visit');

--- a/suite-native/trading-atoms/src/components/Error/__tests__/ServerOffline.test.tsx
+++ b/suite-native/trading-atoms/src/components/Error/__tests__/ServerOffline.test.tsx
@@ -1,10 +1,12 @@
-import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { ServerOffline, type ServerOfflineProps } from '../ServerOffline';
 
 describe('ServerOffline', () => {
     const renderServerOffline = (props: Partial<ServerOfflineProps>) =>
-        renderWithBasicProvider(<ServerOffline onRetryPress={jest.fn()} {...props} />);
+        renderWithProviders(<ServerOffline onRetryPress={jest.fn()} {...props} />, {
+            providers: ['intl'],
+        });
 
     it('should call onRetryPress when "Try again" button is pressed', () => {
         const retryPressMock = jest.fn();

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/NetworkAndAccountCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/NetworkAndAccountCard.test.tsx
@@ -41,6 +41,7 @@ describe('NetworkAndAccountCard', () => {
                         },
                     },
                 }),
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeInfoHeader.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeInfoHeader.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { Text } from '@suite-native/atoms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { TradeInfoHeader } from '../TradeInfoHeader';
 
 describe('TradeInfoHeader', () => {
     const renderTradeInfoRow = (title: string, props = {}) =>
-        renderWithBasicProvider(<TradeInfoHeader title={title} {...props} />);
+        renderWithProviders(<TradeInfoHeader title={title} {...props} />, { providers: ['intl'] });
 
     it('should render title', () => {
         const { getByText } = renderTradeInfoRow('Test Title', {});

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeInfoRow.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeInfoRow.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { Text } from '@suite-native/atoms';
-import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
+import { renderWithProviders, userEvent } from '@suite-native/test-utils';
 
 import { TradeInfoRow } from '../TradeInfoRow';
 
 describe('TradeInfoRow', () => {
-    const renderTradeInfoRow = (props = {}) => renderWithBasicProvider(<TradeInfoRow {...props} />);
+    const renderTradeInfoRow = (props = {}) =>
+        renderWithProviders(<TradeInfoRow {...props} />, { providers: ['intl'] });
 
     it('should render children content', () => {
         const { getByText } = renderTradeInfoRow({ children: <Text>Test Content</Text> });

--- a/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/TradeInfo/__tests__/TradeSideCard.test.tsx
@@ -48,6 +48,7 @@ describe('TradeSideCard', () => {
                         },
                     } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
                 }),
+                providers: ['intl'],
             },
         );
 

--- a/suite-native/trading-atoms/src/components/__tests__/AccountAddress.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/AccountAddress.test.tsx
@@ -1,12 +1,13 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { AccountAddress } from '../AccountAddress';
 
 describe('AccountAddress', () => {
     describe('full form', () => {
         it('should render full address', () => {
-            const { getByText } = renderWithBasicProvider(
+            const { getByText } = renderWithProviders(
                 <AccountAddress address="0x1234567890abcdef" />,
+                { providers: ['intl'] },
             );
 
             expect(getByText('0x1234567890abcdef')).toBeTruthy();
@@ -15,15 +16,18 @@ describe('AccountAddress', () => {
 
     describe('short form', () => {
         it('should render address with ellipsis', () => {
-            const { getByText } = renderWithBasicProvider(
+            const { getByText } = renderWithProviders(
                 <AccountAddress address="0x1234567890abcdef" form="short" />,
+                { providers: ['intl'] },
             );
 
             expect(getByText('0x123456...')).toBeTruthy();
         });
 
         it('should render full address when it is shorter than 9 characters', () => {
-            const { getByText } = renderWithBasicProvider(<AccountAddress address="0x123456" />);
+            const { getByText } = renderWithProviders(<AccountAddress address="0x123456" />, {
+                providers: ['intl'],
+            });
 
             expect(getByText('0x123456')).toBeTruthy();
         });

--- a/suite-native/trading-atoms/src/components/__tests__/AmountEditingDoneButton.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/AmountEditingDoneButton.test.tsx
@@ -1,13 +1,15 @@
 import { Keyboard } from 'react-native';
 
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { AmountEditingDoneButton } from '../AmountEditingDoneButton';
 
 describe('AmountEditingDoneButton', () => {
     it('should remove focus from active input', () => {
         const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
-        const { getByText } = renderWithBasicProvider(<AmountEditingDoneButton />);
+        const { getByText } = renderWithProviders(<AmountEditingDoneButton />, {
+            providers: ['intl'],
+        });
 
         fireEvent.press(getByText('Done'));
 

--- a/suite-native/trading-atoms/src/components/__tests__/BottomSheetSearchInputWithCancel.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/BottomSheetSearchInputWithCancel.test.tsx
@@ -1,5 +1,5 @@
 import { type BottomSheetSearchInputProps } from '@suite-native/atoms';
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { BottomSheetSearchInputWithCancel } from '../BottomSheetSearchInputWithCancel';
 
@@ -17,9 +17,9 @@ jest.mock('@trezor/react-utils', () => {
 
 describe('SearchInputWithCancel', () => {
     const renderSearchInputWithCancel = (props: Partial<BottomSheetSearchInputProps>) =>
-        renderWithBasicProvider(
-            <BottomSheetSearchInputWithCancel onChange={jest.fn()} {...props} />,
-        );
+        renderWithProviders(<BottomSheetSearchInputWithCancel onChange={jest.fn()} {...props} />, {
+            providers: ['intl', 'bottomSheet'],
+        });
 
     it('should render without "Cancel" button by default', async () => {
         const { queryByText } = await renderSearchInputWithCancel({});

--- a/suite-native/trading-atoms/src/components/__tests__/EmptyComponent.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/EmptyComponent.test.tsx
@@ -1,11 +1,12 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { EmptyComponent } from '../EmptyComponent';
 
 describe('EmptyComponent', () => {
     it('should render given title and description', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <EmptyComponent title="TITLE" description="DESCRIPTION" />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('TITLE')).toBeTruthy();

--- a/suite-native/trading-atoms/src/components/__tests__/NetworkBadge.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/NetworkBadge.test.tsx
@@ -1,11 +1,11 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { NetworkBadge } from '../NetworkBadge';
 
 describe('NetworkBadge', () => {
     const renderPlatformBadge = (symbol: NetworkSymbol) =>
-        renderWithBasicProvider(<NetworkBadge symbol={symbol} />);
+        renderWithProviders(<NetworkBadge symbol={symbol} />, { providers: ['intl'] });
 
     it('should render badge with platform name', () => {
         const { getByLabelText } = renderPlatformBadge('eth');

--- a/suite-native/trading-atoms/src/components/__tests__/OverviewRow.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/OverviewRow.test.tsx
@@ -1,14 +1,15 @@
 import { Text } from '@suite-native/atoms';
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { OverviewRow } from '../OverviewRow';
 
 describe('OverviewRow', () => {
     it('should use title as left text as well as a11yLabel', () => {
-        const { getByText, getByLabelText } = renderWithBasicProvider(
+        const { getByText, getByLabelText } = renderWithProviders(
             <OverviewRow title="Title" onPress={jest.fn()}>
                 <Text>Child</Text>
             </OverviewRow>,
+            { providers: ['intl'] },
         );
 
         expect(getByText('Title')).toBeTruthy();
@@ -17,10 +18,11 @@ describe('OverviewRow', () => {
 
     it('should call onPress callback when clicked', () => {
         const onPress = jest.fn();
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <OverviewRow title="Title" onPress={onPress}>
                 <Text>Child</Text>
             </OverviewRow>,
+            { providers: ['intl'] },
         );
 
         fireEvent.press(getByText('Title'));
@@ -29,20 +31,22 @@ describe('OverviewRow', () => {
     });
 
     it('should render warning when added', () => {
-        const { queryByHintText } = renderWithBasicProvider(
+        const { queryByHintText } = renderWithProviders(
             <OverviewRow title="Title" warning="Warning message">
                 <Text>Child</Text>
             </OverviewRow>,
+            { providers: ['intl'] },
         );
 
         expect(queryByHintText('Warning')).toHaveTextContent(/^.Warning message$/);
     });
 
     it('should not render warning when not added', () => {
-        const { queryByHintText } = renderWithBasicProvider(
+        const { queryByHintText } = renderWithProviders(
             <OverviewRow title="Title">
                 <Text>Child</Text>
             </OverviewRow>,
+            { providers: ['intl'] },
         );
 
         expect(queryByHintText('Warning')).not.toBeOnTheScreen();

--- a/suite-native/trading-atoms/src/components/__tests__/WaitingCard.test.tsx
+++ b/suite-native/trading-atoms/src/components/__tests__/WaitingCard.test.tsx
@@ -1,12 +1,14 @@
 import { Text } from 'react-native';
 
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { WaitingCard, type WaitingCardProps } from '../WaitingCard';
 
 describe('ProviderWaitingCard', () => {
     const renderProviderWaitingCard = (props: Partial<WaitingCardProps>) =>
-        renderWithBasicProvider(<WaitingCard title="TITLE" subtitle="SUBTITLE" {...props} />);
+        renderWithProviders(<WaitingCard title="TITLE" subtitle="SUBTITLE" {...props} />, {
+            providers: ['intl'],
+        });
 
     it('should render', () => {
         const { getByText } = renderProviderWaitingCard({});

--- a/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useBottomSheetControls.test.ts
@@ -1,6 +1,6 @@
 import { Keyboard } from 'react-native';
 
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 import { useBottomSheetControls } from '../useBottomSheetControls';
 
@@ -11,13 +11,17 @@ describe('useBottomSheetControls', () => {
 
     describe('isSheetVisible', () => {
         it('should be false by default', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const { result } = renderHookWithProviders(() => useBottomSheetControls(), {
+                providers: ['intl', 'navigation', 'bottomSheet'],
+            });
 
             expect(result.current.isSheetVisible).toBe(false);
         });
 
         it('should be true after showTradeableAssetsSheet call and Keyboard.dismiss should be called one time', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const { result } = renderHookWithProviders(() => useBottomSheetControls(), {
+                providers: ['intl', 'navigation', 'bottomSheet'],
+            });
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
@@ -29,7 +33,9 @@ describe('useBottomSheetControls', () => {
         });
 
         it('should be false after hideSheet call and Keyboard.dismiss should be called two times by default', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const { result } = renderHookWithProviders(() => useBottomSheetControls(), {
+                providers: ['intl', 'navigation', 'bottomSheet'],
+            });
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
@@ -42,7 +48,9 @@ describe('useBottomSheetControls', () => {
         });
 
         it('should be false after hideSheet call with shouldHideKeyboard=true and Keyboard.dismiss should be called two times', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const { result } = renderHookWithProviders(() => useBottomSheetControls(), {
+                providers: ['intl', 'navigation', 'bottomSheet'],
+            });
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {
@@ -55,7 +63,9 @@ describe('useBottomSheetControls', () => {
         });
 
         it('should be false after hideSheet call with shouldHideKeyboard=false and Keyboard.dismiss should be called only once', () => {
-            const { result } = renderHookWithBasicProvider(() => useBottomSheetControls());
+            const { result } = renderHookWithProviders(() => useBottomSheetControls(), {
+                providers: ['intl', 'navigation', 'bottomSheet'],
+            });
             const keyboardDismissSpy = jest.spyOn(Keyboard, 'dismiss');
 
             act(() => {

--- a/suite-native/trading-atoms/src/hooks/__tests__/useSectionList.test.tsx
+++ b/suite-native/trading-atoms/src/hooks/__tests__/useSectionList.test.tsx
@@ -1,13 +1,13 @@
 import { Text } from 'react-native';
 
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 
 import { type UseSectionListProps, useSectionList } from '../useSectionList';
 
 const renderUseSectionListHook = <T, U = undefined>(
     initialProps: Partial<UseSectionListProps<T, U>>,
 ) =>
-    renderHookWithBasicProvider(
+    renderHookWithProviders(
         ({
             data = [],
             noSingletonSectionHeader = false,
@@ -24,9 +24,7 @@ const renderUseSectionListHook = <T, U = undefined>(
                 renderSectionHeader,
                 SectionEmptyComponent,
             }),
-        {
-            initialProps,
-        },
+        { providers: ['intl'], initialProps },
     );
 
 describe('useSectionList', () => {

--- a/suite-native/trading-browser-auth/src/components/__tests__/ConfirmationFailed.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ConfirmationFailed.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { ConfirmationFailed } from '../ConfirmationFailed';
 
@@ -12,7 +12,8 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 describe('ConfirmationFailed', () => {
-    const renderConfirmationFailed = () => renderWithBasicProvider(<ConfirmationFailed />);
+    const renderConfirmationFailed = () =>
+        renderWithProviders(<ConfirmationFailed />, { providers: ['intl', 'navigation'] });
 
     it('should navigate back on button press', () => {
         const { getByText } = renderConfirmationFailed();

--- a/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ProviderConfirmationStatusInfo.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 import { type ProviderConfirmationStatus } from '@suite-native/trading-types';
 
 import { ProviderConfirmationStatusInfo } from '../ProviderConfirmationStatusInfo';
@@ -11,7 +11,9 @@ jest.mock('../../hooks/useProviderConfirmationStatus', () => ({
 
 describe('ProviderConfirmationStatusInfo', () => {
     const renderProviderConfirmationStatusInfo = () =>
-        renderWithBasicProvider(<ProviderConfirmationStatusInfo />);
+        renderWithProviders(<ProviderConfirmationStatusInfo />, {
+            providers: ['intl', 'navigation'],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-browser-auth/src/components/__tests__/ProviderStatusDevButtons.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/__tests__/ProviderStatusDevButtons.test.tsx
@@ -19,7 +19,10 @@ describe('ProviderStatusDevButtons', () => {
     let store: TestStore;
 
     const renderProviderStatusDevButtons = () =>
-        renderWithStoreProvider(<ProviderStatusDevButtons />, { store });
+        renderWithStoreProvider(<ProviderStatusDevButtons />, {
+            store,
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserAuth.test.ts
@@ -61,7 +61,10 @@ describe('useBrowserAuth', () => {
     let store: TestStore;
 
     const renderUseBrowserAuth = (tradingType: TradingType = 'sell') =>
-        renderHookWithStoreProvider(() => useBrowserAuth(tradingType), { store });
+        renderHookWithStoreProvider(() => useBrowserAuth(tradingType), {
+            store,
+            providers: ['intl'],
+        });
 
     const defaultWalletState = getWalletState();
 
@@ -105,6 +108,7 @@ describe('useBrowserAuth', () => {
             mockOpenBrowserAsync.mockResolvedValue({ type: WebBrowserResultType.OPENED });
             const { result } = renderHookWithStoreProvider(() => useBrowserAuth(undefined), {
                 store,
+                providers: ['intl'],
             });
 
             await act(async () => {

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserStateChangeCallbacks.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useBrowserStateChangeCallbacks.test.ts
@@ -28,6 +28,7 @@ describe('useBrowserStateChangeCallbacks', () => {
     const renderUseBrowserwStateChangeCallbacks = (tradingType: TradingType | undefined) =>
         renderHookWithStoreProvider(() => useBrowserStateChangeCallbacks(tradingType), {
             store,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useDispatchProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useDispatchProviderConfirmationStatus.test.ts
@@ -18,7 +18,10 @@ describe('useDispatchProviderConfirmationStatus', () => {
     let store: TestStore;
 
     const renderUseDispatchProviderConfirmationStatus = () =>
-        renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), { store });
+        renderHookWithStoreProvider(() => useDispatchProviderConfirmationStatus(), {
+            store,
+            providers: [],
+        });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useOnForegroundCallback.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useOnForegroundCallback.test.ts
@@ -1,6 +1,6 @@
 import { AppState } from 'react-native';
 
-import { act, renderHookWithBasicProvider, screen } from '@suite-native/test-utils';
+import { act, renderHookWithProviders, screen } from '@suite-native/test-utils';
 
 import { useOnForegroundCallback } from '../useOnForegroundCallback';
 
@@ -15,7 +15,9 @@ describe('useOnForegroundCallback', () => {
     const appStateSpy = jest.spyOn(AppState, 'addEventListener');
 
     const renderUseOnFocusCallback = () =>
-        renderHookWithBasicProvider(() => useOnForegroundCallback(mockCallback), {});
+        renderHookWithProviders(() => useOnForegroundCallback(mockCallback), {
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/__tests__/useProviderConfirmationStatus.test.ts
@@ -25,6 +25,7 @@ describe('useProviderConfirmationStatus', () => {
     const renderUseProviderConfirmationStatus = () =>
         renderHookWithStoreProvider(() => useProviderConfirmationStatus(), {
             store,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/trading-debug/src/components/__tests__/CopyableText.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/CopyableText.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { CopyableText, type CopyableTextProps } from '../CopyableText';
 
@@ -10,7 +10,7 @@ jest.mock('@suite-native/clipboard', () => ({
 
 describe('CopyableText', () => {
     const renderCopyableText = (props: Partial<CopyableTextProps>) =>
-        renderWithBasicProvider(<CopyableText text="TEST TEXT" {...props} />);
+        renderWithProviders(<CopyableText text="TEST TEXT" {...props} />, { providers: ['intl'] });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-debug/src/components/__tests__/CopyableText.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/CopyableText.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@suite-native/clipboard', () => ({
 
 describe('CopyableText', () => {
     const renderCopyableText = (props: Partial<CopyableTextProps>) =>
-        renderWithProviders(<CopyableText text="TEST TEXT" {...props} />, { providers: ['intl'] });
+        renderWithProviders(<CopyableText text="TEST TEXT" {...props} />, { providers: [] });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-debug/src/components/__tests__/DebugModeCopyableText.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/DebugModeCopyableText.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { DebugModeCopyableText, type DebugModeCopyableTextProps } from '../DebugModeCopyableText';
 
@@ -10,7 +10,9 @@ jest.mock('../../hooks/useTradingDebugModeFlag', () => ({
 
 describe('DebugModeCopyableText', () => {
     const renderDebugModeCopyableText = (props: Partial<DebugModeCopyableTextProps>) =>
-        renderWithBasicProvider(<DebugModeCopyableText text="TEST TEXT" {...props} />);
+        renderWithProviders(<DebugModeCopyableText text="TEST TEXT" {...props} />, {
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         mockDebugMode = true;

--- a/suite-native/trading-debug/src/components/__tests__/DebugModeView.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/DebugModeView.test.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@suite-native/atoms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { DebugModeView } from '../DebugModeView';
 
@@ -11,10 +11,11 @@ jest.mock('../../hooks/useTradingDebugModeFlag', () => ({
 
 describe('DebugModeView', () => {
     const renderDebugModeView = () =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <DebugModeView>
                 <Text>TEST TEXT</Text>
             </DebugModeView>,
+            { providers: ['intl'] },
         );
 
     beforeEach(() => {

--- a/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.test.tsx
+++ b/suite-native/trading-debug/src/components/__tests__/TradingEnvironmentWarning.test.tsx
@@ -37,6 +37,7 @@ describe('TradingEnvironmentWarning', () => {
                     },
                 } satisfies PreloadedStatePartial<StateFromReducersMapObject<typeof reducer>>,
             }),
+            providers: ['intl'],
         });
 
     it('should render nothing when tradingEnvironment is [production]', () => {

--- a/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.test.ts
+++ b/suite-native/trading-debug/src/hooks/__tests__/useTradingDebugModeFlag.test.ts
@@ -5,7 +5,10 @@ import { useTradingDebugModeFlag } from '../useTradingDebugModeFlag';
 
 describe('useTradingDebugModeFlag', () => {
     const renderUseDebugModeFlag = (preloadedState = {}) =>
-        renderHookWithStoreProvider(() => useTradingDebugModeFlag(), { preloadedState });
+        renderHookWithStoreProvider(() => useTradingDebugModeFlag(), {
+            preloadedState,
+            providers: [],
+        });
 
     it.each([true, false])('should respect FF [%s]', ffValue => {
         const { result } = renderUseDebugModeFlag({

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryListItem.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryListItem.test.tsx
@@ -1,5 +1,5 @@
 import { nonSanctionedRegional } from '@suite-common/trading';
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { CountryListItem, type CountryListItemProps } from '../CountryListItem';
 
@@ -7,8 +7,9 @@ describe('CountryListItem', () => {
     const usData = nonSanctionedRegional.countriesOptionsMap.get('US')!;
 
     const renderCountryListItem = (props: Partial<CountryListItemProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <CountryListItem isSelected={false} onPress={jest.fn()} {...usData} {...props} />,
+            { providers: ['intl'] },
         );
     it('should render flag and name', () => {
         const { getByText } = renderCountryListItem({});

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.test.tsx
@@ -5,7 +5,7 @@ import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { Form, useForm } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
 import { useAnalytics } from '@suite-native/services';
-import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders, renderWithProviders } from '@suite-native/test-utils';
 import {
     createLightStore,
     createStaticReducer,
@@ -83,9 +83,10 @@ describe('CountryOfResidencePicker', () => {
             store: createTradingResidenceStore(),
         });
 
-        return renderWithBasicProvider(
+        return renderWithProviders(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" {...props} />,
             {
+                providers: ['intl', 'navigation', 'bottomSheet'],
                 wrapper: ({ children }) => <Form form={result.current}>{children}</Form>,
             },
         );
@@ -145,13 +146,15 @@ describe('CountryOfResidencePicker', () => {
     });
 
     it('should render even when no value is selected', () => {
-        const formWithoutCountrySet = renderHookWithBasicProvider(() =>
-            useForm<TradingLocationFormValues>({ validation: locationFormValidationSchema }),
+        const formWithoutCountrySet = renderHookWithProviders(
+            () => useForm<TradingLocationFormValues>({ validation: locationFormValidationSchema }),
+            { providers: ['intl', 'bottomSheet'] },
         );
 
-        const { getByLabelText } = renderWithBasicProvider(
+        const { getByLabelText } = renderWithProviders(
             <CountryOfResidencePicker testID="TEST_ID" context="settings" />,
             {
+                providers: ['intl', 'navigation', 'bottomSheet'],
                 wrapper: ({ children }) => (
                     <Form form={formWithoutCountrySet.result.current}>{children}</Form>
                 ),

--- a/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/__tests__/CountryOfResidencePicker.test.tsx
@@ -81,6 +81,7 @@ describe('CountryOfResidencePicker', () => {
     const renderCountryOfResidencePicker = (props: Partial<CountryOfResidencePickerProps> = {}) => {
         const { result } = renderHookWithStoreProvider(() => useLocationForm(), {
             store: createTradingResidenceStore(),
+            providers: ['intl'],
         });
 
         return renderWithProviders(

--- a/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ConfirmLocationButton.test.tsx
@@ -48,6 +48,7 @@ describe('ConfirmLocationButton', () => {
         renderWithStoreProvider(<ConfirmLocationButton afterConfirm={jest.fn} {...props} />, {
             wrapper: LocationForm,
             store,
+            providers: ['intl'],
         });
 
     beforeEach(() => {
@@ -88,6 +89,7 @@ describe('ConfirmLocationButton', () => {
         const { getByText } = renderWithStoreProvider(<ConfirmLocationButtonWithChangedCountry />, {
             wrapper: LocationForm,
             store,
+            providers: ['intl'],
         });
 
         fireEvent.press(getByText('Confirm location'));

--- a/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/OnboardingButtons.test.tsx
@@ -25,6 +25,7 @@ describe('OnboardingButtons', () => {
         renderWithStoreProvider(<OnboardingButtons {...props} />, {
             wrapper: LocationForm,
             store,
+            providers: ['intl'],
         });
 
     beforeEach(() => {

--- a/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/ResidenceCheckAwareAnimatedBox.test.tsx
@@ -6,6 +6,7 @@ describe('ResidenceCheckAwareAnimatedBox', () => {
     const renderResidenceCheckAwareAnimatedBox = (preloadedState = {}) =>
         renderWithStoreProvider(<ResidenceCheckAwareAnimatedBox testID="TEST_ID" />, {
             preloadedState,
+            providers: [],
         });
 
     it('should have no border when residence check is enabled', () => {

--- a/suite-native/trading-residence/src/components/__tests__/SkipButton.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/SkipButton.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
+import { fireEvent, renderWithProviders } from '@suite-native/test-utils';
 
 import { SkipButton, type SkipButtonProps } from '../SkipButton';
 
@@ -10,7 +10,7 @@ jest.mock('../../hooks/useCountrySelectionAnalyticsReport', () => ({
 
 describe('SkipButton', () => {
     const renderSkipButton = (props: Partial<SkipButtonProps>) =>
-        renderWithBasicProvider(<SkipButton onPress={jest.fn()} {...props} />);
+        renderWithProviders(<SkipButton onPress={jest.fn()} {...props} />, { providers: ['intl'] });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-residence/src/components/__tests__/TradingAvailability.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingAvailability.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { TradingAvailability } from '../TradingAvailability';
 
@@ -9,7 +9,8 @@ jest.mock('../../hooks/useIsTradingAvailableForForm', () => ({
 }));
 
 describe('TradingAvailability', () => {
-    const renderTradingAvailability = () => renderWithBasicProvider(<TradingAvailability />);
+    const renderTradingAvailability = () =>
+        renderWithProviders(<TradingAvailability />, { providers: ['intl'] });
 
     it('should render negative message when selected country is not whitelisted', () => {
         mockIsTradingAvailableForForm = false;

--- a/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.test.tsx
+++ b/suite-native/trading-residence/src/components/__tests__/TradingLocationSettings.test.tsx
@@ -21,7 +21,10 @@ describe('TradingLocationSettings', () => {
     let store: TestStore;
 
     const renderTradingLocationSettings = (props: TradingLocationSettingsProps) =>
-        renderWithStoreProvider(<TradingLocationSettings {...props} />, { store });
+        renderWithStoreProvider(<TradingLocationSettings {...props} />, {
+            store,
+            providers: ['intl', 'navigation'],
+        });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-residence/src/hooks/__tests__/useAvailableScreenSquare.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useAvailableScreenSquare.test.ts
@@ -1,6 +1,6 @@
 import type { LayoutChangeEvent } from 'react-native';
 
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 import {
     HEADER_HEIGHT,
@@ -22,7 +22,9 @@ describe('useAvailableScreenSquare', () => {
         }) as LayoutChangeEvent;
 
     const renderUseAvailableScreenSpace = (maximumSize = MAXIMUM_SIZE) =>
-        renderHookWithBasicProvider(() => useAvailableScreenSquare(MINIMUM_SIZE, maximumSize));
+        renderHookWithProviders(() => useAvailableScreenSquare(MINIMUM_SIZE, maximumSize), {
+            providers: ['intl'],
+        });
 
     it('should return MAXIMUM_SIZE when totalAvailableHeight is larger than MAXIMUM_SIZE', () => {
         // totalAvailableHeight = 1334 - 100 = 1234 which is > MAXIMUM_SIZE = 300

--- a/suite-native/trading-residence/src/hooks/__tests__/useCountrySelectionAnalyticsReport.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useCountrySelectionAnalyticsReport.test.ts
@@ -1,6 +1,6 @@
 import { events } from '@suite-native/analytics';
 import { useAnalytics } from '@suite-native/services';
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 import { useCountrySelectionAnalyticsReport } from '../useCountrySelectionAnalyticsReport';
 
@@ -17,7 +17,9 @@ describe('useCountrySelectionAnalyticsReport', () => {
     const reportMock = jest.fn();
 
     const renderUseCountrySelectionAnalyticsReport = () =>
-        renderHookWithBasicProvider(() => useCountrySelectionAnalyticsReport());
+        renderHookWithProviders(() => useCountrySelectionAnalyticsReport(), {
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.test.tsx
@@ -4,7 +4,7 @@ import { type TradingCountryCode } from '@suite-common/trading';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { Form } from '@suite-native/forms';
 import { localeReducer } from '@suite-native/intl';
-import { renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders } from '@suite-native/test-utils';
 import {
     act,
     createLightStore,
@@ -34,7 +34,8 @@ describe('useFormCountryCode', () => {
         });
 
     const renderUseFormCountryCode = (locationForm: TradingLocationFormType) =>
-        renderHookWithBasicProvider(() => useFormCountryCode(), {
+        renderHookWithProviders(() => useFormCountryCode(), {
+            providers: ['intl'],
             wrapper: ({ children }) => <Form form={locationForm}>{children}</Form>,
         });
 

--- a/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useFormCountryCode.test.tsx
@@ -31,6 +31,7 @@ describe('useFormCountryCode', () => {
                     }),
                 },
             }),
+            providers: ['intl'],
         });
 
     const renderUseFormCountryCode = (locationForm: TradingLocationFormType) =>

--- a/suite-native/trading-residence/src/hooks/__tests__/useIsTradingAvailableForForm.test.tsx
+++ b/suite-native/trading-residence/src/hooks/__tests__/useIsTradingAvailableForForm.test.tsx
@@ -9,6 +9,7 @@ describe('useIsTradingAvailableForForm', () => {
         renderHookWithStoreProvider(() => useIsTradingAvailableForForm(), {
             wrapper: LocationForm,
             preloadedState,
+            providers: ['intl'],
         });
 
     it.each<[boolean, TradingCountryCode | undefined]>([

--- a/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.test.ts
+++ b/suite-native/trading-residence/src/hooks/__tests__/useLocationForm.test.ts
@@ -18,7 +18,7 @@ describe('useLocationForm', () => {
     let store: TestStore;
 
     const renderUseLocationForm = () =>
-        renderHookWithStoreProvider(() => useLocationForm(), { store });
+        renderHookWithStoreProvider(() => useLocationForm(), { store, providers: ['intl'] });
 
     beforeEach(() => {
         store = createLightStore({

--- a/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/SettingsTradingLocationScreen.test.tsx
@@ -57,6 +57,7 @@ describe('TradingLocationSettingsScreen', () => {
                     }),
                 },
             }),
+            providers: ['intl', 'bottomSheet', 'navigation'],
         });
 
     beforeEach(() => {

--- a/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/__tests__/TradingLocationModalScreen.test.tsx
@@ -78,6 +78,7 @@ describe('TradingLocationModalScreen', () => {
                         }),
                     },
                 }),
+                providers: ['intl', 'bottomSheet', 'navigation'],
             },
         );
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItem.test.tsx
@@ -1,7 +1,7 @@
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
-import { renderWithBasicProvider, within } from '@suite-native/test-utils';
+import { renderWithProviders, within } from '@suite-native/test-utils';
 
 import { type StatefulReviewOutput } from '../../../types';
 import { ReviewOutputItem, type ReviewOutputItemProps } from '../ReviewOutputItem';
@@ -22,7 +22,7 @@ jest.mock('../ReviewOutputItemValues', () => ({
 
 describe('ReviewOutputItem', () => {
     const renderReviewOutputItem = (props: Partial<ReviewOutputItemProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <ReviewOutputItem
                 accountKey={
                     'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
@@ -35,6 +35,7 @@ describe('ReviewOutputItem', () => {
                 }}
                 {...props}
             />,
+            { providers: ['intl', 'formatter'] },
         );
 
     it.each<[StatefulReviewOutput['type'], string]>([

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemList.test.tsx
@@ -34,7 +34,10 @@ describe('ReviewOutputItemList', () => {
                 }
                 {...props}
             />,
-            { preloadedState: { wallet: getWalletState() } },
+            {
+                preloadedState: { wallet: getWalletState() },
+                providers: ['intl', 'formatter'],
+            },
         );
 
     beforeEach(() => {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputItemValues.test.tsx
@@ -25,6 +25,7 @@ describe('ReviewOutputItemValues', () => {
             />,
             {
                 preloadedState,
+                providers: ['intl', 'formatter'],
             },
         );
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/__tests__/ReviewOutputSummaryItem.test.tsx
@@ -1,6 +1,6 @@
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import {
     ReviewOutputSummaryItem,
@@ -23,7 +23,7 @@ jest.mock('../ReviewOutputItemValues', () => ({
 
 describe('ReviewOutputSummaryItem', () => {
     const renderReviewOutputSummaryItem = (props: Partial<ReviewOutputSummaryItemProps>) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <ReviewOutputSummaryItem
                 accountKey={
                     'eth-account-1' as AccountKey // Todo: create properly via `createAccountKey()`
@@ -32,6 +32,7 @@ describe('ReviewOutputSummaryItem', () => {
                 onLayout={jest.fn()}
                 {...props}
             />,
+            { providers: ['intl'] },
         );
 
     it('should render nothing when summaryOutput is not specified', () => {

--- a/suite-native/transaction-management/src/components/__tests__/SlidingFooterOverlay.test.tsx
+++ b/suite-native/transaction-management/src/components/__tests__/SlidingFooterOverlay.test.tsx
@@ -1,14 +1,15 @@
 import { Text } from '@suite-native/atoms';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { SlidingFooterOverlay } from '../SlidingFooterOverlay';
 
 describe('SlidingFooterOverlay', () => {
     it('should render children', () => {
-        const { getByText, getByTestId } = renderWithBasicProvider(
+        const { getByText, getByTestId } = renderWithProviders(
             <SlidingFooterOverlay activeStepOffset={123}>
                 <Text>CHILDREN</Text>
             </SlidingFooterOverlay>,
+            { providers: ['intl'] },
         );
 
         expect(getByText('CHILDREN')).toBeOnTheScreen();
@@ -18,8 +19,9 @@ describe('SlidingFooterOverlay', () => {
     });
 
     it('should render without children', () => {
-        const { getByTestId } = renderWithBasicProvider(
+        const { getByTestId } = renderWithProviders(
             <SlidingFooterOverlay activeStepOffset={321} />,
+            { providers: ['intl'] },
         );
 
         expect(getByTestId('sliding-footer-overlay')).toHaveStyle({

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFee.test.tsx
@@ -51,6 +51,7 @@ describe('CustomFee', () => {
                 }),
             {
                 preloadedState: defaultState,
+                providers: ['intl'],
             },
         );
 
@@ -84,6 +85,7 @@ describe('CustomFee', () => {
 
         return renderWithStoreProvider(<CustomFee {...finalProps} />, {
             preloadedState: defaultState,
+            providers: ['intl', 'formatter', 'bottomSheet'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
     };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeCard.test.tsx
@@ -33,6 +33,7 @@ describe('CustomFeeCard', () => {
                 }),
             {
                 preloadedState: defaultState,
+                providers: ['intl'],
             },
         );
 
@@ -50,6 +51,7 @@ describe('CustomFeeCard', () => {
 
         return renderWithStoreProvider(<CustomFeeCard {...finalProps} />, {
             preloadedState: defaultState,
+            providers: ['intl', 'formatter'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
     };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeInputs.test.tsx
@@ -45,6 +45,7 @@ describe('CustomFeeInputs', () => {
             {
                 store,
                 preloadedState: defaultState,
+                providers: ['intl'],
             },
         );
 
@@ -63,6 +64,7 @@ describe('CustomFeeInputs', () => {
         return renderWithStoreProvider(<CustomFeeInputs {...finalProps} />, {
             preloadedState: defaultState,
             store,
+            providers: ['intl', 'formatter'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
     };

--- a/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/__tests__/CustomFeeLabel.test.tsx
@@ -26,6 +26,7 @@ describe('CustomFeeLabel', () => {
                 }),
             {
                 preloadedState: defaultState,
+                providers: ['intl'],
             },
         );
 
@@ -41,6 +42,7 @@ describe('CustomFeeLabel', () => {
     }) =>
         renderWithStoreProvider(<CustomFeeLabel networkType={networkType} />, {
             preloadedState: defaultState,
+            providers: ['intl', 'formatter'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOption.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOption.test.tsx
@@ -82,6 +82,7 @@ describe('FeeOption', () => {
             {
                 store,
                 preloadedState: getPreloadedState(),
+                providers: ['intl', 'formatter'],
             },
         );
     };

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionErrorMessage.test.tsx
@@ -1,10 +1,12 @@
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { FeeOptionErrorMessage } from '../FeeOptionErrorMessage';
 
 describe('FeeOptionErrorMessage', () => {
     const renderFeeOptionErrorMessage = (isVisible: boolean) =>
-        renderWithBasicProvider(<FeeOptionErrorMessage isVisible={isVisible} />);
+        renderWithProviders(<FeeOptionErrorMessage isVisible={isVisible} />, {
+            providers: ['intl'],
+        });
 
     it('should render error message when visible', () => {
         const { getByText, queryByTestId } = renderFeeOptionErrorMessage(true);

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/__tests__/FeeOptionsList.test.tsx
@@ -84,6 +84,7 @@ describe('FeeOptionsList', () => {
                 }),
             {
                 store,
+                providers: ['intl'],
             },
         );
 
@@ -103,6 +104,7 @@ describe('FeeOptionsList', () => {
 
         return renderWithStoreProvider(<FeeOptionsList {...finalProps} />, {
             store,
+            providers: ['intl', 'formatter'],
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
     };

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeeLabelTranslation.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeeLabelTranslation.test.tsx
@@ -1,16 +1,17 @@
 import type { NetworkType } from '@suite-common/wallet-config';
 import { Text } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderWithProviders } from '@suite-native/test-utils';
 
 import { FeeLabelTranslation } from '../FeeLabelTranslation';
 
 describe('FeeLabelTranslation', () => {
     const renderFeeLabelTranslation = (networkType: NetworkType) =>
-        renderWithBasicProvider(
+        renderWithProviders(
             <Text>
                 <FeeLabelTranslation networkType={networkType} />
             </Text>,
+            { providers: ['intl'] },
         );
 
     it('should render "Maximum fee" for [ethereum]', () => {

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeeSummaryCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeeSummaryCard.test.tsx
@@ -20,6 +20,7 @@ describe('FeeSummaryCard', () => {
     const renderCard = (props: Partial<typeof defaultProps> = {}) =>
         renderWithStoreProvider(<FeeSummaryCard {...defaultProps} {...props} />, {
             preloadedState: getPreloadedState(),
+            providers: ['intl', 'formatter'],
         });
 
     it('should render fee label for bitcoin', () => {

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesContent.test.tsx
@@ -65,6 +65,7 @@ describe('FeesContent', () => {
             </TestFormWrapper>,
             {
                 preloadedState: getPreloadedState(),
+                providers: ['intl', 'formatter', 'bottomSheet'],
             },
         );
     };

--- a/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/__tests__/FeesFooter.test.tsx
@@ -86,6 +86,7 @@ describe('FeesFooter', () => {
             {
                 store,
                 preloadedState: getPreloadedState(),
+                providers: ['intl', 'formatter'],
             },
         );
     };

--- a/suite-native/transaction-management/src/hooks/__tests__/useActiveStepOffset.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useActiveStepOffset.test.ts
@@ -1,6 +1,6 @@
 import { type LayoutChangeEvent } from 'react-native';
 
-import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderHookWithProviders } from '@suite-native/test-utils';
 
 import { useActiveStepOffset } from '../useActiveStepOffset';
 
@@ -9,7 +9,8 @@ describe('useActiveStepOffset', () => {
         ({ nativeEvent: { layout: { height } } }) as LayoutChangeEvent;
 
     const renderUseReviewOutputItemListHeights = (initialActiveStep: number) =>
-        renderHookWithBasicProvider(({ activeStep }) => useActiveStepOffset(activeStep), {
+        renderHookWithProviders(({ activeStep }) => useActiveStepOffset(activeStep), {
+            providers: ['intl'],
             initialProps: { activeStep: initialActiveStep },
         });
 

--- a/suite-native/transaction-management/src/hooks/__tests__/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useIsNetworkReserveBannerVisible.test.ts
@@ -30,7 +30,10 @@ describe('useIsNetworkReserveBannerVisible', () => {
     });
 
     const renderHook = (params: Parameters<typeof useIsNetworkReserveBannerVisible>[0]) =>
-        renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), { store });
+        renderHookWithStoreProvider(() => useIsNetworkReserveBannerVisible(params), {
+            store,
+            providers: [],
+        });
 
     it('returns false for null symbol, null amount, null balance, or no-reserve network', () => {
         expect(renderHook({ symbol: undefined, amount: '1', balance: '2' }).result.current).toBe(

--- a/suite-native/transaction-management/src/hooks/__tests__/useOutputsReviewBackInterceptor.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useOutputsReviewBackInterceptor.test.ts
@@ -1,4 +1,4 @@
-import { renderHookWithBasicProvider, waitFor } from '@suite-native/test-utils';
+import { renderHookWithProviders, waitFor } from '@suite-native/test-utils';
 
 import { useOutputsReviewBackInterceptor } from '../useOutputsReviewBackInterceptor';
 
@@ -16,7 +16,9 @@ jest.mock('../useShowReviewCancellationAlert', () => ({
 
 describe('useOutputsReviewBackInterceptor', () => {
     const renderUseOutputsReviewBackInterceptor = (onReviewCanceled: () => void = jest.fn()) =>
-        renderHookWithBasicProvider(() => useOutputsReviewBackInterceptor(onReviewCanceled));
+        renderHookWithProviders(() => useOutputsReviewBackInterceptor(onReviewCanceled), {
+            providers: ['intl'],
+        });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
@@ -1,7 +1,7 @@
 import { Text } from 'react-native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-native/test-utils';
+import { renderHookWithProviders, renderWithProviders } from '@suite-native/test-utils';
 
 import {
     type UsePrecomposedTransactionErrorProps,
@@ -24,8 +24,9 @@ describe('usePrecomposedTransactionError', () => {
     it.each([[null], [undefined], ['INVALID_ERROR'], ['']])(
         'should return null when error is %s',
         error => {
-            const { result } = renderHookWithBasicProvider(() =>
-                usePrecomposedTransactionError({ error, networkSymbol }),
+            const { result } = renderHookWithProviders(
+                () => usePrecomposedTransactionError({ error, networkSymbol }),
+                { providers: ['intl'] },
             );
 
             expect(result.current).toBeNull();
@@ -64,24 +65,27 @@ describe('usePrecomposedTransactionError', () => {
             expectedErrorMsg: 'Insufficient funds for staking.',
         },
     ])('should return correct translation data for $error', ({ error, expectedErrorMsg }) => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <ErrorText error={error} networkSymbol={networkSymbol} />,
+            { providers: ['intl'] },
         );
 
         expect(getByText(expectedErrorMsg)).toBeOnTheScreen();
     });
 
     it('should handle context without network symbol', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('Insufficient  to cover the transaction fee.')).toBeOnTheScreen();
     });
 
     it('should handle different network symbols', () => {
-        const { getByText } = renderWithBasicProvider(
+        const { getByText } = renderWithProviders(
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" networkSymbol="eth" />,
+            { providers: ['intl'] },
         );
 
         expect(getByText('Insufficient ETH to cover the transaction fee.')).toBeOnTheScreen();

--- a/suite-native/transaction-management/src/hooks/__tests__/useShowReviewCancellationAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useShowReviewCancellationAlert.test.ts
@@ -25,7 +25,10 @@ describe('useShowReviewCancellationAlert', () => {
     let store: TestStore;
 
     const renderUseShowReviewCancellationAlert = () =>
-        renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), { store });
+        renderHookWithStoreProvider(() => useShowReviewCancellationAlert(), {
+            store,
+            providers: [],
+        });
 
     beforeEach(() => {
         mockShowAlert.mockClear();

--- a/suite-native/transaction-management/src/hooks/__tests__/useWaitForButtonRequest.test.ts
+++ b/suite-native/transaction-management/src/hooks/__tests__/useWaitForButtonRequest.test.ts
@@ -14,6 +14,7 @@ describe('useWaitForButtonRequest.ts', () => {
         renderHookWithStoreProvider(
             ({ onButtonRequest }) => useWaitForButtonRequest(onButtonRequest),
             {
+                providers: [],
                 initialProps: {
                     onButtonRequest: initialCallback,
                 },

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesFetching.test.ts
@@ -52,6 +52,7 @@ describe('useFeesFetching', () => {
     }) =>
         renderHookWithStoreProvider(() => useFeesFetching({ networkSymbol, isRefetchDisabled }), {
             store,
+            providers: [],
         });
 
     beforeEach(() => {

--- a/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/__tests__/useFeesForm.test.ts
@@ -12,6 +12,7 @@ describe('useFeesForm', () => {
 
     const renderUseFeesForm = (props: UseFeesFormProps = mockProps) =>
         renderHookWithStoreProvider(() => useFeesForm(props), {
+            providers: ['intl'],
             preloadedState: {
                 wallet: {
                     fees: {},
@@ -109,6 +110,7 @@ describe('useFeesForm', () => {
 
     it('should handle empty fee levels without crashing', () => {
         const { result } = renderHookWithStoreProvider(() => useFeesForm(mockProps), {
+            providers: ['intl'],
             preloadedState: {
                 wallet: {
                     fees: {},


### PR DESCRIPTION
… mock

Introduce renderWithProviders with opt-in intl/navigation/services/formatter/bottomSheet flags so tests can skip the provider mounts they don't need. SafeAreaProvider + StylesProvider stay always-on. renderWithBasicProvider / BasicProviderForTests kept as aliases for backward compatibility with the 64 existing consumers.

Also mock @suite-native/services globally so transitive useAnalytics calls (e.g. via useActiveColorScheme) don't need the real Provider in unit tests. Migrate CryptoIconWithNetwork as the first consumer.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/test-providers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/test-providers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/test-providers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/test-providers/web/](https://dev.suite.sldev.cz/suite-web/juriczech/test-providers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T15:40:08.167Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T14:23:14.012Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->