### PR TITLE
fix(suite-native): update ui of earn consents actions buttons

### DIFF
--- a/suite-native/module-earn/src/components/EarnConsentsEntryPeriodCard.tsx
+++ b/suite-native/module-earn/src/components/EarnConsentsEntryPeriodCard.tsx
@@ -35,8 +35,10 @@ const buttonsRowStyle = prepareNativeStyle(utils => ({
     gap: utils.spacings.sp12,
 }));
 
-const learnMoreButtonStyle = prepareNativeStyle(() => ({ flex: 3 }));
-const confirmButtonStyle = prepareNativeStyle(() => ({ flex: 7 }));
+const confirmButtonStyle = prepareNativeStyle(() => ({
+    flexGrow: 1,
+    flexShrink: 1,
+}));
 
 export const EarnConsentsEntryPeriodCard = ({
     onConfirm,
@@ -116,7 +118,6 @@ export const EarnConsentsEntryPeriodCard = ({
                             priority="secondary"
                             size="medium"
                             onPress={handleLearnMore}
-                            style={applyStyle(learnMoreButtonStyle)}
                         >
                             <Translation id="generic.buttons.learnMore" />
                         </Button>


### PR DESCRIPTION
## Description

Update ui of the earn consents actions buttons. Update texts to correspondent on Desktop.


## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27096

## Screenshots:
<img width="1290" height="1961" alt="image" src="https://github.com/user-attachments/assets/c1c6a9f4-a5f3-4893-8eea-4b2cd982611b" />

<img width="1290" height="2043" alt="image" src="https://github.com/user-attachments/assets/89c9c439-49b1-44bf-b372-79ed53480c76" />


