### PR TITLE
chore(transport-bluetooth): drop irrelevant mainFields override in UI build

### DIFF
--- a/packages/transport-bluetooth/webpack/webpack.build.js
+++ b/packages/transport-bluetooth/webpack/webpack.build.js
@@ -68,7 +68,6 @@ module.exports = {
     resolve: {
         modules: [SRC, 'node_modules'],
         extensions: ['.tsx', '.ts', '.jsx', '.js'],
-        mainFields: ['main', 'module'], // prevent wrapping default exports by harmony export (bignumber.js in ripple issue)
     },
     performance: {
         hints: false,


### PR DESCRIPTION
## Summary
Drops a copy-pasted `mainFields` override in the bluetooth daemon dev UI webpack config:

```js
mainFields: ['main', 'module'], // prevent wrapping default exports by harmony export (bignumber.js in ripple issue)
```

The reason is irrelevant for `transport-bluetooth`: there is **no bignumber.js or xrpl/ripple** in the dep tree, and the UI bundle entry (`src/ui/index.tsx`) only pulls in React, react-dom, and the local `TrezorBluetooth` client.

The line was added in commit `c73dbc6f92` (Feb 2024, "feat(transport-bluetooth): add server dev UI"), copy-pasted from `blockchain-link/webpack/workers.{web,module}.js` where the comment is genuine.

## Effect
After removal, webpack falls back to its default `mainFields` for `target: 'web'` (`['browser', 'module', 'main']`) — the standard choice for a browser UI bundle.

## Test plan
- [x] `yarn workspace @trezor/transport-bluetooth build:ui` produces a working bundle
- [x] `yarn workspace @trezor/transport-bluetooth dev:server` opens the dev UI without runtime errors

## Related
- #27216 — drop redundant `vm` fallback in web config
- #27217 — drop fallbacks duplicated by base in connect config
- #27237 — drop stray `'events'` from connect mangle reserved list

Part of a series of small PRs auditing webpack configs across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `packages/transport-bluetooth/webpack/webpack.build.js`, which is a webpack build configuration file for the Bluetooth transport package. This file is not referenced by any E2E tests (no static mapping exists), and none of the analyzed E2E tests touch Bluetooth transport functionality, webpack build configuration, or the transport-bluetooth package. The change is confined to build tooling and has no runtime impact on the Suite application's behavior that would be exercised by any existing E2E test. No tests are recommended.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport-bluetooth/webpack/webpack.build.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/transport-bluetooth/webpack/webpack.build.js`

_Updated: 2026-04-30T12:31:27.663Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/bluetooth-mainfields&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/bluetooth-mainfields&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 13 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:36:39.134Z • 13 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T12:35:45.842Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/bluetooth-mainfields/web/](https://dev.suite.sldev.cz/suite-web/mroz22/bluetooth-mainfields/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->