### PR TITLE
refactor(suite): tron resources ui

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react';
 
-import { Column, ProgressBar, Row, Text, Tooltip } from '@trezor/components';
+import { Card, Column, ProgressBar, Row, Text, Tooltip } from '@trezor/components';
 
 export type ResourceProps = {
     label: ReactNode;
@@ -10,15 +10,17 @@ export type ResourceProps = {
 };
 
 export const Resource = ({ label, tooltip, available, total }: ResourceProps) => (
-    <Column gap={8} minWidth={200} maxWidth={400} flex="1">
-        <Row justifyContent="space-between" alignItems="center">
-            <Tooltip hasIcon content={tooltip}>
-                <Text>{label}</Text>
-            </Tooltip>
-            <Text>
-                {available} / {total}
-            </Text>
-        </Row>
-        <ProgressBar value={available} max={total} />
-    </Column>
+    <Card>
+        <Column gap={8} minWidth={200} flex="1">
+            <Row justifyContent="space-between" alignItems="center">
+                <Tooltip hasIcon content={tooltip}>
+                    <Text>{label}</Text>
+                </Tooltip>
+                <Text>
+                    {available} / {total}
+                </Text>
+            </Row>
+            <ProgressBar value={available} max={total} />
+        </Column>
+    </Card>
 );

--- a/packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx
@@ -1,6 +1,8 @@
 import { Translation } from '@suite/intl';
 import { type Account } from '@suite-common/wallet-types';
-import { Card, Row } from '@trezor/components';
+import { Flex } from '@trezor/components';
+
+import { useLayoutSize } from 'src/hooks/suite';
 
 import { Resource } from './Resource';
 
@@ -9,6 +11,8 @@ type TronResourcesProps = {
 };
 
 export const TronResources = ({ account }: TronResourcesProps) => {
+    const { isBelowMobile } = useLayoutSize();
+
     if (account.networkType !== 'tron') return null;
 
     const { tronResources } = account.misc;
@@ -28,21 +32,20 @@ export const TronResources = ({ account }: TronResourcesProps) => {
     const totalBandwidth = totalStakedBandwidth + totalFreeBandwidth;
 
     return (
-        <Card>
-            <Row gap={48} flexWrap="wrap">
-                <Resource
-                    label={<Translation id="TR_TRON_BANDWIDTH" />}
-                    tooltip={<Translation id="TR_TRON_BANDWIDTH_TOOLTIP" />}
-                    available={availableBandwidth}
-                    total={totalBandwidth}
-                />
-                <Resource
-                    label={<Translation id="TR_TRON_ENERGY" />}
-                    tooltip={<Translation id="TR_TRON_ENERGY_TOOLTIP" />}
-                    available={availableEnergy}
-                    total={totalEnergy}
-                />
-            </Row>
-        </Card>
+        <Flex gap={16} direction={isBelowMobile ? 'column' : 'row'}>
+            <Resource
+                label={<Translation id="TR_TRON_BANDWIDTH" />}
+                tooltip={<Translation id="TR_TRON_BANDWIDTH_TOOLTIP" />}
+                available={availableBandwidth}
+                total={totalBandwidth}
+            />
+
+            <Resource
+                label={<Translation id="TR_TRON_ENERGY" />}
+                tooltip={<Translation id="TR_TRON_ENERGY_TOOLTIP" />}
+                available={availableEnergy}
+                total={totalEnergy}
+            />
+        </Flex>
     );
 };


### PR DESCRIPTION
## Description

Put Tron resources (energy, bandwidth) to separate cards on desktop/web.

## Screenshots:

<img width="100%" alt="Screenshot 2026-04-28 at 15 54 41" src="https://github.com/user-attachments/assets/a9c81999-99a4-4279-baf0-0e19ed99e07c" />

<img width="100%" alt="Screenshot 2026-04-28 at 15 54 54" src="https://github.com/user-attachments/assets/010c3f29-980f-42b6-a9f2-b2c51f9157f0" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (Resource.tsx and TronResources.tsx) are Tron-specific UI components located in the wallet transactions view for displaying Tron resource information (bandwidth, energy). Despite mapping to 59 tests via static coverage, this is clearly a broad transitive dependency — these components are part of the wallet transactions view bundle that gets imported across many unrelated test paths. None of the 59 mapped tests directly exercise Tron resource display functionality based on the LLM analysis. The only test that touches Tron at all is the receive.test.ts which enables TRX view-only mode, but it tests address receiving, not transaction resource display. There are no E2E tests that specifically verify Tron resource/bandwidth/energy display on the transactions page, so no tests need to be run with high confidence of catching regressions in these specific components.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx`
- `packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/views/wallet/transactions/components/TronResources/Resource.tsx`
- `packages/suite/src/views/wallet/transactions/components/TronResources/TronResources.tsx`

_Updated: 2026-04-28T14:07:27.815Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/tron-resources-ui/web/](https://dev.suite.sldev.cz/suite-web/refactor/tron-resources-ui/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/tron-resources-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/tron-resources-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T19:40:11.711Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T19:39:18.590Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->