### PR TITLE
fix(protobuf): normalize ThpPairingRequest app_name and host_name

### DIFF
--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -9,6 +9,7 @@ import { createDeferred } from '@trezor/utils';
 import { abortThpWorkflow, thpCall } from './thpCall';
 import { DataManager } from '../../data/DataManager';
 import type { IDevice } from '../../types/idevice';
+import { sanitizeString } from '../../utils/formatUtils';
 
 const processQrCodeTag = async (device: IDevice, value: string) => {
     const thpState = device.getThpState();
@@ -283,8 +284,8 @@ export const thpPairing = async (device: IDevice) => {
     // ThpPairingRequest will trigger ButtonRequest.thp_pairing_request flow
     const settings = DataManager.getSettings('thp');
     await thpCall(device, 'ThpPairingRequest', {
-        host_name: settings?.hostName || 'Unknown hostName',
-        app_name: settings?.appName || 'Unknown appName',
+        host_name: sanitizeString(settings?.hostName) || 'Unknown hostName',
+        app_name: sanitizeString(settings?.appName) || 'Unknown appName',
     });
 
     // State HP1

--- a/packages/connect/src/utils/formatUtils.ts
+++ b/packages/connect/src/utils/formatUtils.ts
@@ -70,3 +70,12 @@ type DeepTransformed<T, V> = T extends string
       : T extends object
         ? { [K in keyof T]: DeepTransformed<T[K], V> }
         : T;
+
+export const sanitizeString = (value?: string) => {
+    // replace special chars ’‘ displayed on Trezor
+    // https://github.com/trezor/trezor-suite/pull/21835
+    // https://satoshilabs.slack.com/archives/C078GRAK58U/p1756471857417049
+    if (typeof value === 'string') {
+        return value.replace(/[\u2018\u2019]/g, "'");
+    }
+};

--- a/packages/protobuf/src/encode.ts
+++ b/packages/protobuf/src/encode.ts
@@ -30,10 +30,6 @@ const transform = (fieldType: string, value: any) => {
     if (typeof value === 'number' && !Number.isSafeInteger(value)) {
         throw new RangeError('field value is not within safe integer range');
     }
-    // https://satoshilabs.slack.com/archives/C078GRAK58U/p1756471857417049
-    if (fieldType === 'string' && typeof value === 'string') {
-        value = value.replace(/[’‘]/g, "'");
-    }
 
     return value;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for https://github.com/trezor/trezor-suite/pull/21835 and resolve sentry report:

https://satoshilabs.sentry.io/issues/7401640578/?query=bufbuild&referrer=issue-stream

We should not modify **all** strings but only affected ones - displayed on Trezor (ThpPairingRequest app_name and host_name)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span three files: THP pairing logic (pairing.ts), format utilities (formatUtils.ts), and protobuf encoding (encode.ts). All three map to 121 tests each, indicating they are deeply shared infrastructure. The highest-risk change is pairing.ts since THP pairing is explicitly exercised in onboarding and initial-run tests. The protobuf encode.ts change could affect any device communication, but TrezorConnect integration tests are the most direct exercisers. formatUtils.ts changes carry the least specific risk since no test's LLM analysis highlights format utility usage as a critical path. A focused strategy testing THP pairing flows and TrezorConnect device communication provides the best signal-to-noise ratio.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/device/thp/pairing.ts`
- `packages/connect/src/utils/formatUtils.ts`
- `packages/protobuf/src/encode.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test explicitly exercises the THP pairing flow (enterTHPPairingCode, allowConnectToTrezor) during onboarding. Changes to packages/connect/src/device/thp/pairing.ts directly affect the THP pairing code entry and device connection establishment tested here.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The LLM analysis explicitly mentions 'THP pairing flow (devicePrompt.allowConnectToTrezor, onboardingPage.enterTHPPairingCode)' in source_hints. Changes to pairing.ts could affect the device connection flow that this test depends on for capturing DeviceConnect and TransportType analytics events.
- `suite/e2e/tests/analytics/toggle.test.ts` — Source hints reference 'enterTHPPairingCode' and 'enableAutoconnect' in the onboarding flow. Changes to pairing.ts could affect the THP pairing step that this test uses to complete onboarding before testing analytics toggle behavior.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test explicitly handles 'THP pairing code entry for devices that support THP' and references pairing-related page objects. Changes to pairing.ts directly affect this onboarding flow's THP device pairing step.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — T3W1 onboarding explicitly pairs a device via THP pairing code and dismisses firmware hash check errors. Changes to pairing.ts directly affect the THP pairing step in this T3W1-specific onboarding flow.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect.getAddress through the popup flow which involves protobuf encoding for device communication. Changes to packages/protobuf/src/encode.ts could affect message serialization during the address export and device confirmation steps.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test calls TrezorConnect.getAddress which requires protobuf encoding to communicate with the device. Changes to encode.ts could corrupt the serialized messages sent to the device during address export and verification.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Bitcoin transaction signing via TrezorConnect.signTransaction relies heavily on protobuf encoding to serialize transaction inputs/outputs for the device. Changes to encode.ts could break the transaction signing protocol.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Ethereum transaction signing through TrezorConnect uses protobuf encoding to communicate transaction parameters to the device. Changes to encode.ts could affect the serialization of Ethereum transaction data.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — This test opens the guide panel during onboarding with a device, which involves THP pairing (pairTHP is called in source_hints). Changes to pairing.ts could affect the device pairing prerequisite for the guide panel tests with a connected device.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/utils/formatUtils.ts`

_Updated: 2026-04-28T08:27:48.827Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/protobuf-sanitize-string&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/protobuf-sanitize-string&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/protobuf-sanitize-string&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:33:18.319Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:31:38.176Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/protobuf-sanitize-string/web/](https://dev.suite.sldev.cz/suite-web/fix/protobuf-sanitize-string/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->