### PR TITLE
Experiment disable trading footer animations

### DIFF
--- a/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
+++ b/suite-native/atoms/src/AnimatedDoubleView/AnimatedViewWrapper.tsx
@@ -1,6 +1,11 @@
 import { type ReactNode, useEffect } from 'react';
 import { Pressable } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, {
+    cancelAnimation,
+    useAnimatedStyle,
+    useSharedValue,
+    withTiming,
+} from 'react-native-reanimated';
 
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -47,6 +52,11 @@ export const AnimatedViewWrapper = ({
     useEffect(() => {
         scale.value = withPredefinedTiming(getScale(focused));
         translateY.value = withPredefinedTiming(getTranslateY(focused));
+
+        return () => {
+            cancelAnimation(scale);
+            cancelAnimation(translateY);
+        };
     }, [focused, scale, translateY]);
 
     const animatedStyle = useAnimatedStyle(

--- a/suite-native/atoms/src/Button/TextButton.tsx
+++ b/suite-native/atoms/src/Button/TextButton.tsx
@@ -1,6 +1,11 @@
 import { type ReactNode, useCallback, useEffect } from 'react';
 import { Pressable, type PressableProps } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, {
+    cancelAnimation,
+    useAnimatedStyle,
+    useSharedValue,
+    withTiming,
+} from 'react-native-reanimated';
 
 import { Icon, type IconName } from '@suite-native/icons';
 import { type NativeStyleObject, prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -109,6 +114,8 @@ export const TextButton = ({
     useEffect(() => {
         setAnimatedColor(hasDisabledVisualState ? disabledColor : defaultTextColor);
     }, [defaultTextColor, disabledColor, hasDisabledVisualState, setAnimatedColor]);
+
+    useEffect(() => () => cancelAnimation(animatedColor), [animatedColor]);
 
     const handlePressIn = () => {
         setAnimatedColor(pressedTextColor);

--- a/suite-native/atoms/src/Sheet/useAlertAnimation.ts
+++ b/suite-native/atoms/src/Sheet/useAlertAnimation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import {
     Easing,
+    cancelAnimation,
     interpolateColor,
     runOnJS,
     useAnimatedStyle,
@@ -26,7 +27,9 @@ export const useAlertAnimation = ({ onClose }: { onClose?: () => void }) => {
             duration: ANIMATION_DURATION,
             easing: Easing.out(Easing.cubic),
         });
-    });
+    }, [animatedTransparency, transparency]);
+
+    useEffect(() => () => cancelAnimation(animatedTransparency), [animatedTransparency]);
 
     const animatedSheetWithOverlayStyle = useAnimatedStyle(() => ({
         backgroundColor: interpolateColor(

--- a/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
+++ b/suite-native/atoms/src/Skeleton/BoxSkeleton.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { type AccessibilityProps } from 'react-native';
 import {
+    cancelAnimation,
     interpolate,
     useDerivedValue,
     useSharedValue,
@@ -57,6 +58,8 @@ export const BoxSkeleton = ({
             ENDLESS_ANIMATION_VALUE,
         );
     }, [width, progress]);
+
+    useEffect(() => () => cancelAnimation(progress), [progress]);
 
     const position = useDerivedValue(() => [
         {

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -1,5 +1,7 @@
+import { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+
 import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
-import { Button, VStack } from '@suite-native/atoms';
+import { AnimatedBox, Button, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
@@ -37,19 +39,23 @@ export const ExchangeConfirmation = () => {
             ) : (
                 <>
                     {canProceed && (
-                        <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
-                            <Translation id="moduleTrading.tradingScreen.buttons.continue" />
-                        </Button>
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                            <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
+                                <Translation id="moduleTrading.tradingScreen.buttons.continue" />
+                            </Button>
+                        </AnimatedBox>
                     )}
                     {canRevoke && (
-                        <Button
-                            onPress={selectQuoteForRevoke}
-                            testID={REVOKE_TEST_ID}
-                            intent="neutral"
-                            priority="secondary"
-                        >
-                            <Translation id="moduleTrading.tradingScreen.buttons.revoke" />
-                        </Button>
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                            <Button
+                                onPress={selectQuoteForRevoke}
+                                testID={REVOKE_TEST_ID}
+                                intent="neutral"
+                                priority="secondary"
+                            >
+                                <Translation id="moduleTrading.tradingScreen.buttons.revoke" />
+                            </Button>
+                        </AnimatedBox>
                     )}
                 </>
             )}

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.tsx
@@ -1,4 +1,4 @@
-import { FadeIn, FadeOut, LinearTransition } from 'react-native-reanimated';
+import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { type ApprovalStatus, getApprovalStatus } from '@suite-common/trading';
 import { AnimatedBox, Button, VStack } from '@suite-native/atoms';
@@ -39,14 +39,14 @@ export const ExchangeConfirmation = () => {
             ) : (
                 <>
                     {canProceed && (
-                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut}>
                             <Button onPress={selectQuote} testID={CONFIRMATION_TEST_ID}>
                                 <Translation id="moduleTrading.tradingScreen.buttons.continue" />
                             </Button>
                         </AnimatedBox>
                     )}
                     {canRevoke && (
-                        <AnimatedBox entering={FadeIn} exiting={FadeOut} layout={LinearTransition}>
+                        <AnimatedBox entering={FadeIn} exiting={FadeOut}>
                             <Button
                                 onPress={selectQuoteForRevoke}
                                 testID={REVOKE_TEST_ID}

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.tsx
@@ -1,5 +1,12 @@
 import { memo } from 'react';
-import { LinearTransition } from 'react-native-reanimated';
+import { Platform } from 'react-native';
+import {
+    FadeInUp,
+    FadeOutUp,
+    LinearTransition,
+    StretchInY,
+    StretchOutY,
+} from 'react-native-reanimated';
 
 import { AnimatedBox, Card, VStack } from '@suite-native/atoms';
 import { AmountEditingDoneButton } from '@suite-native/trading-atoms';
@@ -21,6 +28,9 @@ type ExchangeFormMemoizedProps = {
 const EXCHANGE_FORM_TEST_ID = '@trading/exchange/form';
 const AMOUNT_EDITING_DONE_BUTTON_TEST_ID = '@trading/exchange/amount-editing-done-button';
 
+const cardEnteringAnimation = Platform.OS === 'android' ? StretchInY : FadeInUp;
+const cardExitingAnimation = Platform.OS === 'android' ? StretchOutY : FadeOutUp;
+
 const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoizedProps) => (
     <AnimatedBox layout={LinearTransition}>
         <VStack spacing="sp16" testID={EXCHANGE_FORM_TEST_ID}>
@@ -31,10 +41,16 @@ const ExchangeFormMemoized = memo(({ isAmountInputActive }: ExchangeFormMemoized
                 <AmountEditingDoneButton testID={AMOUNT_EDITING_DONE_BUTTON_TEST_ID} />
             ) : (
                 <>
-                    <Card noPadding>
-                        <ExchangeReceiveAccountPicker />
-                        <ExchangeRateAndProviderPicker />
-                    </Card>
+                    <AnimatedBox
+                        layout={LinearTransition}
+                        entering={cardEnteringAnimation}
+                        exiting={cardExitingAnimation}
+                    >
+                        <Card noPadding>
+                            <ExchangeReceiveAccountPicker />
+                            <ExchangeRateAndProviderPicker />
+                        </Card>
+                    </AnimatedBox>
                     <ExchangeConfirmation />
                 </>
             )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Revert previous change that disabled button animations on trading exchange
- Make sure animations using `withTiming` inside `useEffect` are properly unmounted.
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27152

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=experiment-disable-trading-footer-animations&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->