### PR TITLE
Move Privacy section to the top of Settings > Application

### DIFF
--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -92,14 +92,32 @@ export const SettingsGeneral = () => {
 
                 <SettingsSection
                     isBelowLaptop={isBelowLaptop}
-                    title={<Translation id="TR_LOCALIZATION" />}
-                    icon="flag"
+                    title={<Translation id="TR_PRIVACY" />}
+                    icon="lock"
                 >
-                    <Language />
-                    <BaseCurrency />
-                    {hasBitcoinNetworks && <BitcoinAmountUnit />}
+                    <AutoEject />
+                    {isDesktop() && !isLinux() && <BioAuthSettings />}
+                    {(isDesktop() || (isWeb() && isTorEnabled)) && (
+                        <>
+                            {isDesktop() && <Tor />}
+                            {(isTorEnabled || torStatus === TorStatus.Enabling) && (
+                                <TorOnionLinks />
+                            )}
+                            {torExternalExperimentalFeature && <TorExternal />}
+                        </>
+                    )}
                 </SettingsSection>
             </div>
+
+            <SettingsSection
+                isBelowLaptop={isBelowLaptop}
+                title={<Translation id="TR_LOCALIZATION" />}
+                icon="flag"
+            >
+                <Language />
+                <BaseCurrency />
+                {hasBitcoinNetworks && <BitcoinAmountUnit />}
+            </SettingsSection>
 
             <SettingsSection
                 isBelowLaptop={isBelowLaptop}
@@ -114,22 +132,6 @@ export const SettingsGeneral = () => {
                         <ConnectLabelingProvider />
                     ))}
                 <LegacyLabelingMigration />
-            </SettingsSection>
-
-            <SettingsSection
-                isBelowLaptop={isBelowLaptop}
-                title={<Translation id="TR_PRIVACY" />}
-                icon="lock"
-            >
-                <AutoEject />
-                {isDesktop() && !isLinux() && <BioAuthSettings />}
-                {(isDesktop() || (isWeb() && isTorEnabled)) && (
-                    <>
-                        {isDesktop() && <Tor />}
-                        {(isTorEnabled || torStatus === TorStatus.Enabling) && <TorOnionLinks />}
-                        {torExternalExperimentalFeature && <TorExternal />}
-                    </>
-                )}
             </SettingsSection>
 
             <SettingsSection


### PR DESCRIPTION
## QA Notes
- Reorders the Settings > Application sections so Privacy appears first.
- Places Localization second and Labeling third, while leaving the remaining sections in their existing order.
- No copy or functional changes were made.

<!-- LLM-TEST-SELECTOR:HEADING:START -->
## 🤖 LLM Test Recommendations
<!-- LLM-TEST-SELECTOR:HEADING:END -->

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to SettingsGeneral.tsx, which renders the Settings > General/Application page. This file maps to 91 tests statically, indicating it's a broadly imported component, but most of those tests only pass through it incidentally during onboarding or navigation. The highest risk is to tests that directly exercise settings controls (fiat, theme, language, analytics toggle, EAP, application log) on the general settings page. A focused set of 6 tests covers the direct functionality and key interaction paths through this view.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test directly exercises the SettingsGeneral view component that was changed. It tests fiat currency changes, theme changes, language changes, analytics toggle, and suite version display — all rendered by SettingsGeneral.tsx.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test validates theme and language autodetection behavior that flows through the general settings page. Changes to SettingsGeneral.tsx could affect how autodetect preferences are rendered or toggled.
- `suite/e2e/tests/settings/application-log.test.ts` — This test navigates to Settings > General and interacts with the application log button, which is rendered within the SettingsGeneral view. Changes to the component layout could affect log button visibility or behavior.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test directly interacts with the analytics toggle switch on the Settings > Application page (SettingsGeneral), verifying enable/disable behavior and analytics event emission from the settings UI.
- `suite/e2e/tests/analytics/events.test.ts` — This test exercises Settings > Application tab to change language, fiat currency, BTC units, and theme — all controls within SettingsGeneral.tsx. It then validates analytics events reflect these setting changes.
- `suite/e2e/tests/general/eap-modal.test.ts` — This test interacts with the Early Access Program join button on the Settings > Application page, which is part of the SettingsGeneral view. Changes could affect the EAP section rendering.

</details>

_Updated: 2026-05-03T12:02:27.424Z_
<!-- LLM-TEST-SELECTOR:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/move-privacy-section-to-the-top-of-settings-application&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/move-privacy-section-to-the-top-of-settings-application&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 12 test(s)</summary>

| Test | Type |
|------|------|
| Export transactions > Go to account and try to export all possible variants (pdf, csv, json) | 🤖 auto |
| TrezorConnect popup web - no onboarding > popup blocked by browser returns handshake failed error | 🤖 auto |
| TrezorConnect popup web > focuses existing popup if already open | 🤖 auto |
| Metadata lifecycle > Choice persistence and reset behavior | 🤖 auto |
| Metadata - wallet labeling > labels can be enabled and edited when different wallet is open | 🤖 auto |
| Metadata - wallet labeling > persists wallet labels | 🤖 auto |
| Quarantine test: "Onboarding - create wallet,Success (basic)" | 🙋 manual |
| Quarantine test: "Database migration,Db migration between: release/22.5/web => develop/web" | 🙋 manual |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine CANARY test: "Trading - Sell BTC" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-05-03T12:10:04.455Z • 12 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 15 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Public Keys > Check ada XPUB | 🤖 auto |
| Onboarding - create wallet > Success (Shamir backup) | 🤖 auto |
| Coin Settings > go to wallet settings page, check BTC, activate few networks, deactivate them, set custom backend | 🤖 auto |
| Account types suite > Add-account-types-non-BTC-coins | 🤖 auto |
| Onboarding - create wallet > Success (basic) | 🤖 auto |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Receive transaction,Receive a ETH transaction" | 🙋 manual |
| Quarantine test: "Global receive and send,Global receive" | 🙋 manual |
| Bridge > App acquired device, EXTERNAL bridge is restarted, app reconnects | 🤖 auto |
| Bridge > App spawns bundled bridge and stops it after app quit | 🤖 auto |
| Bridge > App in daemon mode spawns node-bridge | 🤖 auto |
| Quarantine test: "Multiple sessions,Session overtaken by another" | 🙋 manual |
| Quarantine test: "Send Base,User can perform ethereum sending on base network" | 🙋 manual |
| Quarantine CANARY test: "Use regtest to test pending transactions,Send couple of pending txs and check that they are pending until mined" | 🙋 manual |

</details>

_Updated: 2026-05-03T12:08:21.921Z • 15 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/move-privacy-section-to-the-top-of-settings-application/web/](https://dev.suite.sldev.cz/suite-web/refactor/move-privacy-section-to-the-top-of-settings-application/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->