### PR TITLE
feat(suite): add trezorsuite://guide-support deeplink

### DIFF
--- a/packages/suite/src/actions/suite/constants/guideConstants.ts
+++ b/packages/suite/src/actions/suite/constants/guideConstants.ts
@@ -4,3 +4,4 @@ export const SET_INDEX_NODE = '@guide/set-index-node' as const;
 export const SET_VIEW = '@guide/set-view' as const;
 export const UNSET_NODE = '@guide/unset-node' as const;
 export const OPEN_NODE = '@guide/open-node' as const;
+export const SET_SUPPORT_CONSENT_AUTO_OPEN = '@guide/set-support-consent-auto-open' as const;

--- a/packages/suite/src/actions/suite/guideActions.ts
+++ b/packages/suite/src/actions/suite/guideActions.ts
@@ -1,5 +1,6 @@
 import type { ActiveView, GuideCategory, GuideNode } from '@suite-common/suite-types';
 
+import { type SupportConsentAutoOpen } from 'src/reducers/suite/guideReducer';
 import { type Dispatch } from 'src/types/suite';
 
 import { GUIDE } from './constants';
@@ -10,7 +11,11 @@ export type GuideAction =
     | { type: typeof GUIDE.SET_INDEX_NODE; payload: GuideCategory }
     | { type: typeof GUIDE.SET_VIEW; payload: ActiveView }
     | { type: typeof GUIDE.UNSET_NODE }
