### PR TITLE
feat(suite-common): implement isStablecoinYieldSupported fw version check

### DIFF
--- a/suite-common/device/src/deviceUtils.ts
+++ b/suite-common/device/src/deviceUtils.ts
@@ -5,6 +5,8 @@ import type {
     TrezorDeviceWithState,
 } from '@suite-common/suite-types';
 import { type Device } from '@trezor/connect';
+import { DeviceModelInternal, getFirmwareVersionArray } from '@trezor/device-utils';
+import { versionUtils } from '@trezor/utils';
 
 export const DeviceCancelledErr = (): DeviceCancelledErrType => ({
     type: 'DeviceCancelled' as const,
@@ -35,10 +37,15 @@ export const shouldDeviceBeRemembered = ({
 export const isApprovalFlowSupported = (device: TrezorDevice | undefined) =>
     !device?.unavailableCapabilities?.['evmApproval'];
 
-export const isStablecoinYieldSupported = (_device: TrezorDevice | undefined) =>
-    // TODO: Replace with actual fw capability check once defined in trezor/trezor-firmware#6435.
-    // device?.unavailableCapabilities?.['erc4626'] !== 'update-required';
-    true;
+export const isStablecoinYieldSupported = (device: TrezorDevice | undefined) => {
+    if (device?.features?.internal_model === DeviceModelInternal.T1B1) {
+        return true;
+    }
+
+    const firmware = getFirmwareVersionArray(device);
+
+    return firmware !== null && versionUtils.isNewerOrEqual(firmware, [2, 11, 2]);
+};
 
 export const isTrezorDeviceWithState = (
     device: TrezorDevice | undefined,


### PR DESCRIPTION
## Description

Implements `isStablecoinYieldSupported` in suite-common/device to determine whether a device supports stablecoin yield (ERC-4626 vaults). The check is based on firmware version (>= 2.11.2), as no dedicated capability flag exists yet. 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25659

## Screenshots:

<img width="717" height="343" alt="image" src="https://github.com/user-attachments/assets/528f264d-d258-43c8-9461-0f203c6785fa" />

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to suite-common/device/src/deviceUtils.ts, a broad utility file referenced by 121 tests. This file likely contains device identification, state management, instance comparison, and connection status utilities used across the entire application. Since the specific nature of the change is unknown, the recommended strategy focuses on tests that most directly exercise device state management, device switching, wallet instance handling, and device connection status — areas where deviceUtils functions are most likely to have a visible impact. Most tests are recommended at medium priority since they exercise device-related functionality but the exact impact depends on which utility functions were modified.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/device/src/deviceUtils.ts`

</details>

**Recommended tests (9)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The DeviceConnect analytics event asserts on device metadata (firmware version, model, backup_type, pin_protection, passphrase_protection, totalInstances, totalDevices) which are likely computed or formatted using deviceUtils. Changes to deviceUtils could alter how device properties are reported in analytics events.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet discovery involves device state management (eject wallet, add standard wallet, device switcher) which relies on device utilities for identifying and managing device/wallet instances. Changes to deviceUtils could affect discovery or wallet switching behavior.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test verifies device session management (session stealing, 'Use Here' vs 'Connected' status, device switcher behavior) which directly depends on device utility functions for determining device state, session ownership, and device status display.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test verifies sequential numbering and labeling of standard vs passphrase wallets in the device switcher. deviceUtils likely contains logic for computing wallet instance numbering (totalInstances) and device/wallet identification, which this test directly validates.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Duplicate passphrase wallet detection likely uses deviceUtils to compare wallet instances and determine if a passphrase wallet already exists. Changes could affect whether duplicates are correctly identified.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test verifies multi-coin wallet discovery with reload interruption recovery. deviceUtils is likely involved in device state tracking during discovery (status transitions, device connection state), and changes could affect discovery completion behavior.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test checks that onboarding state persists across reloads and that device connection status (@deviceStatus-connected) is correctly shown after onboarding. deviceUtils may be involved in determining the connected device status indicator.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test simulates device disconnect during backup and checks device disconnected/reconnected status indicators. deviceUtils likely provides helper functions for determining device connection state that this test exercises.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect behavior with passphrase caching and wallet persistence in device switcher. deviceUtils may be used to determine if a device instance matches a remembered wallet after reconnection.

</details>

_Updated: 2026-04-28T15:40:59.942Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/stablecoin-yield-fw-gate&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/stablecoin-yield-fw-gate&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/stablecoin-yield-fw-gate&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-fw-gate/web/](https://dev.suite.sldev.cz/suite-web/feat/stablecoin-yield-fw-gate/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 33 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Sell Ethereum > Sell Ethereum token USDC | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Firmware - check readiness > Suite detects that firmware is ready | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Passphrase with cardano > verify cardano address behind passphrase | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-28T15:45:52.937Z • 33 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-28T15:45:16.929Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->