### PR TITLE
fix(connect): unify suppressBackupWarning across getPublicKey methods

### DIFF
--- a/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
+++ b/packages/connect/src/api/cardano/api/cardanoGetPublicKey.ts
@@ -18,10 +18,10 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
+import { computeConfirmMissingBackup } from '../../common/computeConfirmMissingBackup';
 import { bundlify } from '../../common/paramsValidator';
 interface Params {
     proto: PROTO.CardanoGetPublicKey;
-    suppressBackupWarning?: boolean;
 }
 
 export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPublicKey', Params[]> {
@@ -44,14 +44,17 @@ export default class CardanoGetPublicKey extends AbstractMethod<'cardanoGetPubli
                 show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : false,
             };
 
-            return { proto, suppressBackupWarning: batch.suppressBackupWarning };
+            return { proto };
         });
 
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.confirmMissingBackup = !this.params.every(
-            batch => batch.suppressBackupWarning || !batch.proto.show_display,
+        this.confirmMissingBackup = computeConfirmMissingBackup(
+            payload.bundle.map((batch, i) => ({
+                showOnTrezor: this.params[i].proto.show_display,
+                suppressBackupWarning: batch.suppressBackupWarning,
+            })),
         );
         this.requiredDeviceCapabilities = ['Capability_Cardano'];
         this.requiredFirmwareCoins = [getMiscNetwork('Cardano')];

--- a/packages/connect/src/api/common/__tests__/computeConfirmMissingBackup.test.ts
+++ b/packages/connect/src/api/common/__tests__/computeConfirmMissingBackup.test.ts
@@ -1,0 +1,40 @@
+import { computeConfirmMissingBackup } from '../computeConfirmMissingBackup';
+
+describe('computeConfirmMissingBackup', () => {
+    it('returns false when no batch wants to display on device', () => {
+        expect(
+            computeConfirmMissingBackup([
+                { showOnTrezor: false, suppressBackupWarning: undefined },
+                { showOnTrezor: undefined, suppressBackupWarning: undefined },
+            ]),
+        ).toBe(false);
+    });
+
+    it('returns true when a batch wants to display and does not suppress', () => {
+        expect(
+            computeConfirmMissingBackup([{ showOnTrezor: true, suppressBackupWarning: undefined }]),
+        ).toBe(true);
+    });
+
+    it('returns false when every batch that displays also suppresses', () => {
+        expect(
+            computeConfirmMissingBackup([
+                { showOnTrezor: true, suppressBackupWarning: true },
+                { showOnTrezor: false, suppressBackupWarning: undefined },
+            ]),
+        ).toBe(false);
+    });
+
+    it('returns true if at least one displaying batch does not suppress', () => {
+        expect(
+            computeConfirmMissingBackup([
+                { showOnTrezor: true, suppressBackupWarning: true },
+                { showOnTrezor: true, suppressBackupWarning: false },
+            ]),
+        ).toBe(true);
+    });
+
+    it('returns false for empty input', () => {
+        expect(computeConfirmMissingBackup([])).toBe(false);
+    });
+});

--- a/packages/connect/src/api/common/computeConfirmMissingBackup.ts
+++ b/packages/connect/src/api/common/computeConfirmMissingBackup.ts
@@ -1,0 +1,11 @@
+type Item = {
+    showOnTrezor: boolean | undefined;
+    suppressBackupWarning: boolean | undefined;
+};
+
+// Shared semantics for `*GetPublicKey` methods: ask the user to confirm
+// missing backup only when at least one batch wants to display the key on
+// the device and does not explicitly suppress the warning. Background
+// fetches (no `showOnTrezor`) are silent.
+export const computeConfirmMissingBackup = (items: Item[]) =>
+    !items.every(item => item.suppressBackupWarning || !item.showOnTrezor);

--- a/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumGetPublicKey.ts
@@ -19,6 +19,7 @@ import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getEthereumNetwork, getUniqueNetworks } from '../../../data/coinInfo';
 import { getNetworkLabel } from '../../../utils/ethereumUtils';
 import { getSerializedPath, validatePath } from '../../../utils/pathUtils';
