### PR TITLE
Add @suite-common/earn-stablecoin workspace

### DIFF
--- a/suite-common/earn-stablecoin/package.json
+++ b/suite-common/earn-stablecoin/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "@suite-common/earn-stablecoin",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "type": "module",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    }
+}

--- a/suite-common/earn-stablecoin/src/tx-simulation/hooks/useYieldTxSimulation.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/hooks/useYieldTxSimulation.ts
@@ -1,0 +1,2 @@
+// TODO: add hooks for stablecoin yield TX simulation
+export function useYieldTxSimulation() {}

--- a/suite-common/earn-stablecoin/src/tx-simulation/index.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/index.ts
@@ -1,0 +1,1 @@
+export { useYieldTxSimulation } from './hooks/useYieldTxSimulation';

--- a/suite-common/earn-stablecoin/tsconfig.json
+++ b/suite-common/earn-stablecoin/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11011,6 +11011,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite-common/earn-stablecoin@workspace:suite-common/earn-stablecoin":
+  version: 0.0.0-use.local
+  resolution: "@suite-common/earn-stablecoin@workspace:suite-common/earn-stablecoin"
+  languageName: unknown
+  linkType: soft
+
 "@suite-common/earn-staking-api@workspace:*, @suite-common/earn-staking-api@workspace:suite-common/earn-staking-api":
   version: 0.0.0-use.local
   resolution: "@suite-common/earn-staking-api@workspace:suite-common/earn-staking-api"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since there're going to be several different flows and other separated business logic, I'd suggest placing it to sub-dirs in the package. This will mitigate future issues with cir. dep. and provide easily readable structure. 🙏 Then the usage:

```ts
import { useYieldTxSimulation } from '@suite-common/earn-stablecoin/src/tx-simulation'
import { ... } from '@suite-common/earn-stablecoin/src/supply'
import { ... } from '@suite-common/earn-stablecoin/src/withdraw'
```

I wanted to get rid off the "src" via `package.json#exports` but it works only with Webpack, not with Vite (required adding additional custom logic to Vite config). Anyway it's not needed. 

## Related Issue

Resolve #25641

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within the `suite-common/earn-stablecoin` package, which is a new or evolving module related to earn/stablecoin transaction simulation (useYieldTxSimulation hook, index exports, package.json, tsconfig.json). None of the existing E2E tests have any static coverage mapping to these files, and none of the LLM-analyzed tests reference earn-stablecoin functionality, yield transaction simulation, or stablecoin-specific flows. The staking tests cover ETH/ADA/SOL staking via Everstake but are unrelated to stablecoin yield simulation. Since this appears to be new infrastructure code not yet wired into any user-facing flow exercised by existing E2E tests, no tests need to be run.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/earn-stablecoin/package.json`
- `suite-common/earn-stablecoin/src/tx-simulation/hooks/useYieldTxSimulation.ts`
- `suite-common/earn-stablecoin/src/tx-simulation/index.ts`
- `suite-common/earn-stablecoin/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/earn-stablecoin/package.json`
- `suite-common/earn-stablecoin/src/tx-simulation/hooks/useYieldTxSimulation.ts`
- `suite-common/earn-stablecoin/src/tx-simulation/index.ts`
- `suite-common/earn-stablecoin/tsconfig.json`

_Updated: 2026-04-28T09:43:38.375Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/common-stablecoin&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/common-stablecoin&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/common-stablecoin&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:49:52.745Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:48:31.996Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/common-stablecoin/web/](https://dev.suite.sldev.cz/suite-web/feat/common-stablecoin/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->