### PR TITLE
Harden security headers

### DIFF
--- a/packages/suite-web/constants/webSecurityHeaders.ts
+++ b/packages/suite-web/constants/webSecurityHeaders.ts
@@ -13,7 +13,7 @@ const PRODUCTION_SECURITY_HEADERS = {
     /**
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
      */
-    'strict-transport-security': 'max-age=31536000',
+    'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
 
     /**
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade-Insecure-Requests
@@ -39,7 +39,7 @@ const PRODUCTION_SECURITY_HEADERS = {
      * It's experimental feature and not supported by all browsers.
      */
     'permissions-policy':
-        'usb=(self), camera=(self), clipboard-write=(self), local-network-access=(self), geolocation=(), microphone=(), payment=(), hid=(), serial=(), fullscreen=(), accelerometer=(), gyroscope=(), magnetometer=(), storage-access=(), bluetooth=()',
+        'usb=(self), camera=(self), clipboard-write=(self), local-network-access=(self), geolocation=(), microphone=(), payment=(), hid=(), serial=(), fullscreen=(), accelerometer=(), gyroscope=(), magnetometer=(), storage-access=(), bluetooth=(), clipboard-read=(), display-capture=(), picture-in-picture=(), idle-detection=(), screen-wake-lock=()',
 
     /**
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
@@ -67,6 +67,10 @@ const PRODUCTION_SECURITY_HEADERS = {
         'connect-src': ['data:', '*'],
         'upgrade-insecure-requests': true,
         'script-src': ['self', 'unsafe-eval'],
+        'form-action': ['self'],
+        'frame-ancestors': ['self'],
+        'base-uri': ['none'],
+        'object-src': ['self'],
         'report-uri': SENTRY_REPORT_URL,
         'report-to': 'csp-endpoint',
     },

--- a/packages/suite-web/types/securityHeaders.ts
+++ b/packages/suite-web/types/securityHeaders.ts
@@ -9,6 +9,10 @@ export type ContentSecurityPolicyRules = {
     'upgrade-insecure-requests': true;
     'report-uri': string;
     'report-to': string;
+    'form-action': string[];
+    'frame-ancestors': string[];
+    'base-uri': string[];
+    'object-src': string[];
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Several minor improvements of security headers.

Resolve [#187](https://github.com/trezor/trezor-suite-private/issues/187)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are `packages/suite-web/constants/webSecurityHeaders.ts` and `packages/suite-web/types/securityHeaders.ts`. These are build-time/server-configuration files that define web security headers (e.g., CSP, HSTS, X-Frame-Options) and their TypeScript types for the suite-web package. They are not runtime application code consumed by the browser bundle, so no E2E Playwright tests exercise this code path directly. No static coverage mapping exists, and none of the analyzed E2E tests touch security header logic, server configuration, or HTTP response header behavior. The risk of user-facing regression from these changes is negligible from an E2E perspective; validation would be better served by unit tests or integration tests that verify the HTTP response headers returned by the web server.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-web/constants/webSecurityHeaders.ts`
- `packages/suite-web/types/securityHeaders.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite-web/constants/webSecurityHeaders.ts`
- `packages/suite-web/types/securityHeaders.ts`

_Updated: 2026-04-24T08:26:51.179Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/security-headers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/security-headers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T07:26:37.715Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T07:24:51.476Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/security-headers/web/](https://dev.suite.sldev.cz/suite-web/feat/security-headers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->