### PR TITLE
fix(suite): match token row send/receive button order with header

### DIFF
--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -356,11 +356,11 @@ const TokenRowBasicActions = ({
                         isDisabled: !canSwapToken,
                     },
                     {
-                        label: <Translation id="TR_NAV_SEND" />,
-                        'data-testid': '@trading/tokens/send-button',
-                        icon: 'arrowUp',
-                        onClick: onSendButtonClick,
-                        isDisabled: token.balance === '0',
+                        label: <Translation id="TR_NAV_RECEIVE" />,
+                        'data-testid': '@trading/tokens/receive-button',
+                        icon: 'arrowDown',
+                        onClick: onReceiveButtonClick,
+                        isDisabled: !canReceiveToken,
                         isHidden:
                             type !== 'defi' &&
                             (tokenStatusType === TokenManagementAction.HIDE
@@ -368,11 +368,11 @@ const TokenRowBasicActions = ({
                                 : true),
                     },
                     {
-                        label: <Translation id="TR_NAV_RECEIVE" />,
-                        'data-testid': '@trading/tokens/receive-button',
-                        icon: 'arrowDown',
-                        onClick: onReceiveButtonClick,
-                        isDisabled: !canReceiveToken,
+                        label: <Translation id="TR_NAV_SEND" />,
+                        'data-testid': '@trading/tokens/send-button',
+                        icon: 'arrowUp',
+                        onClick: onSendButtonClick,
+                        isDisabled: token.balance === '0',
                         isHidden:
                             type !== 'defi' &&
                             (tokenStatusType === TokenManagementAction.HIDE
@@ -503,15 +503,6 @@ const TokenRowBasicActions = ({
                             </ButtonGroup>
                         ) : (
                             <ButtonGroup intent="neutral" priority="secondary">
-                                <Tooltip content={<Translation id="TR_NAV_SEND" />}>
-                                    <IconButton
-                                        isDisabled={token.balance === '0'}
-                                        key="token-send"
-                                        icon="arrowUp"
-                                        onClick={onSendButtonClick}
-                                    />
-                                </Tooltip>
-
                                 <Tooltip
                                     content={
                                         <Translation
@@ -528,6 +519,15 @@ const TokenRowBasicActions = ({
                                         icon="arrowDown"
                                         isDisabled={!canReceiveToken}
                                         onClick={onReceiveButtonClick}
+                                    />
+                                </Tooltip>
+
+                                <Tooltip content={<Translation id="TR_NAV_SEND" />}>
+                                    <IconButton
+                                        isDisabled={token.balance === '0'}
+                                        key="token-send"
+                                        icon="arrowUp"
+                                        onClick={onSendButtonClick}
                                     />
                                 </Tooltip>
                             </ButtonGroup>


### PR DESCRIPTION
Matched the token row send/receive button.

## Notes for QA

**Happy paths**
- Open a token-holding account (e.g. ERC-20 on ETH) — verify per-row buttons show Receive (↓) then Send (↑), matching the primary header order.
- Click token row Receive — verify receive address flow opens as before.
- Click token row Send — verify send form opens with token prefilled.

Edge cases**
- Below-tablet width — verify per-row dropdown lists Receive above Send.
- Token with zero balance — verify Send is disabled, Receive still works.
- Locked / security-check-failed device — verify Receive tooltip shows the compromised-state message and button is disabled.
- Cardano account tokens — verify Receive navigates to wallet-receive route (not address modal).
- DeFi tokens table — verify Supply/Withdraw (+/−) button order is **unchanged**.


Resolve https://github.com/trezor/trezor-suite/issues/27023

## Screenshots:
<img width="1647" height="602" alt="Screenshot 2026-04-24 at 13 15 53" src="https://github.com/user-attachments/assets/0f95cb45-a834-45c0-8dcb-4444cd1bb346" />
<img width="1648" height="704" alt="Screenshot 2026-04-24 at 13 16 02" src="https://github.com/user-attachments/assets/db407174-144d-4a2e-b1be-5c6b59733105" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to TokenRowActions.tsx, a component within the tokens table that likely provides action buttons (buy, sell, swap, etc.) for token rows. There is no static test coverage mapping for this file, indicating it may not be directly exercised by any E2E test. The trading/navigation test is the closest match as it explicitly tests navigating to buy/sell/swap forms from token-level entry points (openBuyTradingOfToken, openSellTradingOfToken, openSwapTradingOfToken), which would interact with token row action UI. The risk is moderate since token action buttons are user-facing but the change scope is narrow.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `../../suite/e2e/tests/trading/navigation.test.ts` — TokenRowActions.tsx is a component in the tokens table that likely provides action buttons (buy, sell, swap) for individual tokens. The navigation test covers navigating to buy/sell/swap trading forms from specific tokens (e.g., openBuyTradingOfToken, openSellTradingOfToken, openSwapTradingOfToken), which would exercise token row action buttons.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/dashboard/assets.test.ts` — The assets test covers the dashboard assets section including buy actions for assets in table/grid view. TokenRowActions may share UI patterns or components with the asset buy buttons, and changes could affect how token actions render in similar table views.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`

_Updated: 2026-04-24T11:17:53.559Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=send-receive-arrow-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=send-receive-arrow-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-25T11:28:38.652Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-25T11:26:38.430Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/send-receive-arrow-button/web/](https://dev.suite.sldev.cz/suite-web/send-receive-arrow-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->