### PR TITLE
Adding callId to Connect requests

### DIFF
--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -56,8 +56,9 @@ const parseArgv = () => {
         if (arg.startsWith('--')) {
             const key = arg.slice(2);
             if (key.includes('=')) {
-                const [k, v] = key.split('=');
-                add(k, v.toLowerCase());
+                const [k, ...rest] = key.split('=');
+                const v = rest.join('=');
+                add(k, k === 'params' ? v : v.toLowerCase());
             } else if (add(key, argv[i + 1])) i++;
         } else if (arg.startsWith('-') && arg.length === 2) {
             if (add(arg[1], argv[i + 1])) i++;

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -153,6 +153,7 @@ const run = async () => {
     console.log('Running @trezor/connect CLI with args', args);
 
     TrezorConnect.on('DEVICE_EVENT', async event => {
+        console.info('DEVICE_EVENT', event);
         if (event.type === 'device-connect_unacquired' || event.type === 'device-connect') {
             if (testIsRunning) {
                 return;
@@ -203,7 +204,7 @@ const run = async () => {
     });
 
     TrezorConnect.on('UI_EVENT', async event => {
-        console.warn('UI_EVENT', event.type);
+        console.info('UI_EVENT', event);
 
         if (event.type === 'ui-request_confirmation') {
             return TrezorConnect.uiResponse({

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -10,7 +10,7 @@ import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types/coinInfo';
 import type { Device } from '../types/device';
 import type { SelectFeeLevel } from '../types/fees';
-import type { MessageFactoryFn } from '../types/utils';
+import { type MessageFactoryFn } from '../types/utils';
 
 export const UI_EVENT = 'UI_EVENT';
 export const UI_REQUEST = {
@@ -317,16 +317,26 @@ export type UiEvent =
 export type UiEventMessage = UiEvent & {
     event: typeof UI_EVENT;
     requestId?: string;
+    callId?: string;
 };
 
-export const createUiMessage: MessageFactoryFn<typeof UI_EVENT, UiEvent> = (
-    type,
-    payload,
-    requestId,
-) =>
-    ({
+// type CreateUiMessageOptions = {
+//     requestId?: string;
+//     callId?: string;
+// };
+
+export const createUiMessage = ((
+    type: UiEvent['type'],
+    payload?: UiEvent extends { payload: infer P } ? P : undefined,
+    options?: { requestId?: string; callId?: string },
+) => {
+    const { requestId, callId } = options ?? {};
+
+    return {
         event: UI_EVENT,
         type,
         payload,
         requestId,
-    }) as any;
+        callId,
+    };
+}) as MessageFactoryFn<typeof UI_EVENT, UiEvent>;

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -18,6 +18,11 @@ export interface CommonParams {
     keepSession?: boolean;
     useCardanoDerivation?: boolean;
     /**
+     * Client-provided correlation token forwarded to related UI events during this call.
+     * Must be a valid UUID; the method validator throws `Method_InvalidParameter` otherwise.
+     */
+    callId?: string;
+    /**
      * internal flag. if set to true, call will only return info about the method, not execute it.
      * todo: this should be moved to another argument instead of mixing this with params
      */

--- a/packages/connect-common/src/types/utils.ts
+++ b/packages/connect-common/src/types/utils.ts
@@ -6,17 +6,24 @@ export type MessageFactoryFn<Group, Event> = UnionToIntersection<
             ? (
                   type: Event['type'],
                   payload: Event['payload'],
-                  requestId?: string,
+                  options?: { requestId?: string; callId?: string },
               ) => {
                   event: Group;
                   type: Event['type'];
                   payload: Event['payload'];
                   requestId?: string;
+                  callId?: string;
               }
             : (
                   type: Event['type'],
                   payload?: undefined,
-                  requestId?: string,
-              ) => { event: Group; type: Event['type']; payload: undefined; requestId?: string }
+                  options?: { requestId?: string; callId?: string },
+              ) => {
+                  event: Group;
+                  type: Event['type'];
+                  payload: undefined;
+                  requestId?: string;
+                  callId?: string;
+              }
         : never
 >;

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -293,7 +293,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
                         accountTypes: discovery.types.map(t => t.type),
                         accounts: discovery.accounts,
                     },
-                    dfd.requestId,
+                    { requestId: dfd.requestId },
                 ),
             );
             const uiResp = await dfd.promise;
@@ -321,7 +321,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
                         coinInfo,
                         accounts,
                     },
-                    dfd.requestId,
+                    { requestId: dfd.requestId },
                 ),
             );
         });
@@ -333,7 +333,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
                         type: 'end',
                         coinInfo,
                     },
-                    dfd.requestId,
+                    { requestId: dfd.requestId },
                 ),
             );
         });
