### PR TITLE
fix(suite-native): show Staked label on unstake account card

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2692,7 +2692,7 @@ export const messages = {
         earnFormScreen: {
             title: '{assetName} staking',
             unstakeTitle: 'Unstake {displaySymbol}',
-            availableBalance: 'Available balance',
+            staked: 'Staked',
             unstakingTimeline: 'Unstaking timeline',
             unstakingPeriodInfo:
                 'The unstaking period is currently {days, plural, one {~# day} other {~# days}}',

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -66,7 +66,7 @@ export const UnstakeFlowScreen = () => {
             <AccountDetailsCard
                 accountKey={accountKey}
                 isStakeVariant
-                titleLabel={<Translation id="earn.earnFormScreen.availableBalance" />}
+                titleLabel={<Translation id="earn.earnFormScreen.staked" />}
                 cryptoAmount={stakedBalance ?? undefined}
             />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace "available balance" with "staked" in the account card title for the unstake flow.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27141

## Screenshots:
<img width="1290" height="2627" alt="image" src="https://github.com/user-attachments/assets/22193307-5ab4-4cf7-955e-6755444aadb1" />
