### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2952,10 +2952,6 @@ export const messages = defineMessages({
             'User is instructed to enter words from seed (backup) into the form in browser',
         id: 'TR_RANDOM_SEED_WORDS_DISCLAIMER',
     },
-    TR_SEND: {
-        defaultMessage: 'Send',
-        id: 'TR_SEND',
-    },
     TR_RECEIVE: {
         defaultMessage: 'Receive',
         id: 'TR_RECEIVE',


### PR DESCRIPTION
## Summary
Removes unused translation strings from \`messages.ts\` that are no longer referenced in the codebase.

**Keys removed (1):**
- \`TR_SEND\`

Identified by the \`translations:list-unused\` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite/intl/src/messages.ts affects the internationalization message definitions used across the entire Trezor Suite application. Since no static coverage mapping exists for this file, all test recommendations are inferred from LLM analysis of test behaviors and source hints. The autodetect test has the highest risk as it directly validates localized message content against expected strings. Other tests that assert translation keys or language-related settings have medium risk. The overall strategy focuses on tests that explicitly reference the intl/messages system rather than broadly testing all UI that happens to display translated text.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses @suite/intl messages to verify that the onboarding heading text matches the expected localized string (TR_ONBOARDING_DATA_COLLECTION_HEADING). Changes to suite/intl/src/messages.ts could alter message definitions, keys, or formatting, directly breaking these assertions.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies language change functionality and analytics events that reference translation keys. The intl messages module underpins the translation system, and changes could affect how language switching or translated settings labels are rendered and asserted.
- `../../suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies that language preferences (Spanish) persist across database migrations and checks the language select input displays the correct label. Changes to the intl messages module could affect how locale labels are resolved or displayed after migration.
- `../../suite/e2e/tests/trading/swap-coins.test.ts` — This test's source_hints explicitly reference @suite/intl (TranslationKey, translation system) and it asserts multiple translation keys (TR_EXCHANGE_DETAIL_SUCCESS_TITLE, TR_TX_CONFIRMING, TR_TX_CONFIRMED). Changes to the messages module could affect how these translation keys resolve.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `../../suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test checks that the analytics consent heading is visible during onboarding, which relies on translated message strings from the intl module. A change to messages.ts could affect the heading text or its rendering.
- `../../suite/e2e/tests/suite/initial-run.test.ts` — This test verifies onboarding UI elements that display translated text (analytics toggle, complete-onboarding button). If messages.ts changes affect onboarding-related translation keys, these UI elements could fail to render correctly.

</details>

_Updated: 2026-04-23T07:48:48.182Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260423&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260423&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 30 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T07:54:14.254Z • 30 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T07:52:23.429Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260423/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260423/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->