+import { computeConfirmMissingBackup } from '../../common/computeConfirmMissingBackup';
 import { bundlify } from '../../common/paramsValidator';
 
 type Params = {
@@ -51,6 +52,12 @@ export default class EthereumGetPublicKey extends AbstractMethod<'ethereumGetPub
 
         this.requiredFirmwareCoins = params.map(({ network }) => network);
         this.hasBundle = hasBundle;
+        this.confirmMissingBackup = computeConfirmMissingBackup(
+            payload.bundle.map((batch, i) => ({
+                showOnTrezor: this.params[i].proto.show_display,
+                suppressBackupWarning: batch.suppressBackupWarning,
+            })),
+        );
         this.requiredDeviceCapabilities = ['Capability_Ethereum'];
     }
 

--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -18,6 +18,7 @@ import type {
 } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
 import { getBitcoinNetwork } from '../data/coinInfo';
+import { computeConfirmMissingBackup } from './common/computeConfirmMissingBackup';
 import { bundlify, validateCoinPath } from './common/paramsValidator';
 import { getPublicKeyLabel } from '../utils/accountUtils';
 import { validatePath } from '../utils/pathUtils';
@@ -25,7 +26,6 @@ import { validatePath } from '../utils/pathUtils';
 type Params = {
     proto: PROTO.GetPublicKey;
     coinInfo?: BitcoinNetworkInfo;
-    suppressBackupWarning?: boolean;
     unlockPath?: PROTO.UnlockPath;
 };
 
@@ -66,7 +66,6 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
                 proto,
                 coinInfo,
                 unlockPath: batch.unlockPath,
-                suppressBackupWarning: batch.suppressBackupWarning,
             };
         });
 
@@ -74,8 +73,11 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
 
         this.requiredFirmwareCoins = params.map(({ coinInfo }) => coinInfo);
         this.hasBundle = hasBundle;
-        this.confirmMissingBackup = !this.params.every(
-            batch => batch.suppressBackupWarning || !batch.proto.show_display,
+        this.confirmMissingBackup = computeConfirmMissingBackup(
+            payload.bundle.map((batch, i) => ({
+                showOnTrezor: this.params[i].proto.show_display,
+                suppressBackupWarning: batch.suppressBackupWarning,
+            })),
         );
     }
 

--- a/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
+++ b/packages/connect/src/api/solana/api/solanaGetPublicKey.ts
@@ -18,6 +18,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
+import { computeConfirmMissingBackup } from '../../common/computeConfirmMissingBackup';
 import { bundlify } from '../../common/paramsValidator';
 
 export default class SolanaGetPublicKey extends AbstractMethod<
@@ -44,7 +45,12 @@ export default class SolanaGetPublicKey extends AbstractMethod<
         super(message, params);
 
         this.hasBundle = hasBundle;
-        this.confirmMissingBackup = true;
+        this.confirmMissingBackup = computeConfirmMissingBackup(
+            payload.bundle.map((batch, i) => ({
+                showOnTrezor: this.params[i].show_display,
+                suppressBackupWarning: batch.suppressBackupWarning,
+            })),
+        );
         this.requiredDeviceCapabilities = ['Capability_Solana'];
         this.requiredFirmwareCoins = [getMiscNetwork('Solana')];
     }

