### PR TITLE
fix(trading): filter non-tradable swap target assets

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetOptionsContext.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetOptionsContext.tsx
@@ -6,9 +6,11 @@ import { type TradingAssetOption, useTradingAssets } from '@suite-common/trading
 
 const AssetOptionsContext = createContext<{
     assets: TradingAssetOption[];
+    includedCryptoIds: Set<CryptoId>;
     excludedCryptoIds: Set<CryptoId>;
 }>({
     assets: [],
+    includedCryptoIds: new Set(),
     excludedCryptoIds: new Set(),
 });
 
@@ -27,7 +29,7 @@ export function AssetOptionsProvider({
     const contextValue = useMemo(() => {
         const { assets } = buildAssetOptions({ includedCryptoIds });
 
-        return { assets, excludedCryptoIds };
+        return { assets, includedCryptoIds, excludedCryptoIds };
     }, [buildAssetOptions, excludedCryptoIds, includedCryptoIds]);
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -145,7 +145,7 @@ export function useBuildTradingAssetOptions({
     search,
     networkSymbol,
 }: UseBuildTradingAssetOptionsProps) {
-    const { assets, excludedCryptoIds } = useAssetsContext();
+    const { assets, includedCryptoIds, excludedCryptoIds } = useAssetsContext();
     const accountsWithTokens = useAgregatedAccountsWithTokens();
 
     return useMemo(() => {
@@ -169,9 +169,23 @@ export function useBuildTradingAssetOptions({
             );
         }
 
-        const allAccountsWithTokens = accountsWithTokens.filter(
-            excludeCryptoIds(excludedCryptoIds),
-        );
+        const allAccountsWithTokens = accountsWithTokens
+            .filter(excludeCryptoIds(excludedCryptoIds))
+            .filter(accountOrToken => {
+                switch (accountOrToken.type) {
+                    case 'account':
+                        return includedCryptoIds.has(getCryptoId(accountOrToken.account.symbol));
+                    case 'token':
+                        return includedCryptoIds.has(
+                            getCryptoId(
+                                accountOrToken.account.symbol,
+                                accountOrToken.token.contract,
+                            ),
+                        );
+                    default:
+                        return false;
+                }
+            });
 
         const filteredAccounts = allAccountsWithTokens
             .filter(accountOrToken => {
@@ -264,5 +278,5 @@ export function useBuildTradingAssetOptions({
         });
 
         return { listItems, networks: orderedNetworks };
-    }, [accountsWithTokens, assets, excludedCryptoIds, networkSymbol, search]);
+    }, [accountsWithTokens, assets, includedCryptoIds, excludedCryptoIds, networkSymbol, search]);
 }


### PR DESCRIPTION
## Description

- Pass the tradable asset id set through the buy asset options context.
- Filter account-held coins and tokens in the swap `To` asset picker to assets that are actually tradable.
- Keep non-tradable assets out of the selector even when they already exist on the selected account.

## Notes for QA

- Open Wallet > Trade > Swap on an account that holds tokens or assets that are not currently tradable.
- Open the `To` asset selector and verify only tradable assets are listed.
- Switch accounts or search for an asset you hold but cannot trade and verify it does not appear in the `To` selector.

## Related Issue

Resolve #27092

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two files in the trading asset picker: AssetOptionsContext (a React context providing asset options to trading forms) and useBuildTradingAssetOptions (the hook that constructs those options). These are core to how buy/sell/swap forms display and filter available crypto assets. The highest risk is in swap and buy flows that explicitly select or filter assets (especially tokens), where a regression would prevent users from finding or selecting the correct asset. Tests that only transitively import these files (like dashboard assets or sell tests that don't use the buy asset picker) carry lower risk.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetOptionsContext.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — This test directly exercises the swap flow including asset selection via the AssetPickerModal. The changed useBuildTradingAssetOptions hook builds the options displayed in the asset picker, and AssetOptionsContext provides the context consumed during asset selection in swap forms.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swap coins test fills in a swap form specifying sell and buy assets, which requires the asset picker to build and display asset options correctly. Both changed files directly affect how swap asset options are constructed and provided via context.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — This test swaps a Solana token (USDT) to Bitcoin, requiring the asset picker to correctly display token assets built by useBuildTradingAssetOptions. A regression in asset option building would break token-to-coin swap flows.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swapping SPL tokens (USDT to USDC) exercises token asset selection in the asset picker modal. The useBuildTradingAssetOptions hook directly controls which token options appear, making this a critical test for the changed code.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test selects a specific token (Jupiter/JUP) from the asset picker with network and search filters. The AssetOptionsContext and useBuildTradingAssetOptions directly power the asset picker's filtering and option building for buy flows.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy Bitcoin flow uses the trading form with asset selection powered by AssetOptionsContext. While BTC is a default asset and less likely to be affected by option-building changes, the context change could still affect form initialization.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — The buy Ethereum flow opens the trading panel and selects Ethereum as the asset to buy. AssetOptionsContext provides the asset options for the buy form, and a regression could prevent ETH from appearing or being selectable.
- `suite/e2e/tests/trading/navigation.test.ts` — Navigation test verifies that buy/sell/swap forms open with the correct cryptocurrency pre-selected, including token-level navigation (TrueUSD, USDC). AssetOptionsContext is responsible for providing the asset options that determine which asset is displayed when the form opens.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test verifies that swapping to an asset on a disabled network (XLM) still shows provider info. The useBuildTradingAssetOptions hook must correctly build options even for disabled networks, making this a meaningful edge case for the changed code.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This swap fee test fills in a swap form with BTC-to-ETH assets. While the focus is on fee display, the asset selection step depends on options built by useBuildTradingAssetOptions and served through AssetOptionsContext.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This swap fee test fills a swap form with ETH-to-BTC assets. The asset selection relies on the changed context and hook to populate available options, though the test focus is primarily on fee display.
- `suite/e2e/tests/trading/buy-negative.test.ts` — The negative buy test interacts with the asset picker buy modal dropdown to verify form loading. AssetOptionsContext powers this dropdown, and a regression could prevent the form from loading correctly.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test initiates a buy action for BTC from the dashboard assets section. While it transitively imports AssetOptionsContext via the trading page, the test primarily verifies that the trading page section becomes visible rather than exercising asset option building directly.

</details>

_Updated: 2026-04-29T12:25:06.034Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/27092-swap-to-asset-tradable-options&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/27092-swap-to-asset-tradable-options&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T12:29:59.269Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T12:28:29.834Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/27092-swap-to-asset-tradable-options/web/](https://dev.suite.sldev.cz/suite-web/fix/27092-swap-to-asset-tradable-options/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->