### PR TITLE
refactor(suite-native): remove redundant trading state types

### DIFF
--- a/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/buySlice.test.ts
@@ -1,9 +1,9 @@
 import type { CryptoId } from 'invity-api';
 
+import { type TradingBuyState } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { buyQuotes, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
-import { type TradingBuyState } from '@suite-native/trading-types';
 
 import { buyActions, buyReducer } from '../buySlice';
 

--- a/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/exchangeSlice.test.ts
@@ -1,9 +1,9 @@
 import type { CryptoId } from 'invity-api';
 
+import { type TradingExchangeState } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { exchangeQuotes, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
-import { type TradingExchangeState } from '@suite-native/trading-types';
 
 import { exchangeActions, exchangeReducer } from '../exchangeSlice';
 

--- a/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/__tests__/sellSlice.test.ts
@@ -1,9 +1,9 @@
 import type { CryptoId } from 'invity-api';
 
+import { type TradingSellState } from '@suite-common/trading';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { banxaCreditCardSellQuote, sellQuotes } from '@suite-native/trading-fixtures';
-import { type TradingSellState } from '@suite-native/trading-types';
 
 import { sellActions, sellReducer } from '../sellSlice';
 

--- a/suite-native/trading-types/src/state.ts
+++ b/suite-native/trading-types/src/state.ts
@@ -1,9 +1,6 @@
 import type { ProviderMetadata } from 'invity-api';
 
 import type {
-    TradingBuyState as CommonTradingBuyState,
-    TradingExchangeState as CommonTradingExchangeState,
-    TradingSellState as CommonTradingSellState,
     TradingState as CommonTradingState,
     InvityServerEnvironment,
     TradingCountryCode,
@@ -11,12 +8,6 @@ import type {
 } from '@suite-common/trading';
 
 import type { ProviderConfirmationStatus } from './general';
-
-export type TradingBuyState = CommonTradingBuyState;
-
-export type TradingExchangeState = CommonTradingExchangeState;
-
-export type TradingSellState = CommonTradingSellState;
 
 export type TradingResidenceState = {
     country: TradingCountryCode | undefined;
@@ -32,9 +23,6 @@ export type TradingResidenceRootState = {
 };
 
 export interface TradingState extends CommonTradingState {
-    buy: TradingBuyState;
-    exchange: TradingExchangeState;
-    sell: TradingSellState;
     residence: TradingResidenceState;
     tradingEnvironment: InvityServerEnvironment;
     tradeOrderIdToBeOpened: string | undefined;


### PR DESCRIPTION
## Summary

Removes redundant native trading state type aliases and uses the common trading state types directly in reducer tests.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/check-type-decls&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->