### PR TITLE
Add fixes only needed for CI to make validation pass on release branch

### DIFF
--- a/.github/workflows/test-trezor-user-env-link-e2e.yml
+++ b/.github/workflows/test-trezor-user-env-link-e2e.yml
@@ -39,5 +39,5 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker run -d --network=host ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+          docker run -d --network=host ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
           yarn workspace @trezor/trezor-user-env-link test:e2e

--- a/docker/docker-compose.connect-test.yml
+++ b/docker/docker-compose.connect-test.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-ci-e2e.yml
+++ b/docker/docker-compose.suite-ci-e2e.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-desktop-ci.yml
+++ b/docker/docker-compose.suite-desktop-ci.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.suite-dev.yml
+++ b/docker/docker-compose.suite-dev.yml
@@ -3,7 +3,7 @@
 
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - DISPLAY=$DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/docker/docker-compose.suite-native-ci.yml
+++ b/docker/docker-compose.suite-native-ci.yml
@@ -2,7 +2,7 @@ services:
   trezor-user-env-unix:
     network_mode: "host"
     container_name: trezor-user-env.unix
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/docker/docker-compose.transport-test-ci.yml
+++ b/docker/docker-compose.transport-test-ci.yml
@@ -1,6 +1,6 @@
 services:
   trezor-user-env-unix:
-    image: ghcr.io/trezor/trezor-user-env:4b238368db1e1e710fdabb4eaf210b64b4c5a8ce
+    image: ghcr.io/trezor/trezor-user-env:22107ff76993bfd2e0dfb6235c23c32c0665bf1c
     environment:
       - SDL_VIDEODRIVER=dummy
       - XDG_RUNTIME_DIR=/var/tmp

--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const version = require('./package.json').suiteVersion;
 const baseConfig = require('../../jest.config.base');
 
@@ -17,6 +19,7 @@ const babelConfig = {
             },
         ],
     ],
+    plugins: [path.resolve(__dirname, './jest.transformImportMetaUrlPlugin.js')],
 };
 
 /**

--- a/packages/suite/jest.transformImportMetaUrlPlugin.js
+++ b/packages/suite/jest.transformImportMetaUrlPlugin.js
@@ -1,0 +1,31 @@
+module.exports = function transformImportMetaUrlPlugin({ types: t }) {
+    return {
+        name: 'transform-import-meta-url-for-jest',
+        visitor: {
+            MemberExpression(path) {
+                if (
+                    !t.isMetaProperty(path.node.object) ||
+                    path.node.object.meta.name !== 'import' ||
+                    path.node.object.property.name !== 'meta' ||
+                    !t.isIdentifier(path.node.property, { name: 'url' }) ||
+                    path.node.computed
+                ) {
+                    return;
+                }
+
+                path.replaceWith(
+                    t.memberExpression(
+                        t.callExpression(
+                            t.memberExpression(
+                                t.callExpression(t.identifier('require'), [t.stringLiteral('url')]),
+                                t.identifier('pathToFileURL'),
+                            ),
+                            [t.identifier('__filename')],
+                        ),
+                        t.identifier('href'),
+                    ),
+                );
+            },
+        },
+    };
+};


### PR DESCRIPTION
## Description

- E2E tests were failing on release branch because of new FW missing on trezor-urser-env version on release brach.
- Workaround for SharedWorker include `import.meta.url` that needs transformation for jest, but works natively on develop where we switched to swc.
