### PR TITLE
chore(connect): use buf for tron encoding

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -121,6 +121,7 @@
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
     },
     "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
         "@ethereumjs/common": "^10.1.1",
         "@ethereumjs/tx": "^10.1.1",
         "@fivebinaries/coin-selection": "3.0.0",

--- a/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
+++ b/packages/connect/src/api/tron/__tests__/tronEncode.test.ts
@@ -1,26 +1,36 @@
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 import {
     estimateTronTransferBandwidth,
     estimateTronTrc20Bandwidth,
 } from '../estimateTronBandwidth';
-import { encodeBroadcastTransaction, encodeTransferRawData } from '../tronEncode';
-import { TransactionType } from '../tronProtobuf';
+import { encodeTronContractRawData } from '../tronEncode';
+import { decodeBroadcastTransaction, encodeBroadcastTransaction } from '../tronProtobuf';
 
 const OWNER_ADDRESS = '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58';
 const TO_ADDRESS = '4141f82674a30ae1328745d08afe2d1a0a24195283';
 
 const TRX_TRANSFER = {
-    from: OWNER_ADDRESS,
-    to: TO_ADDRESS,
     amount: '18123456',
-    refBlockBytes: 'e942',
-    refBlockHash: '6394747da9fee421',
-    expiration: 1752562632000,
-    timestamp: 1752562572000,
     signature:
         'a7f8602b02413e9dded0170daa5b4ada9a2679198af276be456f4faea1bc326f5070789bec5e6471de3f726f4fe0c9daced8df183e4a62804db26d5650c59a521c',
-};
+    contract: {
+        type: 'TransferContract',
+        parameter: {
+            value: {
+                owner_address: OWNER_ADDRESS,
+                to_address: TO_ADDRESS,
+                amount: 18123456,
+            },
+        },
+    },
+    blockParams: {
+        ref_block_bytes: 'e942',
+        ref_block_hash: '6394747da9fee421',
+        expiration: 1752562632000,
+        timestamp: 1752562572000,
+    },
+} as const;
 
 const TRC20_TRIGGER = {
     data: 'a9059cbb000000000000000000000000d093f24888ab06073a4bdffbb8107db1ea9dc0a000000000000000000000000000000000000000000000000000000000013bb450',
@@ -40,12 +50,14 @@ describe('tron/estimateTronTrc20Bandwidth', () => {
 
 describe('tron/encodeBroadcastTransaction', () => {
     it('embeds rawData and signature for a TRX transfer', () => {
-        const rawDataHex = bytesToHex(encodeTransferRawData(TRX_TRANSFER));
+        const rawDataHex = bytesToHex(
+            encodeTronContractRawData(TRX_TRANSFER.contract, TRX_TRANSFER.blockParams),
+        );
         const result = encodeBroadcastTransaction(rawDataHex, TRX_TRANSFER.signature);
 
-        const decoded = TransactionType.toObject(TransactionType.decode(hexToBytes(result)));
-        expect(bytesToHex(decoded.rawData as Uint8Array)).toBe(rawDataHex);
+        const decoded = decodeBroadcastTransaction(result);
+        expect(bytesToHex(decoded.rawData)).toBe(rawDataHex);
         expect(decoded.signature).toHaveLength(1);
-        expect(bytesToHex(decoded.signature[0] as Uint8Array)).toBe(TRX_TRANSFER.signature);
+        expect(bytesToHex(decoded.signature[0])).toBe(TRX_TRANSFER.signature);
     });
 });

--- a/packages/connect/src/api/tron/api/tronSignTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronSignTransaction.ts
@@ -13,7 +13,8 @@ import { Assert } from '@trezor/schema-utils';
 import type { MethodMessage, MethodPermission } from '../../../core/AbstractMethod';
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { validatePath } from '../../../utils/pathUtils';
-import { encodeBroadcastTransaction, encodeTronContractRawData } from '../tronEncode';
+import { encodeTronContractRawData } from '../tronEncode';
+import { encodeBroadcastTransaction } from '../tronProtobuf';
 
 // Transform official Tron field names to protobuf field names.
 const transformContract = (input: TronContractInput): TronContracts => {

--- a/packages/connect/src/api/tron/tronEncode.ts
+++ b/packages/connect/src/api/tron/tronEncode.ts
@@ -1,119 +1,9 @@
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { create, toBinary } from '@bufbuild/protobuf';
+import { hexToBytes } from '@noble/hashes/utils.js';
 
 import type { TronContracts } from '@trezor/connect-common/src/types/api/tron';
-
-import {
-    AnyType,
-    CONTRACT_TYPE_TRANSFER,
-    CONTRACT_TYPE_TRIGGER_SMART_CONTRACT,
-    TRANSFER_CONTRACT_TYPE_URL,
-    TRIGGER_SMART_CONTRACT_TYPE_URL,
-    TransactionRawType,
-    TransactionType,
-    TransferContractType,
-    TriggerSmartContractType,
-} from './tronProtobuf';
-
-export type EncodeTransferRawDataParams = {
-    from: string;
-    to: string;
-    amount: string; // in SUN
-    refBlockBytes: string;
-    refBlockHash: string;
-    expiration: number;
-    timestamp: number;
-};
-
-export const encodeTransferRawData = ({
-    from,
-    to,
-    amount,
-    refBlockBytes,
-    refBlockHash,
-    expiration,
-    timestamp,
-}: EncodeTransferRawDataParams): Uint8Array => {
-    const ownerBytes = hexToBytes(from);
-    const toBytes = hexToBytes(to);
-
-    const contractBytes = TransferContractType.encode(
-        TransferContractType.fromObject({
-            ownerAddress: Buffer.from(ownerBytes),
-            toAddress: Buffer.from(toBytes),
-            amount,
-        }),
-    ).finish();
-
-    return TransactionRawType.encode(
-        TransactionRawType.fromObject({
-            refBlockBytes: Buffer.from(hexToBytes(refBlockBytes)),
-            refBlockHash: Buffer.from(hexToBytes(refBlockHash)),
-            expiration,
-            timestamp,
-            contract: [
-                {
-                    type: CONTRACT_TYPE_TRANSFER,
-                    parameter: AnyType.fromObject({
-                        typeUrl: TRANSFER_CONTRACT_TYPE_URL,
-                        value: Buffer.from(contractBytes),
-                    }),
-                },
-            ],
-        }),
-    ).finish();
-};
-
-export type EncodeTriggerSmartContractRawDataParams = {
-    from: string;
-    contractAddress: string;
-    data: string; // calldata hex (without 0x)
-    refBlockBytes: string;
-    refBlockHash: string;
-    expiration: number;
-    timestamp: number;
-    feeLimit: number;
-};
-
-export const encodeTriggerSmartContractRawData = ({
-    from,
-    contractAddress,
-    data,
-    refBlockBytes,
-    refBlockHash,
-    expiration,
-    timestamp,
-    feeLimit,
-}: EncodeTriggerSmartContractRawDataParams): Uint8Array => {
-    const ownerBytes = hexToBytes(from);
-    const contractAddressBytes = hexToBytes(contractAddress);
-
-    const contractBytes = TriggerSmartContractType.encode(
-        TriggerSmartContractType.fromObject({
-            ownerAddress: Buffer.from(ownerBytes),
-            contractAddress: Buffer.from(contractAddressBytes),
-            data: Buffer.from(hexToBytes(data)),
-        }),
-    ).finish();
-
-    return TransactionRawType.encode(
-        TransactionRawType.fromObject({
-            refBlockBytes: Buffer.from(hexToBytes(refBlockBytes)),
-            refBlockHash: Buffer.from(hexToBytes(refBlockHash)),
-            expiration,
-            timestamp,
-            feeLimit,
-            contract: [
-                {
-                    type: CONTRACT_TYPE_TRIGGER_SMART_CONTRACT,
-                    parameter: AnyType.fromObject({
-                        typeUrl: TRIGGER_SMART_CONTRACT_TYPE_URL,
-                        value: Buffer.from(contractBytes),
-                    }),
-                },
-            ],
-        }),
-    ).finish();
-};
+import { protobufManager } from '@trezor/protobuf/src/bufbuild-loader';
+import { TronRawContractType } from '@trezor/protobuf/src/definitions/messages-tron';
 
 // DATA_HEX_PROTOBUF_EXTRA + MAX_RESULT_SIZE_IN_TX + A_SIGNATURE
 export const TRON_BANDWIDTH_FORMULA_OVERHEAD = 3 + 64 + 67;
@@ -126,39 +16,51 @@ type BlockParams = {
     fee_limit?: number;
 };
 
-export const encodeTronContractRawData = (
-    contract: TronContracts,
-    blockParams: BlockParams,
-): Uint8Array => {
-    const { ref_block_bytes, ref_block_hash, expiration, timestamp, fee_limit } = blockParams;
+const contractTypeUrl = (name: string) => `type.googleapis.com/protocol.${name}`;
 
+const getSchema = (name: string) => {
+    if (!protobufManager) {
+        throw new Error('ProtobufManager not initialized');
+    }
+
+    return protobufManager.findSchema(name).schema;
+};
+
+type InnerContract = { type: TronRawContractType; bytes: Uint8Array };
+
+const encodeInnerContract = (contract: TronContracts): InnerContract => {
     switch (contract.type) {
         case 'TransferContract': {
             const { owner_address, to_address, amount } = contract.parameter.value;
+            const schema = getSchema('TronTransferContract');
 
-            return encodeTransferRawData({
-                from: owner_address ?? '',
-                to: to_address ?? '',
-                amount: String(amount ?? 0),
-                refBlockBytes: ref_block_bytes,
-                refBlockHash: ref_block_hash,
-                expiration,
-                timestamp,
-            });
+            return {
+                type: TronRawContractType.TransferContract,
+                bytes: toBinary(
+                    schema,
+                    create(schema, {
+                        ownerAddress: hexToBytes(owner_address ?? ''),
+                        toAddress: hexToBytes(to_address ?? ''),
+                        amount: BigInt(amount ?? 0),
+                    }),
+                ),
+            };
         }
         case 'TriggerSmartContract': {
             const { owner_address, contract_address, data } = contract.parameter.value;
+            const schema = getSchema('TronTriggerSmartContract');
 
-            return encodeTriggerSmartContractRawData({
-                from: owner_address ?? '',
-                contractAddress: contract_address ?? '',
-                data: data ?? '',
-                refBlockBytes: ref_block_bytes,
-                refBlockHash: ref_block_hash,
-                expiration,
-                timestamp,
-                feeLimit: fee_limit ?? 0,
-            });
+            return {
+                type: TronRawContractType.TriggerSmartContract,
+                bytes: toBinary(
+                    schema,
+                    create(schema, {
+                        ownerAddress: hexToBytes(owner_address ?? ''),
+                        contractAddress: hexToBytes(contract_address ?? ''),
+                        data: hexToBytes(data ?? ''),
+                    }),
+                ),
+            };
         }
         default:
             throw new Error(
@@ -167,12 +69,32 @@ export const encodeTronContractRawData = (
     }
 };
 
-export const encodeBroadcastTransaction = (rawDataHex: string, signatureHex: string): string =>
-    bytesToHex(
-        TransactionType.encode(
-            TransactionType.fromObject({
-                rawData: Buffer.from(hexToBytes(rawDataHex)),
-                signature: [Buffer.from(hexToBytes(signatureHex))],
-            }),
-        ).finish(),
+export const encodeTronContractRawData = (
+    contract: TronContracts,
+    blockParams: BlockParams,
+): Uint8Array => {
+    const { type, bytes } = encodeInnerContract(contract);
+    const { ref_block_bytes, ref_block_hash, expiration, timestamp, fee_limit } = blockParams;
+    const schema = getSchema('TronRawTransaction');
+
+    return toBinary(
+        schema,
+        create(schema, {
+            refBlockBytes: hexToBytes(ref_block_bytes),
+            refBlockHash: hexToBytes(ref_block_hash),
+            expiration: BigInt(expiration),
+            timestamp: BigInt(timestamp),
+            // fee_limit is only valid for smart-contract calls; TRON ignores it on transfers.
+            feeLimit: contract.type === 'TriggerSmartContract' ? BigInt(fee_limit ?? 0) : undefined,
+            contract: [
+                {
+                    type,
+                    parameter: {
+                        typeUrl: contractTypeUrl(contract.type),
+                        value: bytes,
+                    },
+                },
+            ],
+        }),
     );
+};

--- a/packages/connect/src/api/tron/tronProtobuf.ts
+++ b/packages/connect/src/api/tron/tronProtobuf.ts
@@ -1,71 +1,33 @@
-import { parseConfigure } from '@trezor/protobuf';
+import { BinaryReader, BinaryWriter, WireType } from '@bufbuild/protobuf/wire';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 
-const TRON_CHAIN_SCHEMA = {
-    nested: {
-        protocol: {
-            nested: {
-                // Defined under `protocol` (not `google.protobuf`) to avoid protobufjs
-                // well-known-type special-casing; wire format is identical.
-                Any: {
-                    fields: {
-                        typeUrl: { type: 'string', id: 1 },
-                        value: { type: 'bytes', id: 2 },
-                    },
-                },
-                TransferContract: {
-                    fields: {
-                        ownerAddress: { type: 'bytes', id: 1 },
-                        toAddress: { type: 'bytes', id: 2 },
-                        amount: { type: 'int64', id: 3 },
-                    },
-                },
-                TriggerSmartContract: {
-                    fields: {
-                        ownerAddress: { type: 'bytes', id: 1 },
-                        contractAddress: { type: 'bytes', id: 2 },
-                        data: { type: 'bytes', id: 4 },
-                    },
-                },
-                Contract: {
-                    fields: {
-                        type: { type: 'int32', id: 1 },
-                        parameter: { type: 'Any', id: 2 },
-                    },
-                },
-                TransactionRaw: {
-                    fields: {
-                        refBlockBytes: { type: 'bytes', id: 1 },
-                        refBlockHash: { type: 'bytes', id: 4 },
-                        expiration: { type: 'int64', id: 8 },
-                        contract: { rule: 'repeated', type: 'Contract', id: 11 },
-                        timestamp: { type: 'int64', id: 14 },
-                        feeLimit: { type: 'int64', id: 18 },
-                    },
-                },
-                // rawData is typed as `bytes` (not TransactionRaw) because we receive it
-                // pre-encoded from the firmware. bytes and a nested message share the same
-                // length-delimited wire format, so the encoding is identical.
-                Transaction: {
-                    fields: {
-                        rawData: { type: 'bytes', id: 1 },
-                        signature: { rule: 'repeated', type: 'bytes', id: 2 },
-                    },
-                },
-            },
-        },
-    },
+// The TRON-network `Transaction { bytes rawData=1, repeated bytes signature=2 }`
+// envelope isn't part of the Trezor protobuf schema, so we emit and parse its
+// two length-delimited fields directly against the wire format.
+
+export const encodeBroadcastTransaction = (rawDataHex: string, signatureHex: string): string => {
+    const writer = new BinaryWriter();
+    writer.tag(1, WireType.LengthDelimited).bytes(hexToBytes(rawDataHex));
+    writer.tag(2, WireType.LengthDelimited).bytes(hexToBytes(signatureHex));
+
+    return bytesToHex(writer.finish());
 };
 
-const root = parseConfigure(TRON_CHAIN_SCHEMA);
+export const decodeBroadcastTransaction = (hex: string) => {
+    const reader = new BinaryReader(hexToBytes(hex));
+    let rawData: Uint8Array | undefined;
+    const signature: Uint8Array[] = [];
+    while (reader.pos < reader.len) {
+        const [fieldNo] = reader.tag();
+        if (fieldNo === 1) {
+            rawData = reader.bytes();
+        } else if (fieldNo === 2) {
+            signature.push(reader.bytes());
+        } else {
+            throw new Error(`Unexpected field ${fieldNo} in broadcast transaction`);
+        }
+    }
+    if (!rawData) throw new Error('Missing rawData in broadcast transaction');
 
-export const AnyType = root.lookupType('protocol.Any');
-export const TransferContractType = root.lookupType('protocol.TransferContract');
-export const TriggerSmartContractType = root.lookupType('protocol.TriggerSmartContract');
-export const TransactionRawType = root.lookupType('protocol.TransactionRaw');
-export const TransactionType = root.lookupType('protocol.Transaction');
-
-export const TRANSFER_CONTRACT_TYPE_URL = 'type.googleapis.com/protocol.TransferContract';
-export const TRIGGER_SMART_CONTRACT_TYPE_URL = 'type.googleapis.com/protocol.TriggerSmartContract';
-
-export const CONTRACT_TYPE_TRANSFER = 1; // ContractType.TransferContract
-export const CONTRACT_TYPE_TRIGGER_SMART_CONTRACT = 31; // ContractType.TriggerSmartContract
+    return { rawData, signature };
+};

--- a/suite-native/app/metro.config.js
+++ b/suite-native/app/metro.config.js
@@ -63,6 +63,7 @@ const config = {
                 // See: https://github.com/trezor/trezor-suite/issues/20733
                 // modules exports defined in the package `exports` map.
                 '@bufbuild/protobuf/codegenv2': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/codegenv2/index.js`,
+                '@bufbuild/protobuf/wire': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/wire/index.js`,
                 '@bufbuild/protobuf/wkt': `${rootNodeModulesPath}/@bufbuild/protobuf/dist/cjs/wkt/index.js`,
                 '@evolu/react-native': `${rootNodeModulesPath}/@evolu/react-native/dist/src/index.js`,
                 '@evolu/react-native/expo-sqlite': `${rootNodeModulesPath}/@evolu/react-native/dist/src/exports/expo-sqlite.js`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15955,6 +15955,7 @@ __metadata:
   resolution: "@trezor/connect@workspace:packages/connect"
   dependencies:
     "@babel/preset-typescript": "npm:^7.28.5"
+    "@bufbuild/protobuf": "npm:^2.11.0"
     "@ethereumjs/common": "npm:^10.1.1"
     "@ethereumjs/tx": "npm:^10.1.1"
     "@fivebinaries/coin-selection": "npm:3.0.0"


### PR DESCRIPTION
## Description

Remove custom `tronProtobuf` logic built on `protobufjs` and replace it using existing FW definitions built with `bufbuild`. 
The network transaction envelope is not part of FW definitions and is constructed manually.
`tronEncode` is refactored and simplified.

## Notes for QA

Make sure Tron send and fee calculations work, both TRX and tokens
Please check if #26736 and #26756 are resolved afterwards

## Related Issue

Related to #24240 initiative

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tron-encode-bufbuild&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tron-encode-bufbuild&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tron-encode-bufbuild&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T12:40:53.164Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T15:58:15.147Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/tron-encode-bufbuild/web/](https://dev.suite.sldev.cz/suite-web/tron-encode-bufbuild/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->