### PR TITLE
refactor(utils): use globalThis.crypto.getRandomValues in getRandomInt

### DIFF
--- a/packages/utils/src/getRandomInt.ts
+++ b/packages/utils/src/getRandomInt.ts
@@ -1,5 +1,3 @@
-import { getRandomValues as cryptoGetRandomValues } from 'crypto';
-
 /**
  * Before changing anything here, see the Modulo Bias problem!
  * @see https://research.kudelskisecurity.com/2020/07/28/the-definitive-guide-to-modulo-bias-and-how-to-avoid-it/
@@ -35,10 +33,12 @@ export const getRandomInt = (min: number, max: number) => {
         );
     }
 
-    const getRandomValues =
-        typeof window !== 'undefined'
-            ? (array: ArrayBufferView<ArrayBuffer>) => window.crypto.getRandomValues(array)
-            : (array: ArrayBufferView<ArrayBuffer>) => cryptoGetRandomValues(array);
+    if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+        throw new Error(
+            'Web Crypto API (globalThis.crypto.getRandomValues) is not available in this environment. ' +
+                'Requires a secure browser context (HTTPS) or Node.js 19+.',
+        );
+    }
 
     const array = new Uint32Array(1); // This provides 32 bits of entropy.
 
@@ -50,7 +50,7 @@ export const getRandomInt = (min: number, max: number) => {
 
     let randomValue: number;
     do {
-        getRandomValues(array);
+        globalThis.crypto.getRandomValues(array);
         randomValue = array[0];
     } while (randomValue >= maxRange);
 

--- a/packages/utils/tests/getRandomInt.test.ts
+++ b/packages/utils/tests/getRandomInt.test.ts
@@ -12,6 +12,24 @@ describe(getRandomInt.name, () => {
         expect(() => getRandomInt(0, -1)).toThrow(EXPECTED_ERROR.message);
     });
 
+    it('raises error when Web Crypto API is not available', () => {
+        const originalCrypto = globalThis.crypto;
+
+        // @ts-expect-error: intentionally removing crypto to simulate unsupported environment
+        delete globalThis.crypto;
+
+        try {
+            expect(() => getRandomInt(0, 10)).toThrow(
+                'Web Crypto API (globalThis.crypto.getRandomValues) is not available in this environment.',
+            );
+        } finally {
+            Object.defineProperty(globalThis, 'crypto', {
+                value: originalCrypto,
+                configurable: true,
+            });
+        }
+    });
+
     it('raises error for range > 2^32', () => {
         const EXPECTED_ERROR = new RangeError(
             'This function only provide 32 bits of entropy, therefore range cannot be more then 2^32.',


### PR DESCRIPTION
## Summary

Switch `@trezor/utils/getRandomInt` from `crypto.getRandomValues` to `globalThis.crypto.getRandomValues`. Available uniformly in Node 24+, browsers and Web Workers, so the `typeof window` branch can go.

cc @peter-sanderson — original author of this implementation per `git log` (commit 3f4312e834, _feat: implement strong randomInt that works in browser without need for polyfill lib_), would love a sanity check on the entropy/modulo-bias side.

## Why

- Removes a workspace-level `import 'crypto'` that pulls `crypto-browserify` into webpack bundles.
- Fixes a latent bug: `typeof window !== 'undefined'` is `false` inside a Web Worker, so workers were silently falling back to the Node `crypto.getRandomValues` import (resolved by webpack to `crypto-browserify`'s shim) instead of using the Web Crypto API. With `globalThis.crypto.getRandomValues`, all environments use the same call site:
  - browser / Web Worker → Web Crypto API (`window.crypto` / `self.crypto` aliased on `globalThis`)
  - Node 24+ → built-in `globalThis.crypto` (stable since Node 19)

The modulo-bias rejection sampling loop is unchanged.

## Out of scope

This is split out of #27149 (blockchain-link crypto-browserify cleanup) so the entropy change can be reviewed in isolation. That larger PR depends on this landing first (or being squashed in).

## Test plan

- [x] `yarn workspace @trezor/utils test:unit` (3 passed, including the `randomInt`-equivalence checks)
- [ ] @peter-sanderson sanity check on the call-site swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to `getRandomInt`, a broad utility function mapped to 121 tests. Since it's a simple math utility, the risk of regression is low and widely dispersed. The only test with specific evidence of direct usage is `discovery.test.ts`, which uses `getRandomInt` to compute a random reload delay. All other 120+ tests transitively import this utility but show no specific dependence on its behavior in their test logic. A minimal test run focusing on the discovery test provides reasonable confidence.

<details><summary><b>Changed files (1)</b></summary>

- `packages/utils/src/getRandomInt.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly imports and uses getRandomInt from @trezor/utils to generate a random delay before page reload during discovery. A change to getRandomInt's behavior (e.g., range, return type) could cause the reload timing logic to break or produce unexpected values.

</details>

_Updated: 2026-04-28T13:54:56.480Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/get-random-int-web-crypto&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/get-random-int-web-crypto&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:50:34.582Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:49:26.720Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/get-random-int-web-crypto/web/](https://dev.suite.sldev.cz/suite-web/mroz22/get-random-int-web-crypto/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->