### PR TITLE
Fix hypothetical subscription id bug in blockchain-link websocket

### DIFF
--- a/packages/blockchain-link/src/workers/baseWebsocket.ts
+++ b/packages/blockchain-link/src/workers/baseWebsocket.ts
@@ -3,16 +3,16 @@ import {
     WebsocketClient,
     type WebsocketRequest,
     type WebsocketResponse,
+    type WebsocketSendParams,
 } from '@trezor/websocket-client';
 
 interface Subscription<T> {
     id: string;
     type: T;
-    callback: (result: any) => void;
 }
 
 export abstract class BaseWebsocket<T extends Record<string, any>> extends WebsocketClient<T> {
-    private readonly subscriptions: Subscription<keyof T>[] = [];
+    private readonly subscriptions: Subscription<keyof T & string>[] = [];
 
     async onPing() {
         // make sure that connection is alive if there are subscriptions
@@ -35,21 +35,21 @@ export abstract class BaseWebsocket<T extends Record<string, any>> extends Webso
             if (!messageSettled) {
                 const subs = this.subscriptions.find(s => s.id === id);
                 if (subs) {
-                    subs.callback(data);
+                    // @ts-expect-error Dunno how to resolve this issue
+                    this.emit(subs.type, data);
                 }
             }
         });
     }
 
