### PR TITLE
fix(suite-native): include account staking dashboard in navigation af…

### DIFF
--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { CommonActions } from '@react-navigation/native';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
@@ -33,20 +34,29 @@ import {
 } from '@suite-native/transaction-management';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
+import { isMobileSupportedStakingNetwork } from '../constants';
 
 const navigateToClaimedTransactionAction = ({
     accountKey,
+    symbol,
     txid,
 }: {
     accountKey: AccountKey;
+    symbol: NetworkSymbol;
     txid: string;
 }) =>
     CommonActions.reset({
-        index: 1,
+        index: 2,
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
                 params: { screen: AppTabsRoutes.EarnStack },
+            },
+            {
+                name: isMobileSupportedStakingNetwork(symbol)
+                    ? RootStackRoutes.StakingManagement
+                    : RootStackRoutes.StakingDetail,
+                params: { accountKey },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,
@@ -101,8 +111,11 @@ export const ClaimTransactionDataReviewScreen = ({
     }, [closeSheet, showSignSuccessMessage]);
 
     const handleViewTransaction = useCallback(() => {
-        navigation.dispatch(navigateToClaimedTransactionAction({ accountKey, txid }));
-    }, [accountKey, navigation, txid]);
+        if (!account) return;
+        navigation.dispatch(
+            navigateToClaimedTransactionAction({ accountKey, symbol: account.symbol, txid }),
+        );
+    }, [account, accountKey, navigation, txid]);
 
     return (
         <ConfirmOnTrezorWrapper

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -3,12 +3,14 @@ import { useSelector } from 'react-redux';
 
 import { CommonActions, useFocusEffect } from '@react-navigation/native';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
     selectAccountByKey,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, LottieAnimation, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
@@ -33,21 +35,30 @@ import {
 } from '@suite-native/transaction-management';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
+import { isMobileSupportedStakingNetwork } from '../constants';
 import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
 
 const navigateToStakedTransactionAction = ({
     accountKey,
+    symbol,
     txid,
 }: {
-    accountKey: string;
+    accountKey: AccountKey;
+    symbol: NetworkSymbol;
     txid: string;
 }) =>
     CommonActions.reset({
-        index: 1,
+        index: 2,
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
                 params: { screen: AppTabsRoutes.EarnStack },
+            },
+            {
+                name: isMobileSupportedStakingNetwork(symbol)
+                    ? RootStackRoutes.StakingManagement
+                    : RootStackRoutes.StakingDetail,
+                params: { accountKey },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,
@@ -115,8 +126,11 @@ export const EarnTransactionDataReviewScreen = ({
     }, [closeSheet, showSignSuccessMessage]);
 
     const handleViewTransaction = useCallback(() => {
-        navigation.dispatch(navigateToStakedTransactionAction({ accountKey, txid }));
-    }, [accountKey, navigation, txid]);
+        if (!account) return;
+        navigation.dispatch(
+            navigateToStakedTransactionAction({ accountKey, symbol: account.symbol, txid }),
+        );
+    }, [account, accountKey, navigation, txid]);
 
     return (
         <ConfirmOnTrezorWrapper

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -3,12 +3,14 @@ import { useSelector } from 'react-redux';
 
 import { CommonActions, useFocusEffect } from '@react-navigation/native';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
     selectAccountByKey,
     selectTransactionByAccountKeyAndTxid,
 } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { Button, Card, LottieAnimation, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
@@ -33,21 +35,30 @@ import {
 } from '@suite-native/transaction-management';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
+import { isMobileSupportedStakingNetwork } from '../constants';
 import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
 
 const navigateToUnstakedTransactionAction = ({
     accountKey,
+    symbol,
     txid,
 }: {
-    accountKey: string;
+    accountKey: AccountKey;
+    symbol: NetworkSymbol;
     txid: string;
 }) =>
     CommonActions.reset({
-        index: 1,
+        index: 2,
         routes: [
             {
                 name: RootStackRoutes.AppTabs,
                 params: { screen: AppTabsRoutes.EarnStack },
+            },
+            {
+                name: isMobileSupportedStakingNetwork(symbol)
+                    ? RootStackRoutes.StakingManagement
+                    : RootStackRoutes.StakingDetail,
+                params: { accountKey },
             },
             {
                 name: RootStackRoutes.TransactionDetailStack,
@@ -115,8 +126,11 @@ export const UnstakeTransactionDataReviewScreen = ({
     }, [closeSheet, showSignSuccessMessage]);
 
     const handleViewTransaction = useCallback(() => {
-        navigation.dispatch(navigateToUnstakedTransactionAction({ accountKey, txid }));
-    }, [accountKey, navigation, txid]);
+        if (!account) return;
+        navigation.dispatch(
+            navigateToUnstakedTransactionAction({ accountKey, symbol: account.symbol, txid }),
+        );
+    }, [account, accountKey, navigation, txid]);
 
     return (
         <ConfirmOnTrezorWrapper


### PR DESCRIPTION
## Description

Earn staking transaction review now resets navigation with the staking dashboard under transaction detail, so back navigates correctly after signing.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27090
