### PR TITLE
fix(suite-native): fix token detail header and token receive

### DIFF
--- a/suite-native/accounts/src/components/TokenReceiveCard.tsx
+++ b/suite-native/accounts/src/components/TokenReceiveCard.tsx
@@ -1,9 +1,8 @@
 import { useSelector } from 'react-redux';
 
-import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
+import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Badge, Box, ErrorMessage, Text, VStack } from '@suite-native/atoms';
 import { TokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
@@ -29,13 +28,6 @@ const valuesContainerStyle = prepareNativeStyle(utils => ({
 
 export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps) => {
     const { applyStyle } = useNativeStyles();
-
-    const { accountDescriptor, networkSymbol, deviceStaticSessionId } = parseAccountKey(accountKey);
-    const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
-
-    const accountLabel = useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
-        selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
-    );
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -51,6 +43,8 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
 
     const tokenName = getTokenName(token.name);
 
+    const networkName = getNetwork(symbol).name;
+
     return (
         <VStack>
             <Box flexDirection="row" justifyContent="space-between" alignItems="center">
@@ -64,7 +58,7 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
                             label={
                                 <Translation
                                     id="moduleAccounts.tokens.runOn"
-                                    values={{ accountLabel }}
+                                    values={{ networkName }}
                                 />
                             }
                             size="small"

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2015,11 +2015,10 @@ export const messages = {
     moduleAccounts: {
         accountNotFound: 'Account {accountKey} not found.',
         tokens: {
-            runOn: 'Run on {accountLabel}',
+            runOn: 'Run on {networkName}',
             errorMessage: 'Token not found.',
         },
         accountDetail: {
-            accountLabelBadge: 'Run on {accountLabel}',
             stablecoinYield: {
                 infoText: 'This token represents your deposit and all rewards in stablecoin yield.',
                 vault: 'Vault',

--- a/suite-native/intl/translations/cs-CZ.json
+++ b/suite-native/intl/translations/cs-CZ.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "24h změna",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "Cena {coinName}",
     "moduleAccounts.accountNotFound": "Účet {accountKey} nenalezen.",
-    "moduleAccounts.tokens.runOn": "Běží na {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Běží na {networkName}",
     "moduleAccounts.tokens.errorMessage": "Token nebyl nalezen.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Běží na {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/de-DE.json
+++ b/suite-native/intl/translations/de-DE.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "24h-Änderung",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "{coinName}-Preis",
     "moduleAccounts.accountNotFound": "Account {accountKey} nicht gefunden.",
-    "moduleAccounts.tokens.runOn": "Läuft auf {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Läuft auf {networkName}",
     "moduleAccounts.tokens.errorMessage": "Token nicht gefunden.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Läuft auf {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "24h change",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "{coinName} price",
     "moduleAccounts.accountNotFound": "Account {accountKey} not found.",
-    "moduleAccounts.tokens.runOn": "Run on {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Run on {networkName}",
     "moduleAccounts.tokens.errorMessage": "Token not found.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Run on {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/es-ES.json
+++ b/suite-native/intl/translations/es-ES.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "Cambio en 24h",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "Precio de {coinName}",
     "moduleAccounts.accountNotFound": "Cuenta {accountKey} no encontrada.",
-    "moduleAccounts.tokens.runOn": "Ejecutar en {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Ejecutar en {networkName}",
     "moduleAccounts.tokens.errorMessage": "No se ha encontrado el token.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Ejecutar en {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/fr-FR.json
+++ b/suite-native/intl/translations/fr-FR.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "Variation sur 24 h",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "Prix du {coinName}",
     "moduleAccounts.accountNotFound": "Compte {accountKey} introuvable.",
-    "moduleAccounts.tokens.runOn": "Fonctionne sur {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Fonctionne sur {networkName}",
     "moduleAccounts.tokens.errorMessage": "Token introuvable.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Fonctionne sur {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "Ce token représente votre dépôt et toutes les récompenses en rendement stablecoin.",

--- a/suite-native/intl/translations/ja-JP.json
+++ b/suite-native/intl/translations/ja-JP.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "24時間の変動",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "{coinName} の価格",
     "moduleAccounts.accountNotFound": "{accountKey}アカウントが見つかりません。",
-    "moduleAccounts.tokens.runOn": "{accountLabel} 上で実行",
+    "moduleAccounts.tokens.runOn": "{networkName} 上で実行",
     "moduleAccounts.tokens.errorMessage": "トークンが見つかりません.",
     "moduleAccounts.accountDetail.accountLabelBadge": "{accountLabel} 上で実行",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/pt-BR.json
+++ b/suite-native/intl/translations/pt-BR.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "Variação 24h",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "Preço de {coinName}",
     "moduleAccounts.accountNotFound": "Conta {accountKey} não encontrada.",
-    "moduleAccounts.tokens.runOn": "Executar em {accountLabel}",
+    "moduleAccounts.tokens.runOn": "Executar em {networkName}",
     "moduleAccounts.tokens.errorMessage": "Token não encontrado.",
     "moduleAccounts.accountDetail.accountLabelBadge": "Executar em {accountLabel}",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "This token represents your deposit and all rewards in stablecoin yield.",

--- a/suite-native/intl/translations/zh-CN.json
+++ b/suite-native/intl/translations/zh-CN.json
@@ -1037,7 +1037,7 @@
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.changeIn24h": "24 小时内的变动",
     "moduleAccountManagement.accountDetailContentScreen.coinPriceCard.coinPrice": "{coinName} 价格",
     "moduleAccounts.accountNotFound": "未找到帐户 {accountKey}。",
-    "moduleAccounts.tokens.runOn": "在 {accountLabel} 上运行",
+    "moduleAccounts.tokens.runOn": "在 {networkName} 上运行",
     "moduleAccounts.tokens.errorMessage": "未能找到此代币。",
     "moduleAccounts.accountDetail.accountLabelBadge": "在 {accountLabel} 上运行",
     "moduleAccounts.accountDetail.stablecoinYield.infoText": "该代币代表您的存款以及以稳定币形式获得的所有收益。",

--- a/suite-native/module-accounts-management/package.json
+++ b/suite-native/module-accounts-management/package.json
@@ -22,7 +22,6 @@
         "@suite-common/earn-stablecoin-api": "workspace:*",
         "@suite-common/fiat-services": "workspace:*",
         "@suite-common/graph": "workspace:*",
-        "@suite-common/suite-sync": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -2,14 +2,9 @@ import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
-import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
-import {
-    type AccountsRootState,
-    selectAccountByKey,
-    selectAccountNetworkSymbol,
-} from '@suite-common/wallet-core';
+import { getNetwork } from '@suite-common/wallet-config';
+import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
 import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
@@ -31,15 +26,6 @@ export const TokenAccountDetailScreenHeader = ({
 }: TokenAccountDetailScreenHeaderProps) => {
     const { translate } = useTranslate();
 
-    const { accountDescriptor, networkSymbol, deviceStaticSessionId } = parseAccountKey(accountKey);
-    const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
-    const account = useSelector((state: AccountsRootState) =>
-        selectAccountByKey(state, accountKey),
-    );
-    const accountLabel = useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
-        selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
-    );
-
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -53,7 +39,7 @@ export const TokenAccountDetailScreenHeader = ({
         return null;
     }
 
-    const accountLabelBadge = accountLabel ?? account?.accountLabel ?? '';
+    const networkName = getNetwork(symbol).name;
 
     return (
         <ScreenHeader
@@ -75,8 +61,8 @@ export const TokenAccountDetailScreenHeader = ({
                                 numberOfLines={1}
                                 ellipsizeMode="tail"
                             >
-                                {translate('moduleAccounts.accountDetail.accountLabelBadge', {
-                                    accountLabel: accountLabelBadge,
+                                {translate('moduleAccounts.tokens.runOn', {
+                                    networkName,
                                 })}
                             </Text>
                         </VStack>

--- a/suite-native/module-accounts-management/tsconfig.json
+++ b/suite-native/module-accounts-management/tsconfig.json
@@ -11,9 +11,6 @@
         },
         { "path": "../../suite-common/graph" },
         {
-            "path": "../../suite-common/suite-sync"
-        },
-        {
             "path": "../../suite-common/token-definitions"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13099,7 +13099,6 @@ __metadata:
     "@suite-common/earn-stablecoin-api": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/graph": "workspace:*"
-    "@suite-common/suite-sync": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

"Runs on ..." badge and header should not use the account label but network name to clearly indicate on what network the token is.

I will update crowdin after this is merged (accountLabel changed to networkName param)

## Notes for QA

Please Account detail screens for different tokens on different networks and also Receive screens. Both with and without account labels.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/26990

## Screenshots:

| BEFORE | AFTER | 
| -- | -- | 
|   <img width="390" height="843" alt="image" src="https://github.com/user-attachments/assets/24f46951-cba1-41e4-9b86-077df48b7dc1" /> |   <img width="391" height="846" alt="image" src="https://github.com/user-attachments/assets/0f633067-17ca-43a4-b0c6-008e9a42d15b" /> | 
| <img width="394" height="225" alt="image" src="https://github.com/user-attachments/assets/0b6b5d73-8130-41cf-85ec-be805017a34d" /> |  <img width="395" height="224" alt="image" src="https://github.com/user-attachments/assets/4058d610-c397-49f1-94c9-bb73779f2572" />  | 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/token-network-name-header&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/token-network-name-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/token-network-name-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T15:42:42.108Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T15:41:48.577Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/token-network-name-header/web/](https://dev.suite.sldev.cz/suite-web/fix/native/token-network-name-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->