### PR TITLE
feat(components): add shared PendingTransactionInfo component

### DIFF
--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.stories.tsx
@@ -1,0 +1,36 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+import { action } from 'storybook/actions';
+
+import { PendingTransactionInfo as PendingTransactionInfoComponent } from './PendingTransactionInfo';
+
+type StoryArgs = {
+    title: string;
+    txidLabel: string;
+    txidComponent: string;
+    hasLink: boolean;
+};
+
+const meta: Meta<StoryArgs> = {
+    title: 'PendingTransactionInfo',
+    component: PendingTransactionInfoComponent,
+};
+
+export default meta;
+
+export const PendingTransactionInfo: StoryObj<StoryArgs> = {
+    args: {
+        title: 'Confirming approval...',
+        txidLabel: 'Transaction ID',
+        txidComponent: '0x1234...5678',
+        hasLink: true,
+    },
+    argTypes: {
+        hasLink: { control: 'boolean' },
+    },
+    render: ({ hasLink, ...args }) => (
+        <PendingTransactionInfoComponent
+            {...args}
+            onTxClick={hasLink ? action('onTxClick') : undefined}
+        />
+    ),
+};

--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
@@ -1,0 +1,47 @@
+import { type ReactNode } from 'react';
+
+import { Column, Link, Paragraph, Row, Spinner } from '@trezor/components';
+
+export type PendingTransactionInfoProps = {
+    title: ReactNode;
+    txidLabel: ReactNode;
+    txidComponent: ReactNode;
+    onTxClick?: () => void;
+};
+
+export const PendingTransactionInfo = ({
+    title,
+    txidLabel,
+    txidComponent,
+    onTxClick,
+}: PendingTransactionInfoProps) => (
+    <Column width="100%" alignItems="flex-start">
+        <Row alignItems="flex-start" gap={12}>
+            <Spinner size={20} margin={{ top: 4 }} />
+
+            <Column>
+                <Paragraph
+                    typographyStyle="body-md"
+                    intent="neutral"
+                    priority="secondary"
+                    align="start"
+                >
+                    {title}
+                </Paragraph>
+
+                <Row gap={4} flexWrap="wrap" alignItems="center">
+                    <Paragraph
+                        typographyStyle="body-md"
+                        intent="neutral"
+                        priority="secondary"
+                        align="start"
+                    >
+                        {txidLabel}
+                    </Paragraph>
+
+                    {onTxClick ? <Link onClick={onTxClick}>{txidComponent}</Link> : txidComponent}
+                </Row>
+            </Column>
+        </Row>
+    </Column>
+);

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -62,3 +62,7 @@ export {
 } from './components/EmojiRatingSelector/EmojiRatingSelector';
 export { QuickActionButton } from './components/QuickActionButton/QuickActionButton';
 export { TooltipRow } from './components/TooltipRow/TooltipRow';
