### PR TITLE
refactor(connect): move parseCoinsJson out of DataManager.load()

### DIFF
--- a/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/BitcoinFeeLevels.test.ts
@@ -1,9 +1,7 @@
 import { BlockchainLink } from '@trezor/blockchain-link';
 import type { FeeLevel } from '@trezor/connect-common';
-import coinsJSONEth from '@trezor/connect-data/files/coins-eth.json';
-import coinsJSON from '@trezor/connect-data/files/coins.json';
 
-import { getBitcoinNetwork, parseCoinsJson } from '../../../data/coinInfo';
+import { getBitcoinNetwork } from '../../../data/coinInfo';
 import { dispose, initBlockchain } from '../../BlockchainLink';
 import { BitcoinFeeLevels } from '../BitcoinFeeLevels';
 
@@ -35,9 +33,6 @@ const estimateFeeMockIncomplete: typeof BlockchainLink.prototype.estimateFee = p
     );
 
 describe('BitcoinFeeLevels', () => {
-    // load coin definitions
-    parseCoinsJson({ ...coinsJSON, ...coinsJSONEth });
-
     afterAll(() => {
         dispose();
         jest.clearAllMocks();

--- a/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/__tests__/EthereumFeeLevels.test.ts
@@ -1,14 +1,10 @@
 import { BlockchainLink } from '@trezor/blockchain-link';
-import coinsJSONEth from '@trezor/connect-data/files/coins-eth.json';
-import coinsJSON from '@trezor/connect-data/files/coins.json';
 
-import { getEthereumNetwork, parseCoinsJson } from '../../../data/coinInfo';
+import { getEthereumNetwork } from '../../../data/coinInfo';
 import { initBlockchain } from '../../BlockchainLink';
 import { EthereumFeeLevels } from '../EthereumFeeLevels';
 
 describe('api/ethereum/Fees', () => {
-    parseCoinsJson({ ...coinsJSON, ...coinsJSONEth });
-
     const ETH_REQUEST = { blocks: [1] };
 
     const ETH_EIP1559_RESPONSE = [

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -2,8 +2,6 @@
 
 import type { ConnectSettings, LocalFirmwares } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import coinsEth from '@trezor/connect-data/files/coins-eth.json';
-import coins from '@trezor/connect-data/files/coins.json';
 import type {
     ConditionalRelease,
     DeviceModelInternal,
@@ -13,7 +11,6 @@ import type {
     ReleasesConfig,
 } from '@trezor/device-utils';
 
-import { parseCoinsJson } from './coinInfo';
 import {
     getFirmwareReleaseConfig,
     getOnlyLocalFirmwareReleaseConfig,
@@ -53,11 +50,6 @@ export class DataManager {
         this.settings = settings;
 
         if (!withAssets) return;
-
-        parseCoinsJson({
-            ...coins,
-            ...coinsEth,
-        });
 
         const { config: localFirmwareReleaseConfig } = getOnlyLocalFirmwareReleaseConfig();
         this.localFirmwareReleaseConfig = localFirmwareReleaseConfig;

--- a/packages/connect/src/data/__tests__/coinInfo.test.ts
+++ b/packages/connect/src/data/__tests__/coinInfo.test.ts
@@ -1,12 +1,6 @@
-import coinsJSON from '@trezor/connect-data/files/coins.json';
-
-import { getAllNetworks, getCoinInfo, getUniqueNetworks, parseCoinsJson } from '../coinInfo';
+import { getAllNetworks, getCoinInfo, getUniqueNetworks } from '../coinInfo';
 
 describe('data/coinInfo', () => {
-    beforeAll(() => {
-        parseCoinsJson(coinsJSON);
-    });
-
     it('getUniqueNetworks', () => {
         const inputs = [
             getCoinInfo('btc'),

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -5,6 +5,8 @@ import type {
     MiscNetworkInfo,
 } from '@trezor/connect-common/src/types/coinInfo';
 import type { DerivationPath } from '@trezor/connect-common/src/types/params';
+import coinsEth from '@trezor/connect-data/files/coins-eth.json';
+import coins from '@trezor/connect-data/files/coins.json';
 import { cloneObject } from '@trezor/utils';
 
 import { getBitcoinFeeLevels, getEthereumFeeLevels, getMiscFeeLevels } from './defaultFeeLevels';
@@ -237,7 +239,7 @@ const parseMiscNetworksJSON = (json: any) => {
     });
 };
 
-export const parseCoinsJson = (json: any) => {
+const parseCoinsJson = (json: any) => {
     Object.keys(json).forEach(key => {
         switch (key) {
             case 'bitcoin':
@@ -259,3 +261,6 @@ export const getUniqueNetworks = <T extends { shortcut: string }>(networks: (T |
     }, []);
 
 export const getAllNetworks = () => [...bitcoinNetworks, ...ethereumNetworks, ...miscNetworks];
+
+// Populate the network registries from the bundled coin definitions on module load.
+parseCoinsJson({ ...coins, ...coinsEth });

--- a/packages/connect/src/utils/__fixtures__/accountUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/accountUtils.ts
@@ -1,18 +1,5 @@
-import coinsJSONEth from '@trezor/connect-data/files/coins-eth.json';
-import coinsJSON from '@trezor/connect-data/files/coins.json';
-
-import {
-    getBitcoinNetwork,
-    getEthereumNetwork,
-    getMiscNetwork,
-    parseCoinsJson,
-} from '../../data/coinInfo';
+import { getBitcoinNetwork, getEthereumNetwork, getMiscNetwork } from '../../data/coinInfo';
 import type { getAccountLabel, isUtxoBased } from '../accountUtils';
-
-parseCoinsJson({
-    ...coinsJSON,
-    ...coinsJSONEth,
-});
 
 export const getAccountLabelFixtures: TestFixtures<typeof getAccountLabel> = [
     {

--- a/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/ethereumUtils.ts
@@ -1,13 +1,5 @@
-import coinsJSONEth from '@trezor/connect-data/files/coins-eth.json';
-import coinsJSON from '@trezor/connect-data/files/coins.json';
-
-import { getEthereumNetwork, parseCoinsJson } from '../../data/coinInfo';
+import { getEthereumNetwork } from '../../data/coinInfo';
 import type { getNetworkLabel } from '../ethereumUtils';
-
-parseCoinsJson({
-    ...coinsJSON,
-    ...coinsJSONEth,
-});
 
 export const getNetworkLabelFixtures: TestFixtures<typeof getNetworkLabel> = [
     {

--- a/packages/connect/src/utils/__fixtures__/formatUtils.ts
+++ b/packages/connect/src/utils/__fixtures__/formatUtils.ts
@@ -1,9 +1,5 @@
-import coinsJSON from '@trezor/connect-data/files/coins.json';
-
-import { getBitcoinNetwork, parseCoinsJson } from '../../data/coinInfo';
+import { getBitcoinNetwork } from '../../data/coinInfo';
 import type { formatAmount } from '../formatUtils';
-
-parseCoinsJson(coinsJSON);
 
 export const formatAmountFixtures: TestFixtures<typeof formatAmount> = [
     {

--- a/packages/connect/src/utils/__tests__/addressUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/addressUtils.test.ts
@@ -1,15 +1,8 @@
-import coinsJSON from '@trezor/connect-data/files/coins.json';
-
-import { getBitcoinNetwork, parseCoinsJson } from '../../data/coinInfo';
+import { getBitcoinNetwork } from '../../data/coinInfo';
 import * as fixtures from '../__fixtures__/addressUtils';
 import * as utils from '../addressUtils';
 
 describe('utils/addressUtils', () => {
-    beforeAll(() => {
-        // load coin definitions
-        parseCoinsJson(coinsJSON);
-    });
-
     describe('isValidAddress', () => {
         fixtures.validAddresses.forEach(f => {
             it(`${f.description} ${f.address}`, () => {

--- a/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/deviceFeaturesUtils.test.ts
@@ -1,9 +1,7 @@
 import type { CoinInfo, Features } from '@trezor/connect-common';
-import coinsJSONEth from '@trezor/connect-data/files/coins-eth.json';
-import coinsJSON from '@trezor/connect-data/files/coins.json';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { getAllNetworks, parseCoinsJson } from '../../data/coinInfo';
+import { getAllNetworks } from '../../data/coinInfo';
 import {
     getUnavailableCapabilities,
     parseCapabilities,
@@ -26,12 +24,6 @@ const T1B1_UPDATE_REQUIRED = {
 describe('utils/deviceFeaturesUtils', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-    });
-    beforeAll(() => {
-        parseCoinsJson({
-            ...coinsJSON,
-            ...coinsJSONEth,
-        });
     });
 
     it('parseCapabilities', () => {
@@ -102,7 +94,9 @@ describe('utils/deviceFeaturesUtils', () => {
     });
 
     describe('getUnavailableCapabilities', () => {
-        const coins = getAllNetworks();
+        // Capability-only tests (T2T1 update-required / no-support below) intentionally
+        // run against an empty coin list so the assertion can isolate capability handling.
+        const coins: CoinInfo[] = [];
         beforeEach(() => {
             jest.resetModules();
         });


### PR DESCRIPTION
> **DataManager architecture refactor — Phase 1 of an ongoing series.**
>
> Open PRs in the series:
> 1. **#27106 (this PR)** — move `parseCoinsJson` out of `DataManager.load()`
> 2. #27157 — extract `FirmwareReleaseStore` from `DataManager`
> 3. #27209 — extract `LocalFirmwareStore` from `DataManager`
> 4. #27210 — replace `DataManager` with `settingsStore` and inline the load lifecycle (final)
>
> Built on top of the already-merged cleanup PRs (#27077, #27087, #27088). Phases 1 and 2 are independent of each other; phases 3 and 4 each cherry-pick the previous phases to avoid conflicts and rebase cleanly when those land.

## Summary

Coin definition parsing was a side-effect of `DataManager.load()`: it mutated module-level arrays in `coinInfo.ts` via `parseCoinsJson`, even though those arrays are `coinInfo`'s own concern and the JSON inputs are static imports from `@trezor/connect-data`.

Move the call into `coinInfo.ts` itself, where it runs once on module load, and drop the `coins` / `coinsEth` / `parseCoinsJson` plumbing from `DataManager`. `DataManager` no longer needs to know that coins exist.

`parseCoinsJson` is now an internal-only function (no longer exported). Several test files and fixtures used to call it themselves at top-level / `beforeAll`; those redundant calls and their JSON imports are removed in the same change.

## Compatibility

- `withAssets=false` on `DataManager.load(...)` previously skipped both coin parsing and firmware release config; it now skips only the firmware release config flow. No production caller passes `false`.

## Test plan

- [ ] CI typecheck passes for `@trezor/connect`
- [ ] CI unit tests for `@trezor/connect` remain green (init flow, fees, fw revision, address utils, etc. all exercise coin lookups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/parsecoins-out/web/](https://dev.suite.sldev.cz/suite-web/mroz22/parsecoins-out/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->