### PR TITLE
chore(suite-build): drop obsolete typeforce mangle reserved list

### DIFF
--- a/packages/suite-build/configs/connect.webpack.config.ts
+++ b/packages/suite-build/configs/connect.webpack.config.ts
@@ -82,10 +82,6 @@ const connect: webpack.Configuration = {
     performance: {
         hints: false,
     },
-    // @trezor/utxo-lib NOTE:
-    // When uglifying the javascript, you must exclude the following variable names from being mangled:
-    // Array, BigInteger, Boolean, Buffer, ECPair, Function, Number, Point and Script.
-    // This is because of the function-name-duck-typing used in typeforce.
     optimization: {
         emitOnErrors: true,
         moduleIds: 'named',
@@ -93,22 +89,6 @@ const connect: webpack.Configuration = {
             new TerserPlugin({
                 parallel: true,
                 extractComments: false,
-                terserOptions: {
-                    mangle: {
-                        reserved: [
-                            'Array',
-                            'BigInteger',
-                            'Boolean',
-                            'Buffer',
-                            'ECPair',
-                            'Function',
-                            'Number',
-                            'Point',
-                            'Script',
-                            'events',
-                        ],
-                    },
-                },
             }),
         ],
         usedExports: true,


### PR DESCRIPTION
## Summary
Drops the entire `terserOptions.mangle.reserved` list (and the comment block above it) in `connect.webpack.config.ts`. The list protected 9 constructor names that `@trezor/utxo-lib`'s `typeforce` library duck-typed via `Function.name` (`Array`, `BigInteger`, `Boolean`, `Buffer`, `ECPair`, `Function`, `Number`, `Point`, `Script`).

`typeforce` was replaced by `@sinclair/typebox` in commit [`68fdbb289d`](https://github.com/trezor/trezor-suite/commit/68fdbb289d) — *"chore(utxo-lib): replace typeforce with typebox"* (March 2026). The new validation uses `Kind`/`type` discriminators on schema objects, no `.name` reflection — so terser is free to mangle these identifiers.

## Verification
- `packages/utxo-lib/src/types/validation.ts` — typebox-based, no `.name` checks.
- `packages/address-validator/src/crypto/biginteger.js` (only other place where `BigInteger` lives in the bundled source) — uses only `typeof` checks, no `.name` reflection.
- Repo-wide grep for `.name === 'BigInteger'`, `.name === 'ECPair'`, `.name === 'Point'`, `.name === 'Script'` returns zero hits.

## What stays
- `TerserPlugin` instance with `parallel: true, extractComments: false` — unchanged. (The connect-specific minimizer is still load-bearing because `base.webpack.config.ts`'s TerserPlugin excludes `static/connect`.)

## Test plan
- [ ] `yarn workspace @trezor/suite-build build:web` produces a working bundle (terser mangle pass succeeds with no reserved overrides)
- [ ] `yarn workspace @trezor/suite-build build:desktop` works
- [ ] No utxo-lib / address-validator / connect runtime errors on the resulting bundle (typeforce-style `.name` checks would fail loudly)

## Related
- #27216 — drop redundant `vm` fallback in web config
- #27217 — drop fallbacks duplicated by base in connect config
- #27238 — drop irrelevant mainFields override in transport-bluetooth UI build

Part of a series of small PRs auditing webpack configs across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/webpack-mangle-events&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/webpack-mangle-events&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-01T13:44:19.751Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:47:28.232Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/webpack-mangle-events/web/](https://dev.suite.sldev.cz/suite-web/mroz22/webpack-mangle-events/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->