### PR TITLE
Bump `node-fetch` to 3.3.2

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -15,7 +15,6 @@
         "uuid",
         "uint8array-tools",
         "bitcore-lib",
-        "@types/node-fetch",
         "@arethetypeswrong/cli"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
         "@trezor/eslint": "workspace:*",
         "@types/jest": "29.5.12",
         "@types/node": "22.13.10",
-        "@types/node-fetch": "^2.6.12",
         "babel-jest": "30.0.0",
         "depcheck": "^1.4.7",
         "eslint": "^9.39.4",

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -39,7 +39,6 @@
     "devDependencies": {
         "@trezor/node-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
-        "@types/node-fetch": "^2.6.12",
         "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
         "ws": "^8.20.0"

--- a/packages/coinjoin/package.json
+++ b/packages/coinjoin/package.json
@@ -40,7 +40,7 @@
         "@trezor/node-utils": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@types/node-fetch": "^2.6.12",
-        "node-fetch": "2.6.7",
+        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
         "ws": "^8.20.0"
     }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -162,7 +162,7 @@
         "@vitest/browser-playwright": "^4.1.0",
         "crypto-browserify": "3.12.0",
         "jest": "29.7.0",
-        "node-fetch": "2.6.7",
+        "node-fetch": "^3.3.2",
         "process": "^0.11.10",
         "stream-browserify": "^3.0.0",
         "tsx": "^4.21.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -157,7 +157,6 @@
         "@trezor/trezor-user-env-link": "workspace:*",
         "@types/jws": "^3.2.11",
         "@types/node": "22.13.10",
-        "@types/node-fetch": "^2.6.12",
         "@types/w3c-web-usb": "^1.0.14",
         "@vitest/browser-playwright": "^4.1.0",
         "crypto-browserify": "3.12.0",

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@trezor/node-utils": "workspace:^",
         "@trezor/utils": "workspace:*",
-        "node-fetch": "2.6.7",
+        "node-fetch": "^3.3.2",
         "socks-proxy-agent": "8.0.5",
         "ws": "^8.20.0"
     },

--- a/packages/request-manager/package.json
+++ b/packages/request-manager/package.json
@@ -23,7 +23,6 @@
     },
     "devDependencies": {
         "@trezor/eslint": "workspace:*",
-        "@types/node-fetch": "^2.6.12",
         "ts-node": "^10.9.2"
     }
 }

--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -20,7 +20,6 @@
 @types/jws
 @types/lodash
 @types/node
-@types/node-fetch
 @types/semver
 @types/sharedworker
 @types/w3c-web-usb

--- a/yarn.lock
+++ b/yarn.lock
@@ -15467,7 +15467,6 @@ __metadata:
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     "@trezor/utxo-lib": "workspace:*"
-    "@types/node-fetch": "npm:^2.6.12"
     cross-fetch: "npm:^4.1.0"
     golomb: "npm:1.2.0"
     n64: "npm:^0.2.10"
@@ -15786,7 +15785,6 @@ __metadata:
     "@trezor/utxo-lib": "workspace:*"
     "@types/jws": "npm:^3.2.11"
     "@types/node": "npm:22.13.10"
-    "@types/node-fetch": "npm:^2.6.12"
     "@types/w3c-web-usb": "npm:^1.0.14"
     "@vitest/browser-playwright": "npm:^4.1.0"
     cbor: "npm:^10.0.12"
@@ -16018,7 +16016,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@trezor/node-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
-    "@types/node-fetch": "npm:^2.6.12"
     node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     ts-node: "npm:^10.9.2"
@@ -17607,7 +17604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.6.12, @types/node-fetch@npm:^2.6.4":
+"@types/node-fetch@npm:^2.6.4":
   version: 2.6.13
   resolution: "@types/node-fetch@npm:2.6.13"
   dependencies:
@@ -44520,7 +44517,6 @@ __metadata:
     "@trezor/eslint": "workspace:*"
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:22.13.10"
-    "@types/node-fetch": "npm:^2.6.12"
     babel-jest: "npm:30.0.0"
     depcheck: "npm:^1.4.7"
     eslint: "npm:^9.39.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15471,7 +15471,7 @@ __metadata:
     cross-fetch: "npm:^4.1.0"
     golomb: "npm:1.2.0"
     n64: "npm:^0.2.10"
-    node-fetch: "npm:2.6.7"
+    node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     ws: "npm:^8.20.0"
   languageName: unknown
@@ -15794,7 +15794,7 @@ __metadata:
     crypto-browserify: "npm:3.12.0"
     jest: "npm:29.7.0"
     jws: "npm:^4.0.1"
-    node-fetch: "npm:2.6.7"
+    node-fetch: "npm:^3.3.2"
     process: "npm:^0.11.10"
     stream-browserify: "npm:^3.0.0"
     tsx: "npm:^4.21.0"
@@ -16019,7 +16019,7 @@ __metadata:
     "@trezor/node-utils": "workspace:^"
     "@trezor/utils": "workspace:*"
     "@types/node-fetch": "npm:^2.6.12"
-    node-fetch: "npm:2.6.7"
+    node-fetch: "npm:^3.3.2"
     socks-proxy-agent: "npm:8.0.5"
     ts-node: "npm:^10.9.2"
     ws: "npm:^8.20.0"
