### PR TITLE
Fix Suite Web on Android

### DIFF
--- a/suite/suite-sync/src/Db.worker.ts
+++ b/suite/suite-sync/src/Db.worker.ts
@@ -1,0 +1,29 @@
+/// <reference lib="webworker" />
+declare const self: DedicatedWorkerGlobalScope;
+
+// Vendored from @evolu/web/src/local-first/Db.worker.ts because @evolu/web's
+// `exports` field doesn't expose this entry point. Imports are rewritten to
+// the package's public surface. Remove together with createEvoluDepsFixed.ts
+// once https://github.com/evoluhq/evolu/issues/670 is resolved.
+
+import { createRandomBytes } from '@evolu/common';
+import { startDbWorker } from '@evolu/common/local-first';
+import { installPolyfills } from '@evolu/common/polyfills';
+import {
+    createLeaderLock,
+    createRun,
+    createWasmSqliteDriver,
+    createWorkerDeps,
+    createWorkerSelf,
+} from '@evolu/web';
+
+installPolyfills();
+
+const run = createRun({
+    ...createWorkerDeps(),
+    createSqliteDriver: createWasmSqliteDriver,
+    leaderLock: createLeaderLock(),
+    randomBytes: createRandomBytes(),
+});
+
+run(startDbWorker(createWorkerSelf(self)));

--- a/suite/suite-sync/src/Shared.worker.ts
+++ b/suite/suite-sync/src/Shared.worker.ts
@@ -1,0 +1,21 @@
+/// <reference lib="webworker" />
+declare const self: SharedWorkerGlobalScope;
+
+// Vendored from @evolu/web/src/local-first/Shared.worker.ts because @evolu/web's
+// `exports` field doesn't expose this entry point. Imports are rewritten to
+// the package's public surface. Remove together with createEvoluDepsFixed.ts
+// once https://github.com/evoluhq/evolu/issues/670 is resolved.
+
+import { createWebSocket } from '@evolu/common';
+import { initSharedWorker } from '@evolu/common/local-first';
+import { installPolyfills } from '@evolu/common/polyfills';
+import { createRun, createSharedWorkerSelf, createWorkerDeps } from '@evolu/web';
+
+installPolyfills();
+
+const run = createRun({
+    ...createWorkerDeps(),
+    createWebSocket,
+});
+
+run(initSharedWorker(createSharedWorkerSelf(self)));

--- a/suite/suite-sync/src/createEvoluDepsFixed.ts
+++ b/suite/suite-sync/src/createEvoluDepsFixed.ts
@@ -1,0 +1,52 @@
+import type { ConsoleDep } from '@evolu/common';
+import { createEvoluDeps as createCommonEvoluDeps } from '@evolu/common/local-first';
+import type {
+    CreateDbWorker,
+    DbWorkerInit,
+    EvoluDeps,
+    SharedWorkerInput,
+} from '@evolu/common/local-first';
+import { createMessageChannel, createSharedWorker, createWorker } from '@evolu/web';
+
+const getSharedWorker = () => {
+    if ('SharedWorker' in globalThis) {
+        return new SharedWorker(new URL('./Shared.worker.ts', import.meta.url), {
+            type: 'module',
+        });
+    }
+
+    const regularWorker = new Worker(new URL('./Shared.worker.ts', import.meta.url), {
+        type: 'module',
+    });
+
+    return { port: regularWorker } as unknown as SharedWorker;
+};
+
+// This is a temporary workaround to fix Suite Web in browsers without SharedWorker support (Chrome Android).
+// Once this is implemented directly in Evolu, we will remove this method.
+// See Evolu issue https://github.com/evoluhq/evolu/issues/670
+export const createEvoluDepsFixed = (deps: Partial<ConsoleDep> = {}): EvoluDeps => {
+    const createDbWorker: CreateDbWorker = () =>
+        createWorker<DbWorkerInit, never>(
+            new Worker(new URL('./Db.worker.ts', import.meta.url), {
+                type: 'module',
+            }),
+        );
+
+    const sharedWorker = createSharedWorker<SharedWorkerInput>(getSharedWorker());
+
+    return createCommonEvoluDeps({
+        ...deps,
+        createDbWorker,
+        createMessageChannel,
+        reloadApp: url => {
+            // Not exported from Evolu, so copy pasted here.
+            if (typeof document === 'undefined') {
+                return;
+            }
+
+            location.replace(url ?? '/');
+        },
+        sharedWorker,
+    });
+};

