### PR TITLE
feat(suite): Add move & resize menu

### DIFF
--- a/packages/suite-desktop-core/src/libs/menu.ts
+++ b/packages/suite-desktop-core/src/libs/menu.ts
@@ -4,6 +4,13 @@ import { isDevEnv } from '@suite-common/suite-utils';
 
 import { restartApp } from './app-utils';
 import type { MainWindowProxy } from './main-window-proxy';
+import {
+    WindowTile,
+    centerWindow,
+    restorePreviousWindowBounds,
+    tileWindow,
+    toggleWindowFullScreen,
+} from './window-tiling';
 
 const isMac = process.platform === 'darwin';
 
@@ -99,6 +106,131 @@ export const buildMainMenu = (mainWindowProxy: MainWindowProxy) => {
         // Extend "Window"
         mainMenuTemplate[3].submenu.push(
             { type: 'separator' },
+            {
+                label: 'Fill',
+                accelerator: 'Ctrl+Alt+F',
+                click: () => {
+                    const win = mainWindowProxy.getInstance();
+                    if (!win) return;
+                    tileWindow({ win, tile: WindowTile.FullScreen });
+                },
+            },
+            {
+                label: 'Center',
+                accelerator: 'Ctrl+Alt+C',
+                click: () => {
+                    const win = mainWindowProxy.getInstance();
+                    if (!win) return;
+                    centerWindow(win);
+                },
+            },
+            {
+                label: 'Full Screen',
+                accelerator: 'Ctrl+Alt+Return',
+                click: () => {
+                    const win = mainWindowProxy.getInstance();
+                    if (!win) return;
+                    toggleWindowFullScreen(win);
+                },
+            },
+            { type: 'separator' },
+            {
+                // Electron uses '&' for mnemonics on some platforms; '&&' keeps a literal '&'
+                label: 'Move && Resize',
+                submenu: [
+                    {
+                        label: 'Halves',
+                        enabled: false,
+                    },
+                    {
+                        label: 'Left',
+                        accelerator: 'Ctrl+Alt+Left',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.LeftHalf });
+                        },
+                    },
+                    {
+                        label: 'Right',
+                        accelerator: 'Ctrl+Alt+Right',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.RightHalf });
+                        },
+                    },
+                    {
+                        label: 'Top',
+                        accelerator: 'Ctrl+Alt+Up',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.TopHalf });
+                        },
+                    },
+                    {
+                        label: 'Bottom',
+                        accelerator: 'Ctrl+Alt+Down',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.BottomHalf });
+                        },
+                    },
+                    { type: 'separator' },
+                    {
+                        label: 'Quarters',
+                        enabled: false,
+                    },
+                    {
+                        label: 'Top Left',
+                        accelerator: 'Ctrl+Alt+1',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.TopLeftQuarter });
+                        },
+                    },
+                    {
+                        label: 'Top Right',
+                        accelerator: 'Ctrl+Alt+2',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.TopRightQuarter });
+                        },
+                    },
+                    {
+                        label: 'Bottom Left',
+                        accelerator: 'Ctrl+Alt+3',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.BottomLeftQuarter });
+                        },
+                    },
+                    {
+                        label: 'Bottom Right',
+                        accelerator: 'Ctrl+Alt+4',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            tileWindow({ win, tile: WindowTile.BottomRightQuarter });
+                        },
+                    },
+                    { type: 'separator' },
+                    {
+                        label: 'Return to Previous Size',
+                        accelerator: 'Ctrl+Alt+R',
+                        click: () => {
+                            const win = mainWindowProxy.getInstance();
+                            if (!win) return;
+                            restorePreviousWindowBounds(win);
+                        },
+                    },
+                ],
+            },
             { role: 'front' },
             { type: 'separator' },
             { role: 'window' },

