### PR TITLE
refactor(connect): extract LocalFirmwareStore from DataManager

### DIFF
--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -39,6 +39,7 @@ import { onCallFirmwareUpdate } from './onCallFirmwareUpdate';
 import { dispose as disposeBackend } from '../backend/BlockchainLink';
 import { DataManager } from '../data/DataManager';
 import { initializeFirmwareConfig } from '../data/firmwareInfo';
+import * as localFirmwareStore from '../data/localFirmwareStore';
 import { loadProtobufModules } from '../data/protobufLoader';
 import type { Device, DeviceEvents } from '../device/Device';
 import type { IDeviceList } from '../device/DeviceList';
@@ -819,7 +820,7 @@ export class Core extends EventEmitter {
             case UI_RESPONSE.RECEIVE_FIRMWARE: {
                 const localFirmwares = message.payload && parseLocalFirmwares(message.payload);
                 if (localFirmwares) {
-                    DataManager.setLocalFirmwares(localFirmwares);
+                    localFirmwareStore.set(localFirmwares);
                 }
                 break;
             }
@@ -909,7 +910,7 @@ export class Core extends EventEmitter {
             const localFirmwares =
                 settings.localFirmwares && parseLocalFirmwares(settings.localFirmwares);
             if (localFirmwares) {
-                DataManager.setLocalFirmwares(localFirmwares);
+                localFirmwareStore.set(localFirmwares);
             }
             await loadProtobufModules();
             const { debug, priority, manifest } = DataManager.getSettings();

--- a/packages/connect/src/data/DataManager.ts
+++ b/packages/connect/src/data/DataManager.ts
@@ -1,6 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/DataManager.js
 
-import type { ConnectSettings, LocalFirmwares } from '@trezor/connect-common';
+import type { ConnectSettings } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 
 import * as firmwareReleaseStore from './firmwareReleaseStore';
@@ -8,7 +8,6 @@ import type { InitializeFirmwareConfig } from './firmwareReleaseStore';
 
 export class DataManager {
     private static settings: ConnectSettings;
-    private static localFirmwares: LocalFirmwares = { firmwareDir: '', firmwareList: [] };
 
     public static async load(
         settings: ConnectSettings,
@@ -51,12 +50,5 @@ export class DataManager {
         }
 
         return this.settings;
-    }
-
-    public static setLocalFirmwares(firmwares: LocalFirmwares): void {
-        this.localFirmwares = firmwares;
-    }
-    public static getLocalFirmwares(): LocalFirmwares {
-        return this.localFirmwares;
     }
 }

--- a/packages/connect/src/data/firmwareInfo.ts
+++ b/packages/connect/src/data/firmwareInfo.ts
@@ -23,6 +23,7 @@ import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
 import { DataManager } from './DataManager';
 import * as firmwareReleaseStore from './firmwareReleaseStore';
+import * as localFirmwareStore from './localFirmwareStore';
 import { getReleaseAsset, getReleasesAssetByDeviceModelAndFirmwareType } from '../utils/assetUtils';
 import { httpRequest } from '../utils/assets';
 import { getOnlineFirmwareBaseUrl } from '../utils/firmwareReleaseConfigUtils';
@@ -180,7 +181,7 @@ export const getReleaseByVersion = async (
 
     const releaseName = buildLocalReleaseName(firmwareType, deviceModel, firmwareVersion);
 
-    const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
+    const { firmwareDir, firmwareList } = localFirmwareStore.get();
     if (
         isFirmwareCacheUsedForSelectedSource(DataManager.getSettings('firmwareChannel')) &&
         firmwareList.includes(releaseName)
@@ -641,7 +642,7 @@ export const getFirmwareLocation = ({
         };
     }
 
-    const { firmwareDir, firmwareList } = DataManager.getLocalFirmwares();
+    const { firmwareDir, firmwareList } = localFirmwareStore.get();
     if (
         isFirmwareCacheUsedForSelectedSource(DataManager.getSettings('firmwareChannel')) &&
         firmwareList.includes(firmwareName)

--- a/packages/connect/src/data/localFirmwareStore.ts
+++ b/packages/connect/src/data/localFirmwareStore.ts
@@ -1,0 +1,9 @@
+import type { LocalFirmwares } from '@trezor/connect-common';
+
+let firmwares: LocalFirmwares = { firmwareDir: '', firmwareList: [] };
+
+export const set = (next: LocalFirmwares): void => {
+    firmwares = next;
+};
+
+export const get = (): LocalFirmwares => firmwares;


### PR DESCRIPTION
> **DataManager architecture refactor — Phase 3 of an ongoing series.**
>
> Open PRs in the series:
> 1. ~~#27106~~ (merged) — move `parseCoinsJson` out of `DataManager.load()`
> 2. #27157 — extract `FirmwareReleaseStore` from `DataManager`
> 3. **#27209 (this PR)** — extract `LocalFirmwareStore` from `DataManager`
> 4. #27210 — replace `DataManager` with `settingsStore` and inline the load lifecycle (final)
>
> The branch cherry-picks #27157 to avoid `DataManager.ts` conflicts. Once #27157 merges, this PR rebases cleanly to a single Phase 3 commit.

## Summary

`DataManager` still held a `localFirmwares` field plus its setter and getter — a small mutable cache used by the firmware-popup flow. Move it to a dedicated pure module so `DataManager` keeps shrinking toward a settings-only role.

The new `localFirmwareStore` exposes `set` and `get`. Four call sites swap (`core/index.ts` × 2 setters, `firmwareInfo.ts` × 2 getters).

After this lands, `DataManager` is just `settings`, `load()`, `updateSettings`, `isLoaded`, `getSettings` — ready for the final Phase 4 collapse.

## Test plan

- [ ] CI typecheck passes for `@trezor/connect`
- [ ] CI unit tests for `@trezor/connect` remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/local-firmware-store/web/](https://dev.suite.sldev.cz/suite-web/mroz22/local-firmware-store/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/local-firmware-store&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->