### PR TITLE
fix(suite): don't show days to staking pool until it is fetched

### DIFF
--- a/suite-common/staking/src/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/__fixtures__/ethereumStaking.ts
@@ -540,7 +540,7 @@ export const getDaysToAddToPoolFixture = [
         result: undefined,
     },
     {
-        description: 'should return 2 if blockTime is undefined',
+        description: 'should return undefined if blockTime is undefined',
         args: {
             stakeTxs: [{}], // blockTime is undefined
             validatorsQueue: {
@@ -548,7 +548,7 @@ export const getDaysToAddToPoolFixture = [
                 activationTime: 86400,
             } satisfies EthValidatorsQueue,
         },
-        result: 2,
+        result: undefined,
     },
     {
         description: 'should return the number of days to wait',

--- a/suite-common/staking/src/utils/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.ts
@@ -558,8 +558,13 @@ export const getDaysToAddToPool = (
         return undefined;
     }
 
+    const lastTxBlockTime = stakeTxs[0]?.blockTime;
+
+    if (!lastTxBlockTime) {
+        return undefined;
+    }
+
     const now = Math.floor(Date.now() / 1000);
-    const lastTxBlockTime = stakeTxs[0]?.blockTime || now;
 
     const secondsToWait =
         lastTxBlockTime + validatorsQueue.addingDelay + validatorsQueue.activationTime - now;


### PR DESCRIPTION
## Description

Don't show incorrect days to add to staking pool when the data is not fetched.

## Related Issue

Resolve #26622 

## Screenshots:

https://github.com/user-attachments/assets/f0062606-c78a-4fcb-a5fe-17f5d48841b9

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are scoped to Ethereum staking utility functions and their test fixtures within `suite-common/staking`. The risk is concentrated in ETH staking E2E flows (initial stake, stake more, unstake/claim, and form validation). The `ethereumStaking.ts` file maps to 121 tests via transitive imports, but only the staking-specific tests have concrete paths through the changed staking logic. The recommended strategy is to run all ETH staking E2E tests as high priority and the staking analytics navigation test as medium priority, while safely skipping the ~116 other transitively-mapped tests that don't exercise staking code paths.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/staking/src/__fixtures__/ethereumStaking.ts`
- `suite-common/staking/src/utils/ethereumStaking.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test directly exercises ETH staking flows. The changed file `ethereumStaking.ts` contains utility functions for Ethereum staking, and the fixtures file provides test data for these utilities. Changes to staking calculations, validation, or state logic would directly affect the initial stake flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The stake-more flow relies on Ethereum staking utilities for calculating staking amounts, pending balances, and progress indicators. Changes to ethereumStaking.ts utility functions or their fixtures could break the additional staking workflow and balance transitions.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake test covers ETH unstaking and claiming flows which depend on ethereumStaking utility functions for computing staked/unstaking/claimable amounts and fee calculations. These are core Ethereum staking operations directly impacted by the changed files.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test validates the ETH staking form including minimum amount validation, decimal precision, insufficient funds checks, percentage buttons, max button with withdrawal buffer, and crypto/fiat switching. These validations likely use ethereumStaking.ts utilities for computing withdrawal buffers and balance calculations.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test verifies staking navigation analytics events for ETH and ADA. While it focuses on analytics event payloads rather than staking logic, the staking navigation components may depend on ethereumStaking utilities to determine staking availability or state, which could affect whether navigation buttons appear.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/staking/src/__fixtures__/ethereumStaking.ts`

_Updated: 2026-05-01T14:02:58.084Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-pool&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-pool&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/staking-pool&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-01T15:00:47.181Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 14 test(s)</summary>

| Test | Type |
|------|------|
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:59:17.990Z • 14 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/staking-pool/web/](https://dev.suite.sldev.cz/suite-web/fix/staking-pool/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->