### PR TITLE
chore(connect): drop any in pathUtils and Cardano typedCall helpers

### DIFF
--- a/packages/connect/src/api/cardano/cardanoOutputs.ts
+++ b/packages/connect/src/api/cardano/cardanoOutputs.ts
@@ -4,6 +4,7 @@
 
 import { CardanoAddressParameters, CardanoAssetGroup } from '@trezor/connect-common';
 import type { PROTO } from '@trezor/connect-common';
+import type { MessagesSchema as Messages } from '@trezor/protobuf';
 import { Assert, Type } from '@trezor/schema-utils';
 
 import { addressParametersToProto, validateAddressParameters } from './cardanoAddressParameters';
@@ -66,7 +67,7 @@ export const transformOutput = (output: unknown): OutputWithData => {
     return result;
 };
 
-export const sendOutput = async (typedCall: any, outputWithData: OutputWithData) => {
+export const sendOutput = async (typedCall: Messages.TypedCall, outputWithData: OutputWithData) => {
     const MAX_CHUNK_SIZE = 1024 * 2; // 1024 hex-encoded bytes
 
     const { output, tokenBundle, inlineDatum, referenceScript } = outputWithData;

--- a/packages/connect/src/api/cardano/cardanoUtils.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.ts
@@ -126,11 +126,11 @@ export const composeTxPlan = (
 export const hexStringByteLength = (s: string) => s.length / 2;
 
 export const sendChunkedHexString = async (
-    typedCall: any,
+    typedCall: PROTO.TypedCall,
     data: string,
     chunkSize: number,
-    messageType: string,
-    responseType = 'CardanoTxItemAck',
+    messageType: PROTO.MessageKey,
+    responseType: PROTO.MessageKey = 'CardanoTxItemAck',
 ) => {
     let processedSize = 0;
     while (processedSize < data.length) {

--- a/packages/connect/src/utils/__tests__/pathUtils.test.ts
+++ b/packages/connect/src/utils/__tests__/pathUtils.test.ts
@@ -1,4 +1,11 @@
-import { getAccountType, getHDPath, getOutputScriptType, getScriptType } from '../pathUtils';
+import {
+    getAccountType,
+    getHDPath,
+    getOutputScriptType,
+    getScriptType,
+    toHardened,
+    validatePath,
+} from '../pathUtils';
 
 describe('utils/pathUtils', () => {
     it('getScriptType', () => {
@@ -49,5 +56,60 @@ describe('utils/pathUtils', () => {
         expect(getAccountType([])).toEqual('p2pkh');
         expect(getAccountType([0])).toEqual('p2pkh');
         expect(getAccountType(undefined)).toEqual('p2pkh');
+    });
+
+    describe('validatePath', () => {
+        it('parses string path with hardened apostrophe', () => {
+            expect(validatePath("m/44'/0'/0'")).toEqual([
+                toHardened(44),
+                toHardened(0),
+                toHardened(0),
+            ]);
+            expect(validatePath("m/44'/0'/0'/0/0")).toEqual([
+                toHardened(44),
+                toHardened(0),
+                toHardened(0),
+                0,
+                0,
+            ]);
+        });
+
+        it('passes number[] path through unchanged', () => {
+            const path = [toHardened(44), toHardened(0), toHardened(0), 0, 0];
+            expect(validatePath(path)).toEqual(path);
+        });
+
+        it('returns empty array for "m" or []', () => {
+            expect(validatePath('m')).toEqual([]);
+            expect(validatePath([])).toEqual([]);
+        });
+
+        it('throws for malformed string path', () => {
+            expect(() => validatePath('not-a-path')).toThrow(/Not a valid path/);
+            expect(() => validatePath("m/abc'")).toThrow(/Not a valid path/);
+        });
+
+        it('throws for negative values', () => {
+            expect(() => validatePath([-1, 0])).toThrow(/Path cannot contain negative values/);
+            expect(() => validatePath("m/-1'/0'")).toThrow(/Path cannot contain negative values/);
+        });
+
+        it('throws for NaN inside number[]', () => {
+            expect(() => validatePath([NaN, 0, 0])).toThrow(/Not a valid path/);
+        });
+
+        it('throws when path is shorter than required length', () => {
+            expect(() => validatePath([0, 1], 3)).toThrow(/Not a valid path/);
+            expect(() => validatePath("m/44'", 3)).toThrow(/Not a valid path/);
+        });
+
+        it('returns first 3 elements when base flag is set', () => {
+            const path = [toHardened(44), toHardened(0), toHardened(0), 0, 0];
+            expect(validatePath(path, 0, true)).toEqual([
+                toHardened(44),
+                toHardened(0),
+                toHardened(0),
+            ]);
+        });
     });
 });

--- a/packages/connect/src/utils/pathUtils.ts
+++ b/packages/connect/src/utils/pathUtils.ts
@@ -155,15 +155,14 @@ export const validatePath = (path: DerivationPath, length = 0, base = false): nu
     if (typeof path === 'string') {
         valid = getHDPath(path);
     } else if (Array.isArray(path)) {
-        valid = path.map((p: any) => {
-            const n = parseInt(p, 10);
-            if (Number.isNaN(n)) {
+        valid = path.map(p => {
+            if (Number.isNaN(p)) {
                 throw PATH_NOT_VALID;
-            } else if (n < 0) {
+            } else if (p < 0) {
                 throw PATH_NEGATIVE_VALUES;
             }
 
-            return n;
+            return p;
         });
     }
     if (!valid) throw PATH_NOT_VALID;


### PR DESCRIPTION
## Summary

Two small `any` cleanups in `packages/connect/src` plus tests for the affected helper:

1. **`pathUtils.ts:158` — redundant `(p: any)`**. Inside `Array.isArray(path)` TS already narrows `path` to `number[]`, so the annotation only widened the type. Removed it; the equally redundant `parseInt(...)` round-trip in the same branch is also gone (the value was already a number).
2. **`cardanoOutputs.sendOutput` / `cardanoUtils.sendChunkedHexString`** — `typedCall: any` → `PROTO.TypedCall`. Message names and payloads are now validated at the call sites instead of slipping through. `messageType` / `responseType` tightened to `PROTO.MessageKey`.
3. **Tests for `validatePath`**. The function is called from ~15 API methods (signMessage, authorizeCoinjoin, unlockPath, stellar/tezos/solana/ripple sign methods, …) but had zero direct test coverage. Added 8 cases covering string parsing, number[] pass-through, NaN/negative rejection, length validation, and the base flag.

## Related

Part of the connect type-hardening series:
- #27070 — initial PR (merged): `FirmwareCapability` literal union
- #27113 — predecessor: `requiredFirmwareCapabilities` and `paramsValidator` typing

## Test plan

- [x] `yarn workspace @trezor/connect type-check` passes (clean tsbuildinfo)
- [x] `yarn workspace @trezor/connect-common type-check` passes
- [x] `yarn workspace @trezor/connect test:unit src/utils/__tests__/pathUtils.test.ts` — 11/11 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/typedcall-pathutils-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->