### PR TITLE
Remove outdated timer expectation from useExchangeSelectQuote tests

### DIFF
--- a/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/__tests__/useExchangeSelectQuote.test.ts
@@ -269,7 +269,6 @@ describe('useExchangeSelectQuote', () => {
                         quote: expect.objectContaining({
                             quoteId: mercuryoFixedBestQuote?.quoteId,
                         }),
-                        timer: expect.objectContaining({ timeSpent: { seconds: 0 } }),
                     }),
                 }),
             );
@@ -372,7 +371,6 @@ describe('useExchangeSelectQuote', () => {
                             quote: expect.objectContaining({
                                 quoteId: mercuryoFixedBestQuote.quoteId,
                             }),
-                            timer: expect.objectContaining({ timeSpent: { seconds: 0 } }),
                         }),
                     }),
                 );


### PR DESCRIPTION
Just a fix of disabled suite-native trading tests.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-native-trade-timer-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->