### PR TITLE
fix(trading): use invity symbol for wallet tokens in asset picker

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingDefaultSellAsset.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingDefaultSellAsset.ts
@@ -5,7 +5,7 @@ import { type CryptoId } from 'invity-api';
 import {
     type TradingAssetSellOption,
     createAssetNativeTokenOption,
-    createAssetTokenOption,
+    useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkConfigWithoutTestnets } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -25,6 +25,7 @@ export function useTradingDefaultSellAsset({
     cryptoId,
 }: UseTradingDefaultSellAssetProps) {
     const findAccountOrToken = useTradingFindAccountOrToken();
+    const { resolveAssetTokenOption } = useTradingAssets();
     const accountOrToken = useMemo(() => {
         if (!cryptoId || !accountKey) {
             return null;
@@ -43,7 +44,7 @@ export function useTradingDefaultSellAsset({
 
         if (token) {
             return {
-                ...createAssetTokenOption(account.symbol, token),
+                ...resolveAssetTokenOption(account.symbol, token),
                 accountKey: account.key,
             } satisfies TradingAssetSellOption;
         }
@@ -54,7 +55,7 @@ export function useTradingDefaultSellAsset({
             ),
             accountKey: account.key,
         } satisfies TradingAssetSellOption;
-    }, [accountOrToken]);
+    }, [accountOrToken, resolveAssetTokenOption]);
 
     return { account, defaultAsset };
 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import {
     type TradingAssetOption,
     createAssetNativeTokenOption,
-    createAssetTokenOption,
+    useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkConfigWithoutTestnets } from '@suite-common/wallet-config';
 
@@ -15,6 +15,8 @@ export interface UseUpdateFormInputProps {
 }
 
 export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormInputProps) {
+    const { resolveAssetTokenOption } = useTradingAssets();
+
     const handleAssetClick = useCallback(
         (asset: TradingAssetListItem) => {
             switch (asset.type) {
@@ -28,7 +30,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
                 }
 
                 case 'token': {
-                    onAssetSelect(createAssetTokenOption(asset.account.symbol, asset.token));
+                    onAssetSelect(resolveAssetTokenOption(asset.account.symbol, asset.token));
                     break;
                 }
                 case 'asset': {
@@ -39,7 +41,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
 
             closeModal();
         },
-        [closeModal, onAssetSelect],
+        [closeModal, onAssetSelect, resolveAssetTokenOption],
     );
 
     return handleAssetClick;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import {
     type TradingAssetSellOption,
     createAssetNativeTokenOption,
-    createAssetTokenOption,
+    useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkConfigWithoutTestnets } from '@suite-common/wallet-config';
 
@@ -15,6 +15,8 @@ export interface UseUpdateFormInputProps {
 }
 
 export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormInputProps) {
+    const { resolveAssetTokenOption } = useTradingAssets();
+
     const handleAssetClick = useCallback(
         (asset: AssetPickerListItem) => {
             switch (asset.type) {
@@ -30,7 +32,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
 
                 case 'token': {
                     onAssetSelect({
-                        ...createAssetTokenOption(asset.account.symbol, asset.token),
+                        ...resolveAssetTokenOption(asset.account.symbol, asset.token),
                         accountKey: asset.account.key,
                     });
                     break;
@@ -39,7 +41,7 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
 
             closeModal();
         },
-        [closeModal, onAssetSelect],
+        [closeModal, onAssetSelect, resolveAssetTokenOption],
     );
 
     return handleAssetClick;

--- a/suite-common/trading/src/__fixtures__/coins.json
+++ b/suite-common/trading/src/__fixtures__/coins.json
@@ -68,5 +68,15 @@
             "sell": false,
             "exchange": true
         }
+    },
+    "ethereum--0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c": {
+        "symbol": "ausdc",
+        "name": "aEthUSDC",
+        "coingeckoId": "aave-v3-usdc",
+        "services": {
+            "buy": false,
+            "sell": false,
+            "exchange": true
+        }
     }
 }

--- a/suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts
+++ b/suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts
@@ -1,0 +1,81 @@
+import { type Coins, type CryptoId } from 'invity-api';
+
+import coins from '../../__fixtures__/coins.json';
+import { createTradingTestState, renderHookWithTradingStore } from '../../__tests__/testUtils';
+import { useTradingAssets } from '../useTradingAssets';
+
+const AUSDC_CONTRACT = '0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c';
+const UNKNOWN_TOKEN_CONTRACT = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+const renderHook = (preloadedCoins: Coins | null = coins as Coins) =>
+    renderHookWithTradingStore(() => useTradingAssets(), {
+        preloadedState: createTradingTestState({
+            info: {
+                coins: preloadedCoins ?? undefined,
+                platforms: undefined,
+                paymentMethods: [],
+            },
+        }),
+    });
+
+describe('resolveAssetTokenOption', () => {
+    it('uses invity symbol when token is known to invity', () => {
+        const { result } = renderHook();
+
+        const option = result.current.resolveAssetTokenOption('eth', {
+            contract: AUSDC_CONTRACT,
+            symbol: 'aEthUSDC',
+            name: 'Aave Ethereum USDC',
+        });
+
+        expect(option.symbol).toBe('ausdc');
+        expect(option.displaySymbol).toBe('AUSDC');
+        expect(option.name).toBe('aEthUSDC');
+        expect(option.contractAddress).toBe(AUSDC_CONTRACT);
+        expect(option.networkSymbol).toBe('eth');
+        expect(option.isNativeToken).toBe(false);
+    });
+
+    it('falls back to blockbook symbol when token is unknown to invity', () => {
+        const { result } = renderHook();
+
+        const option = result.current.resolveAssetTokenOption('eth', {
+            contract: UNKNOWN_TOKEN_CONTRACT,
+            symbol: 'aEthUSDC',
+            name: 'Aave Ethereum USDC',
+        });
+
+        expect(option.symbol).toBe('aEthUSDC');
+        expect(option.displaySymbol).toBe('aEthUSDC');
+        expect(option.contractAddress).toBe(UNKNOWN_TOKEN_CONTRACT);
+        expect(option.networkSymbol).toBe('eth');
+        expect(option.isNativeToken).toBe(false);
+    });
+
+    it('falls back to blockbook symbol when invity coins are not loaded', () => {
+        const { result } = renderHook(null);
+
+        const option = result.current.resolveAssetTokenOption('eth', {
+            contract: AUSDC_CONTRACT,
+            symbol: 'aEthUSDC',
+            name: 'Aave Ethereum USDC',
+        });
+
+        expect(option.symbol).toBe('aEthUSDC');
+        expect(option.contractAddress).toBe(AUSDC_CONTRACT);
+    });
+
+    it('returns consistent cryptoId regardless of symbol source', () => {
+        const { result } = renderHook();
+
+        const cryptoId = `ethereum--${AUSDC_CONTRACT}` as CryptoId;
+
+        const optionWithInvity = result.current.resolveAssetTokenOption('eth', {
+            contract: AUSDC_CONTRACT,
+            symbol: 'aEthUSDC',
+            name: 'Aave Ethereum USDC',
+        });
+
+        expect(optionWithInvity.id).toBe(cryptoId);
+    });
+});

--- a/suite-common/trading/src/hooks/useTradingAssets.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.ts
@@ -284,7 +284,32 @@ export function useTradingAssets() {
         [getCoinsAndPlatforms],
     );
 
-    return { buildAssetOptions, createAssetOptionFromCryptoId };
+    const resolveAssetTokenOption = useCallback(
+        (
+            networkSymbol: NetworkSymbol,
+            token: Pick<TokenInfo, 'contract' | 'symbol' | 'name'>,
+        ): TradingAssetOptionWithContractAddress => {
+            const { coins, platforms } = getCoinsAndPlatforms();
+            const cryptoId = getCryptoId(networkSymbol, token.contract) as CryptoId;
+
+            if (coins?.[cryptoId]) {
+                const result = createAssetOption({
+                    cryptoId,
+                    coinInfo: coins[cryptoId],
+                    platformInfo: getTradingPlatformsInfoByCryptoId(platforms, cryptoId),
+                });
+
+                if (result !== null && !result.isNativeToken) {
+                    return result;
+                }
+            }
+
+            return createAssetTokenOption(networkSymbol, token);
+        },
+        [getCoinsAndPlatforms],
+    );
+
+    return { buildAssetOptions, createAssetOptionFromCryptoId, resolveAssetTokenOption };
 }
 
 export type UseTradingAssets = ReturnType<typeof useTradingAssets>;

--- a/suite/e2e/tests/trading/navigation.test.ts
+++ b/suite/e2e/tests/trading/navigation.test.ts
@@ -66,8 +66,8 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
                 // There is instability in test, sell form has Ethereum instead of USD Coin
                 // We cannot reproduce it manually, so we are using retry workaround to stabilize automation
                 await expect(async () => {
-                    await walletPage.openSellTradingOfToken('eth', 'USD Coin');
-                    await tradingPage.verifySellFormOpened(/USD Coin/);
+                    await walletPage.openSellTradingOfToken('eth', 'USDC');
+                    await tradingPage.verifySellFormOpened(/USDC/);
                 }).toPass({ timeout: 15_000 });
             });
 
