### PR TITLE
refactor(connect): apply generic AbstractGetAddress to all coins (experiment)

### DIFF
--- a/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetAddress.ts
@@ -1,24 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/CardanoGetAddress.js
 
-import {
-    Bundle,
-    CardanoGetAddress as CardanoGetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
+import { Bundle, CardanoGetAddress as CardanoGetAddressSchema } from '@trezor/connect-common';
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath } from '../../../utils/pathUtils';
+import { AbstractGetAddress } from '../../common/AbstractGetAddress';
 import { bundlify } from '../../common/paramsValidator';
 import {
     addressParametersFromProto,
@@ -32,32 +21,44 @@ type Params = {
     address?: string;
 };
 
-export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
+type RunResponse = {
+    addressParameters: ReturnType<typeof addressParametersFromProto>;
+    protocolMagic: number;
+    networkId: number;
+    serializedPath: string;
+    serializedStakingPath: string;
+    address: string;
+    mac?: string;
+};
 
+export default class CardanoGetAddress extends AbstractGetAddress<
+    'cardanoGetAddress',
+    Params,
+    RunResponse
+> {
     constructor(message: MethodMessage<'cardanoGetAddress'>) {
         const { hasBundle, payload } = bundlify(message.payload);
 
-        // validate bundle type
         Assert(Bundle(CardanoGetAddressSchema), payload);
 
-        const params = payload.bundle.map(batch => {
+        const params: Params[] = payload.bundle.map(batch => {
             validateAddressParameters(batch.addressParameters);
 
-            const proto = {
-                address_parameters: addressParametersToProto(batch.addressParameters),
-                protocol_magic: batch.protocolMagic,
-                network_id: batch.networkId,
-                derivation_type:
-                    typeof batch.derivationType !== 'undefined'
-                        ? batch.derivationType
-                        : PROTO.CardanoDerivationType.ICARUS_TREZOR,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+            return {
+                proto: {
+                    address_parameters: addressParametersToProto(batch.addressParameters),
+                    protocol_magic: batch.protocolMagic,
+                    network_id: batch.networkId,
+                    derivation_type:
+                        typeof batch.derivationType !== 'undefined'
+                            ? batch.derivationType
+                            : PROTO.CardanoDerivationType.ICARUS_TREZOR,
+                    show_display:
+                        typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                    chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+                },
+                address: batch.address,
             };
-
-            return { proto, address: batch.address };
         });
 
         super(message, params);
@@ -67,10 +68,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         this.confirmMissingBackup = true;
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];
-    }
-
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
     }
 
     get info() {
@@ -83,18 +80,6 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         return 'Export multiple Cardano addresses';
     }
 
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(
-                    this.params[this.progress].proto.address_parameters.address_n,
-                ),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
-    }
-
     get confirmation() {
         return !this.useUi
             ? undefined
@@ -104,6 +89,32 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
               };
     }
 
+    protected getAddressN(param: Params) {
+        return param.proto.address_parameters.address_n;
+    }
+
+    protected getShowDisplay(param: Params) {
+        return param.proto.show_display ?? false;
+    }
+
+    protected paramForSilent(param: Params) {
+        return { ...param, proto: { ...param.proto, show_display: false } };
+    }
+
+    protected getPreviousAddress(param: Params) {
+        return param.address;
+    }
+
+    protected setPreviousAddress(param: Params, address: string) {
+        param.address = address;
+    }
+
+    protected preProcessBatch(param: Params) {
+        param.proto.address_parameters = modifyAddressParametersForBackwardsCompatibility(
+            param.proto.address_parameters,
+        );
+    }
+
     async _call({ proto }: Params) {
         const cmd = this.getDevice().getCommands();
         const response = await cmd.typedCall('CardanoGetAddress', 'CardanoAddress', proto);
@@ -111,60 +122,20 @@ export default class CardanoGetAddress extends AbstractMethod<'cardanoGetAddress
         return response.message;
     }
 
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-
-            batch.proto.address_parameters = modifyAddressParametersForBackwardsCompatibility(
-                batch.proto.address_parameters,
-            );
-
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call(batch);
-
-            responses.push({
-                addressParameters: addressParametersFromProto(batch.proto.address_parameters),
-                protocolMagic: batch.proto.protocol_magic,
-                networkId: batch.proto.network_id,
-                serializedPath: getSerializedPath(batch.proto.address_parameters.address_n),
-                serializedStakingPath: getSerializedPath(
-                    batch.proto.address_parameters.address_n_staking,
-                ),
-                address: response.address,
-                mac: response.mac,
-            });
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
+    protected buildRunResponse(
+        param: Params,
+        response: { address: string; mac?: string },
+    ): RunResponse {
+        return {
+            addressParameters: addressParametersFromProto(param.proto.address_parameters),
+            protocolMagic: param.proto.protocol_magic,
+            networkId: param.proto.network_id,
+            serializedPath: getSerializedPath(param.proto.address_parameters.address_n),
+            serializedStakingPath: getSerializedPath(
+                param.proto.address_parameters.address_n_staking,
+            ),
+            address: response.address,
+            mac: response.mac,
+        };
     }
 }

