### PR TITLE
chore(connect): drop two single-purpose barrel files

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -49,15 +49,7 @@
                 "types": "./lib/*.d.ts",
                 "default": "./lib/*.js"
             },
-            "./libESM/*": "./libESM/*",
-            "./lib/events": {
-                "types": "./lib/events/index.d.ts",
-                "default": "./lib/events/index.js"
-            },
-            "./libESM/events": {
-                "types": "./libESM/events/index.d.mts",
-                "default": "./libESM/events/index.mjs"
-            }
+            "./libESM/*": "./libESM/*"
         },
         "browser": {
             "./lib/index.js": "./lib/index-browser.js",
@@ -68,12 +60,10 @@
             "./libESM/utils/assets.mjs": "./libESM/utils/assets-browser.mjs",
             "./libESM/workers/workers.mjs": "./libESM/workers/workers-browser.mjs",
             "./lib/data/*": "./lib/data/*.js",
-            "./lib/events": "./lib/events/index.js",
             "./lib/exports": "./lib/exports.js",
             "./lib/impl/*": "./lib/impl/*.js",
             "./lib/utils/*": "./lib/utils/*.js",
             "./libESM/data/*": "./libESM/data/*",
-            "./libESM/events/index.mjs": "./libESM/events/index.mjs",
             "./libESM/exports.mjs": "./libESM/exports.mjs",
             "./libESM/impl/*": "./libESM/impl/*",
             "./libESM/utils/*": "./libESM/utils/*"
@@ -87,12 +77,10 @@
             "./libESM/utils/assets.mjs": "./libESM/utils/assets.native.mjs",
             "./libESM/workers/workers.mjs": "./libESM/workers/workers.native.mjs",
             "./lib/data/*": "./lib/data/*.js",
-            "./lib/events": "./lib/events/index.js",
             "./lib/exports": "./lib/exports.js",
             "./lib/impl/*": "./lib/impl/*.js",
             "./lib/utils/*": "./lib/utils/*.js",
             "./libESM/data/*": "./libESM/data/*",
-            "./libESM/events/index.mjs": "./libESM/events/index.mjs",
             "./libESM/exports.mjs": "./libESM/exports.mjs",
             "./libESM/impl/*": "./libESM/impl/*",
             "./libESM/utils/*": "./libESM/utils/*"

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -15,7 +15,7 @@ import { isNotUndefined, versionUtils } from '@trezor/utils';
 
 import { DEFAULT_FIRMWARE_RANGE, getFirmwareRange } from '../api/common/paramsValidator';
 import type { Device } from '../device/Device';
-import type { UiPromiseCreator } from '../events';
+import type { UiPromiseCreator } from '../events/ui-promise';
 
 export { DEFAULT_FIRMWARE_RANGE };
 

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -42,7 +42,7 @@ import { initializeFirmwareConfig } from '../data/firmwareInfo';
 import type { Device, DeviceEvents } from '../device/Device';
 import type { IDeviceList } from '../device/DeviceList';
 import { DeviceList, assertDeviceListConnected } from '../device/DeviceList';
-import * as workflows from '../device/workflow';
+import { validateState } from '../device/workflow/validateState';
 import { createUiPromiseManager } from '../utils/uiPromiseManager';
 
 // custom log
@@ -135,7 +135,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
 
     // Make sure that device will display pin/passphrase
     if (method.useDeviceState) {
-        await workflows.validateState({
+        await validateState({
             device,
             method,
             signal: context.signal,

--- a/packages/connect/src/device/workflow/index.ts
+++ b/packages/connect/src/device/workflow/index.ts
@@ -1,1 +1,0 @@
-export { validateState } from './validateState';

--- a/packages/connect/src/events/index.ts
+++ b/packages/connect/src/events/index.ts
@@ -1,1 +1,0 @@
-export type * from './ui-promise';

--- a/packages/connect/src/utils/uiPromiseManager.ts
+++ b/packages/connect/src/utils/uiPromiseManager.ts
@@ -2,7 +2,12 @@ import { DEVICE } from '@trezor/connect-common';
 import type { DeviceUniquePath } from '@trezor/connect-common/src/types/device';
 import { arrayPartition, createDeferred } from '@trezor/utils';
 
-import type { AnyUiPromise, UiPromise, UiPromiseCreator, UiPromiseResponse } from '../events';
+import type {
+    AnyUiPromise,
+    UiPromise,
+    UiPromiseCreator,
+    UiPromiseResponse,
+} from '../events/ui-promise';
 
 export const createUiPromiseManager = () => {
     let _uiPromises: AnyUiPromise[] = [];


### PR DESCRIPTION
## Summary

Cleanup found via `ts-prune` scan + manual verification.

`packages/connect/src/events/index.ts` and `packages/connect/src/device/workflow/index.ts` each contained a single one-line re-export. They added an indirection layer without any abstraction value. Removed both barrels and rewrote the three callers (`core/AbstractMethod.ts`, `utils/uiPromiseManager.ts`, `core/index.ts`) to import directly from the source files.

Bonus: `validateState` in `core/index.ts` is now imported by name instead of via the `workflows.` namespace prefix, matching how every other helper in that file is consumed.

## ⚠️ BREAKING

`events/index.ts` was exposed as a public subpath via `package.json`'s `publishConfig.exports` (`./lib/events`, `./libESM/events`). Those entries are removed as part of this PR — there is no internal consumer in the monorepo, and external consumers can switch to:
- `@trezor/connect/lib/events/ui-promise` (served by the existing `./lib/*` / `./libESM/*` wildcards), or
- the top-level `@trezor/connect` package entry, which re-exports the types via `@trezor/connect-common`.

Minimising public surface area is intentional.

## Related

Same `ts-prune`-driven cleanup pass as #27129 (dead `estimateTronBandwidth` wrapper).

## Test plan

- [x] `yarn workspace @trezor/connect type-check` passes (clean tsbuildinfo)
- [x] `install-connect-local` CI step (publishConfig validation) — should pass after removing the now-stale subpath entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-trim-barrels/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-trim-barrels/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-trim-barrels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-trim-barrels&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:34:50.578Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->