### PR TITLE
XLM: improve Stellar token icon resolution

### DIFF
--- a/packages/blockchain-link-utils/src/stellar.ts
+++ b/packages/blockchain-link-utils/src/stellar.ts
@@ -375,3 +375,25 @@ export const getTokenMetadata = async (): Promise<TokenDetailByMint> => {
 export const isValidAssetCode = (code: string): boolean => /^[a-zA-Z0-9]{1,12}$/.test(code);
 
 export const isValidAddress = (address: string): boolean => StrKey.isValidEd25519PublicKey(address);
+
+/**
+ * Derive the public-network Soroban contract id for a classic Stellar asset
+ * in strict `CODE-ISSUER` form.
+ *
+ * This is intentionally hard-coded to `Networks.PUBLIC`.
+ */
+export const computeSorobanAssetContractId = (classicAssetContract: string): string => {
+    const contractParts = classicAssetContract.split('-');
+
+    if (contractParts.length !== 2) {
+        throw new Error('Invalid Stellar asset contract format.');
+    }
+
+    const [assetCode, issuer] = contractParts;
+
+    if (!isValidAssetCode(assetCode) || !isValidAddress(issuer)) {
+        throw new Error('Invalid Stellar asset contract format.');
+    }
+
+    return new Asset(assetCode, issuer).contractId(Networks.PUBLIC);
+};

--- a/packages/blockchain-link-utils/src/tests/stellar.test.ts
+++ b/packages/blockchain-link-utils/src/tests/stellar.test.ts
@@ -5,6 +5,7 @@ import { BigNumber } from '@trezor/utils';
 import {
     type StellarAsset,
     buildSendTransaction,
+    computeSorobanAssetContractId,
     toStroops,
     transformTransaction,
 } from '../stellar';
@@ -50,6 +51,30 @@ describe('stellar/utils', () => {
                 });
                 expect(result).toEqual(expectedOutput);
             });
+        });
+    });
+
+    describe('computeSorobanAssetContractId', () => {
+        const classic = 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+        const expectedSACId = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
+
+        it('derives the Soroban contract id from a classic CODE-ISSUER', () => {
+            expect(computeSorobanAssetContractId(classic)).toBe(expectedSACId);
+        });
+
+        it('throws when the input is not in strict CODE-ISSUER format', () => {
+            expect(() => computeSorobanAssetContractId(classic.replace('-', ':'))).toThrow(
+                'Invalid Stellar asset contract format.',
+            );
+            expect(() => computeSorobanAssetContractId(`${classic}-1`)).toThrow(
+                'Invalid Stellar asset contract format.',
+            );
+            expect(() => computeSorobanAssetContractId(expectedSACId)).toThrow(
+                'Invalid Stellar asset contract format.',
+            );
+            expect(() => computeSorobanAssetContractId('not-stellar')).toThrow(
+                'Invalid Stellar asset contract format.',
+            );
         });
     });
 });

--- a/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/tokenUtils.test.ts
@@ -1,5 +1,5 @@
 import { getContractAddressForNetworkSymbolFixtures } from '../__fixtures__/tokenUtils';
-import { getContractAddressForNetworkSymbol } from '../tokenUtils';
+import { getAssetLogoContractAddresses, getContractAddressForNetworkSymbol } from '../tokenUtils';
 
 describe('getContractAddressForNetworkSymbol', () => {
     getContractAddressForNetworkSymbolFixtures.forEach(
@@ -10,4 +10,23 @@ describe('getContractAddressForNetworkSymbol', () => {
             });
         },
     );
+});
+
+describe('getAssetLogoContractAddresses', () => {
+    it('returns [policyId, contract] for ada', () => {
+        const policyId = 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535';
+        const contract = `${policyId}41474958`;
+        expect(getAssetLogoContractAddresses('ada', contract)).toEqual([policyId, contract]);
+    });
+
+    it('returns [sacId, contract] for xlm', () => {
+        const classic = 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+        const expectedSACId = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
+        expect(getAssetLogoContractAddresses('xlm', classic)).toEqual([classic, expectedSACId]);
+    });
+
+    it('returns [contract] for eth', () => {
+        const contract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+        expect(getAssetLogoContractAddresses('eth', contract)).toEqual([contract.toLowerCase()]);
+    });
 });

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -12,6 +12,7 @@ import {
     type TokenTransfer,
 } from '@trezor/blockchain-link-types';
 import { parseAsset } from '@trezor/blockchain-link-utils/src/blockfrost';
+import { computeSorobanAssetContractId } from '@trezor/blockchain-link-utils/src/stellar';
 
 export const getContractAddressForNetworkSymbol = (
     symbol: NetworkSymbolExtended,
@@ -42,6 +43,20 @@ export const getAssetLogoContractAddresses = (
         const policyId = getContractAddressForNetworkSymbol(symbol, contract);
 
         return [policyId, contract];
+    }
+
+    // CoinGecko is gradually migrating Stellar token ids from the classic
+    // `CODE-ISSUER` form used at runtime to Soroban contract addresses. Once a
+    // token is migrated, its icon on the CDN is stored under the Soroban
+    // filename. Fall back to the locally-derived Soroban asset contract id so
+    // the icon is still reachable.
+    if (symbol === 'xlm') {
+        const sorobanAssetContractId = computeSorobanAssetContractId(contract);
+
+        // Keep the classic contract first until CoinGecko finishes the Stellar
+        // migration. Once Soroban ids become the primary CDN key, flip the
+        // order to reduce retries.
+        return [contract, sorobanAssetContractId];
     }
 
     return [getContractAddressForNetworkSymbol(symbol, contract)];

--- a/suite-native/icons/src/CryptoIcon.tsx
+++ b/suite-native/icons/src/CryptoIcon.tsx
@@ -81,8 +81,12 @@ export const CryptoIcon = ({ symbol, contractAddress, size = 'small' }: CryptoIc
 
     /**
      * Retries loading the icon with the next available address in sourceUrls.
-     * This is crucial for ADA, where the logo might be stored
-     * under either the policyId or the full contract address.
+     * This is crucial for:
+     * - ADA, where the logo might be stored under either the policyId or the
+     *   full contract address.
+     * - XLM, where the logo might be stored under either the classic
+     *   CODE-ISSUER address or the Soroban contract id, depending on how far
+     *   CoinGecko has progressed with its Stellar id migration for the token.
      */
     const handleLoadError = () => {
         if (logoIndex + 1 >= sourceUrls.length) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CoinGecko is migrating Stellar token ids from classic `CODE-ISSUER` values to Soroban asset contract ids.

This PR adds a Soroban fallback for Stellar token icons, so `CryptoIcon` can retry loading the icon with both identifiers during the migration period.

## Notes for QA

Please verify that Stellar token icons load correctly.

At the moment, the CDN does not appear to contain any Stellar icons under Soroban contract ids yet, so the fallback path may not be directly testable right now.


## Related Issue

Resolve #26855 

## Screenshots:
N/A
No UI changes.