### PR TITLE
fix(suite): Fix tests for empty state

### DIFF
--- a/suite/e2e/tests/settings/coins.test.ts
+++ b/suite/e2e/tests/settings/coins.test.ts
@@ -21,8 +21,8 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 stream: TestStream.Foundation,
             }),
         },
-        async ({ dashboardPage, settingsPage }) => {
-            const defaultUnchecked: NetworkSymbol[] = [
+        async ({ dashboardPage, settingsPage, assetsSection }) => {
+            const defaultUncheckedMainnet: NetworkSymbol[] = [
                 'btc',
                 'ltc',
                 'eth',
@@ -34,6 +34,9 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 'zec',
                 'ada',
                 'sol',
+            ];
+            // Testnets are not shown in ActivateAssetsModal, must be enabled via coins settings
+            const defaultUncheckedTestnet: NetworkSymbol[] = [
                 'test',
                 'tsep',
                 'thod',
@@ -41,8 +44,12 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 // 'txlm', add when removed from experimental features
                 'dsol',
             ];
+            const defaultUnchecked: NetworkSymbol[] = [
+                ...defaultUncheckedMainnet,
+                ...defaultUncheckedTestnet,
+            ];
 
-            await test.step('No assets are active', async () => {
+            await test.step('Empty state on dashboard', async () => {
                 await settingsPage.toggleTestnetNetworks();
                 await settingsPage.navigateTo('coins');
 
@@ -52,24 +59,26 @@ test.describe('Coin Settings', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
                 // check dashboard with all coins disabled
                 await dashboardPage.navigateTo();
                 await expect(dashboardPage.discoveryEmptyHeader).toHaveTranslation(
-                    'TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY',
+                    'TR_YOUR_WALLET_IS_READY_WHAT',
                 );
                 await expect(dashboardPage.discoveryEmptyDesc).toHaveTranslation(
-                    'TR_ACCOUNT_EXCEPTION_DISCOVERY_EMPTY_DESC',
+                    'TR_DASHBOARD_ACTIVATE_ASSETS_DESC',
                 );
                 await expect(dashboardPage.discoveryEmptyPrimaryButton).toHaveTranslation(
-                    'TR_COIN_SETTINGS',
+                    'TR_DASHBOARD_GET_STARTED',
                 );
             });
 
             await test.step('Activate assets', async () => {
                 await dashboardPage.discoveryEmptyPrimaryButton.click();
+                for (const network of defaultUncheckedMainnet) {
+                    await assetsSection.activateAssetsModalNetworkButton(network).click();
+                }
+                await assetsSection.activateAssetsModalSaveButton.click();
                 await settingsPage.navigateTo('coins');
-                for (const network of defaultUnchecked) {
+                await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
+                for (const network of defaultUncheckedTestnet) {
                     await settingsPage.coinsTab.enableNetwork(network);
-                    if (network === 'ada') {
-                        await settingsPage.coinsTab.temporarilySetOfficialCardanoBackend();
-                    }
                 }
             });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the coins.test.ts E2E test itself, so the primary risk is that test modifications introduced regressions or failures in the test. Running the changed test at high priority is essential. A few closely related tests that share the same Settings > Coins tab UI and coin enable/disable/discovery workflows should be run at medium priority to ensure no shared page object or infrastructure changes cause collateral breakage.

<details><summary><b>Changed files (1)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This is the directly changed file itself. It is an E2E test file, so it should be run to verify the test modifications work correctly and pass.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test exercises the same Settings > Coins tab UI (settingsPage.coinsTab) with network enable/disable and custom backend configuration. Changes to the coins test may reflect UI or behavioral changes in the coins settings page that could affect this closely related test.
- `suite/e2e/tests/dashboard/assets.test.ts` — The coins.test.ts exercises enabling/disabling networks and verifying dashboard empty discovery state. The assets test also enables networks (LTC) via settingsPage.coinsTab and verifies dashboard asset display, sharing the same coin settings and discovery infrastructure.
- `suite/e2e/tests/wallet/discovery.test.ts` — The coins test validates coin activation, discovery empty states, and testnet toggling. The discovery test activates multiple coins from the same coins tab and validates discovery completion, sharing the same entry points and coin activation workflows.

</details>

_Updated: 2026-04-27T15:23:21.302Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-tests-for-empty-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-tests-for-empty-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 24 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T15:28:54.762Z • 24 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Send Eth > User can initiate ethereum sending | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T15:28:17.246Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-tests-for-empty-state/web/](https://dev.suite.sldev.cz/suite-web/fix-tests-for-empty-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->