### PR TITLE
fix(suite): open desktop deeplink in firefox

### DIFF
--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -11,10 +11,9 @@ export const useOpenSuiteDesktop = () => {
     const windowFocused = useWindowFocus();
     const handleOpenSuite = () => {
         const iframe = document.createElement('iframe');
+        iframe.src = SUITE_BRIDGE_DEEPLINK;
         iframe.style.display = 'none';
         document.body.appendChild(iframe);
-
-        iframe.src = SUITE_BRIDGE_DEEPLINK;
 
         // fallback in case deeplink does not work
         window.setTimeout(() => {


### PR DESCRIPTION
## Description

Fix the "Open the Trezor Suite desktop app" deeplink

I compared with Connect v9 code which was working and noticed there's a difference that `src` is set afterwards

## Related Issue

Resolve #26952

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `useOpenSuiteDesktop.ts` is a hook that maps to 121 tests, indicating it is a broadly imported global utility/shared component. This hook likely provides functionality related to opening or redirecting to the Trezor Suite desktop app (e.g., a "Get Desktop App" prompt or deep-link). None of the 121 mapped tests' LLM analyses mention `useOpenSuiteDesktop` in their source_hints, behaviors, or key_assertions — they all transitively import it through shared layout components. Without specific evidence that any test exercises the open-Suite-desktop functionality directly, no tests should be recommended at high or medium priority. The risk of this change is low since it appears to be a narrowly-scoped UI hook for desktop app promotion that is not directly exercised by any existing E2E test.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts`

_Updated: 2026-04-27T12:12:49.515Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/26952-firefox-deeplink&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/26952-firefox-deeplink&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T12:18:17.880Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T12:17:24.968Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/26952-firefox-deeplink/web/](https://dev.suite.sldev.cz/suite-web/fix/26952-firefox-deeplink/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->