### PR TITLE
test(address-validator): document broken cashaddr checksum

### DIFF
--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -1201,6 +1201,19 @@ describe('WAValidator.validate()', function () {
             invalid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');
         });
 
+        // KNOWN BUG: bch_validator.verifyChecksum uses Array.prototype.concat on a Uint8Array,
+        // which appends it as a single element instead of spreading. The bitwise ops in polymod
+        // then yield NaN, so the checksum check effectively never fails and any address that
+        // passes the length/charset/case filters is accepted. These assertions document the
+        // current behavior; they must FLIP from valid → invalid once the cashaddr checksum is
+        // fixed in a follow-up.
+        it('incorrectly accepts bitcoincash addresses with corrupted checksums (known bug)', function () {
+            // Tampered last char of a known-valid address
+            valid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808', 'bch');
+            // Tampered middle of a known-valid address
+            valid('bitcoincash:qq4v32mtagxac29my6gxx6fd4tmqg8rysu23dax807', 'bch');
+        });
+
         it('should return false for incorrect litecoin addresses', function () {
             commonTests('litecoin');
             // do not allow old ltc addresses


### PR DESCRIPTION
Adds a regression test that documents a real bug in `bch_validator`: any BCH address that passes the length/charset/case filters is accepted as valid, regardless of its cashaddr checksum.

## Root cause

`verifyChecksum` does `polymod(hrpExpand(hrp).concat(data))` where `data` is a `Uint8Array`. `Array.prototype.concat` does **not** spread typed arrays — it appends the `Uint8Array` as a single element. The bitwise operations in `polymod` then produce `NaN`, so the comparison `=== 1` is always false. Result: the checksum is never enforced.

## What this PR does

Pins the current (buggy) behavior with a test, named `incorrectly accepts bitcoincash addresses with corrupted checksums (known bug)`. Two assertions: tampered last char and tampered middle of a known-valid cashaddr — both currently return `valid: true`.

The test must flip from `valid` to `invalid` once the cashaddr checksum is implemented correctly in a follow-up.

## Why I want a second pair of eyes

@evgenysl could you verify in Suite that this also reproduces end-to-end on the classic send form?
- Open Suite, switch to a BCH (mainnet) account
- Open Send and paste a tampered cashaddr like `bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808` (valid format, broken checksum) into the recipient field
- See whether the field accepts it as valid (no `RECIPIENT_IS_NOT_VALID` error)

If it does, that confirms the bug has user-visible impact (typos in BCH recipient addresses are not caught) and we should prioritize the actual checksum fix.

## Test plan

- [x] `yarn workspace @trezor/address-validator run test:unit` — 173/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
