### PR TITLE
test(e2e-suite): fix migration CSP violation and explicit network act…

### DIFF
--- a/suite/e2e/support/pageObjects/assetsSection.ts
+++ b/suite/e2e/support/pageObjects/assetsSection.ts
@@ -37,7 +37,6 @@ export class AssetsSection {
 
     @step()
     async enableNetworkViaActivateAssetsModal(symbol: NetworkSymbol) {
-        await this.enableMoreCoins.click();
         await this.activateAssetsModalNetworkButton(symbol).click();
         await this.activateAssetsModalSaveButton.click();
     }

--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -1,10 +1,11 @@
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 import { NetworkSymbol } from '@suite-common/wallet-config';
 
 import { step } from '../common';
 import { DevicePrompt } from './devicePrompt';
 import { DeviceFixture } from '../device';
+import { expect } from '../testExtends/customMatchers';
 
 export type graphRangeOptions = 'day' | 'week' | 'month' | 'year' | 'all';
 export type PromoBannerType = 'tex' | 'ts7';
@@ -59,6 +60,9 @@ export class DashboardPage {
     readonly discoveryEmptyPrimaryButton: Locator;
     readonly promoBannerButton = (bannerTyp: PromoBannerType): Locator =>
         this.page.getByTestId(`@dashboard/promo-banner/${bannerTyp}/button`);
+    readonly discoveryFailed: Locator;
+    readonly discoveryFailedHeader: Locator;
+    readonly discoveryFailedDesc: Locator;
 
     constructor(
         private readonly page: Page,
@@ -115,6 +119,9 @@ export class DashboardPage {
         this.discoveryEmptyPrimaryButton = this.page.getByTestId(
             '@exception/discovery-empty/brand-button',
         );
+        this.discoveryFailed = this.page.getByTestId('@exception/discovery-failed');
+        this.discoveryFailedHeader = this.page.getByTestId('@exception/discovery-failed/header');
+        this.discoveryFailedDesc = this.page.getByTestId('@exception/discovery-failed/description');
     }
 
     @step()
@@ -219,5 +226,26 @@ export class DashboardPage {
     @step()
     async openDevice(index: number) {
         await this.page.getByTestId(`@switch-device/wallet-on-index/${index}`).click();
+    }
+
+    @step()
+    async verifyDiscoveryEmpty() {
+        await expect(this.discoveryEmptyHeader).toHaveTranslation('TR_YOUR_WALLET_IS_READY_WHAT');
+        await expect(this.discoveryEmptyDesc).toHaveTranslation(
+            'TR_DASHBOARD_ACTIVATE_ASSETS_DESC',
+        );
+        await expect(this.discoveryEmptyPrimaryButton).toHaveTranslation(
+            'TR_DASHBOARD_GET_STARTED',
+        );
+    }
+
+    @step()
+    async verifyDiscoveryFailed() {
+        await expect(this.discoveryFailed).toBeVisible();
+        await expect(this.discoveryFailedHeader).toHaveTranslation('TR_DASHBOARD_DISCOVERY_ERROR');
+        await expect(this.discoveryFailedDesc).toContainTranslation(
+            'TR_DASHBOARD_DISCOVERY_ERROR_PARTIAL_DESC',
+            { values: { details: 'Device not found' } },
+        );
     }
 }

--- a/suite/e2e/tests/dashboard/assets.test.ts
+++ b/suite/e2e/tests/dashboard/assets.test.ts
@@ -26,6 +26,7 @@ test.describe('Assets', { tag: ['@T3W1', '@T3T1', '@smoke'] }, () => {
     });
 
     test('New asset is shown in both grid and row', async ({ page, assetsSection }) => {
+        await assetsSection.enableMoreCoins.click();
         await assetsSection.enableNetworkViaActivateAssetsModal('eth');
         await page.discoveryShouldFinish();
         await assetsSection.verifyAssetContents();

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -20,6 +20,7 @@ test.describe(
     () => {
         test.use({
             deviceSetup: { passphrase_protection: true, mnemonic: 'mnemonic_all' },
+            bypassCSP: true,
         });
 
         test(
@@ -46,7 +47,15 @@ test.describe(
                     ],
                 }),
             },
-            async ({ page, device, devicePrompt, onboardingPage, dashboardPage, walletPage }) => {
+            async ({
+                page,
+                device,
+                devicePrompt,
+                onboardingPage,
+                dashboardPage,
+                walletPage,
+                assetsSection,
+            }) => {
                 const discoveryBar = page.locator(
                     '[data-test="\\@wallet\\/discovery-progress-bar"] div',
                 );
@@ -123,7 +132,21 @@ test.describe(
 
                 await test.step(`Navigate to new version ${migrateToVersion} and check wallet status`, async () => {
                     await page.goto(`${suiteDevInstance}/${migrateToVersion}`);
-                    await expect(dashboardPage.graph).toBeVisible({ timeout: 30_000 });
+                    // PR#26782 No coins activated after onboarding
+                    await test.step('Verify "wallet is ready"', async () => {
+                        await dashboardPage.discoveryEmptyHeader.waitFor({
+                            state: 'attached',
+                            timeout: 30_000,
+                        });
+
+                        await dashboardPage.verifyDiscoveryEmpty();
+                    });
+                    await test.step('Get started - Enable BTC coin', async () => {
+                        await dashboardPage.discoveryEmptyPrimaryButton.click();
+                        await assetsSection.enableNetworkViaActivateAssetsModal('btc');
+
+                        await dashboardPage.verifyDiscoveryFailed();
+                    });
                     await page.getByTestId('@account-menu/btc/normal/0').click();
                     await walletPage.openAccount({ symbol: 'btc' });
                     await dashboardPage.openDeviceSwitcher();


### PR DESCRIPTION
…ivation

## Description

**Content-Security-Policy (CSP) Violation**: The version` release/22.5/web` is loading depends on an older version of Trezor Connect (v8.2.9-beta.3). This older version uses inline scripts within its `iframe.html`. ggThe server dev.suite.sldev.cz is serving a CSP header that only allows 'self' and 'unsafe-eval'. It does not allow 'unsafe-inline'.

The solution is to bypass CSP in the browser context for this test suite.

**No default coins**: Because of the [PR#26782](https://github.com/trezor/trezor-suite/pull/26782), the BTC coin has to be manually enabled.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies two page object files (assetsSection.ts, dashboardPage.ts) and two test files (assets.test.ts, db-migration.test.ts). The highest risk is in the directly changed tests which must be run. The page object changes have medium-wide impact since dashboardPage is used by many tests for device switching, navigation, and wallet management, while assetsSection is used by tests that verify asset display on the dashboard. The recommended strategy is to run the two directly changed tests at high priority, then cover the most impactful consumers of the modified page objects at medium priority.

<details><summary><b>Changed files (4)</b></summary>

- `suite/e2e/support/pageObjects/assetsSection.ts`
- `suite/e2e/support/pageObjects/dashboardPage.ts`
- `suite/e2e/tests/dashboard/assets.test.ts`
- `suite/e2e/tests/suite/db-migration.test.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This is one of the directly changed files. It tests the assets section on the dashboard including buy actions in table/grid views and enabling new assets. Changes to assetsSection.ts and dashboardPage.ts page objects directly support this test.
- `suite/e2e/tests/suite/db-migration.test.ts` — This is one of the directly changed test files. It validates database migration behavior including theme persistence, passphrase wallets, send form drafts, and transaction history across Suite versions.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test uses both dashboardPage (portfolioFiatAmount, hideBalanceButton, deviceSwitchingOpenButton) and assetsSection (assetFiatAmount, tableIcon) page objects which were both changed. Changes to these page objects could break discreet mode assertions.
- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to the dashboard and uses dashboardPage.navigateTo and dashboardPage.stakeButton to test staking analytics from the dashboard assets section. Changes to dashboardPage could affect these interactions.
- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test uses dashboardPage page object (promoBannerButton, navigateTo) to interact with promotional banners on the dashboard. Changes to dashboardPage could break banner interaction selectors.
- `suite/e2e/tests/settings/electrum.test.ts` — This test uses assetsSection (fiatAmount for RegTest asset) and dashboardPage to verify balances after Electrum backend discovery. Changes to assetsSection page object could affect asset fiat amount assertions.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test uses dashboardPage extensively (device switcher, eject wallet, add standard wallet actions) to test wallet discovery. Changes to dashboardPage page object could break device switcher interactions.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This is a sibling database migration test that shares similar migration patterns with the changed db-migration.test.ts. If migration test infrastructure was refactored, this test could also be affected.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test heavily uses dashboardPage (deviceStatus, deviceSwitchingOpenButton, solveIssuesButton, deviceStatusOnSwitchDevice, walletAtIndex). Changes to dashboardPage page object could break session management assertions.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Uses dashboardPage (openDeviceSwitcher, addUnusedHiddenWallet, addHiddenWallet, passphraseDuplicateHeader). If dashboardPage's device switcher or hidden wallet methods were modified, this test could break.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Uses dashboardPage (openDeviceSwitcher, addUnusedHiddenWallet, addStandardWallet, ejectWallet, walletAtIndex). Changes to dashboardPage's wallet management methods could affect wallet numbering verification.

</details>

_Updated: 2026-04-29T20:46:44.061Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-db-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-db-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-29T20:52:28.434Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-29T20:51:03.276Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-db-migration/web/](https://dev.suite.sldev.cz/suite-web/test/fix-db-migration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->