--- a/packages/suite-desktop-core/src/libs/window-tiling.ts
+++ b/packages/suite-desktop-core/src/libs/window-tiling.ts
@@ -1,0 +1,185 @@
+import { screen } from 'electron';
+
+import { exhaustive } from '@trezor/type-utils';
+
+import type { StrictBrowserWindow } from '../typed-electron';
+
+export const WindowTile = {
+    LeftHalf: 'LeftHalf',
+    RightHalf: 'RightHalf',
+    TopHalf: 'TopHalf',
+    BottomHalf: 'BottomHalf',
+    FullScreen: 'FullScreen',
+    TopLeftQuarter: 'TopLeftQuarter',
+    TopRightQuarter: 'TopRightQuarter',
+    BottomLeftQuarter: 'BottomLeftQuarter',
+    BottomRightQuarter: 'BottomRightQuarter',
+} as const;
+
+export type WindowTile = (typeof WindowTile)[keyof typeof WindowTile];
+
+const previousBoundsByWindowId = new Map<number, Electron.Rectangle>();
+
+const getWorkAreaForWindow = (win: StrictBrowserWindow) => {
+    const windowBounds = win.getBounds();
+    const display = screen.getDisplayMatching(windowBounds);
+
+    return display.workArea;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const getTiledBounds = ({
+    win,
+    tile,
+}: {
+    win: StrictBrowserWindow;
+    tile: WindowTile;
+}): Electron.Rectangle => {
+    const workArea = getWorkAreaForWindow(win);
+    const [minWidth, minHeight] = win.getMinimumSize();
+
+    const halfWidth = Math.floor(workArea.width / 2);
+    const halfHeight = Math.floor(workArea.height / 2);
+
+    const maxWidth = workArea.width;
+    const maxHeight = workArea.height;
+
+    const widthHalf = clamp(halfWidth, minWidth, maxWidth);
+    const heightHalf = clamp(halfHeight, minHeight, maxHeight);
+
+    const widthFull = clamp(workArea.width, minWidth, maxWidth);
+    const heightFull = clamp(workArea.height, minHeight, maxHeight);
+
+    switch (tile) {
+        case WindowTile.LeftHalf:
+            return { x: workArea.x, y: workArea.y, width: widthHalf, height: heightFull };
+        case WindowTile.RightHalf:
+            return {
+                x: workArea.x + (workArea.width - widthHalf),
+                y: workArea.y,
+                width: widthHalf,
+                height: heightFull,
+            };
+        case WindowTile.TopHalf:
+            return { x: workArea.x, y: workArea.y, width: widthFull, height: heightHalf };
+        case WindowTile.BottomHalf:
+            return {
+                x: workArea.x,
+                y: workArea.y + (workArea.height - heightHalf),
+                width: widthFull,
+                height: heightHalf,
+            };
+        case WindowTile.FullScreen:
+            return { x: workArea.x, y: workArea.y, width: widthFull, height: heightFull };
+        case WindowTile.TopLeftQuarter:
+            return { x: workArea.x, y: workArea.y, width: widthHalf, height: heightHalf };
+        case WindowTile.TopRightQuarter:
+            return {
+                x: workArea.x + (workArea.width - widthHalf),
+                y: workArea.y,
+                width: widthHalf,
+                height: heightHalf,
+            };
+        case WindowTile.BottomLeftQuarter:
+            return {
+                x: workArea.x,
+                y: workArea.y + (workArea.height - heightHalf),
+                width: widthHalf,
+                height: heightHalf,
+            };
+        case WindowTile.BottomRightQuarter:
+            return {
+                x: workArea.x + (workArea.width - widthHalf),
+                y: workArea.y + (workArea.height - heightHalf),
+                width: widthHalf,
+                height: heightHalf,
+            };
+        default:
+            return exhaustive(tile);
+    }
+};
+
+export const tileWindow = ({ win, tile }: { win: StrictBrowserWindow; tile: WindowTile }) => {
+    if (win.isDestroyed()) {
+        return;
+    }
+
+    // Make the bounds deterministic; tiling a maximized/fullscreen window can be flaky.
+    if (win.isFullScreen()) {
+        win.setFullScreen(false);
+    }
+    if (win.isMaximized()) {
+        win.unmaximize();
+    }
+
+    const currentBounds = win.getBounds();
+    previousBoundsByWindowId.set(win.id, currentBounds);
+
+    const nextBounds = getTiledBounds({ win, tile });
+    win.setBounds(nextBounds, true);
+};
+
+export const restorePreviousWindowBounds = (win: StrictBrowserWindow) => {
+    if (win.isDestroyed()) {
+        return;
+    }
+
+    const previousBounds = previousBoundsByWindowId.get(win.id);
+    if (!previousBounds) {
+        return;
+    }
+
+    if (win.isFullScreen()) {
+        win.setFullScreen(false);
+    }
+    if (win.isMaximized()) {
+        win.unmaximize();
+    }
+
+    win.setBounds(previousBounds, true);
+};
+
+export const hasPreviousWindowBounds = (win: StrictBrowserWindow) =>
+    previousBoundsByWindowId.has(win.id);
+
+export const centerWindow = (win: StrictBrowserWindow) => {
+    if (win.isDestroyed()) {
+        return;
+    }
+
+    if (win.isFullScreen()) {
+        win.setFullScreen(false);
+    }
+    if (win.isMaximized()) {
+        win.unmaximize();
+    }
+
+    const workArea = getWorkAreaForWindow(win);
+    const currentBounds = win.getBounds();
+
+    const x = workArea.x + Math.floor((workArea.width - currentBounds.width) / 2);
+    const y = workArea.y + Math.floor((workArea.height - currentBounds.height) / 2);
+
+    win.setBounds(
+        {
+            ...currentBounds,
+            x,
+            y,
+        },
+        true,
+    );
+};
+
+export const toggleWindowFullScreen = (win: StrictBrowserWindow) => {
+    if (win.isDestroyed()) {
+        return;
+    }
+
+    const shouldEnterFullScreen = !win.isFullScreen();
+    if (shouldEnterFullScreen && win.isMaximized()) {
+        win.unmaximize();
+    }
+
+    win.setFullScreen(shouldEnterFullScreen);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- adds fullscreen, center and fill to app menu
- adds move & resize menu to app menu
- unfortunately we can't use global/fn shortcut, so we use different shortcuts than users are used to use across the system


## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<img width="932" height="940" alt="image" src="https://github.com/user-attachments/assets/f7333fe1-8e17-4a27-b8ec-ae5f9e973c78" />


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to two desktop-core library files: menu.ts (application menu configuration) and window-tiling.ts (window tiling/positioning logic). These are Electron-specific modules with no static test coverage mappings. The risk is low-to-moderate since these affect desktop app chrome (menus, window layout) rather than core business logic. The only tests that exercise Electron app lifecycle (window creation, titles, initialization) are the bridge/spawn tests, which are recommended at medium priority. Most E2E tests run in browser contexts where these desktop-specific modules are not loaded.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/libs/menu.ts`
- `packages/suite-desktop-core/src/libs/window-tiling.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `../../suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test exercises the Electron app lifecycle including window management and bridge spawning. Changes to menu.ts (application menu) and window-tiling.ts (window positioning/tiling) could affect Electron window initialization, title display, and app lifecycle behavior tested here.
- `../../suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches multiple Electron app instances and verifies window titles and initialization. Changes to window-tiling.ts could affect window positioning on launch, and menu.ts changes could affect app initialization in daemon vs UI mode.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/libs/menu.ts`
- `packages/suite-desktop-core/src/libs/window-tiling.ts`

_Updated: 2026-04-27T16:26:35.235Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-move-resize-menu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-move-resize-menu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 24 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Trading - Sell inputs,Sell form % inputs and limits" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-27T16:31:55.046Z • 24 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Send Eth > User can initiate ethereum sending | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-27T16:31:05.402Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-move-resize-menu/web/](https://dev.suite.sldev.cz/suite-web/add-move-resize-menu/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->