### PR TITLE
Update ui of earn consents actions buttons

### DIFF
--- a/suite-native/module-earn/src/components/EarnConsentsEntryPeriodCard.tsx
+++ b/suite-native/module-earn/src/components/EarnConsentsEntryPeriodCard.tsx
@@ -35,9 +35,6 @@ const buttonsRowStyle = prepareNativeStyle(utils => ({
     gap: utils.spacings.sp12,
 }));
 
-const learnMoreButtonStyle = prepareNativeStyle(() => ({ flex: 3 }));
-const confirmButtonStyle = prepareNativeStyle(() => ({ flex: 7 }));
-
 export const EarnConsentsEntryPeriodCard = ({
     onConfirm,
     entryPeriodInDays,
@@ -112,21 +109,16 @@ export const EarnConsentsEntryPeriodCard = ({
                 <HStack style={applyStyle(buttonsRowStyle)}>
                     {learnMoreUrl && (
                         <Button
+                            flex={1}
                             intent="info"
                             priority="secondary"
                             size="medium"
                             onPress={handleLearnMore}
-                            style={applyStyle(learnMoreButtonStyle)}
                         >
                             <Translation id="generic.buttons.learnMore" />
                         </Button>
                     )}
-                    <Button
-                        intent="info"
-                        size="medium"
-                        onPress={handleConfirm}
-                        style={applyStyle(confirmButtonStyle)}
-                    >
+                    <Button flex={2} intent="info" size="medium" onPress={handleConfirm}>
                         <Translation id="generic.buttons.understand" />
                     </Button>
                 </HStack>


### PR DESCRIPTION
## Description

Update ui of the earn consents actions buttons

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27096

## Screenshots:
<img width="1288" height="1983" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-28 at 16 04 25" src="https://github.com/user-attachments/assets/1284bd91-5ceb-429c-a184-a16208169d81" />
<img width="1290" height="1959" alt="Simulator Screenshot - iPhone 16 Plus - 2026-04-28 at 16 05 48" src="https://github.com/user-attachments/assets/4e6184f1-f824-4432-ac9e-9a30f467e45a" />
