### PR TITLE
fix(trading): fix DEX post-trade UX bugs

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx
@@ -148,14 +148,18 @@ export const TradingDetailExchange = () => {
                         </Paragraph>
                         <Box margin={{ top: 32, bottom: 12 }}>
                             <TradingDetailStepList>
-                                <TradingDetailExchangePaymentSending
-                                    trade={trade.data}
-                                    account={sendAccount}
-                                    composedTransaction={composedTransaction}
-                                />
+                                {!trade.data.isDex && (
+                                    <TradingDetailExchangePaymentSending
+                                        trade={trade.data}
+                                        account={sendAccount}
+                                        composedTransaction={composedTransaction}
+                                    />
+                                )}
                                 <TradingDetailExchangePaymentConverting
                                     trade={trade.data}
                                     provider={provider}
+                                    account={trade.data.isDex ? sendAccount : undefined}
+                                    isDex={trade.data.isDex}
                                 />
                                 <BulletList.Item
                                     state="pending"

--- a/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting.tsx
@@ -3,29 +3,35 @@ import { type ExchangeProviderInfo, type ExchangeTrade } from 'invity-api';
 import { Translation, useTranslation } from '@suite/intl';
 import { type BulletListItemState, Card, Column } from '@trezor/components';
 
+import { type Account } from 'src/types/wallet';
+
 import { TradingDetailProviderInfo } from '../TradingDetailProviderInfo';
 import { TradingDetailStep } from '../TradingDetailStep';
 import { TradingDetailSupportBanner } from '../TradingDetailSupportBanner';
 
-const getState = (trade: ExchangeTrade): BulletListItemState => {
+const getState = (trade: ExchangeTrade, isDex?: boolean): BulletListItemState => {
     switch (trade.status) {
         case 'SUCCESS':
             return 'done';
         case 'CONVERTING':
             return 'active';
         default:
-            return 'pending';
+            return isDex ? 'active' : 'pending';
     }
 };
 
 type TradingDetailExchangePaymentConvertingProps = {
     trade: ExchangeTrade;
     provider?: ExchangeProviderInfo;
+    account?: Account;
+    isDex?: boolean;
 };
 
 export const TradingDetailExchangePaymentConverting = ({
     trade,
     provider,
+    account,
+    isDex,
 }: TradingDetailExchangePaymentConvertingProps) => {
     const { translationString } = useTranslation();
 
@@ -33,7 +39,7 @@ export const TradingDetailExchangePaymentConverting = ({
 
     return (
         <TradingDetailStep
-            state={getState(trade)}
+            state={getState(trade, isDex)}
             title={
                 <Translation
                     id="TR_TRADING_DETAIL_PROCESSING"
@@ -48,6 +54,7 @@ export const TradingDetailExchangePaymentConverting = ({
                 <Column gap={24}>
                     {provider && (
                         <TradingDetailProviderInfo
+                            account={account}
                             orderId={trade.orderId}
                             provider={provider}
                             trade={trade}

--- a/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts
@@ -263,7 +263,7 @@ describe('confirmExchangeTradeThunk', () => {
         });
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(store.getActions().length).toEqual(4);
+        expect(store.getActions().length).toEqual(3);
         expect(exchange.transactionId).toBeUndefined();
         expect(exchange.isLoading).toBeFalsy();
         expect(!!response).toBeFalsy();
@@ -338,7 +338,7 @@ describe('confirmExchangeTradeThunk', () => {
             });
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(store.getActions().length).toEqual(5);
+            expect(store.getActions().length).toEqual(4);
             expect(exchange.transactionId).toBeUndefined();
 
             expect(exchange.isLoading).toBeFalsy();
@@ -390,7 +390,7 @@ describe('confirmExchangeTradeThunk', () => {
             const { exchange } = store.getState().wallet.trading;
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(store.getActions().length).toEqual(5);
+            expect(store.getActions().length).toEqual(4);
             expect(exchange.transactionId).toBeUndefined();
 
             expect(exchange.isLoading).toBeFalsy();
@@ -438,7 +438,7 @@ describe('confirmExchangeTradeThunk', () => {
         const { exchange } = store.getState().wallet.trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(store.getActions().length).toEqual(5);
+        expect(store.getActions().length).toEqual(4);
         expect(exchange.transactionId).toBeUndefined();
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(tradeResponse);
@@ -486,7 +486,7 @@ describe('confirmExchangeTradeThunk', () => {
             const { exchange } = store.getState().wallet.trading;
 
             expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-            expect(store.getActions().length).toEqual(5);
+            expect(store.getActions().length).toEqual(4);
             expect(exchange.transactionId).toBeUndefined();
             expect(exchange.isLoading).toBeFalsy();
             expect(exchange.selectedQuote).toEqual(tradeResponse);
@@ -534,7 +534,7 @@ describe('confirmExchangeTradeThunk', () => {
         const { exchange } = store.getState().wallet.trading;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(store.getActions().length).toEqual(5);
+        expect(store.getActions().length).toEqual(4);
         expect(exchange.transactionId).toBeUndefined();
         expect(exchange.isLoading).toBeFalsy();
         expect(exchange.selectedQuote).toEqual(tradeResponse);
@@ -587,7 +587,7 @@ describe('confirmExchangeTradeThunk', () => {
         expect(store.getActions().length).toEqual(5);
         expect(exchange.transactionId).toBe(mockResponse.orderId);
         expect(exchange.isLoading).toBeFalsy();
-        expect(exchange.selectedQuote).toEqual(exchange.selectedQuote);
+        expect(exchange.selectedQuote).toEqual(tradeResponse);
         expect(mockNextStep).toHaveBeenCalledTimes(1);
         expect(trading.trades[0]).toEqual({
             tradeType: 'exchange',

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -166,11 +166,12 @@ describe('sendDexTransactionThunk', () => {
                 createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
             );
 
+        const nextStep = jest.fn();
         const result = await store.dispatch(
             exchangeThunks.sendDexTransactionThunk({
                 account,
                 returnUrl,
-                nextStep: jest.fn(),
+                nextStep,
                 triggerAnalyticsTradeConfirmation: jest.fn(),
                 processResponseData: jest.fn(),
                 signAndPushSendFormTransaction: jest.fn(),
@@ -185,6 +186,8 @@ describe('sendDexTransactionThunk', () => {
         expect(confirmExchangeTradeThunkSpy).toHaveBeenCalledTimes(1);
         expect(confirmTradeThunkArgs.trade?.approvalSendTxHash).toEqual('txid');
         expect(confirmTradeThunkArgs.trade?.status).toEqual('APPROVAL_PENDING');
+        expect(nextStep).not.toHaveBeenCalled();
+        expect(confirmTradeThunkArgs.nextStep).toBe(nextStep);
     });
 
     it('should successfully call confirmTradeThunk for making trade', async () => {
@@ -213,11 +216,12 @@ describe('sendDexTransactionThunk', () => {
                 createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
             );
 
+        const nextStep = jest.fn();
         const result = await store.dispatch(
             exchangeThunks.sendDexTransactionThunk({
                 account,
                 returnUrl,
-                nextStep: jest.fn(),
+                nextStep,
                 triggerAnalyticsTradeConfirmation: jest.fn(),
                 processResponseData: jest.fn(),
                 signAndPushSendFormTransaction: jest.fn(),
@@ -240,5 +244,8 @@ describe('sendDexTransactionThunk', () => {
         expect(confirmExchangeTradeThunkSpy).toHaveBeenCalledTimes(1);
         expect(trade?.receiveTxHash).toEqual('txid');
         expect(trade?.status).toEqual('CONFIRMING');
+        expect(store.getState().wallet.trading.exchange.transactionId).toEqual(trade?.orderId);
+        expect(nextStep).toHaveBeenCalledTimes(1);
+        expect(confirmTradeThunkArgs.nextStep).toBeUndefined();
     });
 });

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -25,7 +25,7 @@ export type ConfirmExchangeTradeThunkProps = {
 
     triggerAnalyticsTradeConfirmation: () => void;
     processResponseData: (response: ExchangeTrade) => void;
-    nextStep: () => void;
+    nextStep?: () => void;
 };
 
 export const confirmExchangeTradeThunk = createThunk(
@@ -66,8 +66,6 @@ export const confirmExchangeTradeThunk = createThunk(
                 trade = { ...trade, fromAddress: refundAddress };
             }
         }
-
-        dispatch(tradingExchangeActions.saveTransactionId(undefined));
 
         const response = await invityAPI.doExchangeTrade({
             trade,
@@ -127,6 +125,7 @@ export const confirmExchangeTradeThunk = createThunk(
         }
 
         // CONFIRMING, SUCCESS, LOADING
+        dispatch(tradingExchangeActions.saveSelectedQuote(response));
         dispatch(
             tradingActions.saveTrade({
                 tradeType: 'exchange',
@@ -150,7 +149,7 @@ export const confirmExchangeTradeThunk = createThunk(
             return response;
         }
 
-        nextStep();
+        nextStep?.();
 
         return response;
     },

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -7,6 +7,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
+import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeAccountKey,
@@ -135,7 +136,10 @@ export const sendDexTransactionThunk = createThunk<
             receiveAddress: selectedQuote.receiveAddress, // just for type assurance
         };
 
-        if (selectedQuote.status === 'CONFIRM' && selectedQuote.approvalType !== 'ZERO') {
+        const isSwapTx =
+            selectedQuote.status === 'CONFIRM' && selectedQuote.approvalType !== 'ZERO';
+
+        if (isSwapTx) {
             trade.receiveTxHash = txid;
             trade.status = 'CONFIRMING';
 
@@ -149,6 +153,9 @@ export const sendDexTransactionThunk = createThunk<
                     receiveAccountKey,
                 }),
             );
+            dispatch(tradingExchangeActions.saveTransactionId(trade.orderId));
+
+            nextStep();
         } else {
             trade.approvalSendTxHash = txid;
             trade.status = 'APPROVAL_PENDING';
@@ -162,7 +169,7 @@ export const sendDexTransactionThunk = createThunk<
                 account,
                 triggerAnalyticsTradeConfirmation,
                 processResponseData,
-                nextStep,
+                nextStep: isSwapTx ? undefined : nextStep,
             }),
         );
     },


### PR DESCRIPTION
## Description

- After a DEX swap tx is broadcast, navigate to post-trade immediately instead of waiting for the full swap to complete (1inch issue). `saveTransactionId` and `nextStep` are now called in `sendDexTransactionThunk` for the swap case, making `nextStep` optional in `confirmExchangeTradeThunk`.
- Hide the "sending" step in the post-trade stepper for DEX trades and set the "converting" step to active state immediately — fixing the 3-step UI that should only show 2 steps (LI.FI issue).

## Notes for QA

- Do a DEX swap via 1inch: after signing and broadcasting the tx, you should land on the post-trade page immediately showing "DEX is processing your swap" — not be stuck on the confirmation screen until the swap completes.
- Do a DEX swap via LI.FI: the post-trade stepper should show 2 steps, not 3.

## Related Issue

Resolve #25343

## Screenshot
<img width="1702" height="1164" alt="image" src="https://github.com/user-attachments/assets/dd5d6832-8058-4e89-a3d0-8ba69c11094c" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify the exchange detail UI components (TradingDetailExchange and TradingDetailExchangePaymentConverting) and their underlying thunks (confirmExchangeTradeThunk and sendDexTransactionThunk). The thunk files map to 121 tests each due to broad transitive imports, but only the swap/exchange trading tests actually exercise these code paths. The unit test files for the thunks have no E2E coverage mapping (they are unit tests themselves). The highest risk is in the swap trading flows where exchange detail status, amounts, and provider info are displayed — these should be prioritized.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchange.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingDetail/TradingDetailExchange/TradingDetailExchangePaymentConverting.tsx`
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the full swap flow including exchange detail views and transaction confirmation. The changed TradingDetailExchange and TradingDetailExchangePaymentConverting components are directly used in the swap detail/confirmation UI that this test validates (success status, crypto amounts, provider name).
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test validates the complete swap lifecycle including status transitions (SENDING → CONFIRMING → CONVERTING → SUCCESS) which directly exercises the TradingDetailExchange and TradingDetailExchangePaymentConverting components. The CONVERTING status specifically maps to the PaymentConverting component.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test verifies swap transaction detail including success status, exchange type, and provider name — all rendered by the TradingDetailExchange component. Changes to the exchange detail view could cause regressions in these assertions.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test validates swap token-to-token transaction detail including TR_EXCHANGE_DETAIL_SUCCESS_TITLE status, exchange type, and confirmation crypto amounts — all rendered through the changed TradingDetailExchange component.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This live swap test validates the exchange detail success status and confirmation amounts in a real environment. While it directly uses TradingDetailExchange, it's medium priority because it's a live test with longer execution time and the mocked variants above already cover the component.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This live test exercises the swap detail sidebar showing send/receive amounts, provider info, and exchange rate type — all rendered by TradingDetailExchange. It also validates the CONVERTING status which maps to the PaymentConverting component.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test validates swap trade detail views including status translations, send/receive amounts, and provider info in the detail sidebar. These are rendered by TradingDetailExchange. Changes to the exchange detail component could break the detail panel assertions.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-common/trading/src/thunks/exchange/__tests__/confirmExchangeTradeThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`

_Updated: 2026-04-23T05:07:32.639Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25343/dex-post-trade&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/25343/dex-post-trade&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25343/dex-post-trade&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/25343/dex-post-trade/web/](https://dev.suite.sldev.cz/suite-web/fix/25343/dex-post-trade/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T05:01:25.532Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 30 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T05:11:55.935Z • 30 test(s) total_
<!-- QUARANTINE-LIST:web:END -->