--- a/packages/connect/src/api/common/AbstractGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractGetAddress.ts
@@ -1,0 +1,98 @@
+import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+
+import type { MethodContext, MethodPermission, MethodReturnType } from '../../core/AbstractMethod';
+import { AbstractMethod } from '../../core/AbstractMethod';
+import { getSerializedPath } from '../../utils/pathUtils';
+
+export type AllGetAddressMethodName =
+    | 'getAddress'
+    | 'ethereumGetAddress'
+    | 'cardanoGetAddress'
+    | 'rippleGetAddress'
+    | 'stellarGetAddress'
+    | 'tezosGetAddress'
+    | 'solanaGetAddress'
+    | 'tronGetAddress';
+
+type CallResult = { address: string; mac?: string };
+
+export abstract class AbstractGetAddress<
+    Name extends AllGetAddressMethodName,
+    Param,
+    RunResponse,
+> extends AbstractMethod<Name, Param[]> {
+    hasBundle?: boolean;
+    progress = 0;
+
+    get requiredPermissions(): MethodPermission[] {
+        return ['read'];
+    }
+
+    protected abstract getAddressN(param: Param): number[];
+    protected abstract getShowDisplay(param: Param): boolean;
+    protected abstract paramForSilent(param: Param): Param;
+    protected abstract getPreviousAddress(param: Param): string | undefined;
+    protected abstract setPreviousAddress(param: Param, address: string): void;
+
+    protected abstract _call(param: Param): Promise<CallResult>;
+
+    protected abstract buildRunResponse(param: Param, response: CallResult): RunResponse;
+
+    protected addressesEqual(requested: string, actual: string): boolean {
+        return requested === actual;
+    }
+
+    protected preProcessBatch(_param: Param): void {}
+
+    getButtonRequestData(code: string) {
+        if (code === 'ButtonRequest_Address') {
+            const param = this.params[this.progress];
+
+            return {
+                type: 'address' as const,
+                serializedPath: getSerializedPath(this.getAddressN(param)),
+                address: this.getPreviousAddress(param) || 'not-set',
+            };
+        }
+    }
+
+    async run({ sendCoreMessage }: MethodContext): Promise<MethodReturnType<Name>> {
+        const responses: RunResponse[] = [];
+
+        for (let i = 0; i < this.params.length; i++) {
+            const batch = this.params[i];
+            this.preProcessBatch(batch);
+
+            if (this.getShowDisplay(batch)) {
+                const silent = await this._call(this.paramForSilent(batch));
+                const prev = this.getPreviousAddress(batch);
+                if (typeof prev === 'string') {
+                    if (!this.addressesEqual(prev, silent.address)) {
+                        throw ERRORS.TypedError('Method_AddressNotMatch');
+                    }
+                } else {
+                    this.setPreviousAddress(batch, silent.address);
+                }
+            }
+
+            const rawResponse = await this._call(batch);
+            const response = this.buildRunResponse(batch, rawResponse);
+            responses.push(response);
+
+            if (this.hasBundle) {
+                sendCoreMessage(
+                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
+                        total: this.params.length,
+                        progress: i,
+                        response,
+                    }),
+                );
+            }
+
+            this.progress++;
+        }
+
+        return (this.hasBundle ? responses : responses[0]) as MethodReturnType<Name>;
+    }
+}

