### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9554,10 +9554,6 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_PENDING_WITHDRAW',
         defaultMessage: 'Confirming withdrawal...',
     },
-    TR_EARN_YIELD_APPROVAL_INSUFFICIENT: {
-        id: 'TR_EARN_YIELD_APPROVAL_INSUFFICIENT',
-        defaultMessage: 'Approval amount is lower than the requested amount.',
-    },
     TR_EARN_YIELD_APPROVAL_TOO_LOW: {
         id: 'TR_EARN_YIELD_APPROVAL_TOO_LOW',
         defaultMessage: 'Approval is too low. Modify approval or lower the amount.',


### PR DESCRIPTION
## Summary

Removes unused translation strings from \`messages.ts\` that are no longer referenced in the codebase.

**Keys removed (1):**
- \`TR_EARN_YIELD_APPROVAL_INSUFFICIENT\`

Identified by the \`translations:list-unused\` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to suite/intl/src/messages.ts, which is the internationalization message definitions module used broadly across the Suite application. Since no static coverage mapping exists for this file, tests were inferred from LLM analysis. The autodetect test is highest priority as it directly exercises intl message rendering and locale detection. Several other tests that explicitly assert against translation keys from this module are included at medium priority. The risk is moderate — if message IDs, default values, or descriptor shapes changed, any UI assertion comparing against translated text could break.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses @suite/intl messages to verify that the onboarding analytics heading matches localized strings (English and Spanish). Changes to suite/intl/src/messages.ts could alter message definitions, breaking these assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies language changes (English to Spanish) and checks translated UI text on settings pages. The intl messages module defines the translation keys and message descriptors used throughout the app, so changes could affect how translated strings render in settings.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly references @suite/intl messages for validation error translations (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, TR_TRADING_COUNTRY_WORLD). Changes to the messages module could affect these translated validation strings.
- `../../suite/e2e/tests/staking/staking-form.test.ts` — This test asserts against multiple translation keys from the intl messages module (TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, AMOUNT_IS_NOT_SET, TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL). Changes to message definitions could break these validation assertions.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test uses @suite/intl messages for graph time range labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, TR_DATE_MONTH_LONG, TR_DATE_YEAR_LONG, TR_ALL). Changes to these message definitions could cause time range label assertions to fail.

</details>

_Updated: 2026-04-28T08:11:52.673Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260428&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260428&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:17:08.882Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:15:46.586Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260428/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260428/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->