### PR TITLE
chore(tests): hybrid swc+babel jest transform for suite-native

### DIFF
--- a/jest.config.base.swc.js
+++ b/jest.config.base.swc.js
@@ -1,24 +1,6 @@
 const path = require('path');
 
-const swcConfig = {
-    jsc: {
-        parser: {
-            syntax: 'typescript',
-            tsx: true,
-            decorators: true,
-        },
-        transform: {
-            react: {
-                runtime: 'automatic',
-            },
-            decoratorVersion: '2022-03',
-        },
-        target: 'esnext',
-    },
-    module: {
-        type: 'commonjs',
-    },
-};
+const swcConfig = require('./jest.config.swc-transform');
 
 module.exports = {
     rootDir: process.cwd(),

--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -10,6 +10,8 @@ const babelConfig = {
     presets: ['babel-preset-expo'],
 };
 
+const swcConfig = require('./jest.config.swc-transform');
+
 module.exports = {
     rootDir: process.cwd(),
     moduleFileExtensions,
@@ -30,14 +32,18 @@ module.exports = {
     },
     testEnvironment: 'jsdom',
     preset: 'jest-expo',
-
+    // SWC has no Flow support; React Native source in node_modules (allowed through
+    // transformIgnorePatterns) ships Flow types, so .js/.jsx must go through babel.
+    // Inspiration from GH issue comment: https://github.com/swc-project/jest/issues/85#issuecomment-1122482982
     transform: {
-        '\\.(js|jsx|ts|tsx)$': ['babel-jest', babelConfig],
+        '\\.(ts|tsx)$': ['@swc/jest', swcConfig],
+        '\\.(js|jsx)$': ['babel-jest', babelConfig],
     },
     transformIgnorePatterns: [
         'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|@shopify/react-native-skia|@shopify/flash-list|@noble|@scure|@evolu|nanoid|msgpackr|@gorhom|uuid|react-intl|@formatjs/*|intl-messageformat)',
     ],
     setupFiles: [
+        '<rootDir>/../../suite-native/test-utils/src/mocks/reanimatedMock.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/expoAndRNMock.jsx',
         '<rootDir>/../../suite-native/test-utils/src/mocks/everstakeJestSetup.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/TextEncoderMock.js',

--- a/jest.config.swc-transform.js
+++ b/jest.config.swc-transform.js
@@ -1,0 +1,19 @@
+module.exports = {
+    jsc: {
+        parser: {
+            syntax: 'typescript',
+            tsx: true,
+            decorators: true,
+        },
+        transform: {
+            react: {
+                runtime: 'automatic',
+            },
+            decoratorVersion: '2022-03',
+        },
+        target: 'esnext',
+    },
+    module: {
+        type: 'commonjs',
+    },
+};

--- a/suite-native/test-utils/package.json
+++ b/suite-native/test-utils/package.json
@@ -26,6 +26,7 @@
         "react-native-keyboard-controller": "1.20.7",
         "react-native-mmkv": "~4.3.0",
         "react-native-permissions": "5.4.4",
+        "react-native-reanimated": "~4.2.1",
         "react-native-safe-area-context": "5.6.2",
         "react-native-worklets": "~0.7.2"
     }

--- a/suite-native/test-utils/src/mocks/reanimatedMock.js
+++ b/suite-native/test-utils/src/mocks/reanimatedMock.js
@@ -1,0 +1,1 @@
+jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -14277,6 +14277,7 @@ __metadata:
     react-native-keyboard-controller: "npm:1.20.7"
     react-native-mmkv: "npm:~4.3.0"
     react-native-permissions: "npm:5.4.4"
+    react-native-reanimated: "npm:~4.2.1"
     react-native-safe-area-context: "npm:5.6.2"
     react-native-worklets: "npm:~0.7.2"
   languageName: unknown


### PR DESCRIPTION
Use @swc/jest for .ts/.tsx and keep babel-jest for .js/.jsx (needed for
react-native source which contains Flow annotations SWC can't strip).
Adds a global Reanimated mock so worklet calls (normally rewritten by
the babel-preset-expo plugin) become no-ops under SWC.

#### Comparison of: 
1. SWC + Babel hybrid combination
2. Pure babel 

Both of these were ran with for the whole of `suite-native/*` tests with **NO JEST CACHE** so it's a big difference from the numbers we're used to seeing in normal PR runs, but it's better comparison. No jest cache makes our previous setup extremely ineffective but all the more reason for the SWC results to be mindblowing 🤯 
Comparison here: https://github.com/trezor/trezor-suite/actions/runs/24992317180?pr=27098

#### Suite native test runs on this branch with NX & Jest caching set to default options that we use for all runs:
`test:unit:native`:
<img width="742" height="917" alt="Snímek obrazovky 2026-04-27 v 15 53 52" src="https://github.com/user-attachments/assets/35f80928-8d2d-47e1-8ea8-4308dcb7304d" />
`test:unit:native:trading`:
<img width="737" height="498" alt="Snímek obrazovky 2026-04-27 v 15 54 07" src="https://github.com/user-attachments/assets/5647eaf0-743b-4086-8b31-9364480dc456" />

Resolve https://github.com/trezor/trezor-suite/issues/26915