### PR TITLE
feat(utils): extend createDeferredManager to use UUID

### DIFF
--- a/packages/utils/src/createDeferredManager.ts
+++ b/packages/utils/src/createDeferredManager.ts
@@ -2,32 +2,34 @@ import { type TimerId } from '@trezor/type-utils';
 
 import { type Deferred, createDeferred } from './createDeferred';
 
-type ManagedDeferred<T> = Deferred<T, number> & { deadline: number };
+type ManagedDeferred<T, ID extends string | number> = Deferred<T, ID> & { deadline: number };
 
-type DeferredManagerOptions = {
+type DeferredManagerOptions<ID extends string | number = number> = {
     /** default timeout for promises without explicitly specified timeout */
     timeout?: number;
     /** callback which is called whenever a promise time out, with its id */
-    onTimeout?: (promiseId: number) => void;
-    /** from which id should the promises start (for specific use case, should be removed in the future) */
+    onTimeout?: (promiseId: ID) => void;
+    /** custom ID generator; when provided, replaces the default incrementing counter */
+    generateId?: () => ID;
+    /** from which id should the promises start; only used with the default numeric counter */
     initialId?: number;
 };
 
-type IdPromise<T> = { promiseId: number; promise: Promise<T> };
+type IdPromise<ID, T> = { promiseId: ID; promise: Promise<T> };
 
-export type DeferredManager<T> = {
+export type DeferredManager<T, ID extends string | number = number> = {
     /** How many pending promises are there */
     length: () => number;
     /** Creates new pending promise (with optional timeout) and returns it and its unique id */
-    create: (timeout?: number) => IdPromise<T>;
+    create: (timeout?: number) => IdPromise<ID, T>;
     /** Waits until there is less than `concurrency` promises and then creates a new one */
-    createConcurrent: (concurrency: number, timeout?: number) => Promise<IdPromise<T>>;
+    createConcurrent: (concurrency: number, timeout?: number) => Promise<IdPromise<ID, T>>;
     /** Resolves (and removes) promise with given id by given value and returns whether it was present or not */
-    resolve: (promiseId: number, value: T) => boolean;
+    resolve: (promiseId: ID, value: T) => boolean;
     /** Resolves (and removes) all pending promises by given value */
-    resolveAll: (getValue: (promiseId: number) => T) => void;
+    resolveAll: (getValue: (promiseId: ID) => T) => void;
     /** Rejects (and removes) promise with given id by given error and returns whether it was present or not */
-    reject: (promiseId: number, error: Error) => boolean;
+    reject: (promiseId: ID, error: Error) => boolean;
     /** Rejects (and removes) all pending promises by given error */
     rejectAll: (error: Error) => void;
 };
@@ -37,17 +39,19 @@ export type DeferredManager<T> = {
  * (usually requests), which can be resolved or rejected in a random order, or they can
  * time out
  *
- * @param options optional default timeout and onTimeout callback
+ * @param options optional default timeout, onTimeout callback, and custom ID generator
  *
  * @returns Deferred promise manager instance
  */
-export const createDeferredManager = <T = any>(
-    options?: DeferredManagerOptions,
-): DeferredManager<T> => {
-    const { initialId = 0, timeout: defaultTimeout = 0, onTimeout } = options ?? {};
-    const promises: ManagedDeferred<T>[] = [];
+export const createDeferredManager = <T = any, ID extends string | number = number>(
+    options?: DeferredManagerOptions<ID>,
+): DeferredManager<T, ID> => {
+    const { initialId = 0, timeout: defaultTimeout = 0, onTimeout, generateId } = options ?? {};
+    const promises: ManagedDeferred<T, ID>[] = [];
 
-    let ID = initialId;
+    let counter = initialId;
+    const getNextId: () => ID = generateId ?? (() => counter++ as unknown as ID);
+
     let timeoutHandle: TimerId | undefined;
     let onRemovePromise = createDeferred();
 
@@ -84,8 +88,8 @@ export const createDeferredManager = <T = any>(
     };
 
     const create = (timeout = defaultTimeout) => {
-        const promiseId = ID++;
-        const deferred = createDeferred<T, number>(promiseId);
+        const promiseId = getNextId();
+        const deferred = createDeferred<T, ID>(promiseId);
         const deadline = timeout && Date.now() + timeout;
         promises.push({ ...deferred, deadline });
         if (timeout) replanTimeout();
@@ -101,7 +105,7 @@ export const createDeferredManager = <T = any>(
         return create(timeout);
     };
 
-    const extract = (promiseId: number) => {
+    const extract = (promiseId: ID) => {
         const index = promises.findIndex(({ id }) => id === promiseId);
         const [promise] = index >= 0 ? promises.splice(index, 1) : [undefined];
         if (promise) onPromiseRemoved();
@@ -110,14 +114,14 @@ export const createDeferredManager = <T = any>(
         return promise;
     };
 
-    const resolve = (promiseId: number, value: T) => {
+    const resolve = (promiseId: ID, value: T) => {
         const promise = extract(promiseId);
         promise?.resolve(value);
 
         return !!promise;
     };
 
-    const resolveAll = (getValue: (promiseId: number) => T) => {
+    const resolveAll = (getValue: (promiseId: ID) => T) => {
         promises.forEach(promise => promise.resolve(getValue(promise.id)));
         const deleted = promises.splice(0, promises.length);
         if (deleted.length) {
@@ -126,7 +130,7 @@ export const createDeferredManager = <T = any>(
         }
     };
 
-    const reject = (promiseId: number, error: Error) => {
+    const reject = (promiseId: ID, error: Error) => {
         const promise = extract(promiseId);
         promise?.reject(error);
 

--- a/packages/utils/tests/createDeferredManager.test.ts
+++ b/packages/utils/tests/createDeferredManager.test.ts
@@ -50,6 +50,68 @@ describe('createDeferredManager', () => {
         expect(onTimeout).toHaveBeenNthCalledWith(3, second.promiseId);
     });
 
+    it('generateId — uses provided function instead of counter', async () => {
+        const ids = ['uuid-a', 'uuid-b', 'uuid-c'];
+        let callCount = 0;
+        const generateId = () => ids[callCount++];
+
+        const manager = createDeferredManager({ generateId });
+
+        const first = manager.create();
+        const second = manager.create();
+
+        expect(first.promiseId).toBe('uuid-a');
+        expect(second.promiseId).toBe('uuid-b');
+
+        setTimeout(() => manager.resolve('uuid-a', 'resolved-a'), 100);
+        jest.advanceTimersByTime(100);
+
+        await expect(first.promise).resolves.toBe('resolved-a');
+        expect(manager.length()).toBe(1);
+
+        manager.resolve('uuid-b', 'resolved-b');
+        await expect(second.promise).resolves.toBe('resolved-b');
+        expect(manager.length()).toBe(0);
+    });
+
+    it('generateId — onTimeout receives string id', () => {
+        const onTimeout = jest.fn();
+        let seq = 0;
+        const manager = createDeferredManager({
+            timeout: 200,
+            onTimeout,
+            generateId: () => `id-${++seq}`,
+        });
+
+        const first = manager.create();
+        const second = manager.create(100);
+
+        jest.advanceTimersByTime(150);
+
+        expect(onTimeout).toHaveBeenCalledTimes(1);
+        expect(onTimeout).toHaveBeenCalledWith('id-2');
+        expect(typeof second.promiseId).toBe('string');
+        expect(typeof first.promiseId).toBe('string');
+    });
+
+    it('generateId — works with crypto.randomUUID', async () => {
+        const manager = createDeferredManager({ generateId: () => crypto.randomUUID() });
+
+        const first = manager.create();
+        const second = manager.create();
+
+        expect(first.promiseId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+        expect(first.promiseId).not.toBe(second.promiseId);
+
+        manager.resolve(first.promiseId, 'ok');
+        manager.resolve(second.promiseId, 'ok2');
+
+        await expect(first.promise).resolves.toBe('ok');
+        await expect(second.promise).resolves.toBe('ok2');
+    });
+
     it('reject all but first', async () => {
         const onTimeout = jest.fn();
         const manager = createDeferredManager({


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Allowing to pass a function that will generate the UUID so it is flexible to work with different ways of generating IDs. The functions keeps working as before with 'number' counter if no 

Prerequesit for https://github.com/trezor/trezor-suite/issues/27037

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Related https://github.com/trezor/trezor-suite/issues/27037

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to `packages/utils/src/createDeferredManager.ts` (a utility) and its corresponding unit test file. The `createDeferredManager` utility maps to 121 E2E tests via static coverage, indicating it is a deeply shared, low-level dependency (broad global utility). The unit test file has no static E2E coverage, which is expected. Since the change is to a generic deferred/promise manager utility, none of the 121 E2E tests exercise this utility's behavior directly — they all transitively import it through many layers of abstraction. The LLM analysis of every mapped test confirms that none of them test deferred manager behavior, promise resolution patterns, or anything closely related to the changed utility's API surface. The unit test (`createDeferredManager.test.ts`) is the appropriate validation layer for this change. No E2E tests need to be run.

<details><summary><b>Changed files (2)</b></summary>

- `packages/utils/src/createDeferredManager.ts`
- `packages/utils/tests/createDeferredManager.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/utils/tests/createDeferredManager.test.ts`

_Updated: 2026-04-27T13:17:32.762Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/uuid-for-connect-call-response&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/uuid-for-connect-call-response&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T13:23:27.178Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T13:22:05.079Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/uuid-for-connect-call-response/web/](https://dev.suite.sldev.cz/suite-web/feat/uuid-for-connect-call-response/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->