### PR TITLE
Mobile Swap: fix unresponsive Continue button in trade form

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -1,27 +1,17 @@
-import {
-    type AnimatedProps,
-    FadeIn,
-    FadeOut,
-    FadeOutDown,
-    LinearTransition,
-} from 'react-native-reanimated';
+import { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
 
 import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
-import { AnimatedBox, AnimatedVStack, Button } from '@suite-native/atoms';
+import { AnimatedBox, Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { useExchangeSelectQuote } from '../../hooks/exchange/useExchangeSelectQuote';
 import { useTradingStellarActivateToken } from '../../hooks/general/useTradingStellarActivateToken';
 
-export type ExchangeConfirmationProps = {
-    enteringAnimation?: AnimatedProps<any>['entering'];
-};
-
 export const CONFIRMATION_TEST_ID = '@trading/exchange/continue-button';
 export const REVOKE_TEST_ID = '@trading/exchange/revoke-button';
 
-export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmationProps) => {
+export const ExchangeConfirmation = () => {
     const form = useExchangeFormContext();
     const receiveAsset = form.watch('receiveAsset');
     const receiveCryptoId = receiveAsset?.cryptoId;
@@ -43,7 +33,7 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
         });
 
     return (
-        <AnimatedVStack entering={enteringAnimation} exiting={FadeOutDown} spacing="sp16">
+        <VStack spacing="sp16">
             {isReceivingInactiveStellarToken ? (
                 activateButtonElement
             ) : (
@@ -69,6 +59,6 @@ export const ExchangeConfirmation = ({ enteringAnimation }: ExchangeConfirmation
                     )}
                 </>
             )}
-        </AnimatedVStack>
+        </VStack>
     );
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
@@ -1,5 +1,12 @@
 import { memo } from 'react';
-import { FadeIn, FadeInDown, LinearTransition } from 'react-native-reanimated';
+import { Platform } from 'react-native';
+import {
+    FadeInUp,
+    FadeOutUp,
+    LinearTransition,
+    StretchInY,
+    StretchOutY,
+} from 'react-native-reanimated';
 
 import { AnimatedBox, Card, VStack } from '@suite-native/atoms';
 import { AmountEditingDoneButton } from '@suite-native/trading-atoms';
@@ -12,68 +19,47 @@ import { ExchangeReceiveAccountPicker } from './receive/ExchangeReceiveAccountPi
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
 import { useExchangeQuotes } from '../../hooks/exchange/useExchangeQuotes';
 import { useFocusedValueWatch } from '../../hooks/general/useFocusedValueWatch';
-import { useMountedRecentlyFlag } from '../../hooks/general/useMountedRecentlyFlag';
-
-type ExchangeFormProps = {
-    shouldAnimateEntering?: boolean;
-};
 
 type ExchangeFormMemoizedProps = {
     isAmountInputActive: boolean;
-    shouldAnimateEntering?: boolean;
 };
 
 const EXCHANGE_FORM_TEST_ID = '@trading/exchange/form';
 const AMOUNT_EDITING_DONE_BUTTON_TEST_ID = '@trading/exchange/amount-editing-done-button';
 
-const getEnteringAnimation = (isFormMountedRecently?: boolean, shouldAnimateEntering?: boolean) => {
-    if (!isFormMountedRecently) {
-        return FadeInDown;
-    }
+const cardEnteringAnimation = Platform.OS === 'android' ? StretchInY : FadeInUp;
+const cardExitingAnimation = Platform.OS === 'android' ? StretchOutY : FadeOutUp;
 
-    return shouldAnimateEntering ? FadeIn : undefined;
-};
+const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoizedProps) => (
+    <AnimatedBox layout={LinearTransition}>
+        <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
+            <ExchangeAlert />
+            <ExchangeCard isAmountInputActive={isAmountInputActive} />
+            {isAmountInputActive ? (
+                <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
+            ) : (
+                <>
+                    <AnimatedBox
+                        layout={LinearTransition}
+                        entering={cardEnteringAnimation}
+                        exiting={cardExitingAnimation}
+                    >
+                        <Card noPadding>
+                            <ExchangeReceiveAccountPicker />
+                            <ExchangeRateAndProviderPicker />
+                        </Card>
+                    </AnimatedBox>
+                    <ExchangeConfirmation />
+                </>
+            )}
+        </VStack>
+    </AnimatedBox>
+));
 
