### PR TITLE
feat(suite): warn when Caps Lock is on in passphrase input

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
@@ -157,14 +157,17 @@ export const PassphraseInputCard = ({
                             bottomText={errorMessage}
                             hasError={!!errorMessage}
                             rightContent={
-                                <Icon
-                                    size={18}
-                                    intent="neutral"
-                                    priority="secondary"
-                                    name={showPassword ? 'eyeClosed' : 'eye'}
-                                    onClick={() => setShowPassword(prev => !prev)}
-                                    data-testid="@passphrase/show-toggle"
-                                />
+                                // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+                                <span onMouseDown={e => e.preventDefault()}>
+                                    <Icon
+                                        size={18}
+                                        intent="neutral"
+                                        priority="secondary"
+                                        name={showPassword ? 'eyeClosed' : 'eye'}
+                                        onClick={() => setShowPassword(prev => !prev)}
+                                        data-testid="@passphrase/show-toggle"
+                                    />
+                                </span>
                             }
                         />
                         <AnimatePresence initial={false}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -13,6 +13,7 @@ import {
     Icon,
     Image,
     Input,
+    Note,
     Row,
     Text,
     Tooltip,
@@ -44,6 +45,14 @@ const getErrorMessage = (isPassphraseTooLong: boolean, isUsingNonAsciiCharacters
     return null;
 };
 
+const heightFadeMotionProps = {
+    initial: { height: 0, opacity: 0 },
+    animate: { height: 'auto', opacity: 1 },
+    exit: { height: 0, opacity: 0 },
+    transition: { duration: 0.2, ease: motionEasing.transition },
+    style: { overflow: 'hidden' as const },
+};
+
 export const PassphraseInputCard = ({
     deviceModel,
     isLoading,
@@ -56,6 +65,8 @@ export const PassphraseInputCard = ({
     const modal = useSelector(state => state.modal);
     const [internalValue, setInternalValue] = useState('');
     const [showPassword, setShowPassword] = useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+    const [isCapsLockOn, setIsCapsLockOn] = useState(false);
     const { translationString } = useTranslation();
     const value = externalValue ?? internalValue;
     const setValue = setExternalValue ?? setInternalValue;
@@ -69,6 +80,25 @@ export const PassphraseInputCard = ({
         ? false
         : getNonAsciiChars(value) !== null;
     const errorMessage = getErrorMessage(isPassphraseTooLong, isUsingNonAsciiCharacters);
+    const showCapsLockHint = isCapsLockOn && !errorMessage;
+
+    useEffect(() => {
+        if (!isFocused) {
+            setIsCapsLockOn(false);
+
+            return;
+        }
+
+        const handler = (event: KeyboardEvent) => {
+            setIsCapsLockOn(event.getModifierState('CapsLock'));
+        };
+
+        window.addEventListener('keydown', handler);
+
+        return () => {
+            window.removeEventListener('keydown', handler);
+        };
+    }, [isFocused]);
 
     const submit = useCallback(
         (value2: string, passphraseOnDevice?: boolean) => {
@@ -117,6 +147,9 @@ export const PassphraseInputCard = ({
                             data-testid="@passphrase/input"
                             placeholder={translationString('TR_ENTER_PASSPHRASE')}
                             onChange={e => setValue(e.target.value)}
+                            onFocus={() => setIsFocused(true)}
+                            onBlur={() => setIsFocused(false)}
+                            onMouseDown={e => setIsCapsLockOn(e.getModifierState('CapsLock'))}
                             // eslint-disable-next-line jsx-a11y/no-autofocus
                             autoFocus={!isAndroid()}
                             isMasked={!showPassword}
@@ -136,18 +169,20 @@ export const PassphraseInputCard = ({
                         />
                         <AnimatePresence initial={false}>
                             {value && !errorMessage && (
-                                <motion.div
-                                    initial={{ height: 0, opacity: 0 }}
-                                    animate={{ height: 'auto', opacity: 1 }}
-                                    exit={{ height: 0, opacity: 0 }}
-                                    transition={{
-                                        duration: 0.2,
-                                        ease: motionEasing.transition,
-                                    }}
-                                    style={{ overflow: 'hidden' }}
-                                >
-                                    <Box padding={{ top: spacings.xs }}>
+                                <motion.div {...heightFadeMotionProps}>
+                                    <Box padding={{ top: 8 }}>
                                         <PasswordStrengthIndicator password={value} />
+                                    </Box>
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                        <AnimatePresence initial={false}>
+                            {showCapsLockHint && (
+                                <motion.div {...heightFadeMotionProps}>
+                                    <Box padding={{ top: 8 }}>
+                                        <Note>
+                                            <Translation id="TR_PASSPHRASE_CAPS_LOCK_ON" />
+                                        </Note>
                                     </Box>
                                 </motion.div>
                             )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
@@ -162,7 +162,7 @@ export const PassphraseInputCard = ({
                                     intent="neutral"
                                     priority="secondary"
                                     name={showPassword ? 'eyeClosed' : 'eye'}
-                                    onClick={() => setShowPassword(!showPassword)}
+                                    onClick={() => setShowPassword(prev => !prev)}
                                     data-testid="@passphrase/show-toggle"
                                 />
                             }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2895,6 +2895,10 @@ export const messages = defineMessages({
         defaultMessage: 'Passphrases are case-sensitive',
         id: 'TR_PASSPHRASE_CASE_SENSITIVE',
     },
+    TR_PASSPHRASE_CAPS_LOCK_ON: {
+        defaultMessage: 'Caps Lock is on',
+        id: 'TR_PASSPHRASE_CAPS_LOCK_ON',
+    },
     TR_PASSPHRASE_TOO_LONG: {
         defaultMessage: 'Passphrase length exceeds the allowed limit.',
         id: 'TR_PASSPHRASE_TOO_LONG',


### PR DESCRIPTION
Detects Caps Lock via window-level keydown/keyup listeners while the passphrase input is focused, and surfaces a small info-icon hint below the password strength indicator.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a check to the passphrase field for if the Capslock.

Designs: https://www.figma.com/design/PoZxkP3IC6lkLkauUEBGVq/Passphrase--Final-?node-id=2201-4154&t=MG8qNVyizWmg15vB-0

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve [18078](https://github.com/trezor/trezor-suite/issues/18078)

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes span four areas: the PassphraseInputCard UI component, two Suite Sync type/utility files, and the intl messages file. The highest risk is in passphrase-related flows since PassphraseInputCard is directly used for all hidden wallet creation and passphrase entry UIs. Suite Sync changes (ensureWalletSuiteSyncOn and SuiteSyncErrorHandler) pose moderate risk to metadata/labeling sync tests. The messages.ts file maps to 121+ tests but is a global utility; only tests that assert specific translation keys warrant attention. Testing should prioritize passphrase E2E flows and Suite Sync metadata tests.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx`
- `suite-common/suite-sync-types/src/SuiteSyncErrorHandler.ts`
- `suite-common/suite-sync-types/src/storage/ensureWalletSuiteSyncOn.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/passphrase/passphrase.test.ts` — PassphraseInputCard.tsx is the component under test for passphrase entry flows. This test directly exercises passphrase input, confirmation, mismatch detection, visibility toggling, and hidden wallet creation - all behaviors that depend on the PassphraseInputCard component.
- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test exercises the passphrase entry and cancellation flow, directly using the PassphraseInputCard component to fill in a passphrase, submit it, and cancel from the device confirmation prompt.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — This test adds hidden wallets via passphrase entry (using PassphraseInputCard) and verifies duplicate passphrase detection with translated warning messages. Changes to PassphraseInputCard or messages.ts could affect the duplicate detection UI.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test covers passphrase re-entry after device reconnection, passphrase caching, and the full passphrase input flow - all directly exercising PassphraseInputCard functionality including the 'Confirm passphrase' prompt.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test adds multiple hidden wallets via passphrase entry (using PassphraseInputCard) and verifies wallet numbering/labeling with translation keys like TR_PASSPHRASE_WALLET. Changes to messages.ts or PassphraseInputCard could affect these flows.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test adds a hidden wallet with passphrase (using PassphraseInputCard), enters incorrect passphrases, and verifies error toast behavior - directly testing the passphrase input component's behavior with Cardano address verification.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test covers migration from legacy labeling to Suite Sync, which involves ensureWalletSuiteSyncOn logic and the Evolu sync layer. Changes to ensureWalletSuiteSyncOn.ts could directly affect the Suite Sync enablement flow tested here.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises Suite Sync enablement across multiple wallets including passphrase wallets, with Suite Sync banner visibility checks. Changes to ensureWalletSuiteSyncOn.ts and SuiteSyncErrorHandler.ts could affect the sync setup and error handling flows.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test creates labels via Suite Sync and verifies they sync to the Evolu relay. The ensureWalletSuiteSyncOn.ts change could affect Suite Sync initialization, and SuiteSyncErrorHandler.ts could affect error handling during sync operations.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs labels from the Evolu relay server and verifies Suite Sync setup including device confirmation. Changes to ensureWalletSuiteSyncOn.ts directly affect the sync initialization tested here.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — This test enables Suite Sync, removes labels, and verifies null values are synced to the relay. The ensureWalletSuiteSyncOn.ts change could affect the sync enablement flow that precedes label removal.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test verifies translated heading text from the intl messages module (TR_ONBOARDING_DATA_COLLECTION_HEADING). If the messages.ts change modifies this specific key, it would cause a test failure.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/suite-sync-types/src/SuiteSyncErrorHandler.ts`

_Updated: 2026-04-28T10:05:24.220Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=capslock-check-on-passphrase&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=capslock-check-on-passphrase&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=capslock-check-on-passphrase&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 22 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T10:11:06.902Z • 22 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-06T14:59:28.348Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/capslock-check-on-passphrase/web/](https://dev.suite.sldev.cz/suite-web/capslock-check-on-passphrase/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->