### PR TITLE
chore(deps): bump simple-git to ^3.32.3

### DIFF
--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -35,7 +35,7 @@
         "css-loader": "^7.1.3",
         "fs-extra": "^11.3.1",
         "postcss-loader": "^8.2.0",
-        "simple-git": "^3.30.0",
+        "simple-git": "^3.32.3",
         "style-loader": "^4.0.0",
         "tsx": "^4.21.0",
         "webpack": "5.105.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9670,6 +9670,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@simple-git/args-pathspec@npm:1.0.2"
+  checksum: 10/8ff2289110aa1c556aadb67da55c01f9430af6a647a9e4823aa023c59b11d3406819cfaead8a9c71c7fd44231271be9e71179ec817b6a3cb99d1da36cd17788e
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/argv-parser@npm:1.0.3"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.2"
+  checksum: 10/cfb11a054a854135d8262a7aae4b2bd1d2108f3763437080e60dcd9498f32b626857f752bb8b6c6d285cc120a7f221c6a3b2556df9c55c1b30ae136a3ba8e1be
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox-codegen@npm:^0.10.4":
   version: 0.10.5
   resolution: "@sinclair/typebox-codegen@npm:0.10.5"
@@ -16158,7 +16174,7 @@ __metadata:
     fs-extra: "npm:^11.3.1"
     postcss-loader: "npm:^8.2.0"
     semver: "npm:^7.7.1"
-    simple-git: "npm:^3.30.0"
+    simple-git: "npm:^3.32.3"
     style-loader: "npm:^4.0.0"
     tsx: "npm:^4.21.0"
     webpack: "npm:5.105.4"
@@ -42604,14 +42620,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.30.0":
-  version: 3.30.0
-  resolution: "simple-git@npm:3.30.0"
+"simple-git@npm:^3.32.3":
+  version: 3.35.2
+  resolution: "simple-git@npm:3.35.2"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
+    "@simple-git/args-pathspec": "npm:^1.0.2"
+    "@simple-git/argv-parser": "npm:^1.0.3"
     debug: "npm:^4.4.0"
-  checksum: 10/65f78b2598950d4f7ce163ad736e7ad358199e13dd84096524b9f10b093f92278d6d40c7390330e7603f1a048db7d7ee1f5ea3a157eb382e691b5c85de549a6b
+  checksum: 10/4bfb2ac73041db774e8cfaefbc97e4cacf2725d955e458e135647209829336505223128f928aac9f86b92e30d0e7c4128daad0268a1303c2d88fda8be1fda0d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `simple-git` in `@trezor/suite-data` from `^3.30.0` to `^3.32.3`.
- Resolves two dependabot alerts:
  - [GHSA-r275-fr43-pm7q](https://github.com/trezor/trezor-suite/security/dependabot/480) (**critical**) — `blockUnsafeOperationsPlugin` bypass via case-insensitive `protocol.allow` config key enables RCE.
  - [GHSA-jcxm-m3jx-f287](https://github.com/trezor/trezor-suite/security/dependabot/655) (**high**) — command execution via option-parsing bypass.

## Context

`simple-git` is only used in `packages/suite-data/src/guide/index.ts` to clone the GitBook guide source at build time. Both the repository URL (`https://github.com/trezor/trezor-suite-guide.git`) and the revision are hardcoded constants — no user input reaches `git.clone()` or `git.checkout()`. Real-world attack surface is therefore effectively zero, but the bump clears the alerts and keeps the dependency on a patched version.

## Test plan

- [ ] CI green.
- [ ] `yarn workspace @trezor/suite-data guide-pull-content` still successfully clones and checks out the guide repository locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is packages/suite-data/package.json, which is a package metadata file (likely a dependency version bump or script change). No tests statically map to this file, and the LLM analysis of all known tests shows no test that directly exercises or depends on suite-data/package.json behavior. Changes to package.json files typically affect build/bundling rather than runtime behavior, so the risk of a user-facing regression is very low. No targeted E2E tests are recommended; CI build verification and unit tests (if any) for the suite-data package should suffice.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-data/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite-data/package.json`

_Updated: 2026-04-22T15:37:41.028Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/bump-simple-git&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/bump-simple-git&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 29 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-22T15:42:47.451Z • 29 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T12:52:34.814Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/bump-simple-git/web/](https://dev.suite.sldev.cz/suite-web/mroz22/bump-simple-git/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->