### PR TITLE
Webpack bundle cleanup

### DIFF
--- a/packages/connect/src/index.renderer.ts
+++ b/packages/connect/src/index.renderer.ts
@@ -1,0 +1,28 @@
+import { factory } from '@trezor/connect-common';
+
+const dummy = (method: string) => () => {
+    throw new Error(
+        `TrezorConnect.${method} should never be called from electron renderer without using ipcProxy`,
+    );
+};
+
+// Exported to enable using directly
+const TrezorConnect = factory({
+    eventEmitter: {
+        on: dummy('eventEmitter.on'),
+        removeListener: dummy('eventEmitter.removeListener'),
+        removeAllListeners: dummy('eventEmitter.removeAllListeners'),
+    } as any,
+    init: dummy('init'),
+    call: dummy('call'),
+    updateConnectSettings: dummy('updateConnectSettings'),
+    uiResponse: dummy('uiResponse'),
+    cancel: dummy('cancel'),
+    dispose: dummy('dispose'),
+});
+
+export default TrezorConnect;
+
+// allowed only here
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+export * from './exports';

--- a/packages/suite-build/configs/desktop.webpack.config.ts
+++ b/packages/suite-build/configs/desktop.webpack.config.ts
@@ -41,12 +41,11 @@ const config: webpack.Configuration = {
         publicPath: 'auto',
     },
     resolve: {
-        // conditionally mocks message-system config that is being used during build
-        alias: isTestBuild
-            ? {
-                  [messageSystemFile]: messageSystemMockFile,
-              }
-            : {},
+        alias: {
+            '@trezor/connect$': '@trezor/connect/src/index.renderer',
+            // conditionally mocks message-system config that is being used during build
+            ...(isTestBuild ? { [messageSystemFile]: messageSystemMockFile } : {}),
+        },
     },
     plugins: [
         new CopyWebpackPlugin({

--- a/packages/suite/src/services/coinjoin/coinjoinService.ts
+++ b/packages/suite/src/services/coinjoin/coinjoinService.ts
@@ -18,9 +18,7 @@ const loadInstance = (settings: ReturnType<typeof getCoinjoinConfig>) => {
         ] as const);
     }
 
-    return import(/* webpackChunkName: "coinjoin" */ '@trezor/coinjoin').then(
-        pkg => [new pkg.CoinjoinBackend(settings), new pkg.CoinjoinClient(settings)] as const,
-    );
+    throw new Error('Coinjoin supported only in Suite Desktop');
 };
 
 export interface CoinjoinServiceInstance {
@@ -42,10 +40,6 @@ export class CoinjoinService {
         const config = settings ?? getCoinjoinConfig(symbol);
         const [backend, client] = await loadInstance({ ...config, prison });
         const instance = { backend, client };
-        if (!isDesktop()) {
-            // display client log directly in console
-            client.on('log', ({ level, payload }) => console[level](payload));
-        }
 
         this.instances[symbol] = instance;
 


### PR DESCRIPTION
## Description

This pull request makes several changes to improve the handling of TrezorConnect in the renderer process and clarifies platform support for the Coinjoin service. The most important changes are grouped below:

**Renderer Process Integration:**

* Added a new `index.renderer.ts` file in `@trezor/connect` that exports a TrezorConnect factory with stubbed methods, making it available for renderer processes and improving modularity.
* Updated the webpack desktop configuration to alias `@trezor/connect` imports to the new `src/index.renderer` entry, ensuring the correct version is used in the renderer context.

**Platform Support Clarification:**

* Updated the `coinjoinService.ts` to throw an explicit error when attempting to load Coinjoin in the browser, making platform limitations clear at runtime.

## Prerequisites
#27298 
#27300 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/webpack-bundle-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/webpack-bundle-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/webpack-bundle-cleanup/web/](https://dev.suite.sldev.cz/suite-web/chore/webpack-bundle-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 11 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-05T18:00:47.565Z • 11 test(s) total_
<!-- QUARANTINE-LIST:web:END -->