### PR TITLE
Fix BroadcastChannel not available

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -16,6 +16,7 @@ const webChannel = {
 
 export const useConnectPopupWeb = () => {
     const [incomingMessages, setIncomingMessages] = useState<ConnectPopupMessage[]>([]);
+    const [isChannelReady, setIsChannelReady] = useState(false);
     // Start with '*' because we don't know the opener's origin yet.
     // Protocol messages sent before the first incoming message (e.g.
     // POPUP.CORE_LOADED, channel-handshake-confirm) contain no sensitive
@@ -45,15 +46,16 @@ export const useConnectPopupWeb = () => {
         }
     }, []);
 
-    const popupLink = useMemo<ConnectPopupLink>(
-        () => ({
+    const popupLink = useMemo<ConnectPopupLink | null>(() => {
+        if (!isChannelReady) return null;
+
+        return {
             sendMessage: postMessageToParent,
             get origin() {
                 return originRef.current;
             },
-        }),
-        [postMessageToParent],
-    );
+        };
+    }, [postMessageToParent, isChannelReady]);
 
     const consumeMessages = useCallback(() => {
         setIncomingMessages(prev => prev.slice(1));
@@ -83,6 +85,7 @@ export const useConnectPopupWeb = () => {
         try {
             broadcastChannel = new BroadcastChannel(`@trezor/connect-popup/${requestId}`);
             channelRef.current = broadcastChannel;
+            setIsChannelReady(true);
         } catch (error) {
             // TODO: show warning to user
             console.warn('BroadcastChannel is not supported in this browser', error);
@@ -95,6 +98,7 @@ export const useConnectPopupWeb = () => {
             broadcastChannel.removeEventListener('message', onMessage);
             broadcastChannel.close();
             channelRef.current = null;
+            setIsChannelReady(false);
             // TODO: show warning to user
             console.warn('Popup handshake timeout');
         }, 3000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix BroadcastChannel not available.


## Screenshots:

<img width="919" height="106" alt="Snímek obrazovky 2026-04-24 v 10 42 28" src="https://github.com/user-attachments/assets/661d1711-313d-4e19-b761-958e37f4e1d2" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useConnectPopupWeb.tsx, which manages the TrezorConnect popup lifecycle and rendering for web-based integrations. The highest risk is to the Connect popup E2E tests (connectPopupWeb and connectPopupWebextension) that directly exercise this popup flow. The remaining 117+ tests that statically reference this file do so only through transitive imports (it's a broadly-used support hook mounted at the app level), so they are unlikely to be affected. Testing should focus on the TrezorConnect popup flows — happy path, cancellation, and permissions.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/support/suite/useConnectPopupWeb.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup flow in web mode (core-mode=suite-web), which is the exact functionality that useConnectPopupWeb.tsx implements. Any change to this hook would directly affect popup lifecycle, permissions, address confirmation, and cancellation behaviors tested here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises TrezorConnect popup flows via webextension using suite-web core mode. The useConnectPopupWeb hook manages popup rendering and lifecycle for web-based Connect interactions, which this test validates through permissions, address confirmation, cancellation, and popup focus behaviors.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress tests exercise the Connect popup address confirmation flow including verify/error badges and permissions modal, which are rendered within the web popup managed by useConnectPopupWeb. Changes to the hook could affect how the popup renders these confirmation UI elements.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test validates the Connect permissions modal flow including remember/forget functionality. The permissions modal is rendered within the popup context managed by useConnectPopupWeb, so changes to the hook could affect permissions modal display and interaction.

</details>

_Updated: 2026-04-24T08:45:36.875Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/broadcast&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/broadcast&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| Trading - Buy Ethereum > Enable Ethereum on account by buying it | 🤖 auto |
| Trading - Buy Solana > Buy Solana Jupiter token - amount specified in crypto | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| sol staking > first stake on SOL account | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| sol staking > stake more on SOL account | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T08:50:41.390Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T08:01:55.091Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/broadcast/web/](https://dev.suite.sldev.cz/suite-web/fix/broadcast/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->