### PR TITLE
fix(protobuf): bufbuild decode optional message fallback

### DIFF
--- a/packages/protobuf/src/manager.ts
+++ b/packages/protobuf/src/manager.ts
@@ -99,11 +99,12 @@ const patchFieldForDecode = (field: DescField, value: unknown) => {
 };
 
 const transformSchemaFields = (
+    operation: 'encode' | 'decode',
     schema: DescMessage,
     sourceData: Record<string, unknown> | undefined,
-    transformField: (field: DescField, value: unknown) => unknown,
 ) => {
     const transformedData: Record<string, unknown> = {};
+    const transformField = operation === 'encode' ? patchFieldForEncode : patchFieldForDecode;
 
     schema.fields.forEach(schemaField => {
         const fieldValue = sourceData?.[schemaField.name];
@@ -114,9 +115,9 @@ const transformSchemaFields = (
             } else if (schemaField.listKind === 'message') {
                 transformedData[schemaField.name] = fieldValue.map(item =>
                     transformSchemaFields(
+                        operation,
                         schemaField.message,
                         item as Record<string, unknown> | undefined,
-                        transformField,
                     ),
                 );
             } else if (schemaField.listKind === 'scalar') {
@@ -127,13 +128,16 @@ const transformSchemaFields = (
                 transformedData[schemaField.name] = fieldValue; // enum
             }
         } else if (schemaField.fieldKind === 'message') {
-            transformedData[schemaField.name] = fieldValue
-                ? transformSchemaFields(
-                      schemaField.message,
-                      fieldValue as Record<string, unknown>,
-                      transformField,
-                  )
-                : undefined;
+            if (!fieldValue) {
+                // [compatibility]: protobufjs decode returns {} for absent optional message fields.
+                transformedData[schemaField.name] = operation === 'decode' ? {} : undefined;
+            } else {
+                transformedData[schemaField.name] = transformSchemaFields(
+                    operation,
+                    schemaField.message,
+                    fieldValue as Record<string, unknown>,
+                );
+            }
         } else if (schemaField.fieldKind === 'scalar') {
             transformedData[schemaField.name] = transformField(schemaField, fieldValue);
         } else if (schemaField.fieldKind === 'enum') {
@@ -264,7 +268,7 @@ export const ProtobufManager = () => {
     const encode = (messageName: string, data: Record<string, unknown>) => {
         const { schema, messageType } = findSchema(messageName);
 
-        const normalizedPayload = transformSchemaFields(schema, data, patchFieldForEncode);
+        const normalizedPayload = transformSchemaFields('encode', schema, data);
         const messageJson = fromJson(schema, normalizedPayload as Parameters<typeof fromJson>[1]);
         const encodedBytes = toBinary(schema, messageJson);
 
@@ -288,11 +292,7 @@ export const ProtobufManager = () => {
 
         const decoded = fromBinary(schema, patchedPayload, { readUnknownFields: false }); // , { readUnknownFields: true }
         const json = toJson(schema, decoded, { useProtoFieldName: true });
-        const message = transformSchemaFields(
-            schema,
-            json as Record<string, unknown>,
-            patchFieldForDecode,
-        );
+        const message = transformSchemaFields('decode', schema, json as Record<string, unknown>);
 
         return {
             type: messageName,

--- a/packages/protobuf/tests/bufbuild-comprehensive.test.ts
+++ b/packages/protobuf/tests/bufbuild-comprehensive.test.ts
@@ -507,6 +507,58 @@ describe('ProtobufManager comprehensive tests', () => {
         });
     });
 
+    describe('TxRequest with undefined optional fields', () => {
+        const messageName = 'TxRequest';
+
+        const cases = [
+            {
+                description: 'encodes with all fields undefined',
+                data: {},
+            },
+            {
+                description: 'encodes with only request_type',
+                data: { request_type: 0 },
+            },
+            {
+                description: 'encodes with details but no serialized',
+                data: {
+                    request_type: 0,
+                    details: { request_index: 0 },
+                },
+            },
+            {
+                description: 'encodes with serialized but no details',
+                data: {
+                    request_type: 0,
+                    serialized: { serialized_tx: 'deadbeef' },
+                },
+            },
+            {
+                description: 'encodes with empty nested messages',
+                data: {
+                    request_type: 0,
+                    details: {},
+                    serialized: {},
+                },
+            },
+        ];
+
+        cases.forEach(({ description, data }) => {
+            it(`${description}`, () => {
+                const newResult = protobufManager.encode(messageName, data);
+                const oldResult = encodeProtobufJs(lookupType(messageName), data);
+
+                expect(newResult.message.compare(oldResult)).toEqual(0);
+
+                const decoded = protobufManager.decode(messageName, newResult.message);
+
+                const decoded1 = decodeProtobufJs(lookupType(messageName), newResult.message);
+                //expect(decoded.message).toEqual(data);
+                expect(decoded1).toEqual(decoded.message);
+            });
+        });
+    });
+
     describe('error handling', () => {
         it('throws error for unknown message type on encode', () => {
             expect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Should fix issue with bufbuid vs protobufjs `decode` reported in sentry:

https://satoshilabs.sentry.io/issues/7419117101/?project=5193825

if `TxRequest.details` is not present (they are marked as optional in the proto file) then:
- `protobufjs` returns empty object: `TxRequest { details: {} }`
- `bufbuild` returns undefined object: `TxRequest { details: undefined }`

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes involve `packages/protobuf/src/manager.ts` and a unit test file `packages/protobuf/tests/bufbuild-comprehensive.test.ts`. The `manager.ts` file maps to 121 E2E tests, making it a broad global utility (protobuf message management used across the entire Suite). However, none of the LLM-analyzed E2E tests mention protobuf, message encoding/decoding, or the protobuf manager in their source hints or behaviors — they all interact with higher-level UI flows. The unit test file has no static E2E coverage mapping, which is expected since it's a unit test for the protobuf package itself. Without evidence that any specific E2E test's behavior would be directly affected by protobuf manager changes (as opposed to catastrophic breakage that would affect all tests equally), no targeted E2E tests can be recommended with confidence. If the protobuf changes are breaking, virtually any test involving device communication would fail, but that scenario is better caught by the package's own unit tests and a single smoke test from CI rather than by running specific E2E tests.

<details><summary><b>Changed files (2)</b></summary>

- `packages/protobuf/src/manager.ts`
- `packages/protobuf/tests/bufbuild-comprehensive.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/protobuf/tests/bufbuild-comprehensive.test.ts`

_Updated: 2026-04-27T13:19:06.885Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/bufbuild-decode-absent-message&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/bufbuild-decode-absent-message&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T13:24:58.085Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T13:23:53.054Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/bufbuild-decode-absent-message/web/](https://dev.suite.sldev.cz/suite-web/fix/bufbuild-decode-absent-message/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->