### PR TITLE
fix(suite-sync): fall back to noop when SharedWorker is unavailable

### DIFF
--- a/packages/suite/src/views/settings/labeling/Labeling.tsx
+++ b/packages/suite/src/views/settings/labeling/Labeling.tsx
@@ -5,7 +5,7 @@ import { useDevice } from '@suite/device';
 import { Translation, useTranslation } from '@suite/intl';
 import { metadataLabelingActions, metadataThunks } from '@suite/metadata';
 import { Anchor, SettingsAnchor } from '@suite/router';
-import { SuiteSyncServers } from '@suite/suite-sync';
+import { isSuiteSyncRuntimeAvailable, SuiteSyncServers } from '@suite/suite-sync';
 import { events } from '@suite-common/analytics';
 import {
     selectIsSuiteSyncEnabled,
@@ -71,8 +71,9 @@ export const Labeling = () => {
     const deviceStaticSessionId = device?.state?.staticSessionId;
     const { isDeviceLabelingDisabled } = useLabelingDeviceState();
 
-    const showSuiteSync = useSelector(selectIsSuiteSyncFeatureAvailable);
-    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
+    const isRuntimeAvailable = isSuiteSyncRuntimeAvailable();
+    const showSuiteSync = useSelector(selectIsSuiteSyncFeatureAvailable) && isRuntimeAvailable;
+    const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled) && isRuntimeAvailable;
 
     const legacyMetadataState = useSelector(state => state.metadata);
 

--- a/suite/suite-sync/src/createNoopSuiteSync.ts
+++ b/suite/suite-sync/src/createNoopSuiteSync.ts
@@ -1,0 +1,29 @@
+import { type SuiteSync } from '@suite-common/suite-sync-types';
+import { err } from '@trezor/type-utils';
+
+/**
+ * Noop Suite Sync implementation returned when the runtime does not support
+ * the dependencies Suite Sync requires (typically `SharedWorker`, which is
+ * missing in Chrome on Android). The UI should prevent Suite Sync from being
+ * enabled in this situation; these methods exist only as a safety net so that
+ * accidental calls do not crash the app.
+ */
+export const createNoopSuiteSync = (): SuiteSync => {
+    const unavailable = () =>
+        Promise.resolve(err({ type: 'SuiteSyncUnavailableOnDeviceError' } as const));
+
+    return {
+        changeRelayUrl: () => Promise.resolve(),
+        turnOnSuiteSync: unavailable,
+        turnOffSuiteSync: () => Promise.resolve(),
+        ensureWalletSuiteSyncOn: unavailable,
+        turnOffSuiteSyncForWallet: () => Promise.resolve(),
+        dangerouslyWipeAllLabelsFromWallet: unavailable,
+        labeling: {
+            updateWalletLabel: unavailable,
+            updateAccountLabel: unavailable,
+            updateAddressLabel: unavailable,
+            updateOutputLabel: unavailable,
+        },
+    };
+};

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -18,6 +18,8 @@ import {
 import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { type TrezorConnect } from '@trezor/connect';
 
+import { createNoopSuiteSync } from './createNoopSuiteSync';
+import { isSuiteSyncRuntimeAvailable } from './isSuiteSyncRuntimeAvailable';
 import { createTurnOnDesktopSuiteSync } from './turnOnDesktopSuiteSync';
 
 type SuiteSyncDesktopCompositionRootDeps = {
@@ -31,6 +33,10 @@ type SuiteSyncDesktopCompositionRootDeps = {
 export const createSuiteSyncDesktopCompositionRoot = (
     deps: SuiteSyncDesktopCompositionRootDeps,
 ): SuiteSync => {
+    if (!isSuiteSyncRuntimeAvailable()) {
+        return createNoopSuiteSync();
+    }
+
     const console = createConsole({
         level: 'warn',
         formatter: createConsoleFormatter()({ timestampFormat: 'absolute' }),

--- a/suite/suite-sync/src/index.ts
+++ b/suite/suite-sync/src/index.ts
@@ -1,4 +1,5 @@
 export { createSuiteSyncDesktopCompositionRoot } from './createSuiteSyncDesktopCompositionRoot';
+export { isSuiteSyncRuntimeAvailable } from './isSuiteSyncRuntimeAvailable';
 export { SelectSuiteSyncServer } from './SelectSuiteSyncServer';
 export { SuiteSyncServers } from './SuiteSyncServers';
 export { SuiteSyncSettings } from './SuiteSyncSettings';

--- a/suite/suite-sync/src/isSuiteSyncRuntimeAvailable.ts
+++ b/suite/suite-sync/src/isSuiteSyncRuntimeAvailable.ts
@@ -1,0 +1,7 @@
+/**
+ * Suite Sync stores data through Evolu, which relies on `SharedWorker` in the
+ * browser. Chrome on Android does not expose `SharedWorker`, so Suite Sync
+ * cannot run there and must be disabled both at composition and UI level.
+ */
+export const isSuiteSyncRuntimeAvailable = (): boolean =>
+    typeof SharedWorker !== 'undefined';


### PR DESCRIPTION
## Summary

- Suite Sync is wired through `@evolu/web`, which instantiates a `SharedWorker` during `createEvoluDeps`. Chrome on Android does not expose `SharedWorker`, so Suite initialization crashes on that platform even though we officially support it.
- This PR short-circuits `createSuiteSyncDesktopCompositionRoot` to a new `createNoopSuiteSync()` when `SharedWorker` is missing. All Suite Sync methods resolve with a "not implemented" style result (`err({ type: 'SuiteSyncUnavailableOnDeviceError' })`) or a void promise, matching the `SuiteSync` interface.
- The labeling settings UI now combines the existing `selectIsSuiteSyncFeatureAvailable` selector with a runtime `isSuiteSyncRuntimeAvailable()` check so the Suite Sync option is hidden (and any previously enabled state is treated as off) on unsupported browsers.
- Native (`@evolu/react-native`) is unaffected — the guard lives inside the desktop/web composition root only.

## Test plan

- [ ] Load Suite Web in Chrome on Android; confirm the app boots and the labeling dropdown does not offer Suite Sync.
- [ ] Load Suite Web / Desktop in a SharedWorker-capable browser; confirm Suite Sync still initializes normally and can be toggled.
- [ ] Regression: `yarn workspace @suite/suite-sync type-check` and unit tests in `suite-common/suite-sync` still pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the Suite Sync infrastructure (noop implementation, desktop composition root, runtime availability check, and module index) plus the Labeling settings view component. The highest risk is to Suite Sync labeling functionality — any regression in the sync initialization, runtime detection, or noop fallback could break label synchronization across the app. The legacy labeling settings UI is also affected through Labeling.tsx changes. The recommended strategy prioritizes all Suite Sync E2E tests as high priority, followed by legacy metadata tests that interact with the labeling settings page at medium priority.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/settings/labeling/Labeling.tsx`
- `suite/suite-sync/src/createNoopSuiteSync.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`
- `suite/suite-sync/src/index.ts`
- `suite/suite-sync/src/isSuiteSyncRuntimeAvailable.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test directly exercises the migration from legacy labeling to Suite Sync. The changed files include suite-sync modules (createNoopSuiteSync, createSuiteSyncDesktopCompositionRoot, isSuiteSyncRuntimeAvailable, index) which form the Suite Sync infrastructure, and the Labeling.tsx settings view which is the UI entry point for labeling configuration. Changes to either could break this migration flow.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates new labels via Suite Sync for accounts, wallets, addresses, and outputs. The suite-sync module changes (especially createNoopSuiteSync and isSuiteSyncRuntimeAvailable) directly affect whether Suite Sync initializes correctly, and Labeling.tsx is the settings UI for enabling Suite Sync.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Tests multi-wallet Suite Sync labeling including enabling/declining sync on passphrase wallets and verifying data isolation. The suite-sync runtime availability and composition root changes could affect how Suite Sync initializes per wallet, and Labeling.tsx changes could affect the sync banner/enablement UI.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Tests removing previously synced labels via Suite Sync and verifying null propagation to the Evolu relay. Changes to the suite-sync infrastructure (noop, desktop composition root, runtime availability) directly impact whether Suite Sync functions correctly for label CRUD operations.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Tests syncing labels from the Evolu relay server to the Suite app, including device confirmation for Suite Sync setup. The suite-sync module changes (especially isSuiteSyncRuntimeAvailable and the composition root) directly affect whether the sync initialization and data pull work correctly.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Tests the full metadata/labeling lifecycle including enabling, disabling, and re-enabling legacy labeling via the application settings page. The Labeling.tsx component is the settings view where metadata provider selection (TR_LABELING_OFF, TR_LABELING_LEGACY) is managed, making this test sensitive to UI changes in that file.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Tests connecting/disconnecting metadata providers and re-enabling metadata from the settings page (@settings/metadata). The Labeling.tsx component renders the metadata provider connect/disconnect buttons and provider selection dropdown that this test directly interacts with.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Tests switching between Dropbox and Google metadata providers via the settings disconnect/connect flow. The Labeling.tsx settings view contains the disconnect-provider-button and connect-provider-button UI elements that this test exercises directly.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Tests Dropbox API error handling during labeling, including navigating to Settings > Application and using the metadata select input to enable legacy labeling. Changes to Labeling.tsx could affect the metadata provider selection dropdown behavior.
- `suite/e2e/tests/metadata/legacy/google-api-errors.test.ts` — Tests Google API error handling during metadata provider initialization, accessing the metadata select input from Settings > Application. The Labeling.tsx component renders this select input and provider initialization flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The analytics events test checks the SuiteReady event which includes a 'labeling' field in its payload. Changes to Labeling.tsx could theoretically affect the labeling state reported in analytics, though this is an indirect relationship.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite/suite-sync/src/createNoopSuiteSync.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`
- `suite/suite-sync/src/index.ts`
- `suite/suite-sync/src/isSuiteSyncRuntimeAvailable.ts`

_Updated: 2026-04-24T12:22:18.980Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/suitesync-sharedworker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/suitesync-sharedworker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 18 test(s)</summary>

| Test | Type |
|------|------|
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T12:27:50.330Z • 18 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T12:26:07.265Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/suitesync-sharedworker/web/](https://dev.suite.sldev.cz/suite-web/mroz22/suitesync-sharedworker/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->