+export {
+    PendingTransactionInfo,
+    type PendingTransactionInfoProps,
+} from './components/PendingTransactionInfo/PendingTransactionInfo';

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -33,7 +33,7 @@ export type YieldActionStepProps = {
     pendingTransaction?: YieldPendingTransactionState;
     onMaxClick?: () => void;
     onSubmit: () => void;
-    onPendingTxClick?: (txid: string) => void;
+    onPendingTxClick: (txid: string) => void;
 };
 
 export const YieldActionStep = ({

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -108,7 +108,7 @@ export type YieldApproveStepProps = {
     onMaxClick?: () => void;
     onApprove?: () => void;
     onRevoke?: () => void;
-    onPendingTxClick?: (txid: string) => void;
+    onPendingTxClick: (txid: string) => void;
 };
 
 export const YieldApproveStep = ({

--- a/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPendingTransaction.tsx
@@ -1,13 +1,13 @@
 import type { TranslationKey } from '@suite/intl';
 import { Translation } from '@suite/intl';
 import type { YieldPendingTransactionState } from '@suite-common/wallet-core';
-import { Column, Link, Paragraph, Row, Spinner } from '@trezor/components';
+import { PendingTransactionInfo } from '@trezor/product-components';
 
 import { Address } from 'src/components/suite/Address';
 
 type YieldPendingTransactionProps = {
     pendingTransaction: YieldPendingTransactionState;
-    onTxClick?: (txid: string) => void;
+    onTxClick: (txid: string) => void;
 };
 
 const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']): TranslationKey => {
@@ -27,52 +27,19 @@ const getPendingTransactionLabel = (kind: YieldPendingTransactionState['type']):
 export const YieldPendingTransaction = ({
     pendingTransaction,
     onTxClick,
-}: YieldPendingTransactionProps) => {
-    const txidComponent = (
-        <Address
-            isTruncated
-            isChunked={false}
-            value={pendingTransaction.txid}
-            intent="brand"
-            typographyStyle="body-md"
-        />
-    );
-
-    return (
-        <Column width="100%" alignItems="flex-start">
-            <Row alignItems="flex-start" gap={12}>
-                <Spinner size={20} />
-
-                <Column>
-                    <Paragraph
-                        typographyStyle="body-md"
-                        intent="neutral"
-                        priority="secondary"
-                        align="start"
-                    >
-                        <Translation id={getPendingTransactionLabel(pendingTransaction.type)} />
-                    </Paragraph>
-
-                    <Row gap={4} flexWrap="wrap" alignItems="center">
-                        <Paragraph
-                            typographyStyle="body-md"
-                            intent="neutral"
-                            priority="secondary"
-                            align="start"
-                        >
-                            <Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />
-                        </Paragraph>
-
-                        {onTxClick ? (
-                            <Link onClick={() => onTxClick(pendingTransaction.txid)}>
-                                {txidComponent}
-                            </Link>
-                        ) : (
-                            txidComponent
-                        )}
-                    </Row>
-                </Column>
-            </Row>
-        </Column>
-    );
-};
+}: YieldPendingTransactionProps) => (
+    <PendingTransactionInfo
+        title={<Translation id={getPendingTransactionLabel(pendingTransaction.type)} />}
+        txidLabel={<Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />}
+        txidComponent={
+            <Address
+                isTruncated
+                isChunked={false}
+                value={pendingTransaction.txid}
+                intent="brand"
+                typographyStyle="body-md"
+            />
+        }
+        onTxClick={() => onTxClick(pendingTransaction.txid)}
+    />
+);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import styled, { type DefaultTheme, keyframes } from 'styled-components';
+import styled, { type DefaultTheme } from 'styled-components';
 
 import { events } from '@suite/analytics';
 import { Translation } from '@suite/intl';
@@ -13,7 +13,8 @@ import {
     useTradingUtils,
 } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { Banner, Button, Column, Icon, Link, Paragraph, Row } from '@trezor/components';
+import { Banner, Button, Column } from '@trezor/components';
+import { PendingTransactionInfo } from '@trezor/product-components';
 
 import { Address } from 'src/components/suite/Address';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -31,26 +32,6 @@ const TextButton = styled.div<{ $disabled: boolean }>`
         color: ${({ theme, $disabled }) =>
             $disabled ? theme.contentDisabled : theme['contentBrandPressed' as keyof DefaultTheme]};
     }
-`;
-
-const loadingAnimation = keyframes`
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
-    }
-`;
-
-const IconWrapper = styled.div`
-    background-color: inherit;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transform: translateY(2px);
-
-    animation: ${loadingAnimation} 1s linear infinite;
 `;
 
 export const TradingFormApproval = () => {
@@ -355,66 +336,45 @@ export const TradingFormApproval = () => {
             )}
 
             {approvalStep === 'LOADING' && (
-                <Column width="100%" alignItems="flex-start">
-                    <Row alignItems="flex-start" gap={12}>
-                        <IconWrapper>
-                            <Icon name="spinnerGap" size={20} />
-                        </IconWrapper>
-
-                        <Column>
-                            <Paragraph
+                <PendingTransactionInfo
+                    title={
+                        <Translation
+                            id={
+                                allowanceState.approvalType === 'APPROVE'
+                                    ? 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL'
+                                    : 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL'
+                            }
+                        />
+                    }
+                    txidLabel={<Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />}
+                    txidComponent={
+                        tx.approvalTxid ? (
+                            <Address
+                                isTruncated
+                                value={tx.approvalTxid}
+                                intent="brand"
                                 typographyStyle="body-md"
-                                intent="neutral"
-                                priority="secondary"
-                                align="start"
-                            >
-                                <Translation
-                                    id={
-                                        allowanceState.approvalType === 'APPROVE'
-                                            ? 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL'
-                                            : 'TR_EXCHANGE_APPROVAL_FORM_REVOKING_APPROVAL'
-                                    }
-                                />
-                            </Paragraph>
-
-                            <Paragraph
-                                typographyStyle="body-md"
-                                intent="neutral"
-                                priority="secondary"
-                                align="start"
-                            >
-                                <Translation id="TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID" />
-                            </Paragraph>
-
-                            {tx.approvalTxid && (
-                                <Link
-                                    onClick={() => {
-                                        const txid = tx.approvalTxid;
-                                        if (txid) {
-                                            dispatch(
-                                                openModal({
-                                                    type: 'transaction-detail',
-                                                    txid,
-                                                    descriptor: account.descriptor,
-                                                    symbol: account.symbol,
-                                                    deviceState: account.deviceState,
-                                                    flow: 'detail',
-                                                }),
-                                            );
-                                        }
-                                    }}
-                                >
-                                    <Address
-                                        isTruncated
-                                        value={tx.approvalTxid}
-                                        intent="brand"
-                                        typographyStyle="body-md"
-                                    />
-                                </Link>
-                            )}
-                        </Column>
-                    </Row>
-                </Column>
+                            />
+                        ) : (
+                            <Translation id="TR_UNKNOWN" />
+                        )
+                    }
+                    onTxClick={
+                        tx.approvalTxid
+                            ? () =>
+                                  dispatch(
+                                      openModal({
+                                          type: 'transaction-detail',
+                                          txid: tx.approvalTxid!,
+                                          descriptor: account.descriptor,
+                                          symbol: account.symbol,
+                                          deviceState: account.deviceState,
+                                          flow: 'detail',
+                                      }),
+                                  )
+                            : undefined
+                    }
+                />
             )}
         </Column>
     );

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3472,6 +3472,10 @@ export const messages = defineMessages({
         defaultMessage: 'unknown',
         id: 'TR_UNKNOWN_CONFIRMATION_TIME',
     },
+    TR_UNKNOWN: {
+        defaultMessage: 'Unknown',
+        id: 'TR_UNKNOWN',
+    },
     TR_UNKNOWN_TRANSACTION: {
         defaultMessage: 'Unknown transaction',
         id: 'TR_UNKNOWN_TRANSACTION',


### PR DESCRIPTION
## Description

Extracts duplicated pending transaction UI from yield and swap approval flows into a shared `PendingTransactionInfo` component in `@trezor/product-components`.

Migrate `YieldPendingTransaction` and `TradingFormApproval` to use it.

Adds `TR_UNKNOWN` translation key.

## Notes for QA


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27018

## Screenshots:

<img width="560" height="346" alt="image" src="https://github.com/user-attachments/assets/b2b7f1d9-1f29-4343-b0f8-13c063f3c588" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/pending-transaction-info-component&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/pending-transaction-info-component&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T10:00:31.617Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T09:59:01.611Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/pending-transaction-info-component/web/](https://dev.suite.sldev.cz/suite-web/feat/pending-transaction-info-component/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->