### PR TITLE
chore(intl): remove unused translation strings

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11604,14 +11604,6 @@ export const messages = defineMessages({
         id: 'TR_OUTSIDE_STAKING_CARD_TEXT',
         defaultMessage: '{amount} {displaySymbol} (= {fiat}) is currently staked elsewhere.',
     },
-    TR_EARN_YIELD_CLAIMABLE_REWARDS: {
-        id: 'TR_EARN_YIELD_CLAIMABLE_REWARDS',
-        defaultMessage: 'Claimable rewards: {amount}',
-    },
-    TR_EARN_YIELD_CLAIMABLE_REWARDS_NO_AMOUNT: {
-        id: 'TR_EARN_YIELD_CLAIMABLE_REWARDS_NO_AMOUNT',
-        defaultMessage: 'Claimable rewards',
-    },
     TR_EARN_YIELD_CLAIM: {
         id: 'TR_EARN_YIELD_CLAIM',
         defaultMessage: 'Claim',


### PR DESCRIPTION
## Summary
Removes unused translation strings from `messages.ts` that are no longer referenced in the codebase.

**Keys removed (2):**
- `TR_EARN_YIELD_CLAIMABLE_REWARDS`
- `TR_EARN_YIELD_CLAIMABLE_REWARDS_NO_AMOUNT`

Identified by the `translations:list-unused` CI check.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is to suite/intl/src/messages.ts, which is the internationalization message definitions file — a broadly shared utility used across the entire application. No static test mapping exists for this file. Risk depends on the nature of the change: adding new messages is low-risk, while modifying or removing existing message keys/definitions could break any UI text assertion. The recommended strategy focuses on tests that explicitly reference @suite/intl messages in their source hints, with highest priority given to the autodetect test which directly validates localized message content against the intl system.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `../../suite/e2e/tests/settings/autodetect.test.ts` — This test directly imports and uses '@suite/intl messages' to verify that the correct internationalized heading text (TR_ONBOARDING_DATA_COLLECTION_HEADING) is displayed. Changes to suite/intl/src/messages.ts could alter message definitions, keys, or exports, directly breaking these assertions.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `../../suite/e2e/tests/settings/general.test.ts` — This test verifies translated UI strings for fiat currency, theme, language changes, and analytics events. While it doesn't directly import messages.ts, it relies on translation keys and the intl system working correctly. Changes to message definitions could affect displayed text assertions.
- `../../suite/e2e/tests/trading/sell-inputs.test.ts` — This test explicitly references '@suite/intl messages' for validation error translation keys (AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, TR_TRADING_COUNTRY_WORLD). Changes to message definitions in messages.ts could break these validation string assertions.
- `../../suite/e2e/tests/trading/swap-history.test.ts` — This test explicitly references '@suite/intl (messages / translations)' and verifies numerous translated status labels and UI strings (TR_TRADING_LAST_TRANSACTIONS, TR_EXCHANGE_STATUS_*, TR_TRADING_TRANS_ID, etc.). Changes to messages.ts could affect these translation key lookups.
- `../../suite/e2e/tests/wallet/send-base.test.ts` — This test explicitly uses '@suite/intl (messages/translations, TR_GAS_LIMIT)' to verify that the gas limit translation string matches expected values on the device prompt. A change to messages.ts could alter this translation definition.
- `../../suite/e2e/tests/wallet/send-eth.test.ts` — This test explicitly references '@suite/intl (messages / TR_GAS_LIMIT)' and verifies the Ethereum gas limit translation text in the device confirmation prompt. Changes to messages.ts could break this specific assertion.
- `../../suite/e2e/tests/wallet/transactions.test.ts` — This test uses '@suite/intl messages' for graph time range filter labels (TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, etc.) and asserts their visibility. Changes to these message definitions would directly break the test.

</details>

_Updated: 2026-04-30T08:32:07.830Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/remove-unused-strings-20260430&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/remove-unused-strings-20260430&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T08:37:20.029Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T08:35:52.726Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260430/web/](https://dev.suite.sldev.cz/suite-web/chore/remove-unused-strings-20260430/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->