### PR TITLE
Tron - transaction labels

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -1,5 +1,6 @@
 import { Translation, useTranslation } from '@suite/intl';
 import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType } from '@suite-common/wallet-types';
 import {
     getTxHeaderSymbol,
@@ -86,6 +87,37 @@ const getSolTransactionStakeTypeName = (stakeType: StakeType) => {
     }
 };
 
+const getTronTransactionMessageId = (transaction: WalletAccountTransaction) => {
+    const contractType = transaction.tronSpecific?.contractType as TronTxContractType;
+
+    switch (contractType) {
+        case 'AccountCreateContract':
+            return 'TR_TRON_TX_CREATE_ACCOUNT';
+        case 'AccountUpdateContract':
+            return 'TR_TRON_TX_UPDATE_ACCOUNT';
+        case 'CreateSmartContract':
+            return 'TR_TRON_TX_DEPLOY_SMART_CONTRACT';
+        case 'VoteWitnessContract':
+            return 'TR_TRON_TX_VOTE_WITNESS';
+        case 'FreezeBalanceContract':
+        case 'FreezeBalanceV2Contract':
+            return 'TR_TRON_TX_FREEZE_BALANCE';
+        case 'UnfreezeBalanceContract':
+        case 'UnfreezeBalanceV2Contract':
+            return 'TR_TRON_TX_UNFREEZE_BALANCE';
+        case 'WithdrawExpireUnfreezeContract':
+            return 'TR_TRON_TX_WITHDRAW_BALANCE';
+        case 'WithdrawBalanceContract':
+            return 'TR_TRON_TX_CLAIM_REWARDS';
+        case 'DelegateResourceContract':
+            return 'TR_TRON_TX_DELEGATE_RESOURCE';
+        case 'UnDelegateResourceContract':
+            return 'TR_TRON_TX_UNDELEGATE_RESOURCE';
+        default:
+            return undefined;
+    }
+};
+
 export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderProps) => {
     const { translationString } = useTranslation();
 
@@ -107,6 +139,12 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
                 )}
             </>
         );