-    sendMessage(message: WebsocketRequest) {
-        return super.sendMessage(message).catch(error => {
+    sendMessage(message: WebsocketRequest, params: WebsocketSendParams = {}) {
+        return super.sendMessage(message, params).catch(error => {
             throw new CustomError(error.message);
         });
     }
 
-    protected addSubscription<E extends keyof T>(type: E, callback: (result: T[E]) => void) {
-        const id = this.messages.nextId().toString();
-        this.subscriptions.push({ id, type, callback });
+    protected addSubscription<E extends keyof T & string>(type: E, id: number) {
+        this.subscriptions.push({ id: id.toString(), type });
     }
 
     protected removeSubscription(type: keyof T) {

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -143,9 +143,11 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     subscribeAddresses(addresses: string[]) {
         this.removeSubscription('notification');
-        this.addSubscription('notification', result => this.emit('notification', result));
 
-        return this.send('subscribeAddresses', { addresses });
+        return this.sendMessage(
+            { method: 'subscribeAddresses', params: { addresses } },
+            { onIdCreated: id => this.addSubscription('notification', id) },
+        );
     }
 
     unsubscribeAddresses() {
@@ -156,9 +158,11 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     subscribeBlock() {
         this.removeSubscription('block');
-        this.addSubscription('block', result => this.emit('block', result));
 
-        return this.send('subscribeNewBlock');
+        return this.sendMessage(
+            { method: 'subscribeNewBlock' },
+            { onIdCreated: id => this.addSubscription('block', id) },
+        );
     }
 
     unsubscribeBlock() {
@@ -169,9 +173,11 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     subscribeFiatRates(currency?: string) {
         this.removeSubscription('fiatRates');
-        this.addSubscription('fiatRates', result => this.emit('fiatRates', result));
 
-        return this.send('subscribeFiatRates', { currency });
+        return this.sendMessage(
+            { method: 'subscribeFiatRates', params: { currency } },
+            { onIdCreated: id => this.addSubscription('fiatRates', id) },
+        );
     }
 
     unsubscribeFiatRates() {
@@ -182,9 +188,11 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
 
     subscribeMempool() {
         this.removeSubscription('mempool');
-        this.addSubscription('mempool', result => this.emit('mempool', result));
 
-        return this.send('subscribeNewTransaction');
+        return this.sendMessage(
+            { method: 'subscribeNewTransaction' },
+            { onIdCreated: id => this.addSubscription('mempool', id) },
+        );
     }
 
     unsubscribeMempool() {

--- a/packages/blockchain-link/src/workers/blockfrost/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockfrost/websocket.ts
@@ -69,16 +69,20 @@ export class BlockfrostAPI extends BaseWebsocket<BlockfrostEvents> {
 
     subscribeBlock() {
         this.removeSubscription('block');
-        this.addSubscription('block', result => this.emit('block', result));
 
-        return this.send('SUBSCRIBE_BLOCK');
+        return this.sendMessage(
+            { command: 'SUBSCRIBE_BLOCK' },
+            { onIdCreated: id => this.addSubscription('block', id) },
+        );
     }
 
     subscribeAddresses(addresses: string[]) {
         this.removeSubscription('notification');
-        this.addSubscription('notification', result => this.emit('notification', result));
 
-        return this.send('SUBSCRIBE_ADDRESS', { addresses });
+        return this.sendMessage(
+            { command: 'SUBSCRIBE_ADDRESS', params: { addresses } },
+            { onIdCreated: id => this.addSubscription('notification', id) },
+        );
     }
 
     unsubscribeBlock() {

--- a/packages/utils/src/createDeferredManager.ts
+++ b/packages/utils/src/createDeferredManager.ts
@@ -18,8 +18,6 @@ type IdPromise<T> = { promiseId: number; promise: Promise<T> };
 export type DeferredManager<T> = {
     /** How many pending promises are there */
     length: () => number;
-    /** ID of the next created promise (for specific use case, should be removed in the future) */
-    nextId: () => number;
     /** Creates new pending promise (with optional timeout) and returns it and its unique id */
     create: (timeout?: number) => IdPromise<T>;
     /** Waits until there is less than `concurrency` promises and then creates a new one */
@@ -54,8 +52,6 @@ export const createDeferredManager = <T = any>(
     let onRemovePromise = createDeferred();
 
     const length = () => promises.length;
-
-    const nextId = () => ID;
 
     const onPromiseRemoved = () => {
         const { resolve } = onRemovePromise;
@@ -146,5 +142,5 @@ export const createDeferredManager = <T = any>(
         }
     };
 
-    return { length, nextId, create, createConcurrent, resolve, reject, resolveAll, rejectAll };
+    return { length, create, createConcurrent, resolve, reject, resolveAll, rejectAll };
 };

--- a/packages/websocket-client/src/client.ts
+++ b/packages/websocket-client/src/client.ts
@@ -25,6 +25,8 @@ type WebsocketClientEvents = {
     disconnected: undefined;
 };
 
+export type WebsocketSendParams = { timeout?: number; onIdCreated?: (id: number) => void };
+
 export type WebsocketRequest = Record<string, any>;
 export type WebsocketResponse = WebSocket.Data;
 
@@ -105,7 +107,10 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         this.onClose();
     }
 
-    async sendMessage(message: WebsocketRequest, { timeout }: { timeout?: number } = {}) {
+    async sendMessage(
+        message: WebsocketRequest,
+        { timeout, onIdCreated }: WebsocketSendParams = {},
+    ) {
         const { ws } = this;
         if (!ws || !this.isConnected()) throw new WebsocketError('websocket_not_initialized');
 
@@ -120,6 +125,8 @@ export class WebsocketClient<Events extends Record<string, any>> extends TypedEm
         } else {
             promise = this.messages.create(timeout);
         }
+
+        onIdCreated?.(promise.promiseId);
 
         const req = { id: promise.promiseId.toString(), ...message };
 

--- a/packages/websocket-client/src/index.ts
+++ b/packages/websocket-client/src/index.ts
@@ -3,4 +3,5 @@ export {
     type WebsocketRequest,
     type WebsocketResponse,
     WebsocketError,
+    type WebsocketSendParams,
 } from './client';


### PR DESCRIPTION
## Description

Due to implementing `DeferredManager.createConcurrent` in #27136, it is possible that `DeferredManager.nextId` would return different message id than it is later used (because of asynchronicity), which would break websocket subscriptions.

I've (hopefully) resolved it by propagating `onIdCreated` hook through all the levels of websocket's hierarchy, which should always return the correct id.

This is also helpful to #27107, as it allows not to implement broken `nextId` in case of custom `generateId`.

_Note: I don't know how to properly resolve typed emitter issue in websocket base class, but we can probably presume it's fine?_

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect low-level WebSocket infrastructure (baseWebsocket.ts, websocket-client, and protocol-specific websocket implementations for Blockbook and Blockfrost). These are critical networking components used for blockchain communication, but they are deeply internal — most E2E tests interact with them only indirectly through mocked backends. The highest risk is in tests that configure custom backends or rely on real WebSocket connections during discovery. The createDeferredManager.ts change maps to 121 tests but is a broad utility; no test's LLM analysis indicates direct dependency on deferred manager behavior, so those tests are omitted. Four of the five changed files have no static test coverage, reflecting their infrastructure nature.

<details><summary><b>Changed files (5)</b></summary>

- `packages/blockchain-link/src/workers/baseWebsocket.ts`
- `packages/blockchain-link/src/workers/blockbook/websocket.ts`
- `packages/blockchain-link/src/workers/blockfrost/websocket.ts`
- `packages/utils/src/createDeferredManager.ts`
- `packages/websocket-client/src/client.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test configures custom blockbook backend servers and verifies discovery works with them. Changes to blockbook/websocket.ts and baseWebsocket.ts directly affect how Suite connects to custom Blockbook backends, which this test exercises end-to-end.
- `suite/e2e/tests/settings/electrum.test.ts` — This test configures a custom Electrum backend and verifies discovery completes. While the Electrum backend uses a different protocol, the baseWebsocket.ts changes could affect the shared WebSocket infrastructure used across all blockchain-link workers.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test specifically configures custom Blockbook backends for BTC and LTC and verifies account discovery completes. Changes to blockbook/websocket.ts and baseWebsocket.ts directly affect the WebSocket connection layer used during Blockbook-based discovery.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coins (BTC, LTC, ETH, ADA, XRP, etc.) and verifies discovery completes after a reload interruption. The WebSocket changes in baseWebsocket.ts and the blockbook/blockfrost workers affect how blockchain connections are established during multi-coin discovery.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test uses a mocked Blockfrost backend for Cardano staking operations. Changes to blockfrost/websocket.ts could affect the WebSocket connection to Blockfrost, though the test uses mocks which may bypass the actual WebSocket layer.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test enables the Cardano network and verifies account details, send form, and receive address. Cardano uses the Blockfrost backend, so changes to blockfrost/websocket.ts could affect connectivity during account discovery and operations.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/websocket-client/src/client.ts`
- `packages/utils/src/createDeferredManager.ts`

_Updated: 2026-04-29T11:00:37.954Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/subscription-id&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/subscription-id&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T12:01:42.752Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T12:00:01.703Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/subscription-id/web/](https://dev.suite.sldev.cz/suite-web/fix/subscription-id/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->