### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2605,14 +2605,6 @@ export const messages = defineMessages({
         id: 'TR_DUST_PHISHING_ERROR_EMPTY',
         defaultMessage: 'Dust threshold cannot be empty',
     },
-    TR_GAP_LIMIT_ERROR_EMPTY: {
-        id: 'TR_GAP_LIMIT_ERROR_EMPTY',
-        defaultMessage: 'Gap limit cannot be empty',
-    },
-    TR_GAP_LIMIT_ERROR_NUMBER: {
-        id: 'TR_GAP_LIMIT_ERROR_NUMBER',
-        defaultMessage: 'Enter a valid whole number',
-    },
     TR_GAP_LIMIT_ERROR_POSITIVE: {
         id: 'TR_GAP_LIMIT_ERROR_POSITIVE',
         defaultMessage: 'Gap limit must be a positive number',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (2):**
- `TR_GAP_LIMIT_ERROR_EMPTY`
- `TR_GAP_LIMIT_ERROR_NUMBER`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to suite/intl/src/messages.ts, which is the internationalization message definitions module — a broadly shared utility across the entire application. No static coverage mapping exists for this file, so all recommendations are inferred from LLM analysis of test source hints. The highest risk is to tests that directly reference specific translation keys or intl message formatting in their assertions. The autodetect test is the most critical since it directly validates localized heading text from this module. Other tests that assert on specific translation keys (fee labels, validation errors, time range labels) carry medium risk. The overall risk is moderate — message definition changes could silently break UI text assertions across many tests, but the impact depends on which specific messages were modified.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses @suite/intl messages to verify that the onboarding analytics heading text matches localized strings (including Spanish translations). Changes to suite/intl/src/messages.ts could alter message definitions, keys, or default values, directly breaking these assertions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies language change functionality and analytics events that reference language-related settings. The intl messages module underpins the translation system used when switching languages (e.g., English to Spanish), so changes could affect how language labels or translation keys are resolved.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly references @suite/intl messages for validation error translations (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, TR_TRADING_COUNTRY_WORLD). Changes to the messages module could affect these translation key definitions or their parameterized formatting.
- `../../suite/e2e/tests/wallet/send-base.test.ts` — This test references @suite/intl messages directly (TR_GAS_LIMIT) for verifying fee display translations on the device prompt. A change to the messages module could alter this translation key's definition.
- `../../suite/e2e/tests/wallet/send-eth.test.ts` — This test references @suite/intl messages (TR_GAS_LIMIT) for verifying Ethereum fee display translations in the device prompt. Changes to message definitions could break these assertions.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test uses @suite/intl messages for graph time range labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, TR_DATE_MONTH_LONG, TR_DATE_YEAR_LONG, TR_ALL). Changes to these message definitions would directly break the time range filter assertions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/trading/swap-history.test.ts` — This test references @suite/intl messages for multiple translation keys used in swap history status labels and headings (TR_TRADING_LAST_TRANSACTIONS, TR_EXCHANGE_STATUS_SUCCESS, etc.). Changes to these specific message definitions could affect assertions.

</details>

_Updated: 2026-04-29T13:04:09.497Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260429&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260429&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T13:09:24.072Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T13:07:42.969Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260429/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260429/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->