### PR TITLE
fix(ci): Fixed issues with auto-quarantine (canary quarantine and arc…

### DIFF
--- a/packages/e2e-utils/src/currentsApi/types.ts
+++ b/packages/e2e-utils/src/currentsApi/types.ts
@@ -93,6 +93,7 @@ export interface TestResultItem {
     runId: string;
     instanceId: string;
     spec: string;
+    tags?: string[];
     status: 'passed' | 'failed' | 'pending' | 'skipped';
     flaky: boolean;
     commit: TestResultCommit;

--- a/packages/e2e-utils/src/quarantineBot/api.ts
+++ b/packages/e2e-utils/src/quarantineBot/api.ts
@@ -1,6 +1,11 @@
 import { type computeStats, normalizeTitlePath } from './actions';
-import { AUTO_QUARANTINE_PREFIX, EXPLORER_LOOKBACK_DAYS } from './config';
-import { createAction, currentsRequest, getActions } from '../currentsApi/api';
+import {
+    AUTO_QUARANTINE_PREFIX,
+    CANARY_QUARANTINE_PREFIX,
+    EXPLORER_LOOKBACK_DAYS,
+    FW_CANARY_TAG,
+} from './config';
+import { createAction, currentsRequest, deleteAction, getActions } from '../currentsApi/api';
 import type { Action, TestExplorerItem, TestsExplorerResponse } from '../currentsApi/types';
 import { debug } from '../logger';
 
@@ -8,8 +13,47 @@ export async function getAutoQuarantineActions(projectId: string): Promise<Actio
     const actions = await getActions(projectId);
 
     return actions.filter(
-        a => a.name.startsWith(AUTO_QUARANTINE_PREFIX) && a.action.some(r => r.op === 'quarantine'),
+        a =>
+            a.status === 'active' &&
+            (a.name.startsWith(AUTO_QUARANTINE_PREFIX) ||
+                a.name.startsWith(CANARY_QUARANTINE_PREFIX)) &&
+            a.action.some(r => r.op === 'quarantine'),
     );
+}
+
+/**
+ * Replace a global quarantine action with one scoped to fw canary runs only
+ * (identified by the `fwCanary` Currents tag). The original action is deleted
+ * and a new one is created with the `[auto-quarantine, canary]` prefix and an
+ * additional `tag: inc fwCanary` matcher condition.
+ */
+export async function narrowQuarantineToCanary(projectId: string, action: Action): Promise<Action> {
+    const titlePathCond = action.matcher.cond.find(
+        c => c.type === 'titlePath' && Array.isArray(c.value),
+    );
+    if (!titlePathCond || !Array.isArray(titlePathCond.value)) {
+        throw new Error(`Cannot extract titlePath from action "${action.name}"`);
+    }
+    const titlePath = titlePathCond.value as string[];
+    const name = `${CANARY_QUARANTINE_PREFIX} ${titlePath.join(' > ').slice(0, 80)}`;
+    const description =
+        action.description +
+        `\nNarrowed to fw canary (tag: ${FW_CANARY_TAG}) on ${new Date().toISOString().slice(0, 10)}.`;
+
+    await deleteAction(action.actionId);
+
+    return createAction(projectId, {
+        name,
+        description,
+        action: [{ op: 'quarantine' }],
+        matcher: {
+            op: 'AND',
+            cond: [
+                { type: 'titlePath', op: 'incAll', value: titlePath },
+                { type: 'tag', op: 'inc', value: [FW_CANARY_TAG] },
+            ],
+        },
+    });
 }
 
 /**

--- a/packages/e2e-utils/src/quarantineBot/config.ts
+++ b/packages/e2e-utils/src/quarantineBot/config.ts
@@ -3,6 +3,8 @@ export { CURRENTS_API_BASE, DEVELOP_BRANCH, TEST_RESULTS_PAGE_SIZE } from '../cu
 export const EXPLORER_LOOKBACK_DAYS = 2; // window used by Tests Explorer to discover active tests
 
 export const AUTO_QUARANTINE_PREFIX = '[auto-quarantine]';
+export const CANARY_QUARANTINE_PREFIX = '[auto-quarantine, canary]';
+export const FW_CANARY_TAG = 'fwCanary';
 
 /**
  * Heuristic thresholds

--- a/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts
@@ -1,9 +1,14 @@
 import { extractKeyFromAction } from './actions';
-import { findSignaturesForTitleKeys, getAutoQuarantineActions } from './api';
-import { DEVELOP_BRANCH, EXPLORER_LOOKBACK_DAYS } from './config';
+import {
+    findSignaturesForTitleKeys,
+    getAutoQuarantineActions,
+    narrowQuarantineToCanary,
+} from './api';
+import { DEVELOP_BRANCH, EXPLORER_LOOKBACK_DAYS, FW_CANARY_TAG } from './config';
+import { deleteAction, getLatestRunIdOnBranch, getResultsFromRun } from '../currentsApi/api';
 import { debug, log, warn } from '../logger';
 import type { SlackEvent } from './types';
-import { deleteAction, getLatestRunIdOnBranch, getResultsFromRun } from '../currentsApi/api';
+import type { TestResultItem } from '../currentsApi/types';
 
 /**
  * Unquarantine auto-quarantined tests that passed in the latest run on the
@@ -14,9 +19,15 @@ import { deleteAction, getLatestRunIdOnBranch, getResultsFromRun } from '../curr
  * on the main branch — without waiting for the broader statistical threshold
  * used by the regular health-check (`unquarantinePassingTests`).
  *
- * A test is only unquarantined if ALL its instances in the run passed (i.e.
- * every Playwright project that executed it reported a pass). This handles
- * multi-project runs where the same test title can appear more than once.
+ * When tag information is available in results, fw canary instances (tagged
+ * `fwCanary`) are evaluated separately from regular instances:
+ *  - Regular all pass + canary all pass (or no canary) → full unquarantine.
+ *  - Regular all pass + some canary still fail → narrow the quarantine action
+ *    to canary-only (tag: fwCanary), keeping the test visible in regular runs.
+ *  - Any regular instance fails → keep quarantine unchanged.
+ *
+ * If the API does not return tag information (all tags undefined), the
+ * function falls back to the original behaviour: all instances must pass.
  *
  * To minimise API calls the function never loads the full run. Instead it:
  *   1. Fetches only the auto-quarantined actions (one API call).
@@ -85,14 +96,14 @@ export async function nightlyUnquarantineFromLatestRun(
 
     // For each quarantined test, fetch only its own results filtered to the
     // latest run. One API call per test — no unrelated spec data is loaded.
-    const instanceStats = new Map<string, { total: number; passed: number }>();
+    const resultsByKey = new Map<string, TestResultItem[]>();
     await Promise.all(
         [...quarantinedByKey.keys()].map(async key => {
             const signature = signatureByKey.get(key);
             if (!signature) {
                 debug(`  no signature for key ${key} — leaving quarantined`);
 
-                return; // test not seen in the explorer lookback window — leave quarantined
+                return;
             }
             const results = await getResultsFromRun(signature, runId, EXPLORER_LOOKBACK_DAYS);
             debug(
@@ -101,52 +112,116 @@ export async function nightlyUnquarantineFromLatestRun(
                     ? `(${results.filter(r => r.status === 'passed').length} passed)`
                     : '',
             );
-            if (results.length === 0) {
-                return;
+            if (results.length > 0) {
+                resultsByKey.set(key, results);
             }
-            instanceStats.set(key, {
-                total: results.length,
-                passed: results.filter(r => r.status === 'passed').length,
-            });
         }),
     );
 
     let unquarantinedCount = 0;
+    let narrowedCount = 0;
 
     for (const [testKey, action] of quarantinedByKey) {
         const testTitle = (JSON.parse(testKey) as string[]).join(' > ');
-        const stats = instanceStats.get(testKey);
+        const results = resultsByKey.get(testKey);
 
-        if (!stats || stats.total === 0) {
+        if (!results || results.length === 0) {
             log(`  ↳ Not seen in run: "${testTitle.slice(0, 80)}" — keeping quarantine.`);
             continue;
         }
 
-        if (stats.passed < stats.total) {
+        // When the API returns tag information, evaluate canary and regular
+        // instances separately. Fall back to treating all results as regular
+        // (original behaviour) when tags are not present in the response.
+        const hasTagInfo = results.some(r => r.tags !== undefined);
+        const canaryResults = hasTagInfo
+            ? results.filter(r => r.tags?.includes(FW_CANARY_TAG))
+            : [];
+        const regularResults = hasTagInfo
+            ? results.filter(r => !r.tags?.includes(FW_CANARY_TAG))
+            : results;
+
+        debug(
+            `  key ${testKey.slice(0, 60)}: hasTagInfo=${hasTagInfo}`,
+            `regular=${regularResults.length} canary=${canaryResults.length}`,
+        );
+
+        if (regularResults.length === 0) {
+            // Only canary instances ran this test in the latest develop run.
+            // Keep the quarantine — we need regular instances to pass first.
             log(
-                `  ↳ Not all instances passed (${stats.passed}/${stats.total}): "${testTitle.slice(0, 80)}" — keeping quarantine.`,
+                `  ↳ Only canary instances in run: "${testTitle.slice(0, 80)}" — keeping quarantine.`,
             );
             continue;
         }
 
-        log(
-            `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" (${stats.total} instance(s) all passed) ✓`,
-        );
-        await deleteAction(action.actionId);
-        debug(`  deleted action: actionId=${action.actionId}`);
-        unquarantinedCount++;
+        const regularPassed = regularResults.filter(r => r.status === 'passed').length;
 
-        slackEvents.push({
-            kind: 'unquarantined',
-            projectId,
-            titlePath: JSON.parse(testKey) as string[],
-            signature: undefined,
-            passes: stats.passed,
-            executions: stats.total,
-        });
+        if (regularPassed < regularResults.length) {
+            log(
+                `  ↳ Not all regular instances passed (${regularPassed}/${regularResults.length}): "${testTitle.slice(0, 80)}" — keeping quarantine.`,
+            );
+            continue;
+        }
+
+        // All regular instances passed. Now check canary.
+        const canaryPassed = canaryResults.filter(r => r.status === 'passed').length;
+        const canaryAllPassed = canaryResults.length === 0 || canaryPassed === canaryResults.length;
+        const signature = signatureByKey.get(testKey);
+
+        if (canaryAllPassed) {
+            log(
+                `  ↳ Unquarantining: "${testTitle.slice(0, 80)}" (${results.length} instance(s) all passed) ✓`,
+            );
+            await deleteAction(action.actionId);
+            debug(`  deleted action: actionId=${action.actionId}`);
+            unquarantinedCount++;
+
+            slackEvents.push({
+                kind: 'unquarantined',
+                projectId,
+                titlePath: JSON.parse(testKey) as string[],
+                signature,
+                passes: results.filter(r => r.status === 'passed').length,
+                executions: results.length,
+            });
+        } else {
+            // Regular passed but canary still failing. If the action is already
+            // canary-scoped, there is nothing to update — just keep it.
+            const alreadyCanaryScoped = action.matcher.cond.some(
+                c =>
+                    c.type === 'tag' &&
+                    (c.value === FW_CANARY_TAG ||
+                        (Array.isArray(c.value) && c.value.includes(FW_CANARY_TAG))),
+            );
+
+            if (alreadyCanaryScoped) {
+                log(
+                    `  ↳ Canary still failing (${canaryPassed}/${canaryResults.length}): "${testTitle.slice(0, 80)}" — keeping canary quarantine.`,
+                );
+                continue;
+            }
+
+            log(
+                `  ↳ Narrowing to canary: "${testTitle.slice(0, 80)}" (regular ${regularPassed}/${regularResults.length} passed, canary ${canaryPassed}/${canaryResults.length} passed) ✓`,
+            );
+            const narrowedAction = await narrowQuarantineToCanary(projectId, action);
+            debug(`  narrowed action: actionId=${narrowedAction.actionId}`);
+            narrowedCount++;
+
+            slackEvents.push({
+                kind: 'narrowed',
+                projectId,
+                titlePath: JSON.parse(testKey) as string[],
+                signature,
+                actionId: narrowedAction.actionId,
+                regularPasses: regularPassed,
+                regularTotal: regularResults.length,
+            });
+        }
     }
 
-    if (unquarantinedCount === 0) {
+    if (unquarantinedCount === 0 && narrowedCount === 0) {
         log('  ✓ No quarantined tests found passing in all instances of the latest run.');
     }
 }

--- a/packages/e2e-utils/src/quarantineBot/quarantine.ts
+++ b/packages/e2e-utils/src/quarantineBot/quarantine.ts
@@ -1,6 +1,7 @@
 import { computeStats, extractKeyFromAction, getTestKey, normalizeTitlePath } from './actions';
 import { createQuarantineAction } from './api';
 import {
+    CANARY_QUARANTINE_PREFIX,
     EXPLORER_LOOKBACK_DAYS,
     PRE_FILTER_FAILURE_RATE,
     QUARANTINE_FAILURE_RATE,
@@ -26,9 +27,18 @@ export async function quarantineFailingTests(
 ): Promise<void> {
     log(`\n── [${projectLabel}] Checking for failing tests to quarantine ──`);
 
-    const alreadyQuarantinedKeys = new Set(
-        existingActions.map(a => extractKeyFromAction(a)).filter(Boolean) as string[],
-    );
+    const canaryActionByKey = new Map<string, Action>();
+    const alreadyQuarantinedKeys = new Set<string>();
+
+    for (const action of existingActions) {
+        const key = extractKeyFromAction(action);
+        if (!key) continue;
+        if (action.name.startsWith(CANARY_QUARANTINE_PREFIX)) {
+            canaryActionByKey.set(key, action);
+        } else {
+            alreadyQuarantinedKeys.add(key);
+        }
+    }
     debug(`  already quarantined keys: ${alreadyQuarantinedKeys.size}`);
 
     const candidateTests = activeTests.filter(
@@ -90,6 +100,13 @@ export async function quarantineFailingTests(
                 `(${failurePercent}% fail rate, ${stats.failures}/${stats.executions} latest runs)`,
         );
 
+        const existingCanary = canaryActionByKey.get(getTestKey(test));
+        if (existingCanary) {
+            log(`  ↳ Removing stale canary-scoped action before creating global quarantine.`);
+            await deleteAction(existingCanary.actionId);
+            debug(`  deleted canary action: actionId=${existingCanary.actionId}`);
+        }
+
         const action = await createQuarantineAction(projectId, test, stats);
         debug(`  created action: actionId=${action.actionId}`);
         slackEvents.push({
@@ -131,6 +148,13 @@ export async function unquarantinePassingTests(
     debug(`  active tests index: ${testsByKey.size} entries`);
 
     for (const action of existingActions) {
+        if (action.name.startsWith(CANARY_QUARANTINE_PREFIX)) {
+            log(
+                `  ↳ Skipping canary-scoped action: "${action.name.slice(0, 80)}" — managed by nightly unquarantine only.`,
+            );
+            continue;
+        }
+
         const testKey = extractKeyFromAction(action);
         if (!testKey) {
             warn(`  ↳ Could not extract title from action "${action.name}", skipping.`);

--- a/packages/e2e-utils/src/quarantineBot/slack.ts
+++ b/packages/e2e-utils/src/quarantineBot/slack.ts
@@ -62,6 +62,7 @@ export function buildSlackSummary(
 
         const quarantinedEvents = projectEvents.filter(e => e.kind === 'quarantined');
         const unquarantinedEvents = projectEvents.filter(e => e.kind === 'unquarantined');
+        const narrowedEvents = projectEvents.filter(e => e.kind === 'narrowed');
 
         const lines: string[] = [`*${projectLabel}*`];
 
@@ -86,6 +87,19 @@ export function buildSlackSummary(
                     : '';
                 lines.push(
                     `• ${truncateTitle(event.titlePath)} — ${event.passes}/${event.executions} passed${resultsLink}`,
+                );
+            }
+        }
+
+        if (narrowedEvents.length > 0) {
+            lines.push(`:arrows_counterclockwise: *Narrowed to canary (${narrowedEvents.length})*`);
+            for (const event of narrowedEvents) {
+                const resultsLink = event.signature
+                    ? ` · <${currentsTestUrl(projectId, event.signature)}|results>`
+                    : '';
+                const actionUrl = currentsActionUrl(projectId, event.actionId);
+                lines.push(
+                    `• ${truncateTitle(event.titlePath)} — passes in regular (${event.regularPasses}/${event.regularTotal}), still failing in fw canary · <${actionUrl}|action>${resultsLink}`,
                 );
             }
         }

--- a/packages/e2e-utils/src/quarantineBot/types.ts
+++ b/packages/e2e-utils/src/quarantineBot/types.ts
@@ -15,6 +15,15 @@ export type SlackEvent =
           signature: string | undefined;
           passes: number;
           executions: number;
+      }
+    | {
+          kind: 'narrowed';
+          projectId: string;
+          titlePath: string[];
+          signature: string | undefined;
+          actionId: string;
+          regularPasses: number;
+          regularTotal: number;
       };
 
 export interface FailedTestFromRun {


### PR DESCRIPTION
…hived actions)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 7 changed files are in `packages/e2e-utils/src/quarantineBot/` and `packages/e2e-utils/src/currentsApi/types.ts`, which are internal tooling utilities for the quarantine bot (used for managing flaky/quarantined E2E tests) and Currents API type definitions. These are CI/CD infrastructure modules, not application source code. None of the analyzed E2E tests reference quarantine bot functionality or Currents API types in their behaviors, entry points, or source hints. There is no static coverage mapping and no inferrable test coverage for these changes. The risk to user-facing application behavior is effectively zero — no E2E tests need to be run for this change.

<details><summary><b>Changed files (7)</b></summary>

- `packages/e2e-utils/src/currentsApi/types.ts`
- `packages/e2e-utils/src/quarantineBot/api.ts`
- `packages/e2e-utils/src/quarantineBot/config.ts`
- `packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts`
- `packages/e2e-utils/src/quarantineBot/quarantine.ts`
- `packages/e2e-utils/src/quarantineBot/slack.ts`
- `packages/e2e-utils/src/quarantineBot/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (7)**
- `packages/e2e-utils/src/currentsApi/types.ts`
- `packages/e2e-utils/src/quarantineBot/api.ts`
- `packages/e2e-utils/src/quarantineBot/config.ts`
- `packages/e2e-utils/src/quarantineBot/nightlyUnquarantine.ts`
- `packages/e2e-utils/src/quarantineBot/quarantine.ts`
- `packages/e2e-utils/src/quarantineBot/slack.ts`
- `packages/e2e-utils/src/quarantineBot/types.ts`

_Updated: 2026-04-23T14:21:27.615Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-ci-autoquarantine-canary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ci-autoquarantine-canary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-23T14:51:52.180Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Suite Sync - Labelling > Create new labels | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-23T14:50:22.725Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ci-autoquarantine-canary/web/](https://dev.suite.sldev.cz/suite-web/fix-ci-autoquarantine-canary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->