### PR TITLE
refactor(protocol): deduplicate littleEndianBytesToBigInt

### DIFF
--- a/packages/protocol/src/protocol-thp/crypto/curve25519.ts
+++ b/packages/protocol/src/protocol-thp/crypto/curve25519.ts
@@ -1,5 +1,7 @@
 // TypeScript implementation of elligator2 https://www.rfc-editor.org/rfc/rfc9380.html#ell2-opt
 
+import { littleEndianBytesToBigInt } from './tools';
+
 let constants: ReturnType<typeof getConstants> | undefined;
 
 const getConstants = (): {
@@ -39,16 +41,6 @@ const getConstants = (): {
 
     return ctx;
 };
-
-// python int.from_bytes(array, "little")
-function littleEndianBytesToBigInt(bytes: Uint8Array): bigint {
-    let result = 0n;
-    for (let i = 0; i < bytes.length; i++) {
-        result += BigInt(bytes[i]) << (8n * BigInt(i));
-    }
-
-    return result;
-}
 
 // python int.to_bytes(32, "little")
 function bigintToLittleEndianBytes(value: bigint, length: number = 32): Uint8Array {

--- a/packages/protocol/src/protocol-thp/crypto/pairing.ts
+++ b/packages/protocol/src/protocol-thp/crypto/pairing.ts
@@ -232,35 +232,15 @@ export const validateCodeEntryTag = (
     }
 };
 
-export const validateQrCodeTag = (
-    { handshakeHash }: ThpHandshakeCredentials,
+const validatePairingTag = (
+    handshakeHash: Buffer,
+    method: ThpPairingMethod,
+    secret: Buffer,
     value: string,
-    secret: string, // ThpQrCodeSecret.secret
+    errorCode: string,
 ) => {
-    // Assert that value = SHA-256(ThpPairingMethod.QrCode || h || secret)
     const shaCtx = createHash('sha256');
-    shaCtx.update(Buffer.from([ThpPairingMethod.QrCode]));
-    shaCtx.update(handshakeHash);
-    shaCtx.update(Buffer.from(secret, 'hex'));
-
-    const calculatedValue = shaCtx.digest().subarray(0, 16);
-    const expectedValue = Buffer.from(value, 'hex').subarray(0, 16);
-    if (calculatedValue.compare(expectedValue) !== 0) {
-        throw new Error(
-            `HP6: code mismatch ${calculatedValue.toString('hex')} != ${expectedValue.toString('hex')}`,
-        );
-    }
-};
-
-// validate ThpNfcTagTrezor
-export const validateNfcTag = (
-    { handshakeHash }: ThpHandshakeCredentials,
-    value: string, // ThpNfcTagTrezor.tag
-    secret: Buffer, // ThpState.nfcSecret
-) => {
-    // Assert that value = SHA-256(ThpPairingMethod.NFC || h || secret)
-    const shaCtx = createHash('sha256');
-    shaCtx.update(Buffer.from([ThpPairingMethod.NFC]));
+    shaCtx.update(Buffer.from([method]));
     shaCtx.update(handshakeHash);
     shaCtx.update(secret);
 
@@ -268,7 +248,30 @@ export const validateNfcTag = (
     const expectedValue = Buffer.from(value, 'hex').subarray(0, 16);
     if (calculatedValue.compare(expectedValue) !== 0) {
         throw new Error(
-            `HP7: code mismatch ${calculatedValue.toString('hex')} != ${expectedValue.toString('hex')}`,
+            `${errorCode}: code mismatch ${calculatedValue.toString('hex')} != ${expectedValue.toString('hex')}`,
         );
     }
 };
+
+export const validateQrCodeTag = (
+    { handshakeHash }: ThpHandshakeCredentials,
+    value: string,
+    secret: string, // ThpQrCodeSecret.secret
+) =>
+    // Assert that value = SHA-256(ThpPairingMethod.QrCode || h || secret)
+    validatePairingTag(
+        handshakeHash,
+        ThpPairingMethod.QrCode,
+        Buffer.from(secret, 'hex'),
+        value,
+        'HP6',
+    );
+
+// validate ThpNfcTagTrezor
+export const validateNfcTag = (
+    { handshakeHash }: ThpHandshakeCredentials,
+    value: string, // ThpNfcTagTrezor.tag
+    secret: Buffer, // ThpState.nfcSecret
+) =>
+    // Assert that value = SHA-256(ThpPairingMethod.NFC || h || secret)
+    validatePairingTag(handshakeHash, ThpPairingMethod.NFC, secret, value, 'HP7');


### PR DESCRIPTION
## Summary

- Remove the private copy of `littleEndianBytesToBigInt` in `curve25519.ts`
- Import the identical implementation from `tools.ts` (same directory)
- Refactor similar code in packages/protocol/src/protocol-thp/crypto/pairing.ts to a more concise version
- No functional change

## Test plan

- [ ] TypeScript compiles without errors in `packages/protocol`
- [ ] Existing unit tests for THP crypto pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `packages/protocol/src/protocol-thp/crypto/curve25519.ts` is a low-level cryptographic primitive (Curve25519) used in the Trezor Host Protocol (THP). It maps to 121 tests, indicating it is a deeply shared dependency — likely transitively imported through the protocol/THP layer that is used during device communication and pairing. None of the 121 mapped E2E tests directly exercise Curve25519 cryptographic operations in their test behaviors; they all interact with higher-level UI flows (analytics, backup, trading, wallet operations, etc.) that only transitively depend on the THP protocol layer. Since no test's LLM analysis mentions curve25519, elliptic curve operations, or THP cryptographic handshakes as a directly exercised behavior, there is no specific evidence that any individual E2E test would regress from this change. The appropriate testing strategy is to rely on unit/integration tests for the crypto module itself rather than running E2E tests, as the E2E tests provide no targeted coverage of this change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/protocol/src/protocol-thp/crypto/curve25519.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/protocol/src/protocol-thp/crypto/curve25519.ts`

_Updated: 2026-05-01T13:45:00.880Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dry-little-endian-bytes-to-bigint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dry-little-endian-bytes-to-bigint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:33:00.533Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:31:50.916Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dry-little-endian-bytes-to-bigint/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dry-little-endian-bytes-to-bigint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->