### PR TITLE
refactor(connect): drop node:crypto from thp/firmware code

### DIFF
--- a/packages/connect/src/api/firmware/calculateXPubHash.ts
+++ b/packages/connect/src/api/firmware/calculateXPubHash.ts
@@ -1,4 +1,5 @@
-import { createHash } from 'crypto';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 
 import type { XPubHashesPerBip43Path } from '@trezor/connect-common';
 
@@ -7,7 +8,7 @@ import type { XPubHashesPerBip43Path } from '@trezor/connect-common';
  * This function provides a conventional way to hash them.
  */
 export const calculateXPubHash = (xpub: string): string =>
-    createHash('sha256').update(xpub, 'utf8').digest('hex');
+    bytesToHex(sha256(new TextEncoder().encode(xpub)));
 
 export const calculateXPubHashes = (xpubs: Record<string, string>): XPubHashesPerBip43Path => {
     const hashes: XPubHashesPerBip43Path = {};

--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from '@noble/hashes/utils.js';
 
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { protobufManager } from '@trezor/protobuf';
@@ -34,7 +34,7 @@ export const createThpChannel = async (device: IDevice) => {
 
     // set default channel and create random nonce
     thpState.setChannel(protocolThp.constants.THP_DEFAULT_CHANNEL);
-    const nonce = randomBytes(8);
+    const nonce = Buffer.from(randomBytes(8));
     const createChannel = await thpCall(device, 'ThpCreateChannelRequest', { nonce });
 
     const { properties, ...resp } = createChannel.message;
@@ -81,7 +81,7 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
     const tryToUnlock = unlockPin ? 1 : 0;
 
     // 1. Generate a new ephemeral X25519 key pair (host_ephemeral_privkey, host_ephemeral_pubkey).
-    const hostEphemeralKeys = protocolThp.getCurve25519KeyPair(randomBytes(32));
+    const hostEphemeralKeys = protocolThp.getCurve25519KeyPair(Buffer.from(randomBytes(32)));
 
     // 2. Send the message HandshakeInitiationReq(host_ephemeral_pubkey) to the host.
     const handshakeInit = await thpCall(device, 'ThpHandshakeInitRequest', {

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -1,4 +1,5 @@
-import { createHash, randomBytes } from 'crypto';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, concatBytes, randomBytes } from '@noble/hashes/utils.js';
 
 import type { UiResponseThpPairingTag } from '@trezor/connect-common';
 import { DEVICE } from '@trezor/connect-common';
@@ -11,16 +12,18 @@ import * as settingsStore from '../../data/settingsStore';
 import type { IDevice } from '../../types/idevice';
 import { sanitizeString } from '../../utils/formatUtils';
 
+const sha256Hex = (...parts: Uint8Array[]): string => bytesToHex(sha256(concatBytes(...parts)));
+
 const processQrCodeTag = async (device: IDevice, value: string) => {
     const thpState = device.getThpState();
     if (!thpState?.handshakeCredentials) {
         throw ERRORS.TypedError('Device_ThpStateMissing');
     }
 
-    const tagSha = createHash('sha256')
-        .update(thpState.handshakeCredentials.handshakeHash)
-        .update(Buffer.from(value, 'hex'))
-        .digest('hex');
+    const tagSha = sha256Hex(
+        thpState.handshakeCredentials.handshakeHash,
+        Buffer.from(value, 'hex'),
+    );
     const qrCodeSecret = await thpCall(device, 'ThpQrCodeTag', {
         tag: tagSha,
     });
@@ -43,11 +46,11 @@ const processNfcTag = async (device: IDevice, value: string) => {
         throw new Error('missing nfcSecret');
     }
 
-    const tagSha = createHash('sha256')
-        .update(Buffer.from([protocolThp.ThpPairingMethod.NFC]))
-        .update(thpState.handshakeCredentials.handshakeHash)
-        .update(Buffer.from(value, 'hex'))
-        .digest('hex');
+    const tagSha = sha256Hex(
+        Buffer.from([protocolThp.ThpPairingMethod.NFC]),
+        thpState.handshakeCredentials.handshakeHash,
+        Buffer.from(value, 'hex'),
+    );
 
     const nfcTagTrezor = await thpCall(device, 'ThpNfcTagHost', {
         tag: tagSha,
@@ -302,7 +305,7 @@ export const thpPairing = async (device: IDevice) => {
     // State HP2
     if (selectMethod.type === 'ThpCodeEntryCommitment') {
         // store handshakeCommitment and validate later in `processCodeEntry`
-        const codeEntryChallenge = randomBytes(32);
+        const codeEntryChallenge = Buffer.from(randomBytes(32));
         const handshakeCommitment = Buffer.from(selectMethod.message.commitment, 'hex');
         thpState.updateHandshakeCredentials({
             handshakeCommitment,
@@ -328,7 +331,7 @@ export const thpPairing = async (device: IDevice) => {
     if (selectMethod.type === 'ThpPairingPreparationsFinished') {
         if (thpState.pairingMethod === protocolThp.ThpPairingMethod.NFC) {
             // generate random secret and store it
-            thpState.setNfcSecret(randomBytes(16));
+            thpState.setNfcSecret(Buffer.from(randomBytes(16)));
         }
 
         // State HP6 and HP7

--- a/packages/connect/src/device/workflow/checkFirmwareHash.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from '@noble/hashes/utils.js';
 
 import type { FirmwareHashCheckError, FirmwareHashCheckResult } from '@trezor/connect-common';
 import type { Log } from '@trezor/connect-common/src/utils/debug';
@@ -79,7 +79,7 @@ export const checkFirmwareHash = async ({
         internal_model: device.features.internal_model,
         firmwareVersion,
         fw: Buffer.from(strippedBinary),
-        key: randomBytes(32),
+        key: Buffer.from(randomBytes(32)),
     });
 
     // handle rejection of call by a counterfeit device. If unhandled, it crashes device initialization,


### PR DESCRIPTION
## Summary

Replace the four `import 'crypto'` call sites in `@trezor/connect` with Web Crypto / `@noble/hashes` equivalents. First step toward removing the `crypto-browserify` polyfill from Suite's browser bundle.

| file | change |
| --- | --- |
| `src/api/firmware/calculateXPubHash.ts` | `createHash('sha256')` → `sha256` from `@noble/hashes/sha2.js` + `bytesToHex` |
| `src/device/workflow/checkFirmwareHash.ts` | `randomBytes(32)` → `randomBytes` from `@noble/hashes/utils.js` (CSPRNG-backed) |
| `src/device/thp/handshake.ts` | same `randomBytes` swap to `@noble/hashes/utils.js` |
| `src/device/thp/pairing.ts` | chained `createHash('sha256').update(...).update(...).digest('hex')` → `sha256(concatBytes(...))` via local `sha256Hex` helper; `randomBytes` swap as above |

## Why

These were the last 4 workspace-level `import 'crypto'` declarations in `@trezor/connect`. Removing them is a precondition for dropping `crypto-browserify` from `packages/suite-build/configs/base.webpack.config.ts` (the shared fallback that polyfills `crypto` for the whole Suite browser bundle).

## Follow-ups (not in this PR)

This PR does **not** remove `crypto-browserify` / `stream-browserify` from `packages/suite-build/configs/base.webpack.config.ts` `resolve.fallback`. The polyfill is still required because:

- **Other workspace packages in the public dep tree** still import `node:crypto`:
  - `@trezor/protocol` — THP crypto (SHA-256, HMAC, AES-256-GCM, randomBytes) in `src/protocol-thp/crypto/{tools,pairing,aesgcm}.ts`
  - `@trezor/device-authenticity` — randomBytes and ECDSA P-256 verification with PEM keys in `src/{utils,verifySignatures}.ts`
- **Transitive third-party deps** still pull `node:crypto` (notably `jws`, a runtime dep of `@trezor/connect`).

Each migration is a separate PR — they touch distinct package boundaries and can proceed in parallel after this PR lands.

## Related PRs

- **#27149** — `chore(blockchain-link): drop crypto-browserify and stream-browserify`. Same migration pattern applied to `@trezor/blockchain-link`; independent of this PR — touches disjoint files.
- **#27160** — `refactor(utils): use globalThis.crypto.getRandomValues in getRandomInt`. The `@trezor/utils.getRandomInt` change extracted from #27149 for an independent review pass by @peter-sanderson. Not a hard dependency for this PR.

## Test coverage per changed file

### `calculateXPubHash.ts` — sha256 hash swap

- **Test:** [`packages/connect/src/api/firmware/__tests__/calculateXPubHash.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/firmware/__tests__/calculateXPubHash.test.ts) — **5 cases**, all green after the swap.
- **Fixtures:** 2 hard-coded `(xpub, expected sha256 hex)` vectors covering BIP-84 BTC and BIP-44 ETH derivations:
  - `m/84'/0'/0'` → `62fb0296584531819ca112c129c547e0eb806300f07f3bc08ae086163034d09a`
  - `m/44'/60'/0'` → `6896a5c657f3af9e21b1d2038b69b8da921bb070820c245a0353c498a0686f05`
- **What this proves:** the swap is **byte-equivalent**. `bytesToHex(sha256(new TextEncoder().encode(xpub)))` produces the exact same hex as `createHash('sha256').update(xpub, 'utf8').digest('hex')`. The downstream `calculateXPubHashes` and `checkXPubWithHashes` cases verify the helper composition still works.
- **Confidence: high.** Pure deterministic transform, fixture-pinned.

### `checkFirmwareHash.ts` — randomBytes swap for challenge key

- **Direct unit test:** [`packages/connect/src/device/__tests__/checkFirmwareHash.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/device/__tests__/checkFirmwareHash.test.ts) — 6 cases (match / mismatch / malformed / exception / timeout / unknown release). However, `calculateFirmwareHash` is **mocked** via `jest.mock`, so the `randomBytes(32)` call site is reached but its output is **not** verified — the test asserts on outer flow control, not the random key.
- **Adjacent fixture test:** [`packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/src/api/firmware/__tests__/calculateFirmwareHash.test.ts) — **10 cases** pinning the hash output for `(model, fw version, key)` triples with a deterministic key (`Buffer.from('0123456789abcdef')`). Not the swapped code path, but proves the hash function consuming the random key is fixture-stable.
- **Integration:** CI job [`node-init-api-flaky`](https://github.com/trezor/trezor-suite/actions/runs/25340325471/job/74295729860) exercises the real `checkFirmwareHash` flow against the emulator with real random keys — the only place the new `randomBytes` source is actually invoked end-to-end.
- **What's not pinned by tests:** the contract "32 bytes of CSPRNG output". Same gap existed for the prior `node:crypto.randomBytes(32)` — both are standard library calls returning `Uint8Array` of the requested length.
- **Confidence: medium.** Outer flow is well-tested; the random source itself is exercised only through e2e/CI.

### `device/thp/handshake.ts` — randomBytes for nonce (8 B) and ephemeral X25519 key (32 B)

- **No direct unit test exists for this file.** Note: `packages/connect/src/device/__tests__/handshakeWorkflow.test.ts` covers `device/workflow/handshake.ts` (USB-level acquisition handshake), **not** `device/thp/handshake.ts` (THP protocol handshake) — different code path, mentioning it would be misleading.
- **Integration:** [`packages/connect/e2e/tests/device/thpPairing.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/e2e/tests/device/thpPairing.test.ts) — **7 e2e cases** against the trezor-user-env emulator. Each case (except the "no matching method" failure path) reaches `createThpChannel` and `thpHandshake` as a precursor to pairing, so both `randomBytes(8)` (nonce) and `randomBytes(32)` (X25519 keypair) call sites are exercised on **every successful run**:
  - `'ThpPairing SkipPairing'`, `'ThpPairing NFC'`, `'ThpPairing with credentials (autoconnect: false)'`, `'ThpPairing with credentials (autoconnect: true)'`, `'ThpPairing invalid CodeEntry'`, `'ThpPairing cancel workflow'`, `'ThpState cancel workflow'`.
- **CI:** [`node-thpPairing-thp`](https://github.com/trezor/trezor-suite/actions/runs/25340325471/job/74295729887) and [`web-thpPairing-thp`](https://github.com/trezor/trezor-suite/actions/runs/25340325471/job/74295729836) — both green on this PR.
- **What this proves:** the swap doesn't break the THP handshake — bad nonce or malformed X25519 key would surface as device-side `ThpHandshakeRejected` / curve25519 failure. The 32-byte X25519 input is the most consequential — `getCurve25519KeyPair` would throw on wrong length, and the resulting shared secret would diverge from the device, breaking subsequent AES-GCM decrypts. Green e2e = wire-level correctness.
- **Confidence: high** (for the swap) / **medium** (for randomness quality — not directly asserted, but unchanged from prior `node:crypto.randomBytes` and `@noble/hashes/utils.js#randomBytes` delegates to the same `globalThis.crypto.getRandomValues` in browsers and `crypto.randomBytes` in Node).

### `device/thp/pairing.ts` — `sha256Hex` helper + `randomBytes` for CodeEntry challenge (32 B) and NFC secret (16 B)

- **No direct unit test exists for this file.**
- **Integration:** same e2e file, [`thpPairing.test.ts`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/e2e/tests/device/thpPairing.test.ts). Per-branch coverage:
  - `sha256Hex` in `processNfcTag` (3-input chain: `[method] || handshakeHash || value`) — covered by `'ThpPairing NFC'`.
  - `sha256Hex` in `processQrCodeTag` (2-input chain: `handshakeHash || value`) — **not covered** by any e2e case. There is no `ThpPairing QrCode` test. The new `sha256(concatBytes(a, b))` formulation is byte-equivalent to the prior `createHash('sha256').update(a).update(b).digest('hex')` per the SHA-256 streaming property, but this is **review-asserted, not test-asserted**.
  - `randomBytes(32)` for `codeEntryChallenge` — covered by `'ThpPairing with credentials (autoconnect: true)'`, `'ThpPairing invalid CodeEntry'`, `'ThpPairing cancel workflow'`.
  - `randomBytes(16)` for `nfcSecret` — covered by `'ThpPairing NFC'`.
- **What's not pinned by tests:** the QR Code `sha256Hex` chain. Mitigation: the device verifies the tag and the workflow would error on mismatch; gap is in our own test suite, not in the protocol's wire-level safety.
- **Confidence: medium-high.** NFC + CodeEntry paths are e2e-covered; QR Code path relies on the algebraic argument that `sha256(a || b) === sha256.update(a).update(b).digest()`.

## Overall change safety

**Low-to-medium risk.**

- `calculateXPubHash` — pure deterministic sha256, fixture-pinned: **low**.
- `checkFirmwareHash` — swaps source of 32 random bytes, consumer signature unchanged, real-emulator CI exercises it: **low**.
- `handshake.ts` / `pairing.ts` — same `randomBytes` swap pattern. `sha256(concatBytes(a, b))` is semantically identical to `createHash('sha256').update(a).update(b).digest()` (SHA-256 treats both as the same single message). All NFC + CodeEntry e2e branches green; QR Code branch covered only by algebraic argument.

## Test plan

- [x] `yarn workspace @trezor/connect type-check`
- [x] `yarn workspace @trezor/connect test:unit -- --testPathPattern "thp|firmware|XPubHash"` — 13 suites, **116 passed**
- [x] Full `yarn workspace @trezor/connect test:unit` — 482 passed, 1 pre-existing flaky failure in `DeviceList.test.ts › .init() with pendingTransportEvent (multiple transports)`. Verified flaky by re-running on `origin/develop` without my changes — still fails identically. Unrelated to this PR.
- [x] `node-thpPairing-thp` + `web-thpPairing-thp` CI jobs — green.
- [ ] Manual smoke test of connect-popup / connect-iframe in a Suite session.

## Out of scope

- Migration of `@trezor/protocol` THP crypto and `@trezor/device-authenticity` (separate PRs — see Follow-ups).
- `jws` → `jose` migration in `@trezor/connect` runtime deps (separate PR).
- `suite-native/app` polyfills — RN runtime needs a native crypto implementation (`react-native-quick-crypto` or similar). Separate strategic decision.
- Empirical scan of remaining transitive `crypto-browserify` consumers in the Suite browser bundle (deferred until workspace-level migrations above land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-drop-node-crypto/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-drop-node-crypto/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-drop-node-crypto&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-drop-node-crypto&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T20:04:26.727Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
