### PR TITLE
chore(protobuf): skip unused ETHEREUM_DISPLAY_FORMAT definition types

### DIFF
--- a/packages/protobuf/scripts/protobuf-patches/index.ts
+++ b/packages/protobuf/scripts/protobuf-patches/index.ts
@@ -297,6 +297,17 @@ export const SKIP = [
     'TransactionType', // connect uses custom definition
     'TxInput', // declared in TxInputType patch
     'TxOutput', // declared in TxOutputType patch
+    // ETHEREUM_DISPLAY_FORMAT definition types — not consumed in trezor-suite,
+    // and EthereumABITupleInfo<->EthereumABIValueInfo form a cyclic schema
+    // dependency that the topological sort cannot break.
+    'EthereumABIType',
+    'EthereumABITupleInfo',
+    'EthereumABIValueInfo',
+    'EthereumERC7730FieldFormatterType',
+    'EthereumERC7730ContainerPath',
+    'EthereumERC7730Path',
+    'EthereumERC7730FieldInfo',
+    'EthereumDisplayFormatInfo',
     // not implemented
     'DebugSwipeDirection',
     'DebugLinkDecision',


### PR DESCRIPTION
## Summary

The scheduled `[Test] connect misc` workflow has been failing on `develop` (latest [run](https://github.com/trezor/trezor-suite/actions/runs/25085641415)) because upstream `trezor-firmware/main` added a new ETHEREUM_DISPLAY_FORMAT definition family with a true cyclic schema dependency (`EthereumABITupleInfo` ↔ `EthereumABIValueInfo` reference each other). The topological sort in `protoc-gen-plugin.ts` cannot break the cycle, so the regenerated `src/definitions/messages-definitions.ts` ends up with a forward reference and `eslint --fix` fails:

```
Cyclic type dependency detected while sorting schema types: EthereumABITupleInfo
…
src/definitions/messages-definitions.ts
  31:22  error  'EthereumABITupleInfo' was used before it was defined  @typescript-eslint/no-use-before-define
```

## What changes

None of the new types are consumed anywhere in `trezor-suite` (verified by full-repo grep):

- `EthereumABIType` (enum)
- `EthereumABITupleInfo`
- `EthereumABIValueInfo`
- `EthereumERC7730FieldFormatterType` (enum)
- `EthereumERC7730ContainerPath` (enum)
- `EthereumERC7730Path`
- `EthereumERC7730FieldInfo`
- `EthereumDisplayFormatInfo`

Add them to the existing `SKIP` list in `protobuf-patches/index.ts` so the codegen does not emit them. The cycle source is gone, the lint failure with it.

The existing `DefinitionType` enum picks up the new `ETHEREUM_DISPLAY_FORMAT = 3` value automatically — nothing else changes in `messages-definitions.ts` between the current and regenerated output.

## Why not fix the cycle properly

`@sinclair/typebox-codegen` only emits `Type.Recursive` for self-references, not for cross-cycles. Handling `A ↔ B` would require either inlining one type into the other (lossy) or extending the codegen to wrap both in a single `Type.Recursive` — significant work for types nobody currently consumes.

If/when trezor-suite needs to read ETHEREUM_DISPLAY_FORMAT definitions, the right call is to revisit at that point with a hand-written `DEFINITION_PATCH` for the cyclic pair.

## Test plan

- [ ] `[Test] connect misc / test-protobuf` job goes green on this PR
- [ ] No regression on the existing `messages-definitions.ts` consumers (`DefinitionType`, `EthereumNetworkInfo`, `EthereumTokenInfo`, `SolanaTokenInfo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `packages/protobuf/scripts/protobuf-patches/index.ts` is a build-time script used for patching protobuf definitions during code generation. It is not runtime application code and is not imported by any application source or test. No static coverage mapping exists, and none of the E2E tests exercise protobuf patch script functionality — they all test runtime Suite application behavior (onboarding, wallet, trading, analytics, etc.). The risk of this change causing a runtime regression detectable by E2E tests is negligible. No E2E tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/protobuf/scripts/protobuf-patches/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/protobuf/scripts/protobuf-patches/index.ts`

_Updated: 2026-04-29T08:28:28.061Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/protobuf-abi-tuple-order&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/protobuf-abi-tuple-order&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T08:33:47.983Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T08:32:13.731Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/protobuf-abi-tuple-order/web/](https://dev.suite.sldev.cz/suite-web/mroz22/protobuf-abi-tuple-order/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->