### PR TITLE
wip: TrezorConnect cancell by callId

### DIFF
--- a/packages/connect-cli/src/args.ts
+++ b/packages/connect-cli/src/args.ts
@@ -56,8 +56,9 @@ const parseArgv = () => {
         if (arg.startsWith('--')) {
             const key = arg.slice(2);
             if (key.includes('=')) {
-                const [k, v] = key.split('=');
-                add(k, v.toLowerCase());
+                const [k, ...rest] = key.split('=');
+                const v = rest.join('=');
+                add(k, k === 'params' ? v : v.toLowerCase());
             } else if (add(key, argv[i + 1])) i++;
         } else if (arg.startsWith('-') && arg.length === 2) {
             if (add(arg[1], argv[i + 1])) i++;

--- a/packages/connect-cli/src/index.ts
+++ b/packages/connect-cli/src/index.ts
@@ -134,6 +134,7 @@ const runTestCase = async (device: Device) => {
             result = await TrezorConnect.applySettings({ device, ...params });
             break;
         default:
+            console.log('params', params);
             result = await TrezorConnect.getAddress({ device, path: "m/44'/0'/0'/0/0", ...params });
     }
 
@@ -153,6 +154,7 @@ const run = async () => {
     console.log('Running @trezor/connect CLI with args', args);
 
     TrezorConnect.on('DEVICE_EVENT', async event => {
+        console.info('DEVICE_EVENT', event);
         if (event.type === 'device-connect_unacquired' || event.type === 'device-connect') {
             if (testIsRunning) {
                 return;
@@ -203,7 +205,7 @@ const run = async () => {
     });
 
     TrezorConnect.on('UI_EVENT', async event => {
-        console.warn('UI_EVENT', event.type);
+        console.info('UI_EVENT', event);
 
         if (event.type === 'ui-request_confirmation') {
             return TrezorConnect.uiResponse({

--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -57,7 +57,7 @@ export type CallMethodAnyResponse = ReturnType<CallMethodUnion>;
 export type CallMethod = (params: CallMethodPayload) => Promise<any>;
 
 export interface CoreCallMessage {
-    id: number;
+    id: string;
     type: typeof CORE_CALL;
     payload: CallMethodPayload;
 }
@@ -67,7 +67,7 @@ export const RESPONSE_EVENT = 'RESPONSE_EVENT';
 export type MethodResponseMessage = {
     event: typeof RESPONSE_EVENT;
     type: typeof RESPONSE_EVENT;
-    id: number;
+    id: string;
 
     device?: DeviceIdentity;
 } & (
@@ -84,7 +84,7 @@ export type MethodResponseMessage = {
 );
 
 export const createResponseMessage = (
-    id: number,
+    id: string,
     success: boolean,
     payload: any,
     deviceIdentity:

--- a/packages/connect-common/src/events/core.ts
+++ b/packages/connect-common/src/events/core.ts
@@ -49,7 +49,7 @@ export const parseMessage = <T extends CoreRequestMessage | CoreEventMessage = n
         device: messageData.device,
     };
 
-    if (typeof messageData.id === 'number') {
+    if (typeof messageData.id === 'string') {
         (message as any).id = messageData.id;
     }
 

--- a/packages/connect-common/src/events/popup.ts
+++ b/packages/connect-common/src/events/popup.ts
@@ -42,7 +42,7 @@ export interface PopupHandshake {
 
 export interface PopupClosedMessage {
     type: typeof POPUP.CLOSED;
-    payload: { error: any } | null;
+    payload: { error?: any; callId?: string } | null;
 }
 
 export interface PopupContentScriptLoaded {

--- a/packages/connect-common/src/events/transport.ts
+++ b/packages/connect-common/src/events/transport.ts
@@ -42,7 +42,7 @@ export interface TransportRequestWebUSBDevice {
 }
 
 export interface TransportGetInfo {
-    id: number;
+    id: string;
     type: typeof TRANSPORT.GET_INFO;
     payload?: undefined;
 }

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -10,7 +10,6 @@ import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types/coinInfo';
 import type { Device } from '../types/device';
 import type { SelectFeeLevel } from '../types/fees';
-import type { MessageFactoryFn } from '../types/utils';
 
 export const UI_EVENT = 'UI_EVENT';
 export const UI_REQUEST = {
@@ -317,16 +316,19 @@ export type UiEvent =
 export type UiEventMessage = UiEvent & {
     event: typeof UI_EVENT;
     requestId?: string;
+    callId?: string;
 };
 
-export const createUiMessage: MessageFactoryFn<typeof UI_EVENT, UiEvent> = (
-    type,
-    payload,
-    requestId,
-) =>
+export const createUiMessage = (
+    type: UiEvent['type'],
+    payload?: any,
+    requestId?: string,
+    callId?: string,
+): UiEventMessage =>
     ({
         event: UI_EVENT,
         type,
         payload,
         requestId,
+        callId,
     }) as any;

--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -152,8 +152,8 @@ export class TrezorConnectDynamic implements ConnectFactoryDependencies<Record<n
         }
     }
 
-    public cancel(error?: string) {
-        return this.getTarget().cancel(error);
+    public cancel(params?: string | { error?: string; callId?: string }) {
+        return this.getTarget().cancel(params);
     }
 
     public dispose() {

--- a/packages/connect-common/src/messageChannel/abstract.ts
+++ b/packages/connect-common/src/messageChannel/abstract.ts
@@ -25,7 +25,7 @@ export interface AbstractMessageChannelConstructorParams {
 
 export type Message<IncomingMessages extends { type: string }> = IncomingMessages & {
     channel: AbstractMessageChannelConstructorParams['channel'];
-    id: number;
+    id: string;
     success: boolean;
     payload: Extract<IncomingMessages, { type: IncomingMessages['type'] }> | undefined;
 };
@@ -40,7 +40,7 @@ export abstract class AbstractMessageChannel<
 > extends TypedEmitter<{
     message: Message<IncomingMessages>;
 }> {
-    protected messages = createDeferredManager();
+    protected messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
     /** queue of messages that were scheduled before handshake */
     protected messagesQueue: any[] = [];
 

--- a/packages/connect-common/src/types/api/cancel.ts
+++ b/packages/connect-common/src/types/api/cancel.ts
@@ -1,1 +1,1 @@
-export declare function cancel(params?: string): void;
+export declare function cancel(params?: string | { error?: string; callId?: string }): void;

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -17,6 +17,8 @@ export interface CommonParams {
     device?: DeviceIdentity & { useEmptyPassphrase?: boolean };
     keepSession?: boolean;
     useCardanoDerivation?: boolean;
+    /** client-provided correlation token forwarded to related UI events during this call */
+    callId?: string;
     /**
      * internal flag. if set to true, call will only return info about the method, not execute it.
      * todo: this should be moved to another argument instead of mixing this with params

--- a/packages/connect-mobile/src/index.ts
+++ b/packages/connect-mobile/src/index.ts
@@ -13,7 +13,7 @@ import { createDeferredManager, removeTrailingSlashes } from '@trezor/utils';
 
 type BuildUrlParams = {
     method: string;
-    id: number;
+    id: string;
     params: any;
     connectSrc: string | undefined;
     callbackUrl: string;
@@ -22,7 +22,7 @@ type BuildUrlParams = {
 
 const buildUrl = ({ method, id, params, connectSrc, callbackUrl, manifest }: BuildUrlParams) => {
     const urlWithParams = new URL(callbackUrl);
-    urlWithParams.searchParams.set('id', id.toString());
+    urlWithParams.searchParams.set('id', id);
 
     return (
         removeTrailingSlashes(connectSrc || DEFAULT_DOMAIN_MAJOR_VER) +
@@ -45,7 +45,7 @@ interface ConnectSettingsMobile {
 
 export class TrezorConnectDeeplink implements ConnectFactoryDependencies<ConnectSettingsMobile> {
     public eventEmitter = new ConnectEmitter();
-    private messages = createDeferredManager();
+    private messages = createDeferredManager({ generateId: (): string => crypto.randomUUID() });
 
     private manifest?: Manifest;
 
@@ -53,7 +53,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         return Promise.resolve(createErrorMessage(ERRORS.TypedError('Method_InvalidPackage')));
     }
 
-    private openDeeplink: (method: string, id: number, params: any) => void = () => {
+    private openDeeplink: (method: string, id: string, params: any) => void = () => {
         throw ERRORS.TypedError('Init_NotInitialized');
     };
 
@@ -131,8 +131,7 @@ export class TrezorConnectDeeplink implements ConnectFactoryDependencies<Connect
         try {
             parsedUrl = new URL(url);
             id = parsedUrl.searchParams.get('id');
-            if (!id || isNaN(Number(id))) throw new Error('Missing `id` parameter.');
-            id = Number(id);
+            if (!id) throw new Error('Missing `id` parameter.');
         } catch (error) {
             this.resolveMessagePromises({ success: false, error });
 

--- a/packages/connect-web/src/impl/core-in-suite-desktop.ts
+++ b/packages/connect-web/src/impl/core-in-suite-desktop.ts
@@ -30,7 +30,9 @@ export class CoreInSuiteDesktop implements ConnectImpl {
         return Promise.resolve(undefined);
     }
 
-    public cancel(_error?: string) {
+    public cancel(_error?: string | { error?: string; callId?: string }) {
+        console.log('cancel in CoreInSuiteDesktop');
+        //TODO: do it here as well
         this.ws.sendMessage({
             type: POPUP.CLOSED,
             payload: { error: _error },

--- a/packages/connect/e2e/tests/device/cancel.test.ts
+++ b/packages/connect/e2e/tests/device/cancel.test.ts
@@ -12,6 +12,8 @@ const getAddress = (showOnTrezor: boolean, coin: string = 'regtest') =>
     });
 
 const passphraseHandler = (value: string) => () => {
+    console.log('passphraseHandler');
+    console.log('value', value);
     TrezorConnect.uiResponse({
         type: 'ui-receive_passphrase',
         payload: {
@@ -23,6 +25,7 @@ const passphraseHandler = (value: string) => () => {
 };
 
 const addressHandler = () => () => {
+    console.log('addressHandler');
     TrezorConnect.uiResponse({
         type: 'ui-receive_confirmation',
         payload: true,
@@ -152,6 +155,34 @@ describe('TrezorConnect.cancel', () => {
 
         expect(response.success).toEqual(false);
 
+        await assertGetAddressWorks();
+    });
+
+    it.only('Passphrase request - Cancel by callId', async () => {
+        await setup(controller, {
+            mnemonic: 'mnemonic_all',
+            passphrase_protection: true,
+        });
+        await initTrezorConnect(controller);
+
+        // Start a call with a specific callId
+        const callA = TrezorConnect.getAddress({
+            path: "m/84'/1'/0'/0/0",
+            coin: 'regtest',
+            showOnTrezor: false,
+            callId: 'call-A',
+        });
+
+        // Wait for passphrase prompt then cancel only this call by its callId
+        await new Promise<void>(resolve => {
+            TrezorConnect.on('ui-request_passphrase', () => resolve());
+        });
+        TrezorConnect.cancel({ callId: 'call-A' });
+
+        const responseA = await callA;
+        expect(responseA.success).toEqual(false);
+
+        // After a targeted cancel the device should still be usable
         await assertGetAddressWorks();
     });
 

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -105,6 +105,8 @@ function validateDeviceState(device: CallMethodPayload['device']): DeviceState |
 export abstract class AbstractMethod<Name extends CallMethodPayload['method'], Params = undefined> {
     public responseID: string;
 
+    public callId?: string;
+
     public device: Device | undefined;
 
     protected params: Params;
@@ -160,6 +162,8 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         this.name = payload.method;
         this.params = params;
         this.responseID = message.id ?? '';
+        console.log('payload.callId in AbstractMethod', payload.callId);
+        this.callId = payload.callId;
         this.deviceState = validateDeviceState(payload.device);
         this.keepSession = typeof payload.keepSession === 'boolean' ? payload.keepSession : false;
         this.skipFinalReload = true;

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -48,7 +48,7 @@ export type MethodContext = {
 };
 
 export type MethodMessage<Name extends CallMethodPayload['method']> = {
-    id?: number;
+    id?: string;
     payload: Payload<Name>;
 };
 
@@ -103,7 +103,7 @@ function validateDeviceState(device: CallMethodPayload['device']): DeviceState |
 }
 
 export abstract class AbstractMethod<Name extends CallMethodPayload['method'], Params = undefined> {
-    public responseID: number;
+    public responseID: string;
 
     public device: Device | undefined;
 
@@ -159,7 +159,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
         const { payload } = message;
         this.name = payload.method;
         this.params = params;
-        this.responseID = message.id || 0;
+        this.responseID = message.id ?? '';
         this.deviceState = validateDeviceState(payload.device);
         this.keepSession = typeof payload.keepSession === 'boolean' ? payload.keepSession : false;
         this.skipFinalReload = true;

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -113,6 +113,7 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
                         view: 'no-backup',
                     },
                     uiPromise.requestId,
+                    method.callId,
                 ),
             );
 
@@ -125,13 +126,13 @@ const inner = async (context: CoreContext, method: AbstractMethod<any>, device: 
             }
         }
         // show notification
-        sendCoreMessage(createUiMessage(UI_REQUEST.DEVICE_NEEDS_BACKUP, device.toMessageObject()));
+        sendCoreMessage(createUiMessage(UI_REQUEST.DEVICE_NEEDS_BACKUP, device.toMessageObject(), undefined, method.callId));
     }
 
     // notify if firmware is outdated but not required
     if (device.firmwareStatus === 'outdated') {
         // show notification
-        sendCoreMessage(createUiMessage(UI_REQUEST.FIRMWARE_OUTDATED, device.toMessageObject()));
+        sendCoreMessage(createUiMessage(UI_REQUEST.FIRMWARE_OUTDATED, device.toMessageObject(), undefined, method.callId));
     }
 
     // Make sure that device will display pin/passphrase
@@ -442,15 +443,15 @@ const onDeviceButtonHandler =
                 ...request,
                 device: device.toMessageObject(),
                 data,
-            }),
+            }, undefined, method?.callId),
         );
         if (addressRequest && !method?.useUi) {
-            sendCoreMessage(createUiMessage(UI_REQUEST.ADDRESS_VALIDATION, data));
+            sendCoreMessage(createUiMessage(UI_REQUEST.ADDRESS_VALIDATION, data, undefined, method?.callId));
         }
     };
 
 const onDevicePinHandler =
-    (device: Device, context: CoreContext) =>
+    (device: Device, context: CoreContext, callId?: string) =>
     async ({ type, callback }: DeviceEvents['pin']) => {
         const { uiPromises, sendCoreMessage } = context;
         // create ui promise
@@ -461,6 +462,7 @@ const onDevicePinHandler =
                 UI_REQUEST.REQUEST_PIN,
                 { device: device.toMessageObject(), type },
                 uiPromise.requestId,
+                callId,
             ),
         );
         // wait for pin
@@ -480,7 +482,7 @@ const onDevicePinHandler =
     };
 
 const onDeviceWordHandler =
-    (device: Device, context: CoreContext) =>
+    (device: Device, context: CoreContext, callId?: string) =>
     async ({ type, callback }: DeviceEvents['word']) => {
         const { uiPromises, sendCoreMessage } = context;
         // create ui promise
@@ -490,6 +492,7 @@ const onDeviceWordHandler =
                 UI_REQUEST.REQUEST_WORD,
                 { device: device.toMessageObject(), type },
                 uiPromise.requestId,
+                callId,
             ),
         );
         // wait for word
@@ -509,7 +512,7 @@ const onDeviceWordHandler =
     };
 
 const onDevicePassphraseHandler =
-    (device: Device, context: CoreContext) =>
+    (device: Device, context: CoreContext, callId?: string) =>
     async ({ callback }: DeviceEvents['passphrase']) => {
         const { uiPromises, sendCoreMessage } = context;
         // create ui promise
@@ -520,6 +523,7 @@ const onDevicePassphraseHandler =
                 UI_REQUEST.REQUEST_PASSPHRASE,
                 { device: device.toMessageObject() },
                 uiPromise.requestId,
+                callId,
             ),
         );
         // wait for passphrase
@@ -552,7 +556,7 @@ const onEmptyPassphraseHandler =
     };
 
 const onThpPairingHandler =
-    (device: Device, context: CoreContext) =>
+    (device: Device, context: CoreContext, callId?: string) =>
     async ({ callback, payload }: DeviceEvents['thp_pairing']) => {
         const { uiPromises, sendCoreMessage } = context;
         // create ui promise
@@ -566,6 +570,7 @@ const onThpPairingHandler =
                     ...payload,
                 },
                 uiPromise.requestId,
+                callId,
             ),
         );
         // wait for response
@@ -614,26 +619,27 @@ const registerDeviceEvents =
     (context: CoreContext, method?: AbstractMethod<any>) => (device: Device) => {
         device.removeAllListeners();
         device.on(DEVICE.BUTTON, onDeviceButtonHandler(device, context, method));
-        device.on(DEVICE.PIN, onDevicePinHandler(device, context));
-        device.on(DEVICE.WORD, onDeviceWordHandler(device, context));
+        device.on(DEVICE.PIN, onDevicePinHandler(device, context, method?.callId));
+        device.on(DEVICE.WORD, onDeviceWordHandler(device, context, method?.callId));
         device.on(
             DEVICE.PASSPHRASE,
             (method?.useEmptyPassphrase ? onEmptyPassphraseHandler : onDevicePassphraseHandler)(
                 device,
                 context,
+                method?.callId,
             ),
         );
         device.on(DEVICE.PASSPHRASE_ON_DEVICE, () => {
             context.sendCoreMessage(
                 createUiMessage(UI_REQUEST.REQUEST_PASSPHRASE_ON_DEVICE, {
                     device: device.toMessageObject(),
-                }),
+                }, undefined, method?.callId),
             );
         });
         device.on(DEVICE.FIRMWARE_VERSION_CHANGED, payload => {
             context.sendCoreMessage(createDeviceMessage(DEVICE.FIRMWARE_VERSION_CHANGED, payload));
         });
-        device.on(DEVICE.THP_PAIRING, onThpPairingHandler(device, context));
+        device.on(DEVICE.THP_PAIRING, onThpPairingHandler(device, context, method?.callId));
         device.on(DEVICE.THP_CREDENTIALS_CHANGED, onThpCredentialsChangedHandler(device, context));
         device.on(DEVICE.THP_PAIRING_STATUS_CHANGED, onThpPhaseChangedHandler(device, context));
     };
@@ -765,6 +771,7 @@ export class Core extends EventEmitter {
         _log.debug('handleMessage', message.type);
 
         switch (message.type) {
+            // TODO(karliatto): we probably want to rename this.
             case POPUP.CLOSED:
                 onPopupClosed(
                     this.getCoreContext(),

--- a/packages/connect/src/core/index.ts
+++ b/packages/connect/src/core/index.ts
@@ -649,12 +649,35 @@ const registerDeviceEvents =
  * @returns {void}
  * @memberof Core
  */
-const onPopupClosed = (context: CoreContext, customErrorMessage?: string) => {
+const onPopupClosed = (context: CoreContext, customErrorMessage?: string, callId?: string) => {
+    console.log('onPopupClosed');
+    console.log('onPopupClosed');
+    console.log('onPopupClosed');
+    console.log('onPopupClosed');
+    console.log('callId', callId);
     const { uiPromises, deviceList, callMethods, resetWaitForFirstMethod, sendCoreMessage } =
         context;
     const error = customErrorMessage
         ? ERRORS.TypedError('Method_Cancel', customErrorMessage)
         : ERRORS.TypedError('Method_Interrupted');
+
+    if (callId) {
+        const method = callMethods.find(m => m.callId === callId);
+        if (method) {
+            // Interrupt the device if it is currently running this method.
+            // This throws inside device.run(), which triggers the normal error-response
+            // path in onCallDevice — so we don't send a response manually here.
+            if (method.device?.isUsedHere()) {
+                method.device.interrupt(error);
+            } else {
+                // Device not yet acquired — reject pending UI promises to unblock the method.
+                uiPromises.rejectAll(error);
+            }
+        }
+
+        return;
+    }
+
     // Device was already acquired. Try to interrupt running action which will throw error from onCall try/catch block
     if (deviceList.isConnected() && deviceList.getDeviceCount() > 0) {
         deviceList.getAllDevices().forEach(d => {
@@ -768,6 +791,7 @@ export class Core extends EventEmitter {
     }
 
     handleMessage(message: CoreRequestMessage) {
+        console.log('handleMessage in core');
         _log.debug('handleMessage', message.type);
 
         switch (message.type) {
@@ -776,6 +800,7 @@ export class Core extends EventEmitter {
                 onPopupClosed(
                     this.getCoreContext(),
                     message.payload ? message.payload.error : null,
+                    message.payload?.callId,
                 );
                 break;
 

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -45,9 +45,10 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         this.settings = parseConnectSettings();
         this.log = initLog('@trezor/connect');
         this.coreManager = initCoreState();
-        this.messagePromises = createDeferredManager<Omit<MethodResponseMessage, 'event' | 'type'>>(
-            { initialId: 1 },
-        );
+        this.messagePromises = createDeferredManager<
+            Omit<MethodResponseMessage, 'event' | 'type'>,
+            string
+        >({ generateId: (): string => crypto.randomUUID() });
     }
 
     // handle messages to core
@@ -67,7 +68,7 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
 
         switch (event) {
             case RESPONSE_EVENT: {
-                const { id = 0, success, device } = message;
+                const { id = '', success, device } = message;
                 const resolved = this.messagePromises.resolve(
                     id,
                     success

--- a/packages/connect/src/impl/core-in-module.ts
+++ b/packages/connect/src/impl/core-in-module.ts
@@ -177,8 +177,13 @@ export abstract class CoreInModule implements ConnectFactoryDependencies<Connect
         this.handleCoreMessage(response);
     }
 
-    public cancel(error?: string) {
-        this.handleCoreMessage({ type: POPUP.CLOSED, payload: error ? { error } : null });
+    public cancel(params?: string | { error?: string; callId?: string }) {
+        console.log('params in cancel core-in-module', params);
+        const payload =
+            typeof params === 'string'
+                ? { error: params }
+                : params ?? null;
+        this.handleCoreMessage({ type: POPUP.CLOSED, payload });
     }
 
     public dispose() {

--- a/suite-native/app/e2e/tests/deeplinkPopup.test.ts
+++ b/suite-native/app/e2e/tests/deeplinkPopup.test.ts
@@ -88,7 +88,7 @@ describe('Deeplink connect popup. [@androidOnly @T3T1]', () => {
 
         jestExpect(response).toEqual({
             success: true,
-            id: jestExpect.any(Number),
+            id: jestExpect.any(String),
             payload: jestExpect.objectContaining({
                 path: [2147483697, 2147483648, 2147483648, 0, 0],
                 serializedPath: "m/49'/0'/0'/0/0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description




## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/experiment-cancel/web/](https://dev.suite.sldev.cz/suite-web/feat/experiment-cancel/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/experiment-cancel&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/experiment-cancel&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 20 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect webextension -> Suite Web > TrezorConnect.getAddress | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancelled from calling application | 🤖 auto |
| TrezorConnect webextension -> Suite Web > closing popup window | 🤖 auto |
| TrezorConnect webextension -> Suite Web > focuses existing popup if already open | 🤖 auto |
| TrezorConnect webextension -> Suite Web > second call after popup was closed by user should work | 🤖 auto |
| TrezorConnect webextension -> Suite Web > call cancellation | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| sol staking > unstake and claim on SOL account | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-04-30T14:57:53.110Z • 20 test(s) total_
<!-- QUARANTINE-LIST:web:END -->