### PR TITLE
fix(connect): do not log uninitialized device error for WipeDevice method

### DIFF
--- a/packages/connect/src/device/DeviceCurrentSession.ts
+++ b/packages/connect/src/device/DeviceCurrentSession.ts
@@ -43,6 +43,8 @@ const allowedCallsBeforeInitialize: Messages.MessageKey[] = [
     'FirmwareUpload',
     // Wallet recovery may also be called before Initialize
     'RecoveryDevice',
+    // Factory reset
+    'WipeDevice',
     // There are other, which are allowed by firmware (ApplySettings,...) but we do not use them this way in connect.
 ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Put WipeDevice method on allow list for uninitialized devices to prevent false positive Sentry errors.

## Notes for QA

Try wipe device and Factory reset device, it should work the same, only no error in console and Sentry.


[Sentry report ](https://www.notion.so/satoshilabs/Capture-Runtime-typedCall-Device-not-initialized-when-calling-WipeDevice-call-Initialize-first-43a8970fc1fd421b90a8ea5bfddb1288?source=copy_link)


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/allow-wipe-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/allow-wipe-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/allow-wipe-device/web/](https://dev.suite.sldev.cz/suite-web/fix/allow-wipe-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T08:34:51.789Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->