+    }
+
+    // Tron-specific transactions
+    const tronTransactionMessageId = getTronTransactionMessageId(transaction);
+    if (tronTransactionMessageId) {
+        return <BlurUrls text={translationString(tronTransactionMessageId)} />;
     }
 
     const solanaStakeType = transaction?.solanaSpecific?.stakeOperation?.type;

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -79,11 +79,11 @@ const getTransactionMessageId = ({ transaction, isPending }: GetTransactionMessa
 const getSolTransactionStakeTypeName = (stakeType: StakeType) => {
     switch (stakeType) {
         case 'stake':
-            return 'Stake';
+            return 'TR_TX_STAKE_STAKE';
         case 'unstake':
-            return 'Unstake';
+            return 'TR_TX_STAKE_UNSTAKE';
         case 'claim':
-            return 'Claim Withdraw Request';
+            return 'TR_TX_STAKE_CLAIM';
     }
 };
 
@@ -149,9 +149,11 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     const solanaStakeType = transaction?.solanaSpecific?.stakeOperation?.type;
     if (solanaStakeType) {
+        const translationId = getSolTransactionStakeTypeName(solanaStakeType);
+
         return (
             <>
-                {getSolTransactionStakeTypeName(solanaStakeType)}
+                {translationId && <Translation id={translationId} />}
                 {isSupportedSolStakingNetworkSymbol(transaction.symbol) && (
                     <UnstakingTxAmount transaction={transaction} />
                 )}

--- a/suite-common/token-definitions/src/phishing/detectors.ts
+++ b/suite-common/token-definitions/src/phishing/detectors.ts
@@ -144,7 +144,7 @@ const isUnknownTxPhishing: PhishingDetectorFn = ({ transaction }) => {
 };
 
 const isTrc10TransferPhishing: PhishingDetectorFn = ({ transaction }) => {
-    const isTrc10Transfer = transaction.tronSpecific?.operation === 'trc10_transfer';
+    const isTrc10Transfer = transaction.tronSpecific?.contractType === 'TransferAssetContract';
 
     return createResult(isTrc10Transfer, transaction);
 };

--- a/suite-common/wallet-constants/src/index.ts
+++ b/suite-common/wallet-constants/src/index.ts
@@ -6,3 +6,4 @@ export * from './solanaStakingConstants';
 export * from './cardanoConstants';
 export * from './stakingConstants';
 export * from './accountConstants';
+export type * from './tronConstants';

--- a/suite-common/wallet-constants/src/tronConstants.ts
+++ b/suite-common/wallet-constants/src/tronConstants.ts
@@ -1,0 +1,34 @@
+export type TronTxContractType =
+    | 'AccountCreateContract' // Creates a new basic TRON account
+    | 'TransferContract' // Executes basic TRX transfer operations
+    | 'TransferAssetContract' // Executes TRC-10 token transfers
+    | 'VoteWitnessContract' // Votes for Super Representatives (SRs)
+    | 'WitnessCreateContract' // Registers to become an SR candidate
+    | 'WitnessUpdateContract' // Updates the public information of an SR
+    | 'AssetIssueContract' // Creates and configures a TRC-10-standard token
+    | 'ParticipateAssetIssueContract' // Participates in TRC-10 token crowdsales
+    | 'AccountUpdateContract' // Updates basic account information
+    | 'FreezeBalanceContract' // Stakes TRX to obtain Bandwidth/Energy resources (Deprecated, please use FreezeBalanceV2Contract)
+    | 'UnfreezeBalanceContract' // Unfreezes staked TRX in Stake1.0
+    | 'WithdrawBalanceContract' // Allows SRs to claim block rewards or users to claim voting rewards
+    | 'UnfreezeAssetContract' // Unfreezes frozen TRC-10 token (requires issuer authorization)
+    | 'UpdateAssetContract' // Modifies basic parameters of an issued TRC-10 token
+    | 'ProposalCreateContract' // Creates a new proposal to modify network parameters
+    | 'ProposalApproveContract' // SRs vote on proposals
+    | 'ProposalDeleteContract' // Deletes an existing network parameter modification proposal
+    | 'SetAccountIdContract' // Sets a custom unique identifier (Account ID) for an account
+    | 'CustomContract' // Executes legacy custom contract logic (deprecated)
+    | 'CreateSmartContract' // Deploys a smart contract
+    | 'TriggerSmartContract' // Interacts with a smart contract
+    | 'GetContract' // Queries detailed information about a smart contract
+    | 'UpdateSettingContract' // Modifies the user resource consumption ratio of a smart contract (the resource allocation ratio between developers and users)
+    | 'UpdateEnergyLimitContract' // Modifies the Energy consumption limit of a smart contract
+    | 'AccountPermissionUpdateContract' // Manages the multi-signature permission configuration of an account
+    | 'ClearABIContract' // Clears the ABI definition of a smart contract
+    | 'UpdateBrokerageContract' // Adjusts the commission ratio for SRs
+    | 'DelegateResourceContract' // Implements resource delegation operations (such as Bandwidth and Energy)
+    | 'UnDelegateResourceContract' // Implements resource undelegation operations
+    | 'FreezeBalanceV2Contract' // Used to stake TRX to obtain Bandwidth or Energy resources in Stake 2.0 of the TRON network (the original 1.0 staking method has been deprecated)
+    | 'UnfreezeBalanceV2Contract' // Used to unfreeze staked TRX and return the Bandwidth/Energy resources (used in conjunction with FreezeBalanceV2Contract)
+    | 'WithdrawExpireUnfreezeContract' // Used to withdraw TRX funds that have passed the unstaking waiting period (must be executed after initiating UnfreezeBalanceV2Contract)
+    | 'CancelAllUnfreezeV2Contract'; // Used to cancel all uncompleted unstaking operations (revokes initiated unstaking requests within the unstaking waiting period)

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2132,6 +2132,18 @@ export const messages = {
             claiming: 'Claiming',
             changeDelegate: 'Change delegate',
             changingDelegate: 'Changing delegate',
+            tron: {
+                createAccount: 'Create Account',
+                updateAccount: 'Update Account',
+                deploySmartContract: 'Deploy Smart Contract',
+                voteWitness: 'Vote Witness',
+                freezeBalance: 'Freeze Balance',
+                unfreezeBalance: 'Unfreeze Balance',
+                withdrawBalance: 'Withdraw Balance',
+                claimRewards: 'Claim Rewards',
+                delegateResource: 'Delegate Resource',
+                undelegateResource: 'Undelegate Resource',
+            },
         },
         TransactionDetailScreen: {
             sheetSubtitle: 'Transaction #{transactionId}',

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -23,6 +23,7 @@
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
+        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -1,3 +1,4 @@
+import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { getTxStakeType } from '@suite-common/wallet-utils';
 import { Text } from '@suite-native/atoms';
@@ -74,6 +75,37 @@ export const getTransactionName = (
     }
 };
 
+const getTronTransactionMessage = (transaction: WalletAccountTransaction) => {
+    const contractType = transaction.tronSpecific?.contractType as TronTxContractType;
+
+    switch (contractType) {
+        case 'AccountCreateContract':
+            return 'transactions.name.tron.createAccount';
+        case 'AccountUpdateContract':
+            return 'transactions.name.tron.updateAccount';
+        case 'CreateSmartContract':
+            return 'transactions.name.tron.deploySmartContract';
+        case 'VoteWitnessContract':
+            return 'transactions.name.tron.voteWitness';
+        case 'FreezeBalanceContract':
+        case 'FreezeBalanceV2Contract':
+            return 'transactions.name.tron.freezeBalance';
+        case 'UnfreezeBalanceContract':
+        case 'UnfreezeBalanceV2Contract':
+            return 'transactions.name.tron.unfreezeBalance';
+        case 'WithdrawExpireUnfreezeContract':
+            return 'transactions.name.tron.withdrawBalance';
+        case 'WithdrawBalanceContract':
+            return 'transactions.name.tron.claimRewards';
+        case 'DelegateResourceContract':
+            return 'transactions.name.tron.delegateResource';
+        case 'UnDelegateResourceContract':
+            return 'transactions.name.tron.undelegateResource';
+        default:
+            return undefined;
+    }
+};
+
 export const TransactionName = ({ transaction, isPending, variant }: TransactionNameProps) => {
     const ethName = transaction.ethereumSpecific?.parsedData?.name;
 
@@ -89,6 +121,16 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
                 ) : (
                     <Translation id="transactions.name.stellarTrustlineAdded" />
                 )}
+            </Text>
+        );
+    }
+
+    // Tron-specific transactions
+    const tronTransactionMessageId = getTronTransactionMessage(transaction);
+    if (tronTransactionMessageId) {
+        return (
+            <Text variant={variant}>
+                <Translation id={tronTransactionMessageId} />
             </Text>
         );
     }

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -22,6 +22,9 @@
             "path": "../../suite-common/wallet-config"
         },
         {
+            "path": "../../suite-common/wallet-constants"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10187,6 +10187,18 @@ export const messages = defineMessages({
         id: 'TR_STAKE_ACKNOWLEDGE_ENTRY_PERIOD',
         defaultMessage: 'I acknowledge the entry period.',
     },
+    TR_TX_STAKE_STAKE: {
+        id: 'TR_TX_STAKE_STAKE',
+        defaultMessage: 'Stake',
+    },
+    TR_TX_STAKE_UNSTAKE: {
+        id: 'TR_TX_STAKE_UNSTAKE',
+        defaultMessage: 'Unstake',
+    },
+    TR_TX_STAKE_CLAIM: {
+        id: 'TR_TX_STAKE_CLAIM',
+        defaultMessage: 'Claim Withdraw Request',
+    },
     TR_STAKE_STAKE: {
         id: 'TR_STAKE_STAKE',
         defaultMessage: 'Stake',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5415,6 +5415,46 @@ export const messages = defineMessages({
         id: 'TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP',
         defaultMessage: 'New TRON accounts require a one-time 1 TRX network fee to activate.',
     },
+    TR_TRON_TX_CREATE_ACCOUNT: {
+        id: 'TR_TRON_TX_CREATE_ACCOUNT',
+        defaultMessage: 'Create Account',
+    },
+    TR_TRON_TX_UPDATE_ACCOUNT: {
+        id: 'TR_TRON_TX_UPDATE_ACCOUNT',
+        defaultMessage: 'Update Account',
+    },
+    TR_TRON_TX_DEPLOY_SMART_CONTRACT: {
+        id: 'TR_TRON_TX_DEPLOY_SMART_CONTRACT',
+        defaultMessage: 'Deploy Smart Contract',
+    },
+    TR_TRON_TX_VOTE_WITNESS: {
+        id: 'TR_TRON_TX_VOTE_WITNESS',
+        defaultMessage: 'Vote Witness',
+    },
+    TR_TRON_TX_FREEZE_BALANCE: {
+        id: 'TR_TRON_TX_FREEZE_BALANCE',
+        defaultMessage: 'Freeze Balance',
+    },
+    TR_TRON_TX_UNFREEZE_BALANCE: {
+        id: 'TR_TRON_TX_UNFREEZE_BALANCE',
+        defaultMessage: 'Unfreeze Balance',
+    },
+    TR_TRON_TX_WITHDRAW_BALANCE: {
+        id: 'TR_TRON_TX_WITHDRAW_BALANCE',
+        defaultMessage: 'Withdraw Balance',
+    },
+    TR_TRON_TX_CLAIM_REWARDS: {
+        id: 'TR_TRON_TX_CLAIM_REWARDS',
+        defaultMessage: 'Claim Rewards',
+    },
+    TR_TRON_TX_DELEGATE_RESOURCE: {
+        id: 'TR_TRON_TX_DELEGATE_RESOURCE',
+        defaultMessage: 'Delegate Resource',
+    },
+    TR_TRON_TX_UNDELEGATE_RESOURCE: {
+        id: 'TR_TRON_TX_UNDELEGATE_RESOURCE',
+        defaultMessage: 'Undelegate Resource',
+    },
     TR_EXPERIMENTAL_TRON_VIEW_ONLY: {
         id: 'TR_EXPERIMENTAL_TRON_VIEW_ONLY',
         defaultMessage: 'Tron (Beta)',

--- a/yarn.lock
+++ b/yarn.lock
@@ -14631,6 +14631,7 @@ __metadata:
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
+    "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"


### PR DESCRIPTION
## Description

Introduce transaction labels for Tron.

## Related Issue

Resolve #26384 

## Screenshots:

<img width="100%" alt="Screenshot 2026-04-27 at 10 56 10" src="https://github.com/user-attachments/assets/57d6c7f2-4a33-4e30-bbd3-1950bf0104b0" />

<img width="100%" alt="IMG_7954" src="https://github.com/user-attachments/assets/d2a35e96-1b1f-4506-b719-1a1d7768b179" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies Tron-specific wallet constants (tronConstants.ts), the wallet-constants barrel export (index.ts), the TransactionHeader UI component, and the i18n messages file. The highest risk area is Tron-related functionality since tronConstants.ts is new/modified and the receive test explicitly exercises TRX. TransactionHeader changes could affect transaction list display across many views, but the component maps to 121 tests indicating it's a broadly shared component — only tests that specifically assert on transaction item headings or labels warrant targeted coverage. The messages.ts change is a global file, so only tests whose specific translation keys may be affected are recommended.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx`
- `suite-common/wallet-constants/src/index.ts`
- `suite-common/wallet-constants/src/tronConstants.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test enables TRX (Tron) as an experimental feature and tests receiving TRX. The changes to tronConstants.ts and wallet-constants/src/index.ts directly affect Tron network configuration, and messages.ts likely contains new/modified TRX-related translation strings used in the receive flow.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — TransactionHeader.tsx renders transaction headings like 'Sending to self', 'Sending', 'Receiving' etc. This test explicitly verifies those labels (TR_SENDING_SYMBOL_TO_SELF, TR_SENDING_SYMBOL, TR_RECEIVING_SYMBOL) in the pending transaction list, making it directly sensitive to changes in the TransactionHeader component and related message strings.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test navigates to the BTC account page and interacts with the transaction list, searching for transactions by address. TransactionHeader.tsx is rendered for each transaction item, and changes to it could affect transaction display or search functionality.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test imports CARDANO_STAKING_REGISTRATION_DEPOSIT from @suite-common/wallet-constants, which is exported through the changed index.ts. Any accidental breakage in the barrel export could cause this test's import to fail, and it validates core Cardano staking deposit amounts.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test also references CARDANO_STAKING_REGISTRATION_DEPOSIT from wallet-constants. Changes to index.ts re-exports could affect the availability of this constant used in unstake flow assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test verifies transaction output labels, which are rendered alongside TransactionHeader. Changes to the header component could affect how output labels and transaction items are displayed together in the transaction list view.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-constants/src/tronConstants.ts`

_Updated: 2026-04-24T12:05:33.348Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-tx-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-tx-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-tx-label&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:16:18.435Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:14:50.957Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-tx-label/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-tx-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->