### PR TITLE
feat(suite-native): rename the Coins section in settings to Networks

### DIFF
--- a/suite-native/coin-enabling/src/components/BtcOnlyCoinEnablingContent.tsx
+++ b/suite-native/coin-enabling/src/components/BtcOnlyCoinEnablingContent.tsx
@@ -1,31 +1,9 @@
-import { Box, Text, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import { Box } from '@suite-native/atoms';
 
 import { BtcOnlySvg } from '../assets/BtcOnlySvg';
 
-const contentStyle = prepareNativeStyle(_ => ({
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-}));
-
-export const BtcOnlyCoinEnablingContent = () => {
-    const { applyStyle } = useNativeStyles();
-
-    return (
-        <Box style={applyStyle(contentStyle)}>
-            <VStack spacing="sp24" alignItems="center">
-                <BtcOnlySvg />
-                <VStack spacing="sp8">
-                    <Text textAlign="center" variant="headline-sm">
-                        <Translation id="moduleSettings.coinEnabling.btcOnly.title" />
-                    </Text>
-                    <Text textAlign="center" color="contentSecondary">
-                        <Translation id="moduleSettings.coinEnabling.btcOnly.subtitle" />
-                    </Text>
-                </VStack>
-            </VStack>
-        </Box>
-    );
-};
+export const BtcOnlyCoinEnablingContent = () => (
+    <Box flex={0.6} alignItems="center" justifyContent="center">
+        <BtcOnlySvg />
+    </Box>
+);

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1126,9 +1126,9 @@ export const messages = {
                     title: 'Eject wallets',
                     subtitle: 'Hide wallet without connected Trezor',
                 },
-                coinEnabling: {
-                    title: 'Coins',
-                    subtitle: 'Manage assets that you want to use',
+                networks: {
+                    title: 'Networks',
+                    subtitle: 'Enable networks to receive assets',
                 },
                 suiteSync: {
                     title: 'Suite Sync',
@@ -1389,6 +1389,15 @@ export const messages = {
                 subtitle: 'Use facial or fingerprint verification to unlock the app.',
             },
             discreetMode: 'Discreet mode',
+        },
+        networks: {
+            title: 'Networks',
+            subtitle: {
+                configurable:
+                    'Enable networks to buy or receive assets. Turn off networks you don’t intend to use to speed up loading.',
+                bitcoinOnly:
+                    'Your device is running Bitcoin-only firmware. There’s nothing more to configure here.',
+            },
         },
         coinEnabling: {
             initialSetup: {

--- a/suite-native/module-settings/src/components/FeaturesSettings.tsx
+++ b/suite-native/module-settings/src/components/FeaturesSettings.tsx
@@ -46,9 +46,9 @@ export const FeaturesSettings = () => {
             />
             <AppSettingsCardWithIconLayout
                 icon="coins"
-                title={<Translation id="moduleSettings.items.features.coinEnabling.title" />}
-                subtitle={<Translation id="moduleSettings.items.features.coinEnabling.subtitle" />}
-                onPress={() => navigateTo(SettingsStackRoutes.SettingsCoinEnabling)}
+                title={<Translation id="moduleSettings.items.features.networks.title" />}
+                subtitle={<Translation id="moduleSettings.items.features.networks.subtitle" />}
+                onPress={() => navigateTo(SettingsStackRoutes.SettingsNetworks)}
                 isDisabled={hasDiscovery}
                 testID="@settings/coin-enabling"
             />

--- a/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
+++ b/suite-native/module-settings/src/navigation/SettingsStackNavigator.tsx
@@ -11,9 +11,9 @@ import { BitcoinBackendsScreen } from '../screens/BitcoinBackendsScreen';
 import { SettingsAdvancedScreen } from '../screens/SettingsAdvancedScreen';
 import { SettingsAppLogScreen } from '../screens/SettingsAppLogScreen';
 import { SettingsAutoEjectScreen } from '../screens/SettingsAutoEjectScreen';
-import { SettingsCoinEnablingScreen } from '../screens/SettingsCoinEnablingScreen';
 import { SettingsDustPhishingScreen } from '../screens/SettingsDustPhishingScreen';
 import { SettingsExperimentalScreen } from '../screens/SettingsExperimentalScreen';
+import { SettingsNetworksScreen } from '../screens/SettingsNetworksScreen';
 import { SettingsPreferencesScreen } from '../screens/SettingsPreferencesScreen';
 import { SettingsPrivacyScreen } from '../screens/SettingsPrivacyScreen';
 import { SettingsSuiteSyncScreen } from '../screens/SettingsSuiteSyncScreen';
@@ -52,9 +52,9 @@ export const SettingsStackNavigator = () => (
             component={SettingsAppLogScreen}
         />
         <SettingsStack.Screen
-            options={{ title: SettingsStackRoutes.SettingsCoinEnabling }}
-            name={SettingsStackRoutes.SettingsCoinEnabling}
-            component={SettingsCoinEnablingScreen}
+            options={{ title: SettingsStackRoutes.SettingsNetworks }}
+            name={SettingsStackRoutes.SettingsNetworks}
+            component={SettingsNetworksScreen}
         />
         <SettingsStack.Screen
             options={{ title: SettingsStackRoutes.SettingsSuiteSync }}

--- a/suite-native/module-settings/src/screens/SettingsNetworksScreen.tsx
+++ b/suite-native/module-settings/src/screens/SettingsNetworksScreen.tsx
@@ -6,7 +6,7 @@ import { selectDiscoveryNetworkSymbols } from '@suite-native/discovery';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 
-export const SettingsCoinEnablingScreen = () => {
+export const SettingsNetworksScreen = () => {
     const availableNetworkSymbols = useSelector(selectDiscoveryNetworkSymbols);
     const hasBitcoinOnlyFirmware = useSelector(selectHasBitcoinOnlyFirmware);
 
@@ -17,8 +17,16 @@ export const SettingsCoinEnablingScreen = () => {
         <Screen
             header={
                 <DynamicScreenHeader
-                    title={<Translation id="moduleSettings.coinEnabling.settings.title" />}
-                    subtitle={<Translation id="moduleSettings.coinEnabling.settings.subtitle" />}
+                    title={<Translation id="moduleSettings.networks.title" />}
+                    subtitle={
+                        <Translation
+                            id={
+                                showNetworks
+                                    ? 'moduleSettings.networks.subtitle.configurable'
+                                    : 'moduleSettings.networks.subtitle.bitcoinOnly'
+                            }
+                        />
+                    }
                 />
             }
         >

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -99,7 +99,7 @@ export type SettingsStackParamList = {
     [SettingsStackRoutes.SettingsViewOnly]: undefined;
     [SettingsStackRoutes.SettingsSupport]: undefined;
     [SettingsStackRoutes.SettingsAppLog]: undefined;
-    [SettingsStackRoutes.SettingsCoinEnabling]: undefined;
+    [SettingsStackRoutes.SettingsNetworks]: undefined;
     [SettingsStackRoutes.SettingsSuiteSync]: undefined;
     [SettingsStackRoutes.SettingsAdvanced]: undefined;
     [SettingsStackRoutes.SettingsDustPhishing]: undefined;

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -253,7 +253,7 @@ export enum SettingsStackRoutes {
     SettingsViewOnly = 'SettingsViewOnly',
     SettingsSupport = 'SettingsSupport',
     SettingsAppLog = 'SettingsAppLog',
-    SettingsCoinEnabling = 'SettingsCoinEnabling',
+    SettingsNetworks = 'SettingsNetworks',
     SettingsSuiteSync = 'SettingsSuiteSync',
     SettingsAdvanced = 'SettingsAdvanced',
     SettingsDustPhishing = 'SettingsDustPhishing',


### PR DESCRIPTION
- The _Coins_ section in settings renamed to _Networks._
- Screen subtitle determined based on FW type.
- Relevant naming adjusted.

## Related Issue

Resolve #27012

## Screenshots

| Settings | Configurable | BTC-only |
| --- | --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/290a8155-ff87-4ee2-92f6-60e44c9af446" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/59da7fc0-d29a-4e30-b7a1-91d610cc40b3" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/daaf5fe6-695f-4bd1-81a4-4082e0f7bf6d" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/settings-networks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->