### PR TITLE
fix(suite-native-26222) swap-provider-select-sometimes-fails-to-open-on-android-app

### DIFF
--- a/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
+++ b/suite-native/atoms/src/Sheet/BottomSheetFlashList.tsx
@@ -61,8 +61,11 @@ export const BottomSheetFlashList = <TItem,>({
 
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
 
-    const handleClose = useCallback(() => {
+    const dismissSheet = useCallback(() => {
         bottomSheetModalRef.current?.dismiss();
+    }, []);
+
+    const handleDismiss = useCallback(() => {
         onClose(false);
     }, [onClose]);
 
@@ -73,22 +76,13 @@ export const BottomSheetFlashList = <TItem,>({
     // minHeight can be higher than maxHeight because of estimatedListHeight, but it must be capped by maxHeight
     const snapPoints = useMemo(() => [Math.min(minHeight, maxHeight)], [minHeight, maxHeight]);
 
-    const handleSheetChanges = useCallback(
-        (index: number) => {
-            if (index === -1) {
-                handleClose();
-            }
-        },
-        [handleClose],
-    );
-
     useEffect(() => {
         if (isVisible) {
             bottomSheetModalRef.current?.present();
         } else {
-            bottomSheetModalRef.current?.dismiss();
+            dismissSheet();
         }
-    }, [isVisible]);
+    }, [dismissSheet, isVisible]);
 
     const BottomSheetListScrollComponent = useBottomSheetScrollableCreator();
 
@@ -98,11 +92,11 @@ export const BottomSheetFlashList = <TItem,>({
             snapPoints={snapPoints}
             maxDynamicContentSize={maxHeight}
             enableDynamicSizing={false}
-            onChange={handleSheetChanges}
+            onDismiss={handleDismiss}
             backdropComponent={props => (
                 <BottomSheetBackdrop
                     {...props}
-                    onPress={handleClose}
+                    onPress={dismissSheet}
                     appearsOnIndex={0}
                     disappearsOnIndex={-1}
                 />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The BottomSheetFlashList component could get into a state where isVisible in the parent no longer matched the actual sheet state. Was happening when you dismiss the sheet and immediately clicking open flipping isVisible flag and the gorhom was ignoring the .present() cuz still doing dismiss().

<!--- Describe your changes in detail -->

## Notes for QA
* Test all components that use BottomSheetFlashList: CountrySheet, BottomSheetSectionList, PaymentMethodSheet, and AccountSelectBottomSheet

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/26222

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/26222-swap-provider-select-sometimes-fails-to-open-on-android-app&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->