### PR TITLE
Connect mobile fee issues in Ethereum signing

### DIFF
--- a/suite-common/connect-popup/package.json
+++ b/suite-common/connect-popup/package.json
@@ -17,7 +17,6 @@
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",
-        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts
+++ b/suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { U_INT_32 } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type TxSimulationAction, type TxSimulationMethod } from '@suite-common/wallet-types';
 
@@ -29,24 +28,13 @@ export function useTxSimulationPopupCall() {
         const { method, payload, fromAddress, source } = txSimulationPopupCall;
 
         switch (method) {
-            case 'ethereumSignTransaction': {
-                const typedPayload =
-                    payload as TxSimulationMethod<'ethereumSignTransaction'>['payload'];
-
+            case 'ethereumSignTransaction':
                 return {
                     method,
-                    payload: {
-                        ...typedPayload,
-                        transaction: {
-                            ...typedPayload.transaction,
-                            // Ensure a high gas limit to prevent out of gas errors during simulation
-                            gasLimit: `0x${U_INT_32.toString(16)}`,
-                        },
-                    },
+                    payload: payload as TxSimulationMethod<'ethereumSignTransaction'>['payload'],
                     fromAddress,
                     sourceOrigin: source.origin,
                 };
-            }
 
             case 'ethereumSignTypedData':
                 return {

--- a/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumSignTransaction.ts
@@ -129,7 +129,7 @@ const preCallHook = async <M extends CallMethodKeys>({
         }
 
         // Modify payload to include selected fee, if present
-        if (method === 'ethereumSignTransaction') {
+        if (method === 'ethereumSignTransaction' && source.type === 'walletconnect') {
             const currentPopupCall = selectConnectPopupCall(getState());
             const typedPayload = payload as any as EthereumSignTransaction;
             if (

--- a/suite-common/connect-popup/tsconfig.json
+++ b/suite-common/connect-popup/tsconfig.json
@@ -7,7 +7,6 @@
         { "path": "../redux-utils" },
         { "path": "../toast-notifications" },
         { "path": "../wallet-config" },
-        { "path": "../wallet-constants" },
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
         { "path": "../../packages/connect" },

--- a/suite-common/tx-simulation/package.json
+++ b/suite-common/tx-simulation/package.json
@@ -14,6 +14,7 @@
         "@blockaid/client": "^0.65.0",
         "@suite-common/react-query": "workspace:^",
         "@suite-common/wallet-config": "workspace:^",
+        "@suite-common/wallet-constants": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
         "react": "19.2.4"
     }

--- a/suite-common/tx-simulation/src/hooks/useTxSimulationPayload.ts
+++ b/suite-common/tx-simulation/src/hooks/useTxSimulationPayload.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { type JsonRpcScanParams } from '@blockaid/client/resources/evm';
 
+import { U_INT_32 } from '@suite-common/wallet-constants';
 import { type TxSimulationAction, type TxSimulationMethod } from '@suite-common/wallet-types';
 
 function transformPayloadOfEthereumSignTransaction({
@@ -19,7 +20,8 @@ function transformPayloadOfEthereumSignTransaction({
                     to: transaction.to || '',
                     value: transaction.value || '0x0',
                     data: transaction.data || '0x',
-                    gas: transaction.gasLimit,
+                    // Ensure a high gas limit to prevent out of gas errors during simulation
+                    gas: `0x${U_INT_32.toString(16)}`,
                 },
             ],
         },

--- a/suite-common/tx-simulation/tsconfig.json
+++ b/suite-common/tx-simulation/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "../react-query" },
         { "path": "../wallet-config" },
+        { "path": "../wallet-constants" },
         { "path": "../wallet-types" }
     ],
     "include": [".", "**/*.json"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10988,7 +10988,6 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
-    "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/connect": "workspace:*"
@@ -11801,6 +11800,7 @@ __metadata:
     "@blockaid/client": "npm:^0.65.0"
     "@suite-common/react-query": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
+    "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     react: "npm:19.2.4"
   languageName: unknown


### PR DESCRIPTION
## Description

WalletConnect flow intentionally overrides default gas fees on Ethereum based on TX simulation, because they are usually not set. 
The problem is this was also affecting other Connect TXs on mobile. With apps such as Rabby, they expect the TX to be the exact same, so changing the fee results in an error.
This PR makes sure that fees are changed for WalletConnect only. 

## Related Issue

Resolve #27183

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-eth-fees-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-eth-fees-mobile&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-eth-fees-mobile&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:31:02.889Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:29:06.449Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-eth-fees-mobile/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-eth-fees-mobile/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->