### PR TITLE
refactor(connect): drop unused DataManager.assets staging field

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -27,14 +27,7 @@ export type InitializeFirmwareConfig = (
     intermediaries: Record<DeviceModelInternal, IntermediaryReleaseConfig[]>;
 }>;
 
-type AssetKeys = `firmware-${string}` | 'coins' | 'coinsEth';
-type AssetCollection = {
-    [K in AssetKeys]?: Record<string, any>;
-};
-
 export class DataManager {
-    static assets: AssetCollection = {};
-
     private static settings: ConnectSettings;
     // at the moment, messages is readonly but it might make sense to modify this in the future, when
     // we implement additive protobufs handling as a part of modularization effort
@@ -62,16 +55,9 @@ export class DataManager {
 
         if (!withAssets) return;
 
-        const assetsMap = {
-            coins,
-            coinsEth,
-        };
-        Object.assign(this.assets, assetsMap);
-
-        // parse coins definitions
         parseCoinsJson({
-            ...this.assets.coins,
-            ...this.assets.coinsEth,
+            ...coins,
+            ...coinsEth,
         });
 
         this.prepareLocalFirmwareReleaseData();


### PR DESCRIPTION
> Part of a small DataManager refactor split into 3 independent PRs:
> 1. **#27077 (this PR)** — drop unused `DataManager.assets` staging field
> 2. #27087 — make `DataManager.getSettings` throw before `load()`
> 3. #27088 — inline DataManager private setter wrappers
>
> All three branch off `develop` and touch different parts of `DataManager.ts`, so they can land in any order.

## Summary

- `AssetKeys` included a `firmware-${string}` template member that was never assigned or read anywhere in the codebase — likely a leftover from the original JS port.
- `DataManager.assets` was only consumed inline by `load()` itself (spread into `parseCoinsJson` immediately after assignment); no external readers (`grep DataManager.assets` returns 0 hits outside the file).
- Removed `AssetKeys`, `AssetCollection`, and the static `assets` field. `coins` / `coinsEth` JSONs are now passed straight into `parseCoinsJson`. Behavior is unchanged.

Net: -16 / +2 lines.

## Test plan

- [ ] CI typecheck passes for `@trezor/connect`
- [ ] CI unit / e2e suites for connect remain green (coin parsing path is exercised on every init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/datamanager-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->