-const ExchangeFormMemoized = memo(
-    ({ isAmountInputActive, shouldAnimateEntering }: ExchangeFormMemoizedProps) => {
-        const isFormMountedRecently = useMountedRecentlyFlag();
-
-        const enteringAnimation = getEnteringAnimation(
-            isFormMountedRecently,
-            shouldAnimateEntering,
-        );
-
-        return (
-            <AnimatedBox layout={LinearTransition}>
-                <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
-                    <ExchangeAlert />
-                    <ExchangeCard isAmountInputActive={isAmountInputActive} />
-                    {isAmountInputActive ? (
-                        <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
-                    ) : (
-                        <>
-                            <Card noPadding>
-                                <ExchangeReceiveAccountPicker />
-                                <ExchangeRateAndProviderPicker />
-                            </Card>
-                            <ExchangeConfirmation enteringAnimation={enteringAnimation} />
-                        </>
-                    )}
-                </VStack>
-            </AnimatedBox>
-        );
-    },
-);
-
-export const ExchangeForm = ({ shouldAnimateEntering }: ExchangeFormProps) => {
+export const ExchangeForm = () => {
     const exchangeForm = useExchangeFormContext();
     const isAmountInputActiveDebounced = useFocusedValueWatch(exchangeForm.watch);
     useExchangeQuotes(exchangeForm);
 
-    return (
-        <ExchangeFormMemoized
-            isAmountInputActive={isAmountInputActiveDebounced}
-            shouldAnimateEntering={shouldAnimateEntering}
-        />
-    );
+    return <ExchangeFormMemoized isAmountInputActive={isAmountInputActiveDebounced} />;
 };

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormSkeleton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormSkeleton.tsx
@@ -4,15 +4,15 @@ import { SkeletonLargeRow, SkeletonSmall } from '@suite-native/trading-atoms';
 export const ExchangeFormSkeleton = () => (
     <>
         <Card>
-            <VStack>
-                <SkeletonSmall widthPercentage={0.2} />
-                <SkeletonLargeRow leftWidthPercentage={0.4} rightWidthPercentage={0.35} />
-            </VStack>
-        </Card>
-        <Card>
-            <VStack>
-                <SkeletonSmall widthPercentage={0.2} />
-                <SkeletonLargeRow leftWidthPercentage={0.4} rightWidthPercentage={0.3} />
+            <VStack spacing="sp16">
+                <VStack>
+                    <SkeletonSmall widthPercentage={0.2} />
+                    <SkeletonLargeRow leftWidthPercentage={0.4} rightWidthPercentage={0.35} />
+                </VStack>
+                <VStack>
+                    <SkeletonSmall widthPercentage={0.2} />
+                    <SkeletonLargeRow leftWidthPercentage={0.4} rightWidthPercentage={0.3} />
+                </VStack>
             </VStack>
         </Card>
     </>

--- a/suite-native/module-trading/src/components/exchange/ExchangeTabContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTabContent.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { ServerOffline } from '@suite-native/trading-atoms';
 
@@ -11,7 +11,6 @@ export const ExchangeTabContent = () => {
     const [reloadOrdinal, setReloadOrdinal] = useState(0);
     const { isLoading, lastLoadedTimestamp, isFullyLoaded } = useExchangeData(reloadOrdinal);
     const isLoadingFinished = !isLoading && lastLoadedTimestamp > 0;
-    const wasSkeletonDisplayed = useRef(!isLoadingFinished);
 
     if (isLoadingFinished && !isFullyLoaded) {
         return <ServerOffline onRetryPress={() => setReloadOrdinal(n => n + 1)} />;
@@ -23,7 +22,7 @@ export const ExchangeTabContent = () => {
 
     return (
         <ExchangeFormContextProvider>
-            <ExchangeForm shouldAnimateEntering={wasSkeletonDisplayed.current} />
+            <ExchangeForm />
         </ExchangeFormContextProvider>
     );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Updates animations on Exchange Form Screen.
- This update should hopefully prevent animations to fail and obstruct UI.
- Updates Exchange form skeleton according to recent layout changes.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve 27152

## Screenshots:
### Skeleton
<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-28 at 15 02 25" src="https://github.com/user-attachments/assets/a04f5985-afd6-4fd7-8fe3-ca53e05185d6" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=27152-mobile-continue-button-becomes-unresponsive-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->