### PR TITLE
Mobile Trade: Confirm fee section cta missing mobile

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.tsx
@@ -1,13 +1,17 @@
 import { memo } from 'react';
+import Animated, { FadeInDown, FadeOut } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
-import type { ExchangeTrade } from 'invity-api';
 
-import { parseCryptoId } from '@suite-common/trading';
+import {
+    isFinalStatus,
+    parseCryptoId,
+    selectTradingExchangeSelectedQuote,
+} from '@suite-common/trading';
 import { selectSendPrecomposedTx } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { Button } from '@suite-native/atoms';
+import { Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import {
     type AppTabsParamList,
@@ -16,10 +20,10 @@ import {
     TradingStackRoutes,
 } from '@suite-native/navigation';
 import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 export type ExchangePreviewContinueButtonProps = {
     isDisabled: boolean;
-    quote?: ExchangeTrade;
     onSignTransactionNavigation: () => void;
 };
 
@@ -29,18 +33,23 @@ type NavigationProp = StackToTabCompositeNavigationProp<
     AppTabsParamList
 >;
 
+const footerStyle = prepareNativeStyle(utils => ({
+    paddingHorizontal: utils.spacings.sp16,
+    paddingBottom: utils.spacings.sp16,
+}));
+
 const EXCHANGE_PREVIEW_CONTINUE_BUTTON_TEST_ID = '@trading/exchange-preview/continue-button';
 
 export const ExchangePreviewContinueButton = memo(
-    ({ isDisabled, quote, onSignTransactionNavigation }: ExchangePreviewContinueButtonProps) => {
+    ({ isDisabled, onSignTransactionNavigation }: ExchangePreviewContinueButtonProps) => {
         const navigation = useNavigation<NavigationProp>();
+        const { applyStyle } = useNativeStyles();
 
+        const quote = useSelector(selectTradingExchangeSelectedQuote);
         const precomposedTransaction = useSelector(selectSendPrecomposedTx);
         const fromAccount = useSelector(selectExchangeSelectedSendAccount);
-
-        if (precomposedTransaction?.type !== 'final') {
-            return null;
-        }
+        const isTXFinalType = precomposedTransaction?.type === 'final';
+        const isTradeFinalized = isFinalStatus('exchange', quote?.status);
 
         const handleSignTransaction = () => {
             if (!quote || !fromAccount) {
@@ -68,14 +77,28 @@ export const ExchangePreviewContinueButton = memo(
             onSignTransactionNavigation();
         };
 
+        if (isTradeFinalized) {
+            return null;
+        }
+
+        if (isDisabled && !isTXFinalType) {
+            return null;
+        }
+
         return (
-            <Button
-                onPress={handleSignTransaction}
-                isDisabled={isDisabled}
-                testID={EXCHANGE_PREVIEW_CONTINUE_BUTTON_TEST_ID}
-            >
-                <Translation id="generic.buttons.continue" />
-            </Button>
+            <Animated.View entering={FadeInDown} exiting={FadeOut}>
+                <ScreenFooterGradient />
+                <Box style={applyStyle(footerStyle)}>
+                    <Button
+                        onPress={handleSignTransaction}
+                        isDisabled={isDisabled}
+                        isLoading={!isTXFinalType}
+                        testID={EXCHANGE_PREVIEW_CONTINUE_BUTTON_TEST_ID}
+                    >
+                        <Translation id="generic.buttons.continue" />
+                    </Button>
+                </Box>
+            </Animated.View>
         );
     },
 );

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode, memo } from 'react';
-import Animated from 'react-native-reanimated';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
 
 import { type TradingRootState, selectTradingProviderKycPolicy } from '@suite-common/trading';
-import { InlineAlertBox, VStack } from '@suite-native/atoms';
+import { AnimatedVStack, InlineAlertBox, VStack } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { ExchangeFeePickerCard } from './ExchangeFeePickerCard';
@@ -51,18 +51,20 @@ export const ExchangePreviewView = memo(
                         <InlineAlertBox variant="critical" title={txnErrorString} />
                     </Animated.View>
                 )}
-                <ExchangeFromAccountTradePreviewCard quote={quote} />
-                <ExchangeToAccountTradePreviewCard quote={quote} />
-                <ExchangeFiatDeviationWarning quote={quote} />
-                <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
-                {isFusionPlus && <ExchangeFusionPlusInfo />}
-                {kycWarning && (
-                    <InlineAlertBox
-                        variant="warning"
-                        title={kycWarning}
-                        accessibilityHint={translate('generic.warning')}
-                    />
-                )}
+                <AnimatedVStack layout={LinearTransition}>
+                    <ExchangeFromAccountTradePreviewCard quote={quote} />
+                    <ExchangeToAccountTradePreviewCard quote={quote} />
+                    <ExchangeFiatDeviationWarning quote={quote} />
+                    <ExchangeFeePickerCard quote={quote} isTxnError={isTxnError} />
+                    {isFusionPlus && <ExchangeFusionPlusInfo />}
+                    {kycWarning && (
+                        <InlineAlertBox
+                            variant="warning"
+                            title={kycWarning}
+                            accessibilityHint={translate('generic.warning')}
+                        />
+                    )}
+                </AnimatedVStack>
             </VStack>
         );
     },

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, memo } from 'react';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
@@ -47,7 +47,7 @@ export const ExchangePreviewView = memo(
                     />
                 )}
                 {isTxnError && (
-                    <Animated.View>
+                    <Animated.View layout={LinearTransition} entering={FadeIn} exiting={FadeOut}>
                         <InlineAlertBox variant="critical" title={txnErrorString} />
                     </Animated.View>
                 )}

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/__tests__/ExchangePreviewContinueButton.test.tsx
@@ -29,6 +29,7 @@ describe('ExchangePreviewContinueButton', () => {
                 exchange: {
                     tradingAccountKey: 'btc-account-1' as AccountKey,
                     receiveAccountKey: 'eth-account-1' as AccountKey,
+                    selectedQuote: mercuryoFixedWorstQuote,
                 },
             },
             send: {
@@ -49,7 +50,6 @@ describe('ExchangePreviewContinueButton', () => {
         renderWithTradingProvider(
             <ExchangePreviewContinueButton
                 isDisabled={false}
-                quote={mercuryoFixedWorstQuote}
                 onSignTransactionNavigation={jest.fn()}
                 {...props}
             />,
@@ -63,13 +63,13 @@ describe('ExchangePreviewContinueButton', () => {
         jest.restoreAllMocks();
     });
 
-    it('should render nothing when precomposed transaction is not in final state', () => {
-        const { toJSON } = renderExchangePreviewContinueButton(
+    it('should render disabled button when precomposed transaction is not in final state', () => {
+        const { getByText } = renderExchangePreviewContinueButton(
             {},
             { wallet: { send: { precomposedTx: { type: 'composing' } as any } } },
         );
 
-        expect(toJSON()).toBeNull();
+        expect(getByText('Continue')).toBeDisabled();
     });
 
     it('should render continue button', () => {
@@ -102,13 +102,36 @@ describe('ExchangePreviewContinueButton', () => {
         expect(queryByTestId('@trading/exchange-preview/continue-button/loading')).toBeNull();
     });
 
+    it('should render nothing when quote is finalized', () => {
+        const { toJSON } = renderExchangePreviewContinueButton(
+            {},
+            {
+                wallet: {
+                    trading: {
+                        exchange: {
+                            selectedQuote: { ...mercuryoFixedWorstQuote, status: 'SUCCESS' },
+                        },
+                    },
+                },
+            },
+        );
+
+        expect(toJSON()).toBeNull();
+    });
+
     it('should fire console.warn and do not navigate when quote is not specified', async () => {
         const mockOnSignTransactionNavigation = jest.fn();
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-        const { getByText } = renderExchangePreviewContinueButton({
-            quote: undefined,
-            onSignTransactionNavigation: mockOnSignTransactionNavigation,
-        });
+        const { getByText } = renderExchangePreviewContinueButton(
+            { onSignTransactionNavigation: mockOnSignTransactionNavigation },
+            {
+                wallet: {
+                    trading: {
+                        exchange: { selectedQuote: undefined },
+                    },
+                },
+            },
+        );
 
         await userEvent.press(getByText('Continue'));
 

--- a/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
+++ b/suite-native/module-trading/src/screens/TradingExchangePreviewScreen.tsx
@@ -155,20 +155,20 @@ const TradingExchangePreviewScreenContent = ({
     const errorString = txnErrorString ?? quote?.error;
 
     return (
-        <Screen header={<ExchangePreviewScreenHeader />}>
+        <Screen
+            header={<ExchangePreviewScreenHeader />}
+            footer={
+                <ExchangePreviewContinueButton
+                    isDisabled={!!errorString}
+                    onSignTransactionNavigation={onSignTransactionNavigation}
+                />
+            }
+        >
             <ExchangePreviewView
                 quote={quote}
                 txnErrorString={errorString}
                 isApproved={isApproved}
             />
-            {!isFinalized && (
-                <ExchangePreviewContinueButton
-                    quote={quote}
-                    isDisabled={!!errorString}
-                    onSignTransactionNavigation={onSignTransactionNavigation}
-                />
-            )}
-
             <Footer />
         </Screen>
     );

--- a/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
@@ -41,6 +41,10 @@ describe('usePrecomposedTransactionError', () => {
             error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
             expectedErrorMsg: 'Insufficient BTC to cover the transaction fee.',
         },
+        {
+            error: 'NOT-ENOUGH-FUNDS',
+            expectedErrorMsg: 'Insufficient BTC to cover the transaction fee.',
+        },
 
         {
             error: 'AMOUNT_IS_LESS_THAN_RESERVE',

--- a/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/__tests__/usePrecomposedTransactionError.test.tsx
@@ -1,6 +1,7 @@
 import { Text } from 'react-native';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { getTranslation } from '@suite-native/intl';
 import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import {
@@ -16,6 +17,7 @@ const ErrorText = (props: UsePrecomposedTransactionErrorProps) => {
 
 describe('usePrecomposedTransactionError', () => {
     const networkSymbol = 'btc' as NetworkSymbol;
+    const networkDisplaySymbol = 'BTC';
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -35,37 +37,54 @@ describe('usePrecomposedTransactionError', () => {
     it.each([
         {
             error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
-            expectedErrorMsg: 'Insufficient BTC to cover the transaction fee.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                { networkDisplaySymbol },
+            ),
         },
         {
             error: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
-            expectedErrorMsg: 'Insufficient BTC to cover the transaction fee.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                { networkDisplaySymbol },
+            ),
         },
         {
             error: 'NOT-ENOUGH-FUNDS',
-            expectedErrorMsg: 'Insufficient BTC to cover the transaction fee.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                { networkDisplaySymbol },
+            ),
         },
-
         {
             error: 'AMOUNT_IS_LESS_THAN_RESERVE',
-            expectedErrorMsg: 'Recipient account requires minimum reserve to activate.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountIsLessThanReserve',
+            ),
         },
         {
             error: 'REMAINING_BALANCE_LESS_THAN_RENT',
-            expectedErrorMsg:
-                'After sending this amount, your account will have SOL remaining lower than the rent.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.remainingBalanceLessThanRent',
+            ),
         },
         {
             error: 'AMOUNT_IS_NOT_ENOUGH',
-            expectedErrorMsg: "You don't have enough funds.",
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountIsNotEnough',
+            ),
         },
         {
             error: 'AMOUNT_IS_TOO_LOW',
-            expectedErrorMsg: 'Amount is too low.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.amountIsTooLow',
+            ),
         },
         {
             error: 'TR_STAKE_NOT_ENOUGH_FUNDS',
-            expectedErrorMsg: 'Insufficient funds for staking.',
+            expectedErrorMsg: getTranslation(
+                'transactionManagement.precomposedTransaction.errors.stakeNotEnoughFunds',
+            ),
         },
     ])('should return correct translation data for $error', ({ error, expectedErrorMsg }) => {
         const { getByText } = renderWithBasicProvider(
@@ -80,7 +99,14 @@ describe('usePrecomposedTransactionError', () => {
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" />,
         );
 
-        expect(getByText('Insufficient  to cover the transaction fee.')).toBeOnTheScreen();
+        expect(
+            getByText(
+                getTranslation(
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                    { networkDisplaySymbol: '' },
+                ),
+            ),
+        ).toBeOnTheScreen();
     });
 
     it('should handle different network symbols', () => {
@@ -88,6 +114,13 @@ describe('usePrecomposedTransactionError', () => {
             <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" networkSymbol="eth" />,
         );
 
-        expect(getByText('Insufficient ETH to cover the transaction fee.')).toBeOnTheScreen();
+        expect(
+            getByText(
+                getTranslation(
+                    'transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee',
+                    { networkDisplaySymbol: 'ETH' },
+                ),
+            ),
+        ).toBeOnTheScreen();
     });
 });

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
@@ -17,6 +17,7 @@ const VALID_PRECOMPOSED_ERRORS: PrecomposedTransactionError['error'][] = [
     'TR_STAKE_NOT_ENOUGH_FUNDS',
     'REMAINING_BALANCE_LESS_THAN_RENT',
     'AMOUNT_NOT_ENOUGH_CURRENCY_FEE_WITH_ETH_AMOUNT',
+    'NOT-ENOUGH-FUNDS',
 ];
 
 /**
@@ -43,6 +44,7 @@ export const usePrecomposedTransactionError = ({
 
         switch (error) {
             case 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE':
+            case 'NOT-ENOUGH-FUNDS':
                 return (
                     <Translation
                         id="transactionManagement.precomposedTransaction.errors.amountNotEnoughCurrencyFee"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Displays error also when user has not enough funds for fees.
- Moves continue button to sticky footer on Exchange preview screen.
- Updats animated components for better UX.

<!--- Describe your changes in detail -->

## Notes for QA
- In theory, it might affect send flow and display error about insufficient funds there as well.
- Please take special cate of sell. I did not test it properly.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #26918

## Screenshots:

### Exchange

https://github.com/user-attachments/assets/650a795b-e497-4670-8e8d-5353d0330277



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=26918-swapsell-confirm-fee-section-cta-missing-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->