### PR TITLE
chore(connect-common): tighten FirmwareRule and UnavailableCapabilities types

### DIFF
--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -4,7 +4,7 @@ import type { ThpStateSerialized } from '@trezor/protocol';
 import type { Descriptor } from '@trezor/transport';
 import type { Branded } from '@trezor/type-utils';
 
-import type { FirmwareReleaseConfigInfo } from './firmware';
+import type { FirmwareCapability, FirmwareReleaseConfigInfo } from './firmware';
 
 /**
  * - `busy`               application has an active session but device is currently unresponsive (example: connect to host device screen after RebootToBootloader)
@@ -83,8 +83,10 @@ export type DeviceThpState = {
 
 // NOTE: unavailableCapabilities is an object with information what is NOT supported by this device.
 // in ideal/expected setup this object should be empty but given setup might have exceptions.
-// key = coin shortcut lowercase (ex: btc, eth, xrp) OR field declared in coins.json "supportedFirmware.capability"
-export type UnavailableCapabilities = { [key: string]: UnavailableCapability };
+// key = coin shortcut lowercase (ex: btc, eth, xrp) OR capability declared in config.supportedFirmware
+export type UnavailableCapabilities = Partial<
+    Record<FirmwareCapability | (string & {}), UnavailableCapability>
+>;
 
 export type FirmwareRevisionCheckError =
     | 'revision-mismatch'

--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -15,11 +15,31 @@ export type FirmwareRange = Record<
     { min: FirmwareBoundary; max: FirmwareBoundary }
 >;
 
+export type FirmwareCapability =
+    | 'replaceTransaction'
+    | 'amountUnit'
+    | 'decreaseOutput'
+    | 'eip1559'
+    | 'taproot'
+    | 'signMessageNoScriptType'
+    | 'eip712-domain-only'
+    | 'coinjoin'
+    | 'tutorial'
+    | 'tropicDeviceAuthentication'
+    | 'getFirmwareHash'
+    | 'chunkify'
+    | 'entropyCheck'
+    | 'evmApproval'
+    | 'slip24'
+    | 'evolu'
+    | 'monero'
+    | 'telemetry';
+
 type RuleSelector = RequireAtLeastOne<{
-    coin: string[];
+    coin: Lowercase<string>[];
     coinType: string;
     methods: string[];
-    capabilities: string[];
+    capabilities: FirmwareCapability[];
 }>;
 
 type RuleDeclaration = RequireAtLeastOne<{


### PR DESCRIPTION
## Summary

Replaces #25451 with a smaller, focused change that survives the `FirmwareRule` refactor that landed on develop in the meantime.

- Adds a literal `FirmwareCapability` union in `@trezor/connect-common`.
- Uses it in `FirmwareRule.capabilities` (catches typos in `config.supportedFirmware`).
- Uses it as a hint key in `UnavailableCapabilities` via `Partial<Record<FirmwareCapability | (string & {}), UnavailableCapability>>`, so consumers like `device.unavailableCapabilities.evolu` get autocomplete while coin shortcuts (`btc`, `eth`, …) keep working.
- Tightens `coin` selector to `Lowercase<string>[]`.

The original PR also wanted `methods: CallMethodKeys[]`, but `CallMethodKeys` lives in `packages/connect` and pulling it down into `connect-common` would invert the dependency. Skipping that one for now to keep the diff small and dependency-clean.

## Related

Follow-up PRs in the same connect type-hardening series:
- #27113 — `requiredFirmwareCapabilities` and `paramsValidator` typing
- #27128 — drop `any` in `pathUtils.validatePath` and Cardano `typedCall` helpers

## Test plan

- [x] `yarn workspace @trezor/connect-common type-check` passes
- [x] `yarn workspace @trezor/connect type-check` passes (pre-existing e2e errors are about missing trezor-common submodule fixtures, unrelated)
- [x] `yarn workspace @trezor/suite type-check` shows no new errors related to these types

🤖 Generated with [Claude Code](https://claude.com/claude-code)