### PR TITLE
chore(suite-build): drop redundant vm fallback in web config

### DIFF
--- a/packages/suite-build/configs/web.webpack.config.ts
+++ b/packages/suite-build/configs/web.webpack.config.ts
@@ -33,9 +33,6 @@ const config: webpack.Configuration = {
     output: {
         path: path.join(baseDir, 'build'),
     },
-    resolve: {
-        fallback: { vm: require.resolve('vm-browserify') },
-    },
     plugins: [
         new CopyWebpackPlugin({
             patterns: [


### PR DESCRIPTION
## Summary
- The `vm: vm-browserify` fallback in `packages/suite-build/configs/web.webpack.config.ts` is redundant: `base.webpack.config.ts` declares the exact same value and is always merged before `web` (`merge([connect, base, web])`).
- Removes the now-empty `resolve` block.

## Background
- Web layer added the fallback in March 2025 (#17152, Vite devserver work).
- Base layer added the same `vm: vm-browserify` in June 2025 (commit 41943a009e, JWT verification fix), making the web entry redundant.

## Test plan
- [ ] `yarn workspace @trezor/suite-build build:web` still produces a working bundle
- [ ] No new "Module not found: vm" errors

## Related
- #27217 — drop fallbacks duplicated by base in connect config
- #27237 — drop stray `'events'` from connect mangle reserved list
- #27238 — drop irrelevant mainFields override in transport-bluetooth UI build

Part of a series of small PRs auditing webpack configs across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/webpack-fallback-web/web/](https://dev.suite.sldev.cz/suite-web/mroz22/webpack-fallback-web/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/webpack-fallback-web&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:37:47.329Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->