-    | { type: typeof GUIDE.OPEN_NODE; payload: GuideNode };
+    | { type: typeof GUIDE.OPEN_NODE; payload: GuideNode }
+    | {
+          type: typeof GUIDE.SET_SUPPORT_CONSENT_AUTO_OPEN;
+          payload: SupportConsentAutoOpen | null;
+      };
 
 export const open = (): GuideAction => ({
     type: GUIDE.OPEN,
@@ -31,6 +36,11 @@ export const setView = (payload: ActiveView) => (dispatch: Dispatch) => {
 
     dispatch({ type: GUIDE.SET_VIEW, payload });
 };
+
+export const setSupportConsentAutoOpen = (payload: SupportConsentAutoOpen | null): GuideAction => ({
+    type: GUIDE.SET_SUPPORT_CONSENT_AUTO_OPEN,
+    payload,
+});
 
 export const openNode = (payload: GuideNode) => (dispatch: Dispatch) => {
     if (payload.type === 'page') {

--- a/packages/suite/src/actions/suite/protocolActions.ts
+++ b/packages/suite/src/actions/suite/protocolActions.ts
@@ -14,11 +14,13 @@ import * as walletConnectActions from '@suite-common/walletconnect';
 import {
     SUITE_ANCHOR_DEEPLINK_PREFIX,
     SUITE_BRIDGE_DEEPLINK,
+    SUITE_GUIDE_SUPPORT_DEEPLINK,
     SUITE_TRADING_REDIRECT_DEEPLINKS,
     SUITE_WALLETCONNECT_DEEPLINK,
 } from '@trezor/urls';
 import { isArrayMember } from '@trezor/utils';
 
+import * as guideActions from 'src/actions/suite/guideActions';
 import type { SendFormState } from 'src/reducers/suite/protocolReducer';
 import { asSuiteServices } from 'src/support/extraDependencies';
 import { type Dispatch, type GetState } from 'src/types/suite';
@@ -102,6 +104,12 @@ export const handleProtocolRequest =
                     mapAnchorToRoute[domain.replace(/^@/, '') as AnchorSettingSection];
                 dispatch(goto({ routeName: targetRoute, anchor }));
             }
+        } else if (uri?.startsWith(SUITE_GUIDE_SUPPORT_DEEPLINK)) {
+            const parsed = parseUri(uri);
+            const shareSystemInfo = parsed?.searchParams?.get('shareSystemInfo') === '1';
+            dispatch(guideActions.open());
+            dispatch(guideActions.setView('SUPPORT_FEEDBACK_SELECTION'));
+            dispatch(guideActions.setSupportConsentAutoOpen({ shareSystemInfo }));
         } else if (SUITE_TRADING_REDIRECT_DEEPLINKS.some(deeplink => uri?.startsWith(deeplink))) {
             const parsedUri = parseUri(decodeURIComponent(uri));
             const redirectPath = parsedUri?.searchParams?.get('p');

--- a/packages/suite/src/components/guide/SupportConsentPopover.tsx
+++ b/packages/suite/src/components/guide/SupportConsentPopover.tsx
@@ -1,12 +1,23 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { selectIsAnalyticsEnabled } from '@suite-common/analytics-redux';
 import { selectSupportChatUrl } from '@suite-common/support';
-import { Button, Card, Checkbox, Column, Paragraph, Popover, variables } from '@trezor/components';
+import {
+    Button,
+    Card,
+    Checkbox,
+    Column,
+    Paragraph,
+    Popover,
+    type PopoverRef,
+    variables,
+} from '@trezor/components';
 import { spacingsPx, zIndices } from '@trezor/theme';
 
-import { useSelector } from 'src/hooks/suite';
+import { setSupportConsentAutoOpen } from 'src/actions/suite/guideActions';
+import { GUIDE_ANIMATION_DURATION_MS } from 'src/hooks/guide/useGuide';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 // To match the width of the trigger button in the SupportFeedbackSelection component.
 const POPOVER_WIDTH = `calc(${variables.LAYOUT_SIZE.GUIDE_PANEL_CONTENT_WIDTH} - 2 * ${spacingsPx.lg})`;
@@ -16,12 +27,32 @@ type SupportConsentPopoverProps = {
 };
 
 export const SupportConsentPopover = ({ children }: SupportConsentPopoverProps) => {
+    const dispatch = useDispatch();
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
-    const [isSystemInfoShared, setIsSystemInfoShared] = useState(isAnalyticsEnabled);
+    const autoOpen = useSelector(state => state.guide.supportConsentAutoOpen);
+    const [isSystemInfoShared, setIsSystemInfoShared] = useState(
+        autoOpen?.shareSystemInfo ?? isAnalyticsEnabled,
+    );
     const supportChatUrl = useSelector(state => selectSupportChatUrl(state, isSystemInfoShared));
+    const popoverRef = useRef<PopoverRef>(null);
+
+    useEffect(() => {
+        if (!autoOpen) return;
+
+        setIsSystemInfoShared(autoOpen.shareSystemInfo);
+        // Wait for the guide panel slide-in to finish so the popover doesn't
+        // fly in before the panel has arrived.
+        const timeoutId = setTimeout(() => {
+            popoverRef.current?.open();
+            dispatch(setSupportConsentAutoOpen(null));
+        }, GUIDE_ANIMATION_DURATION_MS);
+
+        return () => clearTimeout(timeoutId);
+    }, [autoOpen, dispatch]);
 
     return (
         <Popover
+            ref={popoverRef}
             zIndex={zIndices.guide}
             popoverOffset={-5}
             placement={{ position: 'bottom', alignment: 'start' }}

--- a/packages/suite/src/reducers/suite/guideReducer.ts
+++ b/packages/suite/src/reducers/suite/guideReducer.ts
@@ -4,11 +4,16 @@ import * as indexNodeJSON from '@trezor/suite-data/files/guide/index.json';
 import { GUIDE } from 'src/actions/suite/constants';
 import { type Action } from 'src/types/suite';
 
+export interface SupportConsentAutoOpen {
+    shareSystemInfo: boolean;
+}
+
 export interface State {
     open: boolean;
     view: ActiveView;
     indexNode: GuideCategory | null;
     currentNode: GuideNode | null;
+    supportConsentAutoOpen: SupportConsentAutoOpen | null;
 }
 
 const indexNode = indexNodeJSON as GuideCategory;
@@ -18,6 +23,7 @@ export const initialState: State = {
     view: 'GUIDE_DEFAULT',
     indexNode,
     currentNode: null,
+    supportConsentAutoOpen: null,
 };
 
 // NOTE: we cannot use immer in this reducer, because GuideCategory mimics the react node and immer uses Object.freeze()
@@ -33,6 +39,7 @@ const guideReducer = (state: State = initialState, action: Action): State => {
                 ...state,
                 open: false,
                 view: 'GUIDE_DEFAULT',
+                supportConsentAutoOpen: null,
             };
         case GUIDE.SET_VIEW:
             return {
@@ -53,6 +60,11 @@ const guideReducer = (state: State = initialState, action: Action): State => {
             return {
                 ...state,
                 currentNode: action.payload,
+            };
+        case GUIDE.SET_SUPPORT_CONSENT_AUTO_OPEN:
+            return {
+                ...state,
+                supportConsentAutoOpen: action.payload,
             };
         default:
             return state;

--- a/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
+++ b/packages/suite/src/support/tests/__fixtures__/defaultAppState.ts
@@ -54,6 +54,7 @@ export const initialAppState: AppState = {
         view: 'GUIDE_DEFAULT',
         indexNode: null,
         currentNode: null,
+        supportConsentAutoOpen: null,
     },
     messageSystem: messageSystemInitialState,
     modal: {

--- a/packages/urls/src/deeplinks.ts
+++ b/packages/urls/src/deeplinks.ts
@@ -3,6 +3,7 @@ import { type SuiteDeeplink } from './types';
 export const SUITE_BRIDGE_DEEPLINK: SuiteDeeplink = 'trezorsuite://bridge-requested-by-a-3rd-party';
 export const SUITE_WALLETCONNECT_DEEPLINK: SuiteDeeplink = 'trezorsuite://walletconnect';
 export const SUITE_ANCHOR_DEEPLINK_PREFIX: SuiteDeeplink = 'trezorsuite://anchor-';
+export const SUITE_GUIDE_SUPPORT_DEEPLINK: SuiteDeeplink = 'trezorsuite://guide-support';
 
 export const SUITE_TRADING_REDIRECT_DEEPLINKS: SuiteDeeplink[] = [
     'trezorsuite://buy-redirect',

--- a/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
@@ -10,6 +10,7 @@ import { isDevelopOrDebugEnv } from '@suite-native/config';
 import {
     type RootStackParamList,
     RootStackRoutes,
+    SettingsStackRoutes,
     type StackToStackCompositeNavigationProps,
 } from '@suite-native/navigation';
 
@@ -34,6 +35,10 @@ const isWalletConnectUrl = (url: string): boolean =>
     url.startsWith('trezorsuite://walletconnect') ||
     /^https:\/\/connect\.trezor\.io\/\d+\/deeplink\/wc/.test(url);
 
+const GUIDE_SUPPORT_URL_PREFIX = 'trezorsuite://guide-support';
+
+const isGuideSupportUrl = (url: string): boolean => url.startsWith(GUIDE_SUPPORT_URL_PREFIX);
+
 // TODO: will be necessary to handle if device is not connected/unlocked so we probably want to wait until user unlock device
 // we already have some modals like biometrics or coin enabled which are waiting for device to be connected
 export const useConnectPopupNavigation = () => {
@@ -57,8 +62,19 @@ export const useConnectPopupNavigation = () => {
             }
         } else if (url && isConnectPopupUrl(url)) {
             dispatch(connectPopupDeeplinkThunk({ url }));
+        } else if (url && isGuideSupportUrl(url)) {
+            try {
+                const parsedUrl = new URL(url);
+                const shareSystemInfo = parsedUrl.searchParams.get('shareSystemInfo') === '1';
+                navigation.navigate(RootStackRoutes.SettingsScreenStack, {
+                    screen: SettingsStackRoutes.SettingsSupport,
+                    params: { autoOpenContactSupport: true, shareSystemInfo },
+                });
+            } catch {
+                // Malformed url, ignore
+            }
         }
-    }, [url, dispatch]);
+    }, [url, dispatch, navigation]);
 
     useEffect(() => {
         if (connectPopupCall?.state === 'deeplink-callback') {

--- a/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
+++ b/suite-native/module-connect-popup/src/hooks/useConnectPopupNavigation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -62,9 +62,17 @@ export const useConnectPopupNavigation = () => {
             }
         } else if (url && isConnectPopupUrl(url)) {
             dispatch(connectPopupDeeplinkThunk({ url }));
-        } else if (url && isGuideSupportUrl(url)) {
+        }
+    }, [url, dispatch]);
+
+    // Guide-support deeplinks are handled via a direct Linking.addEventListener rather than the
+    // Linking.useURL() state hook. This ensures every deeplink invocation triggers navigation,
+    // including repeated calls with the same URL while the app is running in the background
+    // (Linking.useURL() would not update its state in that case, so the effect would not re-fire).
+    const handleGuideSupportUrl = useCallback(
+        (rawUrl: string) => {
             try {
-                const parsedUrl = new URL(url);
+                const parsedUrl = new URL(rawUrl);
                 const shareSystemInfo = parsedUrl.searchParams.get('shareSystemInfo') === '1';
                 navigation.navigate(RootStackRoutes.SettingsScreenStack, {
                     screen: SettingsStackRoutes.SettingsSupport,
@@ -73,8 +81,28 @@ export const useConnectPopupNavigation = () => {
             } catch {
                 // Malformed url, ignore
             }
-        }
-    }, [url, dispatch, navigation]);
+        },
+        [navigation],
+    );
+
+    useEffect(() => {
+        // Cold-start: check whether the app was opened with a guide-support URL.
+        Linking.getInitialURL().then(initialUrl => {
+            if (initialUrl && isGuideSupportUrl(initialUrl)) {
+                handleGuideSupportUrl(initialUrl);
+            }
+        });
+
+        // Background: subscribe to URL events so every invocation navigates,
+        // even when the same URL is re-used and Linking.useURL() would not re-fire.
+        const subscription = Linking.addEventListener('url', ({ url: eventUrl }) => {
+            if (isGuideSupportUrl(eventUrl)) {
+                handleGuideSupportUrl(eventUrl);
+            }
+        });
+
+        return () => subscription.remove();
+    }, [handleGuideSupportUrl]);
 
     useEffect(() => {
         if (connectPopupCall?.state === 'deeplink-callback') {

--- a/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
+++ b/suite-native/module-settings/src/components/ContactSupportAlertAppendix.tsx
@@ -18,9 +18,16 @@ export type ContactSupportAlertAppendixRef = {
     getSupportChatUrl: () => string;
 };
 
-export const ContactSupportAlertAppendix = forwardRef<ContactSupportAlertAppendixRef>((_, ref) => {
+type ContactSupportAlertAppendixProps = {
+    initialShareSystemInfo?: boolean;
+};
+
+export const ContactSupportAlertAppendix = forwardRef<
+    ContactSupportAlertAppendixRef,
+    ContactSupportAlertAppendixProps
+>(({ initialShareSystemInfo }, ref) => {
     const isAnalyticsEnabled = useSelector(selectIsAnalyticsEnabled);
-    const [isChecked, setIsChecked] = useState(isAnalyticsEnabled);
+    const [isChecked, setIsChecked] = useState(initialShareSystemInfo ?? isAnalyticsEnabled);
     const supportChatUrl = useSelector((state: DeviceRootState) =>
         selectSupportChatUrl(state, isChecked),
     );

--- a/suite-native/module-settings/src/components/useContactSupportAlert.tsx
+++ b/suite-native/module-settings/src/components/useContactSupportAlert.tsx
@@ -14,25 +14,33 @@ export const useContactSupportAlert = () => {
     const { showAlert } = useAlert();
     const openLink = useOpenLink();
 
-    const showContactSupportAlert = useCallback(() => {
-        showAlert({
-            title: <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.title" />,
-            textAlign: 'left',
-            appendix: <ContactSupportAlertAppendix ref={appendixRef} />,
-            primaryButtonTitle: (
-                <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.primaryButton" />
-            ),
-            primaryButtonIconRight: 'arrowLineUpRight',
-            onPressPrimaryButton: async () => {
-                if (appendixRef.current) {
-                    // We need to access the URL via a ref to ensure it's always up to date, even if the value changes while the alert is already displayed.
-                    await openLink(appendixRef.current.getSupportChatUrl());
-                }
-            },
-            secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
-            testID: '@contact-support-alert',
-        });
-    }, [showAlert, openLink]);
+    const showContactSupportAlert = useCallback(
+        (options?: { initialShareSystemInfo?: boolean }) => {
+            showAlert({
+                title: <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.title" />,
+                textAlign: 'left',
+                appendix: (
+                    <ContactSupportAlertAppendix
+                        ref={appendixRef}
+                        initialShareSystemInfo={options?.initialShareSystemInfo}
+                    />
+                ),
+                primaryButtonTitle: (
+                    <Translation id="moduleSettings.faq.needHelp.contactSupportAlert.primaryButton" />
+                ),
+                primaryButtonIconRight: 'arrowLineUpRight',
+                onPressPrimaryButton: async () => {
+                    if (appendixRef.current) {
+                        // We need to access the URL via a ref to ensure it's always up to date, even if the value changes while the alert is already displayed.
+                        await openLink(appendixRef.current.getSupportChatUrl());
+                    }
+                },
+                secondaryButtonTitle: <Translation id="generic.buttons.cancel" />,
+                testID: '@contact-support-alert',
+            });
+        },
+        [showAlert, openLink],
+    );
 
     return { showContactSupportAlert };
 };

--- a/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
@@ -1,6 +1,11 @@
 import { useCallback } from 'react';
 
-import { type RouteProp, useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
+import {
+    type RouteProp,
+    useFocusEffect,
+    useNavigation,
+    useRoute,
+} from '@react-navigation/native';
 
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -19,7 +24,10 @@ import { LegalSection } from '../components/LegalSection';
 import { NeedHelpSection } from '../components/NeedHelpSection';
 import { useContactSupportAlert } from '../components/useContactSupportAlert';
 
-type NavigationProp = StackNavigationProps<SettingsStackParamList, SettingsStackRoutes.SettingsSupport>;
+type NavigationProp = StackNavigationProps<
+    SettingsStackParamList,
+    SettingsStackRoutes.SettingsSupport
+>;
 
 export const SettingsSupportScreen = () => {
     const route =
@@ -33,7 +41,10 @@ export const SettingsSupportScreen = () => {
             if (!autoOpenContactSupport) return;
 
             // One-shot param: clear immediately to avoid re-triggering on subsequent focus.
-            navigation.setParams({ autoOpenContactSupport: undefined, shareSystemInfo: undefined });
+            navigation.setParams({
+                autoOpenContactSupport: undefined,
+                shareSystemInfo: undefined,
+            });
             showContactSupportAlert({ initialShareSystemInfo: shareSystemInfo });
         }, [route.params, navigation, showContactSupportAlert]),
     );

--- a/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
@@ -1,27 +1,53 @@
+import { useEffect, useRef } from 'react';
+
+import { type RouteProp, useRoute } from '@react-navigation/native';
+
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+import {
+    DynamicScreenHeader,
+    Screen,
+    type SettingsStackParamList,
+    type SettingsStackRoutes,
+} from '@suite-native/navigation';
 
 import { AboutUsBanners } from '../components/AboutUsBanners';
 import { AppCommitHash } from '../components/AppCommitHash';
 import { FaqCard } from '../components/FaqCard';
 import { LegalSection } from '../components/LegalSection';
 import { NeedHelpSection } from '../components/NeedHelpSection';
+import { useContactSupportAlert } from '../components/useContactSupportAlert';
 
-export const SettingsSupportScreen = () => (
-    <Screen
-        header={
-            <DynamicScreenHeader
-                title={<Translation id="moduleSettings.items.general.support.title" />}
-            />
+export const SettingsSupportScreen = () => {
+    const route =
+        useRoute<RouteProp<SettingsStackParamList, SettingsStackRoutes.SettingsSupport>>();
+    const { showContactSupportAlert } = useContactSupportAlert();
+    const hasAutoOpenedRef = useRef(false);
+
+    useEffect(() => {
+        if (route.params?.autoOpenContactSupport && !hasAutoOpenedRef.current) {
+            hasAutoOpenedRef.current = true;
+            showContactSupportAlert({
+                initialShareSystemInfo: route.params.shareSystemInfo,
+            });
         }
-    >
-        <VStack spacing="sp32">
-            <FaqCard />
-            <NeedHelpSection />
-            <AboutUsBanners />
-            <LegalSection />
-            <AppCommitHash />
-        </VStack>
-    </Screen>
-);
+    }, [route.params, showContactSupportAlert]);
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title={<Translation id="moduleSettings.items.general.support.title" />}
+                />
+            }
+        >
+            <VStack spacing="sp32">
+                <FaqCard />
+                <NeedHelpSection />
+                <AboutUsBanners />
+                <LegalSection />
+                <AppCommitHash />
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsSupportScreen.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import { type RouteProp, useFocusEffect, useNavigation, useRoute } from '@react-navigation/native';
 
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -8,7 +8,8 @@ import {
     DynamicScreenHeader,
     Screen,
     type SettingsStackParamList,
-    type SettingsStackRoutes,
+    SettingsStackRoutes,
+    type StackNavigationProps,
 } from '@suite-native/navigation';
 
 import { AboutUsBanners } from '../components/AboutUsBanners';
@@ -18,20 +19,24 @@ import { LegalSection } from '../components/LegalSection';
 import { NeedHelpSection } from '../components/NeedHelpSection';
 import { useContactSupportAlert } from '../components/useContactSupportAlert';
 
+type NavigationProp = StackNavigationProps<SettingsStackParamList, SettingsStackRoutes.SettingsSupport>;
+
 export const SettingsSupportScreen = () => {
     const route =
         useRoute<RouteProp<SettingsStackParamList, SettingsStackRoutes.SettingsSupport>>();
+    const navigation = useNavigation<NavigationProp>();
     const { showContactSupportAlert } = useContactSupportAlert();
-    const hasAutoOpenedRef = useRef(false);
 
-    useEffect(() => {
-        if (route.params?.autoOpenContactSupport && !hasAutoOpenedRef.current) {
-            hasAutoOpenedRef.current = true;
-            showContactSupportAlert({
-                initialShareSystemInfo: route.params.shareSystemInfo,
-            });
-        }
-    }, [route.params, showContactSupportAlert]);
+    useFocusEffect(
+        useCallback(() => {
+            const { autoOpenContactSupport, shareSystemInfo } = route.params ?? {};
+            if (!autoOpenContactSupport) return;
+
+            // One-shot param: clear immediately to avoid re-triggering on subsequent focus.
+            navigation.setParams({ autoOpenContactSupport: undefined, shareSystemInfo: undefined });
+            showContactSupportAlert({ initialShareSystemInfo: shareSystemInfo });
+        }, [route.params, navigation, showContactSupportAlert]),
+    );
 
     return (
         <Screen

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -97,7 +97,12 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsPreferences]: undefined;
     [SettingsStackRoutes.SettingsPrivacy]: undefined;
     [SettingsStackRoutes.SettingsViewOnly]: undefined;
-    [SettingsStackRoutes.SettingsSupport]: undefined;
+    [SettingsStackRoutes.SettingsSupport]:
+        | {
+              autoOpenContactSupport?: boolean;
+              shareSystemInfo?: boolean;
+          }
+        | undefined;
     [SettingsStackRoutes.SettingsAppLog]: undefined;
     [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
     [SettingsStackRoutes.SettingsSuiteSync]: undefined;


### PR DESCRIPTION
## Description

Adds a deeplink `trezorsuite://guide-support?shareSystemInfo=1` that opens Trezor Suite directly on the support screen with the "Temporarily share system info" checkbox pre-checked. The goal is to give the support team a one-click URL they can put behind helpdesk buttons / email macros so users can reach chat in a single hop, and so tickets arrive with firmware / app / device metadata that speeds up resolution.

Works on **Desktop** (Electron) and **Mobile** (suite-native).

### Desktop (`packages/suite`)

- Extends the `guide` reducer with a one-shot `supportConsentAutoOpen` flag and a matching action.
- `SupportConsentPopover` consumes the flag on mount via the `Popover` imperative ref, waiting `GUIDE_ANIMATION_DURATION_MS` so it appears after the guide panel slide-in completes.
- `handleProtocolRequest` recognises the new URI and dispatches `open` → `setView('SUPPORT_FEEDBACK_SELECTION')` → `setSupportConsentAutoOpen({ shareSystemInfo })`.

### Mobile (`suite-native`)

- `useConnectPopupNavigation` recognises the same URI and navigates to Settings → Support with route params (`autoOpenContactSupport`, `shareSystemInfo`).
- `SettingsSupportScreen` auto-opens the Contact Support alert from those params, forwarding `initialShareSystemInfo` through `useContactSupportAlert` → `ContactSupportAlertAppendix`.
- No `app.config.ts` changes needed — the `trezorsuite://` scheme is already registered.

### Shared

- New `SUITE_GUIDE_SUPPORT_DEEPLINK` constant in `@trezor/urls`.

## Notes for QA

**Desktop**

1. `open "trezorsuite://guide-support?shareSystemInfo=1"` (macOS) / equivalent on Windows/Linux.
2. Expected: window focuses → Suite Guide slides in → Support & Feedback view → "Get faster support" popover appears *after* the slide-in → checkbox is ticked.
3. Click "Contact Trezor Support" → browser opens a support URL whose UTM params include firmware/app/device info (proves the checkbox state is being read).
4. Regression: open the guide manually → Support & Feedback → Trezor Support. Popover still opens on click, checkbox defaults to the analytics-consent value.
5. Second-instance: with Suite already running, re-invoke the URL — existing window should navigate, no duplicate instance.

**Mobile**

1. `npx uri-scheme open "trezorsuite://guide-support?shareSystemInfo=1" --ios` (and `--android`).
2. Expected: app foregrounds → Settings → Support → Contact Support alert shown → "Temporarily share system info" toggle is on.
3. Regression: open Settings → Support manually and tap Contact Support. Toggle defaults to off (unchanged behaviour).

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/guide-support-deeplink&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/guide-support-deeplink&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/guide-support-deeplink&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 10 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-06T10:11:33.158Z • 10 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T10:10:37.358Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/guide-support-deeplink/web/](https://dev.suite.sldev.cz/suite-web/feat/guide-support-deeplink/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->