### PR TITLE
fix(suite-native): use fallback address for dex approval

### DIFF
--- a/suite-common/trading/src/thunks/exchange/__tests__/prefetchDexQuoteApprovalThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/__tests__/prefetchDexQuoteApprovalThunk.test.ts
@@ -3,11 +3,13 @@ import type { ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import type { Account } from '@suite-common/wallet-types';
+import { type AccountAddresses } from '@trezor/connect';
 
-import { accountEth } from '../../../__fixtures__/utils';
+import { accountBtc, accountEth } from '../../../__fixtures__/utils';
 import { invityAPI } from '../../../invityAPI';
 import { initialState } from '../../../reducers/tradingCommonReducer';
 import { prepareTradingReducer } from '../../../reducers/tradingReducer';
+import { getUnusedAddressFromAccount } from '../../../utils';
 import { prefetchDexQuoteApprovalThunk } from '../prefetchDexQuoteApprovalThunk';
 
 jest.mock('../../../invityAPI');
@@ -53,6 +55,53 @@ describe('prefetchDexQuoteApprovalThunk', () => {
         jest.clearAllMocks();
     });
 
+    it('returns early and does not call the API when trade has no quoteId', async () => {
+        const quote = {
+            ...getExchangeTrade('quote-1'),
+            quoteId: undefined,
+        } as unknown as ExchangeTrade;
+        const store = getStore([quote]);
+        const doExchangeTrade = jest.spyOn(invityAPI, 'doExchangeTrade');
+
+        const result = await store.dispatch(
+            prefetchDexQuoteApprovalThunk({
+                account: accountEth as Account,
+                trade: quote,
+            }),
+        );
+
+        expect(result.meta.requestStatus).toBe('fulfilled');
+        expect(result.payload).toBeUndefined();
+        expect(doExchangeTrade).not.toHaveBeenCalled();
+        expect(
+            store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
+        ).toBeUndefined();
+    });
+
+    it('returns early and does not call the API when there is no from address and trade has no fromAddress', async () => {
+        const quote = getExchangeTrade('quote-1');
+        const accountWithoutSpendAddress = {
+            ...accountBtc,
+            addresses: { unused: [], change: [], main: [], used: [] } as AccountAddresses,
+        } as Account;
+        const store = getStore([quote]);
+        const doExchangeTrade = jest.spyOn(invityAPI, 'doExchangeTrade');
+
+        const result = await store.dispatch(
+            prefetchDexQuoteApprovalThunk({
+                account: accountWithoutSpendAddress,
+                trade: { ...quote, fromAddress: undefined },
+            }),
+        );
+
+        expect(result.meta.requestStatus).toBe('fulfilled');
+        expect(result.payload).toBeUndefined();
+        expect(doExchangeTrade).not.toHaveBeenCalled();
+        expect(
+            store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
+        ).toBeUndefined();
+    });
+
     it('does not overwrite existing quote with error-only response', async () => {
         const quote = getExchangeTrade('quote-1');
         const store = getStore([quote]);
@@ -69,14 +118,42 @@ describe('prefetchDexQuoteApprovalThunk', () => {
         );
 
         expect(result.meta.requestStatus).toBe('fulfilled');
+        expect(result.payload).toBeUndefined();
         expect(store.getState().wallet.trading.exchange.quotes).toEqual([quote]);
+        expect(
+            store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
+        ).toBeUndefined();
     });
 
-    it('merges successful response into stored quote', async () => {
+    it('returns undefined and does not update quotes when API returns a falsy response', async () => {
         const quote = getExchangeTrade('quote-1');
         const store = getStore([quote]);
 
-        jest.spyOn(invityAPI, 'doExchangeTrade').mockResolvedValueOnce({
+        jest.spyOn(invityAPI, 'doExchangeTrade').mockResolvedValueOnce(
+            null as unknown as ExchangeTrade,
+        );
+
+        const result = await store.dispatch(
+            prefetchDexQuoteApprovalThunk({
+                account: accountEth as Account,
+                trade: quote,
+            }),
+        );
+
+        expect(result.meta.requestStatus).toBe('fulfilled');
+        expect(result.payload).toBeUndefined();
+        expect(store.getState().wallet.trading.exchange.quotes).toEqual([quote]);
+        expect(
+            store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
+        ).toBeUndefined();
+    });
+
+    it('merges successful response into stored quote and calls approval prefetch on the API', async () => {
+        const quote = getExchangeTrade('quote-1');
+        const store = getStore([quote]);
+        const { address: fromAccount } = getUnusedAddressFromAccount(accountEth as Account);
+
+        const doExchangeTrade = jest.spyOn(invityAPI, 'doExchangeTrade').mockResolvedValueOnce({
             quoteId: quote.quoteId,
             status: 'APPROVAL_REQ',
             preapprovedStringAmount: '0',
@@ -89,6 +166,14 @@ describe('prefetchDexQuoteApprovalThunk', () => {
             }),
         );
 
+        expect(doExchangeTrade).toHaveBeenCalledWith({
+            trade: { ...quote, fromAddress: fromAccount },
+            receiveAddress: fromAccount,
+            refundAddress: fromAccount,
+            returnUrl: undefined,
+            approvalFlow: true,
+        });
+
         const [updatedQuote] = store.getState().wallet.trading.exchange.quotes;
         expect(updatedQuote).toEqual(
             expect.objectContaining({
@@ -98,6 +183,40 @@ describe('prefetchDexQuoteApprovalThunk', () => {
                 preapprovedStringAmount: '0',
             }),
         );
+        expect(
+            store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
+        ).toBeUndefined();
+    });
+
+    it('passes through trade with fromAddress and receiveAddress for the API call', async () => {
+        const fromOnQuote = '0xfrom';
+        const receiveOnQuote = '0xreceive';
+        const quote = {
+            ...getExchangeTrade('quote-1'),
+            fromAddress: fromOnQuote,
+            receiveAddress: receiveOnQuote,
+        } as ExchangeTrade;
+        const store = getStore([quote]);
+        const { address: fromAccount } = getUnusedAddressFromAccount(accountEth as Account);
+
+        const doExchangeTrade = jest.spyOn(invityAPI, 'doExchangeTrade').mockResolvedValueOnce({
+            quoteId: quote.quoteId,
+        } as ExchangeTrade);
+
+        await store.dispatch(
+            prefetchDexQuoteApprovalThunk({
+                account: accountEth as Account,
+                trade: quote,
+            }),
+        );
+
+        expect(doExchangeTrade).toHaveBeenCalledWith({
+            trade: quote,
+            receiveAddress: receiveOnQuote,
+            refundAddress: fromAccount,
+            returnUrl: undefined,
+            approvalFlow: true,
+        });
     });
 
     it('tracks loading state correctly for concurrent prefetches', async () => {
@@ -133,6 +252,7 @@ describe('prefetchDexQuoteApprovalThunk', () => {
             }),
         );
 
+        // Each dispatch sets loading to that quote id; the latest wins while both are in flight
         expect(
             !!store.getState().wallet.trading.exchange.dexQuoteApprovalPrefetchLoadingQuoteId,
         ).toBe(true);

--- a/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts
@@ -35,9 +35,12 @@ export const prefetchDexQuoteApprovalThunk = createThunk(
 
             const quoteToProcess = trade.fromAddress ? trade : { ...trade, fromAddress };
 
+            const receiveAddress =
+                quoteToProcess.receiveAddress ?? quoteToProcess.fromAddress ?? '';
+
             const response = await invityAPI.doExchangeTrade({
                 trade: quoteToProcess,
-                receiveAddress: quoteToProcess.receiveAddress ?? '',
+                receiveAddress,
                 refundAddress: fromAddress ?? quoteToProcess.fromAddress ?? '',
                 returnUrl: undefined,
                 approvalFlow: true,


### PR DESCRIPTION
Use send address as a fallback for dex approval confirmation in order to make 1inch always work.


## Notes for QA
- 1inch should show continue button for approvals even when there is no receive account selected and should be able to continue

## Related Issue

Resolve #27021



<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `prefetchDexQuoteApprovalThunk.ts` is a trading/exchange thunk related to DEX (decentralized exchange) quote approval prefetching. It maps to 121 tests, indicating it is a deeply shared dependency (likely re-exported from a barrel file in the trading package) rather than directly exercised by most of these tests. None of the 121 mapped tests' LLM analyses mention DEX quote approval, DEX swap approval flows, or any behavior that would directly exercise this specific thunk. The trading/swap tests cover CEX (centralized exchange) flows and Invity API integration, not on-chain DEX approval transactions. Without a dedicated E2E test for DEX approval prefetching, there is no high-confidence test to recommend. The risk of regression from this single thunk change is low for existing E2E tests, as the functionality appears to be either untested at the E2E level or only exercised in flows not covered by the current test suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts`

_Updated: 2026-04-24T21:45:33.246Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=27021-mobile-swap-1inch-doesnt-always-work&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=27021-mobile-swap-1inch-doesnt-always-work&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27021-mobile-swap-1inch-doesnt-always-work&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-24T22:03:00.122Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-24T22:00:53.325Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/27021-mobile-swap-1inch-doesnt-always-work/web/](https://dev.suite.sldev.cz/suite-web/27021-mobile-swap-1inch-doesnt-always-work/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->