### PR TITLE
fix(send): autofocus token selector search

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx
@@ -120,6 +120,8 @@ export function SelectTokenAssetModal({
                     searchPlaceholder={translationString('TR_SEARCH_TOKEN_IN_SEND_FORM_MODAL')}
                     search={search}
                     setSearch={setSearch}
+                    // eslint-disable-next-line jsx-a11y/no-autofocus
+                    autoFocus
                 />
             }
             noItemsAvailablePlaceholder={{

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetSearchWithNetworkFilter/AssetSearchWithNetworkFilter.tsx
@@ -13,6 +13,7 @@ export interface AssetSearchWithNetworkFilterProps {
     networkFilter: NetworkSymbol | undefined;
     setNetworkFilter: (networkFilter: NetworkSymbol | undefined) => void;
     networks: NetworkSymbol[];
+    autoFocus?: boolean;
 }
 
 export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetworkFilterInner({
@@ -22,6 +23,7 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
     networkFilter,
     setNetworkFilter,
     networks,
+    autoFocus,
 }: AssetSearchWithNetworkFilterProps) {
     const { translationString } = useTranslation();
 
@@ -31,6 +33,8 @@ export const AssetSearchWithNetworkFilter = memo(function AssetSearchWithNetwork
                 searchPlaceholder={translationString(placeholder)}
                 search={search}
                 setSearch={setSearch}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus={autoFocus}
                 selectConfig={{
                     networks,
                     selectedNetwork: networkFilter,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -108,6 +108,8 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 networkFilter={networkSymbol}
                 setNetworkFilter={setNetworkSymbol}
                 networks={networks}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
             />
 
             <Divider margin={{ top: 16 }} />

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -103,6 +103,8 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                 networkFilter={networkFilter}
                 setNetworkFilter={setNetworkFilter}
                 networks={networks}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
             />
 
             <Divider margin={{ top: 16 }} />


### PR DESCRIPTION
## Description

- Autofocus the search field when opening the send token selector modal.
- Keep the change scoped to the send token selector by reusing the existing `SearchAsset` autofocus support.

## Notes for QA

- Open Wallet > Send on an account with tokens and open the token selector.
- Verify the search field is focused immediately and typing filters the token list without an extra click.
- Reopen the modal and switch between Tokens and Hidden tabs to confirm the selector still opens correctly and the search input remains usable.

## Related Issue

https://github.com/trezor/trezor-suite/issues/27044

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to SelectTokenAssetModal.tsx, a modal component within the wallet send form's token selection flow. There is no static test coverage mapping for this file. The primary risk is that token selection behavior in the send form could be affected when sending tokens on networks like Ethereum, Base, or Solana. Since no tests directly map to this component, recommendations are inferred from tests that exercise the send form and token-related trading flows. The risk is moderate — the change is UI-scoped but could impact any send flow involving token selection.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `../../suite/e2e/tests/trading/navigation.test.ts` — The SelectTokenAssetModal is part of the send form's token selection flow. This navigation test exercises opening trading flows from specific token contexts (e.g., openBuyTradingOfToken, openSellTradingOfToken, openSwapTradingOfToken), which involves asset/token selection UI that may share components with the changed SelectTokenAssetModal.
- `../../suite/e2e/tests/wallet/send-eth.test.ts` — The changed file is directly within the send form's Outputs/TokenSelect path. When sending ETH, users interact with the send form which includes token selection for ERC-20 tokens. Changes to SelectTokenAssetModal could affect how tokens are selected/displayed in the ETH send flow.
- `../../suite/e2e/tests/wallet/send-base.test.ts` — Base is an Ethereum L2 network that supports ERC-20 tokens. The send form for Base likely renders the TokenSelect component tree including SelectTokenAssetModal. Changes could affect token selection behavior during Base send transactions.
- `../../suite/e2e/tests/wallet/send-sol.test.ts` — Solana supports SPL tokens and the send form includes token selection. The SelectTokenAssetModal is part of the send Outputs/TokenSelect hierarchy and could be rendered when sending SOL or selecting SPL tokens for sending.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises the Bitcoin send form with multiple outputs and advanced features. While BTC doesn't have tokens, the send form's Outputs component tree includes TokenSelect, so structural changes to the modal could potentially cause rendering issues in the send form.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/SelectTokenAssetModal.tsx`

_Updated: 2026-04-29T07:54:02.519Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/send-token-search-autofocus&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/send-token-search-autofocus&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Account metadata > dropbox provider | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-06-04T05:51:36.600Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Labeling migration > Migration from local file | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |

</details>

_Updated: 2026-06-04T05:49:24.208Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/send-token-search-autofocus/web/](https://dev.suite.sldev.cz/suite-web/fix/send-token-search-autofocus/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->