@@ -23709,6 +23709,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-uri-to-buffer@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "data-uri-to-buffer@npm:4.0.1"
+  checksum: 10/0d0790b67ffec5302f204c2ccca4494f70b4e2d940fea3d36b09f0bb2b8539c2e86690429eb1f1dc4bcc9e4df0644193073e63d9ee48ac9fce79ec1506e4aa4c
+  languageName: node
+  linkType: hard
+
 "data-urls@npm:^3.0.2":
   version: 3.0.2
   resolution: "data-urls@npm:3.0.2"
@@ -27748,6 +27755,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-blob@npm:^3.1.2, fetch-blob@npm:^3.1.4":
+  version: 3.2.0
+  resolution: "fetch-blob@npm:3.2.0"
+  dependencies:
+    node-domexception: "npm:^1.0.0"
+    web-streams-polyfill: "npm:^3.0.3"
+  checksum: 10/5264ecceb5fdc19eb51d1d0359921f12730941e333019e673e71eb73921146dceabcb0b8f534582be4497312d656508a439ad0f5edeec2b29ab2e10c72a1f86b
+  languageName: node
+  linkType: hard
+
 "fetch-nodeshim@npm:^0.4.6":
   version: 0.4.8
   resolution: "fetch-nodeshim@npm:0.4.8"
@@ -28182,6 +28199,15 @@ __metadata:
     node-domexception: "npm:1.0.0"
     web-streams-polyfill: "npm:4.0.0-beta.3"
   checksum: 10/29622f75533107c1bbcbe31fda683e6a55859af7f48ec354a9800591ce7947ed84cd3ef2b2fcb812047a884f17a1bac75ce098ffc17e23402cd373e49c1cd335
+  languageName: node
+  linkType: hard
+
+"formdata-polyfill@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "formdata-polyfill@npm:4.0.10"
+  dependencies:
+    fetch-blob: "npm:^3.1.2"
+  checksum: 10/9b5001d2edef3c9449ac3f48bd4f8cc92e7d0f2e7c1a5c8ba555ad4e77535cc5cf621fabe49e97f304067037282dd9093b9160a3cb533e46420b446c4e6bc06f
   languageName: node
   linkType: hard
 
@@ -36734,7 +36760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-domexception@npm:1.0.0":
+"node-domexception@npm:1.0.0, node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
   checksum: 10/e332522f242348c511640c25a6fc7da4f30e09e580c70c6b13cb0be83c78c3e71c8d4665af2527e869fc96848924a4316ae7ec9014c091e2156f41739d4fa233
@@ -36770,20 +36796,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7":
-  version: 2.6.7
-  resolution: "node-fetch@npm:2.6.7"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10/4bc9245383db92c35601a798c9a992fdf38d99920ceac11e0e6512ef3014d188b3807ccb060bc6c4bdb57a145030c73f5b5fd6730f665979f9264bc43ca3afea
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:2.7.0, node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -36795,6 +36807,17 @@ __metadata:
     encoding:
       optional: true
   checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: "npm:^4.0.0"
+    fetch-blob: "npm:^3.1.4"
+    formdata-polyfill: "npm:^4.0.10"
+  checksum: 10/24207ca8c81231c7c59151840e3fded461d67a31cf3e3b3968e12201a42f89ce4a0b5fb7079b1fa0a4655957b1ca9257553200f03a9f668b45ebad265ca5593d
   languageName: node
   linkType: hard
 
@@ -46637,6 +46660,13 @@ __metadata:
   version: 4.0.0-beta.3
   resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
   checksum: 10/dcdef67de57d83008f9dc330662b65ba4497315555dd0e4e7bcacb132ffdf8a830eaab8f74ad40a4a44f542461f51223f406e2a446ece1cc29927859b1405853
+  languageName: node
+  linkType: hard
+
+"web-streams-polyfill@npm:^3.0.3":
+  version: 3.3.3
+  resolution: "web-streams-polyfill@npm:3.3.3"
+  checksum: 10/8e7e13501b3834094a50abe7c0b6456155a55d7571312b89570012ef47ec2a46d766934768c50aabad10a9c30dd764a407623e8bfcc74fcb58495c29130edea9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumping `node-fetch` to version 3.x in order to resolve ``DeprecationWarning: `url.parse()` behavior is not standardized...`` errors coming to Sentry.

Also removing `@types/node-fetch` as, [according to docs](https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md#bundled-typescript-types), they're not needed anymore.

## QA

As far as I know, apart from some dev utils, `node-fetch` is used only in request manager when Tor is on, so it's the main thing to test.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to package.json files in three packages (coinjoin, connect, request-manager). These are likely dependency version bumps, metadata changes, or build configuration updates. No source code logic was changed, and no static test coverage mapping exists for package.json files. Without evidence of breaking API changes, new dependencies that alter runtime behavior, or structural changes that would affect test execution, there is no concrete reason to recommend any specific E2E tests. If the package.json changes include major dependency upgrades or script modifications, a broader smoke test suite should be considered, but that cannot be inferred from the available information.

<details><summary><b>Changed files (3)</b></summary>

- `packages/coinjoin/package.json`
- `packages/connect/package.json`
- `packages/request-manager/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/coinjoin/package.json`
- `packages/connect/package.json`
- `packages/request-manager/package.json`

_Updated: 2026-04-23T09:23:21.617Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-node-fetch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-node-fetch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bump-node-fetch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 30 test(s)</summary>

| Test | Type |
|------|------|
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T09:28:09.646Z • 30 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T15:15:39.493Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-node-fetch/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-node-fetch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->