### PR TITLE
fix(urls): update broken help center URLs

### DIFF
--- a/packages/urls/src/urls.ts
+++ b/packages/urls/src/urls.ts
@@ -268,14 +268,14 @@ export const HELP_CENTER_FIRMWARE_REVISION_CHECK_MOBILE: Url = withPlatformUtm(
     'https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/trezor-firmware-authenticity-check',
 );
 export const HELP_CENTER_ENTROPY_CHECK_URL: Url = withPlatformUtm(
-    'https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/entropy-check',
+    'https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/entropy-check-how-trezor-verifies-your-wallet-is-truly-random',
 );
 
 export const HELP_CENTER_REPLACE_BY_FEE_ETHEREUM: Url = withPlatformUtm(
     'https://trezor.io/learn/supported-assets/ethereum-layer-2-EVM/replace-by-fee-rbf-ethereum',
 );
 export const HELP_CENTER_REPLACE_BY_FEE_BITCOIN = withPlatformUtm(
-    'https://trezor.io/learn/supported-assets/bitcoin/replace-by-fee-rbf-bitcoin',
+    'https://trezor.io/learn/supported-assets/bitcoin/speed-up-a-stuck-bitcoin-transaction-with-replace-by-fee-rbf',
 );
 export const HELP_CENTER_CANCEL_TRANSACTION: Url = withPlatformUtm(
     'https://trezor.io/support/troubleshooting/trezor-suite-issues/can-i-cancel-or-reverse-a-transaction',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes urls to the helpcenter that did not exist as the CI failed here https://github.com/trezor/trezor-suite/pull/26527/changes

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to `packages/urls/src/urls.ts`, which is a broadly shared URL constants module imported by 121 tests. Since this file defines URL constants used throughout the application, the primary risk is broken links or incorrect URLs in the UI. The highest-priority test is the link checker which validates all URLs across the app. A few specific tests directly assert on URL values from this module (backup fail page, Safari browser page). Most of the 121 mapped tests only transitively import urls.ts and are unlikely to be affected unless a specific URL constant they rely on was changed.

<details><summary><b>Changed files (1)</b></summary>

- `packages/urls/src/urls.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test crawls all application routes and checks that every hyperlink returns a valid HTTP response. The `packages/urls/src/urls.ts` file defines URL constants (like HELP_CENTER_RECOVERY_ISSUES_URL and others) used across the app. Any change to URL values would directly cause link-check failures.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly asserts that the failed backup setting link href matches the HELP_CENTER_RECOVERY_ISSUES_URL constant from the @trezor/urls module. A change to that URL constant would directly break this assertion.
- `suite/e2e/tests/browser/safari.test.ts` — This test verifies the unsupported browser page content including download links for the Desktop App and Chrome. These download URLs are likely sourced from the urls.ts module, so changes could affect the ARIA snapshot assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/version-page.test.ts` — This test checks that the commit hash links to the correct GitHub commits page URL. If the GitHub repository URL constant is defined in urls.ts and was changed, this assertion would fail.

</details>

_Updated: 2026-04-27T11:26:41.859Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-helpdcenter-nonexisten-urls&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-helpdcenter-nonexisten-urls&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T11:32:51.977Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T11:31:06.056Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-helpdcenter-nonexisten-urls/web/](https://dev.suite.sldev.cz/suite-web/fix-helpdcenter-nonexisten-urls/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->