### PR TITLE
chore(connect): tighten method/capability types in connect

### DIFF
--- a/packages/connect/src/api/common/paramsValidator.ts
+++ b/packages/connect/src/api/common/paramsValidator.ts
@@ -1,7 +1,9 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/helpers/paramsValidator.js
 import type {
+    CallMethodKeys,
     CoinInfo,
     FirmwareBoundary,
+    FirmwareCapability,
     FirmwareRange,
     FirmwareRule,
 } from '@trezor/connect-common';
@@ -10,6 +12,8 @@ import { typedObjectTransformValues, versionUtils } from '@trezor/utils';
 
 import { config } from '../../data/config';
 import { fromHardened } from '../../utils/pathUtils';
+
+type MethodOrCapability = CallMethodKeys | FirmwareCapability;
 
 type ParamType = 'string' | 'number' | 'array' | 'array-buffer' | 'boolean' | 'uint' | 'object';
 
@@ -147,8 +151,8 @@ const filterByCoins = (coins: CoinInfo[]) => {
         ensureArray(rule.coinType).some(coinTypeSet.has.bind(coinTypeSet));
 };
 
-const filterByMethods = (methodsOrCapabilities: string[]) => {
-    const methodSet = new Set(methodsOrCapabilities);
+const filterByMethods = (methodsOrCapabilities: MethodOrCapability[]) => {
+    const methodSet: Set<string> = new Set(methodsOrCapabilities);
 
     return (rule: FirmwareRule) =>
         (!rule.methods && !rule.capabilities) ||
@@ -166,7 +170,7 @@ const getCoinRules = (coins: CoinInfo[], currentRange: FirmwareRange): FirmwareR
     }));
 
 const getConfigRules = (
-    methodsOrCapabilities: string[],
+    methodsOrCapabilities: MethodOrCapability[],
     coins: CoinInfo[],
     currentRange: FirmwareRange,
 ): FirmwareRange[] =>
@@ -181,7 +185,7 @@ const getConfigRules = (
         );
 
 export const getFirmwareRange = (
-    methodsOrCapabilities: string[],
+    methodsOrCapabilities: MethodOrCapability[],
     coins: CoinInfo[],
     currentRange = DEFAULT_FIRMWARE_RANGE,
 ) =>

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -5,6 +5,7 @@ import type {
     CoinInfo,
     CoreEventMessage,
     DeviceState,
+    FirmwareCapability,
     PrecomposeResultFinal,
     StaticSessionId,
     UiRequestButtonData,
@@ -143,7 +144,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     public allowDeviceMode: DeviceMode[]; // used in device management (like ResetDevice allow !UI_REQUEST.INITIALIZED)
 
     protected requiredDeviceCapabilities: Capability[] = [];
-    protected requiredFirmwareCapabilities: string[] = [];
+    protected requiredFirmwareCapabilities: FirmwareCapability[] = [];
     protected requiredFirmwareCoins: (CoinInfo | undefined)[] = [];
 
     public useCardanoDerivation: boolean;


### PR DESCRIPTION
## Summary

Builds on #27070 (`FirmwareCapability` literal union in connect-common). Two small, independent type tightenings:

1. **`AbstractMethod.requiredFirmwareCapabilities: FirmwareCapability[]`** (was `string[]`). Catches typos at the three assignment sites (`signMessage`, `ethereumSignTransaction`, `ethereumSignTypedData`).
2. **`paramsValidator.getFirmwareRange` / `filterByMethods`** take `(CallMethodKeys | FirmwareCapability)[]` so the call site in `AbstractMethod` is fully typed end-to-end. Internal `Set<string>` annotation keeps interaction with `FirmwareRule.methods: string[]` clean.

## Notes

`methods` in `FirmwareRule` stays `string[]` — tightening it to `CallMethodKeys[]` would require pulling connect API types into connect-common (wrong dep direction).

`firmwareReleaseConfigAssets as any` in `assetUtils.ts` was originally bundled in this PR but the cast hides a real type-shape mismatch (JSON literal types do not match `FirmwareReleaseConfig`'s literal unions). Will be addressed as a follow-up via runtime validation rather than another cast.

## Related

Part of the connect type-hardening series:
- #27070 — parent PR (merged): `FirmwareCapability` literal union
- #27128 — follow-up: drop `any` in `pathUtils.validatePath` and Cardano `typedCall` helpers

## Test plan

- [x] `yarn workspace @trezor/connect type-check` passes
- [x] `yarn workspace @trezor/connect-common type-check` passes
- [x] `yarn workspace @trezor/suite type-check` shows no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/fw-capability-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->