### PR TITLE
fix(suite): stake button in account trade box

### DIFF
--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -44,6 +44,18 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
     }) => {
         const gotoRouteName: Route['name'] =
             type === 'stake' ? 'wallet-staking' : `wallet-trading-${type}`;
+        const gotoProps =
+            type === 'stake'
+                ? {
+                      routeName: gotoRouteName,
+                      preserveParams: true,
+                      params: {
+                          symbol: account.symbol,
+                          accountIndex: account.index,
+                          accountType: account.accountType,
+                      },
+                  }
+                : { routeName: gotoRouteName };
         const dataTestId = type === 'stake' ? undefined : `@trading/menu/wallet-trading-${type}`;
 
         const handleOnClick = () => {
@@ -53,7 +65,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                 ),
             );
 
-            dispatch(goto({ routeName: gotoRouteName }));
+            dispatch(goto(gotoProps));
 
             switch (type) {
                 case 'buy':


### PR DESCRIPTION
## Description

Open staking flow for correct account when clicking on `Stake` button in account detail.

## Related Issue

Resolve #27089 

## Screenshots:

https://github.com/user-attachments/assets/bfd43cd6-d45d-4594-98e4-4c93f9880ee4

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a single UI component (TradeBox.tsx) within the wallet transactions view. TradeBox maps to 59 tests statically, indicating it's a broadly imported component rendered as part of the wallet transactions page layout. Most of those 59 tests only transitively import it through the wallet/transactions view and don't directly exercise TradeBox's own functionality (buy/sell/swap/staking navigation buttons). The risk is moderate and focused on trading entry points and navigation from the wallet account view. A small set of trading navigation and dashboard asset tests should provide sufficient confidence.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — TradeBox is rendered within the wallet transactions view and provides buy/trade entry points. The assets test exercises buying BTC from the dashboard which navigates through the trading page section - a flow that TradeBox directly participates in.
- `suite/e2e/tests/trading/navigation.test.ts` — TradeBox is the component that provides trading navigation entry points (buy/sell/swap buttons) from the wallet transactions view. This test validates navigating to Buy/Sell/Swap forms from account trade sections, which directly exercises TradeBox's rendered UI elements.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — TradeBox may contain staking navigation elements. This test verifies StakingNavigate analytics events when navigating to staking from the account menu, which could involve TradeBox as the container for the staking button on the wallet transactions view.

</details>

_Updated: 2026-04-28T08:31:59.520Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/account-stake-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/account-stake-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:37:56.198Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T08:36:20.171Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/account-stake-button/web/](https://dev.suite.sldev.cz/suite-web/fix/account-stake-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->