### PR TITLE
chore(suite-common): add erc20.allowance calldata builder and verifier

### DIFF
--- a/suite-common/calldata/src/builder/evm/allowance.ts
+++ b/suite-common/calldata/src/builder/evm/allowance.ts
@@ -1,0 +1,24 @@
+import { EVM_ABI } from '../../constants/evm';
+import { createEvmEncoder } from '../../encoder/evm';
+import { createPolicy } from '../../policy/createPolicy';
+import { validateAddress } from '../../validation/evm/address';
+import { createBuilder } from '../createBuilder';
+import { createParam } from '../createParam';
+
+const ownerParam = createParam({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error' }),
+});
+
+const spenderParam = createParam({
+    validate: validateAddress,
+    policy: createPolicy({ ZERO_ADDRESS: 'error' }),
+});
+
+export const buildAllowance = createBuilder({
+    params: {
+        owner: ownerParam,
+        spender: spenderParam,
+    },
+    encode: createEvmEncoder(EVM_ABI.erc20.allowance),
+});

--- a/suite-common/calldata/src/calldata.ts
+++ b/suite-common/calldata/src/calldata.ts
@@ -1,3 +1,4 @@
+import { buildAllowance } from './builder/evm/allowance';
 import { buildApprove } from './builder/evm/approve';
 import { buildClaim } from './builder/evm/claim';
 import { buildDeposit } from './builder/evm/deposit';
@@ -9,6 +10,7 @@ import { buildTrc20Transfer } from './builder/tron/trc20/transfer';
 export const Calldata = {
     evm: {
         erc20: {
+            allowance: buildAllowance,
             approve: buildApprove,
             transfer: buildTransfer,
         },

--- a/suite-common/calldata/src/constants/evm.ts
+++ b/suite-common/calldata/src/constants/evm.ts
@@ -2,6 +2,9 @@ import { parseAbi } from 'viem';
 
 export const EVM_ABI = {
     erc20: {
+        allowance: parseAbi([
+            'function allowance(address owner, address spender) returns (uint256)',
+        ]),
         approve: parseAbi(['function approve(address spender, uint256 amount)']),
         transfer: parseAbi(['function transfer(address to, uint256 amount)']),
     },

--- a/suite-common/calldata/src/tests/builder/evm/allowance.test.ts
+++ b/suite-common/calldata/src/tests/builder/evm/allowance.test.ts
@@ -1,0 +1,29 @@
+import { buildAllowance } from '../../../builder/evm/allowance';
+import { asEvmAddress } from '../../../types/evm';
+
+const OWNER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
+
+describe('buildAllowance', () => {
+    it('encodes valid allowance calldata', () => {
+        const result = buildAllowance({ owner: OWNER, spender: SPENDER });
+
+        expect(result.isValid).toBe(true);
+        expect(result.data).toBe(
+            '0xdd62ed3e0000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae30000000000000000000000001231deb6f5749ef6ce6943a275a1d3e7486f4eae',
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('returns error for zero address', () => {
+        const result = buildAllowance({
+            owner: '0x0000000000000000000000000000000000000000',
+            spender: SPENDER,
+        });
+
+        expect(result.isValid).toBe(false);
+        expect(result.data).toBe(null);
+        expect(result.errors).toEqual([{ code: 'ZERO_ADDRESS', path: 'owner', severity: 'error' }]);
+    });
+});

--- a/suite-common/calldata/src/tests/verifier/evm/allowance.test.ts
+++ b/suite-common/calldata/src/tests/verifier/evm/allowance.test.ts
@@ -1,0 +1,25 @@
+import { buildAllowance } from '../../../builder/evm/allowance';
+import { asEvmAddress } from '../../../types/evm';
+import { Verifier } from '../../../verifier';
+
+const OWNER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
+const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
+
+const allowanceHex = buildAllowance({ owner: OWNER, spender: SPENDER }).data!;
+
+describe('verifyAllowance', () => {
+    it('returns isValid true on full match', () => {
+        expect(
+            Verifier.evm.erc20.allowance(allowanceHex, { owner: OWNER, spender: SPENDER }),
+        ).toEqual({ isValid: true, issues: [] });
+    });
+
+    it('returns VALUE_MISMATCH on mismatch', () => {
+        expect(
+            Verifier.evm.erc20.allowance(allowanceHex, {
+                owner: '0x0000000000000000000000000000000000000001',
+                spender: SPENDER,
+            }),
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'owner' }] });
+    });
+});

--- a/suite-common/calldata/src/verifier.ts
+++ b/suite-common/calldata/src/verifier.ts
@@ -4,6 +4,7 @@ import { createVerifier } from './verifier/createVerifier';
 export const Verifier = {
     evm: {
         erc20: {
+            allowance: createVerifier({ abi: EVM_ABI.erc20.allowance }),
             approve: createVerifier({ abi: EVM_ABI.erc20.approve }),
         },
         erc4626: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces calldata builder and verifier for `erc20.allowance` call.

## Related Issue

Resolve #27198

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within the `suite-common/calldata` package, affecting EVM allowance call data building, verification, and related constants. The changed files include unit tests (`allowance.test.ts` for both builder and verifier) and source modules (`allowance.ts`, `calldata.ts`, `verifier.ts`, `evm.ts` constants). While `calldata.ts` and `evm.ts` are transitively imported by 121 E2E tests, these are deep infrastructure utilities for EVM call data encoding/decoding. None of the 121 mapped E2E tests exercise EVM allowance/approval call data paths — they cover analytics, backup, browser compatibility, metadata, onboarding, staking, trading, and general wallet flows that don't directly test call data building or verification. The unit tests (`allowance.test.ts` files) provide the appropriate coverage for these changes. No E2E tests need to be run for this change set.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/calldata/src/builder/evm/allowance.ts`
- `suite-common/calldata/src/calldata.ts`
- `suite-common/calldata/src/constants/evm.ts`
- `suite-common/calldata/src/tests/builder/evm/allowance.test.ts`
- `suite-common/calldata/src/tests/verifier/evm/allowance.test.ts`
- `suite-common/calldata/src/verifier.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/calldata/src/builder/evm/allowance.ts`
- `suite-common/calldata/src/tests/builder/evm/allowance.test.ts`
- `suite-common/calldata/src/tests/verifier/evm/allowance.test.ts`
- `suite-common/calldata/src/verifier.ts`

_Updated: 2026-04-29T15:57:29.686Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/allowance-calldata&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/allowance-calldata&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/allowance-calldata&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T16:02:06.678Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T16:00:49.740Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/allowance-calldata/web/](https://dev.suite.sldev.cz/suite-web/feat/allowance-calldata/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->