### PR TITLE
fix(suite): Unify receive and buy button in account detail with empty…

### DIFF
--- a/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
+++ b/packages/suite/src/components/wallet/AccountExceptionLayout.tsx
@@ -5,7 +5,6 @@ import {
     type ButtonProps,
     Card,
     Column,
-    Divider,
     H2,
     IconCircle,
     type IconCircleIntent,
@@ -26,7 +25,7 @@ interface AccountExceptionLayoutProps {
 
 export const AccountExceptionLayout = (props: AccountExceptionLayoutProps) => (
     <Card data-testid={props['data-testid']}>
-        <Column alignItems="center" margin={{ bottom: 24 }}>
+        <Column gap={4} alignItems="center" margin={{ bottom: 24 }}>
             {props.iconName && props.iconVariant && (
                 <IconCircle
                     name={props.iconName}
@@ -41,17 +40,16 @@ export const AccountExceptionLayout = (props: AccountExceptionLayoutProps) => (
                 priority="secondary"
                 typographyStyle="body-sm"
                 margin={{ top: spacings.xs }}
+                align="center"
             >
                 {props.description}
             </Paragraph>
             {props.actions && (
                 <>
-                    <Divider margin={{ top: spacings.xxl, bottom: spacings.xxl }} />
-                    <Row justifyContent="center" gap={spacings.md} margin={{ bottom: spacings.md }}>
+                    <Row justifyContent="center" gap={spacings.md} margin={{ top: 16 }}>
                         {props.actions?.map(action => (
                             <Button
                                 size="large"
-                                minWidth={160}
                                 {...action}
                                 key={action.key}
                                 data-testid={action['data-testid']}

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -75,27 +75,29 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
             iconVariant="neutral"
             actions={[
                 {
-                    'data-testid': '@accounts/empty-account/receive',
-                    key: '1',
-                    onClick: handleNavigateToReceivePage,
-                    children: isTokensNetwork ? (
-                        <Translation id="TR_RECEIVE" />
-                    ) : (
-                        <Translation
-                            id="TR_RECEIVE_NETWORK"
-                            values={{ networkDisplaySymbol: displaySymbol }}
-                        />
-                    ),
-                },
-                {
                     'data-testid': '@accounts/empty-account/buy',
-                    key: '2',
+                    key: '1',
                     onClick: handleNavigateToBuyPage,
+                    iconLeft: 'currencyCircleDollar',
                     children: isTokensNetwork ? (
                         <Translation id="TR_BUY" />
                     ) : (
                         <Translation
                             id="TR_BUY_NETWORK"
+                            values={{ networkDisplaySymbol: displaySymbol }}
+                        />
+                    ),
+                },
+                {
+                    'data-testid': '@accounts/empty-account/receive',
+                    key: '2',
+                    onClick: handleNavigateToReceivePage,
+                    iconLeft: 'arrowDown',
+                    children: isTokensNetwork ? (
+                        <Translation id="TR_RECEIVE" />
+                    ) : (
+                        <Translation
+                            id="TR_RECEIVE_NETWORK"
                             values={{ networkDisplaySymbol: displaySymbol }}
                         />
                     ),


### PR DESCRIPTION
… wallet

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:



**before:**

<img width="1224" height="919" alt="Screenshot 2026-04-29 at 16 59 05" src="https://github.com/user-attachments/assets/8c16efbb-290d-48ec-8b6c-b686544dacf4" />


**after:**

<img width="1224" height="917" alt="Screenshot 2026-04-29 at 16 57 38" src="https://github.com/user-attachments/assets/693bf948-a671-42c5-98a5-be038524a425" />

**how it looks on empty wallet:**

<img width="1221" height="919" alt="Screenshot 2026-04-29 at 16 57 45" src="https://github.com/user-attachments/assets/44158bbd-2424-4e08-8f52-a71e9f49f5d8" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=update-icons-for-account-hero&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=update-icons-for-account-hero&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T15:07:32.103Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T15:05:51.212Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/update-icons-for-account-hero/web/](https://dev.suite.sldev.cz/suite-web/update-icons-for-account-hero/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two wallet UI components: AccountExceptionLayout (a broadly used layout wrapper for exception states like discovery errors and empty accounts) and AccountEmpty (the specific view shown when an account has no transactions). Both files map to many tests due to their shared/transitive nature, but only a handful of tests directly exercise the exception and empty-account visual states. The recommended strategy focuses on tests that explicitly assert exception/empty account UI states (custom backend errors, offline discovery failures, empty coins) rather than broadly testing all flows that happen to import these components.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/wallet/AccountExceptionLayout.tsx`
- `packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises the scenario where an account fails discovery or is empty, which are the exact UI states rendered by AccountExceptionLayout and AccountEmpty. It asserts 'TR_ACCOUNT_IS_EMPTY_TITLE' and 'TR_ACCOUNT_EXCEPTION_DISCOVERY_ERROR' translations, which are displayed via these components.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test asserts that '@exception/discovery-failed/description' is visible when offline, which is rendered by AccountExceptionLayout. Changes to this layout component could affect how the discovery-failed exception is displayed.
- `suite/e2e/tests/settings/coins.test.ts` — This test verifies the dashboard empty state when no coins are active and tests coin activation flows. The empty account state is closely related to AccountEmpty component rendering when accounts have no transactions.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test exercises the full discovery flow across many coins and checks account balances post-discovery. AccountExceptionLayout is the component that renders when discovery fails or encounters errors, which this test implicitly covers by verifying discovery completes successfully.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test covers the scenario of a disconnected device during wallet operations, which triggers exception/connection states that use AccountExceptionLayout for rendering the disconnected device banner and connection modals in wallet context.

</details>

_Updated: 2026-04-30T06:25:28.586Z_
<!-- LLM-TEST-SELECTOR:END -->