@@ -354,7 +354,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
                     accountTypes: discovery.types.map(t => t.type),
                     coinInfo,
                 },
-                dfd.requestId,
+                { requestId: dfd.requestId },
             ),
         );
 
@@ -435,7 +435,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
                             feeLevels: composer.getFeeLevelList(),
                             coinInfo: this.params.coinInfo,
                         },
-                        resp.requestId,
+                        { requestId: resp.requestId },
                     ),
                 );
 

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -370,7 +370,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                         coinInfo,
                         accounts,
                     },
-                    dfd.requestId,
+                    { requestId: dfd.requestId },
                 ),
             );
         });
@@ -382,7 +382,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                         type: 'end',
                         coinInfo,
                     },
-                    dfd.requestId,
+                    { requestId: dfd.requestId },
                 ),
             );
         });
@@ -402,7 +402,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     defaultAccountType,
                     coinInfo,
                 },
-                dfd.requestId,
+                { requestId: dfd.requestId },
             ),
         );
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -14,7 +14,7 @@ import type {
     UiRequestConfirmation,
 } from '@trezor/connect-common';
 import type { Capability } from '@trezor/protobuf/src/definitions';
-import { isNotUndefined, versionUtils } from '@trezor/utils';
+import { isNotUndefined, isUUID, versionUtils } from '@trezor/utils';
 
 import { DEFAULT_FIRMWARE_RANGE, getFirmwareRange } from '../api/common/paramsValidator';
 import type { Device } from '../device/Device';
@@ -67,6 +67,19 @@ function validateStaticSessionId(input: unknown): StaticSessionId {
     );
 }
 
