### PR TITLE
refactor(connect): extract FirmwareReleaseStore from DataManager

### DIFF
--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -2,41 +2,13 @@
 
 import type { ConnectSettings, LocalFirmwares } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type {
-    ConditionalRelease,
-    DeviceModelInternal,
-    FirmwareReleaseConfig,
-    FirmwareType,
-    IntermediaryReleaseConfig,
-    ReleasesConfig,
-} from '@trezor/device-utils';
 
-import {
-    getFirmwareReleaseConfig,
-    getOnlyLocalFirmwareReleaseConfig,
-} from '../utils/firmwareReleaseConfigUtils';
-
-export type InitializeFirmwareConfig = (
-    config: FirmwareReleaseConfig,
-    isRemote: boolean,
-) => Promise<{
-    releases: ReleasesConfig;
-    intermediaries: Record<DeviceModelInternal, IntermediaryReleaseConfig[]>;
-}>;
+import * as firmwareReleaseStore from './firmwareReleaseStore';
+import type { InitializeFirmwareConfig } from './firmwareReleaseStore';
 
 export class DataManager {
     private static settings: ConnectSettings;
-    // at the moment, messages is readonly but it might make sense to modify this in the future, when
-    // we implement additive protobufs handling as a part of modularization effort
     private static localFirmwares: LocalFirmwares = { firmwareDir: '', firmwareList: [] };
-    private static firmwareReleasesConfig: Partial<
-        Record<keyof typeof DeviceModelInternal, Record<FirmwareType, ConditionalRelease>>
-    > = {};
-    private static firmwareIntermediaryReleasesConfig:
-        | Record<keyof typeof DeviceModelInternal, IntermediaryReleaseConfig[]>
-        | undefined;
-    private static localFirmwareReleaseConfig: FirmwareReleaseConfig;
-    private static initializeFirmwareConfig: InitializeFirmwareConfig;
 
     public static async load(
         settings: ConnectSettings,
@@ -44,32 +16,17 @@ export class DataManager {
         onlyLocalFirmwareConfig = false,
         initializeFirmwareConfig?: InitializeFirmwareConfig,
     ) {
-        if (initializeFirmwareConfig) {
-            this.initializeFirmwareConfig = initializeFirmwareConfig;
-        }
         this.settings = settings;
 
         if (!withAssets) return;
 
-        const { config: localFirmwareReleaseConfig } = getOnlyLocalFirmwareReleaseConfig();
-        this.localFirmwareReleaseConfig = localFirmwareReleaseConfig;
-        await this.loadFirmwareReleaseConfig(onlyLocalFirmwareConfig);
-    }
+        if (!initializeFirmwareConfig) return;
 
-    private static async loadFirmwareReleaseConfig(onlyLocal: boolean): Promise<void> {
-        let firmwareReleaseConfig;
-        if (onlyLocal) {
-            firmwareReleaseConfig = {
-                config: this.localFirmwareReleaseConfig,
-                isRemote: false,
-            };
-        } else {
-            firmwareReleaseConfig = await getFirmwareReleaseConfig(this.settings?.firmwareChannel);
-        }
-        const { config, isRemote } = firmwareReleaseConfig;
-        const firmwareConfig = await this.initializeFirmwareConfig(config, isRemote);
-        this.firmwareReleasesConfig = firmwareConfig.releases;
-        this.firmwareIntermediaryReleasesConfig = firmwareConfig.intermediaries;
+        await firmwareReleaseStore.init(
+            settings.firmwareChannel,
+            onlyLocalFirmwareConfig,
+            initializeFirmwareConfig,
+        );
     }
 
     public static updateSettings(update: Partial<ConnectSettings>) {
@@ -101,17 +58,5 @@ export class DataManager {
     }
     public static getLocalFirmwares(): LocalFirmwares {
         return this.localFirmwares;
-    }
-
-    public static getLocalFirmwareReleaseConfig(): FirmwareReleaseConfig {
-        return this.localFirmwareReleaseConfig;
-    }
-
-    public static getFirmwareReleaseConfig() {
-        return this.firmwareReleasesConfig;
-    }
-
-    public static getFirmwareIntermediaryReleaseConfig() {
-        return this.firmwareIntermediaryReleasesConfig;
     }
 }

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -22,6 +22,7 @@ import { getIntegerInRangeFromString, removeTrailingSlashes, versionUtils } from
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from './DataManager';
+import * as firmwareReleaseStore from './firmwareReleaseStore';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
 import { getOnlineFirmwareBaseUrl } from '../utils/firmwareReleaseConfigUtils';
@@ -39,7 +40,7 @@ const getBundledFirmwareVersion = (
     deviceModel: DeviceModelInternal,
     firmwareType: FirmwareType,
 ): string | undefined => {
-    const localFirmwareReleaseConfig = DataManager.getLocalFirmwareReleaseConfig();
+    const localFirmwareReleaseConfig = firmwareReleaseStore.getLocal();
     const modelReleases = localFirmwareReleaseConfig.releases[deviceModel];
     const bundledRelease = modelReleases?.[firmwareType];
     if (!bundledRelease) {
@@ -137,7 +138,7 @@ export const getReleaseConfig = (
     if (internal_model === DeviceModelInternal.UNKNOWN) {
         return undefined;
     }
-    const firmwareReleaseConfig = DataManager.getFirmwareReleaseConfig();
+    const firmwareReleaseConfig = firmwareReleaseStore.getReleases();
 
     if (!firmwareReleaseConfig) {
         throw new Error('Firmware release config not loaded.');
@@ -288,7 +289,7 @@ export const initializeFirmwareConfig = async (
     }
 
     // We had some issue getting remote so we use local data.
-    const localFirmwareReleaseConfig = DataManager.getLocalFirmwareReleaseConfig();
+    const localFirmwareReleaseConfig = firmwareReleaseStore.getLocal();
     const localReleases = createLocalFirmwareConfig(localFirmwareReleaseConfig);
 
     return {
@@ -319,7 +320,7 @@ const getCurrentVersion = (features: Features): CurrentVersion => {
 };
 
 const getIntermediaryMessageRelease = (features: Features) => {
-    const config = DataManager.getFirmwareIntermediaryReleaseConfig();
+    const config = firmwareReleaseStore.getIntermediary();
     if (!config) {
         throw new Error('Firmware release config not loaded.');
     }
@@ -353,7 +354,7 @@ const getIsBitcoinOnlyAvailable = (features: Features) => {
         return false;
     }
 
-    const firmwareReleaseConfig = DataManager.getFirmwareReleaseConfig();
+    const firmwareReleaseConfig = firmwareReleaseStore.getReleases();
 
     if (!firmwareReleaseConfig) {
         throw new Error('Firmware release config not loaded.');

--- a/packages/connect/src/data/firmwareReleaseStore.ts
+++ b/packages/connect/src/data/firmwareReleaseStore.ts
@@ -1,0 +1,49 @@
+import type { FirmwareChannel } from '@trezor/connect-common/src/types/firmware';
+import type {
+    ConditionalRelease,
+    DeviceModelInternal,
+    FirmwareReleaseConfig,
+    FirmwareType,
+    IntermediaryReleaseConfig,
+    ReleasesConfig,
+} from '@trezor/device-utils';
+
+import {
+    getFirmwareReleaseConfig,
+    getOnlyLocalFirmwareReleaseConfig,
+} from '../utils/firmwareReleaseConfigUtils';
+
+export type InitializeFirmwareConfig = (
+    config: FirmwareReleaseConfig,
+    isRemote: boolean,
+) => Promise<{
+    releases: ReleasesConfig;
+    intermediaries: Record<DeviceModelInternal, IntermediaryReleaseConfig[]>;
+}>;
+
+const local: FirmwareReleaseConfig = getOnlyLocalFirmwareReleaseConfig().config;
+let releases:
+    | Partial<Record<keyof typeof DeviceModelInternal, Record<FirmwareType, ConditionalRelease>>>
+    | undefined;
+let intermediary: Record<keyof typeof DeviceModelInternal, IntermediaryReleaseConfig[]> | undefined;
+
+export const init = async (
+    firmwareChannel: FirmwareChannel | undefined,
+    onlyLocal: boolean,
+    initializeFirmwareConfig: InitializeFirmwareConfig,
+): Promise<void> => {
+    const firmwareReleaseConfig = onlyLocal
+        ? { config: local, isRemote: false as const }
+        : await getFirmwareReleaseConfig(firmwareChannel);
+
+    const result = await initializeFirmwareConfig(
+        firmwareReleaseConfig.config,
+        firmwareReleaseConfig.isRemote,
+    );
+    releases = result.releases;
+    intermediary = result.intermediaries;
+};
+
+export const getLocal = (): FirmwareReleaseConfig => local;
+export const getReleases = () => releases;
+export const getIntermediary = () => intermediary;


### PR DESCRIPTION
> **DataManager architecture refactor — Phase 2 of an ongoing series.**
>
> Open PRs in the series:
> 1. ~~#27106~~ (merged) — move `parseCoinsJson` out of `DataManager.load()`
> 2. **#27157 (this PR)** — extract `FirmwareReleaseStore` from `DataManager`
> 3. #27209 — extract `LocalFirmwareStore` from `DataManager`
> 4. #27210 — replace `DataManager` with `settingsStore` and inline the load lifecycle (final)
>
> Built on top of the already-merged cleanup PRs (#27077, #27087, #27088). Phases 3 and 4 each cherry-pick the previous phases to avoid conflicts and rebase cleanly when those land.

## Summary

`DataManager` held three unrelated concerns: settings, local firmwares, and a firmware-release cache (releases, intermediary, local config plus a DI slot for the initializer). Move the firmware-release cache into a dedicated pure module.

The new `firmwareReleaseStore` exposes `init()` and three query functions (`getLocal`, `getReleases`, `getIntermediary`). `DataManager.load` delegates to `firmwareReleaseStore.init` when an `InitializeFirmwareConfig` is provided; **the public `load()` signature is unchanged**.

Five call sites in `firmwareInfo.ts` now read from the store directly. The `InitializeFirmwareConfig` type lives next to the function that owns it. No external consumer imported it from `DataManager`.

## What changes

- New `packages/connect/src/data/firmwareReleaseStore.ts` (~50 lines) — pure module with `let`-bound state and named exports.
- `DataManager.ts` — drops 4 fields, 1 private method, 3 public getters, 1 type definition, 6 imports. `load()` now delegates the firmware-release init.
- `firmwareInfo.ts` — 5 callsite swaps + 1 added namespace import.

## Compatibility

- `DataManager.load()` signature is unchanged.
- `DataManager.getSettings`, `setLocalFirmwares`, `getLocalFirmwares`, `updateSettings`, `isLoaded` all unchanged.
- The three removed getters (`getLocalFirmwareReleaseConfig`, `getFirmwareReleaseConfig`, `getFirmwareIntermediaryReleaseConfig`) were only consumed by `firmwareInfo.ts` (verified by full-repo grep). Their replacements are simple namespace-prefixed calls.
- `InitializeFirmwareConfig` type was previously exported by `DataManager` but never imported externally; it now lives in `firmwareReleaseStore`.

## Test plan

- [ ] CI typecheck passes for `@trezor/connect`
- [ ] CI unit tests for `@trezor/connect` remain green (init flow + firmware-release-aware paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fw-release-store/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fw-release-store/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->