### PR TITLE
fix(suite): useConnectPopupWeb - send POPUP.CORE_LOADED after the handshake

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -25,7 +25,7 @@ export const useConnectPopupWeb = () => {
     // scoped to that origin.
     const originRef = useRef<string>('*');
     const initialUrl = useRef<string>(window.location.href.split('?')[1] ?? '');
-    const channelRef = useRef<BroadcastChannel | null>(null);
+    const [broadcast, setBroadcast] = useState<BroadcastChannel | null>(null);
 
     /**
      * Send a message back to the caller (opener window or same window).
@@ -35,25 +35,25 @@ export const useConnectPopupWeb = () => {
      * malicious opener from a different origin from intercepting sensitive data
      * such as addresses or signatures.
      */
-    const postMessageToParent = useCallback((message: ConnectPopupOutgoingMessage) => {
-        message.channel = webChannel;
-        if (channelRef.current) {
-            channelRef.current.postMessage(message);
-        } else {
-            // TODO: show warning to user
-            console.error('BroadcastChannel not available', initialUrl.current);
-        }
-    }, []);
 
-    const popupLink = useMemo<ConnectPopupLink>(
-        () => ({
-            sendMessage: postMessageToParent,
+    const popupLink = useMemo<ConnectPopupLink | null>(() => {
+        if (!broadcast) return null;
+
+        return {
+            sendMessage: (message: ConnectPopupOutgoingMessage) => {
+                message.channel = webChannel;
+                if (broadcast) {
+                    broadcast.postMessage(message);
+                } else {
+                    // TODO: show warning to user
+                    console.warn('BroadcastChannel not available', initialUrl.current);
+                }
+            },
             get origin() {
                 return originRef.current;
             },
-        }),
-        [postMessageToParent],
-    );
+        };
+    }, [broadcast]);
 
     const consumeMessages = useCallback(() => {
         setIncomingMessages(prev => prev.slice(1));
@@ -82,7 +82,7 @@ export const useConnectPopupWeb = () => {
         let broadcastChannel: BroadcastChannel | undefined;
         try {
             broadcastChannel = new BroadcastChannel(`@trezor/connect-popup/${requestId}`);
-            channelRef.current = broadcastChannel;
+            setBroadcast(broadcastChannel);
         } catch (error) {
             // TODO: show warning to user
             console.warn('BroadcastChannel is not supported in this browser', error);
@@ -94,7 +94,7 @@ export const useConnectPopupWeb = () => {
             // eslint-disable-next-line @typescript-eslint/no-use-before-define
             broadcastChannel.removeEventListener('message', onMessage);
             broadcastChannel.close();
-            channelRef.current = null;
+            setBroadcast(null);
             // TODO: show warning to user
             console.warn('Popup handshake timeout');
         }, 3000);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix race condition in connect popup web.
`POPUP.CORE_LOADED` - is always sent after suite is loaded, but should be sent only after the bootstrap handshake.

Using similar solution as in `useConnectPopupWebextension` -> popupLink is `null` if there is no established broadcast channel.

It should fix [the reason of this issue](https://github.com/trezor/trezor-suite/pull/27031)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to useConnectPopupWeb.tsx, which manages the TrezorConnect popup lifecycle specifically for the web build of Suite. This is a focused infrastructure hook, so the primary risk is in the Connect popup web flow. The two connectPopup tests (web and webextension) are critical since they directly exercise this functionality. The remaining 119 tests mapped statically are transitive consumers through the app's root support infrastructure and are very unlikely to be affected by changes to this specific hook. Testing strategy should focus on the Connect popup integration tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/support/suite/useConnectPopupWeb.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup flow in web mode (core-mode=suite-web), which is the exact functionality that useConnectPopupWeb.tsx implements. The hook manages the Connect popup lifecycle for web builds, and this test validates happy paths, cancellations, popup blocking, and popup recovery — all behaviors that would break if useConnectPopupWeb changes.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test validates TrezorConnect popup behavior in the webextension context with core-mode=suite-web, which directly depends on the Connect popup web integration managed by useConnectPopupWeb.tsx. It tests popup lifecycle, permissions, cancellations, and recovery flows that are core to this hook's responsibility.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session management and device connection handling across multiple browser tabs/sessions. The useConnectPopupWeb hook is part of the Suite web infrastructure that manages TrezorConnect sessions, so changes could affect session stealing/reclaiming behavior tested here.

</details>

_Updated: 2026-04-27T08:56:21.334Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-connect-popup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-connect-popup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:02:19.127Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:00:01.619Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-connect-popup/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-connect-popup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->