+function validateCallId(callId: unknown): string | undefined {
+    if (callId === undefined) return undefined;
+
+    if (!isUUID(callId)) {
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            `callId must be a valid UUID, got: ${callId}`,
+        );
+    }
+
+    return callId;
+}
+
 // validate expected state from method parameter.
 // it could be undefined
 function validateDeviceState(device: CallMethodPayload['device']): DeviceState | undefined {
@@ -97,6 +110,8 @@ function validateDeviceState(device: CallMethodPayload['device']): DeviceState |
 
 export abstract class AbstractMethod<Name extends CallMethodPayload['method'], Params = undefined> {
     public responseID: string;
+
+    public callId?: string;
 
     public device: Device | undefined;
 
@@ -153,6 +168,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.name = payload.method;
         this.params = params;
         this.responseID = message.id ?? '';
+        this.callId = validateCallId(payload.callId);
         this.deviceState = validateDeviceState(payload.device);
         this.keepSession = typeof payload.keepSession === 'boolean' ? payload.keepSession : false;
         this.skipFinalReload = true;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -7,6 +7,7 @@ import {
     DEVICE,
     POPUP,
     RESPONSE_EVENT,
+    UI_EVENT,
     UI_REQUEST,
     UI_RESPONSE,
     createDeviceMessage,
@@ -52,6 +53,21 @@ import { createUiPromiseManager } from '../utils/uiPromiseManager';
 const _log = initLog('Core');
 
 type CoreContext = ReturnType<Core['getCoreContext']>;
+
+const createSendCoreMessageWithCallId =
+    (sendCoreMessage: CoreContext['sendCoreMessage'], callId?: string) =>
+    (message: CoreEventMessage) => {
+        const isUiRequestMessage = message.event === UI_EVENT && message.type.startsWith('ui-');
+        const hasCallId = 'callId' in message && Boolean(message.callId);
+
+        if (callId && isUiRequestMessage && !hasCallId) {
+            sendCoreMessage({ ...message, callId } as CoreEventMessage);
+
+            return;
+        }
+
+        sendCoreMessage(message);
+    };
 
 /**
  * Find device by device path. Returned device may be unacquired.
@@ -114,7 +130,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
                     {
                         view: 'no-backup',
                     },
-                    uiPromise.requestId,
+                    { requestId: uiPromise.requestId },
                 ),
             );
 
@@ -215,22 +231,31 @@ const onCall = async (context: CoreContext, message: CoreCallMessage) => {
         return Promise.resolve();
     }
 
+    const sendCoreMessageWithCallId = createSendCoreMessageWithCallId(
+        sendCoreMessage,
+        method.callId,
+    );
+    const methodContext: CoreContext = {
+        ...context,
+        sendCoreMessage: sendCoreMessageWithCallId,
+    };
+
     // this method is not using the device, there is no need to acquire
     if (!method.useDevice) {
         try {
             const response = await method.run({
-                sendCoreMessage,
+                sendCoreMessage: sendCoreMessageWithCallId,
                 createUiPromise: uiPromises.create,
             });
-            sendCoreMessage(createResponseMessage(method.responseID, true, response));
+            sendCoreMessageWithCallId(createResponseMessage(method.responseID, true, response));
         } catch (error) {
-            sendCoreMessage(createResponseMessage(method.responseID, false, { error }));
+            sendCoreMessageWithCallId(createResponseMessage(method.responseID, false, { error }));
         }
 
         return Promise.resolve();
     }
 
-    return await onCallDevice(context, message, method);
+    return await onCallDevice(methodContext, message, method);
 };
 
 const onCallDevice = async (
@@ -462,7 +487,7 @@ const onDevicePinHandler =
             createUiMessage(
                 UI_REQUEST.REQUEST_PIN,
                 { device: device.toMessageObject(), type },
-                uiPromise.requestId,
+                { requestId: uiPromise.requestId },
             ),
         );
         // wait for pin
@@ -491,7 +516,7 @@ const onDeviceWordHandler =
             createUiMessage(
                 UI_REQUEST.REQUEST_WORD,
                 { device: device.toMessageObject(), type },
-                uiPromise.requestId,
+                { requestId: uiPromise.requestId },
             ),
         );
         // wait for word
@@ -521,7 +546,7 @@ const onDevicePassphraseHandler =
             createUiMessage(
                 UI_REQUEST.REQUEST_PASSPHRASE,
                 { device: device.toMessageObject() },
-                uiPromise.requestId,
+                { requestId: uiPromise.requestId },
             ),
         );
         // wait for passphrase
@@ -567,7 +592,7 @@ const onThpPairingHandler =
                     device: device.toMessageObject(),
                     ...payload,
                 },
-                uiPromise.requestId,
+                { requestId: uiPromise.requestId },
             ),
         );
         // wait for response
@@ -836,11 +861,15 @@ export class Core extends EventEmitter {
                     assertDeviceListConnected(this.deviceList);
 
                     const coreContext = this.getCoreContext();
+                    const sendCoreMessageWithCallId = createSendCoreMessageWithCallId(
+                        this.sendCoreMessage.bind(this),
+                        message.payload.callId,
+                    );
                     onCallFirmwareUpdate({
                         params: message.payload,
                         context: {
                             deviceList: this.deviceList,
-                            postMessage: this.sendCoreMessage.bind(this),
+                            postMessage: sendCoreMessageWithCallId,
                             selectDevice: path => selectDevice(coreContext, { path }),
                             log: _log,
                             abortSignal: this.abortController.signal,

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -70,7 +70,7 @@ const waitForThpPairingConfirmation = async ({
             {
                 view: thpPairingError ? 'thp-pairing-failed' : 'thp-pairing-start',
             },
-            uiPromise.requestId,
+            { requestId: uiPromise.requestId },
         ),
     );
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,6 +39,7 @@ export * from './isNotNull';
 export * from './isNotNullOrUndefined';
 export * from './isNotUndefined';
 export * from './isUrl';
+export * from './isUUID';
 export * from './isWhitelistedHost';
 export * from './logs';
 export * from './logsManager';

--- a/packages/utils/src/isUUID.ts
+++ b/packages/utils/src/isUUID.ts
@@ -1,0 +1,4 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const isUUID = (value: unknown): value is string =>
+    typeof value === 'string' && UUID_REGEX.test(value);

--- a/packages/utils/tests/isUUID.test.ts
+++ b/packages/utils/tests/isUUID.test.ts
@@ -1,0 +1,18 @@
+import { isUUID } from '../src/isUUID';
+
+describe('isUUID', () => {
+    it('returns true for valid UUIDs', () => {
+        expect(isUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+        expect(isUUID('00000000-0000-0000-0000-000000000000')).toBe(true);
+        expect(isUUID('FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF')).toBe(true);
+        expect(isUUID('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(true);
+    });
+
+    it('returns false for invalid UUIDs', () => {
+        expect(isUUID('')).toBe(false);
+        expect(isUUID('not-a-uuid')).toBe(false);
+        expect(isUUID('550e8400-e29b-41d4-a716')).toBe(false);
+        expect(isUUID('550e8400-e29b-41d4-a716-44665544000g')).toBe(false);
+        expect(isUUID('550e8400e29b41d4a716446655440000')).toBe(false);
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding `callId` param to the Connect requests than then it is added along to the events that connect is sending as part of this original request.

This can be used by clients to correlate original request with the events are are part of it.


```bash
yarn workspace @trezor/connect-cli cli --params='{"callId":"my-test-call"}'
```
This is providing non-valid callId since it has to be a valid UUID so the one below should work properly:

```bash
yarn workspace @trezor/connect-cli cli --params='{"callId":"550e8400-e29b-41d4-a716-446655440000"}'
```

The result should be as below, passing the `callId: '550e8400-e29b-41d4-a716-446655440000'` in each of the events that are related to this request.

```bash
UI_EVENT {
  event: 'UI_EVENT',
  type: 'ui-request_passphrase',
  payload: {
    device: {
       ...
    }
  },
  requestId: '3e5eb3c8-2179-4b51-a60e-b9d9d12e4a92',
  callId: '550e8400-e29b-41d4-a716-446655440000'
}

....

UI_EVENT {
  event: 'UI_EVENT',
  type: 'ui-button',
  payload: {
    code: 'ButtonRequest_Address',
    pages: 1,
    name: 'show_address',
    device: {
      ...
    },
    data: {
      type: 'address',
      serializedPath: "m/44'/0'/0'/0/0",
      address: '....'
    }
  },
  requestId: undefined,
  callId: '550e8400-e29b-41d4-a716-446655440000'
}
....
{
  id: 1,
  success: true,
  payload: {
    path: [....],
    serializedPath: "m/44'/0'/0'/0/0",
    address: '...',
    mac: '....'
  },
  device: {
    path: 'f2aa3ef8',
    state: {
      deriveCardano: false,
      sessionId: '...',
      staticSessionId: '..@...0'
    },
    instance: 0
  }
}
```

You can test that `callId` is passed on other events like `ui-select_account`  by running:

```bash
 yarn workspace @trezor/connect-cli cli   --method=get-account-info   --params='{"path":"","callId":"550e8400-e29b-41d4-a716-446655440000"}'
```

Or if you want to see `ui-bundle_progress` run the command below:

```bash
PARAMS='{"callId":"550e8400-e29b-41d4-a716-446655440000","bundle":[{"coin":"btc","path":"m/84'\''/0'\''/0'\''"},{"coin":"btc","path":"m/84'\''/0'\''/1'\''"}]}'
yarn workspace @trezor/connect-cli cli --method=get-account-info --params="$PARAMS"
```

## Notes for QA
It is possible to test it using connec-cli as it is described in Description above.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/27086

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/add-callid-to-connect/web/](https://dev.suite.sldev.cz/suite-web/feat/add-callid-to-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-callid-to-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/add-callid-to-connect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-callid-to-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 11 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |

</details>

_Updated: 2026-05-07T10:35:05.931Z • 11 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > closing popup window | 🤖 auto |
| TrezorConnect webextension -> Suite Web > focuses existing popup if already open | 🤖 auto |
| TrezorConnect webextension -> Suite Web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T13:53:05.217Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->