### PR TITLE
Limit concurrent messages over Blockbook websocket

### DIFF
--- a/packages/blockchain-link/src/workers/blockbook/index.ts
+++ b/packages/blockchain-link/src/workers/blockbook/index.ts
@@ -466,6 +466,7 @@ class BlockbookWorker extends BaseWorker<BlockbookAPI> {
             pingTimeout,
             keepAlive,
             agent: this.proxyAgent,
+            concurrency: 42,
         });
         await api.connect();
 

--- a/packages/utils/src/createDeferredManager.ts
+++ b/packages/utils/src/createDeferredManager.ts
@@ -13,13 +13,17 @@ type DeferredManagerOptions = {
     initialId?: number;
 };
 
+type IdPromise<T> = { promiseId: number; promise: Promise<T> };
+
 export type DeferredManager<T> = {
     /** How many pending promises are there */
     length: () => number;
     /** ID of the next created promise (for specific use case, should be removed in the future) */
     nextId: () => number;
     /** Creates new pending promise (with optional timeout) and returns it and its unique id */
-    create: (timeout?: number) => { promiseId: number; promise: Promise<T> };
+    create: (timeout?: number) => IdPromise<T>;
+    /** Waits until there is less than `concurrency` promises and then creates a new one */
+    createConcurrent: (concurrency: number, timeout?: number) => Promise<IdPromise<T>>;
     /** Resolves (and removes) promise with given id by given value and returns whether it was present or not */
     resolve: (promiseId: number, value: T) => boolean;
     /** Resolves (and removes) all pending promises by given value */
@@ -47,10 +51,17 @@ export const createDeferredManager = <T = any>(
 
     let ID = initialId;
     let timeoutHandle: TimerId | undefined;
+    let onRemovePromise = createDeferred();
 
     const length = () => promises.length;
 
     const nextId = () => ID;
+
+    const onPromiseRemoved = () => {
+        const { resolve } = onRemovePromise;
+        onRemovePromise = createDeferred();
+        resolve();
+    };
 
     const replanTimeout = () => {
         const now = Date.now();
@@ -86,9 +97,18 @@ export const createDeferredManager = <T = any>(
         return { promiseId, promise: deferred.promise };
     };
 
+    const createConcurrent = async (concurrency: number, timeout?: number) => {
+        while (promises.length >= concurrency) {
+            await onRemovePromise.promise;
+        }
+
+        return create(timeout);
+    };
+
     const extract = (promiseId: number) => {
         const index = promises.findIndex(({ id }) => id === promiseId);
         const [promise] = index >= 0 ? promises.splice(index, 1) : [undefined];
+        if (promise) onPromiseRemoved();
         if (promise?.deadline) replanTimeout();
 
         return promise;
@@ -104,7 +124,10 @@ export const createDeferredManager = <T = any>(
     const resolveAll = (getValue: (promiseId: number) => T) => {
         promises.forEach(promise => promise.resolve(getValue(promise.id)));
         const deleted = promises.splice(0, promises.length);
-        if (deleted.length) replanTimeout();
+        if (deleted.length) {
+            onPromiseRemoved();
+            replanTimeout();
+        }
     };
 
     const reject = (promiseId: number, error: Error) => {
@@ -117,8 +140,11 @@ export const createDeferredManager = <T = any>(
     const rejectAll = (error: Error) => {
         promises.forEach(promise => promise.reject(error));
         const deleted = promises.splice(0, promises.length);
-        if (deleted.length) replanTimeout();
+        if (deleted.length) {
+            onPromiseRemoved();
+            replanTimeout();
+        }
     };
 
-    return { length, nextId, create, resolve, reject, resolveAll, rejectAll };
+    return { length, nextId, create, createConcurrent, resolve, reject, resolveAll, rejectAll };
 };

--- a/packages/utils/tests/createDeferredManager.test.ts
+++ b/packages/utils/tests/createDeferredManager.test.ts
@@ -80,4 +80,51 @@ describe('createDeferredManager', () => {
         expect(onTimeout).toHaveBeenCalledTimes(1);
         expect(onTimeout).toHaveBeenCalledWith(third.promiseId);
     });
+
+    it('concurrency', async () => {
+        const manager = createDeferredManager<void>();
+
+        const first = manager.create();
+        const secondPromise = manager.createConcurrent(2);
+        const thirdPromise = manager.createConcurrent(2);
+
+        let secondSettled = false;
+        secondPromise.then(() => {
+            secondSettled = true;
+        });
+
+        let thirdSettled = false;
+        thirdPromise.then(() => {
+            thirdSettled = true;
+        });
+
+        await Promise.resolve();
+
+        expect(manager.length()).toBe(2);
+        expect(secondSettled).toBe(true);
+        expect(thirdSettled).toBe(false);
+
+        manager.resolve(first.promiseId);
+
+        await first.promise;
+
+        await Promise.resolve();
+
+        expect(manager.length()).toBe(2);
+        expect(secondSettled).toBe(true);
+        expect(thirdSettled).toBe(true);
+
+        const fourth = manager.create();
+
+        expect(manager.length()).toBe(3);
+
+        const second = await secondPromise;
+        const third = await thirdPromise;
+
+        manager.resolve(second.promiseId);
+        manager.resolve(third.promiseId);
+        manager.resolve(fourth.promiseId);
+
+        expect(manager.length()).toBe(0);
+    });
 });

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -13,6 +13,7 @@ type Options = WebsocketOptions & {
     pingTimeout?: number;
     connectionTimeout?: number;
     keepAlive?: boolean;
+    concurrency?: number;
     onSending?: (message: Record<string, any>) => void;
 };
 
@@ -104,12 +105,23 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         this.onClose();
     }
 
-    sendMessage(message: WebsocketRequest, { timeout }: { timeout?: number } = {}) {
+    async sendMessage(message: WebsocketRequest, { timeout }: { timeout?: number } = {}) {
         const { ws } = this;
         if (!ws || !this.isConnected()) throw new WebsocketError('websocket_not_initialized');
-        const { promiseId, promise } = this.messages.create(timeout);
 
-        const req = { id: promiseId.toString(), ...message };
+        let promise;
+        if (this.options.concurrency) {
+            promise = await this.messages.createConcurrent(this.options.concurrency, timeout);
+
+            if (!ws || !this.isConnected()) {
+                this.messages.resolve(promise.promiseId, undefined);
+                throw new WebsocketError('websocket_not_initialized');
+            }
+        } else {
+            promise = this.messages.create(timeout);
+        }
+
+        const req = { id: promise.promiseId.toString(), ...message };
 
         this.setPingTimeout();
 
@@ -117,7 +129,7 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
 
         ws.send(JSON.stringify(req));
 
-        return promise;
+        return promise.promise;
     }
 
     protected sendRawMessage(message: WebSocket.Data) {


### PR DESCRIPTION
## Description

Based on feedback from Blockbook guys, we shouldn't let more than 45 concurrent messages to Blockbook websocket at once, as from now on they would fail.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span four files: `createDeferredManager.ts` (a broad utility used by 121 tests), its unit test, `blockbook/index.ts` (blockchain-link worker), and `websocket-client/client.ts`. The `createDeferredManager` is a low-level async utility whose changes are best validated by its own unit test (which has no E2E mapping). The blockbook worker and websocket client are infrastructure-level networking components that underpin blockchain communication but are deeply abstracted from the UI layer tested by E2E tests. None of the 121 statically-mapped E2E tests show specific evidence in their LLM analysis of directly exercising `createDeferredManager` behavior, blockbook worker internals, or websocket client reconnection logic — they all interact with these through many layers of abstraction. The risk of E2E-visible regressions is low; the unit test for `createDeferredManager` and integration-level tests for blockchain-link/websocket-client (not E2E) are the appropriate validation layer for these changes.

<details><summary><b>Changed files (4)</b></summary>

- `packages/blockchain-link/src/workers/blockbook/index.ts`
- `packages/utils/src/createDeferredManager.ts`
- `packages/utils/tests/createDeferredManager.test.ts`
- `packages/websocket-client/src/client.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/blockchain-link/src/workers/blockbook/index.ts`
- `packages/utils/tests/createDeferredManager.test.ts`
- `packages/websocket-client/src/client.ts`

_Updated: 2026-04-28T09:31:14.145Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockbook-ws-concurrency&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockbook-ws-concurrency&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:37:15.889Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:36:17.198Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/blockbook-ws-concurrency/web/](https://dev.suite.sldev.cz/suite-web/feat/blockbook-ws-concurrency/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->