### PR TITLE
perf(suite-native): hoist flatten(messages) in IntlProviderForTests

### DIFF
--- a/suite-native/intl/src/IntlProviderForTests.tsx
+++ b/suite-native/intl/src/IntlProviderForTests.tsx
@@ -4,12 +4,10 @@ import { messages } from './messages';
 import { flatten } from './utils';
 
 // For uni test we always expect the messages to be in english, so the language selection logic can be omitted here.
-export const IntlProviderForTests = ({ children }: { children: React.ReactNode }) => {
-    const x = flatten(messages);
+const flatMessages = flatten(messages);
 
-    return (
-        <ReactIntlProvider locale="en-US" messages={x}>
-            {children}
-        </ReactIntlProvider>
-    );
-};
+export const IntlProviderForTests = ({ children }: { children: React.ReactNode }) => (
+    <ReactIntlProvider locale="en-US" messages={flatMessages}>
+        {children}
+    </ReactIntlProvider>
+);


### PR DESCRIPTION
Compute the flattened translation map once at module load instead of on every render of every test that mounts the provider.

Refs https://github.com/trezor/trezor-suite/issues/26034

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/native-test-microopt&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->