--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -18,6 +18,7 @@ import type {
 import { AbstractMethod } from '../../../core/AbstractMethod';
 import { getMiscNetwork } from '../../../data/coinInfo';
 import { fromHardened, getSerializedPath, validatePath } from '../../../utils/pathUtils';
+import { computeConfirmMissingBackup } from '../../common/computeConfirmMissingBackup';
 import { bundlify } from '../../common/paramsValidator';
 
 export default class TezosGetPublicKey extends AbstractMethod<
@@ -45,6 +46,12 @@ export default class TezosGetPublicKey extends AbstractMethod<
         super(message, params);
 
         this.hasBundle = hasBundle;
+        this.confirmMissingBackup = computeConfirmMissingBackup(
+            payload.bundle.map((batch, i) => ({
+                showOnTrezor: this.params[i].show_display,
+                suppressBackupWarning: batch.suppressBackupWarning,
+            })),
+        );
         this.requiredDeviceCapabilities = ['Capability_Tezos'];
         this.requiredFirmwareCoins = [getMiscNetwork('Tezos')];
     }

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -15,6 +15,7 @@ import { DashboardPage } from './pageObjects/dashboardPage';
 import { DevicePrompt } from './pageObjects/devicePrompt';
 import { GuidePanel } from './pageObjects/guidePanel';
 import { MetadataPage } from './pageObjects/metadata/metadataPage';
+import { NoBackupModal } from './pageObjects/noBackupModal';
 import { OnboardingPage } from './pageObjects/onboarding/onboardingPage';
 import { PaginationControl } from './pageObjects/pagination';
 import { RecoveryModal } from './pageObjects/recoveryModal';
