### PR TITLE
fix(suite): Fix sidebar notification wrap

### DIFF
--- a/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
+++ b/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
@@ -87,7 +87,7 @@ export const SidebarBanner = ({
                         </Paragraph>
                     )}
                 </Column>
-                <Row gap={10} margin={{ top: 2 }}>
+                <Row gap={10} margin={{ top: 2 }} flexWrap="wrap">
                     <Button
                         intent="brand"
                         type="button"

--- a/suite/desktop-update/src/quickActions/UpdateNotificationBanner.tsx
+++ b/suite/desktop-update/src/quickActions/UpdateNotificationBanner.tsx
@@ -108,7 +108,6 @@ export const UpdateNotificationBanner = () => {
             ctaLabel={<Translation id={translationCallToAction} />}
             closeLabel={<Translation id="TR_DISMISS" />}
             heading={<Translation id={translationHeader} />}
-            description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
             icon={mapUpdateStatusToIcon[updateStatus]}
             onClick={handleOnClick}
             onClose={handleClose}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

before
<img width="510" height="692" alt="image" src="https://github.com/user-attachments/assets/383c6c13-eb85-4089-a586-e0198d03e167" />

after

https://github.com/user-attachments/assets/a06fe5bc-3b6f-4daf-a0e5-6d6d2974d222


<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`, a UI component in the `product-components` package. No tests were found via static coverage mapping, and none of the LLM-analyzed E2E tests reference SidebarBanner behavior, sidebar banner rendering, or product-components in their source hints, behaviors, or entry points. The component is likely used in a sidebar context (possibly promotional or informational banners), but no existing E2E test exercises it directly or indirectly in a way that would be affected by changes. The risk is low for E2E regressions; this change would be better covered by unit or integration tests within the product-components package.

<details><summary><b>Changed files (1)</b></summary>

- `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`

_Updated: 2026-04-30T07:01:41.113Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-sidebar-notification-wrap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-sidebar-notification-wrap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T07:21:51.001Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 13 test(s)</summary>

| Test | Type |
|------|------|
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T07:20:19.148Z • 13 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-sidebar-notification-wrap/web/](https://dev.suite.sldev.cz/suite-web/fix-sidebar-notification-wrap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->