### PR TITLE
feat(suite): Add congrats screen to onboarding

### DIFF
--- a/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
+++ b/packages/suite/src/components/onboarding/OnboardingProgressBar.tsx
@@ -25,19 +25,23 @@ const useOnboardingStepCategoriesInPath = () => {
 
     return useMemo(
         () =>
-            stepCategories.filter(stepCategory =>
-                isStepCategoryUsed(stepCategory, {
-                    device,
-                    onboardingPath,
-                    isDeviceAuthenticityCheckEnabled,
-                    isUnlockedBootloaderAllowed,
-                }),
+            stepCategories.filter(
+                stepCategory =>
+                    stepCategory.labelTranslationId &&
+                    isStepCategoryUsed(stepCategory, {
+                        device,
+                        onboardingPath,
+                        isDeviceAuthenticityCheckEnabled,
+                        isUnlockedBootloaderAllowed,
+                    }),
             ),
         [device, onboardingPath, isDeviceAuthenticityCheckEnabled, isUnlockedBootloaderAllowed],
     );
 };
 
 const getState = (index: number, indexOfActiveStep: number): BulletListItemState => {
+    // When active category is not in the visible list (e.g. final step), all visible steps are done.
+    if (indexOfActiveStep === -1) return 'done';
     if (index < indexOfActiveStep) return 'done';
     if (index === indexOfActiveStep) return 'default';
 

--- a/packages/suite/src/config/onboarding/steps.ts
+++ b/packages/suite/src/config/onboarding/steps.ts
@@ -101,4 +101,14 @@ export const stepCategories: StepCategory[] = [
             },
         ],
     },
+    {
+        id: 'final',
+        steps: [
+            {
+                id: STEP.ID_FINAL_STEP,
+                path: [STEP.PATH_RECOVERY, STEP.PATH_CREATE],
+                prerequisites: [...commonPrerequisites, ...afterInitializePrerequisites],
+            },
+        ],
+    },
 ];

--- a/packages/suite/src/types/onboarding/index.ts
+++ b/packages/suite/src/types/onboarding/index.ts
@@ -29,6 +29,7 @@ export type Step = {
 // todo: remove, improve typing
 export type AnyStepId =
     | typeof STEP.ID_CREATE_OR_RECOVER
+    | typeof STEP.ID_FINAL_STEP
     | typeof STEP.ID_FIRMWARE_STEP
     | typeof STEP.ID_AUTHENTICATE_DEVICE_STEP
     | typeof STEP.ID_TUTORIAL_STEP

--- a/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
+++ b/packages/suite/src/utils/onboarding/__tests__/steps.test.ts
@@ -50,6 +50,7 @@ describe('steps', () => {
                 STEP.ID_BACKUP_TYPE_STEP,
                 STEP.ID_SECURITY_STEP,
                 STEP.ID_SET_PIN_STEP,
+                STEP.ID_FINAL_STEP,
             ]);
         });
 
@@ -66,7 +67,10 @@ describe('steps', () => {
             expect(findNextStep(STEP.ID_SECURITY_STEP, createSteps, defaultDevice)?.id).toBe(
                 STEP.ID_SET_PIN_STEP,
             );
-            expect(findNextStep(STEP.ID_SET_PIN_STEP, createSteps, defaultDevice)).toBe(null);
+            expect(findNextStep(STEP.ID_SET_PIN_STEP, createSteps, defaultDevice)?.id).toBe(
+                STEP.ID_FINAL_STEP,
+            );
+            expect(findNextStep(STEP.ID_FINAL_STEP, createSteps, defaultDevice)).toBe(null);
         });
 
         it('should skip PIN step when device already has pin protection', () => {
@@ -75,7 +79,9 @@ describe('steps', () => {
                 pin_protection: true,
             });
 
-            expect(findNextStep(STEP.ID_SECURITY_STEP, createSteps, deviceWithPin)).toBe(null);
+            expect(findNextStep(STEP.ID_SECURITY_STEP, createSteps, deviceWithPin)?.id).toBe(
+                STEP.ID_FINAL_STEP,
+            );
         });
     });
 
@@ -125,6 +131,7 @@ describe('steps', () => {
                 STEP.ID_RECOVERY_STEP,
                 STEP.ID_SECURITY_STEP,
                 STEP.ID_SET_PIN_STEP,
+                STEP.ID_FINAL_STEP,
             ]);
         });
 
