### PR TITLE
fix(address-validator): enforce cashaddr checksum for BCH addresses

### DIFF
--- a/packages/address-validator/src/bch_validator.ts
+++ b/packages/address-validator/src/bch_validator.ts
@@ -1,91 +1,97 @@
+// CashAddr address format spec:
+// https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md
 import * as BTCValidator from './bitcoin_validator';
-import * as cryptoUtils from './crypto/utils';
 import { addressType } from './crypto/utils';
 
 const DEFAULT_NETWORK_TYPE = 'prod';
-const GENERATOR = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
 
-function polymod(values: number[]): number {
-    let chk = 1;
-    for (let p = 0; p < values.length; ++p) {
-        const top = chk >> 25;
-        chk = ((chk & 0x1ffffff) << 5) ^ values[p];
-        for (let i = 0; i < 5; ++i) {
-            if ((top >> i) & 1) {
-                chk ^= GENERATOR[i];
+// Base32 charset used for the cashaddr payload (see "Base32" in the spec).
+const CASHADDR_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+// Mainnet human-readable prefix; testnet/regtest use 'bchtest'/'bchreg'.
+const CASHADDR_PREFIX = 'bitcoincash';
+
+// BCH polymod generator constants from the cashaddr spec
+// ("Checksum" section): https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#checksum
+const CASHADDR_GENERATOR = [
+    BigInt('0x98f2bc8e61'),
+    BigInt('0x79b76d99e2'),
+    BigInt('0xf33e5fb3c4'),
+    BigInt('0xae2eabe2a8'),
+    BigInt('0x1e4f43e470'),
+];
+
+// Polymod implementation from the cashaddr spec ("Checksum" section):
+// https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#checksum
+function cashAddrPolymod(values: number[]): bigint {
+    let checksum = BigInt(1);
+    for (let i = 0; i < values.length; ++i) {
+        const high = checksum >> BigInt(35);
+        checksum = ((checksum & BigInt('0x07ffffffff')) << BigInt(5)) ^ BigInt(values[i]);
+        for (let j = 0; j < 5; ++j) {
+            if ((high >> BigInt(j)) & BigInt(1)) {
+                checksum ^= CASHADDR_GENERATOR[j];
             }
         }
     }
 
-    return chk;
+    return checksum ^ BigInt(1);
 }
 
-function hrpExpand(hrp: string): number[] {
-    const ret: number[] = [];
-    let p;
-    for (p = 0; p < hrp.length; ++p) {
-        ret.push(hrp.charCodeAt(p) >> 5);
+// Expands the human-readable prefix into the low 5 bits of each character,
+// terminated by a zero, as defined in the cashaddr spec ("Checksum" section).
+function hrpExpand(prefix: string): number[] {
+    const result: number[] = [];
+    for (let i = 0; i < prefix.length; ++i) {
+        result.push(prefix.charCodeAt(i) & 0x1f);
     }
-    ret.push(0);
-    for (p = 0; p < hrp.length; ++p) {
-        ret.push(hrp.charCodeAt(p) & 31);
+    result.push(0);
+
+    return result;
+}
+
+function verifyChecksum(prefix: string, payload: string): boolean {
+    const data = hrpExpand(prefix);
+    for (let i = 0; i < payload.length; ++i) {
+        const v = CASHADDR_CHARSET.indexOf(payload[i]);
+        if (v === -1) return false;
+        data.push(v);
     }
 
-    return ret;
+    return cashAddrPolymod(data) === BigInt(0);
 }
 
-function verifyChecksum(hrp: string, data: number[] | Uint8Array): boolean {
-    // Preserves original JS semantics: Array.prototype.concat does not spread a Uint8Array,
-    // so `data` is appended as a single element. The bitwise ops in polymod then produce NaN,
-    // which means this effectively never returns true for typed-array inputs. A real cashaddr
-    // checksum implementation is tracked as a follow-up.
-    return polymod(hrpExpand(hrp).concat(data as any)) === 1;
-}
+function validateAddress(address: string, currency: any): boolean {
+    if (address.toLowerCase() !== address && address.toUpperCase() !== address) {
+        return false;
+    }
 
-function validateAddress(address: string, currency: any, networkType?: string): boolean {
-    let prefix = 'bitcoincash';
+    const normalized = address.toLowerCase();
+    const colonIndex = normalized.indexOf(':');
     const regexp = new RegExp(currency.regexp);
-    let rawAddress: string;
 
-    const res = address.split(':');
-    if (res.length > 2) {
-        return false;
-    }
-    if (res.length === 1) {
-        rawAddress = address;
-    } else {
-        if (res[0] !== 'bitcoincash') {
+    if (colonIndex !== -1) {
+        const prefix = normalized.slice(0, colonIndex);
+        const payload = normalized.slice(colonIndex + 1);
+        if (prefix !== CASHADDR_PREFIX) {
             return false;
         }
-        rawAddress = res[1];
-    }
-
-    if (!regexp.test(rawAddress)) {
-        return false;
-    }
-
-    if (rawAddress.toLowerCase() !== rawAddress && rawAddress.toUpperCase() !== rawAddress) {
-        return false;
-    }
-
-    const decoded = cryptoUtils.base32.b32decode(rawAddress);
-    if (networkType === 'testnet') {
-        prefix = 'bchtest';
-    }
-
-    try {
-        if (verifyChecksum(prefix, decoded)) {
+        if (!regexp.test(payload)) {
             return false;
         }
-    } catch {
+
+        return verifyChecksum(prefix, payload);
+    }
+
+    if (!regexp.test(normalized)) {
         return false;
     }
 
-    return true;
+    return verifyChecksum(CASHADDR_PREFIX, normalized);
 }
 
 export const isValidAddress = (address: string, currency?: any, networkType?: string): boolean =>
-    validateAddress(address, currency, networkType) ||
+    validateAddress(address, currency) ||
     (currency.symbol !== 'bch' && BTCValidator.isValidAddress(address, currency, networkType));
 
 export const getAddressType = (address: string, currency?: any, networkType?: string) => {

--- a/packages/address-validator/tests/wallet_address_validator.test.ts
+++ b/packages/address-validator/tests/wallet_address_validator.test.ts
@@ -1201,17 +1201,30 @@ describe('WAValidator.validate()', function () {
             invalid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');
         });
 
-        // KNOWN BUG: bch_validator.verifyChecksum uses Array.prototype.concat on a Uint8Array,
-        // which appends it as a single element instead of spreading. The bitwise ops in polymod
-        // then yield NaN, so the checksum check effectively never fails and any address that
-        // passes the length/charset/case filters is accepted. These assertions document the
-        // current behavior; they must FLIP from valid → invalid once the cashaddr checksum is
-        // fixed in a follow-up.
-        it('incorrectly accepts bitcoincash addresses with corrupted checksums (known bug)', function () {
+        it('should return false for bitcoincash addresses with corrupted checksums', function () {
             // Tampered last char of a known-valid address
-            valid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808', 'bch');
+            invalid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808', 'bch');
             // Tampered middle of a known-valid address
-            valid('bitcoincash:qq4v32mtagxac29my6gxx6fd4tmqg8rysu23dax807', 'bch');
+            invalid('bitcoincash:qq4v32mtagxac29my6gxx6fd4tmqg8rysu23dax807', 'bch');
+        });
+
+        it('should return false for mixed-case bitcoincash addresses', function () {
+            invalid('bitcoincash:Qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax807', 'bch');
+            invalid('bitcoincash:QP3WJPA3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');
+        });
+
+        it('should return false for structurally invalid bitcoincash addresses with valid checksums', function () {
+            invalid('bitcoincash:a5a8yrhz', 'bch');
+            invalid('a5a8yrhz', 'bch');
+            invalid('bitcoincash:q0n354ecu', 'bch');
+        });
+
+        it('should return false for non-mainnet bitcoincash addresses', function () {
+            // 'bchtest' (testnet) and 'bchreg' (regtest) prefixes per cashaddr spec:
+            // https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#prefix
+            invalid('bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t', 'bch');
+            invalid('bchtest:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqdpn3jdgd', 'bch');
+            invalid('bchreg:qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqha9s37tt', 'bch');
         });
 
         it('should return false for incorrect litecoin addresses', function () {
@@ -1565,6 +1578,10 @@ describe('WAValidator.validate()', function () {
             invalid('pzuefrpg3kl2ykqe52rxn96pd3kp4qudywr5py', 'bsv');
             invalid('rlt2c2wuxr644encp3as0hygtj9djrsaumku3cex5', 'bsv');
             invalid('qra607y4wnkmnpy3wcmrxmltzkrxywcq85c7watpdx09', 'bsv');
+            invalid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808', 'bsv');
+            invalid('bitcoincash:Qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax807', 'bsv');
+            invalid('bitcoincash:a5a8yrhz', 'bsv');
+            invalid('a5a8yrhz', 'bsv');
         });
 
         it('should return false for incorrect stellar addresses', function () {


### PR DESCRIPTION
## Summary

Fixes #27201 — BCH send form accepted addresses with corrupted checksums, causing a confusing error only at tx composition time instead of immediate field validation.

The root cause was a cascade of bugs in `bch_validator.ts`:

1. **Wrong generator constants** — code used bech32 constants (`0x3b6a57b2…`) instead of cashaddr 40-bit constants (`0x98f2bc8e61…`).
2. **Wrong base32 alphabet** — `b32decode` used RFC 4648 alphabet (`ABCDEFGHIJKLMNOPQRSTUVWXYZ234567`) instead of the cashaddr charset (`qpzry9x8gf2tvdw0s3jn54khce6mua7l`).
3. **`Array.prototype.concat` does not spread `Uint8Array`** — the `Uint8Array` was appended as a single element, making `polymod` return `NaN`; `NaN === 1` is always `false`, so the checksum was never enforced.

Combined effect: any address passing the regex/case filter was accepted as valid regardless of its checksum.

### Fix

Replaced the checksum implementation with cashaddr polymod using BigInt for 40-bit arithmetic (JavaScript bitwise operators are 32-bit only), the cashaddr prefix expansion (`charCode & 0x1f`), and the cashaddr charset mapping.

The validator keeps the current Suite-supported BCH/BSV address shape guard, so a valid checksum alone is not enough: malformed payloads are rejected before being accepted as addresses. It also rejects mixed-case cashaddr strings and rejects non-mainnet BCH prefixes (`bchtest`, `bchreg`) in production BCH validation.

The known-bug test from #27075 now flips from `valid` → `invalid` as intended.

### External references

- [Bitcoin Cash protocol docs: CashAddr encoding](https://documentation.cash/protocol/blockchain/encoding/cashaddr.html) document the CashAddr components, network prefixes (`bitcoincash`, `bchtest`, `bchreg`), Base32 alphabet (`qpzry9x8gf2tvdw0s3jn54khce6mua7l`), mixed-case rejection rule, version-byte length constraints, and checksum `polymod` generator constants.
- [Original CashAddr specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md) defines the Base32 symbol table, the 40-bit checksum generator constants (`0x98f2bc8e61`, `0x79b76d99e2`, `0xf33e5fb3c4`, `0xae2eabe2a8`, `0x1e4f43e470`), prefix expansion using the lower 5 bits of each prefix character, and checksum-only test vectors whose payloads are intentionally invalid.

## Test plan

- [x] `yarn workspace @trezor/address-validator test:unit --coverage=0 wallet_address_validator.test.ts`
- [x] `yarn workspace @trezor/address-validator type-check`
- [x] `yarn workspace @trezor/address-validator test:unit --coverage=0`
- [x] `git diff --check`
- [x] `bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax808` (tampered last char) → `invalid`
- [x] `bitcoincash:qq4v32mtagxac29my6gxx6fd4tmqg8rysu23dax807` (tampered middle) → `invalid`
- [x] All previously valid BCH and BSV cashaddr addresses still accepted
- [x] Mixed-case BCH/BSV cashaddr addresses → `invalid`
- [x] Structurally invalid BCH/BSV payloads with valid cashaddr checksums → `invalid`
- [x] Non-mainnet BCH prefixes (`bchtest`, `bchreg`) → `invalid`
- [ ] Manual: open BCH send form, paste tampered cashaddr → field turns red immediately

Closes #27201
Related: #27075

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to `packages/address-validator/src/bch_validator.js` (a BCH address validation utility) and its corresponding unit test file `packages/address-validator/tests/wallet_address_validator.test.ts`. The `bch_validator.js` file maps to 121 E2E tests, indicating it is a deeply shared utility imported transitively across the entire application. However, none of the 121 mapped E2E tests exercise BCH address validation directly — their LLM analyses show they focus on analytics, backup, browser compatibility, dashboard, firmware, metadata, onboarding, passphrase, recovery, settings, staking, trading, wallet send/receive, and TrezorConnect flows, none of which specifically test BCH address validation logic. The unit test file has no static E2E coverage mapping. The risk is low for E2E regressions since BCH validation changes would only surface if a test explicitly validates or sends to a BCH address, which none of the analyzed tests do. No E2E tests are recommended; the unit test file itself provides the most relevant coverage for this change.

<details><summary><b>Changed files (2)</b></summary>

- `packages/address-validator/src/bch_validator.js`
- `packages/address-validator/tests/wallet_address_validator.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/address-validator/tests/wallet_address_validator.test.ts`

_Updated: 2026-05-01T14:26:14.583Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-test-bug-27075&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-test-bug-27075&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-01T14:31:10.722Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-01T15:21:28.353Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-test-bug-27075/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-test-bug-27075/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->
