### PR TITLE
fix(ci): Fixed fetching quarantined actions

### DIFF
--- a/packages/e2e-utils/src/currentsApi/api.ts
+++ b/packages/e2e-utils/src/currentsApi/api.ts
@@ -2,6 +2,7 @@ import { CURRENTS_API_BASE, DEVELOP_BRANCH, TEST_RESULTS_PAGE_SIZE } from './con
 import { SpecFetchMode } from './types';
 import type {
     Action,
+    ActionStatus,
     ActionsListResponse,
     RawInstanceTest,
     RunData,
@@ -201,19 +202,27 @@ export async function getActiveTests(
 }
 
 /**
- * Fetch all actions for a project.
+ * Fetch actions for a project, optionally filtered by status.
  */
-export async function getActions(projectId: string): Promise<Action[]> {
-    const response = await currentsRequest<ActionsListResponse>(`/actions?projectId=${projectId}`);
+export async function getActions(
+    projectId: string,
+    status?: ActionStatus | ActionStatus[],
+): Promise<Action[]> {
+    const params = new URLSearchParams({ projectId });
+    if (status !== undefined) {
+        const statuses = Array.isArray(status) ? status : [status];
+        statuses.forEach(s => params.append('status', s));
+    }
+    const response = await currentsRequest<ActionsListResponse>(`/actions?${params.toString()}`);
 
     return response.data;
 }
 
 /**
- * Fetch all actions for a project that have a quarantine rule applied.
+ * Fetch active actions for a project that have a quarantine rule applied.
  */
 export async function getAllQuarantineActions(projectId: string): Promise<Action[]> {
-    const actions = await getActions(projectId);
+    const actions = await getActions(projectId, 'active');
 
     return actions.filter(a => a.action.some(r => r.op === 'quarantine'));
 }

--- a/packages/e2e-utils/src/currentsApi/types.ts
+++ b/packages/e2e-utils/src/currentsApi/types.ts
@@ -62,13 +62,15 @@ export interface RuleAction {
     details?: { tags: string[] };
 }
 
+export type ActionStatus = 'active' | 'disabled' | 'archived' | 'expired';
+
 export interface Action {
     actionId: string;
     name: string;
     description: string;
     action: RuleAction[];
     matcher: RuleMatcher;
-    status: string;
+    status: ActionStatus;
     createdAt: string;
     expiresAfter?: string;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are `packages/e2e-utils/src/currentsApi/api.ts` and `packages/e2e-utils/src/currentsApi/types.ts`, which are part of the e2e test utilities package — specifically a "currentsApi" module. This module appears to be an internal API client used by the e2e test infrastructure (likely for reporting or orchestration purposes like the Currents.dev test reporting service), not by the application code under test. No tests statically reference these files, and the LLM analysis of all known tests reveals no test whose behaviors, entry points, or source hints touch a "currentsApi" module. Since these changes affect test infrastructure/tooling rather than application functionality, no E2E tests need to be run to validate application correctness. If the changes break the reporting API client, that would manifest as test infrastructure failures rather than application regressions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/e2e-utils/src/currentsApi/api.ts`
- `packages/e2e-utils/src/currentsApi/types.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/e2e-utils/src/currentsApi/api.ts`
- `packages/e2e-utils/src/currentsApi/types.ts`

_Updated: 2026-04-24T14:04:51.380Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-ci-autoqurantine-fetch-active-actions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-ci-autoqurantine-fetch-active-actions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T14:10:46.047Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T14:09:01.120Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-ci-autoqurantine-fetch-active-actions/web/](https://dev.suite.sldev.cz/suite-web/fix-ci-autoqurantine-fetch-active-actions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->