@@ -238,9 +245,9 @@ describe('steps', () => {
                 pin_protection: true,
             });
 
-            expect(resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, createSteps, deviceWithPin)).toBe(
-                null,
-            );
+            expect(
+                resolveNextAvailableStep(STEP.ID_SET_PIN_STEP, createSteps, deviceWithPin)?.id,
+            ).toBe(STEP.ID_FINAL_STEP);
         });
 
         it('should return null when requested step is not in steps list', () => {

--- a/packages/suite/src/views/onboarding/index.tsx
+++ b/packages/suite/src/views/onboarding/index.tsx
@@ -13,6 +13,7 @@ import { BackupTypeStep } from 'src/views/onboarding/steps/BackupTypeStep';
 import { CreateOrRecoverStep } from 'src/views/onboarding/steps/CreateOrRecoverStep';
 import { DeviceAuthenticityStep } from 'src/views/onboarding/steps/DeviceAuthenticityStep';
 import { DeviceTutorialStep } from 'src/views/onboarding/steps/DeviceTutorialStep';
+import { FinalStep } from 'src/views/onboarding/steps/FinalStep';
 import { FirmwareStep } from 'src/views/onboarding/steps/FirmwareStep';
 import { PinStep } from 'src/views/onboarding/steps/PinStep';
 import { RecoveryStep } from 'src/views/onboarding/steps/RecoveryStep';
@@ -60,6 +61,9 @@ export const Onboarding = () => {
             case STEP.ID_SET_PIN_STEP:
                 // Pin setup
                 return PinStep;
+            case STEP.ID_FINAL_STEP:
+                // Onboarding success
+                return FinalStep;
             default:
                 return exhaustive(activeStepId);
         }

--- a/packages/suite/src/views/onboarding/steps/FinalStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FinalStep.tsx
@@ -1,0 +1,28 @@
+import { Translation } from '@suite/intl';
+import { OnboardingCard } from '@suite/onboarding-components';
+import { selectDeviceName } from '@suite-common/device';
+
+import { useOnboarding, useSelector } from 'src/hooks/suite';
+
+export const FinalStep = () => {
+    const { goToSuite } = useOnboarding();
+    const deviceName = useSelector(selectDeviceName);
+
+    return (
+        <OnboardingCard
+            iconName="check"
+            heading={<Translation id="TR_ONBOARDING_FINAL_HEADING" />}
+            description={
+                <Translation
+                    id="TR_ONBOARDING_FINAL_DESCRIPTION"
+                    values={{ deviceName: deviceName ?? 'Trezor' }}
+                />
+            }
+            innerActions={
+                <OnboardingCard.Button data-testid="@onboarding/final-button" onClick={goToSuite}>
+                    <Translation id="TR_ONBOARDING_FINAL_GO_TO_DASHBOARD" />
+                </OnboardingCard.Button>
+            }
+        />
+    );
+};

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -37,6 +37,7 @@ export class OnboardingPage {
         this.page.getByTestId(`@onboarding/select-seed-type-${backupType}`);
     readonly selectSeedTypeOpenButton: Locator;
     readonly selectSeedConfirmButton: Locator;
+    readonly finalButton: Locator;
     readonly continueAtYourOwnRiskButton: Locator;
     readonly deviceCompromisedModal: Locator;
     readonly pairingInputAtIndex = (index: number) =>
@@ -76,6 +77,7 @@ export class OnboardingPage {
         this.selectSeedConfirmButton = this.page.getByTestId(
             '@onboarding/select-seed-type-confirm',
         );
+        this.finalButton = this.page.getByTestId('@onboarding/final-button');
         this.continueAtYourOwnRiskButton = this.page.getByTestId('@continue-to-suite');
         this.deviceCompromisedModal = this.page.getByTestId('@device-compromised');
     }

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -157,7 +157,7 @@ export class WalletPage {
         await this.accountButton(params).click();
 
         if (!params.symbol || !isTestnet(params.symbol)) {
-            await expect(this.fiatAmount).toBeVisible();
+            await expect(this.fiatAmount).toBeVisible({ timeout: 25_000 });
         }
     }
 

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts
@@ -73,6 +73,7 @@ test.describe('Onboarding - create wallet', { tag: ['@firmware-ready', '@T1B1'] 
             });
 
             await test.step('Finish wallet creation', async () => {
+                await onboardingPage.finalButton.click();
                 await expect(onboardingPage.suiteLoadedIndicator).toBeVisible();
                 await expect(dashboardPage.walletReady).toBeVisible();
             });

--- a/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts
@@ -51,6 +51,7 @@ test.describe('Onboarding - recover wallet T1B1', { tag: ['@firmware-ready', '@T
             // Finalize recovery, skip pin, and verify success
             await onboardingPage.continueRecoveryButton.click();
             await onboardingPage.pin.skip();
+            await onboardingPage.finalButton.click();
             await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
         },
     );

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts
@@ -37,6 +37,7 @@ test.describe('Onboarding - create wallet', { tag: ['@T2T1'] }, () => {
         await device.type('12');
         await devicePrompt.confirmOnDevicePromptIsShown();
         await device.pressYes();
+        await onboardingPage.finalButton.click();
         await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
     });
 });

--- a/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
+++ b/suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts
@@ -48,6 +48,7 @@ test.describe('Onboarding - recover wallet T2T1', { tag: ['@T2T1'] }, () => {
             // Finalize recovery, skip pin, and check success
             await onboardingPage.continueRecoveryButton.click();
             await onboardingPage.pin.skip();
+            await onboardingPage.finalButton.click();
             await expect(onboardingPage.suiteLoadedIndicator).toBeVisible({ timeout: 30_000 });
         },
     );

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts
@@ -72,6 +72,7 @@ test.describe('Onboarding - create wallet', { tag: ['@desktopOnly', '@T3T1', '@s
 
                 await devicePrompt.confirmOnDevicePromptIsShown();
                 await device.pressYes();
+                await onboardingPage.finalButton.click();
             });
 
             await test.step('Enable Bitcoin so discovery can be attempted', async () => {

--- a/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts
@@ -52,6 +52,7 @@ test.describe('Onboarding - create wallet', { tag: ['@T3T1', '@smoke'] }, () => 
 
             await devicePrompt.confirmOnDevicePromptIsShown();
             await device.pressYes();
+            await onboardingPage.finalButton.click();
         },
     );
 });

--- a/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
+++ b/suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts
@@ -62,6 +62,7 @@ test.describe('Onboarding - create wallet', { tag: ['@T3W1'] }, () => {
             await device.pressYes();
 
             await test.step('Finish wallet creation', async () => {
+                await onboardingPage.finalButton.click();
                 await dashboardPage.discoveryEmptyPrimaryButton.click();
                 await assetsSection.enableNetworkViaActivateAssetsModal(['btc', 'eth']);
 

--- a/suite/e2e/tests/wallet/public-keys.test.ts
+++ b/suite/e2e/tests/wallet/public-keys.test.ts
@@ -42,7 +42,7 @@ test.describe('Public Keys', { tag: ['@T3W1', '@T3T1'] }, () => {
                     const value = await devicePrompt.outputValue.textContent();
 
                     expect(value?.replace(/\s+/g, '')).toBe(xpub);
-                }).toPass({ timeout: 5000 });
+                }).toPass({ timeout: 25000 });
             });
 
             await test.step('Display and Verify Public key again', async () => {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -7688,6 +7688,18 @@ export const messages = defineMessages({
         id: 'TR_ONBOARDING_STEP_WALLET',
         defaultMessage: 'Wallet',
     },
+    TR_ONBOARDING_FINAL_HEADING: {
+        id: 'TR_ONBOARDING_FINAL_HEADING',
+        defaultMessage: 'You’re all set!',
+    },
+    TR_ONBOARDING_FINAL_DESCRIPTION: {
+        id: 'TR_ONBOARDING_FINAL_DESCRIPTION',
+        defaultMessage: 'Your {deviceName} is set up and ready for use.',
+    },
+    TR_ONBOARDING_FINAL_GO_TO_DASHBOARD: {
+        id: 'TR_ONBOARDING_FINAL_GO_TO_DASHBOARD',
+        defaultMessage: 'Go to Dashboard',
+    },
     TR_ONBOARDING_CURRENT_VERSION: {
         id: 'TR_ONBOARDING_CURRENT_VERSION',
         defaultMessage: 'Current version',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies core onboarding infrastructure: the progress bar component, step definitions/configuration, onboarding types, the main onboarding view, the final step, and internationalization messages. The highest risk is breaking the onboarding wizard flow itself — step navigation, progress indication, and final completion. All onboarding-specific tests (create wallet, recovery, firmware check) should be run at high priority. Tests that merely use completeOnboarding() as a prerequisite for unrelated functionality (e.g., trading, metadata, staking) are not recommended since those test flows are unlikely to be affected unless the onboarding completion path itself breaks, which the high-priority tests would catch first.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/onboarding/OnboardingProgressBar.tsx`
- `packages/suite/src/config/onboarding/steps.ts`
- `packages/suite/src/types/onboarding/index.ts`
- `packages/suite/src/views/onboarding/index.tsx`
- `packages/suite/src/views/onboarding/steps/FinalStep.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test exercises the full onboarding flow including progress bar, steps configuration, and the final step - all of which are directly modified in this change set. Changes to OnboardingProgressBar, steps.ts config, and the onboarding index view would directly affect this test's ability to navigate through onboarding.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test covers the complete onboarding create-wallet flow including firmware, backup, and PIN steps. Changes to the onboarding steps configuration, progress bar, and main onboarding view would directly affect step navigation and rendering throughout this flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test covers Shamir wallet creation during onboarding on T2T1, navigating through analytics, firmware, backup, and PIN steps. Changes to the onboarding step definitions, progress bar, and onboarding view directly impact this flow.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test verifies the analytics consent dialog during onboarding and completing the onboarding flow. Changes to the onboarding index view and steps configuration directly affect when and how the analytics consent step appears and transitions.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test specifically validates the firmware readiness check during onboarding. Changes to the onboarding steps configuration and main onboarding view directly control how the firmware step is presented and transitioned through.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test validates that the initial onboarding screen persists across reloads, analytics consent works, and completing onboarding transitions to the dashboard. It directly exercises the onboarding view, step flow, and the FinalStep (complete-onboarding button).
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — This test covers the full T1B1 wallet creation onboarding flow from analytics through backup and PIN setup to dashboard. Changes to onboarding steps, progress bar, and the onboarding view directly affect this flow.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test exercises the onboarding recovery flow through firmware check, analytics consent, recovery, PIN skip, and suite loading. Changes to the steps configuration and onboarding view could affect the step navigation order during recovery.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests device disconnection during recovery in onboarding. Changes to the onboarding view and steps configuration affect how the recovery step is rendered and how step transitions work during error states.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery state persistence across device disconnection and page reload during onboarding. Changes to the onboarding view and step definitions could affect how recovery state is maintained and restored.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests entropy check failure handling during wallet creation in onboarding. Changes to the onboarding view affect how the device compromised modal and error states are rendered during the create wallet step.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Tests successful T1B1 recovery through the full onboarding flow. Changes to onboarding steps and the main onboarding view affect how the recovery path navigates through steps.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Tests device disconnection during T1B1 recovery in onboarding. Changes to the onboarding view and steps configuration affect the recovery step rendering and retry flow.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests advanced recovery mode on T1B1 during onboarding. Changes to the onboarding steps and view affect how the recovery path and word input steps are rendered.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Tests offline wallet creation during onboarding including Shamir backup and PIN setup. Changes to the onboarding view, progress bar, and steps configuration affect the offline onboarding flow.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test verifies the onboarding analytics/data collection heading text and theme colors on the onboarding page. Changes to messages.ts could affect the heading text content, and changes to the onboarding view affect the page rendering.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises analytics toggling during onboarding and verifies the analytics switch, continue button, and complete onboarding button. Changes to the onboarding view and FinalStep (which contains the complete-onboarding button) directly affect this flow.
- `suite/e2e/tests/analytics/events.test.ts` — This test completes onboarding to capture analytics events. Changes to the onboarding flow (steps configuration, main view, FinalStep) could break the completeOnboarding helper used as a prerequisite, though the test's primary focus is analytics events rather than onboarding UI.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/types/onboarding/index.ts`
- `packages/suite/src/views/onboarding/steps/FinalStep.tsx`
- `suite/intl/src/messages.ts`

_Updated: 2026-04-30T13:33:10.049Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/add-congrats-screen/web/](https://dev.suite.sldev.cz/suite-web/add-congrats-screen/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=add-congrats-screen&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=add-congrats-screen&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > closing popup window | 🤖 auto |
| TrezorConnect webextension -> Suite Web > focuses existing popup if already open | 🤖 auto |
| TrezorConnect webextension -> Suite Web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T14:56:51.043Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-05T12:17:11.472Z • 12 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->