### PR TITLE
fix(connect-common): harden message channel origin validation

### DIFF
--- a/packages/connect-common/src/messageChannel/__tests__/serviceworker-window-ext-connectable.test.ts
+++ b/packages/connect-common/src/messageChannel/__tests__/serviceworker-window-ext-connectable.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ServiceWorkerWindowExtConnectableChannel } from '../serviceworker-window-ext-connectable';
+
+type TestMessage = { type: 'test-message'; channel?: { peer: string; here: string } };
+
+const ALLOWED_ORIGIN = 'https://connect.trezor.io';
+
+type MessageListener = (
+    message: any,
+    sender: chrome.runtime.MessageSender,
+    sendResponse: (response?: any) => void,
+) => void | boolean;
+
+const installChromeMock = () => {
+    const listeners = new Set<MessageListener>();
+    (globalThis as any).chrome = {
+        runtime: {
+            id: 'test-extension-id',
+            onMessageExternal: {
+                addListener: (cb: MessageListener) => listeners.add(cb),
+                removeListener: (cb: MessageListener) => listeners.delete(cb),
+            },
+        },
+        tabs: { update: jest.fn(), get: jest.fn() },
+    };
+
+    return {
+        invoke: (sender: chrome.runtime.MessageSender, message: any) => {
+            const sendResponse = jest.fn();
+            listeners.forEach(l => l(message, sender, sendResponse));
+
+            return sendResponse;
+        },
+    };
+};
+
+// Mirrors the channel direction expected by AbstractMessageChannel.onMessage:
+// incoming.channel.peer === channel.here && incoming.channel.here === channel.peer.
+const validMessage = {
+    type: 'test-message',
+    channel: { peer: '@trezor/connect-webextension', here: '@trezor/connect-popup' },
+};
+
+const senderWithUrl = (url: string): chrome.runtime.MessageSender =>
+    ({ tab: { url } }) as chrome.runtime.MessageSender;
+
+describe('ServiceWorkerWindowExtConnectableChannel allowedOrigin guard', () => {
+    let chromeMock: ReturnType<typeof installChromeMock>;
+    let channel: ServiceWorkerWindowExtConnectableChannel<TestMessage>;
+    let onMessageSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        chromeMock = installChromeMock();
+        channel = new ServiceWorkerWindowExtConnectableChannel<TestMessage>({
+            channel: {
+                here: '@trezor/connect-webextension',
+                peer: '@trezor/connect-popup',
+            },
+            allowedOrigin: ALLOWED_ORIGIN,
+        });
+        // `onMessage` is protected; spy on the instance to observe acceptance.
+        onMessageSpy = jest.spyOn(channel as any, 'onMessage').mockImplementation(() => undefined);
+        channel.connect();
+    });
+
+    afterEach(() => {
+        channel.disconnect();
+        onMessageSpy.mockRestore();
+        delete (globalThis as any).chrome;
+    });
+
+    it('forwards messages whose sender.tab.url has the exact allowed origin', () => {
+        chromeMock.invoke(senderWithUrl(`${ALLOWED_ORIGIN}/popup.html?x=1`), validMessage);
+
+        expect(onMessageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops the look-alike "https://connect.trezor.io.attacker.com/..." prefix bypass', () => {
+        chromeMock.invoke(
+            senderWithUrl('https://connect.trezor.io.attacker.com/popup.html'),
+            validMessage,
+        );
+
+        expect(onMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops senders on a different scheme (http vs https)', () => {
+        chromeMock.invoke(senderWithUrl('http://connect.trezor.io/popup.html'), validMessage);
+
+        expect(onMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops senders with a malformed sender.tab.url', () => {
+        chromeMock.invoke(senderWithUrl('not a url'), validMessage);
+
+        expect(onMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops senders whose tab has no URL (e.g. missing host_permissions)', () => {
+        chromeMock.invoke({ tab: {} } as chrome.runtime.MessageSender, validMessage);
+
+        expect(onMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('drops messages when allowedOrigin itself is malformed', () => {
+        channel.disconnect();
+        const badChannel = new ServiceWorkerWindowExtConnectableChannel<TestMessage>({
+            channel: {
+                here: '@trezor/connect-webextension',
+                peer: '@trezor/connect-popup',
+            },
+            allowedOrigin: 'not a url',
+        });
+        const badOnMessage = jest
+            .spyOn(badChannel as any, 'onMessage')
+            .mockImplementation(() => undefined);
+        badChannel.connect();
+
+        chromeMock.invoke(senderWithUrl(`${ALLOWED_ORIGIN}/popup.html`), validMessage);
+
+        expect(badOnMessage).not.toHaveBeenCalled();
+        badChannel.disconnect();
+    });
+
+    it('drops messages whose sender has no tab', () => {
+        chromeMock.invoke({} as chrome.runtime.MessageSender, validMessage);
+
+        expect(onMessageSpy).not.toHaveBeenCalled();
+    });
+});

--- a/packages/connect-common/src/messageChannel/__tests__/window-window.test.ts
+++ b/packages/connect-common/src/messageChannel/__tests__/window-window.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import { WindowWindowChannel } from '../window-window';
+
+type TestMessage = {
+    type: 'test-message';
+    channel?: { peer: string; here: string };
+    payload?: any;
+};
+
+const EXPECTED_ORIGIN = 'https://connect.trezor.io';
+const ATTACKER_ORIGIN = 'https://connect.trezor.io.attacker.com';
+
+const dispatchMessage = (origin: string, data: any) => {
+    const event = new MessageEvent('message', { data, origin });
+    window.dispatchEvent(event);
+};
+
+const createChannel = () =>
+    new WindowWindowChannel<TestMessage>({
+        windowHere: window,
+        windowPeer: () => undefined,
+        channel: { here: '@trezor/connect-web', peer: '@trezor/connect-popup' },
+        origin: EXPECTED_ORIGIN,
+    });
+
+describe('WindowWindowChannel origin validation', () => {
+    let channel: ReturnType<typeof createChannel>;
+
+    beforeEach(() => {
+        channel = createChannel();
+    });
+
+    afterEach(() => {
+        channel.disconnect();
+    });
+
+    it('forwards messages from the expected origin to onMessage handlers', () => {
+        const onMessage = jest.fn();
+        channel.on('message', onMessage);
+
+        dispatchMessage(EXPECTED_ORIGIN, {
+            type: 'test-message',
+            channel: { peer: '@trezor/connect-web', here: '@trezor/connect-popup' },
+            payload: { ok: true },
+        });
+
+        expect(onMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops messages from a different origin even with valid channel metadata', () => {
+        const onMessage = jest.fn();
+        channel.on('message', onMessage);
+
+        dispatchMessage(ATTACKER_ORIGIN, {
+            type: 'test-message',
+            channel: { peer: '@trezor/connect-web', here: '@trezor/connect-popup' },
+            payload: { hostile: true },
+        });
+
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it('drops messages from the special "null" origin (sandboxed/file://)', () => {
+        const onMessage = jest.fn();
+        channel.on('message', onMessage);
+
+        dispatchMessage('null', {
+            type: 'test-message',
+            channel: { peer: '@trezor/connect-web', here: '@trezor/connect-popup' },
+        });
+
+        expect(onMessage).not.toHaveBeenCalled();
+    });
+});

--- a/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.ts
@@ -16,12 +16,14 @@ export class ServiceWorkerWindowExtConnectableChannel<
 > extends AbstractMessageChannel<IncomingMessages> {
     private currentId?: () => Promise<number | undefined> | undefined;
     /**
-     * Expected origin (scheme + host) of the popup page.
-     * When set, onMessageExternal messages whose sender.tab.url does not
-     * start with this origin are silently dropped.  This is a
-     * defense-in-depth measure: externally_connectable may match more
-     * origins than intended (e.g. wildcards in manifest), so we
-     * double-check that only the popup we actually opened can talk to us.
+     * Expected origin (scheme + host[:port]) of the popup page.
+     * When set, onMessageExternal messages are accepted only when the parsed
+     * `URL(sender.tab.url).origin` is strictly equal to `URL(allowedOrigin).origin`.
+     * Senders whose URL is malformed, or whose origin does not match exactly,
+     * are silently dropped. This is a defense-in-depth measure: the
+     * externally_connectable manifest entry may match more origins than
+     * intended (e.g. wildcards), so we double-check that only the popup we
+     * actually opened can talk to us.
      */
     private allowedOrigin?: string;
     private messageListener?: (
@@ -199,16 +201,38 @@ export class ServiceWorkerWindowExtConnectableChannel<
             // popup we opened.  externally_connectable patterns may be broader
             // than our popup URL (e.g. wildcard sub-domains), so this ensures
             // only the exact popup origin is accepted.
-            if (
-                this.allowedOrigin &&
-                sender.tab.url &&
-                !sender.tab.url.startsWith(this.allowedOrigin)
-            ) {
-                this.logger?.warn(
-                    `CHANNEL: Sender origin mismatch — expected ${this.allowedOrigin}, got ${sender.tab.url}. Ignoring.`,
-                );
+            if (this.allowedOrigin) {
+                if (!sender.tab.url) {
+                    // tab.url is only populated when the extension has either
+                    // the "tabs" permission or matching host_permissions; an
+                    // empty URL means we cannot verify the sender, so reject.
+                    this.logger?.warn(
+                        `CHANNEL: Missing sender tab URL while allowed origin is configured (allowed=${this.allowedOrigin}). Ignoring.`,
+                    );
 
-                return false;
+                    return false;
+                }
+
+                let senderOrigin: string;
+                let expectedOrigin: string;
+                try {
+                    senderOrigin = new URL(sender.tab.url).origin;
+                    expectedOrigin = new URL(this.allowedOrigin).origin;
+                } catch {
+                    this.logger?.warn(
+                        `CHANNEL: Could not parse sender or allowed origin (sender=${sender.tab.url}, allowed=${this.allowedOrigin}). Ignoring.`,
+                    );
+
+                    return false;
+                }
+
+                if (senderOrigin !== expectedOrigin) {
+                    this.logger?.warn(
+                        `CHANNEL: Sender origin mismatch — expected ${expectedOrigin}, got ${senderOrigin}. Ignoring.`,
+                    );
+
+                    return false;
+                }
             }
 
             // Verify message comes from the correct extension context

--- a/packages/connect-common/src/messageChannel/window-window.ts
+++ b/packages/connect-common/src/messageChannel/window-window.ts
@@ -19,6 +19,7 @@ export class WindowWindowChannel<
 > extends AbstractMessageChannel<IncomingMessages> {
     _windowHere: Window;
     _listener: typeof WindowWindowChannel.prototype.listener;
+    _origin: string;
 
     constructor({
         windowHere,
@@ -43,10 +44,25 @@ export class WindowWindowChannel<
 
         this._listener = this.listener.bind(this);
         this._windowHere = windowHere;
+        this._origin = origin;
         this.connect();
     }
 
     listener(event: MessageEvent<Message<IncomingMessages>>) {
+        // Only accept messages from the expected peer origin. Without this check
+        // any window with a reference to `windowHere` (e.g. an opener or embedder)
+        // could inject messages with spoofed `channel` metadata, since
+        // `AbstractMessageChannel.onMessage` only validates the channel name strings,
+        // which are well-known constants. Reject the special "null" origin
+        // (sandboxed iframes / file://) outright.
+        if (event.origin !== this._origin || event.origin === 'null') {
+            this.logger?.warn(
+                `WindowWindowChannel: ignoring message from unexpected origin "${event.origin}", expected "${this._origin}"`,
+            );
+
+            return;
+        }
+
         const message = {
             ...event.data,
             success: true,


### PR DESCRIPTION
Local branch of #27068

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=thomasbuilds/fix/connect-channel-origin-validation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/thomasbuilds/fix/connect-channel-origin-validation/web/](https://dev.suite.sldev.cz/suite-web/thomasbuilds/fix/connect-channel-origin-validation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T08:55:51.415Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->