### PR TITLE
feat(suite): use the Slip39_Basic_Extendable for NFC flow by default

### DIFF
--- a/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/SecurityStep.tsx
@@ -65,7 +65,7 @@ export const SecurityStep = () => {
                 return {
                     ...params,
                     backup_method: 1,
-                    backup_type: 1 as const,
+                    backup_type: 4 as const,
                 };
             }
 


### PR DESCRIPTION
Update the default backup type for NFC flow.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to SecurityStep.tsx, a key onboarding component responsible for backup configuration and PIN setup during wallet creation. This is a focused UI change with high impact on the onboarding create-wallet flows across all device models (T1B1, T2T1, T3T1, T3W1). The file maps to 121 tests statically, but only onboarding and backup tests directly exercise the SecurityStep component — most other mapped tests merely pass through onboarding via completeOnboarding() helper which may or may not trigger SecurityStep depending on the flow. Priority testing should focus on wallet creation tests across device models, with secondary coverage of recovery flows that include PIN skip steps.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/onboarding/steps/SecurityStep.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — SecurityStep.tsx is part of the onboarding flow, and this test's source_hints explicitly mention 'SecurityStep component'. The test covers creating a wallet during onboarding which directly exercises the security step where users configure backup and PIN — the exact component that was changed.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test covers the T3W1 wallet creation onboarding flow including Shamir backup and PIN setup, which are the core responsibilities of SecurityStep.tsx. The onboarding create-wallet flow directly passes through the security step.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test covers the T2T1 wallet creation onboarding flow including Shamir backup configuration and PIN setup. The SecurityStep component is directly exercised during the backup and PIN portions of onboarding.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test covers T1B1 wallet creation during onboarding, including seed backup and PIN setup steps, which are managed by the SecurityStep component. Changes to SecurityStep could break this device-specific onboarding path.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test covers wallet creation with Shamir backup and PIN setup during offline onboarding. It exercises the SecurityStep component in an offline edge case, which is important for ensuring the changed component handles network-less scenarios.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test covers entropy check failures during wallet creation in onboarding, including backup checkbox interactions and the createBackupButton — UI elements that reside in or are closely related to SecurityStep. Changes could affect error handling in the backup portion of the security step.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test covers the recovery flow during onboarding which passes through the PIN skip step — a part of SecurityStep. If SecurityStep changes affect the PIN setup/skip UI, this recovery path could break.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — This test covers T1B1 recovery during onboarding and includes a PIN skip step that is part of SecurityStep. Changes to the security step's PIN-related UI could affect the recovery completion flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test covers Shamir recovery persistence during onboarding, including completing the onboarding flow after recovery which passes through the skip button and continue button — elements that may be rendered by SecurityStep.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test verifies the initial run/onboarding flow persistence across reloads, including the completeOnboardingButton step. SecurityStep is part of the onboarding wizard, and changes could affect the flow's ability to reach the completion state.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test covers the backup flow which shares UI components (backup checkboxes, backup start/close buttons) with the SecurityStep component's backup sub-section. Changes to SecurityStep could affect how backup prerequisites are presented.

</details>

_Updated: 2026-04-24T12:55:17.319Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=nfc/change-default-backup-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=nfc/change-default-backup-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-26T23:49:42.730Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-26T23:48:00.372Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/nfc/change-default-backup-type/web/](https://dev.suite.sldev.cz/suite-web/nfc/change-default-backup-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->