### PR TITLE
Add support for Tron Note in send form

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -22,6 +22,7 @@ export interface TronChainExtraData {
     bandwidthFee?: string;
     result?: string;
     votes?: TronVoteExtra[];
+    note?: string;
 }
 export interface TronAccountExtraData {
     availableStakedBandwidth: number;

--- a/packages/connect-common/src/types/api/tron/index.ts
+++ b/packages/connect-common/src/types/api/tron/index.ts
@@ -140,6 +140,7 @@ export const TronComposeTransaction = Type.Object({
     blockHash: Type.String(),
     blockHeight: Type.Number(),
     fee_limit: Type.Optional(Type.Number()),
+    data: Type.Optional(Type.String()),
 });
 
 export type TronComposedTransaction = Static<typeof TronComposedTransaction>;

--- a/packages/connect/src/api/tron/api/tronComposeTransaction.ts
+++ b/packages/connect/src/api/tron/api/tronComposeTransaction.ts
@@ -30,7 +30,7 @@ export default class TronComposeTransaction extends AbstractMethod<
 
     // eslint-disable-next-line require-await
     async run() {
-        const { contract, blockHash, blockHeight, fee_limit } = this.params;
+        const { contract, blockHash, blockHeight, fee_limit, data } = this.params;
 
         const ref_block_bytes = blockHeight.toString(16).padStart(16, '0').slice(12, 16);
         const ref_block_hash = blockHash.replace(/^0x/, '').slice(16, 32);
@@ -44,6 +44,7 @@ export default class TronComposeTransaction extends AbstractMethod<
             expiration,
             timestamp,
             fee_limit,
+            data,
         });
 
         return {

--- a/packages/connect/src/api/tron/tronEncode.ts
+++ b/packages/connect/src/api/tron/tronEncode.ts
@@ -14,6 +14,7 @@ type BlockParams = {
     expiration: number;
     timestamp: number;
     fee_limit?: number;
+    data?: string;
 };
 
 const contractTypeUrl = (name: string) => `type.googleapis.com/protocol.${name}`;
@@ -68,7 +69,7 @@ export const encodeTronContractRawData = (
     blockParams: BlockParams,
 ): Uint8Array => {
     const { type, bytes } = encodeInnerContract(contract);
-    const { ref_block_bytes, ref_block_hash, expiration, timestamp, fee_limit } = blockParams;
+    const { ref_block_bytes, ref_block_hash, expiration, timestamp, fee_limit, data } = blockParams;
     const schema = getSchema('TronRawTransaction');
 
     return toBinary(
@@ -80,6 +81,7 @@ export const encodeTronContractRawData = (
             timestamp: BigInt(timestamp),
             // fee_limit is only valid for smart-contract calls; TRON ignores it on transfers.
             feeLimit: contract.type === 'TriggerSmartContract' ? BigInt(fee_limit ?? 0) : undefined,
+            data: data ? hexToBytes(data) : undefined,
             contract: [
                 {
                     type,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -194,6 +194,8 @@ const getOutputTitle = (
             return <Translation id="TR_GAS_PRICE" />;
         case 'txid':
             return <Translation id={isRbf ? 'TR_TXID_RBF' : 'TR_TXID'} />;
+        case 'note':
+            return <Translation id="TR_TRON_NOTE" />;
         case 'data':
             return <Translation id={translation ? translation.label : 'DATA_ETH'} />;
         case 'opreturn':
@@ -296,6 +298,15 @@ const getOutputLines = ({
                     value: value2,
                 },
             ];
+        case 'note': {
+            return [
+                {
+                    id: type,
+                    type: 'default',
+                    value,
+                },
+            ];
+        }
         case 'address':
         case 'data':
         case 'regular_legacy': {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -121,6 +121,8 @@ const Value = ({ value, type, symbol, token, isFiatVisible, state }: ValueProps)
             );
         case 'safe-address':
             return <Address value={value} isDeviceRendered />;
+        case 'note':
+            return <Text>{value}</Text>;
         case 'data':
             return <Data value={value} />;
         case 'amount': {
@@ -166,7 +168,7 @@ export type OutputElementLine = {
     id: string;
     value: string;
     token?: TokenInfo;
-    type: 'default' | 'address' | 'safe-address' | 'data' | 'amount';
+    type: 'default' | 'address' | 'safe-address' | 'note' | 'data' | 'amount';
     label?: ReactNode;
 };
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -302,6 +302,12 @@ export const BasicTxDetails = ({
                         {tx.tronSpecific.bandwidthUsage}
                     </Item>
                 )}
+
+                {tx.tronSpecific?.note && (
+                    <Item label={<Translation id="TR_TRON_NOTE" />} iconName="pencil">
+                        {tx.tronSpecific.note}
+                    </Item>
+                )}
             </Grid>
         </Card>
     );

--- a/packages/suite/src/views/wallet/send/Options/Options.tsx
+++ b/packages/suite/src/views/wallet/send/Options/Options.tsx
@@ -5,6 +5,7 @@ import { CardanoOptions } from './CardanoOptions';
 import { EthereumOptions } from './EthereumOptions/EthereumOptions';
 import { MiscNetworkOptions } from './MiscNetworkOptions/MiscNetworkOptions';
 import { SolanaOptions } from './SolanaOptions/SolanaOptions';
+import { TronOptions } from './TronOptions/TronOptions';
 
 export const Options = () => {
     const {
@@ -15,6 +16,7 @@ export const Options = () => {
         <>
             {networkType === 'bitcoin' && <BitcoinOptions />}
             {networkType === 'ethereum' && <EthereumOptions />}
+            {networkType === 'tron' && <TronOptions />}
             {(networkType === 'ripple' || networkType === 'stellar') && <MiscNetworkOptions />}
             {networkType === 'solana' && <SolanaOptions />}
             {networkType === 'cardano' && <CardanoOptions />}

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+
+import { Translation, useTranslation } from '@suite/intl';
+import { formInputsMaxLength } from '@suite-common/validators';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { Card, Column, H4, Icon, IconButton, Row, Text, Textarea } from '@trezor/components';
+
+import { useSendFormContext } from 'src/hooks/wallet';
+
+const inputAsciiName = 'tronDataAscii';
+const inputHexName = 'transactionData';
+
+type TronNoteProps = {
+    close: () => void;
+};
+
+export const TronNote = ({ close }: TronNoteProps) => {
+    const {
+        account: { symbol },
+        register,
+        watch,
+        setValue,
+        composeTransaction,
+        resetDefaultValue,
+    } = useSendFormContext();
+
+    const { translationString } = useTranslation();
+
+    const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
+
+    const asciiValue = watch(inputAsciiName);
+    const hexValue = watch(inputHexName);
+
+    const isHexTooLong = !hexValue ? false : hexValue.length > formInputsMaxLength.tronNote;
+    const error = isHexTooLong ? translationString('TR_TRON_NOTE_TOO_LONG') : undefined;
+
+    useEffect(() => {
+        setValue(inputHexName, Buffer.from(asciiValue || '', 'utf8').toString('hex'));
+    }, [asciiValue, setValue]);
+
+    useEffect(() => {
+        composeTransaction(inputHexName);
+    }, [hexValue, composeTransaction]);
+
+    const handleClose = () => {
+        resetDefaultValue(inputAsciiName);
+        close();
+    };
+
+    const { ref: inputRef, ...inputField } = register(inputAsciiName);
+
+    return (
+        <Card>
+            <Column gap={12}>
+                <Row alignItems="start" justifyContent="space-between">
+                    <Column gap={2}>
+                        <H4 typographyStyle="body-md">
+                            <Translation id="TR_TRON_NOTE" />
+                        </H4>
+
+                        <Row gap={4}>
+                            <Icon name="info" size={20} intent="neutral" priority="secondary" />
+                            <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                                <Translation
+                                    id="TR_TRON_NOTE_INFO"
+                                    values={{ networkDisplaySymbol }}
+                                />
+                            </Text>
+                        </Row>
+                    </Column>
+
+                    <IconButton
+                        intent="neutral"
+                        priority="secondary"
+                        icon="x"
+                        size="small"
+                        onClick={handleClose}
+                    />
+                </Row>
+
+                <Textarea
+                    hasError={isHexTooLong}
+                    bottomText={error}
+                    defaultValue={asciiValue}
+                    innerRef={inputRef}
+                    rows={3}
+                    characterCount={{
+                        current: hexValue?.length,
+                        max: formInputsMaxLength.tronNote,
+                    }}
+                    {...inputField}
+                />
+            </Column>
+        </Card>
+    );
+};

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronOptions.tsx
@@ -1,0 +1,41 @@
+import { Translation } from '@suite/intl';
+import { type FormOptions } from '@suite-common/wallet-types';
+import { Button, Column, Tooltip } from '@trezor/components';
+
+import { useSendFormContext } from 'src/hooks/wallet';
+
+import { TronNote } from './TronNote';
+
+export const TronOptions = () => {
+    const { getDefaultValue, toggleOption, composeTransaction } = useSendFormContext();
+
+    const options = getDefaultValue('options', []);
+    const isNoteEnabled = options.includes('transactionData');
+
+    const toggle = (option: FormOptions) => {
+        toggleOption(option);
+        composeTransaction();
+    };
+
+    const toggleNote = () => toggle('transactionData');
+
+    return (
+        <Column gap={16}>
+            {!isNoteEnabled && (
+                <Tooltip content={<Translation id="TR_TRON_NOTE_ADD_TOOLTIP" />} cursor="pointer">
+                    <Button
+                        intent="neutral"
+                        priority="secondary"
+                        iconLeft="database"
+                        data-testid="send/open-tron-note"
+                        onClick={toggleNote}
+                    >
+                        <Translation id="TR_TRON_NOTE_ADD" />
+                    </Button>
+                </Tooltip>
+            )}
+
+            {isNoteEnabled && <TronNote close={toggleNote} />}
+        </Column>
+    );
+};

--- a/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
@@ -1,4 +1,5 @@
 import { Translation } from '@suite/intl';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { InfoItem, Tooltip } from '@trezor/components';
 
@@ -36,7 +37,12 @@ export const TronNewAccountInfo = () => {
                 <Tooltip
                     hasIcon
                     maxWidth={328}
-                    content={<Translation id="TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP" />}
+                    content={
+                        <Translation
+                            id="TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP"
+                            values={{ networkDisplaySymbol: getNetworkDisplaySymbol(symbol) }}
+                        />
+                    }
                 >
                     <Translation id="TR_TRON_ACCOUNT_ACTIVATION_FEE" />
                 </Tooltip>

--- a/suite-common/validators/src/inputsLengthConfig.ts
+++ b/suite-common/validators/src/inputsLengthConfig.ts
@@ -13,6 +13,7 @@ export const formInputsMaxLength = {
      * - For UTF-16 encoding: 16384 B / 2 = 8192 B
      */
     ethData: 8192,
+    tronNote: 512,
 
     btcLocktime: 10, // max: 4294967294
     xrpDestinationTag: 10, // max: 4294967295

--- a/suite-common/wallet-core/src/send/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormTronThunks.ts
@@ -277,10 +277,15 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
                   },
               };
 
+        const tronData = formState.transactionData
+            ? formState.transactionData.replace(/^0x/, '')
+            : undefined;
+
         const bandwidthEstimate = await TrezorConnect.tronComposeTransaction({
             contract,
             blockHash: DUMMY_BLOCK_HASH,
             blockHeight: DUMMY_BLOCK_HEIGHT,
+            data: tronData || undefined,
         });
 
         if (!bandwidthEstimate.success) {
@@ -451,11 +456,16 @@ export const signTronSendFormTransactionThunk = createThunk<
                   },
               };
 
+        const tronData = formState.transactionData
+            ? formState.transactionData.replace(/^0x/, '')
+            : undefined;
+
         const composed = await TrezorConnect.tronComposeTransaction({
             contract,
             blockHash,
             blockHeight,
             fee_limit: tokenFeeLimitSun,
+            data: tronData || undefined,
         });
 
         if (!composed.success) {
@@ -480,6 +490,7 @@ export const signTronSendFormTransactionThunk = createThunk<
             expiration,
             timestamp,
             fee_limit: tokenFeeLimitSun,
+            data: tronData || undefined,
             contract: [contract],
         });
 

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -81,7 +81,8 @@ export interface FormState {
     ethereumNonce?: string; // TODO: ethereum RBF
     ethereumDataAscii?: string;
     ethereumAdjustGasLimit?: string; // if used, final gas limit = estimated limit * ethereumAdjustGasLimit
-    transactionData?: string; // used for solana serialized txn from trading api or ethereum txn hex data
+    tronDataAscii?: string;
+    transactionData?: string; // used for solana serialized txn from trading api, ethereum or tron txn hex data
     destinationTag?: string; // For Ripple, Stellar, and Solana
     rbfParams?: RbfTransactionParams;
     isCoinControlEnabled: boolean;

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -7,6 +7,7 @@ export type ReviewOutput =
           type:
               | 'opreturn'
               | 'data'
+              | 'note'
               | 'locktime'
               | 'fee'
               | 'destination-tag'

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -434,8 +434,9 @@ const constructNewFlow = ({
                     outputs.push(tokenOutput);
                     outputs.push({ type: 'address', value: o.address });
                 } else if (
-                    (precomposedForm.transactionData && !isEvmApproval) ||
-                    (isEvmApproval && !isApprovalFlowSupported)
+                    !isTron &&
+                    ((precomposedForm.transactionData && !isEvmApproval) ||
+                        (isEvmApproval && !isApprovalFlowSupported))
                 ) {
                     // EVM contract call
                     outputs.push({ type: 'contract', value: o.address });

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -228,11 +228,15 @@ const constructOldFlow = ({
             });
     }
 
-    if (
-        precomposedForm.transactionData &&
-        (!precomposedTx.token || precomposedForm.yieldMetadata)
-    ) {
-        outputs.push({ type: 'data', value: precomposedForm.transactionData });
+    if (precomposedForm.tronDataAscii) {
+        outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
+    } else {
+        if (
+            precomposedForm.transactionData &&
+            (!precomposedTx.token || precomposedForm.yieldMetadata)
+        ) {
+            outputs.push({ type: 'data', value: precomposedForm.transactionData });
+        }
     }
 
     // For bump fee we have to analyze tx data,
@@ -334,14 +338,18 @@ const constructNewFlow = ({
         });
     }
 
-    if (
-        (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
-        (precomposedForm.transactionData &&
-            precomposedForm.yieldMetadata &&
-            !isUpdatedEthereumSendFlow)
-    ) {
-        outputs.push({ type: 'data', value: precomposedForm.transactionData });
+    if (precomposedForm.tronDataAscii) {
+        outputs.push({ type: 'note', value: precomposedForm.tronDataAscii });
+    } else {
+        if (
+            (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
+            (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
+            (precomposedForm.transactionData &&
+                precomposedForm.yieldMetadata &&
+                !isUpdatedEthereumSendFlow)
+        ) {
+            outputs.push({ type: 'data', value: precomposedForm.transactionData });
+        }
     }
 
     const isRbf = isRbfBumpFeeTransaction(precomposedTx);

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1939,6 +1939,7 @@ export const messages = {
             },
             parametersSheet: {
                 confirmations: 'Confirmations',
+                tronNote: 'Note',
                 feeRate: 'Fee rate',
                 rbf: 'RBF',
                 lockTime: 'Lock time',
@@ -2190,7 +2191,16 @@ export const messages = {
             accountActivationFee: 'Activation Fee',
             accountActivationFeeTitle: 'Activation fee',
             accountActivationFeeDescription:
-                'New TRON accounts require a one-time 1 TRX network fee to activate.',
+                'New TRON accounts require a one-time 1 {networkDisplaySymbol} network fee to activate.',
+            note: {
+                label: 'Note',
+                addButton: 'Add note',
+                editButton: 'Edit note',
+                inputPlaceholder: 'Enter your note',
+                saveButton: 'Save note',
+                removeButton: 'Remove note',
+                info: 'Adds 1 {networkDisplaySymbol} in network fee.',
+            },
         },
         fees: {
             recipient: {
@@ -3345,6 +3355,7 @@ export const messages = {
                 tokenLabel: 'Token',
                 feeLimitLabel: 'Fee Limit',
                 feeLimitSummaryLabel: 'Summary',
+                noteLabel: 'Note',
                 summary: {
                     label: 'Total including fee',
                     totalAmount: 'Total amount',

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -17,11 +17,12 @@ import {
 } from '@suite-native/transaction-management';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { CorrectNetworkMessageCard } from './CorrectNetworkMessageCard';
 import { RecipientInputs } from './RecipientInputs';
 import { SolanaMemoInput } from './SolanaMemoInput';
 import { TronAccountActivationInfo } from './TronAccountActivationInfo';
 import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
-import { CorrectNetworkMessageCard } from './CorrectNetworkMessageCard';
+import { TronNoteInput } from './TronNoteInput';
 
 type SendOutputFieldsProps = {
     accountKey: AccountKey;
@@ -80,6 +81,8 @@ export const SendOutputFields = ({
                     <TronAccountActivationInfo accountKey={accountKey} />
                 </VStack>
             </Card>
+
+            {symbol && getNetworkType(symbol) === 'tron' && <TronNoteInput symbol={symbol} />}
             {symbol && getNetworkType(symbol) === 'solana' && <SolanaMemoInput />}
         </VStack>
     );

--- a/suite-native/module-send/src/components/TronAccountActivationInfo.tsx
+++ b/suite-native/module-send/src/components/TronAccountActivationInfo.tsx
@@ -1,6 +1,7 @@
 import { Pressable } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -68,7 +69,12 @@ export const TronAccountActivationInfo = ({ accountKey }: TronAccountActivationI
                             <Translation id="moduleSend.tron.accountActivationFeeTitle" />
                         </Text>
                         <Text variant="body-sm" color="contentSecondary">
-                            <Translation id="moduleSend.tron.accountActivationFeeDescription" />
+                            <Translation
+                                id="moduleSend.tron.accountActivationFeeDescription"
+                                values={{
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                }}
+                            />
                         </Text>
                     </VStack>
                     <Button onPress={closeModal}>

--- a/suite-native/module-send/src/components/TronNoteInput.tsx
+++ b/suite-native/module-send/src/components/TronNoteInput.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+
+import { formInputsMaxLength } from '@suite-common/validators';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    BottomSheetModal,
+    Button,
+    Card,
+    HStack,
+    IconButton,
+    Input,
+    Text,
+    VStack,
+    useBottomSheetModal,
+} from '@suite-native/atoms';
+import { useFormContext } from '@suite-native/forms';
+import { Icon } from '@suite-native/icons';
+import { Translation, useTranslate } from '@suite-native/intl';
+
+import { type SendOutputsFormValues } from '../sendOutputsFormSchema';
+
+const inputAsciiName = 'tronDataAscii';
+const inputHexName = 'transactionData';
+
+type TronNoteInputProps = {
+    symbol: NetworkSymbol;
+};
+
+export const TronNoteInput = ({ symbol }: TronNoteInputProps) => {
+    const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
+    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { translate } = useTranslate();
+    const [localNote, setLocalNote] = useState('');
+
+    const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
+
+    const asciiValue = watch(inputAsciiName) ?? '';
+    const hexValue = Buffer.from(localNote || '', 'utf8').toString('hex');
+
+    const hexByteSize = hexValue.length;
+    const isHexTooLong = hexByteSize > formInputsMaxLength.tronNote;
+
+    useEffect(() => {
+        setLocalNote(asciiValue);
+    }, [asciiValue]);
+
+    useEffect(() => {
+        setValue(inputHexName, Buffer.from(asciiValue || '', 'utf8').toString('hex'));
+    }, [asciiValue, setValue]);
+
+    const onOpenPress = () => {
+        setLocalNote(asciiValue);
+        openModal();
+    };
+
+    const onSavePress = () => {
+        setValue(inputAsciiName, localNote);
+        setValue(inputHexName, hexValue);
+        closeModal();
+    };
+
+    const onRemovePress = () => {
+        setValue(inputAsciiName, '');
+        setValue(inputHexName, '');
+        setLocalNote('');
+        closeModal();
+    };
+
+    return (
+        <>
+            {asciiValue ? (
+                <Card>
+                    <VStack spacing="sp12" alignItems="center">
+                        <HStack alignItems="center">
+                            <VStack spacing="sp2" flex={1}>
+                                <Text variant="body-sm">
+                                    <Translation id="moduleSend.tron.note.label" />
+                                </Text>
+
+                                <Text variant="body-sm" color="contentSecondary" numberOfLines={1}>
+                                    {asciiValue}
+                                </Text>
+                            </VStack>
+
+                            <IconButton
+                                iconName="pencilSimpleLine"
+                                intent="neutral"
+                                priority="secondary"
+                                onPress={onOpenPress}
+                            />
+                        </HStack>
+
+                        <HStack alignItems="center" spacing="sp4">
+                            <Icon name="info" size={20} />
+                            <Text variant="body-sm">
+                                <Translation
+                                    id="moduleSend.tron.note.info"
+                                    values={{ networkDisplaySymbol }}
+                                />
+                            </Text>
+                        </HStack>
+                    </VStack>
+                </Card>
+            ) : (
+                <Button
+                    iconLeft="pencilSimpleLine"
+                    intent="neutral"
+                    priority="secondary"
+                    onPress={onOpenPress}
+                >
+                    <Translation id="moduleSend.tron.note.addButton" />
+                </Button>
+            )}
+
+            <BottomSheetModal
+                ref={bottomSheetRef}
+                title={<Translation id="moduleSend.tron.note.label" />}
+                isCloseDisplayed
+                onClose={closeModal}
+            >
+                <VStack spacing="sp16">
+                    <HStack alignItems="center" spacing="sp4">
+                        <Icon name="info" size={20} />
+                        <Text variant="body-sm">
+                            <Translation
+                                id="moduleSend.tron.note.info"
+                                values={{ networkDisplaySymbol }}
+                            />
+                        </Text>
+                    </HStack>
+
+                    <VStack spacing="sp4">
+                        <Input
+                            value={localNote}
+                            onChangeText={setLocalNote}
+                            placeholder={translate('moduleSend.tron.note.inputPlaceholder')}
+                            maxLength={formInputsMaxLength.tronNote}
+                            asBottomSheetInput
+                        />
+
+                        <Text
+                            variant="body-xs"
+                            color={isHexTooLong ? 'contentCritical' : 'contentSecondary'}
+                            textAlign="left"
+                        >
+                            {hexByteSize}/{formInputsMaxLength.tronNote} bytes
+                        </Text>
+                    </VStack>
+
+                    <Button onPress={onSavePress} isDisabled={isHexTooLong}>
+                        <Translation id="moduleSend.tron.note.saveButton" />
+                    </Button>
+
+                    {asciiValue && (
+                        <Button intent="neutral" priority="secondary" onPress={onRemovePress}>
+                            <Translation id="moduleSend.tron.note.removeButton" />
+                        </Button>
+                    )}
+                </VStack>
+            </BottomSheetModal>
+        </>
+    );
+};

--- a/suite-native/module-send/src/sendOutputsFormSchema.ts
+++ b/suite-native/module-send/src/sendOutputsFormSchema.ts
@@ -273,6 +273,8 @@ export type OutputsFormValues = yup.InferType<typeof outputSchema>;
 
 export const sendOutputsFormValidationSchema = yup.object({
     outputs: yup.array(outputSchema).required(),
+    transactionData: yup.string(),
+    tronDataAscii: yup.string(),
     isDestinationTagEnabled: yup.boolean(),
     destinationTag: yup
         .string()

--- a/suite-native/module-send/src/utils.ts
+++ b/suite-native/module-send/src/utils.ts
@@ -10,7 +10,7 @@ export const getOutputFieldName = <TField extends SendOutputFieldName>(
 ): `outputs.${number}.${TField}` => `outputs.${index}.${field}`;
 
 export const constructFormDraft = ({
-    formValues: { outputs, ...restFormValues },
+    formValues: { outputs, transactionData, tronDataAscii, ...restFormValues },
     tokenContract,
     feeLevel = { label: 'normal', feePerUnit: '' },
     selectedUtxos = [],
@@ -36,6 +36,8 @@ export const constructFormDraft = ({
     selectedFee: feeLevel.label,
     feePerUnit: feeLevel.feePerUnit,
     feeLimit: feeLevel.feeLimit ?? '',
+    transactionData: transactionData || undefined,
+    tronDataAscii: tronDataAscii || undefined,
     ...restFormValues,
 });
 

--- a/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
@@ -144,6 +144,17 @@ export const TransactionDetailParametersSheet = ({
                             </Box>
                         </Box>
                     </TransactionDetailRow>
+
+                    {transaction.tronSpecific?.note && (
+                        <TransactionDetailRow
+                            title={translate(
+                                'transactions.TransactionDetailScreen.parametersSheet.tronNote',
+                            )}
+                        >
+                            <Text>{transaction.tronSpecific.note}</Text>
+                        </TransactionDetailRow>
+                    )}
+
                     <TransactionDetailRow
                         title={translate(
                             'transactions.TransactionDetailScreen.parametersSheet.confirmations',

--- a/suite-native/module-transactions/src/components/TransactionDetailRow.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailRow.tsx
@@ -14,6 +14,7 @@ const rowStyle = prepareNativeStyle(() => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    gap: 16,
 }));
 
 const valueContainerStyle = prepareNativeStyle(_ => ({

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.tsx
@@ -70,6 +70,8 @@ const OutputLabel = ({
             return <Translation id="transactionManagement.review.outputs.approveLabel" />;
         case 'fee-limit':
             return <Translation id="transactionManagement.review.outputs.feeLimitSummaryLabel" />;
+        case 'note':
+            return <Translation id="transactionManagement.review.outputs.noteLabel" />;
         default:
             return type;
     }

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemContent.tsx
@@ -151,6 +151,9 @@ export const ReviewOutputItemContent = ({
 
             return null;
 
+        case 'note':
+            return <Text variant="body-sm">{value}</Text>;
+
         case 'fee-limit':
             return (
                 <HStack>

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5415,6 +5415,26 @@ export const messages = defineMessages({
         id: 'TR_TRON_FEE_LIMIT_BELOW_RECOMMENDED',
         defaultMessage: 'Fee limit too low',
     },
+    TR_TRON_NOTE: {
+        id: 'TR_TRON_NOTE',
+        defaultMessage: 'Note',
+    },
+    TR_TRON_NOTE_ADD: {
+        id: 'TR_TRON_NOTE_ADD',
+        defaultMessage: 'Add note',
+    },
+    TR_TRON_NOTE_ADD_TOOLTIP: {
+        id: 'TR_TRON_NOTE_ADD_TOOLTIP',
+        defaultMessage: 'Add a note to the transaction.',
+    },
+    TR_TRON_NOTE_TOO_LONG: {
+        id: 'TR_TRON_NOTE_TOO_LONG',
+        defaultMessage: 'Note is too long',
+    },
+    TR_TRON_NOTE_INFO: {
+        id: 'TR_TRON_NOTE_INFO',
+        defaultMessage: 'Adds 1 TRX in network fee.',
+    },
     TR_FEE_LIMIT: {
         id: 'TR_FEE_LIMIT',
         defaultMessage: 'Fee limit',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5433,7 +5433,7 @@ export const messages = defineMessages({
     },
     TR_TRON_NOTE_INFO: {
         id: 'TR_TRON_NOTE_INFO',
-        defaultMessage: 'Adds 1 TRX in network fee.',
+        defaultMessage: 'Adds 1 {networkDisplaySymbol} in network fee.',
     },
     TR_FEE_LIMIT: {
         id: 'TR_FEE_LIMIT',
@@ -5445,7 +5445,8 @@ export const messages = defineMessages({
     },
     TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP: {
         id: 'TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP',
-        defaultMessage: 'New TRON accounts require a one-time 1 TRX network fee to activate.',
+        defaultMessage:
+            'New TRON accounts require a one-time 1 {networkDisplaySymbol} network fee to activate.',
     },
     TR_TRON_TX_CREATE_ACCOUNT: {
         id: 'TR_TRON_TX_CREATE_ACCOUNT',


### PR DESCRIPTION
## Description

This PR introduces Tron note to send form and transaction detail modal.

The screenshots are a bit outdated - now they show info message that the note burns `1 TRX`.

## Related Issue

Resolve #26491 

## Screenshots

<img width="100%" alt="Screenshot 2026-04-30 at 14 15 48" src="https://github.com/user-attachments/assets/dd8faad7-de55-46fc-bebe-12aa2d4a8d3b" />

<img width="100%" alt="Screenshot 2026-04-30 at 14 16 07" src="https://github.com/user-attachments/assets/0c98b6eb-949f-4fad-8bc4-446d8234930d" />

<img width="100%" alt="Screenshot 2026-04-30 at 14 25 22" src="https://github.com/user-attachments/assets/77927c77-821f-473b-a3cb-60e932502bcc" />

<img width="100%" alt="Screenshot 2026-04-30 at 14 25 51" src="https://github.com/user-attachments/assets/80cbfcaf-eb0e-499c-bcaf-69bafdf1a6a8" />

<img width="100%" alt="Screenshot 2026-04-30 at 14 31 06" src="https://github.com/user-attachments/assets/fa0fc59d-eeea-4c17-b100-4970f44018b4" />

<img width="100%" alt="Screenshot 2026-04-30 at 15 26 33" src="https://github.com/user-attachments/assets/00675546-5644-4ece-a696-af03d7c5e389" />

<table>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 09 35" src="https://github.com/user-attachments/assets/66866fcb-2efe-45ea-8f4d-32e744443ed1" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 09 50" src="https://github.com/user-attachments/assets/6f56e819-dcc7-4e56-97c8-84227559187c" />
</td>
</tr>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 09 54" src="https://github.com/user-attachments/assets/0871fe4f-636c-4088-bb71-66abffc67d56" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 09 57" src="https://github.com/user-attachments/assets/b3d01e81-8d2a-4fde-a3f8-dc8f37bb3a82" />
</td>
</tr>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 21 35" src="https://github.com/user-attachments/assets/40257593-42aa-491a-ae32-0428dc4bc94a" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 14 23 39" src="https://github.com/user-attachments/assets/a84070ee-6932-4f9e-bc5f-d21417701c8a" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tron-note&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tron-note&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/tron-note&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Buy Negative scenarios > Buy form handles input limits and empty quotes | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-04T12:54:24.449Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T07:19:57.514Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tron-note/web/](https://dev.suite.sldev.cz/suite-web/feat/tron-note/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->