### PR TITLE
fix: remove debug condition from legacy labeling migration

### DIFF
--- a/packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx
+++ b/packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx
@@ -3,10 +3,7 @@ import { useState } from 'react';
 import { Translation } from '@suite/intl';
 import { selectIsLegacyLabelingVisible } from '@suite/metadata';
 import { selectDeviceStaticSessionId, selectSelectedDevice } from '@suite-common/device';
-import {
-    selectIsSuiteSyncDebugEnabled,
-    selectSuiteSyncInteraction,
-} from '@suite-common/suite-sync';
+import { selectSuiteSyncInteraction } from '@suite-common/suite-sync';
 import { SidebarBanner } from '@trezor/product-components';
 
 import { useSelector } from 'src/hooks/suite';
@@ -20,16 +17,12 @@ export const SuiteSyncPromoBanner = () => {
     const selectedDevice = useSelector(selectSelectedDevice);
     const deviceStaticSessionId = useSelector(selectDeviceStaticSessionId);
 
-    // Todo: remove for the 26.6 release when we want to start advertising for Suite Sync
-    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
-
     const isLegacyLabelingVisible = useSelector(selectIsLegacyLabelingVisible);
     const suiteSyncInteraction = useSelector(state =>
         selectSuiteSyncInteraction(state, deviceStaticSessionId),
     );
     const shouldDisplayBanner =
         !isDismissed &&
-        isSuiteSyncDebugEnabled &&
         isLegacyLabelingVisible &&
         selectedDevice !== undefined &&
         selectedDevice.connected &&

--- a/suite/metadata-migration/src/LegacyLabelingMigration.tsx
+++ b/suite/metadata-migration/src/LegacyLabelingMigration.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
-import { selectIsSuiteSyncDebugEnabled, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { Tooltip } from '@trezor/components';
 import { type StaticSessionId } from '@trezor/connect';
 import { ActionButton, ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -29,12 +29,10 @@ export const LegacyLabelingMigration = ({
     const [isModalVisible, setIsModalVisible] = useState(false);
     const selectedDevice = useSelector(selectSelectedDevice);
     const isSuiteSyncEnabled = useSelector(selectIsSuiteSyncEnabled);
-    const isSuiteSyncDebugEnabled = useSelector(selectIsSuiteSyncDebugEnabled);
 
     const isMigratable = isMigratableDevice(selectedDevice);
 
-    // Todo: remove the `isSuiteSyncDebugEnabled` check after we are confident to offer migration
-    if (!isSuiteSyncEnabled || !isSuiteSyncDebugEnabled) {
+    if (!isSuiteSyncEnabled) {
         return null;
     }
 


### PR DESCRIPTION
Migration of labels is now offered to all users of Legacy labeling. No debug needed.

Resolves: https://github.com/trezor/trezor-suite/issues/27156

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch two components: SuiteSyncPromoBanner.tsx (a UI banner promoting Suite Sync) and LegacyLabelingMigration.tsx (handling migration from legacy labeling to Suite Sync). The highest risk is in the migration path from legacy to Suite Sync labeling, directly covered by the legacy-label-to-suiteSync test. The promo banner change has moderate risk affecting Suite Sync onboarding flows. No static test mapping exists for either file, so all recommendations are inferred from behavioral analysis of the test suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx`
- `suite/metadata-migration/src/LegacyLabelingMigration.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test covers migrating legacy labels to Suite Sync, which directly relates to the LegacyLabelingMigration component changed in suite/metadata-migration/src/LegacyLabelingMigration.tsx. Changes to the migration logic could break this flow.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `../../suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test exercises the SuiteSyncBanner component (suiteSyncBanner, suiteSyncBannerButton), which is likely related to or rendered alongside the changed SuiteSyncPromoBanner.tsx. Changes to the promo banner could affect banner visibility and interaction in the multi-wallet Suite Sync flow.
- `../../suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test exercises the legacy labeling flow (enableLegacyLabeling, account label editing with Dropbox). Changes to LegacyLabelingMigration.tsx could affect how legacy labeling is initialized or displayed, since migration and legacy labeling share infrastructure.
- `../../suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test covers the full metadata/labeling lifecycle including enabling, disabling, and re-enabling legacy labeling. Changes to the LegacyLabelingMigration component could affect how labeling state transitions work.
- `../../suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test enables Suite Sync and creates labels across account, wallet, address, and output types. The SuiteSyncPromoBanner may appear during this flow, and changes could affect the Suite Sync enablement experience.
- `../../suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test covers Suite Sync setup including initiateSuiteSyncSetup, which may involve or be adjacent to the SuiteSyncPromoBanner. Changes to the promo banner component could affect the sync setup flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `../../suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — This test covers enabling/disabling metadata with provider connection management on remembered devices. The LegacyLabelingMigration change could plausibly affect how legacy labels are loaded for remembered devices.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/suite/labeling/SuiteSyncPromoBanner.tsx`

_Updated: 2026-04-30T00:35:42.369Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=un-debug-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=un-debug-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 27 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Receive transaction > Receive a ETH transaction | 🤖 auto |
| Receive transaction > Receive a BTC transaction | 🤖 auto |
| Receive transaction > Receive a SOL transaction | 🤖 auto |
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Trading - Swap tokens > Swap Solana tokens | 🤖 auto |
| Trading - Swap coins > Swap Solana to Bitcoin | 🤖 auto |
| Trading - Swap token to disabled network asset > Show provider info for disabled network asset XLM | 🤖 auto |
| Trading - Swap token to coin > Swap Solana Tether token to Bitcoin | 🤖 auto |
| Trading - Sell Solana > Sell Solana | 🤖 auto |
| Trading - Sell Solana > Sell Solana for compared offer | 🤖 auto |
| Trading - Swap history > View swap order history details | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T00:41:03.236Z • 27 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 16 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Cardano > Basic cardano walkthrough | 🤖 auto |
| Analytics Events - Staking Navigate > Should log the event staking/navigate - ADA from account menu | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T00:39:29.020Z • 16 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/un-debug-migration/web/](https://dev.suite.sldev.cz/suite-web/un-debug-migration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->