--- a/packages/connect/src/api/common/AbstractMiscGetAddress.ts
+++ b/packages/connect/src/api/common/AbstractMiscGetAddress.ts
@@ -1,20 +1,9 @@
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
+import { Bundle, GetAddress as GetAddressSchema } from '@trezor/connect-common';
 import { Assert } from '@trezor/schema-utils';
 
+import { AbstractGetAddress } from './AbstractGetAddress';
 import { bundlify } from './paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../core/AbstractMethod';
-import { AbstractMethod } from '../../core/AbstractMethod';
+import type { MethodMessage } from '../../core/AbstractMethod';
 import { fromHardened, getSerializedPath, validatePath } from '../../utils/pathUtils';
 
 export type MiscGetAddressMethodName =
@@ -35,12 +24,16 @@ export type MiscGetAddressParams = {
     address?: string;
 };
 
+type MiscRunResponse = {
+    path: number[];
+    serializedPath: string;
+    address: string;
+    mac?: string;
+};
+
 export abstract class AbstractMiscGetAddress<
     Name extends MiscGetAddressMethodName,
-> extends AbstractMethod<Name, MiscGetAddressParams[]> {
-    hasBundle?: boolean;
-    progress = 0;
-
+> extends AbstractGetAddress<Name, MiscGetAddressParams, MiscRunResponse> {
     constructor(message: MethodMessage<Name>, pathDepth: number) {
         const { hasBundle, payload } = bundlify(message.payload);
 
@@ -62,10 +55,6 @@ export abstract class AbstractMiscGetAddress<
         this.confirmMissingBackup = true;
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     protected getInfo(coinName: string, showAccountInInfo: boolean) {
         if (this.params.length > 1) {
             return `Export multiple ${coinName} addresses`;
@@ -77,16 +66,6 @@ export abstract class AbstractMiscGetAddress<
         }
 
         return `Export ${coinName} address`;
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
     }
 
     protected getConfirmation(coinName: string) {
@@ -105,55 +84,35 @@ export abstract class AbstractMiscGetAddress<
         };
     }
 
-    protected abstract _call(
-        params: MiscGetAddressParams,
-    ): Promise<{ address: string; mac?: string }>;
+    protected getAddressN(param: MiscGetAddressParams) {
+        return param.proto.address_n;
+    }
 
-    async run({ sendCoreMessage }: MethodContext): Promise<MethodReturnType<Name>> {
-        const responses: {
-            path: number[];
-            serializedPath: string;
-            address: string;
-            mac?: string;
-        }[] = [];
+    protected getShowDisplay(param: MiscGetAddressParams) {
+        return param.proto.show_display;
+    }
 
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
+    protected paramForSilent(param: MiscGetAddressParams) {
+        return { ...param, proto: { ...param.proto, show_display: false } };
+    }
 
-            const response = await this._call(batch);
-            responses.push({
-                path: batch.proto.address_n,
-                serializedPath: getSerializedPath(batch.proto.address_n),
-                address: response.address,
-                mac: response.mac,
-            });
+    protected getPreviousAddress(param: MiscGetAddressParams) {
+        return param.address;
+    }
 
-            if (this.hasBundle) {
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
+    protected setPreviousAddress(param: MiscGetAddressParams, address: string) {
+        param.address = address;
+    }
 
-            this.progress++;
-        }
-
-        return (this.hasBundle ? responses : responses[0]) as MethodReturnType<Name>;
+    protected buildRunResponse(
+        param: MiscGetAddressParams,
+        response: { address: string; mac?: string },
+    ): MiscRunResponse {
+        return {
+            path: param.proto.address_n,
+            serializedPath: getSerializedPath(param.proto.address_n),
+            address: response.address,
+            mac: response.mac,
+        };
     }
 }

--- a/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetAddress.ts
@@ -1,26 +1,15 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/EthereumGetAddress.js
 
-import {
-    Bundle,
-    GetAddress as GetAddressSchema,
-    UI_REQUEST,
-    createUiMessage,
-} from '@trezor/connect-common';
+import { Bundle, GetAddress as GetAddressSchema } from '@trezor/connect-common';
 import type { EthereumNetworkInfoDefinitionValues, PROTO } from '@trezor/connect-common';
-import { ERRORS } from '@trezor/connect-common/src/constants';
 import { Assert } from '@trezor/schema-utils';
 
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../../../core/AbstractMethod';
-import { AbstractMethod } from '../../../core/AbstractMethod';
+import type { MethodMessage } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { stripHexPrefix } from '../../../utils/formatUtils';
 import { getSerializedPath, getSlip44ByPath, validatePath } from '../../../utils/pathUtils';
+import { AbstractGetAddress } from '../../common/AbstractGetAddress';
 import { bundlify } from '../../common/paramsValidator';
 import {
     decodeEthereumDefinition,
@@ -34,27 +23,37 @@ type Params = {
     network?: EthereumNetworkInfoDefinitionValues;
 };
 
-export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
+type RunResponse = {
+    path: number[];
+    serializedPath: string;
+    address: string;
+    mac?: string;
+};
 
+export default class EthereumGetAddress extends AbstractGetAddress<
+    'ethereumGetAddress',
+    Params,
+    RunResponse
+> {
     constructor(message: MethodMessage<'ethereumGetAddress'>) {
         const { hasBundle, payload } = bundlify(message.payload);
 
-        // validate bundle type
         Assert(Bundle(GetAddressSchema), payload);
 
         const params = payload.bundle.map(batch => {
             const path = validatePath(batch.path, 3);
             const network = getEthereumNetwork(path);
 
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+            return {
+                proto: {
+                    address_n: path,
+                    show_display:
+                        typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                    chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+                },
+                address: batch.address,
+                network,
             };
-
-            return { proto, address: batch.address, network };
         });
 
         super(message, params);
@@ -66,13 +65,8 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     async initAsync(): Promise<void> {
         for (let i = 0; i < this.params.length; i++) {
-            // network was maybe already set from 'well-known' definition in init method.
             if (!this.params[i].network) {
                 const slip44 = getSlip44ByPath(this.params[i].proto.address_n);
 
@@ -93,23 +87,12 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         if (this.params.length === 1) {
             return getNetworkLabel('Export #NETWORK address', this.params[0].network);
         }
-        const requestedNetworks = this.params.map(b => b.network);
-        const uniqNetworks = getUniqueNetworks(requestedNetworks);
+        const uniqNetworks = getUniqueNetworks(this.params.map(b => b.network));
         if (uniqNetworks.length === 1 && uniqNetworks[0]) {
             return getNetworkLabel('Export multiple #NETWORK addresses', uniqNetworks[0]);
         }
 
         return 'Export multiple addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
     }
 
     get confirmation() {
@@ -119,62 +102,43 @@ export default class EthereumGetAddress extends AbstractMethod<'ethereumGetAddre
         };
     }
 
-    private async _call(params: Params) {
-        const response = await this.getDevice().getCommands().ethereumGetAddress(params.proto);
+    protected getAddressN(param: Params) {
+        return param.proto.address_n;
+    }
 
+    protected getShowDisplay(param: Params) {
+        return param.proto.show_display ?? false;
+    }
+
+    protected paramForSilent(param: Params) {
+        return { ...param, proto: { ...param.proto, show_display: false } };
+    }
+
+    protected getPreviousAddress(param: Params) {
+        return param.address;
+    }
+
+    protected setPreviousAddress(param: Params, address: string) {
+        param.address = address;
+    }
+
+    protected addressesEqual(requested: string, actual: string): boolean {
+        return stripHexPrefix(requested).toLowerCase() === stripHexPrefix(actual).toLowerCase();
+    }
+
+    async _call(param: Params) {
+        return await this.getDevice().getCommands().ethereumGetAddress(param.proto);
+    }
+
+    protected buildRunResponse(
+        param: Params,
+        response: { address: string; mac?: string },
+    ): RunResponse {
         return {
-            path: params.proto.address_n,
-            serializedPath: getSerializedPath(params.proto.address_n),
+            path: param.proto.address_n,
+            serializedPath: getSerializedPath(param.proto.address_n),
             address: response.address,
             mac: response.mac,
         };
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (
-                        stripHexPrefix(batch.address).toLowerCase() !==
-                        stripHexPrefix(silent.address).toLowerCase()
-                    ) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    // save address for future verification in "getButtonRequestData"
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call({
-                ...batch,
-            });
-            responses.push(response);
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }

--- a/packages/connect/src/api/getAddress.ts
+++ b/packages/connect/src/api/getAddress.ts
@@ -1,19 +1,13 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/GetAddress.js
 
 import { type BitcoinNetworkInfo, Bundle, type PROTO } from '@trezor/connect-common';
-import { UI_REQUEST, createUiMessage } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { GetAddress as GetAddressSchema } from '@trezor/connect-common/src/types/api/getAddress';
 import { Assert } from '@trezor/schema-utils';
 
+import { AbstractGetAddress } from './common/AbstractGetAddress';
 import { bundlify, validateCoinPath } from './common/paramsValidator';
-import type {
-    MethodContext,
-    MethodMessage,
-    MethodPermission,
-    MethodReturnType,
-} from '../core/AbstractMethod';
-import { AbstractMethod } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { fixCoinInfoNetwork, getBitcoinNetwork, getUniqueNetworks } from '../data/coinInfo';
 import { getLabel, getSerializedPath, validatePath } from '../utils/pathUtils';
 
@@ -24,10 +18,14 @@ type Params = {
     unlockPath?: PROTO.UnlockPath;
 };
 
-export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
-    hasBundle?: boolean;
-    progress = 0;
+type RunResponse = {
+    path: number[];
+    serializedPath: string;
+    address: string;
+    mac?: string;
+};
 
+export default class GetAddress extends AbstractGetAddress<'getAddress', Params, RunResponse> {
     constructor(message: MethodMessage<'getAddress'>) {
         const { hasBundle, payload } = bundlify(message.payload);
 
@@ -39,10 +37,9 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
                 ).fill('');
             }
         });
-        // validate bundle type
         Assert(Bundle(GetAddressSchema), payload);
 
-        const params = payload.bundle.map(batch => {
+        const params: Params[] = payload.bundle.map(batch => {
             const path = validatePath(batch.path, 1);
             let coinInfo: BitcoinNetworkInfo | undefined;
             if (batch.coin) {
@@ -59,18 +56,17 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
                 throw ERRORS.TypedError('Method_UnknownCoin');
             }
 
-            // fix coinInfo network values (segwit/legacy)
             coinInfo = fixCoinInfoNetwork(coinInfo, path);
-            const proto = {
-                address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
-                multisig: batch.multisig,
-                script_type: batch.scriptType,
-                chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
-            };
 
             return {
-                proto,
+                proto: {
+                    address_n: path,
+                    show_display:
+                        typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                    multisig: batch.multisig,
+                    script_type: batch.scriptType,
+                    chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
+                },
                 address: batch.address,
                 coinInfo,
                 unlockPath: batch.unlockPath,
@@ -85,32 +81,16 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
         this.confirmMissingBackup = true;
     }
 
-    get requiredPermissions(): MethodPermission[] {
-        return ['read'];
-    }
-
     get info() {
-        // set info
         if (this.params.length === 1) {
             return getLabel('Export #NETWORK address', this.params[0].coinInfo);
         }
-        const requestedNetworks = this.params.map(b => b.coinInfo);
-        const uniqNetworks = getUniqueNetworks(requestedNetworks);
+        const uniqNetworks = getUniqueNetworks(this.params.map(b => b.coinInfo));
         if (uniqNetworks.length === 1 && uniqNetworks[0]) {
             return getLabel('Export multiple #NETWORK addresses', uniqNetworks[0]);
         }
 
         return 'Export multiple addresses';
-    }
-
-    getButtonRequestData(code: string) {
-        if (code === 'ButtonRequest_Address') {
-            return {
-                type: 'address' as const,
-                serializedPath: getSerializedPath(this.params[this.progress].proto.address_n),
-                address: this.params[this.progress].address || 'not-set',
-            };
-        }
     }
 
     get confirmation() {
@@ -122,60 +102,44 @@ export default class GetAddress extends AbstractMethod<'getAddress', Params[]> {
               };
     }
 
+    protected getAddressN(param: Params) {
+        return param.proto.address_n;
+    }
+
+    protected getShowDisplay(param: Params) {
+        return param.proto.show_display ?? false;
+    }
+
+    protected paramForSilent(param: Params) {
+        return { ...param, proto: { ...param.proto, show_display: false } };
+    }
+
+    protected getPreviousAddress(param: Params) {
+        return param.address;
+    }
+
+    protected setPreviousAddress(param: Params, address: string) {
+        param.address = address;
+    }
+
     async _call({ proto, coinInfo, unlockPath }: Params) {
         const cmd = this.getDevice().getCommands();
         if (unlockPath) {
             await cmd.unlockPath(unlockPath);
         }
 
-        const response = await cmd.getAddress(proto, coinInfo);
+        return await cmd.getAddress(proto, coinInfo);
+    }
 
+    protected buildRunResponse(
+        param: Params,
+        response: { address: string; mac?: string },
+    ): RunResponse {
         return {
-            path: proto.address_n,
-            serializedPath: getSerializedPath(proto.address_n),
+            path: param.proto.address_n,
+            serializedPath: getSerializedPath(param.proto.address_n),
             address: response.address,
             mac: response.mac,
         };
-    }
-
-    async run({ sendCoreMessage }: MethodContext) {
-        const responses: MethodReturnType<typeof this.name> = [];
-
-        for (let i = 0; i < this.params.length; i++) {
-            const batch = this.params[i];
-            // silently get address and compare with requested address
-            // or display as default inside popup
-            if (batch.proto.show_display) {
-                const silent = await this._call({
-                    ...batch,
-                    proto: { ...batch.proto, show_display: false },
-                });
-                if (typeof batch.address === 'string') {
-                    if (batch.address !== silent.address) {
-                        throw ERRORS.TypedError('Method_AddressNotMatch');
-                    }
-                } else {
-                    batch.address = silent.address;
-                }
-            }
-
-            const response = await this._call(batch);
-            responses.push(response);
-
-            if (this.hasBundle) {
-                // send progress
-                sendCoreMessage(
-                    createUiMessage(UI_REQUEST.BUNDLE_PROGRESS, {
-                        total: this.params.length,
-                        progress: i,
-                        response,
-                    }),
-                );
-            }
-
-            this.progress++;
-        }
-
-        return this.hasBundle ? responses : responses[0];
     }
 }


### PR DESCRIPTION
## Summary

Experimental maximalist follow-up to #connect-refactor-ideas: applies the shared base class to **every** `*GetAddress` method except Monero.

- Introduces `AbstractGetAddress<Name, Param, RunResponse>` — a fully generic base class with 7 abstract hooks (`getAddressN`, `getShowDisplay`, `paramForSilent`, `getPreviousAddress`, `setPreviousAddress`, `_call`, `buildRunResponse`) and 2 overridable ones (`addressesEqual`, `preProcessBatch`).
- `AbstractMiscGetAddress` now extends the generic base. The 5 Misc subclasses (ripple/stellar/tezos/solana/tron) are unchanged — they still see the same `getInfo()` / `getConfirmation()` helpers.
- **Bitcoin** extends the generic base directly: keeps the multisig workaround, `validateCoinPath`, `fixCoinInfoNetwork`, and the `unlockPath` pre-step inside `_call`.
- **Ethereum** overrides `addressesEqual` for hex normalization and keeps its own `initAsync` for network definitions.
- **Cardano** overrides `preProcessBatch` for the `modifyAddressParametersForBackwardsCompatibility` mutation and has a custom 7-field `buildRunResponse`.
- **Monero** stays out — fundamentally different proto shape, custom hex decode, no bundle progress.

Net: **-44 lines** across the 5 touched files, with the shared `run` loop (silent-call + compare + progress) living in one place.

## Tradeoffs

This is deliberately opened against `mroz22/connect-refactor-ideas` so the team can evaluate the maximalist direction separately from the Misc-only PR:

- **Pro**: one source of truth for the silent-compare + bundle-progress pattern; adding a new coin's `GetAddress` now means filling in hooks, not copy-pasting the loop.
- **Con**: 7 abstract hooks is a lot of surface area; the indirection may be harder to read than the linear original, especially for Bitcoin/Ethereum where the per-coin logic is substantial.
- **Con**: Cardano's `buildRunResponse` / `preProcessBatch` hooks arguably stretch the abstraction — the response shape is very different from the other coins.

Worth landing? The Misc-only PR captures most of the duplication; this one trades readability for another ~100 lines saved. In an AI-agent era the calculation may lean differently either way.

## Test plan

- [x] `yarn workspace @trezor/connect type-check` — clean (pre-existing e2e submodule errors only)
- [x] `yarn workspace @trezor/connect test:unit` — 466/466 passing
- [x] `yarn workspace @trezor/connect lint:js` — clean
- [ ] e2e against emulator for bitcoin/ethereum/cardano get-address flows

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-refactor-all-coins&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->