### PR TITLE
chore(tests): jest-to-swc migration phase 2

### DIFF
--- a/packages/coinjoin/jest.config.js
+++ b/packages/coinjoin/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -1,13 +1,6 @@
 import { Status } from '../../src/client/Status';
 import { coordinatorRequest } from '../../src/client/coordinatorRequest';
 import { STATUS_TIMEOUT } from '../../src/constants';
-
-jest.mock('../../src/client/coordinatorRequest', () => ({
-    ...jest.requireActual('../../src/client/coordinatorRequest'),
-    coordinatorRequest: jest.fn(
-        jest.requireActual('../../src/client/coordinatorRequest').coordinatorRequest,
-    ),
-}));
 import {
     AFFILIATE_INFO,
     DEFAULT_ROUND,
@@ -15,6 +8,13 @@ import {
     createCoinjoinRound,
 } from '../fixtures/round.fixture';
 import { createServer } from '../mocks/server';
+
+jest.mock('../../src/client/coordinatorRequest', () => ({
+    ...jest.requireActual('../../src/client/coordinatorRequest'),
+    coordinatorRequest: jest.fn(
+        jest.requireActual('../../src/client/coordinatorRequest').coordinatorRequest,
+    ),
+}));
 
 // using fakeTimers and async callbacks
 const fastForward = (time: number) => jest.advanceTimersByTimeAsync(time);

--- a/packages/coinjoin/tests/client/Status.test.ts
+++ b/packages/coinjoin/tests/client/Status.test.ts
@@ -1,6 +1,13 @@
 import { Status } from '../../src/client/Status';
-import * as http from '../../src/client/coordinatorRequest';
+import { coordinatorRequest } from '../../src/client/coordinatorRequest';
 import { STATUS_TIMEOUT } from '../../src/constants';
+
+jest.mock('../../src/client/coordinatorRequest', () => ({
+    ...jest.requireActual('../../src/client/coordinatorRequest'),
+    coordinatorRequest: jest.fn(
+        jest.requireActual('../../src/client/coordinatorRequest').coordinatorRequest,
+    ),
+}));
 import {
     AFFILIATE_INFO,
     DEFAULT_ROUND,
@@ -44,6 +51,9 @@ describe('Status', () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
+        (coordinatorRequest as jest.Mock).mockImplementation(
+            jest.requireActual('../../src/client/coordinatorRequest').coordinatorRequest,
+        );
         jest.useRealTimers();
 
         status?.stop();
@@ -61,7 +71,7 @@ describe('Status', () => {
 
         const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
         const coordinatorRequestSpy = jest.fn();
-        jest.spyOn(http, 'coordinatorRequest').mockImplementation(url => {
+        (coordinatorRequest as jest.Mock).mockImplementation(url => {
             if (url === 'status') {
                 coordinatorRequestSpy();
             }
@@ -119,7 +129,7 @@ describe('Status', () => {
 
         const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
         const coordinatorRequestSpy = jest.fn();
-        jest.spyOn(http, 'coordinatorRequest').mockImplementation(url => {
+        (coordinatorRequest as jest.Mock).mockImplementation(url => {
             if (url === 'status') {
                 coordinatorRequestSpy();
             }
@@ -160,7 +170,7 @@ describe('Status', () => {
 
     it('Status identities', async () => {
         const identities: string[] = [];
-        jest.spyOn(http, 'coordinatorRequest').mockImplementation((url, _b, options) => {
+        (coordinatorRequest as jest.Mock).mockImplementation((url, _b, options) => {
             if (url === 'status') {
                 const id = options?.identity;
                 if (id && !identities.includes(id)) {
@@ -290,7 +300,7 @@ describe('Status', () => {
         const affiliateDataBase64 = Buffer.from('{}', 'utf-8').toString('base64');
 
         const coordinatorRequestSpy = jest.fn();
-        jest.spyOn(http, 'coordinatorRequest').mockImplementation(url => {
+        (coordinatorRequest as jest.Mock).mockImplementation(url => {
             if (url === 'status') {
                 coordinatorRequestSpy();
             }

--- a/packages/coinjoin/tests/client/outputRegistration.test.ts
+++ b/packages/coinjoin/tests/client/outputRegistration.test.ts
@@ -1,4 +1,4 @@
-import * as decomposition from '../../src/client/round/outputDecomposition';
+import { outputDecomposition } from '../../src/client/round/outputDecomposition';
 import { outputRegistration } from '../../src/client/round/outputRegistration';
 import { createInput } from '../fixtures/input.fixture';
 import { createCoinjoinRound } from '../fixtures/round.fixture';
@@ -14,6 +14,13 @@ jest.mock('@trezor/utils', () => {
         getWeakRandomNumberInRange: () => 0,
     };
 });
+
+jest.mock('../../src/client/round/outputDecomposition', () => ({
+    ...jest.requireActual('../../src/client/round/outputDecomposition'),
+    outputDecomposition: jest.fn(
+        jest.requireActual('../../src/client/round/outputDecomposition').outputDecomposition,
+    ),
+}));
 
 describe('outputRegistration', () => {
     let server: Awaited<ReturnType<typeof createServer>>;
@@ -55,7 +62,7 @@ describe('outputRegistration', () => {
         });
 
         // Mock outputDecomposition module responses
-        jest.spyOn(decomposition, 'outputDecomposition').mockImplementation(() =>
+        (outputDecomposition as jest.Mock).mockImplementation(() =>
             Promise.resolve([
                 {
                     accountKey: 'account-A',

--- a/packages/connect/jest.config.js
+++ b/packages/connect/jest.config.js
@@ -1,4 +1,4 @@
-const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base');
+const { testPathIgnorePatterns, ...baseConfig } = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/__tests__/paramsValidator.test.ts
@@ -1,6 +1,24 @@
-import * as data from '../../../data/config';
+import { config } from '../../../data/config';
 import * as fixtures from '../__fixtures__/paramsValidator';
 import { getFirmwareRange, validateParams } from '../paramsValidator';
+
+jest.mock('../../../data/config', () => {
+    const actual = jest.requireActual('../../../data/config');
+
+    return {
+        __esModule: true,
+        config: { ...actual.config },
+    };
+});
+
+const originalConfig = jest.requireActual('../../../data/config').config;
+
+const resetConfig = () => {
+    Object.keys(config).forEach(key => {
+        delete (config as Record<string, unknown>)[key];
+    });
+    Object.assign(config, originalConfig);
+};
 
 describe('helpers/paramsValidator', () => {
     describe('validateParams', () => {
@@ -21,12 +39,18 @@ describe('helpers/paramsValidator', () => {
 
     describe('getFirmwareRange', () => {
         afterEach(() => {
-            jest.restoreAllMocks();
+            resetConfig();
         });
 
         fixtures.getFirmwareRange.forEach(f => {
             it(f.description, () => {
-                if (f.config) jest.replaceProperty(data, 'config', f.config as any);
+                if (f.config) {
+                    resetConfig();
+                    Object.keys(config).forEach(key => {
+                        delete (config as Record<string, unknown>)[key];
+                    });
+                    Object.assign(config, f.config);
+                }
 
                 const [method, coinInfo, defaultRange] = f.params;
                 expect(

--- a/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
+++ b/packages/connect/src/core/__tests__/onCallFirmwareUpdate.test.ts
@@ -5,13 +5,24 @@ import { v1 as protocolV1 } from '@trezor/protocol';
 import { buildMessage } from '@trezor/transport/src/utils/send';
 import { Log } from '@trezor/utils';
 
-import * as mockFwHash from '../../api/firmware/calculateFirmwareHash';
+import { calculateFirmwareHash } from '../../api/firmware/calculateFirmwareHash';
 import { DataManager } from '../../data/DataManager';
 import { getBundledRelease, initializeFirmwareConfig } from '../../data/firmwareInfo';
 import { DeviceList } from '../../device/DeviceList';
-// mocks
-import * as mockAssets from '../../utils/assets';
+import { httpRequest } from '../../utils/assets';
 import { onCallFirmwareUpdate } from '../onCallFirmwareUpdate';
+
+jest.mock('../../utils/assets', () => ({
+    ...jest.requireActual('../../utils/assets'),
+    httpRequest: jest.fn(jest.requireActual('../../utils/assets').httpRequest),
+}));
+
+jest.mock('../../api/firmware/calculateFirmwareHash', () => ({
+    ...jest.requireActual('../../api/firmware/calculateFirmwareHash'),
+    calculateFirmwareHash: jest.fn(
+        jest.requireActual('../../api/firmware/calculateFirmwareHash').calculateFirmwareHash,
+    ),
+}));
 
 // NOTE:
 // to disable asset mock and work with the real binaries (tests takes longer):
@@ -236,7 +247,7 @@ describe('onCallFirmwareUpdate', () => {
     });
     beforeEach(() => {
         if (!ASSETS_BASE_URL) {
-            jest.spyOn(mockAssets, 'httpRequest').mockImplementation((url, type) => {
+            (httpRequest as jest.Mock).mockImplementation((url, type) => {
                 if (type === 'json') {
                     return Promise.reject(new Error('Offline'));
                 }
@@ -265,7 +276,7 @@ describe('onCallFirmwareUpdate', () => {
             });
         }
 
-        jest.spyOn(mockFwHash, 'calculateFirmwareHash').mockImplementation((..._args) =>
+        (calculateFirmwareHash as jest.Mock).mockImplementation((..._args) =>
             calculateFirmwareHashMock(),
         );
     });

--- a/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareHashWithRetries.test.ts
@@ -3,8 +3,15 @@ import type { Descriptor } from '@trezor/transport';
 import { Log } from '@trezor/utils';
 
 import { Device } from '../Device';
-import * as checkFirmwareHashModule from '../workflow/checkFirmwareHash';
+import { checkFirmwareHash } from '../workflow/checkFirmwareHash';
 import { checkFirmwareHashWithRetries } from '../workflow/checkFirmwareHashWithRetries';
+
+jest.mock('../workflow/checkFirmwareHash', () => ({
+    ...jest.requireActual('../workflow/checkFirmwareHash'),
+    checkFirmwareHash: jest.fn(
+        jest.requireActual('../workflow/checkFirmwareHash').checkFirmwareHash,
+    ),
+}));
 
 const { createTestTransport } = global.JestMocks;
 
@@ -29,7 +36,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
     });
 
     it('performs check successfully from initial state', async () => {
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
+        (checkFirmwareHash as jest.Mock).mockImplementation(() =>
             Promise.resolve({ success: true }),
         );
 
@@ -39,7 +46,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: null,
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalled();
+        expect(checkFirmwareHash).toHaveBeenCalled();
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: true,
             attemptCount: 1,
@@ -47,7 +54,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
     });
 
     it('performs check with error from initial state', async () => {
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
+        (checkFirmwareHash as jest.Mock).mockImplementation(() =>
             Promise.resolve({ success: false, error: 'hash-mismatch' }),
         );
 
@@ -57,7 +64,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: null,
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalled();
+        expect(checkFirmwareHash).toHaveBeenCalled();
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: false,
             error: 'hash-mismatch',
@@ -72,7 +79,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: { success: true },
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).not.toHaveBeenCalled();
+        expect(checkFirmwareHash).not.toHaveBeenCalled();
         expect(device.setAuthenticityChecks).not.toHaveBeenCalled();
     });
 
@@ -83,12 +90,12 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: { success: false, error: 'hash-mismatch' },
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).not.toHaveBeenCalled();
+        expect(checkFirmwareHash).not.toHaveBeenCalled();
         expect(device.setAuthenticityChecks).not.toHaveBeenCalled();
     });
 
     it('does retry with success for a retriable error', async () => {
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
+        (checkFirmwareHash as jest.Mock).mockImplementation(() =>
             Promise.resolve({ success: true }),
         );
 
@@ -103,7 +110,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             },
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalled();
+        expect(checkFirmwareHash).toHaveBeenCalled();
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: true,
             attemptCount: 2,
@@ -112,7 +119,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
     });
 
     it('does a single retry with error for a retriable error', async () => {
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
+        (checkFirmwareHash as jest.Mock).mockImplementation(() =>
             Promise.resolve({
                 success: false,
                 error: 'other-error',
@@ -131,7 +138,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             },
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalled();
+        expect(checkFirmwareHash).toHaveBeenCalled();
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: false,
             error: 'other-error',
@@ -147,13 +154,13 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: { success: false, error: 'other-error', attemptCount: 9 },
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).not.toHaveBeenCalled();
+        expect(checkFirmwareHash).not.toHaveBeenCalled();
         expect(device.setAuthenticityChecks).not.toHaveBeenCalled();
     });
 
     it('keeps retrying timeout error until time limit is satisfied', async () => {
         let counter = 0;
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() => {
+        (checkFirmwareHash as jest.Mock).mockImplementation(() => {
             counter++;
 
             return Promise.resolve(
@@ -167,7 +174,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: null,
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalledTimes(3);
+        expect(checkFirmwareHash).toHaveBeenCalledTimes(3);
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: false,
             error: 'takes-too-long',
@@ -176,7 +183,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
     });
 
     it('keeps retrying timeout error until retry limit is reached', async () => {
-        jest.spyOn(checkFirmwareHashModule, 'checkFirmwareHash').mockImplementation(() =>
+        (checkFirmwareHash as jest.Mock).mockImplementation(() =>
             Promise.resolve({ success: false, error: 'takes-too-long' }),
         );
 
@@ -186,7 +193,7 @@ describe(checkFirmwareHashWithRetries.name, () => {
             firmwareHash: null,
         }));
         await checkFirmwareHashWithRetries({ device, logger });
-        expect(checkFirmwareHashModule.checkFirmwareHash).toHaveBeenCalledTimes(5);
+        expect(checkFirmwareHash).toHaveBeenCalledTimes(5);
         expect(device.setAuthenticityChecks).toHaveBeenCalledWith({
             success: false,
             error: 'takes-too-long',

--- a/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/__tests__/checkFirmwareRevision.test.ts
@@ -4,9 +4,14 @@ import type { FirmwareRevisionCheckResult } from '@trezor/connect-common/src/typ
 import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
-import * as utilsAssets from '../../utils/assets';
+import { httpRequest } from '../../utils/assets';
 import type { CheckFirmwareRevisionParams } from '../checkFirmwareRevision';
 import { checkFirmwareRevision } from '../checkFirmwareRevision';
+
+jest.mock('../../utils/assets', () => ({
+    ...jest.requireActual('../../utils/assets'),
+    httpRequest: jest.fn(jest.requireActual('../../utils/assets').httpRequest),
+}));
 
 const ONLINE_RELEASES_JSON_MOCK: FirmwareRelease = {
     required: false,
@@ -119,7 +124,7 @@ describe.each(DeviceNames)(`${checkFirmwareRevision.name} for device %s`, intern
         },
     ])(`$it`, async ({ params, expected, httpRequestMock }) => {
         if (httpRequestMock !== undefined) {
-            jest.spyOn(utilsAssets, 'httpRequest').mockImplementation(httpRequestMock);
+            (httpRequest as jest.Mock).mockImplementation(httpRequestMock);
         }
 
         const result = await checkFirmwareRevision({

--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -1,22 +1,29 @@
 const version = require('./package.json').suiteVersion;
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 // all tests have same UTC timezone
 process.env.TZ = 'UTC';
 process.env.LANG = 'en-US';
 process.env.VERSION = version;
 
-const babelConfig = {
-    presets: [
-        ['@babel/preset-env', { targets: { node: 'current' }, modules: 'commonjs' }],
-        '@babel/preset-typescript',
-        [
-            '@babel/preset-react',
-            {
+const swcConfig = {
+    jsc: {
+        parser: {
+            syntax: 'typescript',
+            tsx: true,
+            decorators: true,
+        },
+        transform: {
+            react: {
                 runtime: 'automatic',
             },
-        ],
-    ],
+            decoratorVersion: '2022-03',
+        },
+        target: 'esnext',
+    },
+    module: {
+        type: 'commonjs',
+    },
 };
 
 /**
@@ -73,8 +80,7 @@ module.exports = {
     ],
     testMatch: ['**/*.test.(ts|tsx|js)'],
     transform: {
-        '(d3-|internmap|esm).*\\.js$': ['babel-jest', babelConfig],
-        '\\.(js|jsx|ts|tsx)$': ['babel-jest', babelConfig],
+        '\\.(js|jsx|ts|tsx)$': ['@swc/jest', swcConfig],
     },
     verbose: false,
     watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],

--- a/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
+++ b/packages/suite/src/actions/bluetooth/filterOutNonResponsiveDevices.test.ts
@@ -1,5 +1,10 @@
 import { asBluetoothDeviceId } from '@trezor/connect';
-import * as envUtils from '@trezor/env-utils';
+import { isLinux } from '@trezor/env-utils';
+
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isLinux: jest.fn(),
+}));
 
 import { type DesktopBluetoothDevice } from './DesktopBluetoothDevice';
 import { createMockedBluetoothDevice } from './__tests__/createMockedBluetoothDevice';
@@ -13,7 +18,7 @@ const NOW = 8_000;
 describe(filterOutNonResponsiveDevices.name, () => {
     beforeAll(() => {
         jest.spyOn(Date, 'now').mockReturnValue(NOW);
-        jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
+        (isLinux as jest.Mock).mockReturnValue(false);
     });
 
     afterAll(() => {
@@ -133,7 +138,7 @@ describe(getLastUpdatedLimitForDevice.name, () => {
         jest.restoreAllMocks();
     });
     it('calculates limit as per rssi for platforms other than linux', () => {
-        jest.spyOn(envUtils, 'isLinux').mockReturnValue(false);
+        (isLinux as jest.Mock).mockReturnValue(false);
         expect(getLastUpdatedLimitForDevice(undefined)).toBe(3_000);
         expect(getLastUpdatedLimitForDevice(-35)).toBe(3_000);
         expect(getLastUpdatedLimitForDevice(-70)).toBe(3_000);
@@ -145,7 +150,7 @@ describe(getLastUpdatedLimitForDevice.name, () => {
     });
 
     it('calculates limit as per rssi for linux', () => {
-        jest.spyOn(envUtils, 'isLinux').mockReturnValue(true);
+        (isLinux as jest.Mock).mockReturnValue(true);
         expect(getLastUpdatedLimitForDevice(undefined)).toBe(5_000);
         expect(getLastUpdatedLimitForDevice(-35)).toBe(5_000);
         expect(getLastUpdatedLimitForDevice(-70)).toBe(5_000);

--- a/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/__tests__/Preloader.test.tsx
@@ -6,7 +6,7 @@ import { type RouterState } from '@suite/router';
 import { type AnalyticsState } from '@suite-common/analytics-redux';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type TransportInfo } from '@trezor/connect';
-import * as envUtils from '@trezor/env-utils';
+import { isLinux } from '@trezor/env-utils';
 import { type DeepPartial } from '@trezor/type-utils';
 
 import { type DesktopDeviceState } from 'src/actions/device/deviceSlice';
@@ -18,7 +18,20 @@ import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependencie
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { Preloader } from '../Preloader';
-import * as selectShouldDisplayDeviceCompromisedModule from '../selectShouldDisplayDeviceCompromisedOnRoute';
+import { selectShouldDisplayDeviceCompromisedOnRoute } from '../selectShouldDisplayDeviceCompromisedOnRoute';
+
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isLinux: jest.fn(() => true),
+}));
+
+jest.mock('../selectShouldDisplayDeviceCompromisedOnRoute', () => ({
+    ...jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute'),
+    selectShouldDisplayDeviceCompromisedOnRoute: jest.fn(
+        jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute')
+            .selectShouldDisplayDeviceCompromisedOnRoute,
+    ),
+}));
 
 class ResizeObserverMock {
     observe = jest.fn();
@@ -55,11 +68,6 @@ jest.mock('@trezor/suite-desktop-api', () => ({
         on: (_event: string, _cb: any) => {},
         removeAllListeners: (_event: string) => {},
     },
-}));
-
-jest.mock('@trezor/env-utils', () => ({
-    ...jest.requireActual('@trezor/env-utils'),
-    isLinux: () => true,
 }));
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
@@ -293,7 +301,7 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unreadable device: missing udev on Linux', () => {
-        jest.spyOn(envUtils, 'isLinux').mockImplementation(() => true);
+        (isLinux as jest.Mock).mockImplementation(() => true);
 
         const store = initStore(
             getInitialState({
@@ -322,7 +330,7 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('Unreadable device: missing udev on non-Linux os (should never happen)', () => {
-        jest.spyOn(envUtils, 'isLinux').mockImplementation(() => false);
+        (isLinux as jest.Mock).mockImplementation(() => false);
 
         const store = initStore(
             getInitialState({
@@ -524,12 +532,7 @@ describe(`${Preloader.name} component`, () => {
     });
 
     it('displays DeviceCompromised when shouldDisplayDeviceCompromised is true', () => {
-        const spy = jest
-            .spyOn(
-                selectShouldDisplayDeviceCompromisedModule,
-                'selectShouldDisplayDeviceCompromisedOnRoute',
-            )
-            .mockImplementation(() => true);
+        (selectShouldDisplayDeviceCompromisedOnRoute as jest.Mock).mockImplementation(() => true);
 
         const store = initStore(getInitialState());
         const { unmount } = renderWithProviders(
@@ -540,7 +543,10 @@ describe(`${Preloader.name} component`, () => {
         expect(findByTestId('@device-compromised')).not.toBeNull();
 
         unmount();
-        spy.mockRestore();
+        (selectShouldDisplayDeviceCompromisedOnRoute as jest.Mock).mockImplementation(
+            jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute')
+                .selectShouldDisplayDeviceCompromisedOnRoute,
+        );
     });
 
     it('Required FW update device', () => {

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -7,12 +7,6 @@ import {
     getValidExperimentIds,
     getValidMessages,
 } from '@suite-common/message-system/src/messageSystemUtils';
-
-jest.mock('@suite-common/message-system/src/messageSystemUtils', () => ({
-    ...jest.requireActual('@suite-common/message-system/src/messageSystemUtils'),
-    getValidMessages: jest.fn(),
-    getValidExperimentIds: jest.fn(),
-}));
 import { type AnyAction } from '@suite-common/redux-utils';
 import { type Action } from '@suite-common/suite-types';
 import { configureMockStore } from '@suite-common/test-utils';
@@ -23,6 +17,12 @@ import WalletReducers from 'src/reducers/wallet';
 import { extraDependencies } from 'src/support/extraDependencies';
 
 import messageSystemMiddleware from '../messageSystemMiddleware';
+
+jest.mock('@suite-common/message-system/src/messageSystemUtils', () => ({
+    ...jest.requireActual('@suite-common/message-system/src/messageSystemUtils'),
+    getValidMessages: jest.fn(),
+    getValidExperimentIds: jest.fn(),
+}));
 const messageSystemReducer: Reducer<
     ReturnType<ReturnType<typeof prepareMessageSystemReducer>>,
     AnyAction
@@ -118,7 +118,6 @@ describe('Message system middleware', () => {
             category: 'feature',
         };
 
-        // @ts-expect-error: all properties except category and id are not required for testing
         (getValidMessages as jest.Mock).mockImplementation(() => [
             message1,
             message2,

--- a/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/__tests__/messageSystemMiddleware.test.ts
@@ -3,7 +3,16 @@ import { type Reducer, combineReducers } from '@reduxjs/toolkit';
 import { prepareDeviceReducer } from '@suite-common/device';
 import { geolocationReducer } from '@suite-common/geolocation';
 import { messageSystemActions, prepareMessageSystemReducer } from '@suite-common/message-system';
-import * as messageSystemUtils from '@suite-common/message-system/src/messageSystemUtils';
+import {
+    getValidExperimentIds,
+    getValidMessages,
+} from '@suite-common/message-system/src/messageSystemUtils';
+
+jest.mock('@suite-common/message-system/src/messageSystemUtils', () => ({
+    ...jest.requireActual('@suite-common/message-system/src/messageSystemUtils'),
+    getValidMessages: jest.fn(),
+    getValidExperimentIds: jest.fn(),
+}));
 import { type AnyAction } from '@suite-common/redux-utils';
 import { type Action } from '@suite-common/suite-types';
 import { configureMockStore } from '@suite-common/test-utils';
@@ -110,13 +119,13 @@ describe('Message system middleware', () => {
         };
 
         // @ts-expect-error: all properties except category and id are not required for testing
-        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() => [
+        (getValidMessages as jest.Mock).mockImplementation(() => [
             message1,
             message2,
             message3,
             message4,
         ]);
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => []);
+        (getValidExperimentIds as jest.Mock).mockImplementation(() => []);
 
         const store = initStore(getInitialState(undefined, undefined));
         store.dispatch({
@@ -147,8 +156,8 @@ describe('Message system middleware', () => {
     });
 
     it('saves messages even if there are no valid messages', () => {
-        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() => []);
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => []);
+        (getValidMessages as jest.Mock).mockImplementation(() => []);
+        (getValidExperimentIds as jest.Mock).mockImplementation(() => []);
 
         const store = initStore(getInitialState(undefined, undefined));
         store.dispatch({
@@ -174,8 +183,8 @@ describe('Message system middleware', () => {
     });
 
     it('keeps in-app messages when new file config arrives', () => {
-        jest.spyOn(messageSystemUtils, 'getValidMessages').mockImplementation(() => []);
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => []);
+        (getValidMessages as jest.Mock).mockImplementation(() => []);
+        (getValidExperimentIds as jest.Mock).mockImplementation(() => []);
 
         const manuallyAddedMessageId = 'inapp-1';
         const fileOldId = 'file-1';
@@ -238,9 +247,7 @@ describe('Message system middleware', () => {
             ],
         };
 
-        jest.spyOn(messageSystemUtils, 'getValidExperimentIds').mockImplementation(() => [
-            experiment1.id,
-        ]);
+        (getValidExperimentIds as jest.Mock).mockImplementation(() => [experiment1.id]);
 
         const store = initStore(getInitialState(undefined, undefined));
         store.dispatch({

--- a/suite-common/feedback/jest.config.js
+++ b/suite-common/feedback/jest.config.js
@@ -4,7 +4,7 @@
  * with `-c ../../jest.config.base` option in package.json scripts
  * allows us to run jest tests directly from IDEs.
  */
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/feedback/tests/getFeedbackUrl.test.ts
+++ b/suite-common/feedback/tests/getFeedbackUrl.test.ts
@@ -1,7 +1,12 @@
-import * as helpers from '@trezor/env-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 import { FeedbackType } from '../src';
 import { FEEDBACK_ENDPOINT, getFeedbackUrl } from '../src/getFeedbackUrl';
+
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isCodesignBuild: jest.fn(),
+}));
 
 describe(getFeedbackUrl.name, () => {
     it.each([
@@ -11,8 +16,8 @@ describe(getFeedbackUrl.name, () => {
         ['SUGGESTION', false, `${FEEDBACK_ENDPOINT}/feedback/develop.log`],
     ] as Array<[FeedbackType, boolean, string]>)(
         '(%s, codesign=%s) → %s',
-        (type, isCodesignBuild, expected) => {
-            jest.spyOn(helpers, 'isCodesignBuild').mockReturnValue(isCodesignBuild);
+        (type, codesign, expected) => {
+            (isCodesignBuild as jest.Mock).mockReturnValue(codesign);
             expect(getFeedbackUrl(type)).toBe(expected);
         },
     );

--- a/suite-common/feedback/tests/userData.test.ts
+++ b/suite-common/feedback/tests/userData.test.ts
@@ -1,18 +1,37 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { getFirmwareVersion } from '@trezor/device-utils';
-import * as helpers from '@trezor/env-utils';
+import {
+    getCommitHash,
+    getEnvironment,
+    getOsName,
+    getSuiteVersion,
+    getUserAgent,
+    getWindowHeight,
+    getWindowWidth,
+} from '@trezor/env-utils';
 
 import { buildUserFeedbackData } from '../src/userData';
 
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    getEnvironment: jest.fn(),
+    getOsName: jest.fn(),
+    getUserAgent: jest.fn(),
+    getSuiteVersion: jest.fn(),
+    getCommitHash: jest.fn(),
+    getWindowWidth: jest.fn(),
+    getWindowHeight: jest.fn(),
+}));
+
 describe(buildUserFeedbackData.name, () => {
     beforeEach(() => {
-        jest.spyOn(helpers, 'getEnvironment').mockReturnValue('desktop');
-        jest.spyOn(helpers, 'getOsName').mockReturnValue('linux');
-        jest.spyOn(helpers, 'getUserAgent').mockReturnValue('user-agent');
-        jest.spyOn(helpers, 'getSuiteVersion').mockReturnValue('25.7.0');
-        jest.spyOn(helpers, 'getCommitHash').mockReturnValue('commit-hash');
-        jest.spyOn(helpers, 'getWindowWidth').mockReturnValue(1920);
-        jest.spyOn(helpers, 'getWindowHeight').mockReturnValue(1080);
+        (getEnvironment as jest.Mock).mockReturnValue('desktop');
+        (getOsName as jest.Mock).mockReturnValue('linux');
+        (getUserAgent as jest.Mock).mockReturnValue('user-agent');
+        (getSuiteVersion as jest.Mock).mockReturnValue('25.7.0');
+        (getCommitHash as jest.Mock).mockReturnValue('commit-hash');
+        (getWindowWidth as jest.Mock).mockReturnValue(1920);
+        (getWindowHeight as jest.Mock).mockReturnValue(1080);
     });
 
     it('returns full payload when device is connected', () => {

--- a/suite-common/message-system/jest.config.js
+++ b/suite-common/message-system/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
+++ b/suite-common/message-system/src/__tests__/messageSystemUtils.test.ts
@@ -1,8 +1,19 @@
-import * as envUtils from '@trezor/env-utils';
+import { getEnvironment, getOsName } from '@trezor/env-utils';
 
 import * as fixtures from '../__fixtures__/messageSystemUtils';
-import * as cachedEnvData from '../cachedEnvData';
+import { getCachedOsVersion } from '../cachedEnvData';
 import * as messageSystem from '../messageSystemUtils';
+
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    getEnvironment: jest.fn(),
+    getOsName: jest.fn(),
+}));
+
+jest.mock('../cachedEnvData', () => ({
+    ...jest.requireActual('../cachedEnvData'),
+    getCachedOsVersion: jest.fn(),
+}));
 
 describe('Message system utils', () => {
     describe('createVersionRange', () => {
@@ -125,14 +136,12 @@ describe('Message system utils', () => {
         fixtures.getValidMessages.forEach(f => {
             it(f.description, () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
-                jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
+                (getOsName as jest.Mock).mockImplementation(() => f.osName);
                 userAgentGetter.mockReturnValue(f.userAgent);
-                jest.spyOn(envUtils, 'getEnvironment').mockImplementation(() => f.environment);
+                (getEnvironment as jest.Mock).mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
-                jest.spyOn(cachedEnvData, 'getCachedOsVersion').mockImplementation(
-                    () => f.osVersion,
-                );
+                (getCachedOsVersion as jest.Mock).mockImplementation(() => f.osVersion);
 
                 expect(messageSystem.getValidMessages(f.config, f.options)).toEqual(f.result);
             });
@@ -156,12 +165,10 @@ describe('Message system utils', () => {
         fixtures.getValidExperimentIds.forEach(f => {
             it(f.description, () => {
                 jest.spyOn(Date, 'now').mockImplementation(() => new Date(f.currentDate).getTime());
-                jest.spyOn(envUtils, 'getOsName').mockImplementation(() => f.osName);
+                (getOsName as jest.Mock).mockImplementation(() => f.osName);
                 userAgentGetter.mockReturnValue(f.userAgent);
-                jest.spyOn(cachedEnvData, 'getCachedOsVersion').mockImplementation(
-                    () => f.osVersion,
-                );
-                jest.spyOn(envUtils, 'getEnvironment').mockImplementation(() => f.environment);
+                (getCachedOsVersion as jest.Mock).mockImplementation(() => f.osVersion);
+                (getEnvironment as jest.Mock).mockImplementation(() => f.environment);
                 process.env.VERSION = f.suiteVersion;
 
                 expect(messageSystem.getValidExperimentIds(f.config, f.options)).toEqual(f.result);

--- a/suite-common/suite-sync-quota-manager/jest.config.cjs
+++ b/suite-common/suite-sync-quota-manager/jest.config.cjs
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/suite-sync-quota-manager/src/challenge/tests/prepareChallengeSession.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/tests/prepareChallengeSession.test.ts
@@ -1,10 +1,14 @@
 import { ok } from '@trezor/type-utils';
 
-import * as sessionUtil from '../../util/generateSessionId';
+import { generateSessionId } from '../../util/generateSessionId';
 import { prepareChallengeSession } from '../prepareChallengeSession';
 
+jest.mock('../../util/generateSessionId', () => ({
+    generateSessionId: jest.fn(),
+}));
+
 // mocking generateSessionId to return predictable session IDs
-jest.spyOn(sessionUtil, 'generateSessionId')
+(generateSessionId as jest.Mock)
     .mockReturnValueOnce('mocked-session-id')
     .mockReturnValueOnce('mocked-session-id-2');
 

--- a/suite-common/token-definitions/jest.config.js
+++ b/suite-common/token-definitions/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
+++ b/suite-common/token-definitions/scripts/utils/__tests__/fetchCoins.test.ts
@@ -2,6 +2,16 @@ import { blockfrostUtils } from '@trezor/blockchain-link-utils';
 
 import { getContractAddress } from '../fetchCoins';
 
+jest.mock('@trezor/blockchain-link-utils', () => ({
+    ...jest.requireActual('@trezor/blockchain-link-utils'),
+    blockfrostUtils: {
+        ...jest.requireActual('@trezor/blockchain-link-utils').blockfrostUtils,
+        parseAsset: jest.fn(
+            jest.requireActual('@trezor/blockchain-link-utils').blockfrostUtils.parseAsset,
+        ),
+    },
+}));
+
 describe('getContractAddress', () => {
     afterEach(() => {
         jest.restoreAllMocks();
@@ -13,7 +23,7 @@ describe('getContractAddress', () => {
                 cardano: 'valid_cardano_asset_string',
             };
 
-            const mockParseAsset = jest.spyOn(blockfrostUtils, 'parseAsset');
+            const mockParseAsset = blockfrostUtils.parseAsset as jest.Mock;
             mockParseAsset.mockReturnValue({ policyId: 'mock_policy_id' } as any);
 
             const result = await getContractAddress('cardano', platforms);

--- a/suite-common/trading/jest.config.js
+++ b/suite-common/trading/jest.config.js
@@ -1,4 +1,4 @@
-const baseConfig = require('../../jest.config.base');
+const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,

--- a/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/__tests__/handleBuyRequestThunk.test.ts
@@ -3,7 +3,7 @@ import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { getNetwork } from '@suite-common/wallet-config';
-import * as envUtils from '@trezor/env-utils';
+import { isNative } from '@trezor/env-utils';
 
 import { ALTERNATIVE_QUOTES } from '../../../__fixtures__/buyUtils';
 import { invityAPI } from '../../../invityAPI';
@@ -24,7 +24,11 @@ import { buyThunks } from '../index';
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const createMockQuotes = () =>
     [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES].map(quote => ({ ...quote }));
-const mockedIsNative = jest.spyOn(envUtils, 'isNative');
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isNative: jest.fn(),
+}));
+const mockedIsNative = isNative as jest.Mock;
 
 describe('handleBuyRequestThunk', () => {
     beforeEach(() => {
@@ -33,10 +37,6 @@ describe('handleBuyRequestThunk', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-    });
-
-    afterAll(() => {
-        mockedIsNative.mockRestore();
     });
 
     jest.mock('../../../invityAPI');

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -173,7 +173,7 @@ describe('sendDexTransactionThunk', () => {
             );
 
         const confirmExchangeTradeThunkSpy = (
-            confirmExchangeTradeThunk as jest.Mock
+            confirmExchangeTradeThunk as unknown as jest.Mock
         ).mockImplementation(createThunk('@trading-exchange/thunk/confirmTrade', () => undefined));
 
         const result = await store.dispatch(
@@ -218,7 +218,7 @@ describe('sendDexTransactionThunk', () => {
             );
 
         const confirmExchangeTradeThunkSpy = (
-            confirmExchangeTradeThunk as jest.Mock
+            confirmExchangeTradeThunk as unknown as jest.Mock
         ).mockImplementation(createThunk('@trading-exchange/thunk/confirmTrade', () => undefined));
 
         const result = await store.dispatch(

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendDexTransactionThunk.test.ts
@@ -11,8 +11,20 @@ import { type TradingExchangeState } from '../../../reducers/exchangeReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { tradingThunks } from '../../common';
-import * as confirmExchangeTradeThunk from '../confirmExchangeTradeThunk';
+import { confirmExchangeTradeThunk } from '../confirmExchangeTradeThunk';
 import { exchangeThunks } from '../index';
+
+jest.mock('../confirmExchangeTradeThunk', () => {
+    const actual = jest.requireActual('../confirmExchangeTradeThunk');
+
+    return {
+        ...actual,
+        confirmExchangeTradeThunk: Object.assign(
+            jest.fn(actual.confirmExchangeTradeThunk),
+            actual.confirmExchangeTradeThunk,
+        ),
+    };
+});
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -160,11 +172,9 @@ describe('sendDexTransactionThunk', () => {
                 ),
             );
 
-        const confirmExchangeTradeThunkSpy = jest
-            .spyOn(confirmExchangeTradeThunk, 'confirmExchangeTradeThunk')
-            .mockImplementation(
-                createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
-            );
+        const confirmExchangeTradeThunkSpy = (
+            confirmExchangeTradeThunk as jest.Mock
+        ).mockImplementation(createThunk('@trading-exchange/thunk/confirmTrade', () => undefined));
 
         const result = await store.dispatch(
             exchangeThunks.sendDexTransactionThunk({
@@ -207,11 +217,9 @@ describe('sendDexTransactionThunk', () => {
                 ),
             );
 
-        const confirmExchangeTradeThunkSpy = jest
-            .spyOn(confirmExchangeTradeThunk, 'confirmExchangeTradeThunk')
-            .mockImplementation(
-                createThunk('@trading-exchange/thunk/confirmTrade', () => undefined),
-            );
+        const confirmExchangeTradeThunkSpy = (
+            confirmExchangeTradeThunk as jest.Mock
+        ).mockImplementation(createThunk('@trading-exchange/thunk/confirmTrade', () => undefined));
 
         const result = await store.dispatch(
             exchangeThunks.sendDexTransactionThunk({

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -14,7 +14,19 @@ import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { type TradingTransactionExchange } from '../../../types';
 import { tradingThunks } from '../../common';
 import { exchangeThunks } from '../index';
-import * as sendDexTransactionThunk from '../sendDexTransactionThunk';
+import { sendDexTransactionThunk } from '../sendDexTransactionThunk';
+
+jest.mock('../sendDexTransactionThunk', () => {
+    const actual = jest.requireActual('../sendDexTransactionThunk');
+
+    return {
+        ...actual,
+        sendDexTransactionThunk: Object.assign(
+            jest.fn(actual.sendDexTransactionThunk),
+            actual.sendDexTransactionThunk,
+        ),
+    };
+});
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -112,11 +124,11 @@ describe('sendTransactionThunk', () => {
             },
         });
 
-        const sendDexTransactionThunkSpy = jest
-            .spyOn(sendDexTransactionThunk, 'sendDexTransactionThunk')
-            .mockImplementation(
-                createThunk('@trading-exchange/thunk/sendDexTransactionThunk', () => undefined),
-            );
+        const sendDexTransactionThunkSpy = (
+            sendDexTransactionThunk as jest.Mock
+        ).mockImplementation(
+            createThunk('@trading-exchange/thunk/sendDexTransactionThunk', () => undefined),
+        );
 
         const result = await store
             .dispatch(
@@ -153,14 +165,14 @@ describe('sendTransactionThunk', () => {
             error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
         };
 
-        const sendDexTransactionThunkSpy = jest
-            .spyOn(sendDexTransactionThunk, 'sendDexTransactionThunk')
-            .mockImplementation(
-                createThunk(
-                    '@trading-exchange/thunk/sendDexTransactionThunk',
-                    (_, { rejectWithValue }) => rejectWithValue(rejectValue),
-                ) as any,
-            );
+        const sendDexTransactionThunkSpy = (
+            sendDexTransactionThunk as jest.Mock
+        ).mockImplementation(
+            createThunk(
+                '@trading-exchange/thunk/sendDexTransactionThunk',
+                (_, { rejectWithValue }) => rejectWithValue(rejectValue),
+            ) as any,
+        );
 
         const result = await store.dispatch(
             exchangeThunks.sendTransactionThunk({
@@ -195,10 +207,7 @@ describe('sendTransactionThunk', () => {
             ],
         ])('%s', async (_, tradeTest) => {
             const { store, returnUrl, account } = getMocks();
-            const sendDexTransactionThunkSpy = jest.spyOn(
-                sendDexTransactionThunk,
-                'sendDexTransactionThunk',
-            );
+            const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
 
             const result = await store.dispatch(
                 exchangeThunks.sendTransactionThunk({
@@ -237,10 +246,7 @@ describe('sendTransactionThunk', () => {
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account, trade } = getMocks();
 
-            const sendDexTransactionThunkSpy = jest.spyOn(
-                sendDexTransactionThunk,
-                'sendDexTransactionThunk',
-            );
+            const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
             (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
                 .fn()
                 .mockImplementation(
@@ -291,10 +297,7 @@ describe('sendTransactionThunk', () => {
         const mockNextStep = jest.fn();
         const dateString = new Date().toISOString();
         jest.spyOn(Date.prototype, 'toISOString').mockImplementation(() => dateString);
-        const sendDexTransactionThunkSpy = jest.spyOn(
-            sendDexTransactionThunk,
-            'sendDexTransactionThunk',
-        );
+        const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
 
         const result = await store.dispatch(
             exchangeThunks.sendTransactionThunk({

--- a/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/sendTransactionThunk.test.ts
@@ -125,7 +125,7 @@ describe('sendTransactionThunk', () => {
         });
 
         const sendDexTransactionThunkSpy = (
-            sendDexTransactionThunk as jest.Mock
+            sendDexTransactionThunk as unknown as jest.Mock
         ).mockImplementation(
             createThunk('@trading-exchange/thunk/sendDexTransactionThunk', () => undefined),
         );
@@ -166,7 +166,7 @@ describe('sendTransactionThunk', () => {
         };
 
         const sendDexTransactionThunkSpy = (
-            sendDexTransactionThunk as jest.Mock
+            sendDexTransactionThunk as unknown as jest.Mock
         ).mockImplementation(
             createThunk(
                 '@trading-exchange/thunk/sendDexTransactionThunk',
@@ -207,7 +207,7 @@ describe('sendTransactionThunk', () => {
             ],
         ])('%s', async (_, tradeTest) => {
             const { store, returnUrl, account } = getMocks();
-            const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
+            const sendDexTransactionThunkSpy = sendDexTransactionThunk as unknown as jest.Mock;
 
             const result = await store.dispatch(
                 exchangeThunks.sendTransactionThunk({
@@ -246,7 +246,7 @@ describe('sendTransactionThunk', () => {
         ])('%s', async (_, recomposeAndSignPayload) => {
             const { store, returnUrl, account, trade } = getMocks();
 
-            const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
+            const sendDexTransactionThunkSpy = sendDexTransactionThunk as unknown as jest.Mock;
             (tradingThunks.recomposeAndSignTxThunk as unknown as jest.Mock) = jest
                 .fn()
                 .mockImplementation(
@@ -297,7 +297,7 @@ describe('sendTransactionThunk', () => {
         const mockNextStep = jest.fn();
         const dateString = new Date().toISOString();
         jest.spyOn(Date.prototype, 'toISOString').mockImplementation(() => dateString);
-        const sendDexTransactionThunkSpy = sendDexTransactionThunk as jest.Mock;
+        const sendDexTransactionThunkSpy = sendDexTransactionThunk as unknown as jest.Mock;
 
         const result = await store.dispatch(
             exchangeThunks.sendTransactionThunk({

--- a/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
@@ -95,7 +95,7 @@ describe('confirmSellTradeThunk', () => {
             status: 'CANCELLED',
         };
 
-        (handleSellTradeThunk as jest.Mock).mockImplementation(
+        (handleSellTradeThunk as unknown as jest.Mock).mockImplementation(
             createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
                 fulfillWithValue(trade),
             ),
@@ -174,7 +174,7 @@ describe('confirmSellTradeThunk', () => {
             mockProcessResponseData,
         } = getMocks();
 
-        (handleSellTradeThunk as jest.Mock).mockImplementation(
+        (handleSellTradeThunk as unknown as jest.Mock).mockImplementation(
             createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
                 fulfillWithValue(undefined),
             ),

--- a/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/confirmSellTradeThunk.test.ts
@@ -12,7 +12,19 @@ import { type TradingSellState } from '../../../reducers/sellReducer';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
-import * as handleSellTradeThunk from '../handleSellTradeThunk';
+import { handleSellTradeThunk } from '../handleSellTradeThunk';
+
+jest.mock('../handleSellTradeThunk', () => {
+    const actual = jest.requireActual('../handleSellTradeThunk');
+
+    return {
+        ...actual,
+        handleSellTradeThunk: Object.assign(
+            jest.fn(actual.handleSellTradeThunk),
+            actual.handleSellTradeThunk,
+        ),
+    };
+});
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
@@ -83,13 +95,11 @@ describe('confirmSellTradeThunk', () => {
             status: 'CANCELLED',
         };
 
-        const handleSellTradeThunkSpy = jest
-            .spyOn(handleSellTradeThunk, 'handleSellTradeThunk')
-            .mockImplementation(
-                createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
-                    fulfillWithValue(trade),
-                ),
-            );
+        (handleSellTradeThunk as jest.Mock).mockImplementation(
+            createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
+                fulfillWithValue(trade),
+            ),
+        );
 
         await store
             .dispatch(
@@ -106,7 +116,7 @@ describe('confirmSellTradeThunk', () => {
         const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(handleSellTradeThunkSpy).toHaveBeenCalledTimes(1);
+        expect(handleSellTradeThunk).toHaveBeenCalledTimes(1);
         expect(sellState.selectedQuote).toEqual(trade);
         expect(sellState.formStep).toEqual('SEND_TRANSACTION');
     });
@@ -122,8 +132,6 @@ describe('confirmSellTradeThunk', () => {
         } = getMocks({
             selectedQuote: undefined,
         });
-
-        const handleSellTradeThunkSpy = jest.spyOn(handleSellTradeThunk, 'handleSellTradeThunk');
 
         const trade: SellFiatTrade = {
             ...sellUtilsFixtures.MIN_MAX_QUOTES_LOW[0],
@@ -151,7 +159,7 @@ describe('confirmSellTradeThunk', () => {
         const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(0);
-        expect(handleSellTradeThunkSpy).toHaveBeenCalledTimes(0);
+        expect(handleSellTradeThunk).toHaveBeenCalledTimes(0);
         expect(sellState.selectedQuote).toEqual(undefined);
         expect(sellState.formStep).toEqual('BANK_ACCOUNT');
     });
@@ -166,13 +174,11 @@ describe('confirmSellTradeThunk', () => {
             mockProcessResponseData,
         } = getMocks();
 
-        const handleSellTradeThunkSpy = jest
-            .spyOn(handleSellTradeThunk, 'handleSellTradeThunk')
-            .mockImplementation(
-                createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
-                    fulfillWithValue(undefined),
-                ),
-            );
+        (handleSellTradeThunk as jest.Mock).mockImplementation(
+            createThunk('@trading-sell/thunk/handleTrade', (_, { fulfillWithValue }) =>
+                fulfillWithValue(undefined),
+            ),
+        );
 
         await store
             .dispatch(
@@ -189,7 +195,7 @@ describe('confirmSellTradeThunk', () => {
         const sellState = store.getState().wallet.trading.sell;
 
         expect(mockTriggerAnalyticsTradeConfirmation).toHaveBeenCalledTimes(1);
-        expect(handleSellTradeThunkSpy).toHaveBeenCalledTimes(1);
+        expect(handleSellTradeThunk).toHaveBeenCalledTimes(1);
         expect(sellState.selectedQuote).toBeDefined();
         expect(sellState.formStep).toEqual('BANK_ACCOUNT');
     });

--- a/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/__tests__/handleSellRequestThunk.test.ts
@@ -5,7 +5,7 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
-import * as envUtils from '@trezor/env-utils';
+import { isNative } from '@trezor/env-utils';
 
 import { sellThunks } from '../';
 import { invityAPI } from '../../../invityAPI';
@@ -23,8 +23,13 @@ import {
 } from '../../../types';
 import { sellUtilsFixtures } from '../../../utils/sell/__fixtures__/sellUtils';
 
+jest.mock('@trezor/env-utils', () => ({
+    ...jest.requireActual('@trezor/env-utils'),
+    isNative: jest.fn(),
+}));
+
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
-const mockedIsNative = jest.spyOn(envUtils, 'isNative');
+const mockedIsNative = isNative as jest.Mock;
 
 describe('handleSellRequestThunk', () => {
     beforeEach(() => {
@@ -33,10 +38,6 @@ describe('handleSellRequestThunk', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
-    });
-
-    afterAll(() => {
-        mockedIsNative.mockRestore();
     });
 
     jest.mock('../../../invityAPI');


### PR DESCRIPTION
## Summary

Phase 2 of the Jest transformer migration from `babel-jest` to `@swc/jest`. Follow-up to #26873 which established the SWC base config and migrated the initial wave of packages.

This PR migrates the 11 remaining packages that were skipped in phase 1 because their tests relied on patterns incompatible with SWC's frozen namespace wrapper (e.g. `import * as X` + `jest.spyOn(X, 'method')` or `jest.replaceProperty`).

The trivial parts (benchmark workflow removal + three mechanical config swaps) are split out into #27038 for easy review. Once that merges, the overlapping commits here will auto-skip on rebase.

Each package is one atomic commit. Refactor patterns applied:

- **`import * as ns` + `jest.spyOn(ns, 'fn')`** → named import + `jest.mock(..., () => ({ ...jest.requireActual(...), fn: jest.fn() }))`. Test code uses `(fn as jest.Mock).mockImplementation(...)`.
- **Thunks with attached `.pending/.fulfilled/.rejected` properties** → `Object.assign(jest.fn(actual.fn), actual.fn)` inside the mock factory to preserve the properties.
- **`export * as foo from './bar'` nested re-exports** → nested mock shape that mirrors the namespace.
- **`jest.replaceProperty(namespace, 'config', ...)`** (frozen under SWC) → mock exposes a mutable cloned config object; tests mutate and reset via `Object.assign`.
- **`jest.restoreAllMocks()` won't reset `jest.fn` inside `jest.mock`** → explicit impl reset in `afterEach` where needed.

## Test plan

- [x] `yarn workspace @suite-common/message-system test` — passes
- [x] `yarn workspace @suite-common/trading test` — passes
- [x] `yarn workspace @suite-common/token-definitions test` — passes
- [x] `yarn workspace @trezor/coinjoin test` — passes
- [x] `yarn workspace @trezor/suite test:unit` — 80/80 suites, 631 passing
- [x] `yarn workspace @trezor/connect test:unit` — 50/50 suites, 466 passing

## Benchmark — babel-jest vs @swc/jest

Cold-cache `nx run-many --target=test:unit --exclude='@suite-native/*'` on ubuntu-latest, 3 runs each. [Run #24952556443](https://github.com/trezor/trezor-suite/actions/runs/24952556443).

| transform | runs | min (s) | max (s) | mean (s) | stddev (s) |
|---|---|---|---|---|---|
| babel | 3 | 857.70 | 908.60 | 875.25 | 23.59 |
| swc | 3 | 404.38 | 420.01 | 410.64 | 6.75 |

**Mean speedup:** 2.13x (875.2s → 410.6s)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/jest-swc-phase-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/jest-swc-phase-2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-25T09:46:07.292Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->