### PR TITLE
chore(suite-build): drop fallbacks duplicated by base in connect config

### DIFF
--- a/packages/suite-build/configs/connect.webpack.config.ts
+++ b/packages/suite-build/configs/connect.webpack.config.ts
@@ -66,17 +66,11 @@ const connect: webpack.Configuration = {
         mainFields: ['browser', 'module', 'main'],
 
         fallback: {
-            fs: false, // ignore "fs" import in fastxpub (hd-wallet)
-            vm: false, // ignore "vm" imports in "asn1.js@4.10.1" > crypto-browserify"
             util: require.resolve('util'), // required by "xrpl.js"
             assert: require.resolve('assert'), // required by multiple dependencies
             crypto: require.resolve('crypto-browserify'), // required by multiple dependencies
             stream: require.resolve('stream-browserify'), // required by utxo-lib and keccak
             events: require.resolve('events'),
-            http: false,
-            zlib: false,
-            path: false, // usb
-            os: false, // usb
         },
     },
     performance: {


### PR DESCRIPTION
## Summary
- `connect.webpack.config.ts` is always merged with `base.webpack.config.ts` via `merge([connect, base, ...])` in `packages/suite-build/webpack.config.ts`.
- Several `resolve.fallback` entries in connect duplicate values declared in base, so the connect copies are redundant. webpack-merge resolves duplicate object keys to the later config (base wins).
- Drops these redundant entries:
  - `fs: false` — base has the same value. The `"fastxpub (hd-wallet)"` comment is also stale; neither package is in the dep tree anymore.
  - `http: false`, `zlib: false`, `path: false`, `os: false` — all duplicates of base; the `"usb"` comments on path/os are stale (usb is not in the browser bundle).
  - `vm: false` — **dead code**: base sets `vm: require.resolve('vm-browserify')`, which overrides connect's `false` due to webpack-merge later-wins semantics.

## Kept
- `util`, `assert`, `events` — load-bearing (xrpl, multiple deps, and `EventEmitter` usage in `@trezor/connect`, `@trezor/connect-web`, `@trezor/utils`).
- `crypto: crypto-browserify` and `stream: stream-browserify` — left verbatim; being handled in a separate change.

## Test plan
- [ ] `yarn workspace @trezor/suite-build build:web` produces a working bundle
- [ ] `yarn workspace @trezor/suite-build build:desktop` produces a working bundle
- [ ] No new "Module not found" errors for fs/vm/http/zlib/path/os

## Related
- #27216 — drop redundant `vm` fallback in web config
- #27237 — drop stray `'events'` from connect mangle reserved list
- #27238 — drop irrelevant mainFields override in transport-bluetooth UI build

Part of a series of small PRs auditing webpack `resolve.fallback` declarations across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/webpack-fallback-connect/web/](https://dev.suite.sldev.cz/suite-web/mroz22/webpack-fallback-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/webpack-fallback-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:38:12.812Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->