### PR TITLE
fix(suite): adhere to spaced address settings for cardano on trezor

### DIFF
--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -39,7 +39,6 @@ import TrezorConnect, {
     type Device,
     asBluetoothDeviceId,
 } from '@trezor/connect';
-import { getEnvironment } from '@trezor/env-utils';
 import { exhaustive } from '@trezor/type-utils';
 import { isChanged } from '@trezor/utils';
 
@@ -240,8 +239,6 @@ export const confirmAddressOnDeviceThunk = createThunk(
 
         let response;
 
-        const isCardanoAddressChunked = getEnvironment() === 'mobile';
-
         switch (account.networkType) {
             case 'tron':
                 response = await TrezorConnect.tronGetAddress(params);
@@ -260,7 +257,7 @@ export const confirmAddressOnDeviceThunk = createThunk(
                     protocolMagic: getProtocolMagic(account.symbol),
                     networkId: getNetworkId(),
                     derivationType: getDerivationType(account.accountType),
-                    chunkify: isCardanoAddressChunked,
+                    chunkify,
                 });
                 break;
             case 'ripple':

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -13,7 +13,7 @@ import { formatAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
 import { DeviceFixture } from '../device';
 import type { NormalizedDisplayContent } from '../helpers/displayContentNormalizedParser';
 
-type LineFormats = 'fourTetragrams' | 'evmTetragrams' | 'fullLine';
+type LineFormats = 'fourTetragrams' | 'evmTetragrams' | 'cardanoTetragrams' | 'fullLine';
 
 const DISPLAY_CHAR_LIMIT_T3T1 = 18;
 const STRING_UP_TO_T3T1_DISPLAY_LIMIT = new RegExp(`.{1,${DISPLAY_CHAR_LIMIT_T3T1}}`, 'g');
@@ -88,6 +88,14 @@ const formatEvmAddress = (address: string) => {
     return ['0x' + firstTetragram, ...rest].join(' ');
 };
 
+const formatCardanoAddress = (address: string) => {
+    const formatted = formatAddress(address);
+    const parts = formatted.split(' ');
+    const visibleParts = [...parts.slice(0, 15), '...'];
+
+    return visibleParts.join(' ');
+};
+
 export const transformAddress = (address: string, lineFormat: LineFormats = 'fourTetragrams') => {
     // Address is split to lines on Display so it can fit. There are different formats:
     // 1. Four tetragrams of address:
@@ -111,6 +119,10 @@ export const transformAddress = (address: string, lineFormat: LineFormats = 'fou
 
     if (lineFormat === 'evmTetragrams') {
         return addNewlinesToAddress(formatEvmAddress(address), fourTetragramsOfAddress, ' \n');
+    }
+
+    if (lineFormat === 'cardanoTetragrams') {
+        return addNewlinesToAddress(formatCardanoAddress(address), fourTetragramsOfAddress, ' \n');
     }
 
     if (lineFormat === 'fullLine') {

--- a/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-cardano.test.ts
@@ -57,7 +57,7 @@ test.describe('Passphrase with cardano', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await expect(device).toShowReceiveAddress(correctPassphraseAddr, {
-                lineFormat: 'fullLine',
+                lineFormat: 'cardanoTetragrams',
             });
             await device.pressYes(); // Confirm receive address
 

--- a/suite/e2e/tests/wallet/cardano.test.ts
+++ b/suite/e2e/tests/wallet/cardano.test.ts
@@ -60,7 +60,7 @@ test.describe('Cardano', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 await walletPage.revealAddressButton.click();
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await expect(device).toShowReceiveAddress(receiveAddress, {
-                    lineFormat: 'fullLine',
+                    lineFormat: 'cardanoTetragrams',
                 });
                 await device.pressYes();
                 await expect(walletPage.copyAddressButton).toBeEnabled();


### PR DESCRIPTION
## Description

When the user has address display settings set to `Spaced`, show spaced Cardano addresses on Trezor device.

## Related Issue

Resolve #26621 

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is in deviceThunks.ts, a core device management module that maps to 121 tests, indicating it is a broad shared dependency. The highest risk areas are device connection/disconnection handling, device state transitions, wallet discovery initialization, passphrase session management, and multi-session/device-switching logic. The recommended strategy focuses on tests that directly exercise device lifecycle events (connect, disconnect, reconnect), device-dependent state transitions (discovery, passphrase caching), and scenarios where device thunk behavior is observable through specific UI states or analytics events. Most of the 121 mapped tests only transitively depend on this file and are omitted to keep the test set targeted.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/device/deviceThunks.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — deviceThunks.ts directly manages device-related actions that are core to wallet discovery flows. This test exercises ejecting wallets, adding standard wallets, and discovering accounts — all operations that likely invoke device thunks for device state management and wallet initialization.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test covers Bridge session stealing, device status transitions (Connected/Use Here), and session reclamation — all scenarios that directly depend on device thunks managing device connection state, session handling, and device switching logic.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates the initial onboarding flow including device connection detection and the transition from onboarding to connected device state. deviceThunks likely handles the device connection event that triggers the @deviceStatus-connected element appearing after onboarding completion.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test verifies the full discovery lifecycle including status transitions (starting → complete), reload resilience, and multi-coin discovery. Device thunks are fundamental to initializing device state that triggers and manages the discovery process.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test explicitly asserts DeviceConnect and DeviceDisconnect analytics events, which are likely dispatched from or triggered by device thunks. Changes to deviceThunks could affect the device metadata passed to these events (firmware version, model, pin/passphrase protection status).
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect during backup and validates reconnection behavior, toast notifications, and device state recovery. Device thunks manage the device power off/on lifecycle and state transitions that this test directly exercises.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test dispatches deviceActions.setSimulatedEntropyCheckFail directly through the Redux store, which is closely coupled to device thunks. Changes to device action handling in deviceThunks could affect how entropy check failures are processed and surfaced in the UI.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test validates passphrase wallet caching across device disconnect/reconnect cycles. Device thunks manage device reconnection state and passphrase session caching, which are core to this test's assertions about passphrase re-entry behavior.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test covers adding hidden wallets, switching between passphrase wallets, and passphrase mismatch handling. Device thunks likely manage the device state transitions for passphrase-protected wallet creation and device-cached passphrase sessions.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test validates duplicate passphrase wallet detection, which requires device thunks to correctly manage device instance tracking and wallet deduplication logic when adding hidden wallets.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test validates recovery dry run with device disconnect/reconnect and page reload scenarios. Device thunks manage the device reconnection and state persistence that allows the recovery process to reinitialize after disruption.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test explicitly validates device disconnection detection (deviceDisconnectedStatus), connection modal display, and disconnected device banner — all UI states driven by device thunk actions managing device connection state.

</details>

_Updated: 2026-04-23T13:35:02.922Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/cardano-address-chunkify&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/cardano-address-chunkify&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/cardano-address-chunkify&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T08:57:10.675Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T10:04:16.478Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/cardano-address-chunkify/web/](https://dev.suite.sldev.cz/suite-web/fix/cardano-address-chunkify/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->