### PR TITLE
fix(connect): default tezosGetPublicKey show_display to false

### DIFF
--- a/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
+++ b/packages/connect/src/api/tezos/api/tezosGetPublicKey.ts
@@ -37,7 +37,7 @@ export default class TezosGetPublicKey extends AbstractMethod<
 
             return {
                 address_n: path,
-                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : true,
+                show_display: typeof batch.showOnTrezor === 'boolean' ? batch.showOnTrezor : false,
                 chunkify: typeof batch.chunkify === 'boolean' ? batch.chunkify : false,
             };
         });


### PR DESCRIPTION
## Summary

`tezosGetPublicKey` defaults `show_display` to `true` when `showOnTrezor` is not provided. Every other `*GetPublicKey` method either passes the flag through (BTC, where the firmware proto3 default is `false`) or explicitly defaults to `false` (Cardano, Ethereum, Solana). This PR aligns Tezos with the rest of the family.

## Analysis

### Defaults today

| Coin | `getPublicKey` default `show_display` | `getAddress` default |
|---|---|---|
| BTC | `batch.showOnTrezor` (undefined → firmware default `false`) | `true` |
| Cardano | `false` | `true` |
| Ethereum | `false` | `true` |
| Solana | `false` | `true` |
| Tezos | **`true`** | `true` |

`getAddress` is consistent across all five coins (default `true` — the whole point of the call is to display on device). `getPublicKey` is consistent on four out of five — Tezos is the outlier.

`git blame` on the offending line points back to `chore(connect): move core/methods folder from origin` (April 2022), the migration commit from the standalone `trezor/connect` repository. The default has been carried over unchanged ever since, with no test, comment, or downstream code that relies on it. The most plausible explanation is a copy-paste from `tezosGetAddress.ts`, where `true` is the correct default.

### Why default `false` is the right choice — even given that for some coins `getPublicKey` ≈ `getAddress`

It's tempting to argue that for coins where the public key is a raw key (not an extended one capable of further BIP32-style derivation), `getPublicKey` is essentially equivalent to `getAddress` — same identity, just a different encoding — and so should default to displaying on device. The cleaner axis to look at is **extended key vs raw key**:

| Coin | What `getPublicKey` returns | Caller can derive subtree? |
|---|---|---|
| BTC | xpub (extended) | yes — full BIP32 subtree |
| Cardano | extended public key | yes |
| Ethereum | xpub (extended) | yes (in practice Suite/Ledger Live derive a single address per account; MetaMask-style wallets derive many under one account) |
| Solana | raw ed25519 public key | no (ed25519 / SLIP-0010 has no public-side child derivation) |
| Tezos | raw public key | no |

Solana and Tezos return raw keys — for them, the public key returned by `getPublicKey` *is* the identity at that exact path, the same thing the address encodes. But even with that lens, Solana defaults to `false` and Tezos to `true`. So even by the "raw pubkey = address" reasoning, Tezos is inconsistent with its closest peer.

The convention worth following across the API surface is:

- `getPublicKey` — silent by default. Typical callers (Suite during account discovery, dApps deriving identities for signature verification) want the public key returned without prompting. Anyone who wants a device prompt can either pass `showOnTrezor: true` explicitly, or call `getAddress`, which exists for exactly that purpose.
- `getAddress` — display by default. The whole intent of the call is "show this address to the user on the device".

Tezos `getPublicKey` defaulting to `true` violates that convention without any code, test, or comment justifying it.

## Behavior change

Callers who omitted `showOnTrezor` on `tezosGetPublicKey` and relied on the device prompt appearing will no longer see one. Such callers should pass `showOnTrezor: true` explicitly (or switch to `tezosGetAddress`). No usages relying on the implicit prompt have been identified in this repo.

## Test plan

- [x] Existing `@trezor/connect` test suite remains green
- [ ] Manual: call `tezosGetPublicKey({ path: "m/44'/1729'/0'" })` without `showOnTrezor` — device must NOT prompt
- [ ] Manual: call `tezosGetPublicKey({ path: "m/44'/1729'/0'", showOnTrezor: true })` — device DOES prompt

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/tezos-getpublickey-default&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/tezos-getpublickey-default&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/tezos-getpublickey-default/web/](https://dev.suite.sldev.cz/suite-web/mroz22/tezos-getpublickey-default/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-26T08:11:26.542Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->