### PR TITLE
refactor(connect): inline DataManager private setter wrappers

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -74,20 +74,16 @@ export class DataManager {
             ...this.assets.coinsEth,
         });
 
-        this.prepareLocalFirmwareReleaseData();
+        const { config: localFirmwareReleaseConfig } = getOnlyLocalFirmwareReleaseConfig();
+        this.localFirmwareReleaseConfig = localFirmwareReleaseConfig;
         await this.loadFirmwareReleaseConfig(onlyLocalFirmwareConfig);
-    }
-
-    private static prepareLocalFirmwareReleaseData() {
-        const { config } = getOnlyLocalFirmwareReleaseConfig();
-        this.setLocalFirmwareReleaseConfig(config);
     }
 
     private static async loadFirmwareReleaseConfig(onlyLocal: boolean): Promise<void> {
         let firmwareReleaseConfig;
         if (onlyLocal) {
             firmwareReleaseConfig = {
-                config: this.getLocalFirmwareReleaseConfig(),
+                config: this.localFirmwareReleaseConfig,
                 isRemote: false,
             };
         } else {
@@ -95,8 +91,8 @@ export class DataManager {
         }
         const { config, isRemote } = firmwareReleaseConfig;
         const firmwareConfig = await this.initializeFirmwareConfig(config, isRemote);
-        this.setFirmwareReleaseConfig(firmwareConfig.releases);
-        this.setFirmwareIntermediaryReleaseConfig(firmwareConfig.intermediaries);
+        this.firmwareReleasesConfig = firmwareConfig.releases;
+        this.firmwareIntermediaryReleasesConfig = firmwareConfig.intermediaries;
     }
 
     public static getProtobufMessages() {
@@ -128,26 +124,14 @@ export class DataManager {
         return this.localFirmwares;
     }
 
-    private static setLocalFirmwareReleaseConfig(
-        localFirmwareReleaseConfig: FirmwareReleaseConfig,
-    ) {
-        this.localFirmwareReleaseConfig = localFirmwareReleaseConfig;
-    }
     public static getLocalFirmwareReleaseConfig(): FirmwareReleaseConfig {
         return this.localFirmwareReleaseConfig;
     }
 
-    private static setFirmwareReleaseConfig(releaseConfig: ReleasesConfig): void {
-        this.firmwareReleasesConfig = releaseConfig;
-    }
     public static getFirmwareReleaseConfig() {
         return this.firmwareReleasesConfig;
     }
-    private static setFirmwareIntermediaryReleaseConfig(
-        intermediariesConfig: Record<DeviceModelInternal, IntermediaryReleaseConfig[]>,
-    ) {
-        this.firmwareIntermediaryReleasesConfig = intermediariesConfig;
-    }
+
     public static getFirmwareIntermediaryReleaseConfig() {
         return this.firmwareIntermediaryReleasesConfig;
     }


### PR DESCRIPTION
> Part of a small DataManager refactor split into 3 independent PRs:
> 1. #27077 — drop unused `DataManager.assets` staging field
> 2. #27087 — make `DataManager.getSettings` throw before `load()`
> 3. **#27088 (this PR)** — inline DataManager private setter wrappers
>
> All three branch off `develop` and touch different parts of `DataManager.ts`, so they can land in any order.

## Summary

Three private setters on `DataManager` each had a single call site and only assigned to one private field — pure boilerplate:

- `setLocalFirmwareReleaseConfig`
- `setFirmwareReleaseConfig`
- `setFirmwareIntermediaryReleaseConfig`

Inline them and drop the methods.

Also:
- Inline `prepareLocalFirmwareReleaseData()` — a two-line wrapper called once from `load()`.
- Remove the read-after-write inside the `onlyLocal` branch of `loadFirmwareReleaseConfig`, which was calling `this.getLocalFirmwareReleaseConfig()` to retrieve what had just been stored on the field two lines above. Use the field directly.

The public getters (`getLocalFirmwareReleaseConfig`, `getFirmwareReleaseConfig`, `getFirmwareIntermediaryReleaseConfig`) all stay — they have external callers in `firmwareInfo.ts`.

Net: -22 / +6 lines, no behavior change.

## Test plan

- [ ] CI typecheck passes for `@trezor/connect`
- [ ] CI unit / e2e suites for connect remain green (init flow exercises both `onlyLocal` branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/datamanager-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/datamanager-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/datamanager-cleanup/web/](https://dev.suite.sldev.cz/suite-web/mroz22/datamanager-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T09:23:42.693Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->