### PR TITLE
fix(requirements): write connect snapshots with 4-space indent

### DIFF
--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -155,7 +155,7 @@ const createSnapshot = (
 
 const snapshotFileName = (packageName: string) => `${packageName.replace('@trezor/', '')}.json`;
 
-const stringifySnapshot = (snapshot: Snapshot) => `${JSON.stringify(snapshot, null, 2)}\n`;
+const stringifySnapshot = (snapshot: Snapshot) => `${JSON.stringify(snapshot, null, 4)}\n`;
 
 const validateSnapshots = ({ repoRoot, write }: { repoRoot: string; write: boolean }) => {
     const workspacePackages = collectWorkspacePackages(repoRoot);


### PR DESCRIPTION
## Summary
- `yarn requirements:fix` produced a formatting-only diff in `packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect-*.json` even when nothing real had changed.
- Root cause: `stringifySnapshot` wrote with `JSON.stringify(..., null, 2)` (2 spaces), while the committed snapshots and project-wide `.prettierrc` (`tabWidth: 4`) use 4 spaces. `verify` re-stringified both sides so it passed, but `fix` rewrote the file with the mismatched indentation.
- Switched the helper to 4-space indentation. Existing snapshots already match this format byte-for-byte, so no snapshot files needed to be regenerated.

## Test plan
- [ ] `yarn workspace @trezor/requirements test` passes
- [ ] `yarn requirements:fix` leaves the working tree clean when there are no real changes

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `requireConnectPublicDependencies.ts` is a build-time/lint-time requirement checker for public package dependencies in the `@trezor/connect` ecosystem. It enforces dependency constraints during development/CI and does not affect runtime application behavior, UI flows, or any user-facing functionality tested by the E2E suite. No static test mappings exist, and none of the LLM-analyzed E2E tests reference or exercise package dependency validation logic. No E2E tests are recommended for this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`

_Updated: 2026-04-27T10:09:30.911Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/requirements-fix-format&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/requirements-fix-format&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T10:15:41.317Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T10:14:02.298Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/requirements-fix-format/web/](https://dev.suite.sldev.cz/suite-web/mroz22/requirements-fix-format/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->