### PR TITLE
Mobile - minor UI fixes and improvements

### DIFF
--- a/suite-native/accounts/src/components/TokenReceiveCard.tsx
+++ b/suite-native/accounts/src/components/TokenReceiveCard.tsx
@@ -1,10 +1,15 @@
 import { useSelector } from 'react-redux';
 
 import { type SuiteSyncDataRootState, selectSuiteSyncAccountLabel } from '@suite-common/suite-sync';
-import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    selectAccountByKey,
+    selectAccountNetworkSymbol,
+    selectFormattedAccountType,
+} from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
-import { Badge, Box, ErrorMessage, Text, VStack } from '@suite-native/atoms';
+import { Badge, Box, ErrorMessage, HStack, Text, VStack } from '@suite-native/atoms';
 import { TokenAmountFormatter, TokenToFiatAmountFormatter } from '@suite-native/formatters';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -33,9 +38,19 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
     const { accountDescriptor, networkSymbol, deviceStaticSessionId } = parseAccountKey(accountKey);
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
 
-    const accountLabel = useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
-        selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
     );
+    const formattedAccountType = useSelector((state: AccountsRootState) =>
+        selectFormattedAccountType(state, accountKey),
+    );
+    const accountLabel =
+        useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
+            selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
+        ) ??
+        account?.accountLabel ??
+        '';
+
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
@@ -60,15 +75,21 @@ export const TokenReceiveCard = ({ contract, accountKey }: TokenReceiveCardProps
                     </Box>
                     <Box style={applyStyle(tokenDescriptionStyle)}>
                         <Text>{tokenName}</Text>
-                        <Badge
-                            label={
-                                <Translation
-                                    id="moduleAccounts.tokens.runOn"
-                                    values={{ accountLabel }}
-                                />
-                            }
-                            size="small"
-                        />
+
+                        <HStack alignItems="center" spacing="sp4">
+                            <Text
+                                variant="body-xs"
+                                color="contentSecondary"
+                                numberOfLines={1}
+                                ellipsizeMode="tail"
+                            >
+                                {accountLabel}
+                            </Text>
+
+                            {formattedAccountType && (
+                                <Badge label={formattedAccountType} size="small" />
+                            )}
+                        </HStack>
                     </Box>
                 </Box>
                 <Box style={applyStyle(valuesContainerStyle)}>

--- a/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/TokenToFiatAmountFormatter.tsx
@@ -71,7 +71,7 @@ export const TokenToFiatAmountFormatter = ({
 
     return (
         <Box flexDirection="row">
-            <SignValueFormatter value={signValue} />
+            {!isForcedDiscreetMode && <SignValueFormatter value={signValue} />}
             {amountText}
         </Box>
     );

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1799,11 +1799,9 @@ export const messages = {
     moduleAccounts: {
         accountNotFound: 'Account {accountKey} not found.',
         tokens: {
-            runOn: 'Run on {accountLabel}',
             errorMessage: 'Token not found.',
         },
         accountDetail: {
-            accountLabelBadge: 'Run on {accountLabel}',
             stablecoinYield: {
                 infoText: 'This token represents your deposit and all rewards in stablecoin yield.',
                 vault: 'Vault',

--- a/suite-native/labeling/src/components/EditableLabelLayout.tsx
+++ b/suite-native/labeling/src/components/EditableLabelLayout.tsx
@@ -34,6 +34,7 @@ export const EditableLabelLayout = ({ children, label, testID }: EditableLabelLa
                 }}
                 iconRight="pencil"
                 testID={testID}
+                size="small"
             >
                 {label ?? <Translation id="suiteSync.addLabel" />}
             </TextButton>

--- a/suite-native/labeling/src/components/SendFormLabelEditable.tsx
+++ b/suite-native/labeling/src/components/SendFormLabelEditable.tsx
@@ -17,7 +17,7 @@ export const SendFormLabelEditable = ({ onLabelChange, label }: SendFormLabelEdi
     if (!isLabellingAllowed) return null;
 
     return (
-        <Box flex={1} alignItems="flex-end">
+        <Box alignItems="flex-end">
             <EditableLabelLayout label={label}>
                 {({ onClose }) => (
                     <LabelEditForm

--- a/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenAccountDetailScreenHeader.tsx
@@ -7,12 +7,12 @@ import {
     type AccountsRootState,
     selectAccountByKey,
     selectAccountNetworkSymbol,
+    selectFormattedAccountType,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { parseAccountKey, parseDeviceStaticSessionId } from '@suite-common/wallet-utils';
-import { Box, HStack, Text, VStack } from '@suite-native/atoms';
+import { Badge, Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { CryptoIconWithNetwork } from '@suite-native/icons';
-import { useTranslate } from '@suite-native/intl';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -29,16 +29,20 @@ export const TokenAccountDetailScreenHeader = ({
     accountKey,
     tokenContract,
 }: TokenAccountDetailScreenHeaderProps) => {
-    const { translate } = useTranslate();
-
     const { accountDescriptor, networkSymbol, deviceStaticSessionId } = parseAccountKey(accountKey);
     const { walletDescriptor } = parseDeviceStaticSessionId(deviceStaticSessionId);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const accountLabel = useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
-        selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
+    const formattedAccountType = useSelector((state: AccountsRootState) =>
+        selectFormattedAccountType(state, accountKey),
     );
+    const accountLabel =
+        useSelector((state: AccountsRootState & SuiteSyncDataRootState) =>
+            selectSuiteSyncAccountLabel(state, walletDescriptor, accountDescriptor, networkSymbol),
+        ) ??
+        account?.accountLabel ??
+        '';
 
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -52,8 +56,6 @@ export const TokenAccountDetailScreenHeader = ({
     if (!symbol) {
         return null;
     }
-
-    const accountLabelBadge = accountLabel ?? account?.accountLabel ?? '';
 
     return (
         <ScreenHeader
@@ -69,16 +71,21 @@ export const TokenAccountDetailScreenHeader = ({
                             <Text ellipsizeMode="tail" numberOfLines={1}>
                                 {token?.name}
                             </Text>
-                            <Text
-                                variant="body-xs"
-                                color="contentSecondary"
-                                numberOfLines={1}
-                                ellipsizeMode="tail"
-                            >
-                                {translate('moduleAccounts.accountDetail.accountLabelBadge', {
-                                    accountLabel: accountLabelBadge,
-                                })}
-                            </Text>
+
+                            <HStack alignItems="center" spacing="sp4">
+                                <Text
+                                    variant="body-xs"
+                                    color="contentSecondary"
+                                    numberOfLines={1}
+                                    ellipsizeMode="tail"
+                                >
+                                    {accountLabel}
+                                </Text>
+
+                                {formattedAccountType && (
+                                    <Badge label={formattedAccountType} size="small" />
+                                )}
+                            </HStack>
                         </VStack>
                     </HStack>
                 </Box>

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -86,7 +86,7 @@ export const AddressInput = ({ index, accountKey }: AddressInputProps) => {
 
     return (
         <VStack spacing="sp12">
-            <HStack alignItems="center" spacing="sp12">
+            <HStack alignItems="center" justifyContent="space-between" spacing="sp12">
                 <Text variant="body-sm">
                     <Translation id="moduleSend.outputs.recipients.addressLabel" />
                 </Text>

--- a/suite-native/module-send/src/components/SendOutputsScreenFooter.tsx
+++ b/suite-native/module-send/src/components/SendOutputsScreenFooter.tsx
@@ -14,7 +14,7 @@ export const SendOutputsScreenFooter = ({
 
     return (
         <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
-            <Box paddingHorizontal="sp16" paddingVertical="sp16">
+            <Box paddingVertical="sp16">
                 <Button
                     accessibilityRole="button"
                     accessibilityLabel={translate('generic.validateForm')}

--- a/suite-native/module-send/src/screens/SendOutputsScreen.tsx
+++ b/suite-native/module-send/src/screens/SendOutputsScreen.tsx
@@ -87,7 +87,7 @@ export const SendOutputsScreen = ({
                     </Form>
                 </Box>
                 {isValid && network && (
-                    <Box marginTop="sp24">
+                    <Box marginTop="sp16">
                         <FeeSelector
                             accountKey={accountKey}
                             tokenContract={tokenContract}

--- a/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailParametersSheet.tsx
@@ -132,12 +132,14 @@ export const TransactionDetailParametersSheet = ({
                             <Text numberOfLines={1} style={{ flexShrink: 1 }}>
                                 <TransactionIdFormatter value={transaction.txid} />
                             </Text>
+
                             <Box marginLeft="sp8">
                                 <IconButton
                                     iconName="copy"
                                     onPress={handleClickCopy}
                                     intent="neutral"
                                     priority="secondary"
+                                    size="small"
                                 />
                             </Box>
                         </Box>

--- a/suite-native/transactions/src/components/TransactionListItem.tsx
+++ b/suite-native/transactions/src/components/TransactionListItem.tsx
@@ -79,7 +79,7 @@ export const TransactionListItemValues = ({
                 <EmptyAmountText />
             ) : (
                 <Box flexDirection="row">
-                    {!isFailedTx && <SignValueFormatter value={sign} />}
+                    {!isFailedTx && !isPhishingTransaction && <SignValueFormatter value={sign} />}
                     <CryptoToFiatAmountFormatter
                         value={transaction.amount}
                         symbol={transaction.symbol}


### PR DESCRIPTION
## Description

This PR introduces several minor UI fixes for mobile.

## Screenshots:

Fixed `Review and sign` button horizontal padding: 89e9145b304f46f747e7c08fd8e2905c3a7e18b3

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="100%" alt="01-before" src="https://github.com/user-attachments/assets/ee268cd7-ebf1-48eb-af3a-1017026a4700" />
</td>
<td>
<img width="100%" alt="01-after" src="https://github.com/user-attachments/assets/d9d4bde8-4838-46ff-85bb-2263750856eb" />
</td>
</tr>
</table>

Made the gap between amount and fee picker smaller, so that it is consistent with the remaining gaps: a07e768ca5d24333c3add12e80e2a011e8cdc4ea

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="100%" alt="02-before" src="https://github.com/user-attachments/assets/af3f3ad3-3b0e-42f8-b619-98a0d66d40a7" />
</td>
<td>
<img width="100%" alt="02-after" src="https://github.com/user-attachments/assets/b7ffb15d-655c-4d8a-9d77-4d5c93a43d7b" />
</td>
</tr>
</table>

Moved the `Add label` button to the right and made its font size smaller: ed8538015e6a78ed6924bc20891d8471f64cab3e

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="100%" alt="03-before" src="https://github.com/user-attachments/assets/aca1a8c6-c901-4967-97ae-78fa309eddf4" />
</td>
<td>
<img width="100%" alt="03-after" src="https://github.com/user-attachments/assets/5dc42c63-c1f4-4062-8c79-02dd2cbaac3b" />
</td>
</tr>
</table>

Fix missing account name and badge: 164047448409aaad066d7a4a394b78a5f6f0b8b6

<table>
<tr>
<td>Token Detail</td>
<td>Send Form</td>
</tr>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 20 13 51" src="https://github.com/user-attachments/assets/a18b9d7d-0a84-4a84-a80b-1dbde4b84730" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 20 13 57" src="https://github.com/user-attachments/assets/1ad11a5a-7a7b-4bf3-8e5f-a0e36541a34f" />
</td>
</tr>
</table>

Removed the `+`/`-` signs for redacted amounts (e.g. phishing transactions): f962984e2c2e4e816a5f74d754e550fea8bd7a7e

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td>
<img width="100%" alt="05-before" src="https://github.com/user-attachments/assets/59998304-452d-4c5f-a07b-21c65652c4a3" />
</td>
<td>
<img width="100%" alt="05-after" src="https://github.com/user-attachments/assets/f3f27b9d-1294-402b-9cf6-a0b267f52d62" />
</td>
</tr>
</table>

Make copy button smaller in transaction detail: e0d0a3ae96a0585c0cb4ce93abe55412fdfe8ef7

<table>
<tr>
<td>Token Detail</td>
<td>Send Form</td>
</tr>
<tr>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 20 17 55" src="https://github.com/user-attachments/assets/2bd77d79-3a4a-4e58-82b8-8c3934f06f3b" />
</td>
<td>
<img width="100%" alt="Screenshot 2026-05-01 at 20 18 04" src="https://github.com/user-attachments/assets/8c553b04-b405-4b82-a4a1-f5c3f3da7157" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/ui&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->