### PR TITLE
chore(connect-web): drop stale webpack/e2e devDependencies

### DIFF
--- a/packages/connect-web/package.json
+++ b/packages/connect-web/package.json
@@ -61,10 +61,6 @@
         "@trezor/websocket-client": "workspace:*"
     },
     "devDependencies": {
-        "@babel/preset-typescript": "^7.28.5",
-        "@playwright/browser-chromium": "1.58.2",
-        "@playwright/browser-firefox": "1.58.2",
-        "@playwright/browser-webkit": "1.58.2",
         "@playwright/test": "1.58.2",
         "@trezor/eslint": "workspace:*",
         "@trezor/type-utils": "workspace:*",
@@ -72,9 +68,6 @@
         "@types/jest": "29.5.12",
         "@types/w3c-web-usb": "^1.0.14",
         "@types/web": "^0.0.197",
-        "babel-loader": "^10.1.1",
-        "rimraf": "^6.1.2",
-        "worker-loader": "^3.0.8",
         "xvfb-maybe": "^0.2.1"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15910,10 +15910,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/connect-web@workspace:packages/connect-web"
   dependencies:
-    "@babel/preset-typescript": "npm:^7.28.5"
-    "@playwright/browser-chromium": "npm:1.58.2"
-    "@playwright/browser-firefox": "npm:1.58.2"
-    "@playwright/browser-webkit": "npm:1.58.2"
     "@playwright/test": "npm:1.58.2"
     "@trezor/connect-common": "workspace:*"
     "@trezor/eslint": "workspace:*"
@@ -15924,9 +15920,6 @@ __metadata:
     "@types/jest": "npm:29.5.12"
     "@types/w3c-web-usb": "npm:^1.0.14"
     "@types/web": "npm:^0.0.197"
-    babel-loader: "npm:^10.1.1"
-    rimraf: "npm:^6.1.2"
-    worker-loader: "npm:^3.0.8"
     xvfb-maybe: "npm:^0.2.1"
   peerDependencies:
     tslib: ^2.6.2


### PR DESCRIPTION
## Summary
- Removes seven devDependencies from \`@trezor/connect-web\` that have been unused since their corresponding source was deleted:
  - \`@babel/preset-typescript\`, \`babel-loader\`, \`worker-loader\` — for the inline webpack build (deleted in c0b7220a03, Feb 2026)
  - \`@playwright/browser-{chromium,firefox,webkit}\` — for the e2e suite (deleted in 372d11f819, Jan 2026)
  - \`rimraf\` — only the root \`yarn g:rimraf\` is referenced in scripts
- depcheck flags these once the nx remote cache for \`@trezor/connect-web:depcheck\` is invalidated.

Discovered while working on the bundle-size CI in #27002 — split out so that PR can stay focused on size checks.

## Test plan
- [ ] CI passes \`Other Checks\` (depcheck on connect-web is now clean)
- [ ] No runtime regression — these packages are not imported anywhere in \`packages/connect-web/src\`

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is packages/connect-web/package.json, which is a package metadata file (likely a version bump, dependency update, or script change). There is no static test coverage mapping for this file, and none of the analyzed E2E tests directly exercise or depend on the contents of connect-web's package.json in a way that would be affected by typical package.json changes. The connect-web package is used by the TrezorConnect popup/web tests (connectPopupWeb, connectPopupWebextension), but those tests depend on the built artifacts and runtime behavior rather than package.json metadata. Without knowing the specific nature of the package.json change (e.g., a major dependency version bump vs. a minor metadata edit), the risk is very low and no E2E tests are specifically warranted. If the change involves a dependency version bump that could affect connect-web's runtime behavior, the trezor-connect popup tests would be the first candidates to run manually.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-web/package.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/connect-web/package.json`

_Updated: 2026-04-25T09:12:02.848Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-web-drop-stale-devdeps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-web-drop-stale-devdeps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-25T09:17:59.446Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-25T09:16:40.446Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-web-drop-stale-devdeps/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-web-drop-stale-devdeps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->