### PR TITLE
fix(sentry): properly handle object exceptions

### DIFF
--- a/suite-common/sentry/src/commonBeforeSend.ts
+++ b/suite-common/sentry/src/commonBeforeSend.ts
@@ -1,0 +1,7 @@
+import type { ErrorEvent, EventHint } from '@sentry/core';
+
+import { normalizeObjectErrors } from './normalizeObjectErrors';
+import { redactSentryEvent } from './redactSentryEvent';
+
+export const commonBeforeSend = (event: ErrorEvent, hint: EventHint) =>
+    normalizeObjectErrors(redactSentryEvent(event), hint);

--- a/suite-common/sentry/src/index.ts
+++ b/suite-common/sentry/src/index.ts
@@ -1,3 +1,3 @@
 export * from './constants';
 export { ignoreErrorsCommon } from './ignoreErrors';
-export { redactSentryEvent } from './redactSentryEvent';
+export { commonBeforeSend } from './commonBeforeSend';

--- a/suite-common/sentry/src/normalizeObjectErrors.ts
+++ b/suite-common/sentry/src/normalizeObjectErrors.ts
@@ -1,0 +1,14 @@
+import type { ErrorEvent, EventHint } from '@sentry/core';
+
+/**
+ * Backfill information for Object-type errors, which are otherwise hard to debug.
+ */
+export const normalizeObjectErrors = (event: ErrorEvent | null, hint?: EventHint) => {
+    const originalException = hint?.originalException;
+    if (event && originalException && typeof originalException === 'object') {
+        // in extra, the object is normally readable, better than an [object Object] message
+        event.extra = { originalException };
+    }
+
+    return event;
+};

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -1,7 +1,7 @@
 import { captureConsoleIntegration } from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
 
-import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import { ALLOW_REPORT_TAG, commonBeforeSend } from '@suite-common/sentry';
 import { getEnv, isDebugEnv, isDetoxTestBuild } from '@suite-native/config';
 
 import { ignoreErrors } from './ignoreErrors';
@@ -38,7 +38,7 @@ export const initSentry = () => {
             captureConsoleIntegration({ levels: ['error'] }),
         ],
         enableLogs: true,
-        beforeSend: redactSentryEvent,
+        beforeSend: commonBeforeSend,
         ignoreErrors,
 
         // You can put EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true to `.env.development.local` to debug Sentry locally.

--- a/suite/sentry/src/config.ts
+++ b/suite/sentry/src/config.ts
@@ -1,6 +1,6 @@
 import type { ErrorEvent, Options } from '@sentry/core';
 
-import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
+import { COINJOIN_NETWORK_TAG, COINJOIN_REPORT_TAG, commonBeforeSend } from '@suite-common/sentry';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 import { redactUserPathFromString } from '@trezor/utils';
@@ -53,9 +53,6 @@ const redactCoinjoinData = (event: ErrorEvent): ErrorEvent => {
     return event;
 };
 
-const beforeSend = (event: ErrorEvent) =>
-    redactSentryEvent(redactUserPath(redactCoinjoinData(event)));
-
 const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
     // filter out analytics requests and image fetches
     const isAnalytics =
@@ -75,7 +72,7 @@ const beforeBreadcrumb: Options['beforeBreadcrumb'] = breadcrumb => {
 export const SENTRY_CONFIG = {
     dsn: 'https://6d91ca6e6a5d4de7b47989455858b5f6@o117836.ingest.sentry.io/5193825',
 
-    beforeSend,
+    beforeSend: (event, hint) => commonBeforeSend(redactUserPath(redactCoinjoinData(event)), hint),
     enabled: !isDevEnv, // set to true to enable Sentry logging while testing locally
     maxValueLength: 500, // default 250 is not enough for some errors
     release: process.env.SENTRY_RELEASE,


### PR DESCRIPTION
## Description

Because we have often `[object Object]` events in Sentry, most recently [this annoying noisy thing](https://satoshilabs.sentry.io/issues/7374780363/) , let's try this: catching all object-type errors and putting the raw object into Sentry extras.
Then you can see the `originalException` [in this testing event](https://satoshilabs.sentry.io/issues/7455914018/events/06fedb3ec5a644eca3cdc822931c6032/).
When it's and Error object, [the data is not there](https://satoshilabs.sentry.io/issues/7458570891/events/e57c4a56e67c4e9283adcce578e3e027/)

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within the Sentry error-reporting/telemetry infrastructure (suite-common/sentry, suite-native/sentry, suite/sentry). These modules handle error normalization, beforeSend hooks, and Sentry configuration. They are not part of any user-facing feature flow exercised by the E2E tests — Sentry is a background telemetry concern that captures errors silently without affecting UI behavior, routing, analytics events, or wallet operations. No static test coverage mapping exists for these files, and the LLM analysis of all available E2E tests shows no test that directly or indirectly exercises Sentry error-reporting logic. The risk of user-visible regression from these changes is very low, and unit/integration tests (if any) within the sentry packages themselves would be the appropriate verification layer rather than E2E tests.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/sentry/src/commonBeforeSend.ts`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/normalizeObjectErrors.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-common/sentry/src/commonBeforeSend.ts`
- `suite-common/sentry/src/index.ts`
- `suite-common/sentry/src/normalizeObjectErrors.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite/sentry/src/config.ts`

_Updated: 2026-05-02T17:46:54.942Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sentry-object-errors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sentry-object-errors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/sentry-object-errors&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-02T17:52:27.095Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-02T17:51:08.392Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sentry-object-errors/web/](https://dev.suite.sldev.cz/suite-web/fix/sentry-object-errors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->