### PR TITLE
fix(suite): Fix Suite Guide background

### DIFF
--- a/packages/suite/src/components/guide/GuideViewWrapper.tsx
+++ b/packages/suite/src/components/guide/GuideViewWrapper.tsx
@@ -3,9 +3,10 @@ import { type ReactNode, type UIEventHandler, createContext, useCallback, useSta
 import styled from 'styled-components';
 
 import { variables } from '@trezor/components';
+import { type Elevation, mapElevationToBackground } from '@trezor/theme';
 
-const Wrapper = styled.div`
-    background: ${({ theme }) => theme.surfaceFillPage};
+const Wrapper = styled.div<{ $elevation: Elevation }>`
+    background: ${mapElevationToBackground};
     display: flex;
     height: 100%;
     flex-direction: column;
@@ -32,7 +33,7 @@ export const GuideViewWrapper = ({ children }: GuideViewWrapperProps) => {
     }, []);
 
     return (
-        <Wrapper onScroll={onScroll}>
+        <Wrapper $elevation={-1} onScroll={onScroll}>
             <ContentScrolledContext.Provider value={isScrolled}>
                 {children}
             </ContentScrolledContext.Provider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- text inputs, textarea and selects were almost invisible

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

**before**

<img width="413" height="916" alt="image" src="https://github.com/user-attachments/assets/4a9fff94-efdc-4fa3-8be7-2f47c140d7a3" />


<img width="460" height="917" alt="image" src="https://github.com/user-attachments/assets/305a7147-b521-44c3-a0c9-dffe376417eb" />



**after**

<img width="436" height="919" alt="image" src="https://github.com/user-attachments/assets/a965369d-2cd3-4cb1-9de3-18f785369bf2" />

<img width="434" height="918" alt="image" src="https://github.com/user-attachments/assets/7d276b93-8245-4f4a-a163-fc68d16c9243" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to GuideViewWrapper.tsx, a component specific to the Suite Guide panel UI. Despite mapping to 121 tests via static analysis (indicating it's transitively imported by a broad layout component), the actual risk is concentrated in tests that directly exercise the guide panel functionality. The recommended strategy is to run the two guide-specific tests at high priority and the bug report form test at medium priority, as these are the only tests whose behavior directly depends on GuideViewWrapper rendering.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/guide/GuideViewWrapper.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — GuideViewWrapper is a core component of the Suite Guide panel. This test directly exercises opening the guide panel, navigating content, submitting bug reports, and searching articles — all of which render within or interact with the GuideViewWrapper component.
- `suite/e2e/tests/suite/guide.test.ts` — This test extensively exercises the guide panel functionality: opening/closing it, navigating guide nodes, submitting feedback, searching articles, and opening the guide over modals. All these behaviors render content wrapped by GuideViewWrapper.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — The bug report form is accessed through the Guide panel's Support and Feedback section. GuideViewWrapper likely wraps the guide panel content including the bug report form view, so layout or rendering changes could affect this flow.

</details>

_Updated: 2026-04-28T09:14:26.405Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-guide-background&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-guide-background&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-guide-background/web/](https://dev.suite.sldev.cz/suite-web/update-guide-background/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:19:50.946Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->