--- a/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
+++ b/suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts
@@ -1,5 +1,5 @@
 import { createConsole, createConsoleFormatter } from '@evolu/common';
-import { createEvoluDeps, createRun } from '@evolu/web';
+import { createRun } from '@evolu/web';
 import { type Dispatch } from '@reduxjs/toolkit';
 
 import { type DesktopAnalyticsDep } from '@suite/analytics';
@@ -18,6 +18,7 @@ import {
 import { type SuiteSync } from '@suite-common/suite-sync-types';
 import { type TrezorConnect } from '@trezor/connect';
 
+import { createEvoluDepsFixed } from './createEvoluDepsFixed';
 import { createTurnOnDesktopSuiteSync } from './turnOnDesktopSuiteSync';
 
 type SuiteSyncDesktopCompositionRootDeps = {
@@ -36,7 +37,7 @@ export const createSuiteSyncDesktopCompositionRoot = (
         formatter: createConsoleFormatter()({ timestampFormat: 'absolute' }),
     });
 
-    const evoluDeps = createEvoluDeps({ console });
+    const evoluDeps = createEvoluDepsFixed({ console });
 
     const run = createRun(evoluDeps);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement custom `createEvoluDeps` that is handling unsupported `SharedWorker` as a temporary solution to fix Suite Web on Android. It will be handled in Evolu directly in next release and then we can delete this custom `createEvoluDepsFixed` method.

`SharedWorker` is supported in all major browsers except Android, where it is in the Canary 148 Chrome, that should be released 2026-05-05.  https://caniuse.com/?search=SharedWorker

<!--- Describe your changes in detail -->

## Notes for QA

Test Suite Sync initialization on Web, Desktop (electron) and mobile Web (android)



## Screenshots:
Current state of Suite Web in Chrome Android
<img width="371" height="821" alt="image" src="https://github.com/user-attachments/assets/3a7e5ff7-1784-4879-8f9a-d2364a4ce9ea" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (createEvoluDepsFixed.ts and createSuiteSyncDesktopCompositionRoot.ts) are core infrastructure for the Suite Sync feature, which manages label synchronization via the Evolu relay server. These files configure dependency injection for the desktop Suite Sync composition root. The highest risk is regression in all Suite Sync label operations (create, read, remove, multi-wallet). The legacy-to-Suite-Sync migration test is medium priority as it partially depends on this infrastructure. No static test mappings exist, so all recommendations are inferred from LLM analysis of test behaviors and source hints.

<details><summary><b>Changed files (2)</b></summary>

- `suite/suite-sync/src/createEvoluDepsFixed.ts`
- `suite/suite-sync/src/createSuiteSyncDesktopCompositionRoot.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `../../suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — createSuiteSyncDesktopCompositionRoot.ts is directly responsible for wiring up the Suite Sync desktop dependency graph, which includes Evolu/relay sync infrastructure. This test exercises the full Suite Sync flow of syncing labels from the Evolu relay server, which depends on the composition root being correctly configured.
- `../../suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates and syncs new labels (account, wallet, address, output) via Suite Sync to the Evolu relay server. The changed files directly configure the Evolu dependencies and Suite Sync composition root that power this label synchronization pipeline.
- `../../suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test validates Suite Sync across multiple wallets (standard + passphrase), including owner isolation via Evolu relay. Changes to createEvoluDepsFixed and the desktop composition root directly affect how Evolu owner secrets and sync are initialized per wallet.
- `../../suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test verifies that removing labels syncs null values to the Evolu relay. It directly depends on the Suite Sync infrastructure configured by the changed composition root and Evolu dependency files.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `../../suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test covers migration from legacy Dropbox labels to Suite Sync, seeding the Evolu relay before migration. Changes to the Evolu deps and composition root could affect how the migration initializes and connects to the relay server.

</details>

_Updated: 2026-04-24T14:41:30.999Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/evolu-fix-missing-sharedworker&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/evolu-fix-missing-sharedworker&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 24 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T15:00:26.231Z • 24 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Send Eth > User can initiate ethereum sending | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T15:31:50.449Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/evolu-fix-missing-sharedworker/web/](https://dev.suite.sldev.cz/suite-web/fix/evolu-fix-missing-sharedworker/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->