@@ -50,6 +51,7 @@ type Fixtures = {
     solanaStakingMock: SolanaStakingMock;
     tradingMock: TradingMock;
     connectPermissionsModal: ConnectPermissionsModal;
+    noBackupModal: NoBackupModal;
     stakingSection: StakingSection;
     paginationControl: PaginationControl;
     evoluClient: EvoluClient;
@@ -125,6 +127,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     connectPermissionsModal: async ({ page }, use) => {
         await use(new ConnectPermissionsModal(page));
+    },
+    noBackupModal: async ({ page }, use) => {
+        await use(new NoBackupModal(page));
     },
     stakingSection: async ({ page }, use) => {
         await use(new StakingSection(page));

--- a/suite/e2e/support/pageObjects/noBackupModal.ts
+++ b/suite/e2e/support/pageObjects/noBackupModal.ts
@@ -1,0 +1,9 @@
+import { Locator, Page } from '@playwright/test';
+
+export class NoBackupModal {
+    readonly takeRiskButton: Locator;
+
+    constructor(page: Page) {
+        this.takeRiskButton = page.getByTestId('@no-backup/take-risk-button');
+    }
+}

--- a/suite/e2e/tests/trezor-connect/ethereumGetPublicKeyNoBackup.test.ts
+++ b/suite/e2e/tests/trezor-connect/ethereumGetPublicKeyNoBackup.test.ts
@@ -1,0 +1,79 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+
+// Regression test for https://github.com/trezor/trezor-suite/issues/26869
+// Verifies that `suppressBackupWarning` actually suppresses the no-backup
+// confirmation modal in the Connect popup flow when the device's seed has
+// not been backed up.
+test.describe(
+    'TrezorConnect.ethereumGetPublicKey - suppressBackupWarning',
+    // Tagged @T2T1 only because the trezor-user-env `needs_backup: true` setup
+    // is currently exercised only on T2T1 emulators (see suite/e2e/tests/backup/t2t1-*).
+    { tag: ['@T2T1', '@desktopOnly'] },
+    () => {
+        test.use({
+            electronConf: { exposeConnectWs: true },
+            deviceSetup: { needs_backup: true, mnemonic: 'mnemonic_12' },
+        });
+
+        test.beforeEach(async ({ onboardingPage }) => {
+            await onboardingPage.completeOnboarding();
+            await test.step('Initialize TrezorConnect', async () => {
+                await TrezorConnect.init({
+                    manifest: {
+                        appUrl: 'http://localhost:8080',
+                        email: '',
+                        appName: 'Tester',
+                    },
+                    coreMode: 'suite-desktop',
+                    debug: true,
+                });
+            });
+        });
+
+        test('honors suppressBackupWarning across no-backup scenarios', async ({
+            connectPermissionsModal,
+            noBackupModal,
+            device,
+        }) => {
+            await test.step('shows no-backup modal when display requested without suppress', async () => {
+                const res = TrezorConnect.ethereumGetPublicKey({
+                    path: "m/44'/60'/0'",
+                    showOnTrezor: true,
+                });
+
+                await connectPermissionsModal.rememberCheckbox.click();
+                await connectPermissionsModal.confirmButton.click();
+                await expect(noBackupModal.takeRiskButton).toBeVisible();
+                await noBackupModal.takeRiskButton.click();
+                await device.pressYes();
+
+                expect(await res).toMatchObject({ success: true });
+            });
+
+            await test.step('skips no-backup modal when suppressBackupWarning is true', async () => {
+                const res = TrezorConnect.ethereumGetPublicKey({
+                    path: "m/44'/60'/0'",
+                    showOnTrezor: true,
+                    suppressBackupWarning: true,
+                });
+
+                // Device prompt should appear directly without the no-backup modal in between.
+                await device.pressYes();
+
+                expect(await res).toMatchObject({ success: true });
+                await expect(noBackupModal.takeRiskButton).toBeHidden();
+            });
+
+            await test.step('skips no-backup modal when not displaying on device', async () => {
+                const res = TrezorConnect.ethereumGetPublicKey({
+                    path: "m/44'/60'/0'",
+                });
+
+                expect(await res).toMatchObject({ success: true });
+                await expect(noBackupModal.takeRiskButton).toBeHidden();
+            });
+        });
+    },
+);


### PR DESCRIPTION
## Summary

Fixes #26869.

> ⏸ **Blocked on #27073** (prerequisite) — that PR fixes the `tezosGetPublicKey` default that would otherwise cause an unintended behavior change in this PR (Tezos no-backup modal appearing on every default call). See discussion in #27073 for the full analysis. Merge #27073 first, then this one.

`suppressBackupWarning: true` was inconsistently honored across the `*getPublicKey` family. This PR extracts a shared helper and applies it to BTC, Cardano, Ethereum, Solana and Tezos so the no-backup confirmation modal is gated by the same rule everywhere: trigger only when at least one batch displays on the device without suppressing the warning.

### Behavior changes

- **Ethereum / Tezos**: `confirmMissingBackup` was never set, so the modal never appeared even when displaying on device. Now they ask, and `suppressBackupWarning: true` actually suppresses (this is the regression from #26869).
- **Solana**: previously hardcoded `confirmMissingBackup = true`. Relaxed to follow the same `showOnTrezor` / `suppressBackupWarning` rule as the rest.
- **BTC / Cardano**: semantically unchanged, just routed through the helper.

### Files

- `packages/connect/src/api/common/computeConfirmMissingBackup.ts` — new helper
- `packages/connect/src/api/common/__tests__/computeConfirmMissingBackup.test.ts` — unit tests
- `packages/connect/src/api/getPublicKey.ts` and the cardano / ethereum / solana / tezos `*GetPublicKey.ts` siblings — apply helper
- `suite/e2e/tests/trezor-connect/ethereumGetPublicKeyNoBackup.test.ts` — Suite e2e regression test exercising the ETH popup flow against a `needs_backup: true` device
- `suite/e2e/support/pageObjects/noBackupModal.ts` + fixture wiring

## Test plan

- [x] `yarn workspace @trezor/connect test:unit computeConfirmMissingBackup` — 5/5 green
- [x] `yarn workspace @trezor/connect type-check` — clean
- [ ] Suite e2e `ethereumGetPublicKeyNoBackup.test.ts` (run in CI)
- [ ] Manual repro on device with no backup: confirm modal appears for `showOnTrezor: true`, is skipped with `suppressBackupWarning: true`, and is skipped without `showOnTrezor`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/issue-26869&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/issue-26869&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/issue-26869&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:12:54.538Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-04T20:03:27.071Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/issue-26869/web/](https://dev.suite.sldev.cz/suite-web/mroz22/issue-26869/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->