### PR TITLE
feat(suite): align stablecoin yield flow with the device

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
+++ b/packages/suite/src/actions/wallet/stablecoinYieldSigningThunks.ts
@@ -30,6 +30,7 @@ import {
     AddressDisplayOptions,
     type FormState,
     type PrecomposedTransactionFinal,
+    type YieldFormMetadata,
 } from '@suite-common/wallet-types';
 import {
     convertAmountUnitsToSubunits,
@@ -59,6 +60,8 @@ type BuildYieldReviewTokenParams = {
 type BuildYieldReviewStateParams = BuildYieldReviewTokenParams & {
     parsedTransaction: ParsedTransactionForSigning;
     amount: string;
+    flowType: YieldFormMetadata['type'];
+    vaultName: string;
 };
 
 type BuildYieldReviewStateResult = {
@@ -71,6 +74,8 @@ type SendYieldTransactionParams = {
     amount: string;
     token: YieldFlowDisplayToken;
     transaction: TransactionDto;
+    flowType: YieldFormMetadata['type'];
+    vaultName: string;
     dispatch: Dispatch;
     getState: () => AppState;
 };
@@ -130,6 +135,8 @@ const buildYieldReviewState = ({
     amount,
     token,
     symbol,
+    flowType,
+    vaultName,
 }: BuildYieldReviewStateParams): BuildYieldReviewStateResult => {
     const gasLimit = BigInt(parsedTransaction.gasLimit);
     const gasPriceWei = BigInt(
@@ -170,6 +177,7 @@ const buildYieldReviewState = ({
         isCoinControlEnabled: false,
         hasCoinControlBeenOpened: false,
         selectedUtxos: [],
+        yieldMetadata: { type: flowType, vaultName },
     };
 
     const precomposedTransaction: PrecomposedTransactionFinal = {
@@ -199,6 +207,8 @@ const sendYieldTransaction = async ({
     amount,
     token,
     transaction,
+    flowType,
+    vaultName,
     dispatch,
     getState,
 }: SendYieldTransactionParams) => {
@@ -227,6 +237,8 @@ const sendYieldTransaction = async ({
         amount,
         token,
         symbol: account.symbol,
+        flowType,
+        vaultName,
     });
 
     dispatch(
@@ -363,11 +375,18 @@ export const submitYieldActionThunk = createThunk(
                 return;
             }
 
+            const isWithdraw = flowType === 'withdraw';
+            const reviewAmount = isWithdraw ? requestAmount : amount;
+            const reviewToken = isWithdraw ? flowData.receiptToken : flowData.token;
+            const vaultName = flowData.vault.outputToken?.name ?? flowData.vault.metadata.name;
+
             const result = await sendYieldTransaction({
                 account: flowData.account,
-                amount,
-                token: flowData.token,
+                amount: reviewAmount,
+                token: reviewToken,
                 transaction: actionTransaction,
+                flowType,
+                vaultName,
                 dispatch,
                 getState,
             });

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModal.tsx
@@ -8,6 +8,7 @@ import {
     stakeActions,
 } from '@suite-common/wallet-core';
 import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
 
 import { signAndPushSendFormTransactionThunk } from 'src/actions/wallet/send/sendFormThunks';
 import {
@@ -52,7 +53,11 @@ export const TransactionReviewModal = ({ type, decision }: TransactionReviewModa
     const handleCancelSignTx = () => {
         if (isSend) {
             dispatch(cancelSignSendFormTransactionThunk());
-        } else if (!isYield) {
+        } else if (isYield) {
+            if (!yieldTxReview.serializedTx) {
+                TrezorConnect.cancel('tx-cancelled');
+            }
+        } else {
             dispatch(cancelSignStakingTx());
         }
     };

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -112,6 +112,19 @@ const getTranslationValues = (
         return getStakeTranslations(stakeType, networkType);
     }
 
+    if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+        const isSupply = evmTxType === 'supply';
+
+        return {
+            label: isSupply
+                ? 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE'
+                : 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',
+            value: isSupply
+                ? 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION'
+                : 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
+        };
+    }
+
     return null;
 };
 
@@ -159,10 +172,18 @@ const getOutputTitle = (
             return <Translation id={contractTitle} />;
         case 'address':
         case 'regular_legacy':
+            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+                return <Translation id="TR_EARN_YIELD_VAULT" />;
+            }
+
             return <Translation id={translation ? translation.label : 'TR_RECIPIENT_ADDRESS'} />;
 
         case 'amount':
-            return <Translation id="TR_AMOUNT_SENT" />;
+            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+                return <Translation id="AMOUNT" />;
+            }
+
+            return <Translation id={translation ? translation.label : 'TR_AMOUNT_SENT'} />;
         case 'destination-tag':
             return <Translation id="DESTINATION_TAG" />;
         case 'signing-with':
@@ -278,12 +299,36 @@ const getOutputLines = ({
         case 'address':
         case 'data':
         case 'regular_legacy': {
-            const translation = getTranslationValues(
+            const translationValues = getTranslationValues(
                 networkType,
                 stakeType,
                 evmTxType,
                 device,
-            )?.value;
+            );
+
+            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+                if (type === 'data' && translationValues) {
+                    return [
+                        {
+                            id: 'data',
+                            type: 'default',
+                            value: translationString(translationValues.value, {}),
+                        },
+                    ];
+                }
+
+                if (type === 'address') {
+                    return [
+                        {
+                            id: 'address',
+                            type: 'default',
+                            value,
+                        },
+                    ];
+                }
+            }
+
+            const translation = translationValues?.value;
 
             const defaultOutput = [
                 {
@@ -338,6 +383,32 @@ const getOutputLines = ({
                 },
             ];
         case 'amount': {
+            if (evmTxType === 'supply' || evmTxType === 'withdraw') {
+                return [
+                    {
+                        id: 'amount',
+                        label: (
+                            <Translation
+                                id={
+                                    evmTxType === 'supply'
+                                        ? 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT'
+                                        : 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT'
+                                }
+                            />
+                        ),
+                        value,
+                        type: 'amount',
+                        token: token || nativeToken,
+                    },
+                    {
+                        id: 'chain',
+                        label: <Translation id="TR_CHAIN" />,
+                        value: value2,
+                        type: 'data',
+                    },
+                ];
+            }
+
             const output: OutputElementLine[] = [
                 {
                     id: type,
@@ -395,7 +466,7 @@ const getOutputLines = ({
                 },
                 {
                     id: `${type}-chain`,
-                    label: <Translation id="TR_APPROVE_CHAIN_TITLE" />,
+                    label: <Translation id="TR_CHAIN" />,
                     value: value2,
                     type: 'data',
                 },

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import type { DeviceRootState } from '@suite-common/device';
+import { selectSelectedDevice } from '@suite-common/device';
 import { selectSendFormReviewLastButtonCode } from '@suite-common/wallet-core';
 import type {
     FormState,
@@ -15,6 +16,7 @@ import type {
 import {
     findAccountsByAddress,
     getEvmTransactionTextSignature,
+    getIsUpdatedEthereumSendFlow,
     isEvmApprovalTx,
 } from '@suite-common/wallet-utils';
 import { Column, H4 } from '@trezor/components';
@@ -79,7 +81,11 @@ export const TransactionReviewOutputList = ({
     const outputRefs = useRef<(HTMLDivElement | null)[]>([]);
     const totalOutputRef = useRef<HTMLDivElement | null>(null);
     const accounts = useSelector(state => state.wallet.accounts);
+    const device = useSelector(selectSelectedDevice);
     const { networkType, symbol } = account;
+    const isUpdatedEthereumSendFlow = device
+        ? getIsUpdatedEthereumSendFlow(device, networkType)
+        : false;
     const isMultirecipient = outputs.filter(({ type }) => type === 'address').length > 1;
     const isFirstOutputAddress = outputs[0]?.type === 'address';
 
@@ -176,9 +182,13 @@ export const TransactionReviewOutputList = ({
                                 isRbf={isRbfAction}
                                 isTrading={!!isTrading}
                                 stakeType={stakeType}
-                                evmTxType={getEvmTransactionTextSignature(
-                                    precomposedForm.transactionData,
-                                )}
+                                evmTxType={
+                                    isUpdatedEthereumSendFlow && precomposedForm.yieldMetadata
+                                        ? precomposedForm.yieldMetadata.type
+                                        : getEvmTransactionTextSignature(
+                                              precomposedForm.transactionData,
+                                          )
+                                }
                                 nativeToken={nativeToken}
                             />
                         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -98,10 +98,12 @@ const getLines = ({
             type: 'amount',
         };
 
-        return isUnknownStakingValue ||
-            (isEvmApprovalTx(precomposedForm.transactionData) && isApprovalFlowSupported(device))
-            ? [feeLine]
-            : [amountLine, feeLine];
+        const isFeeOnly =
+            isUnknownStakingValue ||
+            (isEvmApprovalTx(precomposedForm.transactionData) && isApprovalFlowSupported(device)) ||
+            !!precomposedForm.yieldMetadata;
+
+        return isFeeOnly ? [feeLine] : [amountLine, feeLine];
     }
     if (isUpdatedSendFlow) {
         const amount = showAmountWithoutFee ? amountWithoutFee : precomposedTx.totalSpent;
@@ -123,15 +125,27 @@ const getLines = ({
         ];
     }
 
-    return [
-        {
-            id: 'total',
-            label: <Translation id="TR_TOTAL" />,
-            value: precomposedTx.totalSpent,
-            token: tokenInfo,
-            type: 'amount',
-        },
-    ];
+    const totalLine: OutputElementLine = {
+        id: 'total',
+        label: <Translation id="TR_TOTAL" />,
+        value: precomposedTx.totalSpent,
+        token: tokenInfo,
+        type: 'amount',
+    };
+
+    if (precomposedForm.yieldMetadata) {
+        return [
+            totalLine,
+            {
+                id: 'fee',
+                label: <Translation id={feeLabelId} />,
+                value: precomposedTx.fee,
+                type: 'amount',
+            },
+        ];
+    }
+
+    return [totalLine];
 };
 
 export type TransactionReviewTotalOutputProps = {

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -1,9 +1,65 @@
 import { type MiddlewareAPI } from 'redux';
 
+import { selectAccountByKey } from '@suite-common/wallet-core';
 import { UI_REQUEST } from '@trezor/connect';
 import { bluetoothIpc } from '@trezor/transport-bluetooth';
 
 import { type Action, type AppState, type Dispatch } from 'src/types/suite';
+
+const SIGN_TX_NETWORK_TYPES = ['cardano', 'ethereum', 'stellar', 'tron'] as const;
+
+const SIGN_TX_ROUTES = [
+    'wallet-send',
+    'wallet-staking',
+    'wallet-index',
+    'wallet-trading-exchange-confirm',
+    'wallet-trading-sell-confirm',
+    'earn-supply',
+    'earn-withdraw',
+] as const;
+
+const SIGN_TX_CONNECT_METHODS = [
+    'cardanoSignTransaction',
+    'ethereumSignTransaction',
+    'stellarSignTransaction',
+] as const;
+
+const getAccountForButtonRequest = (state: AppState) => {
+    const { account } = state.wallet.selectedAccount;
+    if (account) return account;
+
+    const { accountKey } = state.wallet.stablecoinYield.txReview;
+
+    return selectAccountByKey(state, accountKey);
+};
+
+const shouldRemapToSignTx = (
+    code: string | undefined,
+    name: string | undefined,
+    state: AppState,
+): boolean => {
+    if (
+        name === 'confirm_ethereum_approve' &&
+        (code === 'ButtonRequest_Other' || code === 'ButtonRequest_Warning')
+    ) {
+        return true;
+    }
+
+    if (code !== 'ButtonRequest_Other') return false;
+
+    const account = getAccountForButtonRequest(state);
+    const { activeCall } = state.connectPopup;
+
+    const isInSuite =
+        SIGN_TX_NETWORK_TYPES.some(type => type === account?.networkType) &&
+        SIGN_TX_ROUTES.some(route => route === state.router.route?.name);
+
+    const isInConnectCall =
+        activeCall?.state === 'ongoing' &&
+        SIGN_TX_CONNECT_METHODS.some(method => method === activeCall.method);
+
+    return isInSuite || isInConnectCall;
+};
 
 const buttonRequest =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -25,36 +81,8 @@ const buttonRequest =
         // ugly hack to make Cardano review modal work
         // ugly hack to make Ethereum staking and bump fee review modal on specific devices work
         // root cause of this bug is wrong button request ButtonRequest_Other from CardanoSignTx - should be ButtonRequest_SignTx
-        if (
-            action.type === UI_REQUEST.REQUEST_BUTTON &&
-            action.payload.code === 'ButtonRequest_Other'
-        ) {
-            const {
-                wallet: {
-                    selectedAccount: { account },
-                },
-                connectPopup: { activeCall },
-                router: { route },
-            } = api.getState();
-            const isInSuite =
-                ['cardano', 'ethereum', 'stellar', 'tron'].includes(account?.networkType || '') &&
-                [
-                    'wallet-send',
-                    'wallet-staking',
-                    'wallet-index',
-                    'wallet-trading-exchange-confirm',
-                    'wallet-trading-sell-confirm',
-                    'earn-supply',
-                    'earn-withdraw',
-                ].includes(route?.name || '');
-            const isInConnectCall =
-                activeCall?.state === 'ongoing' &&
-                [
-                    'cardanoSignTransaction',
-                    'ethereumSignTransaction',
-                    'stellarSignTransaction',
-                ].includes(activeCall.method);
-            if (isInSuite || isInConnectCall) {
+        if (action.type === UI_REQUEST.REQUEST_BUTTON) {
+            if (shouldRemapToSignTx(action.payload.code, action.payload.name, api.getState())) {
                 api.dispatch({
                     ...action,
                     payload: { ...action.payload, code: 'ButtonRequest_SignTx' },
@@ -62,31 +90,13 @@ const buttonRequest =
 
                 return action;
             }
-        }
-        if (
-            action.type === UI_REQUEST.REQUEST_BUTTON &&
-            action.payload.name === 'confirm_ethereum_approve' &&
-            (action.payload.code === 'ButtonRequest_Other' ||
-                action.payload.code === 'ButtonRequest_Warning')
-        ) {
-            api.dispatch({
-                ...action,
-                payload: { ...action.payload, code: 'ButtonRequest_SignTx' },
-            });
 
-            return action;
-        }
-
-        if (
-            action.type === UI_REQUEST.REQUEST_BUTTON &&
-            action.payload.code === 'ButtonRequest_Address'
-        ) {
-            const {
-                connectPopup: { activeCall },
-            } = api.getState();
-            // Skip if address confirmation modal open
-            if (activeCall?.state === 'address-confirmation') {
-                return action;
+            if (action.payload.code === 'ButtonRequest_Address') {
+                const { activeCall } = api.getState().connectPopup;
+                // Skip if address confirmation modal open
+                if (activeCall?.state === 'address-confirmation') {
+                    return action;
+                }
             }
         }
 

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -90,4 +90,10 @@ export interface FormState {
     selectedUtxos: AccountUtxo[];
     utxoSorting?: UtxoSorting;
     trading?: FormStateTrading;
+    yieldMetadata?: YieldFormMetadata;
 }
+
+export type YieldFormMetadata = {
+    type: 'supply' | 'withdraw';
+    vaultName: string;
+};

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -245,7 +245,14 @@ export interface RbfTransactionParamsBitcoin {
     locktime?: number;
 }
 
-export type EvmTransactionPurpose = 'transfer' | 'approve' | 'revoke' | 'unknown' | '';
+export type EvmTransactionPurpose =
+    | 'transfer'
+    | 'approve'
+    | 'revoke'
+    | 'unknown'
+    | ''
+    | 'supply'
+    | 'withdraw';
 
 export interface RbfTransactionParamsEthereum {
     type: 'ethereum';

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -228,7 +228,10 @@ const constructOldFlow = ({
             });
     }
 
-    if (precomposedForm.transactionData && !precomposedTx.token) {
+    if (
+        precomposedForm.transactionData &&
+        (!precomposedTx.token || precomposedForm.yieldMetadata)
+    ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
 
@@ -248,7 +251,11 @@ const constructOldFlow = ({
                 value: precomposedForm.destinationTag,
             });
         }
-    } else if ((!isBumpFeeRbf || !precomposedTx.useNativeRbf) && !stakeType) {
+    } else if (
+        (!isBumpFeeRbf || !precomposedTx.useNativeRbf) &&
+        !stakeType &&
+        !precomposedForm.yieldMetadata
+    ) {
         outputs.push({ type: 'fee', value: precomposedTx.fee });
     }
 
@@ -283,6 +290,26 @@ const constructNewFlow = ({
     const hasDestinationTag = 'destinationTag' in precomposedForm;
     const trading = precomposedForm?.trading;
 
+    if (precomposedForm.yieldMetadata && isUpdatedEthereumSendFlow) {
+        outputs.push(
+            { type: 'data', value: '' },
+            { type: 'address', value: precomposedForm.yieldMetadata.vaultName },
+        );
+
+        precomposedTx.outputs.forEach(o => {
+            if ('address' in o && typeof o.address === 'string') {
+                outputs.push({
+                    type: 'amount',
+                    value: o.amount.toString(),
+                    value2: networks[symbol].name,
+                    token: precomposedTx.token,
+                });
+            }
+        });
+
+        return outputs;
+    }
+
     if (networkType === 'stellar') {
         if (!isUpdatedStellarSendFlow) {
             outputs.push({
@@ -309,7 +336,10 @@ const constructNewFlow = ({
 
     if (
         (precomposedForm.transactionData && !precomposedTx.token && !isEvmApproval) ||
-        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported)
+        (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
+        (precomposedForm.transactionData &&
+            precomposedForm.yieldMetadata &&
+            !isUpdatedEthereumSendFlow)
     ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -9524,7 +9524,7 @@ export const messages = defineMessages({
     },
     TR_EARN_YIELD_WITHDRAW: {
         id: 'TR_EARN_YIELD_WITHDRAW',
-        defaultMessage: 'Withdraw',
+        defaultMessage: 'Redeem',
     },
     TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW: {
         id: 'TR_EARN_YIELD_DASHBOARD_SUPPLY_NOW',
@@ -9661,6 +9661,34 @@ export const messages = defineMessages({
     TR_EARN_YIELD_ERROR_TRANSACTION_FAILED: {
         id: 'TR_EARN_YIELD_ERROR_TRANSACTION_FAILED',
         defaultMessage: 'Transaction failed.',
+    },
+    TR_EARN_YIELD_REVIEW_SUPPLY_TITLE: {
+        id: 'TR_EARN_YIELD_REVIEW_SUPPLY_TITLE',
+        defaultMessage: 'Deposit',
+    },
+    TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_REVIEW_SUPPLY_DESCRIPTION',
+        defaultMessage: 'Review details to deposit to vault',
+    },
+    TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE: {
+        id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',
+        defaultMessage: 'Redeem',
+    },
+    TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION: {
+        id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
+        defaultMessage: 'Review details to redeem from vault',
+    },
+    TR_EARN_YIELD_VAULT: {
+        id: 'TR_EARN_YIELD_VAULT',
+        defaultMessage: 'Vault',
+    },
+    TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT: {
+        id: 'TR_EARN_YIELD_REVIEW_SUPPLY_AMOUNT',
+        defaultMessage: 'Deposit amount',
+    },
+    TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT: {
+        id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',
+        defaultMessage: 'Redeem amount',
     },
     TR_EARN_DASHBOARD_ACTIVE: {
         id: 'TR_EARN_DASHBOARD_ACTIVE',
@@ -11371,8 +11399,9 @@ export const messages = defineMessages({
         id: 'TR_REVOKE_AMOUNT_TITLE',
         defaultMessage: 'Token',
     },
-    TR_APPROVE_CHAIN_TITLE: {
-        id: 'TR_APPROVE_CHAIN_TITLE',
+
+    TR_CHAIN: {
+        id: 'TR_CHAIN',
         defaultMessage: 'Chain',
     },
     TR_CONTRACT_REVOKE_TITLE: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR aligns the transaction review modal flow for yield supply/redeem with the device.

## Notes for QA


## Related Issue

Resolve #25657

## Screenshots:

### T3T1

<img width="623" height="773" alt="image" src="https://github.com/user-attachments/assets/c515fb3d-8f01-4de6-a117-e2f70caf9f92" />

<img width="627" height="775" alt="image" src="https://github.com/user-attachments/assets/74efcfd8-4f3d-4068-96d6-a34d0bb8f7ae" />

### T1B1

<img width="603" height="720" alt="image" src="https://github.com/user-attachments/assets/2067dc5f-c954-4bc7-b1c3-d9837a333604" />


<img width="613" height="754" alt="image" src="https://github.com/user-attachments/assets/c753eeb4-c73d-4bb1-a03a-7cfb6879bec4" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-tx-review-modal/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-tx-review-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/earn-tx-review-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-04-30T14:32:07.849Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 19 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > closing popup window | 🤖 auto |
| TrezorConnect webextension -> Suite Web > focuses existing popup if already open | 🤖 auto |
| TrezorConnect webextension -> Suite Web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T14:31:33.627Z • 19 test(s) total_
<!-- QUARANTINE-LIST:web:END -->