@@ -85,8 +85,8 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
             });
 
             await test.step('Swap from token', async () => {
-                await walletPage.openSwapTradingOfToken('eth', 'USD Coin');
-                await tradingPage.verifySwapFormOpened(/USD Coin/);
+                await walletPage.openSwapTradingOfToken('eth', 'USDC');
+                await tradingPage.verifySwapFormOpened(/USDC/);
             });
         },
     );


### PR DESCRIPTION
## Description

- Token symbols in the asset picker were sourced from blockbook, while the trade summary used invity's symbols — causing mismatches (e.g. `aEthUSDC` vs `AUSDC`)
- Added `resolveAssetTokenOption` to `useTradingAssets` that looks up the invity symbol for a token when available, falling back to the blockbook symbol
- Applied this in both buy and sell asset picker hooks

## Notes for QA

1. Go to Swap
2. Select ETH in the From field
3. Select Aave Ethereum USDC in the To field
4. Enter an amount (e.g. 0.01 ETH)
5. Verify the ticker/icon in the To selection field matches the one in the You get summary section

## Related Issue

Resolve trezor/trezor-trade-api#449

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on the trading/swap asset selection logic: two useUpdateFormInput hooks (for buy and sell asset picker modals), the useTradingAssets hook, and associated test fixtures for token resolution. The primary risk is that asset selection in buy/sell/swap flows could break — wrong asset being set, tokens not resolving correctly, or form state not updating. The test strategy focuses on swap tests (which exercise both buy and sell asset pickers simultaneously) at high priority, with individual buy/sell tests at medium priority. The useTradingAssets hook maps to 121 tests but is only meaningfully exercised in trading-related tests; non-trading tests are omitted as they don't exercise asset selection paths.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useUpdateFormInput.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts`
- `suite-common/trading/src/__fixtures__/coins.json`
- `suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts`
- `suite-common/trading/src/hooks/useTradingAssets.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test exercises the swap flow where a user selects buy/sell assets via the AssetPickerModal, directly using the useUpdateFormInput hooks that were changed in both the BuyAsset and SellAsset paths. The test fills swap forms, selects assets, and verifies quotes — all of which depend on correct form input updates when assets are picked.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers swapping SOL to BTC, involving both sell and buy asset selection through the trading form inputs. Changes to useUpdateFormInput in both BuyAsset and SellAsset modals directly affect how selected assets propagate to the form state used in this swap flow.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana token (USDT) to BTC, specifically exercising token-to-coin asset selection. The useUpdateFormInput hooks handle how token selections in the asset picker modal update the form, and useTradingAssets provides the asset options. Changes to token resolution logic (as seen in the fixtures/test file) make this critical.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test specifically covers swapping a token to an asset on a disabled network, testing edge cases in asset selection. The useUpdateFormInput hooks and useTradingAssets must correctly handle assets from disabled networks, making this a direct regression test for the changed logic.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps between two SPL tokens (USDT to USDC on Solana), exercising the token asset picker for both sell and buy sides. The resolveAssetTokenOption logic (which has a new test file and fixture changes) directly impacts how tokens are resolved and selected in these modals.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a Solana SPL token (Jupiter/JUP) using the asset picker to select the token with network and search filters. The useUpdateFormInput hook for BuyAsset and useTradingAssets are directly exercised when the user selects the token in the buy form.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test fills a swap form from BTC to ETH and validates fee calculations. While focused on fees, it still exercises asset selection through the trading form inputs where useUpdateFormInput hooks are invoked.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test fills a swap form from ETH to BTC with custom Ethereum fees. It exercises the trading form input asset selection flow, indirectly using the changed useUpdateFormInput hooks when setting up sell/buy assets.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test opens the trading interface and selects Ethereum as the buy asset, exercising the BuyAsset AssetPickerModal. The useUpdateFormInput hook for buy assets and useTradingAssets are involved in asset selection.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test fills in a buy form for Bitcoin, exercises the receive address selection, and compares offers. It uses the trading form input components where useTradingAssets provides asset data, though the asset picker may not be explicitly opened.
- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms from various entry points including token-level navigation, verifying that the correct asset is displayed. The useUpdateFormInput hooks are responsible for setting the correct asset when navigating to trading forms from token contexts.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the sell flow for Bitcoin, using the trading form where the SellAsset useUpdateFormInput hook is used. Changes to asset selection logic could affect how the sell asset is set in the form.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — This test sells an ERC-20 token (USDC) through the sell flow, selecting a specific token asset. The SellAsset useUpdateFormInput hook handles token selection, and the token resolution logic in useTradingAssets is exercised.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test validates buy form error states and the asset picker dropdown. While focused on validation, it opens the asset picker modal which depends on useTradingAssets for asset listing.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test exercises selling SOL including comparing offers and changing payment methods. The sell form uses the SellAsset form input components where the changed hooks operate.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This live swap test exercises SOL-to-USDC swap with real providers, using the same asset picker and form input paths as the mocked tests. It provides additional confidence but is a live test with higher flakiness risk.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This live test swaps an SPL token (USDT) to SOL coin, specifically testing token asset selection in production-like conditions. It covers the same useUpdateFormInput paths but against live providers.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/trading/src/__fixtures__/coins.json`
- `suite-common/trading/src/hooks/__tests__/resolveAssetTokenOption.test.ts`

_Updated: 2026-04-23T08:02:41.979Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-inconsistent-token-symbol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-inconsistent-token-symbol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-inconsistent-token-symbol&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 30 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T08:07:25.861Z • 30 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T10:08:42.707Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-inconsistent-token-symbol/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-inconsistent-token-symbol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->