### PR TITLE
fix(e2e): Fixed issue in tests caused by ETH being on by default

### DIFF
--- a/suite/e2e/tests/wallet/add-account-types.test.ts
+++ b/suite/e2e/tests/wallet/add-account-types.test.ts
@@ -87,23 +87,22 @@ test.describe('Account types suite', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () =
                 priority: TestPriority.High,
             }),
         },
-        async ({ page, dashboardPage, settingsPage, walletPage, analytics }) => {
+        async ({ dashboardPage, settingsPage, walletPage, analytics }) => {
             const coins: { symbol: NetworkSymbol; path: string }[] = [
                 { symbol: 'ada', path: `m/1852'/1815'/1'` },
                 { symbol: 'eth', path: `m/44'/60'/0'/0/1` },
+                { symbol: 'base', path: `m/44'/60'/0'/0/1` },
             ];
 
-            await settingsPage.navigateTo('coins');
-            for (const coin of coins) {
-                await settingsPage.coinsTab.enableNetwork(coin.symbol as NetworkSymbol);
-                if (coin.symbol === 'ada') {
-                    await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
-                }
-            }
+            const symbolsToEnable = coins
+                .map(c => c.symbol)
+                .filter(symbol => symbol !== 'eth') as NetworkSymbol[];
+            await settingsPage.changeNetworks({
+                enableNetworks: symbolsToEnable,
+            });
 
             await dashboardPage.dashboardMenuButton.click();
             await walletPage.openAccount();
-            await page.discoveryShouldFinish();
 
             analytics.interceptAnalytics();
             await walletPage.filterAccountsButton.click();

--- a/suite/e2e/tests/wallet/discovery.test.ts
+++ b/suite/e2e/tests/wallet/discovery.test.ts
@@ -30,9 +30,10 @@ test.describe('Discovery', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
     }) => {
         await test.step('Activate coins', async () => {
             await settingsPage.navigateTo('coins');
-            for (const symbol of coinsToActivate) {
-                await settingsPage.coinsTab.enableNetwork(symbol);
-                if (symbol === 'ada') {
+            for (const coin of coinsToActivate.filter(symbol => symbol !== 'eth')) {
+                // ETH is activated by default
+                await settingsPage.coinsTab.enableNetwork(coin);
+                if (coin === 'ada') {
                     await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
                 }
             }

--- a/suite/e2e/tests/wallet/export-transactions.test.ts
+++ b/suite/e2e/tests/wallet/export-transactions.test.ts
@@ -29,7 +29,9 @@ test.describe('Export transactions', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
         async ({ page, settingsPage, walletPage, onboardingPage }) => {
             const symbols: NetworkSymbol[] = ['btc', 'ltc', 'eth', 'ada'];
             await settingsPage.changeNetworks({
-                enableNetworks: symbols.filter(symbol => symbol !== 'btc'),
+                enableNetworks: symbols.filter(
+                    symbol => symbol !== 'btc' && symbol !== 'eth',
+                ) as NetworkSymbol[],
             });
 
             for (const symbol of symbols) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are E2E test files themselves, not source/production code. The risk is limited to the tests themselves being broken or updated incorrectly. No production code was changed, so there is no risk of regressions in other tests. The minimal and sufficient strategy is to run exactly these three changed test files.

<details><summary><b>Changed files (3)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts`
- `suite/e2e/tests/wallet/discovery.test.ts`
- `suite/e2e/tests/wallet/export-transactions.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This is one of the directly changed test files. It must be run to verify that the modifications to the test itself are valid and pass correctly.
- `suite/e2e/tests/wallet/discovery.test.ts` — This is one of the directly changed test files. It must be run to verify that the modifications to the test itself are valid and pass correctly.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — This is one of the directly changed test files. It must be run to verify that the modifications to the test itself are valid and pass correctly.

</details>

_Updated: 2026-04-22T14:34:46.921Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-nightly-422&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-nightly-422&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T14:40:18.942Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-22T16:15:20.575Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly-422/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-nightly-422/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->