### PR TITLE
fix(suite-native): offset the iOS caps lock indicator in SecureTextInputField

### DIFF
--- a/suite-native/forms/package.json
+++ b/suite-native/forms/package.json
@@ -15,6 +15,7 @@
         "@mobily/ts-belt": "^3.13.1",
         "@suite-native/atoms": "workspace:*",
         "@suite-native/icons": "workspace:*",
+        "@trezor/styles-native": "workspace:*",
         "react": "19.2.4",
         "react-hook-form": "^7.71.2",
         "react-native": "0.83.2",

--- a/suite-native/forms/src/fields/SecureTextInputField.tsx
+++ b/suite-native/forms/src/fields/SecureTextInputField.tsx
@@ -1,8 +1,9 @@
 import { forwardRef, useState } from 'react';
-import { Pressable } from 'react-native';
+import { Platform, Pressable } from 'react-native';
 
 import { type InputType } from '@suite-native/atoms';
 import { Icon, type IconName } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { type FieldProps, TextInputField } from './TextInputField';
 
@@ -10,6 +11,11 @@ type ToggleSecureTextIconProps = {
     onPress: () => void;
     isTextHidden: boolean;
 };
+
+// Ensures that the caps lock indicator shown on iOS doesn't overlap with the right icon.
+const inputStyle = prepareNativeStyle(({ spacings }) => ({
+    marginRight: Platform.OS === 'ios' ? spacings.sp16 : 0,
+}));
 
 const ToggleSecureTextIcon = ({ onPress, isTextHidden }: ToggleSecureTextIconProps) => {
     const iconName: IconName = isTextHidden ? 'eye' : 'eyeSlash';
@@ -24,6 +30,7 @@ const ToggleSecureTextIcon = ({ onPress, isTextHidden }: ToggleSecureTextIconPro
 export const SecureTextInputField = forwardRef<InputType, FieldProps>(
     ({ ...textInputFieldProps }, ref) => {
         const [isTextHidden, setIsTextHidden] = useState(true);
+        const { applyStyle } = useNativeStyles();
 
         return (
             <TextInputField
@@ -41,6 +48,7 @@ export const SecureTextInputField = forwardRef<InputType, FieldProps>(
                 importantForAutofill="no"
                 autoComplete="off"
                 textContentType="oneTimeCode"
+                style={applyStyle(inputStyle)}
             />
         );
     },

--- a/suite-native/forms/tsconfig.json
+++ b/suite-native/forms/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": { "outDir": "libDev" },
     "references": [
         { "path": "../atoms" },
-        { "path": "../icons" }
+        { "path": "../icons" },
+        { "path": "../../packages/styles-native" }
     ]
 }

--- a/suite-native/passphrase/src/components/PassphraseForm.tsx
+++ b/suite-native/passphrase/src/components/PassphraseForm.tsx
@@ -99,7 +99,6 @@ export const PassphraseForm = ({
                             autoCapitalize="none"
                             onFocus={handleFocusInput}
                             onBlur={() => setIsInputFocused(false)}
-                            secureTextEntry
                             testID="@passphrase/passphraseInput"
                         />
                         {isDirty && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -12833,6 +12833,7 @@ __metadata:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/icons": "workspace:*"
+    "@trezor/styles-native": "workspace:*"
     react: "npm:19.2.4"
     react-hook-form: "npm:^7.71.2"
     react-native: "npm:0.83.2"


### PR DESCRIPTION
Ensure that the caps lock indicator shown on iOS doesn't overlap with the right icon.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/64e5213b-1d78-4ff8-85e4-0e02faa1b62c" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/7473fff8-cbaa-4724-9832-f122b62ec8d3" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/ios-caps-lock-indicator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/ios-caps-lock-indicator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/ios-caps-lock-indicator&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T14:40:25.338Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T14:39:07.906Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/ios-caps-lock-indicator/web/](https://dev.suite.sldev.cz/suite-web/fix/native/ios-caps-lock-indicator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->