### PR TITLE
feat(connect-cli): add get-featues and apply-settings

### DIFF
--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -22,7 +22,10 @@ export const HELP = `@trezor/connect CLI arguments:
     --pairing=code | qr | nfc | skip
 
   Passphrase
-    --passphrase=<value>                      Use passphrase (default: empty)
+    --passphrase=<value>                      Use passphrase value (default: empty string)
+    --passphrase-on-device                    Enter passphrase on device instead of host
+    --cancel-passphrase                       Cancel the call when passphrase is requested
+    --cancel-passphrase-ui                    Respond with missing payload (tests error handling)
 
   Method (default: GetAddress)
     --method=<name>                           Run TrezorConnect method
@@ -31,6 +34,10 @@ export const HELP = `@trezor/connect CLI arguments:
                                                 --method=get-credentials
                                                 --method=get-account-info
                                                 --method=get-account-descriptor
+                                                --method=get-features
+                                                --method=apply-settings
+    --params=<json>                           Extra params passed to the method (JSON object)
+                                                --params='{"use_passphrase": true}'
 `;
 
 // read and parse application arguments

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -101,29 +101,40 @@ const runTestCase = async (device: Device) => {
         process.exit(1);
     }
 
-    // device is ready, start workflow
+    const params = args.params ? JSON.parse(args.params) : {};
+
     let result;
-    if (method === 'fw-update') {
-        result = await fwUpdate(device);
-    } else if (method === 'get-credentials') {
-        result = await TrezorConnect.thpGetCredentials({ device });
-    } else if (method === 'get-account-info') {
-        result = await TrezorConnect.getAccountInfo({
-            device,
-            coin: 'btc',
-            path: "m/84'/0'/0'",
-        });
-    } else if (method === 'get-account-descriptor') {
-        result = await TrezorConnect.getAccountDescriptor({
-            device,
-            coin: 'btc',
-            path: "m/84'/0'/0'",
-        });
-    } else {
-        result = await TrezorConnect.getAddress({
-            device,
-            path: "m/44'/0'/0'/0/0",
-        });
+    switch (method) {
+        case 'fw-update':
+            result = await fwUpdate(device);
+            break;
+        case 'get-credentials':
+            result = await TrezorConnect.thpGetCredentials({ device });
+            break;
+        case 'get-account-info':
+            result = await TrezorConnect.getAccountInfo({
+                device,
+                coin: 'btc',
+                path: "m/84'/0'/0'",
+                ...params,
+            });
+            break;
+        case 'get-account-descriptor':
+            result = await TrezorConnect.getAccountDescriptor({
+                device,
+                coin: 'btc',
+                path: "m/84'/0'/0'",
+                ...params,
+            });
+            break;
+        case 'get-features':
+            result = await TrezorConnect.getFeatures({ device, ...params });
+            break;
+        case 'apply-settings':
+            result = await TrezorConnect.applySettings({ device, ...params });
+            break;
+        default:
+            result = await TrezorConnect.getAddress({ device, path: "m/44'/0'/0'/0/0", ...params });
     }
 
     console.warn(result);
@@ -198,6 +209,7 @@ const run = async () => {
             return TrezorConnect.uiResponse({
                 type: 'ui-receive_confirmation',
                 payload: true,
+                requestId: event.requestId,
             });
         }
 
@@ -210,6 +222,7 @@ const run = async () => {
                 // @ts-expect-error
                 return TrezorConnect.uiResponse({
                     type: 'ui-receive_passphrase',
+                    requestId: event.requestId,
                 });
             }
 
@@ -217,6 +230,7 @@ const run = async () => {
             TrezorConnect.uiResponse({
                 type: 'ui-receive_passphrase',
                 payload: { value, passphraseOnDevice: args['passphrase-on-device'] },
+                requestId: event.requestId,
             });
         }
 
@@ -226,6 +240,7 @@ const run = async () => {
                 TrezorConnect.uiResponse({
                     type: 'ui-receive_thp_pairing_tag',
                     payload: { tag },
+                    requestId: event.requestId,
                 });
             } else {
                 return TrezorConnect.cancel();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add apply features and get-features to connect-cli
It also add requestId to the uiResponse.

I am thinking in ways to improve this connect-cli I find it extremely useful.

## Notes for QA

You could test setting passphrase in device and disableing it by:

```
yarn workspace @trezor/connect-cli cli --method=apply-settings --params='{"use_passphrase": false}'
```

And getting features like:

```
yarn workspace @trezor/connect-cli cli --method=get-features
```


Related https://github.com/trezor/trezor-suite/issues/27037

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/extend-connect-cli/web/](https://dev.suite.sldev.cz/suite-web/feat/extend-connect-cli/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/extend-connect-cli&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 24 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T15:02:14.672Z • 24 test(s) total_
<!-- QUARANTINE-LIST:web:END -->