### PR TITLE
Use UUID for Connect call/response ID

### DIFF
--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -57,7 +57,7 @@ export type CallMethodAnyResponse = ReturnType<CallMethodUnion>;
 export type CallMethod = (params: CallMethodPayload) => Promise<any>;
 
 export interface CoreCallMessage {
-    id: number;
+    id: string;
     type: typeof CORE_CALL;
     payload: CallMethodPayload;
 }
@@ -67,7 +67,7 @@ export const RESPONSE_EVENT = 'RESPONSE_EVENT';
 export type MethodResponseMessage = {
     event: typeof RESPONSE_EVENT;
     type: typeof RESPONSE_EVENT;
-    id: number;
+    id: string;
 
     device?: DeviceIdentity;
 } & (
@@ -84,7 +84,7 @@ export type MethodResponseMessage = {
 );
 
 export const createResponseMessage = (
-    id: number,
+    id: string,
     success: boolean,
     payload: any,
     deviceIdentity:

--- a/packages/connect-common/src/events/core.ts
+++ b/packages/connect-common/src/events/core.ts
@@ -49,7 +49,7 @@ export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = n
         device: messageData.device,
     };
 
-    if (typeof messageData.id === 'number') {
+    if (typeof messageData.id === 'string') {
         (message as any).id = messageData.id;
     }
 

--- a/packages/connect-common/src/events/transport.ts
+++ b/packages/connect-common/src/events/transport.ts
@@ -42,7 +42,7 @@ export interface TransportRequestWebUSBDevice {
 }
 
 export interface TransportGetInfo {
-    id: number;
+    id: string;
     type: typeof TRANSPORT.GET_INFO;
     payload?: undefined;
 }

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -25,7 +25,7 @@ export interface AbstractMessageChannelConstructorParams {
 
 export type Message<IncomingMessages extends { type: string }> = IncomingMessages & {
     channel: AbstractMessageChannelConstructorParams['channel'];
-    id: number;
+    id: string;
     success: boolean;
     payload: Extract<IncomingMessages, { type: IncomingMessages['type'] }> | undefined;
 };
@@ -40,7 +40,7 @@ export abstract class AbstractMessageChannel<
 > extends TypedEmitter<{
     message: Message<IncomingMessages>;
 }> {
-    protected messages = createDeferredManager();
+    protected messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
     /** queue of messages that were scheduled before handshake */
     protected messagesQueue: any[] = [];
 

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -13,7 +13,7 @@ import { createDeferredManager, removeTrailingSlashes } from '@trezor/utils';
 
 type BuildUrlParams = {
     method: string;
-    id: number;
+    id: string;
     params: any;
     connectSrc: string | undefined;
     callbackUrl: string;
@@ -22,7 +22,7 @@ type BuildUrlParams = {
 
 const buildUrl = ({ method, id, params, connectSrc, callbackUrl, manifest }: BuildUrlParams) => {
     const urlWithParams = new URL(callbackUrl);
-    urlWithParams.searchParams.set('id', id.toString());
+    urlWithParams.searchParams.set('id', id);
 
     return (
         removeTrailingSlashes(connectSrc || DEFAULT_DOMAIN_MAJOR_VER) +
@@ -45,7 +45,7 @@ interface ConnectSettingsMobile {
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
     public eventEmitter = new ConnectEmitter();
-    private messages = createDeferredManager();
+    private messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
 
     private manifest?: Manifest;
 
@@ -53,7 +53,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         return Promise.resolve(createErrorMessage(ERRORS.TypedError('Method_InvalidPackage')));
     }
 
-    private openDeeplink: (method: string, id: number, params: any) => void = () => {
+    private openDeeplink: (method: string, id: string, params: any) => void = () => {
         throw ERRORS.TypedError('Init_NotInitialized');
     };
 
@@ -131,8 +131,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         try {
             parsedUrl = new URL(url);
             id = parsedUrl.searchParams.get('id');
-            if (!id || isNaN(Number(id))) throw new Error('Missing `id` parameter.');
-            id = Number(id);
+            if (!id) throw new Error('Missing `id` parameter.');
         } catch (error) {
             this.resolveMessagePromises({ success: false, error });
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -48,7 +48,7 @@ export type MethodContext = {
 };
 
 export type MethodMessage<Name extends CallMethodPayload['method']> = {
-    id?: number;
+    id?: string;
     payload: Payload<Name>;
 };
 
@@ -103,7 +103,7 @@ function validateDeviceState(device: CallMethodPayload['device']): DeviceState |
 }
 
 export abstract class AbstractMethod<Name extends CallMethodPayload['method'], Params = undefined> {
-    public responseID: number;
+    public responseID: string;
 
     public device: Device | undefined;
 
@@ -159,7 +159,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         const { payload } = message;
         this.name = payload.method;
         this.params = params;
-        this.responseID = message.id || 0;
+        this.responseID = message.id ?? '';
         this.deviceState = validateDeviceState(payload.device);
         this.keepSession = typeof payload.keepSession === 'boolean' ? payload.keepSession : false;
         this.skipFinalReload = true;

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -45,9 +45,10 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         this.settings = parseConnectSettings();
         this.log = initLog('@trezor/connect');
         this.coreManager = initCoreState();
-        this.messagePromises = createDeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>(
-            { initialId: 1 },
-        );
+        this.messagePromises = createDeferredManager<
+            Omit<MethodResponseMessage, 'event' | 'type'>,
+            string
+        >({ generateId: (): string => crypto.randomUUID() });
     }
 
     // handle messages to core
@@ -67,7 +68,7 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
 
         switch (event) {
             case RESPONSE_EVENT: {
-                const { id = 0, success, device } = message;
+                const { id = '', success, device } = message;
                 const resolved = this.messagePromises.resolve(
                     id,
                     success

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -88,7 +88,7 @@ describe('Deeplink connect popup. [@androidOnly @T3T1]', () => {
 
         jestExpect(response).toEqual({
             success: true,
-            id: jestExpect.any(Number),
+            id: jestExpect.any(String),
             payload: jestExpect.objectContaining({
                 path: [2147483697, 2147483648, 2147483648, 0, 0],
                 serializedPath: "m/49'/0'/0'/0/0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR changes from using counter number as ID in call / response from connect to use UUID.

## Notes for QA
You can test it like:

* With physical device
```
yarn workspace @trezor/connect-cli cli
```
* With emulator
```
yarn workspace @trezor/connect-cli cli --udp
```

And it should return payload with 'id' looking like:

```json
{
  id: '61205c56-fdf8-44e7-8644-471aa59bad3e',
  success: true,
  payload: {
...
```
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27037

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/id-in-call-response-to-be-uuid/web/](https://dev.suite.sldev.cz/suite-web/feat/id-in-call-response-to-be-uuid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/id-in-call-response-to-be-uuid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/id-in-call-response-to-be-uuid&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T09:14:53.319Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->